### PR TITLE
Add streaming evaluation, Dashboard V2, design docs, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install formatting tools
+        run: pip install "pyink>=24.3.0" "isort>=5.0"
+
+      - name: Run autoformat and check for changes
+        run: |
+          bash autoformat.sh
+          if ! git diff --exit-code src/ tests/ examples/; then
+            echo ""
+            echo "::error::Code is not formatted. Run 'bash autoformat.sh' and commit the changes."
+            exit 1
+          fi
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --tb=short -q
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    needs: [format, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify package version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "Package version: ${VERSION}"
+          ls -la dist/
+          ls dist/ | grep "${VERSION}" || (echo "Version mismatch in built artifacts" && exit 1)
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+*.so
+.pytest_cache/
+.venv/
+venv/
+env/
+
+# Local workspace metadata
+.code*/
+deploy/streaming_evaluation/.streaming_evaluation_state.json
+
+# macOS Finder metadata
+.DS_Store
+.DS_Store?
+._*

--- a/deploy/streaming_evaluation/README.md
+++ b/deploy/streaming_evaluation/README.md
@@ -1,0 +1,124 @@
+# Streaming Evaluation Deployment
+
+This deployment path turns selected recent rows in `agent_events` into
+session-scoped SDK evaluations with a scheduled overlap scan.
+
+```mermaid
+flowchart LR
+  A["agent_events in BigQuery"] --> B["Cloud Scheduler every 5 min"]
+  B --> C["Cloud Run worker"]
+  C --> D["overlap scan + dedupe + checkpoint"]
+  D --> E["SDK evaluate(session_id)"]
+  E --> F["streaming_evaluation_results"]
+```
+
+## What Launches
+
+- terminal rows: `event_type = 'AGENT_COMPLETED'`
+- error rows: `event_type = 'TOOL_ERROR' OR (status = 'ERROR' AND error_message IS NOT NULL)`
+- evaluator profile: `streaming_observability_v1`
+- default cadence: every `5` minutes
+- default overlap window: `15` minutes
+- default result table: `PROJECT.DATASET.streaming_evaluation_results`
+
+## Why This Path
+
+This launch path intentionally does **not** use BigQuery continuous
+queries.
+
+```mermaid
+flowchart LR
+  A["Continuous query"] --> B["lowest latency"]
+  A --> C["higher fixed cost"]
+  C --> D["can reach the low-thousands per month"]
+  D --> E["not a good default"]
+
+  F["Scheduler + overlap scan"] --> G["lower cost"]
+  F --> H["simpler setup"]
+  F --> I["chosen default"]
+```
+
+## Prerequisites
+
+- `gcloud`, `bq`, and `jq`
+- a BigQuery dataset containing `agent_events`
+- permission to deploy Cloud Run and Cloud Scheduler in the target project
+
+No special BigQuery reservation is required for this deployment path.
+The setup script can enable the required Cloud Run, Cloud Build,
+Artifact Registry, and Cloud Scheduler APIs automatically.
+
+## Quick Start
+
+```bash
+cd deploy/streaming_evaluation
+./setup.sh up my-project agent_trace agent_events us-central1
+```
+
+The script will:
+
+- infer the BigQuery dataset location
+- create the result table in the source dataset
+- create hidden checkpoint and run-history tables
+- deploy the `bq-agent-streaming-eval` Cloud Run service
+- create the Cloud Scheduler job that invokes it every `5` minutes
+- print the final result table name and a sample query
+
+After setup, read results directly from BigQuery:
+
+```sql
+SELECT *
+FROM `my-project.agent_trace.streaming_evaluation_results`
+ORDER BY processed_at DESC
+LIMIT 20;
+```
+
+## Hidden Internal State
+
+The setup path also creates internal tables for recovery and debugging:
+
+- `_streaming_eval_state`
+- `_streaming_eval_runs`
+
+These are implementation details. The primary user-facing table remains
+`streaming_evaluation_results`.
+
+## Cleanup
+
+```bash
+cd deploy/streaming_evaluation
+./setup.sh down
+```
+
+`down` deletes the Cloud Scheduler job, removes the Cloud Run service,
+removes the scheduler service account only if this setup created it, and
+deletes the local state file.
+
+`down` intentionally preserves the BigQuery tables:
+
+- `streaming_evaluation_results`
+- `_streaming_eval_state`
+- `_streaming_eval_runs`
+
+This keeps prior evaluation output and internal audit history queryable
+after the deployment is removed. If you want to drop them too, remove
+them manually with `bq rm -t`.
+
+## Customization
+
+Defaults can be overridden with environment variables before running
+`setup.sh`:
+
+- `PROJECT_ID`
+- `DATASET_ID`
+- `SOURCE_TABLE`
+- `RUN_REGION`
+- `RESULT_TABLE`
+- `STATE_TABLE`
+- `RUNS_TABLE`
+- `POLL_SCHEDULE`
+- `OVERLAP_MINUTES`
+- `INITIAL_LOOKBACK_MINUTES`
+
+`RESULT_TABLE` defaults to the same dataset as the source table so the
+result sink stays in the same BigQuery location.

--- a/deploy/streaming_evaluation/main.py
+++ b/deploy/streaming_evaluation/main.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud Run entrypoint for scheduled streaming evaluation."""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask import jsonify
+from flask import request
+
+from worker import handle_scheduled_run
+
+app = Flask(__name__)
+
+
+@app.post("/")
+def handle_request():
+  """HTTP entrypoint for Cloud Scheduler delivery."""
+  body = request.get_json(silent=True)
+  response, status_code = handle_scheduled_run(body or {})
+  return jsonify(response), status_code

--- a/deploy/streaming_evaluation/requirements.txt
+++ b/deploy/streaming_evaluation/requirements.txt
@@ -1,0 +1,6 @@
+flask>=3.0.0
+gunicorn>=22.0.0
+google-cloud-bigquery>=3.0.0
+pydantic>=2.0.0
+pyyaml>=6.0
+typer>=0.9.0

--- a/deploy/streaming_evaluation/setup.sh
+++ b/deploy/streaming_evaluation/setup.sh
@@ -1,0 +1,475 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+MODE="${1:-}"
+PROJECT="${2:-${PROJECT_ID:-}}"
+DATASET="${3:-${DATASET_ID:-}}"
+SOURCE_TABLE="${4:-${SOURCE_TABLE:-agent_events}}"
+RUN_REGION="${5:-${RUN_REGION:-us-central1}}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STATE_FILE="${STATE_FILE:-$SCRIPT_DIR/.streaming_evaluation_state.json}"
+
+SERVICE_NAME="${SERVICE_NAME:-bq-agent-streaming-eval}"
+SCHEDULER_JOB_NAME="${SCHEDULER_JOB_NAME:-bq-agent-streaming-eval-5m}"
+SCHEDULER_SA_NAME="${SCHEDULER_SA_NAME:-bq-agent-stream-eval-sa}"
+RESULT_TABLE="${RESULT_TABLE:-streaming_evaluation_results}"
+STATE_TABLE="${STATE_TABLE:-_streaming_eval_state}"
+RUNS_TABLE="${RUNS_TABLE:-_streaming_eval_runs}"
+POLL_SCHEDULE="${POLL_SCHEDULE:-*/5 * * * *}"
+SCHEDULER_TIME_ZONE="${SCHEDULER_TIME_ZONE:-Etc/UTC}"
+OVERLAP_MINUTES="${OVERLAP_MINUTES:-15}"
+INITIAL_LOOKBACK_MINUTES="${INITIAL_LOOKBACK_MINUTES:-30}"
+
+usage() {
+  cat <<EOF
+Usage:
+  ./setup.sh up PROJECT DATASET [SOURCE_TABLE] [RUN_REGION]
+  ./setup.sh down
+
+Required for "up":
+  PROJECT or PROJECT_ID
+  DATASET or DATASET_ID
+
+Defaults for optional "up" arguments:
+  SOURCE_TABLE=${SOURCE_TABLE}
+  RUN_REGION=${RUN_REGION}
+
+Environment overrides:
+  PROJECT_ID, DATASET_ID, SOURCE_TABLE, RUN_REGION
+  SERVICE_NAME, SCHEDULER_JOB_NAME, SCHEDULER_SA_NAME
+  RESULT_TABLE, STATE_TABLE, RUNS_TABLE
+  POLL_SCHEDULE, SCHEDULER_TIME_ZONE
+  OVERLAP_MINUTES, INITIAL_LOOKBACK_MINUTES
+EOF
+}
+
+require_up_inputs() {
+  if [[ -z "$PROJECT" || -z "$DATASET" ]]; then
+    cat >&2 <<EOF
+PROJECT and DATASET are required for "up".
+
+Examples:
+  ./setup.sh up my-project agent_trace agent_events us-central1
+  PROJECT_ID=my-project DATASET_ID=agent_trace ./setup.sh up
+EOF
+    exit 1
+  fi
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    exit 1
+  fi
+}
+
+enable_service_if_needed() {
+  local service="$1"
+  gcloud services enable "$service" \
+    --project="$PROJECT" \
+    --quiet >/dev/null
+}
+
+normalized_scheduler_service_account_name() {
+  local raw="$1"
+  local normalized
+  normalized="$(
+    printf '%s' "$raw" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+  )"
+
+  if [[ -z "$normalized" ]]; then
+    normalized="schedsa"
+  fi
+  if [[ ! "$normalized" =~ ^[a-z] ]]; then
+    normalized="a${normalized}"
+  fi
+  normalized="${normalized:0:30}"
+  normalized="${normalized%-}"
+  while [[ ${#normalized} -lt 6 ]]; do
+    normalized="${normalized}0"
+  done
+  echo "$normalized"
+}
+
+infer_bq_location() {
+  bq show --format=json "${PROJECT}:${DATASET}" | jq -r '.location'
+}
+
+create_results_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${RESULT_TABLE}\` (
+  dedupe_key STRING NOT NULL,
+  session_id STRING NOT NULL,
+  trace_id STRING,
+  span_id STRING,
+  trigger_kind STRING NOT NULL,
+  trigger_event_type STRING NOT NULL,
+  trigger_timestamp TIMESTAMP NOT NULL,
+  is_final BOOL NOT NULL,
+  evaluator_profile STRING NOT NULL,
+  passed BOOL NOT NULL,
+  aggregate_scores_json STRING NOT NULL,
+  details_json STRING NOT NULL,
+  report_json STRING NOT NULL,
+  processed_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(processed_at)
+CLUSTER BY trigger_kind, session_id;
+SQL
+)"
+}
+
+create_state_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${STATE_TABLE}\` (
+  processor_name STRING NOT NULL,
+  checkpoint_timestamp TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY processor_name;
+SQL
+)"
+}
+
+create_runs_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${RUNS_TABLE}\` (
+  processor_name STRING NOT NULL,
+  run_started_at TIMESTAMP NOT NULL,
+  run_finished_at TIMESTAMP NOT NULL,
+  scan_start TIMESTAMP NOT NULL,
+  scan_end TIMESTAMP NOT NULL,
+  trigger_rows_found INT64 NOT NULL,
+  processed_rows INT64 NOT NULL,
+  duplicate_rows INT64 NOT NULL,
+  ignored_rows INT64 NOT NULL,
+  status STRING NOT NULL,
+  error_message STRING
+)
+PARTITION BY DATE(run_started_at)
+CLUSTER BY status, processor_name;
+SQL
+)"
+}
+
+ensure_scheduler_service_account() {
+  local account_id
+  account_id="$(normalized_scheduler_service_account_name "$SCHEDULER_SA_NAME")"
+  local email="${account_id}@${PROJECT}.iam.gserviceaccount.com"
+  if gcloud iam service-accounts describe "$email" \
+    --project="$PROJECT" >/dev/null 2>&1; then
+    echo "${email}|false"
+    return
+  fi
+
+  gcloud iam service-accounts create "$account_id" \
+    --project="$PROJECT" \
+    --display-name="Streaming evaluation scheduler" \
+    >/dev/null
+  wait_for_service_account "$email"
+  echo "${email}|true"
+}
+
+wait_for_service_account() {
+  local scheduler_sa_email="$1"
+  local attempt
+
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if gcloud iam service-accounts describe "$scheduler_sa_email" \
+      --project="$PROJECT" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 5
+  done
+
+  echo "Service account did not become visible in IAM: ${scheduler_sa_email}" >&2
+  return 1
+}
+
+ensure_scheduler_oidc_binding() {
+  local scheduler_sa_email="$1"
+  local project_number
+  local scheduler_service_agent
+
+  wait_for_service_account "$scheduler_sa_email"
+  project_number="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+  scheduler_service_agent="service-${project_number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
+
+  gcloud iam service-accounts add-iam-policy-binding "$scheduler_sa_email" \
+    --project="$PROJECT" \
+    --member="serviceAccount:${scheduler_service_agent}" \
+    --role="roles/iam.serviceAccountOpenIdTokenCreator" \
+    --quiet >/dev/null
+}
+
+deploy_worker() {
+  local bq_location="$1"
+  local staging
+  staging="$(mktemp -d)"
+  trap 'rm -rf "$staging"' RETURN
+
+  cp "$SCRIPT_DIR/main.py" "$SCRIPT_DIR/worker.py" "$staging/"
+  cp "$SCRIPT_DIR/requirements.txt" "$staging/"
+  cp -R "$REPO_ROOT/src" "$staging/"
+
+  cat > "$staging/Procfile" <<'PROCFILE'
+web: gunicorn --bind :$PORT --workers 1 --timeout 300 --graceful-timeout 30 main:app
+PROCFILE
+
+  gcloud run deploy "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --source="$staging" \
+    --quiet \
+    --no-allow-unauthenticated \
+    --memory=512Mi \
+    --timeout=300 \
+    --concurrency=1 \
+    --min-instances=0 \
+    --max-instances=1 \
+    --set-env-vars="PYTHONPATH=/workspace/src,BQ_AGENT_PROJECT=${PROJECT},BQ_AGENT_DATASET=${DATASET},BQ_AGENT_TABLE=${SOURCE_TABLE},BQ_AGENT_LOCATION=${bq_location},BQ_AGENT_RESULT_PROJECT=${PROJECT},BQ_AGENT_RESULT_DATASET=${DATASET},BQ_AGENT_RESULT_TABLE=${RESULT_TABLE},BQ_AGENT_STATE_PROJECT=${PROJECT},BQ_AGENT_STATE_DATASET=${DATASET},BQ_AGENT_STATE_TABLE=${STATE_TABLE},BQ_AGENT_RUNS_PROJECT=${PROJECT},BQ_AGENT_RUNS_DATASET=${DATASET},BQ_AGENT_RUNS_TABLE=${RUNS_TABLE},BQ_AGENT_OVERLAP_MINUTES=${OVERLAP_MINUTES},BQ_AGENT_INITIAL_LOOKBACK_MINUTES=${INITIAL_LOOKBACK_MINUTES}" \
+    >/dev/null
+}
+
+service_url() {
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --format='value(status.url)'
+}
+
+ensure_scheduler_job() {
+  local scheduler_sa_email="$1"
+  local url="$2"
+  local error_file
+  local error_output
+  local attempt
+
+  wait_for_service_account "$scheduler_sa_email"
+  gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --member="serviceAccount:${scheduler_sa_email}" \
+    --role="roles/run.invoker" \
+    --quiet >/dev/null
+
+  if gcloud scheduler jobs describe "$SCHEDULER_JOB_NAME" \
+    --project="$PROJECT" \
+    --location="$RUN_REGION" >/dev/null 2>&1; then
+    gcloud scheduler jobs delete "$SCHEDULER_JOB_NAME" \
+      --project="$PROJECT" \
+      --location="$RUN_REGION" \
+      --quiet >/dev/null
+  fi
+
+  error_file="$(mktemp)"
+  for attempt in 1 2 3 4 5; do
+    if gcloud scheduler jobs create http "$SCHEDULER_JOB_NAME" \
+      --project="$PROJECT" \
+      --location="$RUN_REGION" \
+      --schedule="$POLL_SCHEDULE" \
+      --time-zone="$SCHEDULER_TIME_ZONE" \
+      --uri="${url}/" \
+      --http-method=POST \
+      --headers=Content-Type=application/json \
+      --message-body='{}' \
+      --oidc-service-account-email="$scheduler_sa_email" \
+      --oidc-token-audience="$url" \
+      --attempt-deadline=300s \
+      >/dev/null 2>"$error_file"; then
+      rm -f "$error_file"
+      return
+    fi
+
+    error_output="$(cat "$error_file")"
+    if [[ "$error_output" != *"NOT_FOUND"* || "$attempt" -eq 5 ]]; then
+      rm -f "$error_file"
+      echo "$error_output" >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+write_state() {
+  local bq_location="$1"
+  local scheduler_sa_email="$2"
+  local scheduler_sa_created="$3"
+
+  cat > "$STATE_FILE" <<EOF
+{
+  "project": "${PROJECT}",
+  "dataset": "${DATASET}",
+  "source_table": "${SOURCE_TABLE}",
+  "run_region": "${RUN_REGION}",
+  "bq_location": "${bq_location}",
+  "service_name": "${SERVICE_NAME}",
+  "scheduler_job_name": "${SCHEDULER_JOB_NAME}",
+  "scheduler_service_account": "${scheduler_sa_email}",
+  "scheduler_service_account_created": ${scheduler_sa_created},
+  "result_table": "${RESULT_TABLE}",
+  "state_table": "${STATE_TABLE}",
+  "runs_table": "${RUNS_TABLE}"
+}
+EOF
+}
+
+up() {
+  require_tool jq
+  require_tool bq
+  require_tool gcloud
+  require_up_inputs
+
+  enable_service_if_needed run.googleapis.com
+  enable_service_if_needed cloudbuild.googleapis.com
+  enable_service_if_needed artifactregistry.googleapis.com
+  enable_service_if_needed cloudscheduler.googleapis.com
+
+  local bq_location
+  bq_location="$(infer_bq_location)"
+
+  create_results_table "$bq_location"
+  create_state_table "$bq_location"
+  create_runs_table "$bq_location"
+
+  deploy_worker "$bq_location"
+
+  local scheduler_sa_result
+  scheduler_sa_result="$(ensure_scheduler_service_account)"
+  local scheduler_sa_email="${scheduler_sa_result%%|*}"
+  local scheduler_sa_created="${scheduler_sa_result##*|}"
+  ensure_scheduler_oidc_binding "$scheduler_sa_email"
+
+  local url
+  url="$(service_url)"
+  ensure_scheduler_job "$scheduler_sa_email" "$url"
+  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
+
+  cat <<EOF
+Streaming evaluation scheduler deployed.
+
+Cloud Run service:
+  ${SERVICE_NAME}
+
+Cloud Scheduler job:
+  ${SCHEDULER_JOB_NAME}
+
+Result table:
+  ${PROJECT}.${DATASET}.${RESULT_TABLE}
+
+Sample query:
+  SELECT *
+  FROM \`${PROJECT}.${DATASET}.${RESULT_TABLE}\`
+  ORDER BY processed_at DESC
+  LIMIT 20;
+EOF
+}
+
+down() {
+  require_tool jq
+  require_tool gcloud
+
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "State file not found: $STATE_FILE" >&2
+    exit 1
+  fi
+
+  local down_project
+  local down_region
+  local down_service
+  local down_job
+  local down_dataset
+  local down_result_table
+  local down_state_table
+  local down_runs_table
+  local scheduler_sa_email
+  local scheduler_sa_created
+
+  down_project="$(jq -r '.project' "$STATE_FILE")"
+  down_dataset="$(jq -r '.dataset' "$STATE_FILE")"
+  down_region="$(jq -r '.run_region' "$STATE_FILE")"
+  down_service="$(jq -r '.service_name' "$STATE_FILE")"
+  down_job="$(jq -r '.scheduler_job_name' "$STATE_FILE")"
+  down_result_table="$(jq -r '.result_table' "$STATE_FILE")"
+  down_state_table="$(jq -r '.state_table' "$STATE_FILE")"
+  down_runs_table="$(jq -r '.runs_table' "$STATE_FILE")"
+  scheduler_sa_email="$(jq -r '.scheduler_service_account' "$STATE_FILE")"
+  scheduler_sa_created="$(jq -r '.scheduler_service_account_created' "$STATE_FILE")"
+
+  gcloud scheduler jobs delete "$down_job" \
+    --project="$down_project" \
+    --location="$down_region" \
+    --quiet >/dev/null 2>&1 || true
+
+  gcloud run services delete "$down_service" \
+    --project="$down_project" \
+    --region="$down_region" \
+    --quiet >/dev/null 2>&1 || true
+
+  if [[ "$scheduler_sa_created" == "true" ]]; then
+    gcloud iam service-accounts delete "$scheduler_sa_email" \
+      --project="$down_project" \
+      --quiet >/dev/null 2>&1 || true
+  fi
+
+  rm -f "$STATE_FILE"
+  cat <<EOF
+Streaming evaluation scheduler resources removed.
+
+BigQuery tables were preserved intentionally:
+  ${down_project}.${down_dataset}.${down_result_table}
+  ${down_project}.${down_dataset}.${down_state_table}
+  ${down_project}.${down_dataset}.${down_runs_table}
+
+To remove them manually:
+  bq rm -t ${down_project}:${down_dataset}.${down_result_table}
+  bq rm -t ${down_project}:${down_dataset}.${down_state_table}
+  bq rm -t ${down_project}:${down_dataset}.${down_runs_table}
+EOF
+}
+
+case "$MODE" in
+  up)
+    up
+    ;;
+  down)
+    down
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/deploy/streaming_evaluation/trigger_query.sql
+++ b/deploy/streaming_evaluation/trigger_query.sql
@@ -1,0 +1,34 @@
+-- Scheduled overlap scan: agent_events -> streaming evaluation worker
+--
+-- Placeholders:
+--   PROJECT      - GCP project id
+--   DATASET      - BigQuery dataset id
+--   SOURCE_TABLE - source table to scan
+--   SCAN_START   - overlap window lower bound (TIMESTAMP literal or parameter)
+--   SCAN_END     - overlap window upper bound (TIMESTAMP literal or parameter)
+
+SELECT
+  session_id,
+  trace_id,
+  span_id,
+  event_type,
+  status,
+  error_message,
+  timestamp AS trigger_timestamp,
+  CASE
+    WHEN event_type = 'AGENT_COMPLETED' THEN 'session_terminal'
+    ELSE 'error_event'
+  END AS trigger_kind
+FROM `PROJECT.DATASET.SOURCE_TABLE`
+WHERE timestamp >= SCAN_START
+  AND timestamp < SCAN_END
+  AND session_id IS NOT NULL
+  AND (
+    event_type = 'AGENT_COMPLETED'
+    OR event_type = 'TOOL_ERROR'
+    OR (
+      status = 'ERROR'
+      AND error_message IS NOT NULL
+    )
+  )
+ORDER BY trigger_timestamp ASC;

--- a/deploy/streaming_evaluation/worker.py
+++ b/deploy/streaming_evaluation/worker.py
@@ -1,0 +1,664 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scheduled streaming evaluation worker logic.
+
+This module keeps Cloud Scheduler request handling, overlap-window
+scanning, SDK execution, and BigQuery persistence independent of Flask
+so the Cloud Run entrypoint can stay thin and the behavior can be unit
+tested without a live server.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import logging
+import os
+from typing import Any
+
+from google.cloud import bigquery
+
+from bigquery_agent_analytics import TraceFilter
+from bigquery_agent_analytics._deploy_runtime import build_client_from_context
+from bigquery_agent_analytics._deploy_runtime import resolve_client_options
+from bigquery_agent_analytics._streaming_evaluation import build_streaming_observability_evaluator
+from bigquery_agent_analytics._streaming_evaluation import compute_scan_start
+from bigquery_agent_analytics._streaming_evaluation import DEFAULT_INITIAL_LOOKBACK_MINUTES
+from bigquery_agent_analytics._streaming_evaluation import DEFAULT_OVERLAP_MINUTES
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_row
+from bigquery_agent_analytics._streaming_evaluation import serialize_streaming_result_row
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_PROCESSOR_NAME
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_RESULTS_TABLE
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_RUNS_TABLE
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_STATE_TABLE
+
+logger = logging.getLogger("bigquery_agent_analytics." + __name__)
+
+_TRIGGER_SCAN_QUERY = """\
+SELECT
+  session_id,
+  trace_id,
+  span_id,
+  event_type,
+  status,
+  error_message,
+  timestamp AS trigger_timestamp,
+  CASE
+    WHEN event_type = 'AGENT_COMPLETED' THEN 'session_terminal'
+    ELSE 'error_event'
+  END AS trigger_kind
+FROM `{project}.{dataset}.{table}`
+WHERE timestamp >= @scan_start
+  AND timestamp < @scan_end
+  AND session_id IS NOT NULL
+  AND (
+    event_type = 'AGENT_COMPLETED'
+    OR event_type = 'TOOL_ERROR'
+    OR (
+      status = 'ERROR'
+      AND error_message IS NOT NULL
+    )
+  )
+ORDER BY trigger_timestamp ASC
+"""
+
+_RESULTS_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @dedupe_key AS dedupe_key,
+    @session_id AS session_id,
+    @trace_id AS trace_id,
+    @span_id AS span_id,
+    @trigger_kind AS trigger_kind,
+    @trigger_event_type AS trigger_event_type,
+    @trigger_timestamp AS trigger_timestamp,
+    @is_final AS is_final,
+    @evaluator_profile AS evaluator_profile,
+    @passed AS passed,
+    @aggregate_scores_json AS aggregate_scores_json,
+    @details_json AS details_json,
+    @report_json AS report_json,
+    @processed_at AS processed_at
+) S
+ON T.dedupe_key = S.dedupe_key
+WHEN NOT MATCHED THEN
+  INSERT (
+    dedupe_key,
+    session_id,
+    trace_id,
+    span_id,
+    trigger_kind,
+    trigger_event_type,
+    trigger_timestamp,
+    is_final,
+    evaluator_profile,
+    passed,
+    aggregate_scores_json,
+    details_json,
+    report_json,
+    processed_at
+  )
+  VALUES (
+    S.dedupe_key,
+    S.session_id,
+    S.trace_id,
+    S.span_id,
+    S.trigger_kind,
+    S.trigger_event_type,
+    S.trigger_timestamp,
+    S.is_final,
+    S.evaluator_profile,
+    S.passed,
+    S.aggregate_scores_json,
+    S.details_json,
+    S.report_json,
+    S.processed_at
+  )
+"""
+
+_LOAD_STATE_QUERY = """\
+SELECT checkpoint_timestamp
+FROM `{project}.{dataset}.{table}`
+WHERE processor_name = @processor_name
+LIMIT 1
+"""
+
+_STATE_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @processor_name AS processor_name,
+    @checkpoint_timestamp AS checkpoint_timestamp,
+    @updated_at AS updated_at
+) S
+ON T.processor_name = S.processor_name
+WHEN MATCHED THEN
+  UPDATE SET
+    checkpoint_timestamp = S.checkpoint_timestamp,
+    updated_at = S.updated_at
+WHEN NOT MATCHED THEN
+  INSERT (
+    processor_name,
+    checkpoint_timestamp,
+    updated_at
+  )
+  VALUES (
+    S.processor_name,
+    S.checkpoint_timestamp,
+    S.updated_at
+  )
+"""
+
+_RUNS_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @processor_name AS processor_name,
+    @run_started_at AS run_started_at,
+    @run_finished_at AS run_finished_at,
+    @scan_start AS scan_start,
+    @scan_end AS scan_end,
+    @trigger_rows_found AS trigger_rows_found,
+    @processed_rows AS processed_rows,
+    @duplicate_rows AS duplicate_rows,
+    @ignored_rows AS ignored_rows,
+    @status AS status,
+    @error_message AS error_message
+) S
+ON T.processor_name = S.processor_name
+  AND T.run_started_at = S.run_started_at
+WHEN MATCHED THEN
+  UPDATE SET
+    run_finished_at = S.run_finished_at,
+    scan_start = S.scan_start,
+    scan_end = S.scan_end,
+    trigger_rows_found = S.trigger_rows_found,
+    processed_rows = S.processed_rows,
+    duplicate_rows = S.duplicate_rows,
+    ignored_rows = S.ignored_rows,
+    status = S.status,
+    error_message = S.error_message
+WHEN NOT MATCHED THEN
+  INSERT (
+    processor_name,
+    run_started_at,
+    run_finished_at,
+    scan_start,
+    scan_end,
+    trigger_rows_found,
+    processed_rows,
+    duplicate_rows,
+    ignored_rows,
+    status,
+    error_message
+  )
+  VALUES (
+    S.processor_name,
+    S.run_started_at,
+    S.run_finished_at,
+    S.scan_start,
+    S.scan_end,
+    S.trigger_rows_found,
+    S.processed_rows,
+    S.duplicate_rows,
+    S.ignored_rows,
+    S.status,
+    S.error_message
+  )
+"""
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+  """Deployment configuration resolved from env vars."""
+
+  source_project: str
+  source_dataset: str
+  source_table: str
+  result_project: str
+  result_dataset: str
+  result_table: str
+  state_project: str
+  state_dataset: str
+  state_table: str
+  runs_project: str
+  runs_dataset: str
+  runs_table: str
+  processor_name: str
+  overlap: timedelta
+  initial_lookback: timedelta
+
+
+@dataclass
+class RunStats:
+  """Counters for one scheduled worker run."""
+
+  trigger_rows_found: int = 0
+  processed_rows: int = 0
+  duplicate_rows: int = 0
+  ignored_rows: int = 0
+
+
+def handle_scheduled_run(
+    body: dict[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], int]:
+  """Process one Cloud Scheduler invocation."""
+  del body  # Reserved for future scheduler metadata.
+
+  run_started_at = now or datetime.now(timezone.utc)
+  client = None
+  config = None
+  scan_start = None
+  stats = RunStats()
+  success_run_finalized = False
+
+  try:
+    client = build_client_from_context({})
+    config = load_runtime_config(client)
+    checkpoint_timestamp = load_checkpoint(client, config)
+    scan_start = compute_scan_start(
+        run_started_at=run_started_at,
+        checkpoint_timestamp=checkpoint_timestamp,
+        overlap=config.overlap,
+        initial_lookback=config.initial_lookback,
+    )
+    evaluator = build_streaming_observability_evaluator()
+
+    for trigger in iter_triggers(client, config, scan_start, run_started_at):
+      stats.trigger_rows_found += 1
+      if isinstance(trigger, _IgnoredTrigger):
+        stats.ignored_rows += 1
+        continue
+      if not trigger.session_id:
+        logger.warning("Ignoring trigger row without session_id")
+        stats.ignored_rows += 1
+        continue
+
+      report = client.evaluate(
+          evaluator=evaluator,
+          filters=TraceFilter.from_cli_args(
+              session_id=trigger.session_id,
+              limit=1,
+          ),
+      )
+      if report.total_sessions == 0:
+        logger.warning(
+            "No events found for session_id=%s; skipping trigger",
+            trigger.session_id,
+        )
+        stats.ignored_rows += 1
+        continue
+
+      result_row = serialize_streaming_result_row(trigger, report)
+      inserted = persist_result_row(client, config, result_row)
+      if inserted:
+        stats.processed_rows += 1
+      else:
+        stats.duplicate_rows += 1
+
+    write_run_history(
+        client=client,
+        config=config,
+        run_started_at=run_started_at,
+        run_finished_at=datetime.now(timezone.utc),
+        scan_start=scan_start,
+        scan_end=run_started_at,
+        stats=stats,
+        status="success",
+        error_message=None,
+    )
+    update_checkpoint(client, config, run_started_at)
+    success_run_finalized = True
+  except Exception as exc:  # pragma: no cover - exercised in tests
+    logger.exception("Scheduled streaming evaluation run failed")
+    if client is not None and config is not None and not success_run_finalized:
+      try:
+        write_run_history(
+            client=client,
+            config=config,
+            run_started_at=run_started_at,
+            run_finished_at=datetime.now(timezone.utc),
+            scan_start=scan_start or run_started_at,
+            scan_end=run_started_at,
+            stats=stats,
+            status="failed",
+            error_message=str(exc),
+        )
+      except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to persist streaming run history")
+    return {"status": "retry", "reason": "internal error"}, 500
+
+  return {
+      "status": "processed",
+      "processor_name": config.processor_name,
+      "scan_start": scan_start.isoformat(),
+      "scan_end": run_started_at.isoformat(),
+      "trigger_rows_found": stats.trigger_rows_found,
+      "processed_rows": stats.processed_rows,
+      "duplicate_rows": stats.duplicate_rows,
+      "ignored_rows": stats.ignored_rows,
+  }, 200
+
+
+def load_runtime_config(client) -> RuntimeConfig:
+  """Resolve worker configuration from deployment env vars."""
+  source_project = client.project_id
+  source_dataset = client.dataset_id
+  source_table = client.table_id
+
+  result_project = os.environ.get("BQ_AGENT_RESULT_PROJECT", source_project)
+  result_dataset = os.environ.get("BQ_AGENT_RESULT_DATASET", source_dataset)
+  result_table = os.environ.get(
+      "BQ_AGENT_RESULT_TABLE", STREAMING_RESULTS_TABLE
+  )
+
+  state_project = os.environ.get("BQ_AGENT_STATE_PROJECT", result_project)
+  state_dataset = os.environ.get("BQ_AGENT_STATE_DATASET", result_dataset)
+  state_table = os.environ.get("BQ_AGENT_STATE_TABLE", STREAMING_STATE_TABLE)
+
+  runs_project = os.environ.get("BQ_AGENT_RUNS_PROJECT", result_project)
+  runs_dataset = os.environ.get("BQ_AGENT_RUNS_DATASET", result_dataset)
+  runs_table = os.environ.get("BQ_AGENT_RUNS_TABLE", STREAMING_RUNS_TABLE)
+
+  overlap_minutes = _env_int(
+      "BQ_AGENT_OVERLAP_MINUTES",
+      DEFAULT_OVERLAP_MINUTES,
+  )
+  initial_lookback_minutes = _env_int(
+      "BQ_AGENT_INITIAL_LOOKBACK_MINUTES",
+      DEFAULT_INITIAL_LOOKBACK_MINUTES,
+  )
+
+  return RuntimeConfig(
+      source_project=source_project,
+      source_dataset=source_dataset,
+      source_table=source_table,
+      result_project=result_project,
+      result_dataset=result_dataset,
+      result_table=result_table,
+      state_project=state_project,
+      state_dataset=state_dataset,
+      state_table=state_table,
+      runs_project=runs_project,
+      runs_dataset=runs_dataset,
+      runs_table=runs_table,
+      processor_name=os.environ.get(
+          "BQ_AGENT_PROCESSOR_NAME",
+          STREAMING_PROCESSOR_NAME,
+      ),
+      overlap=timedelta(minutes=overlap_minutes),
+      initial_lookback=timedelta(minutes=initial_lookback_minutes),
+  )
+
+
+def iter_triggers(
+    client, config: RuntimeConfig, scan_start: datetime, scan_end: datetime
+):
+  """Yield normalized triggers from the overlap scan query."""
+  query = _TRIGGER_SCAN_QUERY.format(
+      project=config.source_project,
+      dataset=config.source_dataset,
+      table=config.source_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+          bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+      ]
+  )
+
+  rows = client.bq_client.query(query, job_config=job_config).result()
+  for row in rows:
+    row_dict = _row_to_dict(row)
+    try:
+      yield parse_trigger_row(row_dict)
+    except ValueError as exc:
+      logger.warning("Ignoring malformed trigger row: %s", exc)
+      yield _IgnoredTrigger(row_dict, str(exc))
+
+
+def load_checkpoint(client, config: RuntimeConfig) -> datetime | None:
+  """Load the last successful run checkpoint timestamp."""
+  query = _LOAD_STATE_QUERY.format(
+      project=config.state_project,
+      dataset=config.state_dataset,
+      table=config.state_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          )
+      ]
+  )
+  rows = list(client.bq_client.query(query, job_config=job_config).result())
+  if not rows:
+    return None
+  return _row_to_dict(rows[0]).get("checkpoint_timestamp")
+
+
+def persist_result_row(
+    client,
+    config: RuntimeConfig,
+    row: dict[str, Any],
+) -> bool:
+  """Persist one result row idempotently via BigQuery MERGE."""
+  query = _RESULTS_MERGE_QUERY.format(
+      project=config.result_project,
+      dataset=config.result_dataset,
+      table=config.result_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "dedupe_key", "STRING", row["dedupe_key"]
+          ),
+          bigquery.ScalarQueryParameter(
+              "session_id", "STRING", row["session_id"]
+          ),
+          bigquery.ScalarQueryParameter("trace_id", "STRING", row["trace_id"]),
+          bigquery.ScalarQueryParameter("span_id", "STRING", row["span_id"]),
+          bigquery.ScalarQueryParameter(
+              "trigger_kind",
+              "STRING",
+              row["trigger_kind"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "trigger_event_type",
+              "STRING",
+              row["trigger_event_type"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "trigger_timestamp",
+              "TIMESTAMP",
+              row["trigger_timestamp"],
+          ),
+          bigquery.ScalarQueryParameter("is_final", "BOOL", row["is_final"]),
+          bigquery.ScalarQueryParameter(
+              "evaluator_profile",
+              "STRING",
+              row["evaluator_profile"],
+          ),
+          bigquery.ScalarQueryParameter("passed", "BOOL", row["passed"]),
+          bigquery.ScalarQueryParameter(
+              "aggregate_scores_json",
+              "STRING",
+              row["aggregate_scores_json"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "details_json",
+              "STRING",
+              row["details_json"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "report_json", "STRING", row["report_json"]
+          ),
+          bigquery.ScalarQueryParameter(
+              "processed_at",
+              "TIMESTAMP",
+              row["processed_at"],
+          ),
+      ]
+  )
+
+  job = client.bq_client.query(query, job_config=job_config)
+  job.result()
+  affected_rows = getattr(job, "num_dml_affected_rows", None)
+  if affected_rows is None:
+    logger.warning(
+        "BigQuery DML stats were unavailable for dedupe_key=%s; "
+        "treating the row as processed",
+        row["dedupe_key"],
+    )
+    return True
+  return bool(affected_rows)
+
+
+def update_checkpoint(
+    client,
+    config: RuntimeConfig,
+    checkpoint_timestamp: datetime,
+) -> None:
+  """Advance the hidden processor checkpoint after a successful run."""
+  query = _STATE_MERGE_QUERY.format(
+      project=config.state_project,
+      dataset=config.state_dataset,
+      table=config.state_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          ),
+          bigquery.ScalarQueryParameter(
+              "checkpoint_timestamp",
+              "TIMESTAMP",
+              checkpoint_timestamp,
+          ),
+          bigquery.ScalarQueryParameter(
+              "updated_at",
+              "TIMESTAMP",
+              datetime.now(timezone.utc),
+          ),
+      ]
+  )
+  client.bq_client.query(query, job_config=job_config).result()
+
+
+def write_run_history(
+    client,
+    config: RuntimeConfig,
+    run_started_at: datetime,
+    run_finished_at: datetime,
+    scan_start: datetime,
+    scan_end: datetime,
+    stats: RunStats,
+    status: str,
+    error_message: str | None,
+) -> None:
+  """Write hidden run metadata for debugging and recovery analysis."""
+  query = _RUNS_MERGE_QUERY.format(
+      project=config.runs_project,
+      dataset=config.runs_dataset,
+      table=config.runs_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          ),
+          bigquery.ScalarQueryParameter(
+              "run_started_at",
+              "TIMESTAMP",
+              run_started_at,
+          ),
+          bigquery.ScalarQueryParameter(
+              "run_finished_at",
+              "TIMESTAMP",
+              run_finished_at,
+          ),
+          bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+          bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+          bigquery.ScalarQueryParameter(
+              "trigger_rows_found",
+              "INT64",
+              stats.trigger_rows_found,
+          ),
+          bigquery.ScalarQueryParameter(
+              "processed_rows",
+              "INT64",
+              stats.processed_rows,
+          ),
+          bigquery.ScalarQueryParameter(
+              "duplicate_rows",
+              "INT64",
+              stats.duplicate_rows,
+          ),
+          bigquery.ScalarQueryParameter(
+              "ignored_rows", "INT64", stats.ignored_rows
+          ),
+          bigquery.ScalarQueryParameter("status", "STRING", status),
+          bigquery.ScalarQueryParameter(
+              "error_message", "STRING", error_message
+          ),
+      ]
+  )
+  client.bq_client.query(query, job_config=job_config).result()
+
+
+class _IgnoredTrigger:
+  """Marker object used to keep per-row scan counts accurate."""
+
+  def __init__(self, row: dict[str, Any], reason: str):
+    self.row = row
+    self.reason = reason
+    self.session_id = ""
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+  """Convert BigQuery rows and dict-like values to plain dicts."""
+  if isinstance(row, dict):
+    return row
+  if hasattr(row, "items"):
+    return dict(row.items())
+  raise TypeError(f"Unsupported row type: {type(row)!r}")
+
+
+def _env_int(name: str, default: int) -> int:
+  """Read an integer env var with a warning fallback."""
+  raw = os.environ.get(name)
+  if raw is None:
+    return default
+  try:
+    return int(raw)
+  except ValueError:
+    logger.warning(
+        "Invalid integer value for %s=%r; using default %s",
+        name,
+        raw,
+        default,
+    )
+    return default

--- a/docs/context_graph_v2_design.md
+++ b/docs/context_graph_v2_design.md
@@ -1,0 +1,558 @@
+# BigQuery Agent Analytics
+## Context Graph V2: System of Reasoning for Agentic Ads — Design Document
+
+**Google ADK v1.21.0+ | Gemini 3 Flash | BigQuery Property Graphs & GQL**
+**March 2026**
+
+---
+
+## 1. Overview
+
+This document describes the design and implementation of Context Graph V2, a **System of Reasoning** layer for agentic advertising built on the BigQuery Agent Analytics SDK. The system constructs a BigQuery Property Graph that cross-links technical execution traces (from ADK) with business-domain entities (extracted via AI.GENERATE), enabling causal reasoning, GQL-based trace reconstruction, and world-change detection for long-running agent-to-agent (A2A) tasks.
+
+The demo provides a production-ready interactive prototype showcasing how organizations can build observability, debugging, and HITL safety layers on top of their multi-agent advertising infrastructure.
+
+### 1.1 Key Capabilities
+
+- **4-Pillar Property Graph** — TechNode (ADK spans) + BizNode (AI.GENERATE extracted) + Caused edges (span lineage) + Evaluated cross-links (artifact lineage)
+- **AI.GENERATE with output_schema** — Strict structured entity extraction using `output_schema` parameter for guaranteed JSON schema conformance
+- **GQL trace reconstruction** — Native Graph Query Language replaces recursive CTEs for quantified-path traversal
+- **World-change detection** — Pre-HITL safety check with fail-closed semantics (query/callback errors → `check_failed=True, is_safe_to_approve=False`)
+- **Artifact lineage** — `artifact_uri` on BizNode and Evaluated edge for GCS object tracking
+- **MERGE with DELETE** — Stale BizNode cleanup via `WHEN NOT MATCHED BY SOURCE ... THEN DELETE`
+- **Parameterized GQL** — `@biz_entity`, `@session_id` prevent SQL injection in graph queries
+
+### 1.2 Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Agent Framework | Google ADK v1.21.0+ |
+| AI Model | Gemini 3 Flash (`gemini-3-flash-preview`) |
+| Data Warehouse | Google BigQuery |
+| Graph Engine | BigQuery Property Graphs (`CREATE PROPERTY GRAPH` DDL) |
+| Query Language | GQL (Graph Query Language) with quantified-path patterns |
+| AI Functions | `AI.GENERATE` with `output_schema` for structured extraction |
+| Tracing | OpenTelemetry (`trace_id`, `span_id`, `parent_span_id`) |
+| Streaming | BigQuery Storage Write API |
+| SDK | `bigquery-agent-analytics` Python package |
+| Frontend | React 18 with inline SVG graph visualization |
+
+### 1.3 Demo Scenario: ADCP Multi-Agent Media Buying
+
+The demo simulates the **Ad Context Protocol (ADCP)** — a multi-agent media buying workflow where:
+
+1. A **Buyer Agent** submits a campaign brief (brand, budget, targeting)
+2. A **Media Planner Agent** queries inventory, matches audiences, and allocates budget
+3. A **Root Agent** pauses for HITL approval before provisioning
+4. **World-change detection** verifies entities haven't drifted during the approval window
+
+Three sessions demonstrate the three possible outcomes:
+
+| Session | Client | Budget | Outcome | World-Change Status |
+|---------|--------|--------|---------|-------------------|
+| `sess-elf-cosmetics` | ELF Cosmetics | $50,000 | Approved | Safe (0 stale / 7 checked) |
+| `sess-nike-summer` | Nike | $200,000 | Drift Detected | 2 stale entities (inventory depleted + price changed) |
+| `sess-tesla-q1` | Tesla | $100,000 | Check Failed | Query error → fail-closed |
+
+---
+
+## 2. Data Model
+
+### 2.1 Core Schema: `agent_events` (ADK Plugin)
+
+The foundation is the ADK `agent_events` table, written by the BigQuery Agent Analytics Plugin:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `timestamp` | TIMESTAMP | Event timestamp (UTC, microsecond precision) |
+| `event_type` | STRING | `LLM_REQUEST`, `TOOL_COMPLETED`, `HITL_CONFIRMATION_REQUEST`, etc. |
+| `agent` | STRING | Agent name (`root_agent`, `media_planner`) |
+| `session_id` | STRING | Conversation session identifier |
+| `invocation_id` | STRING | Single turn within a session |
+| `user_id` | STRING | User identifier |
+| `trace_id` | STRING | OpenTelemetry trace ID (32-char hex) |
+| `span_id` | STRING | OpenTelemetry span ID (16-char hex) |
+| `parent_span_id` | STRING | Parent span for causal chain reconstruction |
+| `content` | JSON | Event payload (user message, tool result, etc.) |
+| `content_parts` | RECORD (REPEATED) | Multimodal segments with `artifact_uri` for GCS refs |
+| `latency_ms` | JSON | Performance metrics |
+| `status` | STRING | `OK` or `ERROR` |
+| `error_message` | STRING | Exception message |
+
+**Partitioning:** `PARTITION BY DATE(timestamp)`
+**Clustering:** `CLUSTER BY event_type, agent, user_id`
+
+### 2.2 BizNode Table: `context_graph_biz_nodes`
+
+Business entities extracted from agent traces via AI.GENERATE:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `biz_node_id` | STRING | Composite key: `span_id:node_type:node_value` |
+| `span_id` | STRING | Source span from `agent_events` |
+| `session_id` | STRING | Session that produced this entity |
+| `node_type` | STRING | Entity category: `Product`, `Targeting`, `Campaign`, `Budget` |
+| `node_value` | STRING | Entity value: `"Instagram Reels"`, `"Gen Z Female 18-24"`, `"$50,000"` |
+| `confidence` | FLOAT64 | Extraction confidence (0.0–1.0) |
+| `artifact_uri` | STRING | GCS URI for persisted artifacts (e.g., campaign config JSON) |
+| `created_at` | TIMESTAMP | Extraction timestamp |
+
+**Key design:** Composite `biz_node_id = span_id:node_type:node_value` prevents key collisions when the same span produces multiple entities of different types.
+
+### 2.3 Cross-Links Table: `context_graph_cross_links`
+
+Edges connecting BizNodes to their source TechNodes:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `link_id` | STRING | Derived from `biz_node_id` |
+| `span_id` | STRING | Source TechNode span |
+| `biz_node_id` | STRING | Destination BizNode |
+| `link_type` | STRING | Relationship type (e.g., `"extracted_from"`) |
+| `artifact_uri` | STRING | Artifact reference on the edge |
+| `created_at` | TIMESTAMP | Link creation time |
+
+### 2.4 Property Graph Model
+
+The Context Graph uses a **4-pillar architecture** implemented as a BigQuery Property Graph:
+
+```
+┌────────────────────────┐     Caused        ┌────────────────────────┐
+│       TechNode         │ ────────────────► │       TechNode         │
+│  (agent_events)        │                   │  (agent_events)        │
+│  KEY: span_id          │                   │  KEY: span_id          │
+│  Props: event_type,    │                   │                        │
+│    agent, timestamp,   │                   │                        │
+│    content, status     │                   │                        │
+└────────────┬───────────┘                   └────────────────────────┘
+             │
+             │ Evaluated (cross-link)
+             │
+             ▼
+┌────────────────────────┐
+│       BizNode          │
+│  (biz_nodes table)     │
+│  KEY: biz_node_id      │
+│  Props: node_type,     │
+│    node_value,         │
+│    confidence,         │
+│    artifact_uri        │
+└────────────────────────┘
+```
+
+**Pillar 1 — TechNode:** The `agent_events` table. Each row is a graph vertex keyed by `span_id`.
+
+**Pillar 2 — BizNode:** The `biz_nodes` table. Business entities extracted via AI.GENERATE, keyed by composite `biz_node_id`.
+
+**Pillar 3 — Caused edges:** Implicit parent→child span lineage. The `agent_events` table doubles as the edge table using `parent_span_id → span_id`.
+
+**Pillar 4 — Evaluated edges:** Explicit cross-links from `cross_links` table, connecting TechNode spans to their extracted BizNodes. Carries `artifact_uri` and `link_type` as edge properties.
+
+---
+
+## 3. BigQuery AI Functions & Graph Queries
+
+### 3.1 AI.GENERATE with output_schema
+
+The key innovation in V2 is using `output_schema` to force structured JSON output from AI.GENERATE, eliminating post-hoc parsing failures:
+
+```sql
+AI.GENERATE(
+  CONCAT('Extract business entities. Entity types: Product, Targeting, Campaign, Budget.',
+         '\nPayload:\n', TO_JSON_STRING(base.content)),
+  endpoint => 'https://aiplatform.googleapis.com/v1/projects/PROJECT/
+    locations/global/publishers/google/models/gemini-3-flash-preview',
+  output_schema => '{"type":"ARRAY","items":{"type":"OBJECT","properties":{
+    "entity_type":{"type":"STRING"},
+    "entity_value":{"type":"STRING"},
+    "confidence":{"type":"NUMBER"}}}}'
+).result
+```
+
+The `output_schema` parameter guarantees the response conforms to the specified JSON schema, producing an array of `{entity_type, entity_value, confidence}` objects.
+
+### 3.2 MERGE with DELETE Semantics
+
+BizNode extraction uses a 3-way MERGE for idempotent upsert with stale cleanup:
+
+```sql
+MERGE `project.dataset.extracted_biz_nodes` AS target
+USING (...) AS source
+ON target.biz_node_id = source.biz_node_id
+WHEN MATCHED THEN UPDATE SET confidence = source.confidence
+WHEN NOT MATCHED BY TARGET THEN INSERT (...)
+WHEN NOT MATCHED BY SOURCE
+  AND target.session_id IN UNNEST(@session_ids) THEN DELETE
+```
+
+The `WHEN NOT MATCHED BY SOURCE ... DELETE` clause removes stale BizNodes that no longer appear in re-extraction results for the given sessions.
+
+### 3.3 Property Graph DDL
+
+```sql
+CREATE OR REPLACE PROPERTY GRAPH `project.dataset.agent_context_graph`
+  NODE TABLES (
+    `project.dataset.agent_events` AS TechNode
+      KEY (span_id) LABEL TechNode
+      PROPERTIES (event_type, agent, timestamp, session_id, invocation_id,
+                  content, latency_ms, status, error_message),
+
+    `project.dataset.extracted_biz_nodes` AS BizNode
+      KEY (biz_node_id) LABEL BizNode
+      PROPERTIES (node_type, node_value, confidence, session_id,
+                  span_id, artifact_uri)
+  )
+  EDGE TABLES (
+    `project.dataset.agent_events` AS Caused
+      KEY (span_id)
+      SOURCE KEY (parent_span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
+      LABEL Caused,
+
+    `project.dataset.context_cross_links` AS Evaluated
+      KEY (link_id)
+      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (biz_node_id) REFERENCES BizNode (biz_node_id)
+      LABEL Evaluated
+      PROPERTIES (artifact_uri, link_type, created_at)
+  )
+```
+
+### 3.4 GQL Reasoning Chain
+
+Trace why a business entity was selected using quantified-path traversal:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (decision:TechNode)-[c:Caused]->{1,20}(step:TechNode)
+    -[e:Evaluated]->(biz:BizNode)
+WHERE decision.event_type = @decision_event_type
+  AND biz.node_value = @biz_entity
+RETURN
+  decision.span_id AS decision_span_id,
+  step.span_id AS reasoning_span_id,
+  step.event_type AS step_type,
+  step.agent AS step_agent,
+  biz.node_type AS entity_type,
+  biz.node_value AS entity_value,
+  biz.confidence AS entity_confidence,
+  biz.artifact_uri AS artifact_uri
+ORDER BY step.timestamp ASC
+```
+
+The pattern `(decision)-[Caused]->{1,20}(step)-[Evaluated]->(biz)` traverses up to 20 hops of causal lineage from a decision event to the business entities it depends on. This replaces recursive CTEs with a declarative graph pattern.
+
+### 3.5 GQL Trace Reconstruction
+
+Native graph traversal replaces recursive CTEs for reconstructing session traces:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (parent:TechNode)-[c:Caused]->(child:TechNode)
+WHERE parent.session_id = @session_id
+   OR child.session_id = @session_id
+RETURN
+  parent.span_id AS parent_span_id,
+  parent.event_type AS parent_event_type,
+  parent.agent AS parent_agent,
+  child.span_id AS child_span_id,
+  child.event_type AS child_event_type,
+  child.agent AS child_agent,
+  child.timestamp AS child_timestamp
+ORDER BY child.timestamp ASC
+```
+
+### 3.6 World-Change Detection Query
+
+Joins BizNodes with agent events to get `evaluated_at` timestamps for freshness checking:
+
+```sql
+SELECT
+  b.node_type,
+  b.node_value,
+  b.confidence,
+  b.span_id,
+  b.artifact_uri,
+  e.timestamp AS evaluated_at
+FROM `project.dataset.extracted_biz_nodes` b
+JOIN `project.dataset.agent_events` e
+  ON b.span_id = e.span_id
+WHERE b.session_id = @session_id
+ORDER BY e.timestamp ASC
+```
+
+---
+
+## 4. World-Change Detection (HITL Safety)
+
+### 4.1 Problem Statement
+
+In long-running A2A workflows (e.g., a media buy that requires human approval), the real world can change between when the agent evaluated entities and when the human approves the decision. Ad inventory can sell out, prices can change, audiences can shift.
+
+### 4.2 Solution: Fail-Closed Detection
+
+The `detect_world_changes()` method implements a pre-HITL safety check:
+
+1. Query all BizNodes for the session with their `evaluated_at` timestamps
+2. For each entity, call a user-supplied `current_state_fn` to check current state
+3. Compare original vs. current state to detect drift
+4. Return a `WorldChangeReport` with alerts and safety verdict
+
+**Fail-closed semantics** are critical:
+
+| Scenario | `is_safe_to_approve` | `check_failed` | Behavior |
+|----------|---------------------|----------------|----------|
+| All entities current | `True` | `False` | Safe to approve |
+| Drift detected | `False` | `False` | Block approval, show alerts |
+| BigQuery query fails | `False` | `True` | Block approval (fail-closed) |
+| `current_state_fn` throws | `False` | `True` | Block approval (fail-closed) |
+
+The fail-closed design ensures that operational failures (API outages, query timeouts) can never be misreported as "safe to approve."
+
+### 4.3 Drift Types
+
+| Drift Type | Example | Severity |
+|-----------|---------|----------|
+| `inventory_depleted` | Yahoo Homepage Takeover → sold out | 0.95 (critical) |
+| `price_changed` | Strava Routes $40K → $52K (+30%) | 0.72 (moderate) |
+| `audience_shifted` | Segment reach dropped below threshold | 0.60 (low) |
+| `campaign_paused` | External campaign suspension | 0.90 (critical) |
+
+### 4.4 Python SDK Usage
+
+```python
+from bigquery_agent_analytics import ContextGraphManager, ContextGraphConfig
+
+cgm = ContextGraphManager(
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    config=ContextGraphConfig(endpoint="gemini-3-flash-preview"),
+)
+
+def check_inventory(node):
+    # Call real-time inventory API
+    return {"available": True, "current_value": "in stock"}
+
+report = cgm.detect_world_changes(
+    session_id="sess-elf-cosmetics",
+    current_state_fn=check_inventory,
+)
+
+print(report.summary())
+# World Change Report - Session: sess-elf-cosmetics
+#   Entities checked : 7
+#   Stale entities   : 0
+#   Safe to approve  : True
+
+# Fail-closed on errors:
+# report.check_failed   # True if query or callback failed
+# report.is_safe_to_approve  # Always False when check_failed=True
+```
+
+---
+
+## 5. Production Query Patterns
+
+The demo includes 5 production-ready BigQuery queries covering the full Context Graph workflow.
+
+### 5.1 Extract Business Entities (AI.GENERATE + output_schema)
+Uses `AI.GENERATE` with `output_schema` to extract typed business entities (Product, Targeting, Campaign, Budget) from agent trace payloads. MERGE with 3-way logic handles upsert and stale cleanup in a single statement.
+
+### 5.2 Property Graph DDL (4-Pillar Architecture)
+`CREATE OR REPLACE PROPERTY GRAPH` DDL defining the 4-pillar graph: TechNode vertices (from `agent_events`), BizNode vertices (from `biz_nodes`), Caused edges (span lineage), and Evaluated edges (cross-links with `artifact_uri`).
+
+### 5.3 GQL Reasoning Chain ("Why was X selected?")
+Quantified-path GQL query that traverses from a HITL decision event through up to 20 hops of causal lineage to the business entities that influenced the decision. Returns the full reasoning chain with confidence scores and artifact URIs.
+
+### 5.4 GQL Trace Reconstruction (replaces recursive CTEs)
+Native GQL traversal of the Caused edge type to reconstruct session traces. Returns parent-child span pairs ordered by timestamp. The SDK merges GQL results with isolated events (spans without edges) for completeness.
+
+### 5.5 World-Change Detection (Fail-Closed)
+Joins BizNodes with agent events to retrieve `evaluated_at` timestamps. The Python SDK layer applies the `current_state_fn` callback and enforces fail-closed semantics.
+
+---
+
+## 6. Interactive Demo Features
+
+### 6.1 Property Graph Visualization
+Interactive SVG-based graph rendering of the 4-pillar architecture. TechNodes (circles) are color-coded by event type: blue (user input), green (agent lifecycle), red (tool calls), yellow (HITL events). BizNodes (rectangles) are color-coded by entity type: orange (Product), cyan (Targeting), green (Budget), purple (Campaign). Caused edges (solid grey) show span lineage; Evaluated edges (dashed blue) show cross-links. Clicking nodes reveals detailed properties.
+
+### 6.2 World-Change Detection Panel
+Dedicated panel showing the pre-HITL safety check results for the selected session. Displays the overall verdict (Safe/Drift Detected/Check Failed), entity counts, and individual drift alerts with severity scores. The "Check Failed" state includes an explanation of fail-closed semantics.
+
+### 6.3 SQL / GQL Query Explorer
+Interactive query browser with 5 production-ready queries. Each query includes full SQL/GQL, category badges (Extraction, Graph, Safety), and feature tags (AI.GENERATE, output_schema, Property Graph, GQL). Syntax-highlighted with dark theme and copy-to-clipboard support.
+
+### 6.4 Python SDK Panel
+Live-updating Python code showing the full SDK workflow for the selected session:
+1. Initialize `ContextGraphManager` with `ContextGraphConfig`
+2. Extract BizNodes via `AI.GENERATE + output_schema`
+3. Create cross-links
+4. Create Property Graph
+5. GQL trace reconstruction via `client.get_session_trace_gql()`
+6. Explain decisions via `cgm.explain_decision()`
+7. World-change detection via `cgm.detect_world_changes()`
+
+### 6.5 Session Selector
+Switch between three ADCP sessions demonstrating different outcomes: approved (ELF Cosmetics), drift detected (Nike), and check failed (Tesla). Each session shows different event counts, BizNode counts, and world-change statuses.
+
+---
+
+## 7. Architecture
+
+### 7.1 Data Flow
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   Agent Runtime (ADK v1.21.0+)           │
+│                                                          │
+│  Buyer Agent ─── Media Planner ─── Root Agent (HITL)     │
+│                        │                                 │
+│              BigQueryAgentAnalyticsPlugin                 │
+│                        │                                 │
+│          BQ Storage Write API (streaming)                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │ Writes events
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│              BigQuery (agent_events)                      │
+│  Partitioned by DATE(timestamp)                          │
+│  Clustered by event_type, agent, user_id                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │ Reads events
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│      BigQuery Agent Analytics SDK (context_graph.py)     │
+│                                                          │
+│  1. AI.GENERATE + output_schema → biz_nodes table        │
+│  2. Cross-links → cross_links table                      │
+│  3. CREATE PROPERTY GRAPH (DDL)                          │
+│  4. GQL queries for reasoning + trace reconstruction     │
+│  5. World-change detection (fail-closed)                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│         BigQuery Property Graph                          │
+│                                                          │
+│  TechNode ──Caused──► TechNode                           │
+│     │                                                    │
+│     └──Evaluated──► BizNode (+ artifact_uri)             │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 7.2 SDK Module: `context_graph.py`
+
+The Context Graph is implemented as a standalone module (`~1300 lines`) in the BigQuery Agent Analytics SDK:
+
+| Class | Responsibility |
+|-------|---------------|
+| `ContextGraphManager` | Main entry point: extraction, cross-links, graph creation, GQL queries, world-change detection |
+| `ContextGraphConfig` | Configuration: endpoint, table names, graph name, extraction prompt |
+| `BizNode` | Dataclass representing an extracted business entity |
+| `WorldChangeReport` | Pydantic model: safety verdict, alerts, fail-closed flag |
+| `WorldChangeAlert` | Pydantic model: individual drift alert with severity |
+
+**Key design decisions:**
+
+| Decision | Rationale |
+|----------|-----------|
+| Standalone module | No internal imports from other SDK modules; independently testable |
+| `output_schema` in AI.GENERATE | Eliminates JSON parsing failures from free-form LLM output |
+| Composite `biz_node_id` | `span_id:node_type:node_value` prevents collisions from same-span multi-entity extraction |
+| MERGE with 3-way logic | Single atomic statement handles insert, update, and stale cleanup |
+| Fail-closed world-change | Query errors and callback errors both produce `check_failed=True, is_safe_to_approve=False` |
+| Legacy endpoint rejection | `project.dataset.model` refs raise `ValueError` instead of silently producing bad Vertex AI URLs |
+| GQL + flat trace merge | GQL returns only edge pairs; SDK merges isolated events from flat SQL for completeness |
+| Timezone-safe sorting | `datetime(1970,1,1,tzinfo=timezone.utc)` fallback instead of naive `datetime.min` |
+
+### 7.3 Client Integration
+
+The `Client` class exposes GQL trace reconstruction:
+
+```python
+# client.py
+def get_session_trace_gql(self, session_id, config=None) -> Trace:
+    """Reconstructs a session trace using GQL graph traversal.
+
+    1. Runs GQL query via ContextGraphManager.reconstruct_trace_gql()
+    2. Fetches flat trace via get_session_trace() for isolated events
+    3. Backfills parent_span_id when spans arrive out of order
+    4. Merges isolated spans not covered by GQL
+    5. Sorts by timezone-aware timestamps
+    6. Falls back to flat SQL when GQL returns no edges
+    """
+```
+
+### 7.4 Visualization Layer
+
+- React 18 frontend with Google Cloud design system styling
+- Inline SVG graph with positioned TechNodes (circles) and BizNodes (rectangles)
+- Caused edges (solid lines) and Evaluated cross-links (dashed lines)
+- Interactive node selection with property panel
+- Dark-themed SQL/GQL code viewer with copy support
+- Session switcher for comparing outcomes across ADCP sessions
+
+---
+
+## 8. Testing
+
+The Context Graph module has 50 dedicated tests covering:
+
+| Test Category | Count | Examples |
+|--------------|-------|---------|
+| BizNode extraction | 5 | AI.GENERATE path, client-side path, output_schema in SQL |
+| BizNode storage & retrieval | 5 | Store with artifact_uri, read back, session filtering |
+| Cross-links | 3 | Create, composite link_id, delete error handling |
+| Property Graph | 3 | DDL generation, graph creation, config override |
+| GQL queries | 4 | Reasoning chain, causal chain, trace reconstruction |
+| World-change detection | 5 | Safe, drift detected, fn exception (fail-closed), query failure (fail-closed) |
+| End-to-end pipeline | 2 | `build_context_graph()`, partial failure handling |
+| Client integration | 4 | `get_session_trace_gql()`, parent backfill, chronological ordering, isolated event merge |
+| Edge cases | 5 | Legacy endpoint rejection, evaluated_at passthrough, MERGE delete, empty sessions |
+
+Full test suite: **562 tests** (50 context graph + 512 existing SDK tests), all passing.
+
+---
+
+## 9. Deployment
+
+The demo is deployed as a single self-contained HTML file with embedded React/Babel. No build step or server is required.
+
+### 9.1 Live Demo
+[https://context-graph-v2-demo.vercel.app](https://context-graph-v2-demo.vercel.app)
+
+### 9.2 Source Code
+- Demo: [`examples/context_graph_v2_demo.html`](../examples/context_graph_v2_demo.html)
+- Notebook: [`examples/context_graph_adcp_demo.ipynb`](../examples/context_graph_adcp_demo.ipynb)
+- SDK module: [`src/bigquery_agent_analytics/context_graph.py`](../src/bigquery_agent_analytics/context_graph.py)
+- Tests: [`tests/test_context_graph.py`](../tests/test_context_graph.py)
+
+### 9.3 Production Deployment Notes
+
+For production use:
+1. Replace simulated session data with real BigQuery connections
+2. Configure Vertex AI connection for AI.GENERATE (`us.vertex_ai_connection`)
+3. Create `agent_events` table using the ADK plugin schema
+4. Set up ADK BigQuery Agent Analytics Plugin for event streaming
+5. Create the BizNode and cross-links tables via `ContextGraphManager`
+6. Configure `current_state_fn` callbacks pointing to real inventory/pricing APIs
+7. Integrate `detect_world_changes()` into HITL approval workflows
+
+---
+
+## 10. Evolution from V1
+
+| Aspect | V1 (Context Graphs & Decision Traces) | V2 (System of Reasoning) |
+|--------|---------------------------------------|--------------------------|
+| Graph Model | Simulated property graph via recursive CTEs | Native BigQuery Property Graph with `CREATE PROPERTY GRAPH` DDL |
+| Entity Extraction | Manual event classification | AI.GENERATE with `output_schema` for structured extraction |
+| Traversal | Recursive CTEs for decision traces | GQL with quantified-path patterns (`->{1,20}`) |
+| Business Layer | Single vertex types (User, Session, LLM, Tool) | Separate TechNode + BizNode with cross-links |
+| Safety | None | World-change detection with fail-closed semantics |
+| Artifacts | Not tracked | `artifact_uri` on BizNode + Evaluated edge |
+| Stale Data | Not handled | MERGE with `WHEN NOT MATCHED BY SOURCE ... DELETE` |
+| SDK Integration | Standalone demo | Full `context_graph.py` module with 50 tests |
+| Query Injection | Raw SQL interpolation | Parameterized `@biz_entity`, `@session_id` |

--- a/docs/context_graph_v3_design.md
+++ b/docs/context_graph_v3_design.md
@@ -1,0 +1,1013 @@
+# BigQuery Agent Analytics
+## Context Graph V3: Decision Semantics for Agentic Ads — Design Document
+
+**Google ADK v1.21.0+ | Gemini 3 Flash | BigQuery Property Graphs & GQL**
+**March 2026**
+
+---
+
+## 1. Overview
+
+This document describes the design and implementation of Context Graph V3, which extends the V2 **System of Reasoning** layer with **Decision Semantics** — a structured model for agent decision points, candidate scoring, and rejection rationale. Built on the BigQuery Agent Analytics SDK, V3 constructs a 6-pillar BigQuery Property Graph that cross-links technical execution traces (from ADK) with business-domain entities (extracted via AI.GENERATE), decision points, and candidate options. This enables causal reasoning, GQL-based trace reconstruction, world-change detection, and EU-compliant audit trails for long-running agent-to-agent (A2A) tasks.
+
+The demo provides a production-ready interactive prototype showcasing how organizations can build observability, debugging, HITL safety layers, and regulatory audit capabilities on top of their multi-agent advertising infrastructure.
+
+### 1.1 Key Capabilities
+
+- **6-Pillar Property Graph** — TechNode (ADK spans) + BizNode (AI.GENERATE extracted) + DecisionPoint (decision nodes) + CandidateNode (candidate options) + Caused edges (span lineage) + Evaluated cross-links (artifact lineage) + MadeDecision edges (span→decision) + CandidateEdge edges (decision→candidate)
+- **Decision Semantics** — Model agent decisions with candidates, scores, selection status (SELECTED/DROPPED), and rejection rationale for EU audit compliance
+- **AI.GENERATE with output_schema** — Strict structured entity and decision extraction using `output_schema` parameter for guaranteed JSON schema conformance
+- **GQL trace reconstruction** — Native Graph Query Language replaces recursive CTEs for quantified-path traversal
+- **EU audit trail** — Forward GQL traversal from TechNode through DecisionPoint to CandidateNode for regulatory compliance
+- **World-change detection** — Pre-HITL safety check with fail-closed semantics (query/callback errors → `check_failed=True, is_safe_to_approve=False`)
+- **Artifact lineage** — `artifact_uri` on BizNode and Evaluated edge for GCS object tracking
+- **MERGE with DELETE** — Stale BizNode cleanup via `WHEN NOT MATCHED BY SOURCE ... THEN DELETE`
+- **Parameterized GQL** — `@biz_entity`, `@session_id`, `@decision_type` prevent SQL injection in graph queries
+
+### 1.2 Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Agent Framework | Google ADK v1.21.0+ |
+| AI Model | Gemini 3 Flash (`gemini-3-flash-preview`) |
+| Data Warehouse | Google BigQuery |
+| Graph Engine | BigQuery Property Graphs (`CREATE PROPERTY GRAPH` DDL) |
+| Query Language | GQL (Graph Query Language) with quantified-path patterns |
+| AI Functions | `AI.GENERATE` with `output_schema` for structured extraction |
+| Tracing | OpenTelemetry (`trace_id`, `span_id`, `parent_span_id`) |
+| Streaming | BigQuery Storage Write API |
+| SDK | `bigquery-agent-analytics` Python package |
+| Frontend | React 18 with inline SVG graph visualization |
+
+### 1.3 Demo Scenario: ADCP Multi-Agent Media Buying with Decision Semantics
+
+The demo simulates the **Ad Context Protocol (ADCP)** — a multi-agent media buying workflow with **Decision Semantics** where:
+
+1. A **Buyer Agent** submits a campaign brief (brand, budget, targeting)
+2. A **Media Planner Agent** queries inventory, matches audiences, allocates budget, and evaluates candidates
+3. A **Root Agent** pauses for HITL approval before provisioning
+4. **Decision Semantics** records which candidates were selected vs. dropped, with scores and rejection rationale
+5. **World-change detection** verifies entities haven't drifted during the approval window
+
+Two sessions demonstrate decision semantics in action:
+
+| Session | Client | Decision Type | Candidates | Selected | Dropped | Rejection Reason |
+|---------|--------|---------------|------------|----------|---------|-----------------|
+| `sess-nike-summer` | Nike | `audience_selection` | 3 | Athletes 18-35 (0.92) | Fitness Enthusiasts (0.71), Running Community (0.65) | Budget constraints |
+| `sess-elf-cosmetics` | ELF Cosmetics | `placement_selection` | 4 | Instagram Reels (0.95), TikTok TopView (0.93) | LinkedIn Sponsored (0.22), Yahoo Homepage (0.31) | Audience mismatch (Gen Z affinity below 0.70) |
+
+---
+
+## 2. Data Model
+
+### 2.1 Core Schema: `agent_events` (ADK Plugin)
+
+The foundation is the ADK `agent_events` table, written by the BigQuery Agent Analytics Plugin:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `timestamp` | TIMESTAMP | Event timestamp (UTC, microsecond precision) |
+| `event_type` | STRING | `LLM_REQUEST`, `TOOL_COMPLETED`, `HITL_CONFIRMATION_REQUEST`, etc. |
+| `agent` | STRING | Agent name (`root_agent`, `media_planner`) |
+| `session_id` | STRING | Conversation session identifier |
+| `invocation_id` | STRING | Single turn within a session |
+| `user_id` | STRING | User identifier |
+| `trace_id` | STRING | OpenTelemetry trace ID (32-char hex) |
+| `span_id` | STRING | OpenTelemetry span ID (16-char hex) |
+| `parent_span_id` | STRING | Parent span for causal chain reconstruction |
+| `content` | JSON | Event payload (user message, tool result, etc.) |
+| `content_parts` | RECORD (REPEATED) | Multimodal segments with `artifact_uri` for GCS refs |
+| `latency_ms` | JSON | Performance metrics |
+| `status` | STRING | `OK` or `ERROR` |
+| `error_message` | STRING | Exception message |
+
+**Partitioning:** `PARTITION BY DATE(timestamp)`
+**Clustering:** `CLUSTER BY event_type, agent, user_id`
+
+### 2.2 BizNode Table: `context_graph_biz_nodes`
+
+Business entities extracted from agent traces via AI.GENERATE:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `biz_node_id` | STRING | Composite key: `span_id:node_type:node_value` |
+| `span_id` | STRING | Source span from `agent_events` |
+| `session_id` | STRING | Session that produced this entity |
+| `node_type` | STRING | Entity category: `Product`, `Targeting`, `Campaign`, `Budget` |
+| `node_value` | STRING | Entity value: `"Instagram Reels"`, `"Gen Z Female 18-24"`, `"$50,000"` |
+| `confidence` | FLOAT64 | Extraction confidence (0.0-1.0) |
+| `artifact_uri` | STRING | GCS URI for persisted artifacts (e.g., campaign config JSON) |
+| `created_at` | TIMESTAMP | Extraction timestamp |
+
+**Key design:** Composite `biz_node_id = span_id:node_type:node_value` prevents key collisions when the same span produces multiple entities of different types.
+
+### 2.3 Cross-Links Table: `context_graph_cross_links`
+
+Edges connecting BizNodes to their source TechNodes:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `link_id` | STRING | Derived from `biz_node_id` |
+| `span_id` | STRING | Source TechNode span |
+| `biz_node_id` | STRING | Destination BizNode |
+| `link_type` | STRING | Relationship type (e.g., `"extracted_from"`) |
+| `artifact_uri` | STRING | Artifact reference on the edge |
+| `created_at` | TIMESTAMP | Link creation time |
+
+### 2.4 Decision Points Table: `decision_points` (NEW in V3)
+
+Decision points identified in agent traces where candidates were evaluated:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `decision_id` | STRING | Unique identifier for this decision point |
+| `session_id` | STRING | Session containing this decision |
+| `span_id` | STRING | The span where the decision was made |
+| `decision_type` | STRING | Category: `audience_selection`, `placement_selection`, `budget_allocation` |
+| `description` | STRING | Human-readable description of the decision |
+
+### 2.5 Candidates Table: `candidates` (NEW in V3)
+
+Candidate options evaluated at each decision point:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `candidate_id` | STRING | Unique identifier for this candidate |
+| `decision_id` | STRING | The decision point this candidate belongs to |
+| `session_id` | STRING | Session containing this candidate |
+| `name` | STRING | Candidate name/label |
+| `score` | FLOAT64 | Evaluation score (0.0-1.0) |
+| `status` | STRING | `SELECTED` or `DROPPED` |
+| `rejection_rationale` | STRING | Why the candidate was dropped (required for DROPPED, supports EU audit) |
+
+### 2.6 Made Decision Edges Table: `made_decision_edges` (NEW in V3)
+
+Edges connecting TechNodes to the DecisionPoints they produced:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `edge_id` | STRING | Composite: `span_id:MADE_DECISION:decision_id` |
+| `span_id` | STRING | Source TechNode span |
+| `decision_id` | STRING | Destination DecisionPoint |
+| `created_at` | TIMESTAMP | Edge creation time |
+
+### 2.7 Candidate Edges Table: `candidate_edges` (NEW in V3)
+
+Edges connecting DecisionPoints to their CandidateNodes:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `edge_id` | STRING | Composite: `decision_id:status:candidate_id` |
+| `decision_id` | STRING | Source DecisionPoint |
+| `candidate_id` | STRING | Destination CandidateNode |
+| `edge_type` | STRING | `SELECTED_CANDIDATE` or `DROPPED_CANDIDATE` |
+| `rejection_rationale` | STRING | Rationale propagated to the edge |
+| `created_at` | TIMESTAMP | Edge creation time |
+
+**Two-table edge model:** BigQuery Property Graph DDL requires separate edge tables when source/destination types differ. `made_decision_edges` connects `TechNode → DecisionPoint`, while `candidate_edges` connects `DecisionPoint → CandidateNode`. These cannot be combined into a single edge table because the SOURCE and DESTINATION key references must be homogeneous within a single EDGE TABLE declaration.
+
+### 2.8 Property Graph Model
+
+The Context Graph uses a **6-pillar architecture** implemented as a BigQuery Property Graph:
+
+```
+┌────────────────────────┐     Caused        ┌────────────────────────┐
+│       TechNode         │ ────────────────► │       TechNode         │
+│  (agent_events)        │                   │  (agent_events)        │
+│  KEY: span_id          │                   │  KEY: span_id          │
+│  Props: event_type,    │                   │                        │
+│    agent, timestamp,   │                   │                        │
+│    content, status     │                   │                        │
+└────────┬───────┬───────┘                   └────────────────────────┘
+         │       │
+         │       │ MadeDecision (NEW)
+         │       │
+         │       ▼
+         │  ┌────────────────────────┐
+         │  │    DecisionPoint       │
+         │  │  (decision_points)     │
+         │  │  KEY: decision_id      │
+         │  │  Props: decision_type, │
+         │  │    description,        │
+         │  │    session_id, span_id │
+         │  └────────┬───────────────┘
+         │           │
+         │           │ CandidateEdge (NEW)
+         │           │
+         │           ▼
+         │  ┌────────────────────────┐
+         │  │    CandidateNode       │
+         │  │  (candidates)          │
+         │  │  KEY: candidate_id     │
+         │  │  Props: name, score,   │
+         │  │    status,             │
+         │  │    rejection_rationale │
+         │  └────────────────────────┘
+         │
+         │ Evaluated (cross-link)
+         │
+         ▼
+┌────────────────────────┐
+│       BizNode          │
+│  (biz_nodes table)     │
+│  KEY: biz_node_id      │
+│  Props: node_type,     │
+│    node_value,         │
+│    confidence,         │
+│    artifact_uri        │
+└────────────────────────┘
+```
+
+**Pillar 1 — TechNode:** The `agent_events` table. Each row is a graph vertex keyed by `span_id`.
+
+**Pillar 2 — BizNode:** The `biz_nodes` table. Business entities extracted via AI.GENERATE, keyed by composite `biz_node_id`.
+
+**Pillar 3 — DecisionPoint (NEW):** The `decision_points` table. Decision moments extracted via AI.GENERATE, keyed by `decision_id`.
+
+**Pillar 4 — CandidateNode (NEW):** The `candidates` table. Options evaluated at each decision point, keyed by `candidate_id`.
+
+**Pillar 5 — Caused edges + Evaluated edges + MadeDecision edges (NEW):** Causal span lineage, cross-links, and span-to-decision linkage.
+
+**Pillar 6 — CandidateEdge edges (NEW):** Decision-to-candidate linkage with `edge_type` (`SELECTED_CANDIDATE` / `DROPPED_CANDIDATE`) and `rejection_rationale` as edge properties.
+
+---
+
+## 3. BigQuery AI Functions & Graph Queries
+
+### 3.1 AI.GENERATE with output_schema (BizNode Extraction)
+
+Structured entity extraction using `output_schema` to force JSON conformance:
+
+```sql
+AI.GENERATE(
+  CONCAT('Extract business entities. Entity types: Product, Targeting, Campaign, Budget.',
+         '\nPayload:\n', TO_JSON_STRING(base.content)),
+  endpoint => 'https://aiplatform.googleapis.com/v1/projects/PROJECT/
+    locations/global/publishers/google/models/gemini-3-flash-preview',
+  output_schema => '{"type":"ARRAY","items":{"type":"OBJECT","properties":{
+    "entity_type":{"type":"STRING"},
+    "entity_value":{"type":"STRING"},
+    "confidence":{"type":"NUMBER"}}}}'
+).result
+```
+
+### 3.2 AI.GENERATE with output_schema (Decision Extraction — NEW in V3)
+
+Decision point extraction uses a dedicated `output_schema` for structured decision data including candidates with scores, selection status, and rejection rationale:
+
+```sql
+SELECT
+  base.span_id,
+  base.session_id,
+  REGEXP_REPLACE(
+    REGEXP_REPLACE(
+      AI.GENERATE(
+        CONCAT(
+          'Identify decision points in this agent payload. ',
+          'A decision point is where the agent evaluated multiple ',
+          'candidates and selected or rejected them. ',
+          'For each decision, return the decision_type, description, ',
+          'and all candidates with name, score (0-1), status ',
+          '(SELECTED or DROPPED), and rejection_rationale ',
+          '(null if selected, required reason if dropped).',
+          '\n\nPayload:\n',
+          COALESCE(
+            JSON_EXTRACT_SCALAR(base.content, '$.text_summary'),
+            JSON_EXTRACT_SCALAR(base.content, '$.response'),
+            JSON_EXTRACT_SCALAR(base.content, '$.text'),
+            TO_JSON_STRING(base.content)
+          )
+        ),
+        endpoint => '{endpoint}',
+        output_schema => '{output_schema}'
+      ).result,
+      r'^```(?:json)?\s*', ''),
+    r'\s*```$', '')
+  AS decisions_json
+FROM `project.dataset.agent_events` AS base
+WHERE base.session_id IN UNNEST(@session_ids)
+  AND base.event_type IN (
+    'LLM_RESPONSE',
+    'TOOL_COMPLETED',
+    'AGENT_COMPLETED',
+    'HITL_CONFIRMATION_REQUEST_COMPLETED'
+  )
+  AND base.content IS NOT NULL
+ORDER BY base.timestamp ASC
+```
+
+The `_DECISION_POINT_OUTPUT_SCHEMA` guarantees the response conforms to an array of decision objects, each containing candidates:
+
+```json
+{
+  "type": "ARRAY",
+  "items": {
+    "type": "OBJECT",
+    "properties": {
+      "decision_type": {"type": "STRING"},
+      "description": {"type": "STRING"},
+      "candidates": {
+        "type": "ARRAY",
+        "items": {
+          "type": "OBJECT",
+          "properties": {
+            "name": {"type": "STRING"},
+            "score": {"type": "NUMBER"},
+            "status": {"type": "STRING"},
+            "rejection_rationale": {"type": "STRING"}
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 3.3 MERGE with DELETE Semantics
+
+BizNode extraction uses a 3-way MERGE for idempotent upsert with stale cleanup:
+
+```sql
+MERGE `project.dataset.extracted_biz_nodes` AS target
+USING (...) AS source
+ON target.biz_node_id = source.biz_node_id
+WHEN MATCHED THEN UPDATE SET confidence = source.confidence
+WHEN NOT MATCHED BY TARGET THEN INSERT (...)
+WHEN NOT MATCHED BY SOURCE
+  AND target.session_id IN UNNEST(@session_ids) THEN DELETE
+```
+
+The `WHEN NOT MATCHED BY SOURCE ... DELETE` clause removes stale BizNodes that no longer appear in re-extraction results for the given sessions.
+
+### 3.4 Property Graph DDL (6-Pillar)
+
+```sql
+CREATE OR REPLACE PROPERTY GRAPH `project.dataset.agent_context_graph`
+  NODE TABLES (
+    -- Technical execution nodes (spans from ADK plugin)
+    `project.dataset.agent_events` AS TechNode
+      KEY (span_id)
+      LABEL TechNode
+      PROPERTIES (
+        event_type, agent, timestamp, session_id, invocation_id,
+        content, latency_ms, status, error_message
+      ),
+    -- Business domain nodes (extracted entities)
+    `project.dataset.extracted_biz_nodes` AS BizNode
+      KEY (biz_node_id)
+      LABEL BizNode
+      PROPERTIES (
+        node_type, node_value, confidence, session_id,
+        span_id, artifact_uri
+      ),
+    -- Decision point nodes (NEW in V3)
+    `project.dataset.decision_points` AS DecisionPoint
+      KEY (decision_id)
+      LABEL DecisionPoint
+      PROPERTIES (
+        session_id, span_id, decision_type, description
+      ),
+    -- Candidate nodes (NEW in V3)
+    `project.dataset.candidates` AS CandidateNode
+      KEY (candidate_id)
+      LABEL CandidateNode
+      PROPERTIES (
+        decision_id, session_id, name, score, status,
+        rejection_rationale
+      )
+  )
+  EDGE TABLES (
+    -- Causal lineage: parent span -> child span
+    `project.dataset.agent_events` AS Caused
+      KEY (span_id)
+      SOURCE KEY (parent_span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
+      LABEL Caused,
+
+    -- Cross-link: technical event -> business entity it evaluated
+    `project.dataset.context_cross_links` AS Evaluated
+      KEY (link_id)
+      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (biz_node_id) REFERENCES BizNode (biz_node_id)
+      LABEL Evaluated
+      PROPERTIES (
+        artifact_uri, link_type, created_at
+      ),
+
+    -- TechNode -> DecisionPoint (span that made the decision) (NEW in V3)
+    `project.dataset.made_decision_edges` AS MadeDecision
+      KEY (edge_id)
+      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      LABEL MadeDecision,
+
+    -- DecisionPoint -> CandidateNode (selected or dropped) (NEW in V3)
+    `project.dataset.candidate_edges` AS CandidateEdge
+      KEY (edge_id)
+      SOURCE KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      DESTINATION KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
+      LABEL CandidateEdge
+      PROPERTIES (
+        edge_type, rejection_rationale, created_at
+      )
+  )
+```
+
+### 3.5 MadeDecision Edge Creation (NEW in V3)
+
+Edges from TechNode spans to the DecisionPoints they produced:
+
+```sql
+INSERT INTO `project.dataset.made_decision_edges`
+  (edge_id, span_id, decision_id, created_at)
+SELECT
+  CONCAT(dp.span_id, ':MADE_DECISION:', dp.decision_id) AS edge_id,
+  dp.span_id,
+  dp.decision_id,
+  CURRENT_TIMESTAMP() AS created_at
+FROM `project.dataset.decision_points` dp
+WHERE dp.session_id IN UNNEST(@session_ids)
+```
+
+### 3.6 CandidateEdge Creation (NEW in V3)
+
+Edges from DecisionPoints to their CandidateNodes with typed edge semantics:
+
+```sql
+INSERT INTO `project.dataset.candidate_edges`
+  (edge_id, decision_id, candidate_id, edge_type,
+   rejection_rationale, created_at)
+SELECT
+  CONCAT(c.decision_id, ':', c.status, ':', c.candidate_id) AS edge_id,
+  c.decision_id,
+  c.candidate_id,
+  CASE c.status
+    WHEN 'SELECTED' THEN 'SELECTED_CANDIDATE'
+    ELSE 'DROPPED_CANDIDATE'
+  END AS edge_type,
+  c.rejection_rationale,
+  CURRENT_TIMESTAMP() AS created_at
+FROM `project.dataset.candidates` c
+WHERE c.session_id IN UNNEST(@session_ids)
+```
+
+### 3.7 GQL Reasoning Chain
+
+Trace why a business entity was selected using quantified-path traversal:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (decision:TechNode)-[c:Caused]->{1,20}(step:TechNode)
+    -[e:Evaluated]->(biz:BizNode)
+WHERE decision.event_type = @decision_event_type
+  AND biz.node_value = @biz_entity
+RETURN
+  decision.span_id AS decision_span_id,
+  step.span_id AS reasoning_span_id,
+  step.event_type AS step_type,
+  step.agent AS step_agent,
+  biz.node_type AS entity_type,
+  biz.node_value AS entity_value,
+  biz.confidence AS entity_confidence,
+  biz.artifact_uri AS artifact_uri
+ORDER BY step.timestamp ASC
+```
+
+### 3.8 GQL EU Audit Trail (NEW in V3)
+
+Forward traversal from TechNode through DecisionPoint to CandidateNode for EU audit compliance:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (step:TechNode)-[md:MadeDecision]->(dp:DecisionPoint)
+    -[ce:CandidateEdge]->(cand:CandidateNode)
+WHERE dp.session_id = @session_id
+  AND dp.decision_type = @decision_type
+RETURN
+  dp.decision_id,
+  dp.decision_type,
+  dp.description AS decision_description,
+  cand.name AS candidate_name,
+  cand.score AS candidate_score,
+  cand.status AS candidate_status,
+  cand.rejection_rationale,
+  ce.edge_type,
+  step.span_id,
+  step.event_type,
+  step.agent
+ORDER BY dp.decision_id, cand.score DESC
+LIMIT @result_limit
+```
+
+The pattern `(step:TechNode)-[md:MadeDecision]->(dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)` is a forward traversal that follows the decision-making chain: which span made the decision, what was decided, and which candidates were evaluated. The `decision_type` clause is optional and filters by decision category (e.g., `audience_selection`, `placement_selection`).
+
+### 3.9 GQL Dropped Candidates (NEW in V3)
+
+Filter for dropped candidates with rejection rationale:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)
+WHERE dp.session_id = @session_id
+  AND ce.edge_type = 'DROPPED_CANDIDATE'
+RETURN
+  dp.decision_id,
+  dp.decision_type,
+  dp.description AS decision_description,
+  cand.name AS candidate_name,
+  cand.score AS candidate_score,
+  cand.rejection_rationale
+ORDER BY dp.decision_id, cand.score DESC
+LIMIT @result_limit
+```
+
+### 3.10 GQL Trace Reconstruction
+
+Native graph traversal replaces recursive CTEs for reconstructing session traces:
+
+```sql
+GRAPH `project.dataset.agent_context_graph`
+MATCH
+  (parent:TechNode)-[c:Caused]->(child:TechNode)
+WHERE parent.session_id = @session_id
+   OR child.session_id = @session_id
+RETURN
+  parent.span_id AS parent_span_id,
+  parent.event_type AS parent_event_type,
+  parent.agent AS parent_agent,
+  child.span_id AS child_span_id,
+  child.event_type AS child_event_type,
+  child.agent AS child_agent,
+  child.timestamp AS child_timestamp
+ORDER BY child.timestamp ASC
+```
+
+### 3.11 World-Change Detection Query
+
+Joins BizNodes with agent events to get `evaluated_at` timestamps for freshness checking:
+
+```sql
+SELECT
+  b.node_type,
+  b.node_value,
+  b.confidence,
+  b.span_id,
+  b.artifact_uri,
+  e.timestamp AS evaluated_at
+FROM `project.dataset.extracted_biz_nodes` b
+JOIN `project.dataset.agent_events` e
+  ON b.span_id = e.span_id
+WHERE b.session_id = @session_id
+ORDER BY e.timestamp ASC
+```
+
+---
+
+## 4. World-Change Detection (HITL Safety)
+
+### 4.1 Problem Statement
+
+In long-running A2A workflows (e.g., a media buy that requires human approval), the real world can change between when the agent evaluated entities and when the human approves the decision. Ad inventory can sell out, prices can change, audiences can shift.
+
+### 4.2 Solution: Fail-Closed Detection
+
+The `detect_world_changes()` method implements a pre-HITL safety check:
+
+1. Query all BizNodes for the session with their `evaluated_at` timestamps
+2. For each entity, call a user-supplied `current_state_fn` to check current state
+3. Compare original vs. current state to detect drift
+4. Return a `WorldChangeReport` with alerts and safety verdict
+
+**Fail-closed semantics** are critical:
+
+| Scenario | `is_safe_to_approve` | `check_failed` | Behavior |
+|----------|---------------------|----------------|----------|
+| All entities current | `True` | `False` | Safe to approve |
+| Drift detected | `False` | `False` | Block approval, show alerts |
+| BigQuery query fails | `False` | `True` | Block approval (fail-closed) |
+| `current_state_fn` throws | `False` | `True` | Block approval (fail-closed) |
+
+The fail-closed design ensures that operational failures (API outages, query timeouts) can never be misreported as "safe to approve."
+
+### 4.3 Drift Types
+
+| Drift Type | Example | Severity |
+|-----------|---------|----------|
+| `inventory_depleted` | Yahoo Homepage Takeover sold out | 0.95 (critical) |
+| `price_changed` | Strava Routes $40K to $52K (+30%) | 0.72 (moderate) |
+| `audience_shifted` | Segment reach dropped below threshold | 0.60 (low) |
+| `campaign_paused` | External campaign suspension | 0.90 (critical) |
+
+### 4.4 Python SDK Usage
+
+```python
+from bigquery_agent_analytics import ContextGraphManager, ContextGraphConfig
+
+cgm = ContextGraphManager(
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    config=ContextGraphConfig(endpoint="gemini-3-flash-preview"),
+)
+
+def check_inventory(node):
+    # Call real-time inventory API
+    return {"available": True, "current_value": "in stock"}
+
+report = cgm.detect_world_changes(
+    session_id="sess-elf-cosmetics",
+    current_state_fn=check_inventory,
+)
+
+print(report.summary())
+# World Change Report - Session: sess-elf-cosmetics
+#   Entities checked : 7
+#   Stale entities   : 0
+#   Safe to approve  : True
+
+# Fail-closed on errors:
+# report.check_failed   # True if query or callback failed
+# report.is_safe_to_approve  # Always False when check_failed=True
+```
+
+---
+
+## 5. Decision Semantics (NEW in V3)
+
+### 5.1 Motivation
+
+EU regulations and enterprise governance increasingly require explainability for automated decisions. When an agent selects audience segments, ad placements, or budget allocations, organizations must be able to answer:
+
+- **What was decided?** — The decision type and description
+- **What were the options?** — All candidates that were evaluated
+- **Why was each option selected or rejected?** — Scores, selection status, and rejection rationale
+- **Which span made the decision?** — Traceability back to the technical execution
+
+Decision Semantics provides a structured model for these requirements, extending the Context Graph with first-class decision and candidate entities.
+
+### 5.2 Data Model
+
+**DecisionPoint** — A moment where the agent evaluated multiple candidates:
+
+```python
+@dataclass
+class DecisionPoint:
+    decision_id: str       # Unique identifier
+    session_id: str        # Session containing this decision
+    span_id: str           # Span where the decision was made
+    decision_type: str     # "audience_selection", "placement_selection", etc.
+    description: str       # Human-readable description
+    timestamp: Optional[datetime] = None
+    metadata: Optional[dict] = None
+```
+
+**Candidate** — An option evaluated at a decision point:
+
+```python
+@dataclass
+class Candidate:
+    candidate_id: str      # Unique identifier
+    decision_id: str       # Parent decision point
+    session_id: str        # Session containing this candidate
+    name: str              # Candidate name/label
+    score: float = 0.0     # Evaluation score (0.0-1.0)
+    status: str = "SELECTED"  # "SELECTED" or "DROPPED"
+    rejection_rationale: Optional[str] = None  # Required for DROPPED
+    properties: Optional[dict] = None          # Additional properties
+```
+
+### 5.3 EU Audit Trail
+
+The EU audit trail uses forward GQL traversal to reconstruct the complete decision chain:
+
+```
+TechNode ──MadeDecision──► DecisionPoint ──CandidateEdge──► CandidateNode
+  (span)                    (decision)                      (candidate)
+```
+
+This traversal returns all candidates (selected and dropped) with their scores, status, and rejection rationale. The `edge_type` on CandidateEdge distinguishes `SELECTED_CANDIDATE` from `DROPPED_CANDIDATE`.
+
+### 5.4 Candidate Scoring
+
+Each candidate receives a score between 0.0 and 1.0, representing the agent's evaluation of the option. Higher scores indicate better fit. The score is extracted by AI.GENERATE from the agent's reasoning payloads.
+
+Example from the Nike audience selection decision:
+
+| Candidate | Score | Status | Rationale |
+|-----------|-------|--------|-----------|
+| Athletes 18-35 | 0.92 | SELECTED | Best reach-to-cost ratio |
+| Fitness Enthusiasts 25-44 | 0.71 | DROPPED | Budget constraints |
+| Running Community 18-30 | 0.65 | DROPPED | Budget constraints |
+
+### 5.5 Rejection Rationale
+
+For DROPPED candidates, `rejection_rationale` is a required field that explains why the option was not selected. This supports:
+
+- **EU regulatory compliance** — Automated decision explainability
+- **Debugging** — Understanding why the agent made a specific choice
+- **HITL review** — Giving human reviewers context for approval decisions
+
+Example from the ELF Cosmetics placement selection:
+
+| Candidate | Score | Status | Rationale |
+|-----------|-------|--------|-----------|
+| Instagram Reels | 0.95 | SELECTED | — |
+| TikTok TopView | 0.93 | SELECTED | — |
+| LinkedIn Sponsored | 0.22 | DROPPED | Gen Z affinity below 0.70 threshold; skews professional/35+ demographic |
+| Yahoo Homepage | 0.31 | DROPPED | Gen Z affinity below 0.70 threshold; audience skews older demographic |
+
+### 5.6 Dual-Path Decision Explanation
+
+The `explain_decision()` method provides two paths:
+
+1. **EU audit path** (when `session_id` is provided): Uses the EU audit GQL query to traverse `TechNode → MadeDecision → DecisionPoint → CandidateEdge → CandidateNode`. Supports `decision_type` filtering and `include_dropped` toggle.
+
+2. **BizNode reasoning chain fallback** (when `session_id` is not provided): Falls back to the original quantified-path GQL query that traverses causal chains from a decision event to business entities.
+
+```python
+# EU audit path: decision semantics
+results = cgm.explain_decision(
+    session_id="sess-nike-summer",
+    decision_type="audience_selection",
+    include_dropped=True,
+)
+
+# BizNode fallback: reasoning chain
+results = cgm.explain_decision(
+    biz_entity="Instagram Reels",
+    decision_event_type="HITL_CONFIRMATION_REQUEST_COMPLETED",
+)
+```
+
+### 5.7 Audit Trail Export
+
+The `export_audit_trail()` method provides a complete export of all decisions and candidates for a session:
+
+```python
+trail = cgm.export_audit_trail(
+    session_id="sess-nike-summer",
+    include_dropped=True,
+    format="dict",  # or "json"
+)
+# Returns:
+# [
+#   {
+#     "decision_id": "dp-nike-audience",
+#     "decision_type": "audience_selection",
+#     "description": "Select target audience for Nike summer campaign",
+#     "span_id": "span-abc123",
+#     "candidates": [
+#       {"candidate_id": "cand-1", "name": "Athletes 18-35",
+#        "score": 0.92, "status": "SELECTED", "rejection_rationale": null},
+#       {"candidate_id": "cand-2", "name": "Fitness Enthusiasts 25-44",
+#        "score": 0.71, "status": "DROPPED",
+#        "rejection_rationale": "Budget constraints"},
+#       ...
+#     ]
+#   }
+# ]
+```
+
+---
+
+## 6. Production Query Patterns
+
+The demo includes 5 production-ready BigQuery queries covering the Decision Semantics workflow.
+
+### 6.1 Extended AI.GENERATE output_schema (Decision Extraction)
+Uses `AI.GENERATE` with `_DECISION_POINT_OUTPUT_SCHEMA` to extract structured decision data from agent payloads, including decision type, description, and all candidates with scores, status, and rejection rationale. Uses MERGE with 3-way logic for upsert and stale cleanup.
+
+### 6.2 Decision & Candidate Tables DDL
+`CREATE TABLE IF NOT EXISTS` DDL for the `decision_points`, `candidates`, `made_decision_edges`, and `candidate_edges` tables that support the Decision Semantics extension.
+
+### 6.3 Extended Property Graph DDL (6-Pillar Architecture)
+`CREATE OR REPLACE PROPERTY GRAPH` DDL defining the 6-pillar graph: TechNode vertices (from `agent_events`), BizNode vertices (from `biz_nodes`), DecisionPoint vertices (from `decision_points`), CandidateNode vertices (from `candidates`), Caused edges (span lineage), Evaluated edges (cross-links), MadeDecision edges (span→decision), and CandidateEdge edges (decision→candidate).
+
+### 6.4 GQL EU Audit Trail ("Why was X shown instead of Y?")
+Forward GQL traversal from TechNode through MadeDecision to DecisionPoint to CandidateEdge to CandidateNode. Returns all candidates with scores, selection status, and rejection rationale. Supports optional `decision_type` filtering.
+
+### 6.5 GQL Dropped Candidates with Rationale
+Filters CandidateEdge edges by `edge_type = 'DROPPED_CANDIDATE'` to surface all rejected options with rationale. Supports EU regulatory compliance requirements for explainability of automated decisions.
+
+---
+
+## 7. Interactive Demo Features
+
+### 7.1 Decision Graph Visualization
+Interactive SVG-based graph rendering of the 6-pillar architecture. TechNodes (circles) are color-coded by event type: blue (user input), green (agent lifecycle), red (tool calls), yellow (HITL events). BizNodes (rectangles) are color-coded by entity type. DecisionPoint nodes (diamonds) represent decision moments. CandidateNode nodes (rounded rectangles) are color-coded by status: green (SELECTED) and red (DROPPED). MadeDecision edges (solid purple) connect spans to decisions; CandidateEdge edges distinguish selected (solid green) from dropped (dashed red) candidates.
+
+### 7.2 Audit Trail Panel
+Dedicated panel showing the complete audit trail for the selected session. Displays all decision points with their candidates, scores, selection status, and rejection rationale. Dropped candidates are highlighted with the reason for rejection. Supports both the full audit view and filtered views (selected-only, dropped-only).
+
+### 7.3 SQL / GQL Query Explorer
+Interactive query browser with 5 production-ready queries. Each query includes full SQL/GQL, category badges (Extraction, Graph, Audit), and feature tags (AI.GENERATE, output_schema, Property Graph, GQL, Decision Semantics). Syntax-highlighted with dark theme and copy-to-clipboard support.
+
+### 7.4 Python SDK Panel
+Live-updating Python code showing the full SDK workflow for the selected session:
+1. Initialize `ContextGraphManager` with `ContextGraphConfig`
+2. Extract BizNodes via `cgm.extract_biz_nodes()`
+3. Extract DecisionPoints and Candidates via `cgm.extract_decision_points()`
+4. Store decision points via `cgm.store_decision_points()`
+5. Create cross-links and decision edges via `cgm.create_cross_links()` and `cgm.create_decision_edges()`
+6. Create Property Graph (6-pillar with `include_decisions=True`)
+7. Explain decisions via `cgm.explain_decision(session_id=..., decision_type=..., include_dropped=True)`
+8. Export audit trail via `cgm.export_audit_trail(session_id=..., format="json")`
+
+### 7.5 Session Selector
+Switch between ADCP sessions demonstrating different decision semantics outcomes: Nike (audience selection with 3 candidates, 2 dropped due to budget) and ELF Cosmetics (placement selection with 4 candidates, 2 dropped due to audience mismatch). Each session shows decision counts, candidate counts, selected/dropped breakdown, and decision types.
+
+---
+
+## 8. Architecture
+
+### 8.1 Data Flow
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   Agent Runtime (ADK v1.21.0+)           │
+│                                                          │
+│  Buyer Agent ─── Media Planner ─── Root Agent (HITL)     │
+│                        │                                 │
+│              BigQueryAgentAnalyticsPlugin                 │
+│                        │                                 │
+│          BQ Storage Write API (streaming)                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │ Writes events
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│              BigQuery (agent_events)                      │
+│  Partitioned by DATE(timestamp)                          │
+│  Clustered by event_type, agent, user_id                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │ Reads events
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│      BigQuery Agent Analytics SDK (context_graph.py)     │
+│                                                          │
+│  1. AI.GENERATE + output_schema → biz_nodes table        │
+│  2. Cross-links → cross_links table                      │
+│  3. AI.GENERATE + output_schema → decision_points +      │
+│     candidates tables (NEW)                              │
+│  4. Decision edges → made_decision_edges +               │
+│     candidate_edges tables (NEW)                         │
+│  5. CREATE PROPERTY GRAPH (6-pillar DDL)                 │
+│  6. GQL queries for reasoning + trace + audit trail      │
+│  7. World-change detection (fail-closed)                 │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│         BigQuery Property Graph (6-pillar)                │
+│                                                          │
+│  TechNode ──Caused──► TechNode                           │
+│     │                                                    │
+│     ├──Evaluated──► BizNode (+ artifact_uri)             │
+│     │                                                    │
+│     └──MadeDecision──► DecisionPoint (NEW)               │
+│                            │                             │
+│                            └──CandidateEdge──►           │
+│                                CandidateNode (NEW)       │
+│                                (SELECTED / DROPPED)      │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 8.2 SDK Module: `context_graph.py`
+
+The Context Graph is implemented as a standalone module (`~2500 lines`) in the BigQuery Agent Analytics SDK:
+
+| Class | Responsibility |
+|-------|---------------|
+| `ContextGraphManager` | Main entry point: extraction, cross-links, graph creation, GQL queries, world-change detection, decision semantics |
+| `ContextGraphConfig` | Configuration: endpoint, table names (including decision tables), graph name, extraction prompt |
+| `BizNode` | Dataclass representing an extracted business entity |
+| `DecisionPoint` | Dataclass representing a decision point with type, description, and span linkage |
+| `Candidate` | Dataclass representing a candidate with score, status, and rejection rationale |
+| `WorldChangeReport` | Pydantic model: safety verdict, alerts, fail-closed flag |
+| `WorldChangeAlert` | Pydantic model: individual drift alert with severity |
+
+**Key design decisions:**
+
+| Decision | Rationale |
+|----------|-----------|
+| Standalone module | No internal imports from other SDK modules; independently testable |
+| `output_schema` in AI.GENERATE | Eliminates JSON parsing failures from free-form LLM output |
+| Composite `biz_node_id` | `span_id:node_type:node_value` prevents collisions from same-span multi-entity extraction |
+| MERGE with 3-way logic | Single atomic statement handles insert, update, and stale cleanup |
+| Fail-closed world-change | Query errors and callback errors both produce `check_failed=True, is_safe_to_approve=False` |
+| Legacy endpoint rejection | `project.dataset.model` refs raise `ValueError` instead of silently producing bad Vertex AI URLs |
+| GQL + flat trace merge | GQL returns only edge pairs; SDK merges isolated events from flat SQL for completeness |
+| Timezone-safe sorting | `datetime(1970,1,1,tzinfo=timezone.utc)` fallback instead of naive `datetime.min` |
+| Two-table edge model | BigQuery Property Graph DDL requires separate edge tables when source/destination types differ |
+| Idempotent delete-then-insert | Decision data uses delete-before-insert instead of MERGE for simplicity with multi-table consistency |
+| Dual-path explain_decision | Session-aware EU audit path with BizNode reasoning chain fallback for backward compatibility |
+
+### 8.3 Client Integration
+
+The `Client` class exposes GQL trace reconstruction:
+
+```python
+# client.py
+def get_session_trace_gql(self, session_id, config=None) -> Trace:
+    """Reconstructs a session trace using GQL graph traversal.
+
+    1. Runs GQL query via ContextGraphManager.reconstruct_trace_gql()
+    2. Fetches flat trace via get_session_trace() for isolated events
+    3. Backfills parent_span_id when spans arrive out of order
+    4. Merges isolated spans not covered by GQL
+    5. Sorts by timezone-aware timestamps
+    6. Falls back to flat SQL when GQL returns no edges
+    """
+```
+
+### 8.4 Visualization Layer
+
+- React 18 frontend with Google Cloud design system styling
+- Inline SVG graph with positioned TechNodes (circles), BizNodes (rectangles), DecisionPoints (diamonds), and CandidateNodes (rounded rectangles)
+- Caused edges (solid lines), Evaluated cross-links (dashed lines), MadeDecision edges (solid purple), CandidateEdge edges (green for selected, red dashed for dropped)
+- Interactive node selection with property panel showing candidate details
+- Dark-themed SQL/GQL code viewer with copy support
+- Session switcher for comparing decision outcomes across ADCP sessions
+- Audit trail panel with decision-level drill-down
+
+---
+
+## 9. Testing
+
+The Context Graph module has 95 dedicated tests covering:
+
+| Test Category | Count | Examples |
+|--------------|-------|---------|
+| BizNode extraction | 5 | AI.GENERATE path, client-side path, output_schema in SQL |
+| BizNode storage & retrieval | 5 | Store with artifact_uri, read back, session filtering |
+| Cross-links | 3 | Create, composite link_id, delete error handling |
+| Property Graph | 5 | DDL generation (4-pillar + 6-pillar), graph creation with/without decisions, config override |
+| GQL queries | 4 | Reasoning chain, causal chain, trace reconstruction |
+| World-change detection | 5 | Safe, drift detected, fn exception (fail-closed), query failure (fail-closed) |
+| End-to-end pipeline | 3 | `build_context_graph()`, partial failure, `build_context_graph(include_decisions=True)` |
+| Client integration | 4 | `get_session_trace_gql()`, parent backfill, chronological ordering, isolated event merge |
+| Edge cases | 5 | Legacy endpoint rejection, evaluated_at passthrough, MERGE delete, empty sessions |
+| DecisionPoint/Candidate models | 3 | SELECTED candidate properties, DROPPED candidate with rationale, config table names |
+| Decision extraction | 6 | AI.GENERATE JSON parsing, client-side stubs, empty rows, bad JSON, empty JSON, extraction failure |
+| Decision storage | 4 | Store success, empty input, DP insert error, candidate insert error, table create failure |
+| Decision edges | 2 | Create MadeDecision + CandidateEdge edges, edge creation failure |
+| Decision DDL | 3 | 6-pillar DDL includes base pillars, custom graph name, edge source/destination types |
+| EU audit GQL | 3 | Basic traversal, decision_type filter, forward traversal direction |
+| Dropped candidates GQL | 1 | `edge_type = 'DROPPED_CANDIDATE'` filter |
+| Decision point queries | 4 | Get decision points for session, get candidates for decision, query failures |
+| explain_decision | 5 | Audit path with all candidates, filter dropped, decision_type filter, GQL error fallback, reasoning chain fallback |
+| export_audit_trail | 3 | Dict format, JSON format, exclude dropped candidates |
+| Idempotent operations | 1 | Delete-before-insert for decision data |
+
+Full test suite: **609 tests** (95 context graph + 514 existing SDK tests), all passing.
+
+---
+
+## 10. Deployment
+
+The demo is deployed as a single self-contained HTML file with embedded React/Babel. No build step or server is required.
+
+### 10.1 Live Demo
+[https://decision-semantics-demo.vercel.app](https://decision-semantics-demo.vercel.app)
+
+### 10.2 Source Code
+- Decision Semantics Demo: [`examples/decision_semantics_demo.html`](../examples/decision_semantics_demo.html)
+- V2 Demo: [`examples/context_graph_v2_demo.html`](../examples/context_graph_v2_demo.html)
+- Notebook: [`examples/context_graph_adcp_demo.ipynb`](../examples/context_graph_adcp_demo.ipynb)
+- SDK module: [`src/bigquery_agent_analytics/context_graph.py`](../src/bigquery_agent_analytics/context_graph.py)
+- Tests: [`tests/test_context_graph.py`](../tests/test_context_graph.py)
+
+### 10.3 Production Deployment Notes
+
+For production use:
+1. Replace simulated session data with real BigQuery connections
+2. Configure Vertex AI connection for AI.GENERATE (`us.vertex_ai_connection`)
+3. Create `agent_events` table using the ADK plugin schema
+4. Set up ADK BigQuery Agent Analytics Plugin for event streaming
+5. Create the BizNode, cross-links, decision_points, candidates, and edge tables via `ContextGraphManager`
+6. Configure `current_state_fn` callbacks pointing to real inventory/pricing APIs
+7. Integrate `detect_world_changes()` into HITL approval workflows
+8. Integrate `export_audit_trail()` into compliance reporting pipelines
+9. Configure `explain_decision()` for EU regulatory audit responses
+
+---
+
+## 11. Evolution from V1/V2
+
+| Aspect | V1 (Context Graphs & Decision Traces) | V2 (System of Reasoning) | V3 (Decision Semantics) |
+|--------|---------------------------------------|--------------------------|------------------------|
+| Graph Model | Simulated property graph via recursive CTEs | 4-pillar: TechNode + BizNode + Caused + Evaluated | 6-pillar: adds DecisionPoint + CandidateNode + MadeDecision + CandidateEdge |
+| Entity Extraction | Manual event classification | AI.GENERATE with `output_schema` for entities | AI.GENERATE with `output_schema` for entities + decisions with candidates |
+| Traversal | Recursive CTEs for decision traces | GQL with quantified-path patterns (`->{1,20}`) | GQL + EU audit forward traversal (TechNode→DecisionPoint→CandidateNode) |
+| Business Layer | Single vertex types (User, Session, LLM, Tool) | Separate TechNode + BizNode with cross-links | TechNode + BizNode + DecisionPoint + CandidateNode with typed edges |
+| Safety | None | World-change detection with fail-closed semantics | World-change detection + decision audit trails |
+| Decision Modeling | Not tracked | Implicit in BizNode reasoning chains | Explicit DecisionPoint + Candidate with scores, status, rationale |
+| Audit Compliance | None | None | EU audit trail with rejection rationale for all dropped candidates |
+| Candidate Scoring | Not tracked | Not tracked | 0.0-1.0 score per candidate with SELECTED/DROPPED status |
+| Edge Types | None | Caused + Evaluated (2 edge tables) | Caused + Evaluated + MadeDecision + CandidateEdge (4 edge tables) |
+| Artifacts | Not tracked | `artifact_uri` on BizNode + Evaluated edge | `artifact_uri` + `rejection_rationale` on CandidateEdge |
+| Stale Data | Not handled | MERGE with `WHEN NOT MATCHED BY SOURCE ... DELETE` | MERGE for BizNodes + idempotent delete-then-insert for decisions |
+| SDK Integration | Standalone demo | Full `context_graph.py` module (~1300 lines, 50 tests) | Extended module (~2500 lines, 95 tests) |
+| Query Injection | Raw SQL interpolation | Parameterized `@biz_entity`, `@session_id` | Parameterized + `@decision_type`, `@result_limit` |
+| Explainability | None | `explain_decision()` via BizNode reasoning chain | Dual-path `explain_decision()`: EU audit GQL + BizNode fallback |

--- a/docs/hatteras_evaluation.md
+++ b/docs/hatteras_evaluation.md
@@ -1,0 +1,594 @@
+# Hatteras-Style Categorical Evaluation Design
+
+## Summary
+
+Add a new categorical evaluation surface to the SDK so users can classify
+agent sessions into user-defined categories directly against traces stored in
+BigQuery, without relying on an external service.
+
+This should be implemented as a new categorical evaluation subsystem, not as
+an overload of the existing numeric `CodeEvaluator` / `LLMAsJudge` report
+path.
+
+The goal is to support Hatteras-like functionality inside the SDK:
+
+- user-defined categorical metrics
+- BigQuery-native batch execution when possible
+- real-time or near-real-time categorical evaluation as the end-state
+- Gemini API fallback when BigQuery-native execution is unavailable
+- optional persistence of classification results back to BigQuery
+
+## Why This Is Worth Adding
+
+Today the SDK supports two major evaluation modes:
+
+- deterministic numeric scoring via `CodeEvaluator`
+- semantic numeric scoring via `LLMAsJudge`
+
+What is missing is a first-class way to answer questions like:
+
+- What kind of issue is this conversation about?
+- Was the user frustrated, satisfied, or neutral?
+- Did the agent behavior fall into one of several reviewed quality buckets?
+- Which business-defined category best describes the session outcome?
+
+That capability is useful for:
+
+- privacy-reviewed or business-reviewed categorical taxonomies
+- operational dashboards and routing
+- continuous quality monitoring
+- post-hoc labeling for analytics, evaluation, and experimentation
+
+## Design Principles
+
+1. Keep the current `Client.evaluate()` contract focused on numeric
+   evaluation.
+2. Add categorical evaluation as a parallel API surface, not a hidden
+   extension of numeric reports.
+3. Prefer one model call per session that returns all requested metric
+   classifications.
+4. Use structured output and strict category validation.
+5. Support both:
+   - BigQuery-native execution via `AI.GENERATE`
+   - Gemini API fallback for environments where BigQuery-native execution is
+     unavailable or undesired
+6. Make persistence optional in phase 1, but mandatory in the final
+   real-time architecture.
+
+## Non-Goals
+
+This design is not proposing:
+
+- a full clone of an external Hatteras service
+- a replacement for `CodeEvaluator`
+- a replacement for `LLMAsJudge`
+- a new remote function or Python UDF surface in the first phase
+- real-time ingestion-time classification in phase 1
+
+Phase 1 should be batch or near-real-time evaluation over existing traces in
+BigQuery.
+
+## Proposed SDK Surface
+
+### New configuration models
+
+```python
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class CategoricalMetricCategory(BaseModel):
+    name: str = Field(description="Category label.")
+    definition: str = Field(description="What this category means.")
+
+
+class CategoricalMetricDefinition(BaseModel):
+    name: str = Field(description="Metric name.")
+    definition: str = Field(description="What this metric measures.")
+    categories: list[CategoricalMetricCategory] = Field(
+        description="Allowed categories for this metric.",
+    )
+    required: bool = Field(
+        default=True,
+        description="Whether this metric must be classified.",
+    )
+
+
+class CategoricalEvaluationConfig(BaseModel):
+    metrics: list[CategoricalMetricDefinition] = Field(
+        description="Metrics to evaluate.",
+    )
+    endpoint: str = Field(
+        default="gemini-2.5-flash",
+        description="Model endpoint for classification.",
+    )
+    temperature: float = Field(
+        default=0.0,
+        description="Sampling temperature.",
+    )
+    persist_results: bool = Field(
+        default=False,
+        description="Write results to BigQuery.",
+    )
+    results_table: Optional[str] = Field(
+        default=None,
+        description="Destination table for results.",
+    )
+    include_justification: bool = Field(
+        default=True,
+        description="Include justification in output.",
+    )
+    prompt_version: Optional[str] = Field(
+        default=None,
+        description="Tracks prompt version for reproducibility.",
+    )
+```
+
+### New result models
+
+```python
+from datetime import datetime
+from datetime import timezone
+from typing import Any, Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class CategoricalMetricResult(BaseModel):
+    metric_name: str
+    category: Optional[str] = None
+    passed_validation: bool = True
+    justification: Optional[str] = None
+    raw_response: Optional[str] = None
+    parse_error: bool = False
+
+
+class CategoricalSessionResult(BaseModel):
+    session_id: str
+    metrics: list[CategoricalMetricResult] = Field(default_factory=list)
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class CategoricalEvaluationReport(BaseModel):
+    dataset: str
+    evaluator_name: str = "categorical_evaluator"
+    total_sessions: int = 0
+    category_distributions: dict[str, dict[str, int]] = Field(
+        default_factory=dict,
+        description="Maps metric_name → {category → count}.",
+    )
+    details: dict[str, Any] = Field(default_factory=dict)
+    session_results: list[CategoricalSessionResult] = Field(default_factory=list)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+```
+
+### New client method
+
+```python
+report = client.evaluate_categorical(
+    config=config,
+    filters=TraceFilter.from_cli_args(last="24h"),
+    dataset="agent_events",
+)
+```
+
+This should be a separate method, not an overload of `Client.evaluate()`,
+because the current numeric report shape (`aggregate_scores`,
+`SessionScore.scores`) is not a clean fit for label-valued results.
+
+## Execution Model
+
+### Preferred path: BigQuery-native batch classification
+
+Use the same design direction already used elsewhere in the SDK:
+
+- SQL builds one transcript per session
+- `AI.GENERATE` performs the classification
+- structured output is returned in typed columns
+- the SDK validates categories against the configured allowlist
+
+The key design choice is:
+
+one model call per session should return all metric classifications
+
+instead of:
+
+one model call per metric per session
+
+because the latter is slower, more expensive, and harder to reason about
+operationally.
+
+### Example output shape
+
+Conceptually, the model should return a structure like:
+
+```text
+results ARRAY<STRUCT<
+  metric_name STRING,
+  category STRING,
+  justification STRING
+>>
+```
+
+If `AI.GENERATE` cannot directly express the final nested schema cleanly,
+phase 1 can use a constrained string/JSON output plus strict SDK-side
+validation. But the target should be structured output, not substring
+parsing.
+
+### Concrete `output_schema` decision
+
+Phase 1 uses a single STRING column containing a JSON array of metric
+results rather than attempting a fully typed `ARRAY<STRUCT<...>>`
+`output_schema`:
+
+```text
+output_schema => 'classifications STRING'
+```
+
+This is a conservative design choice, not a proven platform limitation.
+`AI.GENERATE`'s `output_schema` supports typed arrays (the SDK's
+`insights.py` already uses `ARRAY<STRING>` columns like
+`goal_categories` and `friction_types`), but the multi-metric
+classification payload — an array of structs with heterogeneous fields —
+has not been validated against `output_schema` yet. Starting with a JSON
+STRING envelope keeps phase 1 unblocked while that validation happens.
+
+The SDK parses the JSON string and validates each entry's `category` value
+against the configured allowlist.
+
+### Endpoint precedence
+
+When `config.endpoint` is set, it overrides `Client.endpoint`. This
+matches the existing SDK pattern where evaluator-level config takes
+precedence over client defaults.
+
+## Prompting and Validation
+
+Each metric definition supplies:
+
+- metric name
+- metric definition
+- allowed categories
+- category definitions
+
+The prompt should instruct the model to:
+
+- classify the full session for every configured metric
+- choose exactly one category from the allowed set for each metric
+- optionally return a short justification
+- return no extra categories or free-form labels
+
+The SDK should then:
+
+- normalize category names
+- validate that each category is in the configured allowlist
+- mark invalid or missing outputs with `parse_error=True`
+- store raw output in `raw_response` for debugging
+
+The implementation should explicitly avoid substring matching like
+`if cat in response`, because that is too weak for production categorical
+evaluation.
+
+## BigQuery-Native SQL Shape
+
+The first implementation should follow the same transcript-building pattern
+already used by `LLMAsJudge` and `insights`:
+
+1. Filter sessions with `TraceFilter`
+2. Build one ordered transcript per `session_id`
+3. Call `AI.GENERATE` once per session
+4. Read typed output columns or parse a constrained JSON/string envelope
+5. Convert rows into `CategoricalSessionResult`
+
+This keeps the execution model aligned with the existing SDK design instead of
+introducing a separate trace-by-trace Python-only path.
+
+### Concrete SQL template
+
+```sql
+WITH session_transcripts AS (
+  SELECT
+    session_id,
+    STRING_AGG(
+      CONCAT(
+        event_type,
+        COALESCE(CONCAT(' [', agent, ']'), ''),
+        ': ',
+        COALESCE(
+          JSON_VALUE(content, '$.text_summary'),
+          JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.tool'),
+          ''
+        )
+      ),
+      '\n' ORDER BY timestamp
+    ) AS transcript
+  FROM `{project}.{dataset}.{table}`
+  WHERE {where}
+  GROUP BY session_id
+  HAVING LENGTH(transcript) > 10
+  LIMIT @trace_limit
+)
+SELECT
+  session_id,
+  transcript,
+  (AI.GENERATE(
+    CONCAT(
+      @categorical_prompt,
+      '\n\nTranscript:\n', transcript
+    ),
+    endpoint => '{endpoint}',
+    model_params => JSON '{"generationConfig": {"temperature": 0.0, "maxOutputTokens": 1024}}',
+    output_schema => 'classifications STRING'
+  )).classifications AS classifications
+FROM session_transcripts
+```
+
+`AI.GENERATE` is a scalar function: the first positional argument is the
+prompt, and it returns a STRUCT containing the `output_schema` fields
+plus `full_response` and `status`. The `model_params` JSON must conform
+to the Gemini `GenerateContent` request body format.
+
+## Real-Time Evaluation and Dashboard End-State
+
+Real-time evaluation is an important product goal for this design. The final
+system should support not only offline or scheduled batch classification, but
+also a near-real-time pipeline that produces continuously updating
+categorical metrics for dashboards and alerting.
+
+The key point is that phase 1 does not need to deliver true streaming
+classification, but the architecture should be shaped so the later real-time
+path does not require a redesign of the metric definitions, result schema, or
+validation logic.
+
+### End-state goal
+
+After the full implementation is complete, the SDK should support:
+
+- categorical evaluation of recent sessions with low operational delay
+- persisted session-level categorical results in BigQuery
+- dashboard-friendly tables or views for category trends, distributions, and
+  error counts
+- alerting or monitoring built on top of persisted categorical outputs
+
+### Recommended architecture
+
+The real-time path should be built as a pipeline with clear separation of
+responsibilities:
+
+1. agent events land in the canonical `agent_events` table
+2. a transcript-building step produces session-ready or recent-session-ready
+   inputs
+3. a categorical evaluation step classifies those sessions using the same
+   metric definitions as the batch path
+4. validated results are written to a durable BigQuery results table
+5. dashboard queries or views read from the persisted results table instead of
+   calling the model live on every dashboard refresh
+
+This matters because dashboards should read from stable persisted outputs, not
+invoke LLM evaluation inline. Inline evaluation would be slower, more
+expensive, and harder to audit.
+
+### Real-time delivery options
+
+The implementation can support multiple execution modes over time:
+
+- scheduled micro-batch evaluation over the last N minutes of sessions
+- event-driven evaluation triggered after session completion
+- hybrid mode where batch backfills and real-time classification share the
+  same parsing and persistence code
+
+The recommended first real-time milestone is scheduled micro-batch execution,
+because it is operationally simpler than true per-event streaming and still
+good enough for dashboards that refresh every few minutes.
+
+### Dashboard support
+
+Dashboard support should be treated as a first-class outcome of this design,
+not a side effect.
+
+The persisted results model should support:
+
+- category distribution over time
+- breakdown by agent, environment, experiment, or user segment
+- top failure or escalation categories
+- recent-session monitoring panels
+- drill-down from aggregate counts to example sessions
+
+To support that, the results table should be paired with stable views or
+example queries such as:
+
+- daily category counts by metric
+- rolling 1-hour category counts
+- per-agent category distribution
+- parse error rate and model fallback rate
+
+### Required invariants for the real-time path
+
+To make batch and real-time coexist cleanly, both paths should share:
+
+- the same metric-definition schema
+- the same prompt-building logic
+- the same category validation rules
+- the same persisted results schema
+- the same execution metadata fields, especially `execution_mode`,
+  `prompt_version`, `endpoint`, and `created_at`
+
+If those invariants hold, dashboards and downstream consumers do not need to
+care whether a classification came from batch execution or a real-time path.
+
+### Suggested final-phase deliverables
+
+The final state of this work should include:
+
+- real-time or near-real-time categorical evaluation pipeline
+- durable BigQuery table for categorical evaluation results
+- dashboard-oriented example SQL or views
+- documentation for recommended dashboard patterns
+- operational metrics for fallback rate, parse error rate, and evaluation
+  latency
+
+This is the right end-state because the value of categorical evaluation is not
+just producing labels. The value is making those labels continuously usable
+for monitoring, reporting, and decision-making.
+
+## Fallback Path
+
+When BigQuery-native execution is unavailable or fails, fall back to Gemini
+API execution.
+
+The fallback path should:
+
+- reuse the same metric definitions
+- reuse the same strict validation logic
+- record execution mode in `report.details`
+- preserve as much result shape parity as possible
+
+Example detail fields:
+
+- `execution_mode`: `"ai_generate" | "api_fallback"`
+- `endpoint`
+- `parse_errors`
+- `parse_error_rate`
+- `persisted`
+
+## Persistence Design
+
+Persistence should be optional but designed in phase 1.
+
+### Suggested results table schema
+
+- `session_id STRING`
+- `metric_name STRING`
+- `category STRING`
+- `justification STRING`
+- `passed_validation BOOL`
+- `parse_error BOOL`
+- `raw_response STRING`
+- `endpoint STRING`
+- `execution_mode STRING`
+- `prompt_version STRING`
+- `created_at TIMESTAMP`
+
+This table can later support:
+
+- dashboarding
+- auditing
+- experiment comparison
+- downstream aggregation and drift analysis
+- real-time monitoring views
+
+## Relationship to Existing SDK Components
+
+The implementation lives in a new module:
+`src/bigquery_agent_analytics/categorical_evaluator.py`. It does not
+belong in `evaluators.py`, which is focused on numeric scoring contracts.
+
+This proposal should reuse and align with current SDK patterns:
+
+- `TraceFilter` for session selection
+- `Client.get_session_trace()` transcript semantics
+- BigQuery-native `AI.GENERATE` execution patterns already used in `insights`
+  and other modules
+- Gemini API fallback patterns already used by `LLMAsJudge`
+
+This proposal should not try to force categorical labels into:
+
+- `SessionScore.scores: dict[str, float]`
+- `EvaluationReport.aggregate_scores: dict[str, float]`
+
+Those numeric contracts should remain numeric.
+
+## Suggested Implementation Phases
+
+### Phase 1: Models + BigQuery-native execution (working backend)
+
+- Add Pydantic config, metric, and result models in
+  `categorical_evaluator.py`
+- Add `Client.evaluate_categorical(...)` entry point
+- Build session-transcript SQL and `AI.GENERATE` query template
+- Return one classification payload per session for all metrics
+- Add strict validation and parsing helpers (category allowlist check,
+  JSON envelope parsing)
+- Add unit tests for metric definition validation and result parsing
+- Add integration tests for typed row parsing and invalid-category
+  handling
+
+### Phase 2: Gemini API fallback
+
+- Add API execution path
+- Preserve report shape parity with the BigQuery-native path
+- Add tests for fallback behavior and partial failures
+
+### Phase 3: Persistence
+
+- Add result table DDL/template
+- Add `persist_results=True` flow
+- Add export/query helpers if needed
+
+### Phase 4: CLI exposure
+
+- Optional CLI wrapper after the Python API stabilizes
+- Keep this out of the initial implementation scope
+
+### Phase 5: Real-time evaluation and dashboard support
+
+- Add scheduled micro-batch or event-driven execution for recent sessions
+- Reuse the same metric definitions and validation logic as the batch path
+- Persist real-time classifications into the same results schema
+- Add dashboard-oriented views or example SQL
+- Document recommended dashboard and alerting patterns
+
+## Open Questions
+
+1. ~~Can `AI.GENERATE` express the desired multi-metric structured output
+   directly, or should phase 1 use a constrained JSON/string envelope?~~
+   **Decided:** phase 1 uses a JSON STRING envelope
+   (`output_schema => 'classifications STRING'`). This is a conservative
+   choice while `ARRAY<STRUCT<...>>` support in `output_schema` is
+   validated; see the Concrete `output_schema` decision section.
+2. ~~Should one session produce exactly one result row, or should results be
+   flattened to one row per `(session_id, metric_name)` during
+   parsing/persistence?~~
+   **Decided:** flatten to one row per `(session_id, metric_name)` for
+   persistence. This matches the results table schema shown in the
+   Persistence Design section.
+3. Should justifications be stored by default, or optional because of privacy
+   or storage concerns?
+4. Should the first release support only session-level classification, or also
+   last-turn-only classification?
+5. ~~Should categorical evaluation live in `evaluators.py`, or in a new module
+   such as `categorical_evaluators.py` to avoid conflating numeric and
+   label-based contracts?~~
+   **Decided:** new module `categorical_evaluator.py`. See the Relationship
+   to Existing SDK Components section.
+
+## Acceptance Criteria
+
+- Users can define one or more categorical metrics with explicit allowed
+  categories.
+- Users can run categorical evaluation over filtered sessions in BigQuery.
+- The SDK validates model output against the configured category set.
+- Invalid or missing outputs are surfaced explicitly as parse errors.
+- Results are returned in a dedicated categorical report type.
+- BigQuery-native execution is the preferred path.
+- Gemini API fallback works when BigQuery-native execution is unavailable.
+- Optional persistence path is clearly defined.
+
+## Why This Approach Fits the SDK
+
+The important design choices are:
+
+- categorical evaluation is a new API surface, not a hidden extension of
+  numeric evaluation
+- execution is batch-first, not one LLM call per metric per trace
+- parsing is strict and schema-driven, not substring-based
+- result models are label-oriented, not forced into numeric score containers
+
+That makes the feature much more likely to integrate cleanly with the current
+SDK and to scale operationally.

--- a/docs/implementation_plan_remote_function.md
+++ b/docs/implementation_plan_remote_function.md
@@ -1,0 +1,629 @@
+# Implementation Plan: Remote Function & CLI Interface
+
+**Parent PRD:** [Unified Analytics Interface](prd_unified_analytics_interface.md)
+**Remote Function Rationale:** [Why Remote Function](remote_function_rationale.md)
+**Date:** 2026-03-12
+**SDK Version:** 0.2.0
+
+---
+
+## 0. Repo Validation Summary
+
+Validated against commit `1d05770` (main branch, 2026-03-12). All 5 proposed
+remote function operations and all 9 CLI commands have backing SDK methods.
+Key findings incorporated into this plan:
+
+| Finding | Impact | Resolution |
+|---------|--------|------------|
+| `Trace`/`Span` dataclasses fail `json.dumps()` | Blocks RF + CLI | Phase 1: Add `.to_dict()` with datetime→ISO 8601 |
+| Pydantic `.model_dump()` preserves raw `datetime` | Blocks RF + CLI | Phase 1: Use `.model_dump(mode="json")` everywhere |
+| `_run_sync()` already handles async/sync boundary | No new work | Phase 3: Reuse directly in Cloud Function |
+| CLI `distribution` maps to SDK `deep_analysis()` | Naming alias | Phase 2: CLI aliases the command name |
+| No `deploy/` directory or CLI entry point | Expected | Phase 2 + 3 deliverables |
+
+---
+
+## 1. Phase 1: Serialization & Filter Layer (Week 1)
+
+### 1.1 Uniform Serialization Module
+
+**New file:** `src/bigquery_agent_analytics/serialization.py`
+
+Provides a single `serialize()` function that handles all SDK return types:
+
+```python
+"""Uniform JSON serialization for CLI and Remote Function boundaries."""
+
+import dataclasses
+from datetime import date, datetime
+
+
+def serialize(obj):
+    """Convert any SDK return type to a json.dumps()-safe dict.
+
+    Handles three cases:
+    1. Pydantic BaseModel → .model_dump(mode="json")
+    2. dataclass (Trace, Span, etc.) → recursive dict with datetime→isoformat
+    3. dict/list/primitive → pass through with datetime conversion
+    """
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return _dataclass_to_dict(obj)
+    if isinstance(obj, list):
+        return [serialize(item) for item in obj]
+    if isinstance(obj, dict):
+        return {k: serialize(v) for k, v in obj.items()}
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    return obj
+
+
+def _dataclass_to_dict(obj):
+    result = {}
+    for f in dataclasses.fields(obj):
+        val = getattr(obj, f.name)
+        result[f.name] = serialize(val)
+    return result
+```
+
+**Files changed:**
+- `src/bigquery_agent_analytics/serialization.py` (new, ~40 lines)
+- `src/bigquery_agent_analytics/__init__.py` (export `serialize`)
+
+**Tests:**
+- `tests/test_serialization.py` (new, ~120 lines)
+- Test `serialize(Trace(...))` produces valid `json.dumps()` output
+- Test `serialize(EvaluationReport(...))` converts `created_at` to ISO string
+- Test `serialize(InsightsReport(...))` handles nested `SessionMetadata` datetimes
+- Test `serialize(DriftReport(...))`, `serialize(QuestionDistribution(...))`
+- Test `serialize(dict)` with embedded datetime values
+- Test `serialize([Trace(...), Trace(...)])` for list returns
+- Test round-trip: `json.loads(json.dumps(serialize(obj)))` for every return type
+
+**Exit criterion:** `json.dumps(serialize(result))` succeeds for every `Client`
+public method return type.
+
+### 1.2 TraceFilter CLI Factory
+
+**File changed:** `src/bigquery_agent_analytics/trace.py`
+
+Add class method on `TraceFilter`:
+
+```python
+@classmethod
+def from_cli_args(
+    cls,
+    last: str | None = None,        # "1h", "24h", "7d", "30d"
+    agent_id: str | None = None,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    has_error: bool | None = None,
+    limit: int = 100,
+) -> "TraceFilter":
+    """Build TraceFilter from CLI-style arguments.
+
+    Parses --last time windows (e.g. '1h' → start_time = now - 1 hour).
+    Also used by Remote Function dispatch to parse params JSON.
+    """
+```
+
+Time window parser supports: `Xm` (minutes), `Xh` (hours), `Xd` (days).
+
+**Tests:**
+- `tests/test_trace_filter_factory.py` (new, ~80 lines)
+- Test `from_cli_args(last="1h")` sets `start_time` ~1 hour ago
+- Test `from_cli_args(agent_id="bot")` sets `agent_id`
+- Test `from_cli_args(last="7d", agent_id="bot", limit=50)` combines all
+- Test invalid `last` value raises `ValueError`
+- Test `from_cli_args()` with no args returns default filter
+
+### 1.3 Format Output Layer
+
+**New file:** `src/bigquery_agent_analytics/formatter.py`
+
+```python
+"""Output formatting for CLI and Remote Function responses."""
+
+import json
+
+from .serialization import serialize
+
+
+def format_output(obj, fmt: str = "json") -> str:
+    """Format an SDK result for output.
+
+    Args:
+        obj: Any SDK return type (Trace, EvaluationReport, dict, etc.)
+        fmt: "json", "text", or "table"
+    """
+```
+
+- `json`: `json.dumps(serialize(obj), indent=2)`
+- `text`: Calls `.summary()` if available, else pretty-prints key fields
+- `table`: Simple columnar format for list-like results (traces, scores)
+
+**Files changed:**
+- `src/bigquery_agent_analytics/formatter.py` (new, ~80 lines)
+- `src/bigquery_agent_analytics/__init__.py` (export `format_output`)
+
+**Tests:**
+- `tests/test_formatter.py` (new, ~60 lines)
+
+---
+
+## 2. Phase 2: CLI MVP (Weeks 2–3)
+
+### 2.1 Dependencies & Entry Point
+
+**File changed:** `pyproject.toml`
+
+```toml
+[project.optional-dependencies]
+cli = [
+  "typer>=0.9.0",
+]
+
+[project.scripts]
+bq-agent-sdk = "bigquery_agent_analytics.cli:app"
+```
+
+### 2.2 CLI Module
+
+**New file:** `src/bigquery_agent_analytics/cli.py`
+
+| Command | SDK Method | Return Type | Serialization |
+|---------|-----------|-------------|---------------|
+| `doctor` | `Client.doctor()` | `dict` | `serialize(dict)` |
+| `get-trace` | `Client.get_session_trace()` | `Trace` | `serialize(trace)` via `.to_dict()` |
+| `list-traces` | `Client.list_traces()` | `list[Trace]` | `serialize(traces)` |
+| `evaluate` | `Client.evaluate()` | `EvaluationReport` | `.model_dump(mode="json")` |
+| `insights` | `Client.insights()` | `InsightsReport` | `.model_dump(mode="json")` |
+| `drift` | `Client.drift_detection()` | `DriftReport` | `.model_dump(mode="json")` |
+| `distribution` | `Client.deep_analysis()` | `QuestionDistribution` | `.model_dump(mode="json")` |
+| `hitl-metrics` | `Client.hitl_metrics()` | `dict` | `serialize(dict)` |
+| `views create-all` | `ViewManager.create_all_views()` | `dict[str, str]` | direct |
+
+**v1.0 MVP commands:** `doctor`, `get-trace`, `evaluate`
+**v1.1 commands:** `insights`, `drift`, `distribution`, `hitl-metrics`,
+`list-traces`, `views`
+
+### 2.3 Global Options
+
+All commands share:
+```
+--project-id TEXT       [env: BQ_AGENT_PROJECT]
+--dataset-id TEXT       [env: BQ_AGENT_DATASET]
+--table-id TEXT         [default: agent_events]
+--location TEXT         [default: us-central1]
+--format TEXT           json|text|table [default: json]
+--quiet                 Suppress non-essential output
+```
+
+### 2.4 Evaluate Command Detail
+
+```
+bq-agent-sdk evaluate [OPTIONS]
+  --evaluator TEXT      latency|error_rate|turn_count|token_efficiency|
+                        ttft|cost|llm-judge
+  --threshold FLOAT
+  --criterion TEXT      correctness|hallucination|sentiment|custom
+  --custom-prompt TEXT
+  --agent-id TEXT
+  --last TEXT           1h|24h|7d|30d
+  --limit INT           [default: 100]
+  --exit-code           Return 1 on evaluation failure
+```
+
+Dispatch logic:
+```python
+# Map CLI --evaluator to SDK factory
+EVALUATOR_FACTORIES = {
+    "latency": lambda t: CodeEvaluator.latency(threshold_ms=t),
+    "error_rate": lambda t: CodeEvaluator.error_rate(max_error_rate=t),
+    "turn_count": lambda t: CodeEvaluator.turn_count(max_turns=int(t)),
+    "token_efficiency": lambda t: CodeEvaluator.token_efficiency(max_tokens=int(t)),
+    "ttft": lambda t: CodeEvaluator.ttft(threshold_ms=t),
+    "cost": lambda t: CodeEvaluator.cost_per_session(max_cost_usd=t),
+    "llm-judge": None,  # special handling
+}
+```
+
+### 2.5 Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success / evaluation passed |
+| 1 | Evaluation failed (pass_rate below threshold) |
+| 2 | Infrastructure error (BQ connection, missing table, etc.) |
+
+### 2.6 Tests
+
+**New file:** `tests/test_cli.py` (~300 lines)
+- Mock `Client` construction and all SDK methods
+- Test each v1.0 command produces valid JSON output
+- Test `--exit-code` returns 1 on failure, 0 on pass
+- Test `--format=text` calls `.summary()`
+- Test `--last=1h` correctly parsed
+- Test env var fallback for `--project-id`
+- Test error handling (missing required args, BQ connection failure)
+
+### 2.7 Files Summary
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `src/bigquery_agent_analytics/cli.py` | new | ~350 |
+| `tests/test_cli.py` | new | ~300 |
+| `pyproject.toml` | edit | +8 |
+
+---
+
+## 3. Phase 3: Remote Function (Weeks 4–5)
+
+### 3.1 Directory Structure
+
+```
+deploy/remote_function/
+├── main.py             # functions-framework entry point
+├── requirements.txt    # SDK + functions-framework
+├── deploy.sh           # gcloud deployment script
+├── register.sql        # CREATE FUNCTION DDL template
+└── README.md           # Deployment guide
+```
+
+### 3.2 Entry Point (`main.py`)
+
+```python
+"""BigQuery Remote Function entry point.
+
+Dispatches BigQuery Remote Function calls to SDK methods.
+BigQuery sends batched requests as JSON with a `calls` array;
+each element is [operation, params_json]. We return a `replies`
+array of the same length.
+"""
+
+import json
+import os
+
+import functions_framework
+from flask import jsonify
+
+from bigquery_agent_analytics import Client, serialize
+from bigquery_agent_analytics import CodeEvaluator, LLMAsJudge
+from bigquery_agent_analytics import TraceFilter
+
+
+@functions_framework.http
+def handle_request(request):
+    """HTTP entry point for BigQuery Remote Function."""
+    body = request.get_json(silent=True)
+    if not body or "calls" not in body:
+        return jsonify({"errorMessage": "Missing 'calls' array"}), 400
+
+    # Config from user_defined_context or env vars
+    udc = body.get("userDefinedContext", {})
+    project_id = udc.get("project_id", os.environ.get("BQ_AGENT_PROJECT"))
+    dataset_id = udc.get("dataset_id", os.environ.get("BQ_AGENT_DATASET"))
+
+    if not project_id or not dataset_id:
+        return jsonify({
+            "errorMessage": "project_id and dataset_id required"
+        }), 400
+
+    client = Client(project_id=project_id, dataset_id=dataset_id)
+
+    replies = []
+    for call in body["calls"]:
+        try:
+            operation, params_json = call[0], call[1]
+            params = json.loads(params_json) if isinstance(
+                params_json, str
+            ) else params_json
+            result = _dispatch(client, operation, params)
+            result["_version"] = "1.0"
+            replies.append(result)
+        except Exception as e:
+            replies.append({
+                "_error": {
+                    "code": type(e).__name__,
+                    "message": str(e),
+                },
+                "_version": "1.0",
+            })
+
+    return jsonify({"replies": replies})
+
+
+def _dispatch(client, operation, params):
+    """Route operation to SDK method, return JSON-safe dict."""
+    if operation == "analyze":
+        trace = client.get_session_trace(params["session_id"])
+        return serialize(trace)
+
+    elif operation == "evaluate":
+        evaluator = _build_evaluator(params)
+        filters = TraceFilter.from_cli_args(
+            session_id=params.get("session_id"),
+            agent_id=params.get("agent_filter"),
+            last=params.get("last"),
+        )
+        report = client.evaluate(evaluator=evaluator, filters=filters)
+        return serialize(report)
+
+    elif operation == "judge":
+        judge = _build_judge(params)
+        filters = TraceFilter.from_cli_args(
+            session_id=params.get("session_id"),
+            agent_id=params.get("agent_filter"),
+            last=params.get("last"),
+        )
+        report = client.evaluate(evaluator=judge, filters=filters)
+        return serialize(report)
+
+    elif operation == "insights":
+        filters = TraceFilter.from_cli_args(
+            session_id=params.get("session_id"),
+            agent_id=params.get("agent_filter"),
+            last=params.get("last"),
+        )
+        report = client.insights(filters=filters)
+        return serialize(report)
+
+    elif operation == "drift":
+        filters = TraceFilter.from_cli_args(
+            agent_id=params.get("agent_filter"),
+            last=params.get("last"),
+        )
+        report = client.drift_detection(
+            golden_dataset=params["golden_dataset"],
+            filters=filters,
+        )
+        return serialize(report)
+
+    else:
+        raise ValueError(f"Unknown operation: {operation}")
+
+
+def _build_evaluator(params):
+    """Build CodeEvaluator from params dict."""
+    metric = params.get("metric", "latency")
+    threshold = params.get("threshold", 5000)
+    factories = {
+        "latency": lambda t: CodeEvaluator.latency(threshold_ms=t),
+        "error_rate": lambda t: CodeEvaluator.error_rate(max_error_rate=t),
+        "turn_count": lambda t: CodeEvaluator.turn_count(max_turns=int(t)),
+        "token_efficiency": lambda t: CodeEvaluator.token_efficiency(
+            max_tokens=int(t)
+        ),
+        "ttft": lambda t: CodeEvaluator.ttft(threshold_ms=t),
+        "cost": lambda t: CodeEvaluator.cost_per_session(max_cost_usd=t),
+    }
+    factory = factories.get(metric)
+    if not factory:
+        raise ValueError(f"Unknown metric: {metric}")
+    return factory(threshold)
+
+
+def _build_judge(params):
+    """Build LLMAsJudge from params dict."""
+    criterion = params.get("criterion", "correctness")
+    threshold = params.get("threshold", 0.5)
+    factories = {
+        "correctness": lambda t: LLMAsJudge.correctness(threshold=t),
+        "hallucination": lambda t: LLMAsJudge.hallucination(threshold=t),
+        "sentiment": lambda t: LLMAsJudge.sentiment(threshold=t),
+    }
+    factory = factories.get(criterion)
+    if not factory:
+        raise ValueError(f"Unknown criterion: {criterion}")
+    return factory(threshold)
+```
+
+**Key design decisions:**
+- `_dispatch()` calls sync SDK methods directly — `insights()`,
+  `drift_detection()`, and `deep_analysis()` internally use `_run_sync()`
+  (`client.py:247`) which already handles the async/sync boundary safely
+- `serialize()` from Phase 1 handles all return type → JSON conversion
+- Each failed call produces a per-row `_error` (partial failure semantics)
+- Config from `userDefinedContext` with env var fallback
+
+### 3.3 Requirements
+
+```
+# deploy/remote_function/requirements.txt
+functions-framework==3.*
+bigquery-agent-analytics[llm]>=0.2.0
+```
+
+### 3.4 Deployment Script
+
+```bash
+# deploy/remote_function/deploy.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT="${1:?Usage: deploy.sh PROJECT [REGION] [DATASET]}"
+REGION="${2:-us-central1}"
+DATASET="${3:-agent_analytics}"
+
+echo "==> Deploying Cloud Function..."
+gcloud functions deploy bq-agent-analytics \
+  --gen2 --runtime python312 --region "$REGION" \
+  --entry-point handle_request \
+  --source "$(dirname "$0")" \
+  --trigger-http --no-allow-unauthenticated \
+  --set-env-vars "BQ_AGENT_PROJECT=$PROJECT,BQ_AGENT_DATASET=$DATASET" \
+  --memory 512MB --timeout 120s --min-instances 0
+
+echo "==> Creating CLOUD_RESOURCE connection..."
+bq mk --connection --location=US --connection_type=CLOUD_RESOURCE \
+  --project_id="$PROJECT" analytics-conn 2>/dev/null || true
+
+echo "==> Granting invoker role to connection SA..."
+CONNECTION_SA=$(bq show --connection --format=json \
+  "$PROJECT.us.analytics-conn" | jq -r '.cloudResource.serviceAccountId')
+gcloud functions add-invoker-policy-binding bq-agent-analytics \
+  --region="$REGION" --member="serviceAccount:${CONNECTION_SA}"
+
+echo "==> Done. Register the function with:"
+echo "    bq query --use_legacy_sql=false < register.sql"
+```
+
+### 3.5 Registration DDL
+
+```sql
+-- deploy/remote_function/register.sql
+CREATE OR REPLACE FUNCTION `PROJECT.DATASET.agent_analytics`(
+  operation STRING, params JSON
+) RETURNS JSON
+REMOTE WITH CONNECTION `PROJECT.us.analytics-conn`
+OPTIONS (
+  endpoint = "https://REGION-PROJECT.cloudfunctions.net/bq-agent-analytics",
+  max_batching_rows = 50
+);
+```
+
+### 3.6 Tests
+
+**New file:** `tests/test_remote_function.py` (~250 lines)
+
+- Mock `Client` and test `handle_request()` with sample batched payloads
+- Test each operation returns `_version: "1.0"`
+- Test partial failure: 1 bad session_id in batch of 3 → 2 successes + 1 error
+- Test missing `calls` → 400
+- Test missing `project_id`/`dataset_id` → 400
+- Test unknown operation → per-row error
+- Test all returns are `json.dumps()`-safe (no datetime objects)
+- Test `userDefinedContext` config parsing
+- Test env var fallback
+
+### 3.7 Files Summary
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `deploy/remote_function/main.py` | new | ~160 |
+| `deploy/remote_function/requirements.txt` | new | ~3 |
+| `deploy/remote_function/deploy.sh` | new | ~30 |
+| `deploy/remote_function/register.sql` | new | ~10 |
+| `deploy/remote_function/README.md` | new | ~100 |
+| `tests/test_remote_function.py` | new | ~250 |
+
+---
+
+## 4. Phase 4: CLI v1.1 + Continuous Query Templates (Weeks 6–7)
+
+### 4.1 Remaining CLI Commands
+
+| Command | SDK Method | Notes |
+|---------|-----------|-------|
+| `insights` | `Client.insights()` | `--max-sessions`, `--agent-id`, `--last` |
+| `drift` | `Client.drift_detection()` | `--golden-dataset` required |
+| `distribution` | `Client.deep_analysis()` | **Aliases** SDK method name |
+| `hitl-metrics` | `Client.hitl_metrics()` | |
+| `list-traces` | `Client.list_traces()` | Filter options mirror `TraceFilter` |
+| `views create-all` | `ViewManager.create_all_views()` | `--prefix` option |
+| `views create` | `ViewManager.create_view()` | Takes event type arg |
+
+### 4.2 Continuous Query Templates
+
+```
+deploy/continuous_queries/
+├── realtime_error_analysis.sql
+├── session_scoring.sql
+├── pubsub_alerting.sql
+├── bigtable_dashboard.sql
+└── setup_reservation.md
+```
+
+These are parameterized SQL files (not SDK code). Users substitute
+`PROJECT`, `DATASET`, `CONNECTION` placeholders and run via `bq query
+--continuous=true`.
+
+---
+
+## 5. Phase 5: Documentation & Pilot (Week 8)
+
+### 5.1 Documentation Updates
+
+| File | Changes |
+|------|---------|
+| `SDK.md` | Add CLI, Remote Function, and Continuous Query sections |
+| `README.md` | Add quick-start for CLI and Remote Function |
+
+### 5.2 Examples
+
+| File | Description |
+|------|-------------|
+| `examples/cli_agent_tool.py` | ADK agent using CLI for self-diagnostics |
+| `examples/ci_eval_pipeline.sh` | GitHub Actions evaluation script |
+| `examples/remote_function_dashboard.sql` | Looker query examples |
+| `examples/continuous_query_alerting.sql` | Real-time error alerting |
+
+---
+
+## 6. Dependency Graph
+
+```
+Phase 1 (serialization + filter factory)
+  │
+  ├──→ Phase 2 (CLI MVP) ──→ Phase 4 (CLI v1.1)
+  │                                │
+  └──→ Phase 3 (Remote Function) ──┤
+                                   │
+                                   └──→ Phase 5 (docs + pilot)
+```
+
+Phase 2 and Phase 3 can run **in parallel** after Phase 1 completes.
+
+---
+
+## 7. Operation → SDK Method Reference
+
+Complete mapping from interface operations to current SDK code:
+
+| Operation | SDK Method | File:Line | Return Type | Serialization Strategy |
+|-----------|-----------|-----------|-------------|----------------------|
+| `analyze` | `Client.get_session_trace()` | `client.py` | `Trace` (dataclass) | `serialize()` → recursive `.to_dict()` |
+| `evaluate` | `Client.evaluate(CodeEvaluator)` | `client.py` | `EvaluationReport` (Pydantic) | `.model_dump(mode="json")` |
+| `judge` | `Client.evaluate(LLMAsJudge)` | `client.py` | `EvaluationReport` (Pydantic) | `.model_dump(mode="json")` |
+| `insights` | `Client.insights()` | `client.py` | `InsightsReport` (Pydantic) | `.model_dump(mode="json")` |
+| `drift` | `Client.drift_detection()` | `client.py` | `DriftReport` (Pydantic) | `.model_dump(mode="json")` |
+| `distribution` | `Client.deep_analysis()` | `client.py` | `QuestionDistribution` (Pydantic) | `.model_dump(mode="json")` |
+| `doctor` | `Client.doctor()` | `client.py` | `dict` | `serialize(dict)` |
+| `hitl-metrics` | `Client.hitl_metrics()` | `client.py` | `dict` | `serialize(dict)` |
+| `views` | `ViewManager.create_all_views()` | `views.py` | `dict[str, str]` | direct (str values) |
+
+### Evaluator Factory Methods (already exist)
+
+| CLI `--evaluator` | SDK Factory | File |
+|-------------------|------------|------|
+| `latency` | `CodeEvaluator.latency(threshold_ms)` | `evaluators.py` |
+| `error_rate` | `CodeEvaluator.error_rate(max_error_rate)` | `evaluators.py` |
+| `turn_count` | `CodeEvaluator.turn_count(max_turns)` | `evaluators.py` |
+| `token_efficiency` | `CodeEvaluator.token_efficiency(max_tokens)` | `evaluators.py` |
+| `ttft` | `CodeEvaluator.ttft(threshold_ms)` | `evaluators.py` |
+| `cost` | `CodeEvaluator.cost_per_session(max_cost_usd)` | `evaluators.py` |
+| `llm-judge` | `LLMAsJudge.correctness/hallucination/sentiment(threshold)` | `evaluators.py` |
+
+### SDK Capabilities NOT Exposed (v1.2+ candidates)
+
+| SDK Feature | Class | Potential Operation |
+|-------------|-------|-------------------|
+| Context Graph | `ContextGraphManager` | `context_graph` |
+| Trajectory Evaluation | `BigQueryTraceEvaluator` | `trajectory` |
+| Multi-Trial | `TrialRunner` | `multi_trial` |
+| Grader Pipeline | `GraderPipeline` | `grade` |
+| Memory Service | `BigQueryMemoryService` | (separate interface) |
+| Anomaly Detection & Forecasting | `AnomalyDetector` | `anomaly`, `forecast` |
+
+---
+
+## 8. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Cloud Function cold start > 3s | Medium | Latency SLO breach | `--min-instances=1` for production |
+| `LLMAsJudge` timeout in batch | Medium | Partial failure | Per-row error handling; `max_batching_rows=10` for judge |
+| `typer` version conflict with user deps | Low | CLI install failure | Optional `[cli]` extra isolates dependency |
+| `Trace.to_dict()` missing edge cases | Medium | Serialization crash | Comprehensive test matrix in Phase 1 |
+| `datetime` serialization regression | Medium | Silent JSON errors | CI test: `json.dumps(serialize(x))` for all types |

--- a/docs/ontology_graph_v4_design.md
+++ b/docs/ontology_graph_v4_design.md
@@ -1,0 +1,501 @@
+# Ontology Graph V4 — Configuration-Driven Context Graph
+
+Turn unstructured agent telemetry into a queryable knowledge graph using a
+single YAML file. No code changes required — define your ontology, point
+it at your data, and the SDK handles extraction, materialization, and
+BigQuery Property Graph creation automatically.
+
+**Live demo:** [ontology-v4-deploy.vercel.app](https://ontology-v4-deploy.vercel.app)
+| **Notebook:** [`examples/ontology_graph_v4_demo.ipynb`](../examples/ontology_graph_v4_demo.ipynb)
+
+---
+
+## Why This Matters
+
+Modern ad-tech and commerce platforms make thousands of micro-decisions per
+request — which ad unit to show, which creative to select, which candidate
+to reject and why. These decisions are captured as unstructured agent
+telemetry, but answering questions like *"Why was this ad rejected?"* or
+*"What was the confidence score for each candidate?"* requires tedious
+manual log parsing.
+
+The Ontology Graph V4 pipeline solves this by:
+
+1. **Declaring** your business domain once in YAML — entities, relationships,
+   keys, and table bindings.
+2. **Extracting** structured graph data from raw agent logs using
+   `AI.GENERATE` (Gemini), guided by your ontology.
+3. **Materializing** typed nodes and edges into dedicated BigQuery tables.
+4. **Creating** a native BigQuery Property Graph for GQL traversal.
+
+The result: you can write queries like *"For session X, show me every
+DecisionPoint, the candidates it evaluated, their scores, and why any
+were rejected"* — in native GQL, with full type safety.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────┐
+│   YAML Ontology     │  Entities, relationships, keys, table bindings
+│   Specification     │  (single source of truth)
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐     ┌──────────────────────────────┐
+│   Schema Compiler   │────▶│  Extraction Prompt + Schema   │
+└────────┬────────────┘     └──────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐     ┌──────────────────────────────┐
+│   AI.GENERATE       │────▶│  ExtractedGraph (Pydantic)    │
+│   (BigQuery-native) │     │  Typed nodes + edges          │
+└────────┬────────────┘     └──────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐     ┌──────────────────────────────┐
+│   Materializer      │────▶│  Physical BigQuery Tables     │
+│   (table routing)   │     │  One table per entity/rel     │
+└────────┬────────────┘     └──────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐     ┌──────────────────────────────┐
+│   DDL Transpiler    │────▶│  CREATE PROPERTY GRAPH        │
+│                     │     │  NODE TABLES + EDGE TABLES    │
+└────────┬────────────┘     └──────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│   GQL Queries       │  MATCH (dp)-[ce]->(ad) WHERE ...
+│   (graph traversal) │  Native BigQuery graph analytics
+└─────────────────────┘
+```
+
+---
+
+## YAML Ontology Specification
+
+The YAML spec is the single source of truth. It defines what to extract,
+where to store it, and how to link it in the graph.
+
+### Format Reference
+
+```yaml
+graph:
+  name: My_Context_Graph
+
+  entities:
+    - name: EntityName              # Node type name
+      description: "..."            # Used in AI extraction prompt
+      extends: ParentLabel          # Optional label inheritance
+      binding:
+        source: "{{ env }}.table"   # Physical BigQuery table
+      keys:
+        primary: [id_column]        # Primary key column(s)
+      properties:
+        - name: column_name
+          type: string              # string | int64 | double | bool | timestamp
+
+  relationships:
+    - name: EdgeName                # Edge type name
+      description: "..."
+      from_entity: SourceEntity
+      to_entity: TargetEntity
+      binding:
+        source: "{{ env }}.edge_table"
+        from_columns: [source_key]
+        to_columns: [target_key]
+      properties:
+        - name: edge_property
+          type: double
+```
+
+**Key features:**
+
+- **`{{ env }}` placeholders** — resolved at load time, so the same spec
+  works across dev/staging/prod environments.
+- **Label inheritance** (`extends`) — an entity can carry multiple labels
+  in the graph (e.g., `YahooAdUnit` is also a `Candidate`).
+- **Explicit key routing** — `from_columns` / `to_columns` define how edge
+  tables reference source and target nodes. For Property Graph compilation,
+  these must exactly match the referenced entity's full primary key;
+  subset bindings are supported for table materialization but will be
+  rejected by the DDL transpiler.
+
+### Example: Yahoo ADCP Ad Decisioning
+
+This real-world example models Yahoo's ad decisioning pipeline where
+an agent evaluates candidate ad units at decision points.
+
+```yaml
+graph:
+  name: YMGO_Context_Graph_V3
+
+  entities:
+    - name: mako_DecisionPoint
+      description: "The atomic unit of decisioning where an agent evaluates alternatives."
+      binding:
+        source: "{{ env }}.decision_points"
+      keys:
+        primary: [decision_id]
+      properties:
+        - name: decision_id
+          type: string
+        - name: decision_type
+          type: string
+
+    - name: sup_YahooAdUnit
+      extends: mako_Candidate
+      description: "A specific ad slot on a Yahoo property being evaluated as a candidate."
+      binding:
+        source: "{{ env }}.yahoo_ad_units"
+      keys:
+        primary: [adUnitId]
+      properties:
+        - name: adUnitId
+          type: string
+        - name: adUnitName
+          type: string
+        - name: adUnitSize
+          type: string
+          description: "e.g., '300x250', '728x90'"
+        - name: adUnitPosition
+          type: string
+          description: "ATF (above the fold) | BTF (below the fold)"
+
+    - name: mako_RejectionReason
+      description: "Structured reason why a Candidate was not selected at a DecisionPoint."
+      binding:
+        source: "{{ env }}.rejection_reasons"
+      keys:
+        primary: [rejection_id]
+      properties:
+        - name: rejection_id
+          type: string
+        - name: rejectionType
+          type: string
+          description: "RULE_BASED | MODEL_BASED | TIMEOUT | ERROR"
+        - name: rejectionRule
+          type: string
+          description: "The specific rule or model threshold that caused rejection."
+
+  relationships:
+    - name: CandidateEdge
+      description: "Connects a decision point to the evaluated Yahoo Ad Unit."
+      from_entity: mako_DecisionPoint
+      to_entity: sup_YahooAdUnit
+      binding:
+        source: "{{ env }}.candidate_edges"
+        from_columns: [decision_id]
+        to_columns: [adUnitId]
+      properties:
+        - name: edge_type
+          type: string
+          description: "SELECTED_CANDIDATE or DROPPED_CANDIDATE"
+        - name: mako_scoreValue
+          type: double
+          description: "The confidence or predicted Q-value for this candidate."
+
+    - name: ForCandidate
+      description: "Maps the MAKO rejection rationale directly to the dropped candidate."
+      from_entity: mako_RejectionReason
+      to_entity: sup_YahooAdUnit
+      binding:
+        source: "{{ env }}.rejection_mappings"
+        from_columns: [rejection_id]
+        to_columns: [adUnitId]
+```
+
+This produces the following graph structure:
+
+```
+DecisionPoint ──CandidateEdge──▶ YahooAdUnit ◀──ForCandidate── RejectionReason
+```
+
+---
+
+## Usage
+
+### Python SDK
+
+**One-shot pipeline** — runs the entire flow in a single call:
+
+```python
+from bigquery_agent_analytics import build_ontology_graph, compile_showcase_gql
+
+# Run the full pipeline
+result = build_ontology_graph(
+    session_ids=["adcp-033c95d7a97d", "adcp-040c04837251"],
+    spec_path="ymgo_graph_spec.yaml",
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    env="my-project.agent_analytics",
+)
+
+print(f"Extracted {len(result['graph'].nodes)} nodes, {len(result['graph'].edges)} edges")
+print(f"Property Graph: {result['graph_ref']}")
+
+# Generate a GQL traversal query
+gql = compile_showcase_gql(result["spec"], "my-project", "agent_analytics")
+print(gql)
+```
+
+**Step-by-step** — for more control over each phase:
+
+```python
+from bigquery_agent_analytics import (
+    load_graph_spec,
+    OntologyGraphManager,
+    OntologyMaterializer,
+    OntologyPropertyGraphCompiler,
+    compile_extraction_prompt,
+    compile_output_schema,
+)
+
+# 1. Load spec
+spec = load_graph_spec("ymgo_graph_spec.yaml", env="my-project.agent_analytics")
+
+# 2. Extract graph from agent telemetry
+extractor = OntologyGraphManager(
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    spec=spec,
+    endpoint="gemini-2.5-flash",
+)
+graph = extractor.extract_graph(session_ids=["adcp-033c95d7a97d"])
+
+# 3. Create tables and materialize
+materializer = OntologyMaterializer(
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    spec=spec,
+)
+materializer.create_tables()
+materializer.materialize(graph, session_ids=["adcp-033c95d7a97d"])
+
+# 4. Create Property Graph
+compiler = OntologyPropertyGraphCompiler(
+    project_id="my-project",
+    dataset_id="agent_analytics",
+    spec=spec,
+)
+compiler.create_property_graph()
+```
+
+### CLI
+
+```bash
+# Run the full pipeline
+bq-agent-sdk ontology-build \
+    --project-id=my-project \
+    --dataset-id=agent_analytics \
+    --spec-path=ymgo_graph_spec.yaml \
+    --session-ids=adcp-033c95d7a97d,adcp-040c04837251 \
+    --env=my-project.agent_analytics
+
+# Generate a GQL showcase query
+bq-agent-sdk ontology-showcase-gql \
+    --project-id=my-project \
+    --dataset-id=agent_analytics \
+    --spec-path=ymgo_graph_spec.yaml \
+    --env=my-project.agent_analytics
+```
+
+---
+
+## Generated Property Graph DDL
+
+The SDK dynamically generates BigQuery `CREATE PROPERTY GRAPH` DDL from
+your YAML spec. For the Yahoo ADCP example above:
+
+```sql
+CREATE OR REPLACE PROPERTY GRAPH `my-project.agent_analytics.YMGO_Context_Graph_V3`
+  NODE TABLES (
+    `my-project.agent_analytics.decision_points` AS mako_DecisionPoint
+      KEY (decision_id, session_id)
+      LABEL mako_DecisionPoint
+      PROPERTIES (decision_id, decision_type, session_id, extracted_at),
+    `my-project.agent_analytics.yahoo_ad_units` AS sup_YahooAdUnit
+      KEY (adUnitId, session_id)
+      LABEL sup_YahooAdUnit
+      LABEL mako_Candidate
+      PROPERTIES (adUnitId, adUnitName, adUnitSize, adUnitPosition, session_id, extracted_at),
+    `my-project.agent_analytics.rejection_reasons` AS mako_RejectionReason
+      KEY (rejection_id, session_id)
+      LABEL mako_RejectionReason
+      PROPERTIES (rejection_id, rejectionType, rejectionRule, session_id, extracted_at)
+  )
+  EDGE TABLES (
+    `my-project.agent_analytics.candidate_edges` AS CandidateEdge
+      KEY (decision_id, adUnitId, session_id)
+      SOURCE KEY (decision_id, session_id) REFERENCES mako_DecisionPoint (decision_id, session_id)
+      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)
+      LABEL CandidateEdge
+      PROPERTIES (edge_type, mako_scoreValue, extracted_at),
+    `my-project.agent_analytics.rejection_mappings` AS ForCandidate
+      KEY (rejection_id, adUnitId, session_id)
+      SOURCE KEY (rejection_id, session_id) REFERENCES mako_RejectionReason (rejection_id, session_id)
+      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)
+      LABEL ForCandidate
+      PROPERTIES (extracted_at)
+  )
+```
+
+**Design notes:**
+
+- Node KEY includes `session_id` so the same business entity in different
+  sessions produces distinct graph nodes, making multi-session builds safe.
+- All KEY columns are also listed in PROPERTIES so they are queryable in GQL.
+- `extracted_at` is automatically added to every node and edge table.
+
+---
+
+## GQL Query Examples
+
+Once the Property Graph is created, you can traverse it with native GQL.
+
+### Forward traversal: DecisionPoint to Candidates
+
+```sql
+GRAPH `my-project.agent_analytics.YMGO_Context_Graph_V3`
+MATCH
+  (dp:mako_DecisionPoint)-[ce:CandidateEdge]->(ad:sup_YahooAdUnit)
+WHERE dp.session_id = @session_id
+RETURN
+  dp.decision_id,
+  dp.decision_type,
+  ce.edge_type,
+  ce.mako_scoreValue,
+  ad.adUnitId,
+  ad.adUnitName,
+  ad.adUnitSize,
+  ad.adUnitPosition
+ORDER BY dp.decision_id
+LIMIT 100
+```
+
+### Rejection audit: Why was this ad unit rejected?
+
+```sql
+GRAPH `my-project.agent_analytics.YMGO_Context_Graph_V3`
+MATCH
+  (rr:mako_RejectionReason)-[fc:ForCandidate]->(ad:sup_YahooAdUnit)
+WHERE ad.session_id = @session_id
+RETURN
+  ad.adUnitName,
+  rr.rejectionType,
+  rr.rejectionRule,
+  rr.extracted_at
+ORDER BY ad.adUnitName
+```
+
+### Full decision path: DecisionPoint to Candidate with Rejection Reasons
+
+```sql
+GRAPH `my-project.agent_analytics.YMGO_Context_Graph_V3`
+MATCH
+  (dp:mako_DecisionPoint)-[ce:CandidateEdge]->(ad:sup_YahooAdUnit),
+  (rr:mako_RejectionReason)-[fc:ForCandidate]->(ad)
+WHERE dp.session_id = @session_id
+  AND ce.edge_type = 'DROPPED_CANDIDATE'
+RETURN
+  dp.decision_id,
+  ad.adUnitName,
+  ce.mako_scoreValue AS candidate_score,
+  rr.rejectionType,
+  rr.rejectionRule
+```
+
+---
+
+## Adapting for Your Own Domain
+
+The pipeline is fully generic. To model your own business domain:
+
+1. **Define entities** — your domain objects (e.g., `Customer`, `Order`,
+   `Product`, `Campaign`, `AdCreative`).
+2. **Define relationships** — how they connect (e.g., `Placed` from
+   `Customer` to `Order`, `Contains` from `Order` to `Product`).
+3. **Set table bindings** — where each entity/relationship is stored.
+4. **Run the pipeline** — no code changes needed.
+
+### Minimal example: E-commerce Orders
+
+```yaml
+graph:
+  name: ecommerce_graph
+
+  entities:
+    - name: Customer
+      description: "A customer who places orders."
+      binding:
+        source: "{{ env }}.customers"
+      keys:
+        primary: [customer_id]
+      properties:
+        - name: customer_id
+          type: string
+        - name: customer_name
+          type: string
+
+    - name: Order
+      description: "A purchase order."
+      binding:
+        source: "{{ env }}.orders"
+      keys:
+        primary: [order_id]
+      properties:
+        - name: order_id
+          type: string
+        - name: total_amount
+          type: double
+
+  relationships:
+    - name: Placed
+      description: "Customer placed an order."
+      from_entity: Customer
+      to_entity: Order
+      binding:
+        source: "{{ env }}.placed_edges"
+        from_columns: [customer_id]
+        to_columns: [order_id]
+      properties:
+        - name: placed_at
+          type: string
+```
+
+```bash
+bq-agent-sdk ontology-build \
+    --spec-path=ecommerce_spec.yaml \
+    --session-ids=sess-1,sess-2 \
+    --project-id=my-project \
+    --dataset-id=analytics \
+    --env=my-project.analytics
+```
+
+---
+
+## SDK Module Reference
+
+| Module | Class / Function | Purpose |
+|--------|-----------------|---------|
+| `ontology_models` | `load_graph_spec()` | Parse YAML and resolve `{{ env }}` placeholders |
+| `ontology_schema_compiler` | `compile_extraction_prompt()`, `compile_output_schema()` | Generate AI extraction prompt and JSON schema from spec |
+| `ontology_graph` | `OntologyGraphManager` | Extract typed graph from agent telemetry via AI.GENERATE |
+| `ontology_materializer` | `OntologyMaterializer` | Create tables and route extracted data into them |
+| `ontology_property_graph` | `OntologyPropertyGraphCompiler`, `compile_property_graph_ddl()` | Generate and execute `CREATE PROPERTY GRAPH` DDL |
+| `ontology_orchestrator` | `build_ontology_graph()`, `compile_showcase_gql()` | One-shot pipeline and GQL query generation |
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **YAML over code** | Domain experts can define ontologies without writing Python. Spec changes don't require redeployment. |
+| **`{{ env }}` over Jinja2** | Simple string replacement keeps the spec portable without introducing a template engine dependency. |
+| **Label-only inheritance** | `extends` adds a graph label, not property/binding inheritance. This keeps resolution deterministic and avoids diamond inheritance complexity. |
+| **Session-scoped node identity** | Including `session_id` in every KEY means the same business entity in different sessions produces distinct nodes. This enables multi-session graph builds without collision. |
+| **Delete-then-insert idempotency** | Re-running the pipeline for the same sessions replaces previous data rather than duplicating it. |
+| **BigQuery-native extraction** | `AI.GENERATE` runs server-side in BigQuery, avoiding data transfer costs and keeping the pipeline SQL-native. |

--- a/docs/prd_unified_analytics_interface.md
+++ b/docs/prd_unified_analytics_interface.md
@@ -1,0 +1,2039 @@
+# PRD: Unified Analytics Interface for BigQuery Agent Analytics SDK
+
+**Status:** Draft
+**Issue:** [#22](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/issues/22)
+**Author:** SDK Product Team
+**Date:** 2026-03-06
+
+---
+
+## 1. Validation & Rationale
+
+### 1.1 Is This a Necessary Update?
+
+**Yes.** The SDK today is a Python-library-only toolkit with 16+ analytical
+capabilities (trace retrieval, evaluation, drift detection, insights, context
+graphs, etc.), but every one of them requires a user to write Python code and
+import the library. This creates three gaps:
+
+| Gap | Who is Affected | Why It Matters |
+|-----|----------------|----------------|
+| **SQL-native analytics** | Data analysts, BI engineers, Looker/Data Studio users | Cannot run `SELECT analyze(session_id) FROM traces` — must leave BigQuery to run Python |
+| **Agent self-diagnostics** | Autonomous AI agents (ADK, LangChain, CrewAI) | Agents cannot inspect their own performance without generating complex SQL; CLIs are the natural LLM tool interface |
+| **Automation & CI/CD** | Platform engineers, SRE teams | No scriptable CLI for cron-based eval runs, alerting pipelines, or `git bisect`-style regression checks |
+
+### 1.2 Current State
+
+```
+┌──────────────────────────────────────────────────┐
+│           BigQuery Agent Analytics SDK           │
+│                                                  │
+│  Client.get_trace()      Client.evaluate()       │
+│  Client.insights()       Client.drift_detection()│
+│  Client.doctor()         Client.deep_analysis()  │
+│  Client.hitl_metrics()   Client.context_graph()  │
+│  ViewManager             BigQueryTraceEvaluator   │
+│  TrialRunner             GraderPipeline           │
+│  EvalSuite               EvalValidator            │
+│  BigQueryMemoryService   BigQueryAIClient         │
+│                                                  │
+│  ACCESS: Python import ONLY                      │
+└──────────────────────────────────────────────────┘
+```
+
+### 1.3 Proposed State
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                          Shared Core (Python)                                │
+│     Client, evaluators, insights, feedback, trace, context_graph             │
+├───────────────┬────────────────────┬────────────────────┬────────────────────┤
+│ Python Lib    │ BQ Remote Function │ Continuous Query   │ CLI               │
+│ (existing)    │ (Path A — Batch)   │ (Path A' — Stream) │ (Path B — Agent)  │
+│               │                    │                    │                   │
+│ import Client │ SELECT fn(...)     │ APPENDS() +        │ $ bq-agent-sdk    │
+│ Notebooks     │ Scheduled queries  │ AI.GENERATE_TEXT   │   evaluate ...    │
+│ Python apps   │ Looker, dashboards │ → BQ / Pub/Sub /   │   insights ...    │
+│               │                    │   Bigtable / Spanner│                   │
+└───────────────┴────────────────────┴────────────────────┴────────────────────┘
+```
+
+### 1.4 MVP Scope
+
+**v1.0 = CLI with `evaluate`, `get-trace`, `doctor`, and `--exit-code`.**
+
+This is the smallest cut that unblocks all three personas. Remote Function
+(Path A) and Continuous Query (Path A') ship in v1.1/v1.2. See §8.1 for
+the full MVP definition, feature-to-version mapping, and rationale.
+
+---
+
+## 2. User Personas
+
+### Persona A: Priya — Data Analyst (Remote Function Path)
+
+- Works in BigQuery console and Looker daily
+- Comfortable with SQL, not with Python notebooks
+- Needs to build dashboards showing agent quality metrics
+- Wants to run evaluation and insights directly inside scheduled SQL queries
+
+### Persona B: AgentX — Autonomous AI Agent (CLI Path)
+
+- An ADK-based agent deployed in production
+- Has tool-calling capability (can invoke shell commands)
+- Needs to check its own latency, error rates, and drift before responding
+- Must minimize token overhead — CLI commands are cheaper than SQL generation
+
+### Persona C: Marcus — Platform Engineer (CLI Path)
+
+- Manages agent fleet in CI/CD pipelines
+- Needs nightly eval runs with pass/fail gates
+- Wants `bq-agent-sdk evaluate ... --exit-code` in GitHub Actions
+- Pipes output to monitoring systems (Datadog, PagerDuty)
+
+---
+
+## 3. Path A: BigQuery Remote Function Interface
+
+### 3.1 Overview
+
+Deploy the SDK's analytical logic as a Google Cloud Function (or Cloud Run
+service), register it as a BigQuery Remote Function, and let SQL users call
+SDK features directly from `SELECT` statements.
+
+### 3.2 Supported Operations
+
+All operations go through a single multiplexed function:
+`agent_analytics(operation STRING, params JSON) RETURNS JSON`
+
+| Operation | SDK Method | Params (JSON keys) | Output |
+|-----------|-----------|---------------------|--------|
+| `analyze` | `Client.get_session_trace()` + metrics | `session_id` | JSON with span count, error count, latency, tool calls |
+| `evaluate` | `CodeEvaluator` | `session_id`, `metric`, `threshold` | JSON with passed, score, details |
+| `judge` | `LLMAsJudge` | `session_id`, `criterion` | JSON with score, feedback |
+| `insights` | Facet extraction | `session_id` | JSON with intent, outcome, friction |
+| `drift` | Drift detection | `golden_dataset`, `agent_filter`, `start_date`, `end_date` | JSON with coverage, gaps |
+
+### 3.3 Critical User Journeys (CUJ)
+
+#### CUJ-A1: Priya Builds an Agent Quality Dashboard
+
+**Goal:** Create a Looker dashboard showing per-session quality scores
+updated nightly.
+
+**Journey:**
+
+```
+Step 1: Platform team deploys SDK as Cloud Function
+        $ gcloud functions deploy bq-agent-analytics \
+            --runtime python312 \
+            --entry-point handle_request \
+            --source ./deploy/remote_function/
+
+Step 2: Platform team registers a single multiplexed Remote Function
+        CREATE FUNCTION `project.analytics.agent_analytics`(
+          operation STRING,
+          params JSON
+        ) RETURNS JSON
+        REMOTE WITH CONNECTION `project.us.analytics-conn`
+        OPTIONS (
+          endpoint = 'https://us-central1-project.cloudfunctions.net/bq-agent-analytics'
+        );
+
+Step 3: Priya writes a scheduled query (no Python needed)
+        -- Nightly materialization of agent quality scores
+        CREATE OR REPLACE TABLE `project.analytics.daily_quality` AS
+        WITH recent AS (
+          SELECT DISTINCT session_id, MIN(timestamp) AS timestamp,
+                 ANY_VALUE(agent) AS agent
+          FROM `project.analytics.agent_events`
+          WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+          GROUP BY session_id
+        )
+        SELECT
+          session_id,
+          timestamp,
+          agent,
+          JSON_VALUE(result, '$.error_count') AS error_count,
+          CAST(JSON_VALUE(result, '$.avg_latency_ms') AS FLOAT64) AS avg_latency_ms,
+          JSON_VALUE(result, '$.tool_call_count') AS tool_calls
+        FROM recent,
+        UNNEST([
+          `project.analytics.agent_analytics`(
+            'analyze',
+            JSON_OBJECT('session_id', session_id)
+          )
+        ]) AS result;
+
+Step 4: Priya connects Looker to `daily_quality` table
+        → Dashboard shows latency trends, error rates, tool usage by agent
+```
+
+**End-to-End Example — Batch Evaluation via SQL:**
+
+```sql
+-- Evaluate all sessions from last 24h for latency compliance
+WITH recent_sessions AS (
+  SELECT DISTINCT session_id
+  FROM `myproject.analytics.agent_events`
+  WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+)
+SELECT
+  s.session_id,
+  JSON_VALUE(result, '$.passed') AS passed,
+  JSON_VALUE(result, '$.score') AS latency_score,
+  JSON_VALUE(result, '$.details') AS details
+FROM recent_sessions s,
+UNNEST([
+  `myproject.analytics.agent_analytics`(
+    'evaluate',
+    JSON_OBJECT(
+      'session_id', s.session_id,
+      'metric', 'latency',
+      'threshold', 5000
+    )
+  )
+]) AS result;
+```
+
+**Result:**
+
+| session_id | passed | latency_score | details |
+|-----------|--------|--------------|---------|
+| sess-001 | true | 0.85 | avg_latency_ms=2340, max=4200 |
+| sess-002 | false | 0.32 | avg_latency_ms=7800, max=12400 |
+| sess-003 | true | 0.91 | avg_latency_ms=1850, max=3100 |
+
+---
+
+#### CUJ-A2: Priya Runs LLM-as-Judge at Scale
+
+**Goal:** Score all sessions for correctness using AI, directly in SQL.
+
+```sql
+-- Judge correctness of every session from the "support_bot" agent
+SELECT
+  session_id,
+  CAST(JSON_VALUE(judgment, '$.score') AS FLOAT64) AS correctness_score,
+  JSON_VALUE(judgment, '$.passed') AS passed,
+  JSON_VALUE(judgment, '$.feedback') AS llm_feedback
+FROM (
+  SELECT DISTINCT session_id
+  FROM `myproject.analytics.agent_events`
+  WHERE agent = 'support_bot'
+    AND timestamp >= '2026-03-01'
+) sessions,
+UNNEST([
+  `myproject.analytics.agent_analytics`(
+    'judge',
+    JSON_OBJECT(
+      'session_id', sessions.session_id,
+      'criterion', 'correctness'
+    )
+  )
+]) AS judgment
+WHERE CAST(JSON_VALUE(judgment, '$.score') AS FLOAT64) < 0.7
+ORDER BY correctness_score ASC;
+```
+
+**Result:** Surfaces the lowest-quality sessions for human review — no Python
+required.
+
+---
+
+#### CUJ-A3: Priya Creates a Drift Alert
+
+**Goal:** Scheduled query that alerts when production questions drift from
+golden set.
+
+```sql
+-- Weekly drift check: compare production vs golden questions
+SELECT
+  JSON_VALUE(drift_result, '$.coverage_percentage') AS coverage_pct,
+  JSON_VALUE(drift_result, '$.total_golden') AS golden_count,
+  JSON_VALUE(drift_result, '$.total_production') AS prod_count,
+  JSON_QUERY(drift_result, '$.uncovered_questions') AS gaps
+FROM UNNEST([
+  `myproject.analytics.agent_analytics`(
+    'drift',
+    JSON_OBJECT(
+      'golden_dataset', 'myproject.analytics.golden_questions',
+      'agent_filter', 'support_bot',
+      'start_date', '2026-03-01',
+      'end_date', '2026-03-06'
+    )
+  )
+]) AS drift_result;
+```
+
+---
+
+### 3.4 Remote Function Technical Design
+
+> Reference:
+> [BigQuery Remote Functions](https://cloud.google.com/bigquery/docs/remote-functions)
+
+#### Prerequisites
+
+| Requirement | Detail |
+|-------------|--------|
+| **Connection** | A `CLOUD_RESOURCE` connection (`bq mk --connection --connection_type=CLOUD_RESOURCE`) |
+| **IAM — Creator** | `bigquery.routines.create` on dataset + `bigquery.connections.delegate` on connection |
+| **IAM — Invoker** | `bigquery.routines.get` on dataset + `bigquery.connections.use` on connection |
+| **Service account** | The connection's auto-created SA needs **Cloud Run Invoker** role on the Cloud Function / Cloud Run service |
+| **Return types** | `BOOL`, `BYTES`, `NUMERIC`, `STRING`, `DATE`, `DATETIME`, `TIME`, `TIMESTAMP`, `JSON`. **Not supported:** `ARRAY`, `STRUCT`, `INTERVAL`, `GEOGRAPHY` |
+
+#### Deployment Architecture
+
+```
+┌─────────────────┐     ┌──────────────────────┐     ┌─────────────┐
+│   BigQuery      │────▶│  Cloud Function /     │────▶│  BigQuery   │
+│   SELECT fn()   │     │  Cloud Run            │     │  (queries)  │
+│                 │◀────│  + SDK Core            │◀────│             │
+│   Returns JSON  │     │  handle_request()      │     │             │
+└─────────────────┘     └──────────────────────┘     └─────────────┘
+```
+
+#### Request/Response Contract
+
+BigQuery sends batched rows as HTTP POST requests. Each element in `calls`
+represents one row's arguments. BigQuery automatically determines batch
+size but respects the `max_batching_rows` limit. Retries happen on HTTP
+408, 429, 500, 503, 504. Results are never cached (assumed non-deterministic).
+
+**Request** (POST from BigQuery):
+```json
+{
+  "requestId": "124ab1c",
+  "caller": "//bigquery.googleapis.com/projects/myproject/jobs/bqjob_r1234_00001",
+  "sessionUser": "analyst@company.com",
+  "userDefinedContext": {
+    "project_id": "myproject",
+    "dataset_id": "analytics"
+  },
+  "calls": [
+    ["evaluate", "{\"session_id\":\"sess-001\",\"metric\":\"latency\",\"threshold\":5000}"],
+    ["evaluate", "{\"session_id\":\"sess-002\",\"metric\":\"latency\",\"threshold\":5000}"]
+  ]
+}
+```
+
+**Response** (HTTP 200):
+```json
+{
+  "replies": [
+    "{\"passed\": true, \"score\": 0.85, \"details\": \"avg=2340ms\"}",
+    "{\"passed\": false, \"score\": 0.32, \"details\": \"avg=7800ms\"}"
+  ]
+}
+```
+
+**Error response** (non-retryable 4xx):
+```json
+{
+  "errorMessage": "Unknown operation: foo (max 1KB)"
+}
+```
+
+#### API Versioning & Stability Contract
+
+The remote function response includes a `_version` field for forward
+compatibility. Clients should ignore unknown fields.
+
+```json
+{
+  "replies": [
+    "{\"_version\":\"1.0\",\"passed\":true,\"score\":0.85,\"details\":\"avg=2340ms\"}"
+  ]
+}
+```
+
+**Version guarantees:**
+- **v1.x:** Additive changes only (new fields, new operations). Existing
+  fields and operations are never removed or renamed.
+- **v2.0:** Breaking changes require a new Cloud Function endpoint and
+  new `CREATE FUNCTION` registration.
+
+#### Error Codes
+
+Every per-row error in `replies` uses a structured error object instead of
+a result:
+
+```json
+{
+  "replies": [
+    "{\"passed\":true,\"score\":0.85}",
+    "{\"_error\":{\"code\":\"SESSION_NOT_FOUND\",\"message\":\"No events for session sess-999\"}}"
+  ]
+}
+```
+
+| Error Code | HTTP | Retryable | Description |
+|-----------|------|-----------|-------------|
+| `INVALID_OPERATION` | 400 | No | Unknown operation string |
+| `INVALID_PARAMS` | 400 | No | Missing or malformed params JSON |
+| `SESSION_NOT_FOUND` | 200* | No | No events found for session_id |
+| `EVALUATION_FAILED` | 200* | No | Evaluator raised an exception |
+| `UPSTREAM_TIMEOUT` | 200* | Yes | BigQuery query timed out |
+| `INTERNAL_ERROR` | 200* | Yes | Unexpected SDK error |
+
+*\*Per-row errors return HTTP 200 with error in `replies[i]` so that
+other rows in the batch succeed. Batch-level errors (all rows fail)
+return HTTP 400 with top-level `errorMessage`.*
+
+#### Partial Failure Semantics
+
+BigQuery batches multiple rows into a single HTTP request. The function
+processes each row independently:
+
+- If row 2 of 5 fails, rows 1, 3, 4, 5 return valid results. Row 2
+  returns a `_error` object in its `replies` slot.
+- BigQuery surfaces the `_error` JSON as the column value — the caller
+  can filter with `JSON_VALUE(result, '$._error.code') IS NOT NULL`.
+- Only if **all** rows fail does the function return HTTP 400.
+
+#### Idempotency Guidance
+
+BigQuery may retry requests on transient errors (HTTP 408/429/5xx).
+The function should be safe to call multiple times with the same input:
+
+- `analyze` and `evaluate` are naturally idempotent (read-only queries).
+- `judge` calls AI.GENERATE which may return slightly different scores —
+  this is acceptable (non-deterministic by nature).
+- The `requestId` field can be used for deduplication if the function
+  performs any write operations in the future.
+
+#### CREATE FUNCTION DDL
+
+```sql
+-- 1. Create CLOUD_RESOURCE connection (one-time)
+--    Console: Explorer → +Add → External Connection → "Vertex AI remote models,
+--             remote functions, BigLake and Spanner"
+--    CLI:
+--    bq mk --connection --location=US --project_id=myproject \
+--           --connection_type=CLOUD_RESOURCE analytics-conn
+
+-- 2. Grant Cloud Run Invoker to the connection's service account
+--    (find the SA in connection details → IAM → add role)
+
+-- 3. Register the remote function
+CREATE FUNCTION `myproject.analytics.agent_analytics`(
+  operation STRING,
+  params JSON
+) RETURNS JSON
+REMOTE WITH CONNECTION `myproject.us.analytics-conn`
+OPTIONS (
+  endpoint = 'https://us-central1-myproject.cloudfunctions.net/bq-agent-analytics',
+  user_defined_context = [
+    ("project_id", "myproject"),
+    ("dataset_id", "analytics")
+  ],
+  max_batching_rows = 50
+);
+```
+
+#### Entry Point (`deploy/remote_function/main.py`)
+
+A single multiplexed Cloud Function handles all operations. BigQuery sends
+`(operation STRING, params JSON)` tuples; the function dispatches to the
+appropriate SDK method and returns JSON results.
+
+```python
+import functions_framework
+import json
+import os
+from flask import jsonify
+from bigquery_agent_analytics import Client, CodeEvaluator, LLMAsJudge, TraceFilter
+
+# Initialized once per cold start. Config comes from userDefinedContext
+# (forwarded by BigQuery) or environment variables as fallback.
+_client = None
+
+def _get_client(context: dict) -> Client:
+    global _client
+    if _client is None:
+        _client = Client(
+            project_id=context.get("project_id", os.environ["PROJECT_ID"]),
+            dataset_id=context.get("dataset_id", os.environ["DATASET_ID"]),
+        )
+    return _client
+
+@functions_framework.http
+def handle_request(request):
+    """Entry point called by BigQuery Remote Function framework.
+
+    BigQuery batches rows into `calls`. Each call is [operation, params_json].
+    The `replies` array must have the same length as `calls`.
+    """
+    try:
+        body = request.get_json()
+        context = body.get("userDefinedContext", {})
+        client = _get_client(context)
+        replies = []
+        for call in body["calls"]:
+            operation, params_raw = call[0], call[1]
+            params = json.loads(params_raw) if isinstance(params_raw, str) else params_raw
+            result = _dispatch(client, operation, params)
+            replies.append(json.dumps(result))
+        return jsonify({"replies": replies})
+    except Exception as e:
+        return jsonify({"errorMessage": str(e)[:1024]}), 400
+
+def _dispatch(client, operation, params):
+    if operation == "analyze":
+        trace = client.get_session_trace(params["session_id"])
+        return {
+            "span_count": len(trace.spans),
+            "error_count": len(trace.error_spans),
+            "avg_latency_ms": trace.total_latency_ms,
+            "tool_call_count": len(trace.tool_calls),
+            "final_response": trace.final_response,
+        }
+    elif operation == "evaluate":
+        evaluator = CodeEvaluator.latency(threshold_ms=params["threshold"])
+        report = client.evaluate(evaluator=evaluator,
+            filters=TraceFilter(session_ids=[params["session_id"]]))
+        return report.details[0] if report.details else {}
+    elif operation == "judge":
+        judge = getattr(LLMAsJudge, params["criterion"])()
+        report = client.evaluate(evaluator=judge,
+            filters=TraceFilter(session_ids=[params["session_id"]]))
+        return report.details[0] if report.details else {}
+    elif operation == "drift":
+        report = client.drift_detection(
+            golden_dataset=params["golden_dataset"],
+            filters=TraceFilter(
+                agent_id=params.get("agent_filter"),
+                start_time=params.get("start_date"),
+                end_time=params.get("end_date"),
+            ))
+        return report.model_dump()
+    else:
+        raise ValueError(f"Unknown operation: {operation}")
+```
+
+**Deploy:**
+```bash
+gcloud functions deploy bq-agent-analytics \
+    --gen2 \
+    --runtime python312 \
+    --region us-central1 \
+    --entry-point handle_request \
+    --source ./deploy/remote_function/ \
+    --trigger-http \
+    --no-allow-unauthenticated \
+    --set-env-vars PROJECT_ID=myproject,DATASET_ID=analytics
+```
+
+---
+
+## 3A. Path A-bis: Continuous Queries for Real-Time Analytics
+
+### 3A.1 Overview
+
+> Reference:
+> [BigQuery Continuous Queries](https://cloud.google.com/bigquery/docs/continuous-queries-introduction),
+> [Create Continuous Queries](https://cloud.google.com/bigquery/docs/continuous-queries)
+
+BigQuery **continuous queries** run SQL continuously against new data as it
+arrives, using the `APPENDS()` table function. They process each row as it
+is ingested and write results to BigQuery tables, Pub/Sub, Bigtable, or
+Spanner — enabling real-time, event-driven analytics over agent traces.
+
+#### Key Capabilities and Constraints
+
+| Aspect | Detail |
+|--------|--------|
+| **Trigger** | Automatically fires on new rows via `APPENDS(TABLE ..., start_timestamp)` |
+| **Destinations** | `INSERT INTO` (BigQuery table), `EXPORT DATA` (Pub/Sub, Bigtable, Spanner) |
+| **AI functions** | `AI.GENERATE_TEXT` and `ML.GENERATE_TEXT` — supported for remote models (Gemini, etc.). `AI.GENERATE_TABLE` — **not supported** in continuous queries. `ML.UNDERSTAND_TEXT`, `ML.TRANSLATE` — supported. See [supported AI functions in CQ](https://cloud.google.com/bigquery/docs/continuous-queries-introduction#supported_statements). |
+| **Remote functions** | **Not supported** — continuous queries cannot call user-defined remote functions (`CREATE FUNCTION ... REMOTE`) because remote functions are UDF routines, and CQ disallows all UDFs |
+| **SQL restrictions** | No `JOIN`, `GROUP BY`, `DISTINCT`, aggregates, window functions, `ORDER BY`, `LIMIT` |
+| **Execution** | `bq query --continuous=true` or API `"continuous": true` — not a DDL statement |
+| **Reservation** | Requires Enterprise / Enterprise Plus edition with `CONTINUOUS` job type assignment (max 500 slots) |
+| **Max runtime** | 2 days (user account), 150 days (service account) |
+| **Processing model** | Stateless per-row; no cross-row state. Idle queries consume ~1 slot |
+
+#### Why This Matters for the SDK
+
+The ADK plugin writes events to the `agent_events` table via the BigQuery
+Storage Write API. A continuous query can monitor this table in real-time
+and apply `AI.GENERATE_TEXT` — the same LLM evaluation engine the SDK
+uses — to score, classify, or flag every session as events arrive. **No
+Cloud Function deployment needed; pure SQL.**
+
+This creates a third analytics path:
+
+```
+Path A:  Remote Function   → batch SQL analytics via Cloud Function
+Path A': Continuous Query   → real-time streaming analytics via AI.GENERATE_TEXT
+Path B:  CLI               → agent self-diagnostics and CI/CD
+```
+
+### 3A.2 Critical User Journeys (CUJ)
+
+#### CUJ-A4: Priya Builds Real-Time Error Alerting with Continuous Query + AI.GENERATE_TEXT
+
+**Goal:** Every time an agent session ends with an error, automatically
+classify the failure root cause using Gemini and push an alert to Pub/Sub
+(which routes to Slack/PagerDuty). No Cloud Function, no cron — pure
+streaming SQL.
+
+**Architecture:**
+
+```
+┌──────────────┐    ┌─────────────────────────┐    ┌────────────────┐
+│  ADK Plugin  │───▶│  agent_events table      │───▶│  Continuous    │
+│  (writes     │    │  (BigQuery)              │    │  Query + AI.   │
+│   events)    │    │                          │    │  GENERATE_TEXT │
+└──────────────┘    └─────────────────────────┘    └──────┬─────────┘
+                                                          │
+                                          ┌───────────────┼───────────────┐
+                                          ▼               ▼               ▼
+                                   ┌────────────┐ ┌────────────┐ ┌──────────────┐
+                                   │ error_      │ │ Pub/Sub    │ │ Bigtable     │
+                                   │ analysis    │ │ (→ Slack)  │ │ (low-latency │
+                                   │ table       │ │            │ │  dashboard)  │
+                                   └────────────┘ └────────────┘ └──────────────┘
+```
+
+**Step 1: Create the AI model endpoint for evaluation**
+
+```sql
+-- Create a remote model pointing to Gemini (one-time setup)
+CREATE OR REPLACE MODEL `myproject.analytics.gemini_flash`
+REMOTE WITH CONNECTION `myproject.us.analytics-conn`
+OPTIONS (
+  endpoint = 'gemini-2.5-flash'
+);
+```
+
+**Step 2: Create destination table for analysis results**
+
+```sql
+CREATE TABLE IF NOT EXISTS `myproject.analytics.realtime_error_analysis` (
+  session_id STRING,
+  agent STRING,
+  event_type STRING,
+  error_message STRING,
+  timestamp TIMESTAMP,
+  root_cause STRING,
+  severity STRING,
+  suggested_fix STRING,
+  analyzed_at TIMESTAMP
+);
+```
+
+**Step 3: Launch continuous query (real-time error analysis)**
+
+```bash
+bq query --project_id=myproject --use_legacy_sql=false \
+  --continuous=true \
+  --connection_property=service_account=analytics-cq@myproject.iam.gserviceaccount.com \
+  '
+INSERT INTO `myproject.analytics.realtime_error_analysis`
+SELECT
+  base.session_id,
+  base.agent,
+  base.event_type,
+  base.error_message,
+  base.timestamp,
+  JSON_VALUE(analysis.ml_generate_text_llm_result, "$.root_cause") AS root_cause,
+  JSON_VALUE(analysis.ml_generate_text_llm_result, "$.severity") AS severity,
+  JSON_VALUE(analysis.ml_generate_text_llm_result, "$.suggested_fix") AS suggested_fix,
+  CURRENT_TIMESTAMP() AS analyzed_at
+FROM
+  AI.GENERATE_TEXT(
+    MODEL `myproject.analytics.gemini_flash`,
+    (
+      SELECT
+        session_id,
+        agent,
+        event_type,
+        error_message,
+        timestamp,
+        CONCAT(
+          "Analyze this agent error and return JSON with keys: ",
+          "root_cause (one of: tool_timeout, invalid_input, api_failure, ",
+          "model_error, permission_denied, rate_limit, unknown), ",
+          "severity (critical, high, medium, low), ",
+          "suggested_fix (one sentence). ",
+          "Agent: ", COALESCE(agent, "unknown"),
+          " | Event: ", event_type,
+          " | Error: ", COALESCE(error_message, "no message")
+        ) AS prompt
+      FROM
+        APPENDS(
+          TABLE `myproject.analytics.agent_events`,
+          CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE
+        )
+      WHERE
+        ENDS_WITH(event_type, "_ERROR")
+        OR error_message IS NOT NULL
+        OR status = "ERROR"
+    ),
+    STRUCT(100 AS max_output_tokens, 0.1 AS temperature)
+  ) AS analysis
+'
+```
+
+**What happens at runtime:**
+
+```
+14:00:01  Plugin writes TOOL_ERROR for sess-042
+14:00:02  Continuous query detects new error row via APPENDS()
+14:00:03  AI.GENERATE_TEXT classifies: root_cause=tool_timeout, severity=high
+14:00:03  Result inserted into realtime_error_analysis table
+          → Looker dashboard updates in real-time
+          → (Optional) Second continuous query exports to Pub/Sub → Slack
+```
+
+**Step 4 (Optional): Chain a second continuous query to Pub/Sub for alerts**
+
+```bash
+bq query --project_id=myproject --use_legacy_sql=false \
+  --continuous=true \
+  --connection_property=service_account=analytics-cq@myproject.iam.gserviceaccount.com \
+  '
+EXPORT DATA
+  OPTIONS (
+    format = "CLOUD_PUBSUB",
+    uri = "https://pubsub.googleapis.com/projects/myproject/topics/agent-error-alerts"
+  )
+AS (
+  SELECT
+    TO_JSON_STRING(
+      STRUCT(
+        session_id,
+        agent,
+        root_cause,
+        severity,
+        error_message,
+        suggested_fix
+      )
+    ) AS message,
+    TO_JSON(
+      STRUCT(
+        severity AS severity,
+        agent AS agent
+      )
+    ) AS _ATTRIBUTES
+  FROM
+    APPENDS(
+      TABLE `myproject.analytics.realtime_error_analysis`,
+      CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE
+    )
+  WHERE severity IN ("critical", "high")
+)
+'
+```
+
+**End-to-end result:** Every high-severity agent error is automatically
+analyzed by Gemini within seconds of occurrence, stored in a queryable
+table, and routed to Slack/PagerDuty via Pub/Sub — all with zero
+application code.
+
+---
+
+#### CUJ-A5: Priya Streams Session Quality Scores to Bigtable for Low-Latency Dashboards
+
+**Goal:** Score every completed agent session in real-time and write results
+to Bigtable for sub-millisecond dashboard reads.
+
+```bash
+bq query --project_id=myproject --use_legacy_sql=false \
+  --continuous=true \
+  --connection_property=service_account=analytics-cq@myproject.iam.gserviceaccount.com \
+  '
+EXPORT DATA
+  OPTIONS (
+    format = "CLOUD_BIGTABLE",
+    overwrite = TRUE,
+    uri = "https://bigtable.googleapis.com/projects/myproject/instances/agent-metrics/tables/session-scores"
+  )
+AS (
+  SELECT
+    CONCAT(base.session_id, "#", CAST(base.timestamp AS STRING)) AS rowkey,
+    STRUCT(
+      base.session_id,
+      base.agent,
+      base.timestamp,
+      JSON_VALUE(analysis.ml_generate_text_llm_result, "$.quality_score") AS quality_score,
+      JSON_VALUE(analysis.ml_generate_text_llm_result, "$.outcome") AS outcome,
+      JSON_VALUE(analysis.ml_generate_text_llm_result, "$.summary") AS summary
+    ) AS metrics
+  FROM
+    AI.GENERATE_TEXT(
+      MODEL `myproject.analytics.gemini_flash`,
+      (
+        SELECT
+          session_id,
+          agent,
+          timestamp,
+          CONCAT(
+            "Score this completed agent session. Return JSON with: ",
+            "quality_score (0.0-1.0), outcome (success/partial/failure), ",
+            "summary (one sentence). ",
+            "Agent: ", COALESCE(agent, "unknown"),
+            " | Response: ", COALESCE(
+              JSON_VALUE(content, "$.response"),
+              JSON_VALUE(content, "$.text_summary"),
+              "no response"
+            )
+          ) AS prompt
+        FROM
+          APPENDS(
+            TABLE `myproject.analytics.agent_events`,
+            CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE
+          )
+        WHERE event_type = "AGENT_COMPLETED"
+      ),
+      STRUCT(80 AS max_output_tokens, 0.1 AS temperature)
+    ) AS analysis
+)
+'
+```
+
+### 3A.3 When to Use Which Path
+
+| Scenario | Path | Why |
+|----------|------|-----|
+| Nightly batch evaluation of all sessions | **Remote Function** (Path A) | Needs JOINs, GROUP BY, aggregation — not supported in continuous queries |
+| Real-time error classification as events arrive | **Continuous Query** (Path A') | Stateless per-row processing; AI.GENERATE_TEXT on each error; no deployment needed |
+| Dashboard with sub-second latency | **Continuous Query → Bigtable** | EXPORT DATA to Bigtable for low-latency reads |
+| Alert on critical errors via Slack/PagerDuty | **Continuous Query → Pub/Sub** | EXPORT DATA to Pub/Sub with severity-based attributes |
+| Agent self-diagnostic before responding | **CLI** (Path B) | Agent calls `bq-agent-sdk evaluate` as a tool |
+| CI/CD gate blocking deployment | **CLI** (Path B) | `--exit-code` in GitHub Actions |
+| Ad-hoc drift analysis comparing golden set | **Remote Function** (Path A) | Needs cross-table comparison (JOIN with golden set) |
+| Semantic session clustering | **Remote Function** (Path A) | Needs aggregation and embedding distance (GROUP BY) |
+
+---
+
+## 4. Path B: CLI Interface (`bq-agent-sdk`)
+
+### 4.1 Overview
+
+A command-line tool that wraps the SDK's Python API, designed for two primary
+consumers:
+
+1. **AI agents** that invoke CLI commands as tools (low token overhead)
+2. **Platform engineers** who script evaluation pipelines
+
+#### 4.1.1 Why CLI Instead of MCP for Agent Tool Integration
+
+Recent research and community benchmarks demonstrate that CLI tools
+significantly outperform MCP (Model Context Protocol) servers when used as
+AI agent tools. The `bq-agent-sdk` CLI is designed with these findings in mind.
+
+**Token Efficiency: 35x Reduction**
+
+| Approach | Context Tokens | Notes |
+|----------|---------------|-------|
+| MCP server schema (single service) | ~55,000 | Full tool definitions loaded at session start |
+| MCP server schema (3 services stacked) | ~150,000+ | Each server adds its full schema |
+| CLI command (`bq-agent-sdk evaluate --help`) | ~4,150 | Loaded just-in-time, only when needed |
+| CLI manifest (all commands summarized) | ~100 | One-line descriptions; agent drills into `--help` on demand |
+
+A community benchmark measured a **Token Efficiency Score of 202 for CLI vs
+152 for MCP** on identical tasks, with CLI achieving **28% higher task
+completion rate**. MCP schema pre-loading consumed up to **40% of the
+available context window** before any actual work began.
+
+**LLMs Are CLI-Native**
+
+Large language models are trained on billions of terminal interactions from
+public code repositories, documentation, and Stack Overflow. Commands like
+`git`, `curl`, `jq`, `kubectl`, and `gcloud` are deeply embedded in their
+training data. When an agent sees `bq-agent-sdk evaluate --evaluator=latency
+--threshold=5000 --format=json`, it can infer behavior from structural
+similarity to tools it has seen millions of times — no schema pre-loading
+required.
+
+**Unix Composability**
+
+CLI tools compose naturally via pipes and shell scripting, enabling workflows
+that are difficult or impossible with MCP:
+
+```bash
+# Evaluate → filter failures → alert (three tools, zero MCP schemas)
+bq-agent-sdk evaluate --last=1h --format=json \
+  | jq '.failed_sessions[]' \
+  | xargs -I{} bq-agent-sdk get-trace --session-id={} --format=json \
+  | jq '{session: .session_id, errors: .errors}' \
+  | curl -X POST "$SLACK_WEBHOOK" -d @-
+```
+
+**When MCP Is Still Appropriate**
+
+MCP remains valuable for: (a) structured validation where type-safe schemas
+prevent malformed requests, (b) multi-tenant environments with dynamic tool
+discovery, (c) services without CLI equivalents (e.g., browser automation,
+GUI testing), and (d) tool discovery in large catalogs. For the SDK's
+well-defined analytics operations, CLI is the simpler and more efficient path.
+
+#### 4.1.2 CLI Design Principles for Agent Consumption
+
+The `bq-agent-sdk` CLI follows five principles that maximize its effectiveness
+as an AI agent tool:
+
+1. **Structured JSON output by default** — `--format=json` is the default.
+   Every command returns a parseable JSON object. Agents never need to parse
+   free-form text.
+
+2. **Just-in-time `--help`** — Instead of pre-loading a 55K-token schema,
+   agents call `bq-agent-sdk --help` (~100 tokens) to discover commands, then
+   `bq-agent-sdk evaluate --help` (~200 tokens) to learn a specific command's
+   options. Total context cost: ~300 tokens vs ~55,000 for MCP.
+
+3. **Lightweight manifest** — A one-line-per-command manifest can be embedded
+   in an agent's system prompt at ~100 tokens total:
+   ```
+   bq-agent-sdk doctor    — health check
+   bq-agent-sdk evaluate  — run evaluations (latency, errors, LLM judge)
+   bq-agent-sdk get-trace — retrieve session trace
+   bq-agent-sdk drift     — drift detection against golden set
+   bq-agent-sdk insights  — generate analytics report
+   bq-agent-sdk views     — manage BigQuery views
+   ```
+
+4. **Machine-friendly exit codes** — `--exit-code` returns 0/1 for pass/fail,
+   enabling direct use in conditionals (`if bq-agent-sdk evaluate ...;
+   then ...`).
+
+5. **Environment variable fallbacks** — Global options like `--project-id` and
+   `--dataset-id` can be set via `BQ_AGENT_PROJECT` and `BQ_AGENT_DATASET`,
+   reducing per-invocation token cost for agents that call the CLI repeatedly.
+
+### 4.2 Command Structure
+
+```
+bq-agent-sdk [GLOBAL OPTIONS] <command> [COMMAND OPTIONS]
+
+Global Options:
+  --project-id TEXT       GCP project ID [env: BQ_AGENT_PROJECT]
+  --dataset-id TEXT       BigQuery dataset [env: BQ_AGENT_DATASET]
+  --table-id TEXT         Events table [default: agent_events]
+  --location TEXT         BQ location [default: us-central1]
+  --endpoint TEXT         AI.GENERATE endpoint
+  --connection-id TEXT    BQ connection ID
+  --format TEXT           Output format: json|text|table [default: json]
+  --quiet                 Suppress non-essential output
+
+Commands:
+  doctor                  Run diagnostic health check
+  get-trace               Retrieve and render a trace
+  list-traces             List recent traces with filters
+  evaluate                Run code-based or LLM evaluation
+  insights                Generate insights report
+  drift                   Run drift detection against golden set
+  distribution            Analyze question distribution
+  hitl-metrics            Show HITL interaction metrics
+  views                   Manage per-event-type BigQuery views
+```
+
+### 4.3 Critical User Journeys (CUJ)
+
+#### CUJ-B1: AgentX Checks Its Own Latency Before Responding
+
+**Context:** An ADK agent has a `before_agent_callback` that shells out to
+the CLI to check recent performance. If latency is high, it adjusts its
+strategy (e.g., skips expensive tool calls).
+
+**Agent's Tool Definition (ADK tool-calling schema):**
+```json
+{
+  "name": "check_agent_performance",
+  "description": "Check this agent's recent latency and error rate",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "session_count": {"type": "integer", "default": 10},
+      "metric": {"type": "string", "enum": ["latency", "error_rate", "all"]}
+    }
+  }
+}
+```
+
+**Agent Invocation (what the LLM generates):**
+```bash
+bq-agent-sdk evaluate \
+  --project-id=myproject \
+  --dataset-id=analytics \
+  --agent-id=support_bot \
+  --last=1h \
+  --evaluator=latency \
+  --threshold=5000 \
+  --format=json
+```
+
+**CLI Output (consumed by the agent):**
+```json
+{
+  "evaluator": "latency",
+  "threshold_ms": 5000,
+  "total_sessions": 10,
+  "passed": 7,
+  "failed": 3,
+  "pass_rate": 0.70,
+  "aggregate_scores": {
+    "avg_latency_ms": 3200,
+    "max_latency_ms": 8400,
+    "p95_latency_ms": 6100
+  },
+  "failed_sessions": ["sess-042", "sess-047", "sess-051"]
+}
+```
+
+**Agent's Decision Logic:**
+```
+IF pass_rate < 0.8:
+    → Switch to lighter model (gemini-flash instead of gemini-pro)
+    → Skip optional enrichment tool calls
+    → Add disclaimer: "Response may be less detailed due to system load"
+```
+
+**End-to-End Flow:**
+```
+User → "What's the refund policy for order #1234?"
+       │
+       ▼
+AgentX (before responding):
+  1. Calls: bq-agent-sdk evaluate --agent-id=support_bot --last=1h --evaluator=latency --threshold=5000
+  2. Sees: pass_rate=0.70, avg_latency=3200ms
+  3. Decides: latency is borderline, use lighter model
+  4. Calls: bq-agent-sdk evaluate --agent-id=support_bot --last=1h --evaluator=error_rate --threshold=0.1
+  5. Sees: pass_rate=0.95, error_rate=0.05
+  6. Decides: errors are fine, proceed normally
+       │
+       ▼
+AgentX → "The refund policy for order #1234 is..."
+```
+
+---
+
+#### CUJ-B2: AgentX Retrieves a Past Session for Context
+
+**Context:** A user returns and references a previous conversation. The agent
+retrieves the old session trace to understand context.
+
+**Agent Invocation:**
+```bash
+bq-agent-sdk get-trace \
+  --project-id=myproject \
+  --dataset-id=analytics \
+  --session-id=sess-previous-abc \
+  --format=json \
+  --quiet
+```
+
+**CLI Output:**
+```json
+{
+  "trace_id": "trace-abc-123",
+  "session_id": "sess-previous-abc",
+  "user_id": "user-42",
+  "total_latency_ms": 4500,
+  "span_count": 12,
+  "tool_calls": [
+    {"tool_name": "lookup_order", "args": {"order_id": "1234"}, "status": "OK"},
+    {"tool_name": "check_refund_eligibility", "args": {"order_id": "1234"}, "status": "OK"}
+  ],
+  "final_response": "Your order #1234 is eligible for a full refund...",
+  "errors": []
+}
+```
+
+**Agent uses this context:** "I can see from your previous conversation that
+we confirmed order #1234 is eligible for a refund. Let me process that now."
+
+---
+
+#### CUJ-B3: Marcus Runs Nightly Eval in CI/CD
+
+**Goal:** GitHub Actions workflow that gates deployment on evaluation pass rate.
+
+**`.github/workflows/nightly-eval.yml`:**
+```yaml
+name: Nightly Agent Evaluation
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 2 AM daily
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install SDK
+        run: pip install bigquery-agent-analytics-sdk[cli]
+
+      - name: Run latency evaluation
+        run: |
+          bq-agent-sdk evaluate \
+            --project-id=${{ vars.GCP_PROJECT }} \
+            --dataset-id=analytics \
+            --agent-id=support_bot \
+            --last=24h \
+            --evaluator=latency \
+            --threshold=5000 \
+            --format=json \
+            --exit-code \
+          > eval_latency.json
+
+      - name: Run error rate evaluation
+        run: |
+          bq-agent-sdk evaluate \
+            --project-id=${{ vars.GCP_PROJECT }} \
+            --dataset-id=analytics \
+            --agent-id=support_bot \
+            --last=24h \
+            --evaluator=error_rate \
+            --threshold=0.05 \
+            --format=json \
+            --exit-code \
+          > eval_errors.json
+
+      - name: Run correctness judge
+        run: |
+          bq-agent-sdk evaluate \
+            --project-id=${{ vars.GCP_PROJECT }} \
+            --dataset-id=analytics \
+            --agent-id=support_bot \
+            --last=24h \
+            --evaluator=llm-judge \
+            --criterion=correctness \
+            --threshold=0.7 \
+            --format=json \
+            --exit-code \
+          > eval_correctness.json
+
+      - name: Run drift detection
+        run: |
+          bq-agent-sdk drift \
+            --project-id=${{ vars.GCP_PROJECT }} \
+            --dataset-id=analytics \
+            --golden-dataset=golden_questions \
+            --agent-id=support_bot \
+            --last=24h \
+            --min-coverage=0.85 \
+            --exit-code \
+          > drift_report.json
+
+      - name: Generate insights summary
+        if: always()
+        run: |
+          bq-agent-sdk insights \
+            --project-id=${{ vars.GCP_PROJECT }} \
+            --dataset-id=analytics \
+            --agent-id=support_bot \
+            --last=24h \
+            --max-sessions=50 \
+            --format=text \
+          > insights_summary.txt
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-reports
+          path: |
+            eval_*.json
+            drift_report.json
+            insights_summary.txt
+```
+
+**Key behavior:** `--exit-code` makes the command return exit code 1 when
+evaluation fails, causing the CI step to fail and blocking deployment.
+
+---
+
+#### CUJ-B4: Marcus Pipes CLI Output to Monitoring
+
+**Goal:** Feed evaluation results into Slack alerts and Datadog metrics.
+
+```bash
+#!/bin/bash
+# cron-eval.sh — runs every hour
+
+RESULT=$(bq-agent-sdk evaluate \
+  --project-id=myproject \
+  --dataset-id=analytics \
+  --agent-id=support_bot \
+  --last=1h \
+  --evaluator=latency \
+  --threshold=5000 \
+  --format=json)
+
+PASS_RATE=$(echo "$RESULT" | jq -r '.pass_rate')
+AVG_LATENCY=$(echo "$RESULT" | jq -r '.aggregate_scores.avg_latency_ms')
+
+# Send to Datadog
+curl -X POST "https://api.datadoghq.com/api/v1/series" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -d "{
+    \"series\": [{
+      \"metric\": \"agent.latency.pass_rate\",
+      \"points\": [[$(date +%s), $PASS_RATE]],
+      \"tags\": [\"agent:support_bot\"]
+    }, {
+      \"metric\": \"agent.latency.avg_ms\",
+      \"points\": [[$(date +%s), $AVG_LATENCY]],
+      \"tags\": [\"agent:support_bot\"]
+    }]
+  }"
+
+# Alert Slack if pass rate drops
+if (( $(echo "$PASS_RATE < 0.8" | bc -l) )); then
+  curl -X POST "$SLACK_WEBHOOK" \
+    -d "{\"text\": \"⚠️ Agent latency pass rate dropped to ${PASS_RATE} (threshold: 0.80). Avg: ${AVG_LATENCY}ms\"}"
+fi
+```
+
+---
+
+#### CUJ-B5: AgentX Performs Self-Correction Loop
+
+**Context:** An agent notices repeated errors in a session and uses the CLI
+to diagnose and adapt in real-time.
+
+**Conversation Flow:**
+```
+Turn 1: User asks complex multi-step question
+Turn 2: Agent calls tool → TOOL_ERROR
+Turn 3: Agent calls tool again → TOOL_ERROR
+Turn 4: Agent invokes self-diagnostic:
+
+  $ bq-agent-sdk get-trace \
+      --project-id=myproject \
+      --dataset-id=analytics \
+      --session-id=current-session-456 \
+      --format=json \
+      --quiet
+
+  Output:
+  {
+    "errors": [
+      {"event_type": "TOOL_ERROR", "tool": "database_query",
+       "error_message": "Connection timeout after 30s"},
+      {"event_type": "TOOL_ERROR", "tool": "database_query",
+       "error_message": "Connection timeout after 30s"}
+    ],
+    "error_count": 2,
+    "tool_calls": [
+      {"tool_name": "database_query", "status": "ERROR"},
+      {"tool_name": "database_query", "status": "ERROR"}
+    ]
+  }
+
+Turn 5: Agent recognizes "database_query" tool is timing out
+         → Switches to cached data source
+         → Tells user: "I'm experiencing delays with the live database.
+           Let me check the cached data instead."
+
+Turn 6: Agent calls fallback tool → success → responds with answer
+```
+
+---
+
+#### CUJ-B6: Marcus Runs Doctor Check Before Deployment
+
+**Goal:** Validate SDK configuration and table health before deploying a new
+agent version.
+
+```bash
+$ bq-agent-sdk doctor \
+    --project-id=myproject \
+    --dataset-id=analytics \
+    --format=text
+
+╔══════════════════════════════════════════════════╗
+║         Agent Analytics Health Check             ║
+╠══════════════════════════════════════════════════╣
+║ Table: myproject.analytics.agent_events          ║
+║ Schema: ✓ OK (16/16 required columns present)   ║
+║                                                  ║
+║ Event Coverage (last 24h):                       ║
+║   USER_MESSAGE_RECEIVED    1,234                 ║
+║   LLM_REQUEST              2,456                 ║
+║   LLM_RESPONSE             2,450                 ║
+║   TOOL_STARTING              890                 ║
+║   TOOL_COMPLETED             875                 ║
+║   TOOL_ERROR                  15                 ║
+║   AGENT_STARTING             620                 ║
+║   AGENT_COMPLETED            618                 ║
+║   HITL_CONFIRMATION_REQ       42                 ║
+║   STATE_DELTA                310                 ║
+║                                                  ║
+║ AI.GENERATE_TEXT: ✓ (gemini-2.5-flash)            ║
+║ Connection:  ✓ us-central1.analytics-conn        ║
+║                                                  ║
+║ Warnings:                                        ║
+║   ⚠ 2 AGENT_STARTING events without matching    ║
+║     AGENT_COMPLETED (possible timeout)           ║
+║   ⚠ TOOL_ERROR rate: 1.7% (15/890)              ║
+╚══════════════════════════════════════════════════╝
+```
+
+---
+
+#### CUJ-B7: Marcus Creates BigQuery Views via CLI
+
+```bash
+# Create all per-event-type views
+$ bq-agent-sdk views create-all \
+    --project-id=myproject \
+    --dataset-id=analytics \
+    --prefix=adk_
+
+Created 18 views:
+  ✓ adk_llm_requests
+  ✓ adk_llm_responses
+  ✓ adk_llm_errors
+  ✓ adk_tool_starts
+  ✓ adk_tool_completions
+  ✓ adk_tool_errors
+  ✓ adk_user_messages
+  ✓ adk_agent_starts
+  ✓ adk_agent_completions
+  ✓ adk_invocation_starts
+  ✓ adk_invocation_completions
+  ✓ adk_state_deltas
+  ✓ adk_hitl_credential_requests
+  ✓ adk_hitl_confirmation_requests
+  ✓ adk_hitl_input_requests
+  ✓ adk_hitl_credential_completions
+  ✓ adk_hitl_confirmation_completions
+  ✓ adk_hitl_input_completions
+
+# Create a single view
+$ bq-agent-sdk views create LLM_RESPONSE \
+    --project-id=myproject \
+    --dataset-id=analytics
+```
+
+---
+
+### 4.4 CLI Command Reference (Detailed)
+
+#### `bq-agent-sdk get-trace`
+
+```
+Usage: bq-agent-sdk get-trace [OPTIONS]
+
+  Retrieve and display a single trace or session.
+
+Options:
+  --trace-id TEXT       Retrieve by trace ID
+  --session-id TEXT     Retrieve by session ID
+  --render              Print hierarchical DAG tree [default: false]
+  --format TEXT         json | text | tree [default: json]
+```
+
+**Examples:**
+```bash
+# JSON output for agent consumption
+bq-agent-sdk get-trace --session-id=sess-001 --format=json
+
+# Tree rendering for human debugging
+bq-agent-sdk get-trace --trace-id=trace-abc --render --format=tree
+```
+
+---
+
+#### `bq-agent-sdk list-traces`
+
+```
+Usage: bq-agent-sdk list-traces [OPTIONS]
+
+  List recent traces matching filter criteria.
+
+Options:
+  --agent-id TEXT       Filter by agent name
+  --user-id TEXT        Filter by user ID
+  --session-ids TEXT    Comma-separated session IDs
+  --last TEXT           Time window: 1h, 24h, 7d, 30d
+  --start-time TEXT     ISO8601 start time
+  --end-time TEXT       ISO8601 end time
+  --has-error           Only sessions with errors
+  --no-error            Only sessions without errors
+  --min-latency INT     Minimum latency (ms)
+  --max-latency INT     Maximum latency (ms)
+  --event-types TEXT    Comma-separated event types
+  --limit INT           Max traces [default: 20]
+  --format TEXT         json | text | table [default: json]
+```
+
+**Example:**
+```bash
+# List error sessions from last hour
+bq-agent-sdk list-traces \
+  --agent-id=support_bot \
+  --last=1h \
+  --has-error \
+  --format=table
+
+SESSION_ID        SPANS  ERRORS  LATENCY_MS  STARTED_AT
+sess-042          15     2       8400        2026-03-06T14:23:00Z
+sess-047          8      1       6100        2026-03-06T14:45:00Z
+sess-051          22     3       12400       2026-03-06T15:02:00Z
+```
+
+---
+
+#### `bq-agent-sdk evaluate`
+
+```
+Usage: bq-agent-sdk evaluate [OPTIONS]
+
+  Run code-based or LLM evaluation over traces.
+
+Options:
+  --evaluator TEXT      Evaluator type:
+                          latency, error_rate, turn_count,
+                          token_efficiency, cost,
+                          llm-judge
+  --threshold FLOAT     Pass/fail threshold
+  --criterion TEXT      LLM judge criterion:
+                          correctness, hallucination,
+                          sentiment, custom
+  --custom-prompt TEXT  Custom LLM judge prompt (with --criterion=custom)
+  --agent-id TEXT       Filter by agent
+  --last TEXT           Time window
+  --start-time TEXT     ISO8601 start
+  --end-time TEXT       ISO8601 end
+  --limit INT           Max sessions [default: 100]
+  --exit-code           Return exit code 1 on failure
+  --format TEXT         json | text [default: json]
+```
+
+**Examples:**
+```bash
+# Code-based latency check (agent tool call)
+bq-agent-sdk evaluate --evaluator=latency --threshold=5000 --agent-id=bot --last=1h
+
+# LLM correctness judge (CI pipeline)
+bq-agent-sdk evaluate --evaluator=llm-judge --criterion=correctness \
+  --threshold=0.7 --last=24h --exit-code
+
+# Custom LLM judge with user-defined prompt
+bq-agent-sdk evaluate --evaluator=llm-judge --criterion=custom \
+  --custom-prompt="Rate how well the agent handled PII. Score 0-1." \
+  --threshold=0.9 --last=24h
+```
+
+---
+
+#### `bq-agent-sdk insights`
+
+```
+Usage: bq-agent-sdk insights [OPTIONS]
+
+  Generate comprehensive agent insights report.
+
+Options:
+  --agent-id TEXT       Filter by agent
+  --last TEXT           Time window
+  --max-sessions INT    Max sessions to analyze [default: 50]
+  --format TEXT         json | text [default: json]
+```
+
+**Example:**
+```bash
+bq-agent-sdk insights --agent-id=support_bot --last=24h --format=text
+
+══════════════════════════════════════════════════
+          Agent Insights — support_bot
+══════════════════════════════════════════════════
+Sessions analyzed: 48 / 1,234 total
+
+Goal Distribution:
+  question_answering    62%  (30 sessions)
+  task_automation       25%  (12 sessions)
+  data_retrieval        13%  (6 sessions)
+
+Outcome Distribution:
+  success               78%
+  partial_success       12%
+  failure                8%
+  abandoned              2%
+
+Top Friction Points:
+  1. high_latency         15 sessions (31%)
+  2. too_many_tool_calls   8 sessions (17%)
+  3. repetitive_responses  4 sessions  (8%)
+
+Executive Summary:
+  The support_bot agent shows strong overall performance
+  with 78% success rate. Primary area for improvement is
+  latency — 31% of sessions experienced high latency,
+  particularly in multi-tool workflows. Consider caching
+  frequently-accessed data or parallelizing tool calls.
+══════════════════════════════════════════════════
+```
+
+---
+
+#### `bq-agent-sdk drift`
+
+```
+Usage: bq-agent-sdk drift [OPTIONS]
+
+  Run drift detection against a golden question set.
+
+Options:
+  --golden-dataset TEXT     Golden questions table (required)
+  --agent-id TEXT           Filter by agent
+  --last TEXT               Time window
+  --embedding-model TEXT    Model for semantic matching
+  --min-coverage FLOAT      Minimum coverage to pass [default: 0.0]
+  --exit-code               Return exit code 1 if below min-coverage
+  --format TEXT             json | text [default: json]
+```
+
+---
+
+#### `bq-agent-sdk distribution`
+
+```
+Usage: bq-agent-sdk distribution [OPTIONS]
+
+  Analyze question distribution patterns.
+
+Options:
+  --mode TEXT           Analysis mode:
+                          frequently_asked, frequently_unanswered,
+                          auto_group_using_semantics, custom
+  --categories TEXT     Comma-separated custom categories (with --mode=custom)
+  --top-k INT           Top items per category [default: 10]
+  --agent-id TEXT       Filter by agent
+  --last TEXT           Time window
+  --format TEXT         json | text [default: json]
+```
+
+---
+
+## 5. Security & IAM
+
+### 5.1 Least-Privilege IAM Roles
+
+Each path requires a distinct service account with minimum permissions.
+**Never use the default Compute Engine or App Engine service account.**
+
+#### Remote Function Runtime SA (`bq-analytics-fn@PROJECT.iam`)
+
+This SA runs the Cloud Function / Cloud Run service.
+
+```bash
+# Create SA
+gcloud iam service-accounts create bq-analytics-fn \
+  --display-name="BQ Agent Analytics Remote Function"
+
+# Grant minimum roles
+# 1. Read agent_events table
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:bq-analytics-fn@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/bigquery.dataViewer" \
+  --condition="expression=resource.name.startsWith('projects/PROJECT/datasets/analytics'),title=analytics-only"
+
+# 2. Run BigQuery jobs (for SDK queries)
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:bq-analytics-fn@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/bigquery.jobUser"
+```
+
+| Role | Resource | Why |
+|------|----------|-----|
+| `roles/bigquery.dataViewer` | `analytics` dataset | Read `agent_events` and golden tables |
+| `roles/bigquery.jobUser` | Project | Execute BQ queries from within Cloud Function |
+
+#### BigQuery Connection SA (auto-created)
+
+When you create a `CLOUD_RESOURCE` connection, BigQuery auto-creates a SA.
+Grant it the invoker role on the Cloud Function.
+
+```bash
+# Find the connection's SA
+CONNECTION_SA=$(bq show --connection --format=json PROJECT.us.analytics-conn \
+  | jq -r '.cloudResource.serviceAccountId')
+
+# Grant Cloud Run Invoker so BigQuery can call the function
+gcloud functions add-invoker-policy-binding bq-agent-analytics \
+  --region=us-central1 \
+  --member="serviceAccount:${CONNECTION_SA}"
+```
+
+| Role | Resource | Why |
+|------|----------|-----|
+| `roles/run.invoker` | Cloud Function / Cloud Run | Allow BigQuery to invoke the remote function |
+
+#### Continuous Query SA (`analytics-cq@PROJECT.iam`)
+
+```bash
+gcloud iam service-accounts create analytics-cq \
+  --display-name="BQ Continuous Query SA"
+
+# Read source, write destination, use AI models
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:analytics-cq@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/bigquery.dataEditor" \
+  --condition="expression=resource.name.startsWith('projects/PROJECT/datasets/analytics'),title=analytics-dataset"
+
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:analytics-cq@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/bigquery.jobUser"
+
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:analytics-cq@PROJECT.iam.gserviceaccount.com" \
+  --role="roles/bigquery.connectionUser"
+```
+
+| Role | Resource | Why |
+|------|----------|-----|
+| `roles/bigquery.dataEditor` | `analytics` dataset | Read `agent_events`, write analysis tables |
+| `roles/bigquery.jobUser` | Project | Run continuous query jobs |
+| `roles/bigquery.connectionUser` | Connection | Invoke AI.GENERATE_TEXT via remote model connection |
+
+### 5.2 CLI Authentication
+
+The CLI uses Application Default Credentials (ADC). No service account
+key files.
+
+```bash
+# Interactive login (developer workstation)
+gcloud auth application-default login
+
+# Service account (CI/CD)
+gcloud auth activate-service-account --key-file=sa-key.json
+# or: use Workload Identity Federation (recommended for GitHub Actions)
+```
+
+Required user/SA permissions for CLI:
+- `roles/bigquery.dataViewer` on the analytics dataset
+- `roles/bigquery.jobUser` on the project
+
+---
+
+## 6. Cost Model
+
+### 6.1 Per-1K Sessions Cost Estimate
+
+Costs assume US multi-region, on-demand pricing (March 2026).
+
+| Component | Per 1K Sessions | Assumptions |
+|-----------|----------------|-------------|
+| **BigQuery scan** (CLI / Remote Fn) | ~$0.03 | ~6 MB scanned per session × $6.25/TB |
+| **Cloud Function invocation** (Remote Fn) | ~$0.01 | 1K invocations × $0.40/million + 256MB × 500ms |
+| **AI.GENERATE_TEXT** (Continuous Query) | ~$1.25 | 1K calls × ~500 input tokens × $0.075/1M + ~100 output tokens × $0.30/1M (Gemini 2.5 Flash) |
+| **BigQuery continuous query slots** | ~$0.50/hr idle | 1 slot minimum × Enterprise edition pricing; billed per reservation |
+| **Pub/Sub export** (alerting) | ~$0.004 | 1K messages × $40/million |
+| **Bigtable export** | ~$0.01 | 1K writes × $0.01/100K rows (depends on instance) |
+
+### 6.2 Monthly Cost Scenarios
+
+| Scenario | Volume | Estimated Monthly Cost |
+|----------|--------|----------------------|
+| **Small** (dev/test) | 10K sessions, CLI only | < $1 (BQ scan only) |
+| **Medium** (production) | 100K sessions, CLI + Remote Fn + nightly eval | ~$15 (BQ scan + Cloud Function) |
+| **Large** (streaming) | 500K sessions, all paths + Continuous Query | ~$700 (dominated by CQ reservation + AI.GENERATE_TEXT) |
+
+### 6.3 Cost Optimization
+
+- **Partitioning:** `agent_events` table should be partitioned by `timestamp`
+  (ingestion-time or column). All queries use `--last` / `WHERE timestamp >=`
+  which prunes partitions, reducing scan cost by 90%+.
+- **Materialized views:** Cache `daily_quality` table to avoid re-scanning
+  raw events.
+- **AI.GENERATE_TEXT batching:** Continuous queries process rows as they
+  arrive; no additional batching optimization needed.
+- **Slot reservations:** For continuous queries, a FLEX reservation (per-minute
+  billing) is cheaper than on-demand for sustained workloads.
+
+---
+
+## 7. Per-Path SLOs & Operational Runbook
+
+### 7.1 Service-Level Objectives
+
+| Path | Metric | Target | Measurement |
+|------|--------|--------|-------------|
+| **CLI** | Command latency (p95) | < 10s for `evaluate` (≤ 100 sessions) | CLI timing output (`--verbose`) |
+| **CLI** | Availability | 99.9% (bounded by BigQuery SLA) | BQ job success rate |
+| **CLI** | Max error rate | < 1% of CLI invocations fail due to SDK bugs (vs infra) | Error log classification |
+| **Remote Function** | Response latency (p95) | < 5s for `analyze`, < 15s for `judge` | Cloud Monitoring function latency |
+| **Remote Function** | Availability | 99.5% (Cloud Function + BQ connection) | Cloud Monitoring uptime check |
+| **Remote Function** | Max error rate | < 2% of calls return non-retryable errors | `errorMessage` rate in BQ audit logs |
+| **Remote Function** | Cold start | < 3s (Cloud Function gen2) | Cloud Monitoring cold start metric |
+| **Continuous Query** | Processing latency | < 30s from event ingestion to analysis row written | `analyzed_at - timestamp` delta |
+| **Continuous Query** | Availability | 99% (bounded by Enterprise reservation) | `INFORMATION_SCHEMA.JOBS` status |
+
+### 7.2 Retry Behavior
+
+| Path | Retry Strategy |
+|------|----------------|
+| **CLI** | No automatic retry. User re-runs command. `--exit-code` returns 2 for infra errors (vs 1 for eval failure). |
+| **Remote Function** | BigQuery automatically retries on HTTP 408, 429, 500, 503, 504. The Cloud Function must be **idempotent** for a given `(requestId, call_index)` pair. Non-retryable errors return HTTP 400. |
+| **Continuous Query** | BigQuery restarts failed continuous queries automatically. If a row fails AI.GENERATE_TEXT, the row is skipped (no dead-letter). Monitor via `INFORMATION_SCHEMA.JOBS`. |
+
+### 7.3 Operational Runbook: "What Happens When It Fails"
+
+#### Remote Function Failures
+
+| Failure | Symptom | Diagnosis | Resolution |
+|---------|---------|-----------|------------|
+| **Cold start timeout** | First query after idle returns timeout | Cloud Monitoring → Function latency spike | Set `--min-instances=1` in deployment; increase timeout to 120s |
+| **Batch too large** | HTTP 413 or OOM | Cloud Monitoring → memory usage | Reduce `max_batching_rows` in CREATE FUNCTION DDL (default 50 → 10) |
+| **SDK query fails** | `errorMessage` in response | Cloud Function logs → BQ error | Check SA permissions (§5.1); verify `agent_events` table exists |
+| **Quota exhaustion** | HTTP 429 from Cloud Function | Cloud quotas dashboard | Request quota increase; add `max_batching_rows` limit |
+| **Connection SA expired** | "Permission denied" in BQ | Connection details → SA status | Re-grant `roles/run.invoker` to connection SA |
+
+#### Continuous Query Failures
+
+| Failure | Symptom | Diagnosis | Resolution |
+|---------|---------|-----------|------------|
+| **AI.GENERATE_TEXT quota** | Query pauses / slows | `INFORMATION_SCHEMA.JOBS` → error message | Increase Vertex AI quota; reduce `max_output_tokens` |
+| **Reservation exhausted** | Query queued, not processing | Reservation monitor → slot utilization | Add FLEX slots or reduce concurrent CQ count |
+| **Query exceeds 2-day limit** | Query stops | `INFORMATION_SCHEMA.JOBS` → end_time | Use service account (150-day limit); set up auto-restart cron |
+| **Destination table schema mismatch** | Insert fails | CQ error log → schema error | ALTER TABLE to add new columns; restart CQ |
+| **Pub/Sub topic deleted** | EXPORT DATA fails | CQ error log | Recreate topic; restart CQ |
+
+#### CLI Failures
+
+| Failure | Symptom | Diagnosis | Resolution |
+|---------|---------|-----------|------------|
+| **ADC not configured** | "Could not automatically determine credentials" | `gcloud auth list` | Run `gcloud auth application-default login` |
+| **Dataset not found** | "Not found: Dataset" | Verify `--dataset-id` | Check project/dataset spelling; verify IAM access |
+| **Timeout on large evaluation** | Command hangs > 60s | BQ job duration in console | Add `--limit=50` to reduce session count; use `--last=1h` |
+
+### 7.4 Alerting Recommendations
+
+```bash
+# Cloud Monitoring alert policy for Remote Function errors
+gcloud monitoring policies create \
+  --display-name="BQ Analytics Remote Fn Error Rate" \
+  --condition-filter='resource.type="cloud_function" AND metric.type="cloudfunctions.googleapis.com/function/execution_count" AND metric.labels.status!="ok"' \
+  --condition-threshold-value=0.02 \
+  --condition-threshold-comparison=COMPARISON_GT \
+  --notification-channels=CHANNEL_ID
+
+# BigQuery INFORMATION_SCHEMA query for continuous query health
+SELECT
+  job_id,
+  state,
+  error_result.reason AS error_reason,
+  creation_time,
+  TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), creation_time, HOUR) AS running_hours
+FROM `region-us`.INFORMATION_SCHEMA.JOBS
+WHERE job_type = 'QUERY'
+  AND configuration.query.continuous = TRUE
+  AND creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+ORDER BY creation_time DESC;
+```
+
+---
+
+## 8. Implementation Roadmap
+
+### 8.1 MVP Definition (v1.0)
+
+**v1.0 ships CLI + `evaluate` + `get-trace` + `--exit-code`.** This is the
+minimum surface that unblocks all three personas:
+
+| Feature | Persona Unblocked | Why MVP |
+|---------|-------------------|---------|
+| `bq-agent-sdk evaluate` | Marcus (CI/CD), AgentX (self-diagnostic) | Core value: "is my agent healthy?" |
+| `bq-agent-sdk get-trace` | AgentX (context retrieval) | Enables self-correction loop (CUJ-B5) |
+| `--exit-code` | Marcus (CI/CD gate) | Blocks deploy on eval failure |
+| `--format=json` | AgentX (machine consumption) | Structured output for agent tool use |
+| `bq-agent-sdk doctor` | Marcus (pre-deploy check) | Validates setup before first eval |
+
+**v1.1 (post-MVP):**
+
+| Feature | Target |
+|---------|--------|
+| Remote Function (`agent_analytics()`) | v1.1 — requires Cloud Function deployment infra |
+| `bq-agent-sdk insights`, `drift`, `distribution` | v1.1 — higher-level analytics |
+| `bq-agent-sdk views`, `hitl-metrics`, `list-traces` | v1.1 — convenience commands |
+| Continuous Query templates | v1.2 — requires Enterprise reservation |
+
+### 8.2 Phases
+
+#### Phase 1: Core Refactoring (1 week) — *v1.0*
+
+- [ ] Extract filter-building helpers (`--last`, `--agent-id`, etc.) into
+      shared utility that constructs `TraceFilter` from CLI args or remote
+      function params
+- [ ] Add uniform response serialization layer for both interface boundaries
+      (CLI and Remote Function):
+      - **Dataclass returns** (`Trace`, `Span`, `ContentPart`, `ObjectRef`):
+        Add `Trace.to_dict()` / `Span.to_dict()` methods that recursively
+        convert nested dataclasses and `datetime` fields to JSON-safe dicts
+        (ISO 8601 strings for datetimes)
+      - **Pydantic returns** (`EvaluationReport`, `InsightsReport`,
+        `DriftReport`, `QuestionDistribution`, `WorldChangeReport`): Use
+        `.model_dump(mode="json")` or `.model_dump_json()` — **not** plain
+        `.model_dump()`, which preserves raw `datetime` objects that fail
+        `json.dumps()`. Affected fields include `EvaluationReport.created_at`,
+        `InsightsReport.created_at`, `SessionMetadata.start_time`/`end_time`,
+        etc.
+      - **dict returns** (`doctor()`, `hitl_metrics()`): Verify datetime values
+        are converted to ISO 8601 strings before output
+- [ ] Add `--format` output formatting layer (JSON, text table, tree)
+
+**Exit criteria:**
+- `json.dumps(serialize(result))` succeeds for every `Client` public method
+  return type — including `Trace`, `EvaluationReport`, `InsightsReport`,
+  `DriftReport`, and `QuestionDistribution` (unit test for each)
+- `TraceFilter.from_cli_args()` parses `--last=1h`, `--agent-id=X`,
+  `--session-id=Y` (unit test coverage ≥ 90%)
+- Format layer renders JSON / text / table for a sample trace (snapshot test)
+
+#### Phase 2: CLI MVP (`bq-agent-sdk`) (2 weeks) — *v1.0*
+
+- [ ] Add `typer` dependency (optional `[cli]` extra in `pyproject.toml`)
+- [ ] Implement CLI entry point in `pyproject.toml` `[project.scripts]`
+- [ ] Implement v1.0 commands: `doctor`, `get-trace`, `evaluate`
+- [ ] Add `--exit-code` support for CI/CD integration
+- [ ] Add `--last` time window parser (`1h`, `24h`, `7d`, `30d`)
+- [ ] Write CLI integration tests (mock BQ client, ≥ 85% line coverage)
+- [ ] Write quickstart guide with copy-paste examples
+
+**Exit criteria:**
+- `pip install bigquery-agent-analytics-sdk[cli]` → `bq-agent-sdk --help`
+  works (smoke test in CI)
+- `bq-agent-sdk evaluate --last=1h --evaluator=latency --threshold=5000
+  --exit-code` returns exit code 1 on failure (integration test)
+- `bq-agent-sdk get-trace --session-id=X --format=json` returns valid JSON
+  (integration test)
+- Quickstart guide timed walkthrough completes in < 10 minutes
+- Sample GitHub Actions workflow passes with mock credentials
+
+#### Phase 3: Remote Function (2 weeks) — *v1.1*
+
+- [ ] Create `deploy/remote_function/` directory with:
+      - `main.py` (functions-framework entry point)
+      - `requirements.txt`
+      - `deploy.sh` (gcloud deployment script)
+      - `register.sql` (CREATE FUNCTION DDL templates)
+- [ ] Implement dispatch for: `analyze`, `evaluate`, `judge`, `insights`,
+      `drift`
+- [ ] Use the uniform serialization layer from Phase 1 in `_dispatch()` to
+      convert all SDK return types to JSON-safe dicts before building the
+      reply array (see Phase 1 serialization policy)
+- [ ] Reuse the existing `_run_sync()` bridge (`client.py:247`) for sync
+      wrappers — `insights()`, `drift_detection()`, and `deep_analysis()`
+      already route through it, so the Cloud Function entry point can call
+      these sync methods directly without async/sync boundary concerns
+- [ ] Add Terraform/gcloud deployment automation
+- [ ] Write integration tests with BigQuery Remote Function simulator
+- [ ] Document deployment guide with IAM prerequisites (see §5)
+
+**Exit criteria:**
+- `deploy.sh` deploys to a test project and `SELECT agent_analytics('analyze',
+  JSON'{"session_id":"test"}')` returns valid JSON (end-to-end test)
+- Partial failure in a batch (1 of 5 calls errors) returns per-row error,
+  not batch-level 400 (integration test)
+- All 5 operations return `json.dumps()`-safe responses (no raw `datetime`
+  objects, no dataclass instances) — verified by integration test
+- `deploy/remote_function/README.md` includes IAM roles, cost estimate,
+  and troubleshooting guide
+- Remote Function p95 latency < 5s for `analyze` operation (load test with
+  50 concurrent calls)
+
+#### Phase 4: CLI v1.1 Commands + Continuous Query Templates (2 weeks) — *v1.1/v1.2*
+
+- [ ] Implement remaining CLI commands: `insights`, `drift`, `distribution`,
+      `hitl-metrics`, `list-traces`, `views`
+- [ ] Document LLM tool-calling schema for agent integration
+- [ ] Create `deploy/continuous_queries/` directory with:
+      - `realtime_error_analysis.sql` — AI.GENERATE_TEXT error classification
+      - `session_scoring.sql` — per-session quality scoring
+      - `pubsub_alerting.sql` — critical error → Pub/Sub export
+      - `bigtable_dashboard.sql` — session metrics → Bigtable
+      - `setup_reservation.md` — Enterprise reservation guide
+- [ ] Document AI.GENERATE_TEXT prompt templates aligned with SDK evaluation
+      criteria (correctness, hallucination, sentiment)
+- [ ] Add backfill guide (FOR SYSTEM_TIME AS OF → APPENDS handoff)
+- [ ] Document continuous query monitoring via INFORMATION_SCHEMA.JOBS
+
+**Exit criteria:**
+- All 9 CLI commands pass integration tests (mock BQ client)
+- Each continuous query template runs without syntax errors in BigQuery
+  dry-run mode (`--dry_run` flag)
+- Continuous query monitoring query returns job status for a running
+  template
+
+#### Phase 5: Documentation, Polish & Pilot (1 week) — *v1.0 GA*
+
+- [ ] Update SDK.md with CLI, Remote Function, and Continuous Query sections
+- [ ] Add `examples/cli_agent_tool.py` — example ADK agent using CLI as tool
+- [ ] Add `examples/ci_eval_pipeline.sh` — example CI/CD script
+- [ ] Add `examples/remote_function_dashboard.sql` — example Looker queries
+- [ ] Add `examples/continuous_query_alerting.sql` — real-time error alerting
+- [ ] Update README.md with new interfaces
+- [ ] Run design-partner pilot (see §10)
+
+**Exit criteria:**
+- All examples run without errors against a test dataset
+- Pilot partners complete assigned CUJs within time targets (see §10.2)
+- Zero unresolved P0/P1 bugs from pilot feedback
+
+### 8.3 Migration / Onboarding Path
+
+**Python-only user today → CLI in 15 minutes → Remote Function in 1 day**
+
+#### Step 1: CLI (15 minutes)
+
+```bash
+# Install with CLI extra
+pip install bigquery-agent-analytics-sdk[cli]
+
+# Set environment variables (avoid repeating in every command)
+export BQ_AGENT_PROJECT=myproject
+export BQ_AGENT_DATASET=analytics
+
+# Health check
+bq-agent-sdk doctor
+
+# First evaluation
+bq-agent-sdk evaluate --evaluator=latency --threshold=5000 --last=1h
+
+# Retrieve a specific trace
+bq-agent-sdk get-trace --session-id=sess-001 --format=json
+```
+
+#### Step 2: CI/CD gate (30 minutes)
+
+```yaml
+# Add to .github/workflows/agent-eval.yml
+- name: Install SDK
+  run: pip install bigquery-agent-analytics-sdk[cli]
+
+- name: Gate on latency
+  run: bq-agent-sdk evaluate --evaluator=latency --threshold=5000 --last=24h --exit-code
+```
+
+#### Step 3: Remote Function (1 day)
+
+```bash
+# Clone and deploy
+git clone https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK.git
+cd BigQuery-Agent-Analytics-SDK/deploy/remote_function
+./deploy.sh --project=myproject --region=us-central1
+
+# Register in BigQuery (copy-paste from register.sql)
+bq query --use_legacy_sql=false < register.sql
+
+# First SQL evaluation
+bq query --use_legacy_sql=false \
+  "SELECT \`myproject.analytics.agent_analytics\`('analyze', JSON'{\"session_id\":\"sess-001\"}')"
+```
+
+#### Step 4: Continuous Query (optional, requires Enterprise edition)
+
+```bash
+# Deploy real-time error alerting template
+bq query --use_legacy_sql=false --continuous=true \
+  < deploy/continuous_queries/realtime_error_analysis.sql
+```
+
+---
+
+## 9. Success Metrics
+
+### 9.1 Adoption Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Time-to-first-value (CLI)** | First CLI eval run in < 10 minutes from `pip install` | Timed walkthrough in quickstart guide |
+| **Time-to-first-value (Remote Fn)** | First SQL `agent_analytics()` call in < 30 minutes from repo clone | Timed deploy + query walkthrough |
+| CLI adoption | 20% of SDK users use CLI within 3 months | PyPI download stats for `[cli]` extra |
+| Remote Function deployments | 10 production deployments within 6 months | Deployment telemetry |
+| Agent tool integration | 5 agents use CLI for self-diagnostics | Community feedback / GitHub issues |
+| CI/CD integration | 3 orgs use `--exit-code` in pipelines | Community feedback |
+| Token savings for agents | 35x fewer tokens vs MCP schema loading (~4K vs ~145K); 60% fewer vs SQL generation | Benchmarked comparison against MCP baseline (see §4.1.1) |
+
+### 9.2 User Outcome Metrics
+
+| Outcome | Target | How Measured |
+|---------|--------|--------------|
+| **Mean time to detect agent regression** | < 15 minutes (from event to alert) | Continuous Query → Pub/Sub pipeline latency; CLI cron interval |
+| **MTTR reduction for agent incidents** | 30% reduction vs manual investigation | Before/after comparison during pilot (see §10) |
+| **Eval pipeline setup time** | < 1 hour for full CI/CD gate (evaluate + drift + exit-code) | Pilot partner timed walkthrough |
+| **SQL analyst unblocked** | Priya-persona can build dashboard without filing Python ticket | Pilot partner interview |
+| **Agent self-correction rate** | Agents using CLI self-diagnostics resolve 50% of tool failures without human intervention | Session trace analysis (self-correction loop detected) |
+
+---
+
+## 10. Design-Partner Validation Plan
+
+### 10.1 Pilot Partners
+
+| Partner Profile | Persona | Focus Area | v1 Feature Set |
+|----------------|---------|------------|----------------|
+| **Analyst team** (1 data analyst / BI engineer) | Priya | Remote Function + Looker dashboard | `evaluate`, `analyze` via SQL |
+| **Agent team** (1 agent developer) | AgentX | CLI as agent tool for self-diagnostics | `evaluate`, `get-trace` via CLI |
+| **Platform team** (1 SRE / DevOps engineer) | Marcus | CI/CD pipeline with `--exit-code` | `evaluate`, `drift` via CLI + GitHub Actions |
+
+### 10.2 Pilot Success Criteria
+
+| Criterion | Measurement | Pass Threshold |
+|-----------|-------------|----------------|
+| Time-to-first-eval (CLI) | Timed from `pip install` to first `evaluate` output | < 10 minutes |
+| Time-to-first-eval (Remote Fn) | Timed from repo clone to first SQL `agent_analytics()` result | < 30 minutes |
+| Task completion without help | Pilot user completes assigned CUJ without asking SDK team questions | 2 out of 3 users |
+| Token overhead acceptable | Agent pilot measures context tokens consumed by CLI tool calls | < 5,000 tokens per CLI invocation |
+| CI/CD gate works end-to-end | Platform pilot configures `--exit-code` in real pipeline, blocks on failure | Blocks deploy on eval failure |
+| No P0 bugs | Pilot users report zero data-loss or incorrect evaluation results | 0 P0 bugs |
+
+### 10.3 Pilot Protocol
+
+1. **Week 1:** Onboard 3 pilot partners; provide quickstart guide + 30-min walkthrough
+2. **Weeks 2–3:** Partners use their assigned path independently; SDK team collects:
+   - Setup friction (where did they get stuck?)
+   - Feature gaps (what did they need that was missing?)
+   - Bug reports (severity-tagged)
+3. **Week 4:** Debrief interviews; collect NPS score (0–10) and written feedback
+4. **GA Decision Gate:** Proceed to GA if:
+   - All 3 pilots achieve time-to-first-eval targets
+   - NPS ≥ 7 for 2 out of 3 partners
+   - Zero unresolved P0/P1 bugs
+   - Documentation rated "sufficient" or better by all 3
+
+---
+
+## 11. Non-Goals (Out of Scope)
+
+- **Web UI / dashboard** — Use Looker/Data Studio with remote functions instead
+- **Custom real-time processing** — The SDK does not build a streaming
+  pipeline. Real-time analytics are handled via BigQuery Continuous Query
+  templates (Path A', §3A) which use native `AI.GENERATE_TEXT` — the SDK
+  provides SQL templates but no custom runtime
+- **Agent framework integration** — The CLI is framework-agnostic; specific ADK
+  tool wrappers are a separate effort
+- **Multi-cloud** — BigQuery-only for now
+
+---
+
+## 12. Open Questions
+
+1. **CLI framework:** `click` vs `typer` — typer has better auto-generated
+   help and type inference, but click has broader ecosystem support.
+   **Recommendation:** `typer` (better developer experience, auto-complete,
+   and its auto-generated `--help` output is concise enough for LLM
+   just-in-time consumption — see §4.1.2).
+
+2. **Authentication:** Should the CLI handle `gcloud auth` automatically, or
+   require users to have Application Default Credentials configured?
+   **Recommendation:** Require ADC; add `bq-agent-sdk auth check` command.
+
+3. **Remote function granularity:** ~~One function per operation vs one
+   multiplexed function?~~
+   **Decided:** One multiplexed function `agent_analytics(operation, params)`
+   (simpler deployment, single connection). All CUJs and examples in this
+   document use this approach.
+
+4. **Versioning:** Should the CLI version be tied to the SDK version?
+   **Recommendation:** Yes, single version number for all interfaces.

--- a/docs/proposal_bigquery_agent_cli.md
+++ b/docs/proposal_bigquery_agent_cli.md
@@ -1,0 +1,833 @@
+# Proposal: `bqx` — An Agent-Native BigQuery CLI with Skills
+
+**Status:** Proposal
+**Date:** 2026-03-08
+**Related:** [gws CLI](https://github.com/googleworkspace/cli),
+[Agent Skills](https://agentskills.io),
+[BigQuery Conversational Analytics](https://cloud.google.com/bigquery/docs/conversational-analytics),
+[BigQuery Agent Analytics SDK](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK)
+
+---
+
+## 1. Problem Statement
+
+BigQuery is the most common data platform for AI agent analytics, but its
+CLI tooling (`bq`) was designed in 2012 for human operators. It is:
+
+- **Not extensible** — monolithic Python binary, no plugin or skill system
+- **Not agent-friendly** — inconsistent output formats, no structured JSON
+  default, verbose help text that wastes context tokens
+- **Not AI-aware** — no integration with Conversational Analytics, AI
+  functions, or agent evaluation workflows
+
+Meanwhile, AI agents are becoming the primary consumers of CLI tools.
+Community benchmarks show CLIs achieve **35x token efficiency** over MCP
+schemas and **28% higher task completion** for identical tasks. But agents
+need CLIs designed for them: structured output, progressive disclosure,
+and discoverable skills.
+
+The Google Workspace CLI (`gws`) has proven this model works — 100+ skills,
+dynamic command generation, JSON-first output, and adoption across Claude
+Code, Gemini CLI, Cursor, and others. BigQuery needs the same.
+
+---
+
+## 2. Proposal: `bqx` (BigQuery Extended)
+
+A new agent-native CLI for BigQuery that combines:
+
+1. **Dynamic command generation** from BigQuery APIs (like `gws`)
+2. **Agent Skills** for discoverability (SKILL.md format)
+3. **Conversational Analytics** integration (natural language queries)
+4. **BigQuery Agent Analytics SDK** capabilities (evaluation, traces, drift)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         bqx CLI                                     │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │
+│  │  BigQuery     │  │  Agent       │  │  Conversational│              │
+│  │  API          │  │  Analytics   │  │  Analytics    │              │
+│  │  (dynamic)    │  │  SDK         │  │  API          │              │
+│  │              │  │              │  │              │              │
+│  │  query, mk,  │  │  evaluate,   │  │  ask,         │              │
+│  │  ls, load,   │  │  get-trace,  │  │  create-agent,│              │
+│  │  show, rm    │  │  drift,      │  │  list-agents  │              │
+│  │              │  │  insights    │  │              │              │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘              │
+│         │                 │                 │                       │
+│  ┌──────┴─────────────────┴─────────────────┴───────┐              │
+│  │              Shared Core                          │              │
+│  │  Auth · JSON output · Model Armor · Pagination    │              │
+│  └───────────────────────────────────────────────────┘              │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────┐              │
+│  │              Skills (SKILL.md)                     │              │
+│  │  89 skills: service · helper · persona · recipe   │              │
+│  └──────────────────────────────────────────────────┘              │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Why `bqx`, not extending `bq`
+
+| Factor | `bq` (existing) | `bqx` (proposed) |
+|--------|-----------------|-------------------|
+| Language | Python | Rust (fast startup, single binary) |
+| Extensibility | None | Skills + dynamic command generation |
+| Output format | Mixed text/JSON | JSON-first (+ table, yaml, csv) |
+| Agent consumption | Not designed for agents | Progressive disclosure, SKILL.md |
+| Release cycle | Coupled to gcloud SDK | Independent releases |
+| AI integration | None | Conversational Analytics, AI functions, Agent Analytics |
+| Discovery | Static commands | Dynamic from BigQuery REST API |
+
+---
+
+## 3. Architecture
+
+### 3.1 Dynamic Command Generation (from `gws` pattern)
+
+Like `gws`, `bqx` uses two-phase argument parsing:
+
+1. `argv[1]` identifies the service module (`analytics`, `ca`, or falls
+   through to BigQuery API resource names)
+2. For BigQuery API commands, fetch the
+   [BigQuery Discovery Document](https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest),
+   cache it (24h TTL), and build a `clap::Command` tree dynamically
+
+```bash
+# Dynamic commands (generated from BigQuery REST API Discovery Document)
+bqx datasets list --project-id=myproject
+bqx tables get --project-id=myproject --dataset-id=analytics --table-id=agent_events
+bqx jobs query --query="SELECT 1" --use-legacy-sql=false
+
+# Static commands (Agent Analytics SDK — compiled in)
+bqx analytics evaluate --evaluator=latency --threshold=5000 --last=1h
+bqx analytics get-trace --session-id=sess-001
+bqx analytics drift --golden-dataset=golden_qs
+
+# Static commands (Conversational Analytics API)
+bqx ca ask "What were the top errors yesterday?" --agent=my-data-agent
+bqx ca create-agent --name=agent-analytics --tables=agent_events
+```
+
+### 3.2 Three Command Domains
+
+#### Domain 1: `bqx <resource> <method>` — BigQuery API (dynamic)
+
+Generated from the BigQuery v2 Discovery Document, covering datasets,
+tables, jobs, routines, connections, models, and row-access policies.
+
+```bash
+# List datasets
+bqx datasets list --project-id=myproject
+
+# Run a query (structured output)
+bqx jobs query \
+  --query="SELECT session_id, agent FROM analytics.agent_events LIMIT 5" \
+  --use-legacy-sql=false
+
+# Create a view
+bqx tables insert \
+  --project-id=myproject \
+  --dataset-id=analytics \
+  --json='{"tableReference":{"tableId":"v_errors"},"view":{"query":"SELECT ..."}}'
+
+# Show table schema
+bqx tables get --project-id=myproject --dataset-id=analytics --table-id=agent_events
+```
+
+#### Domain 2: `bqx analytics <command>` — Agent Analytics (static)
+
+Wraps the BigQuery Agent Analytics SDK. Commands are compiled into the
+binary (not dynamically generated) since they don't come from a Discovery
+Document.
+
+```bash
+# Evaluate agent performance
+bqx analytics evaluate \
+  --evaluator=latency \
+  --threshold=5000 \
+  --agent-id=support_bot \
+  --last=1h
+
+# Retrieve a session trace
+bqx analytics get-trace --session-id=sess-001
+
+# Health check
+bqx analytics doctor
+
+# Drift detection
+bqx analytics drift \
+  --golden-dataset=golden_questions \
+  --agent-id=support_bot \
+  --last=7d
+
+# LLM-as-judge evaluation
+bqx analytics evaluate \
+  --evaluator=llm-judge \
+  --criterion=correctness \
+  --threshold=0.7 \
+  --last=24h \
+  --exit-code
+
+# Create event-type views
+bqx analytics views create-all --prefix=adk_
+
+# Generate insights report
+bqx analytics insights --agent-id=support_bot --last=24h
+```
+
+#### Domain 3: `bqx ca <command>` — Conversational Analytics (static)
+
+Wraps the BigQuery Conversational Analytics API, bringing natural language
+queries to the terminal.
+
+```bash
+# Ask a natural language question
+bqx ca ask "Show me the top 5 agents by error rate this week" \
+  --agent=agent-analytics-data-agent
+
+# Ask with a specific table context
+bqx ca ask "What's the p95 latency trend for support_bot?" \
+  --tables=myproject.analytics.agent_events
+
+# Create a data agent with verified queries
+bqx ca create-agent \
+  --name=agent-analytics \
+  --tables=myproject.analytics.agent_events,myproject.analytics.adk_llm_responses \
+  --verified-queries=./deploy/ca/verified_queries.yaml \
+  --instructions="This agent helps analyze AI agent performance metrics."
+
+# List data agents
+bqx ca list-agents --project-id=myproject
+
+# Add a verified query to an existing agent
+bqx ca add-verified-query \
+  --agent=agent-analytics \
+  --question="What is the error rate for agent X?" \
+  --query="SELECT COUNT(CASE WHEN status='ERROR' THEN 1 END) / COUNT(*) FROM ..."
+```
+
+### 3.3 Output Format
+
+All output is JSON by default, with alternative formats via `--format`:
+
+```bash
+# Default: structured JSON (agent-consumable)
+bqx analytics evaluate --evaluator=latency --threshold=5000 --last=1h
+{
+  "evaluator": "latency",
+  "threshold_ms": 5000,
+  "total_sessions": 10,
+  "passed": 7,
+  "failed": 3,
+  "pass_rate": 0.70,
+  "aggregate_scores": {
+    "avg_latency_ms": 3200,
+    "p95_latency_ms": 6100
+  }
+}
+
+# Table format (human-readable)
+bqx analytics evaluate --evaluator=latency --threshold=5000 --last=1h --format=table
+SESSION_ID   PASSED  LATENCY_MS  SCORE
+sess-001     true    2340        0.85
+sess-002     false   7800        0.32
+sess-003     true    1850        0.91
+
+# Dry-run mode (shows what would happen)
+bqx jobs query --query="SELECT 1" --dry-run
+{
+  "dry_run": true,
+  "url": "https://bigquery.googleapis.com/bigquery/v2/projects/myproject/queries",
+  "method": "POST",
+  "body": {"query": "SELECT 1", "useLegacySql": false},
+  "estimated_bytes_processed": 0
+}
+```
+
+### 3.4 Authentication
+
+Five methods, same priority model as `gws`:
+
+| Priority | Method | Use Case |
+|----------|--------|----------|
+| 1 (highest) | `BQX_TOKEN` env var | Pre-obtained access token |
+| 2 | `BQX_CREDENTIALS_FILE` env var | Service account JSON path |
+| 3 | `bqx auth login` (encrypted) | Interactive OAuth, AES-256-GCM at rest |
+| 4 | `GOOGLE_APPLICATION_CREDENTIALS` | Standard ADC fallback |
+| 5 | `gcloud auth application-default` | Implicit gcloud credentials |
+
+```bash
+# Quick start (uses existing gcloud credentials)
+bqx datasets list --project-id=myproject
+
+# Explicit login with scope selection
+bqx auth login -s bigquery,cloud-platform
+
+# Service account (CI/CD)
+export BQX_CREDENTIALS_FILE=/path/to/sa-key.json
+bqx analytics evaluate --evaluator=latency --last=24h --exit-code
+```
+
+### 3.5 Security
+
+- **Model Armor integration:** `--sanitize <template>` screens API responses
+  for prompt injection. `BQX_SANITIZE_TEMPLATE` env var for global default.
+- **Credential encryption:** AES-256-GCM at rest, key in OS keyring.
+- **Destructive operation guards:** Write/delete commands require `--confirm`
+  flag or interactive confirmation. Skill generator blocks destructive
+  methods by default.
+- **Least-privilege defaults:** `bqx auth login` requests only BigQuery
+  scopes, not broad cloud-platform.
+
+---
+
+## 4. Skills Architecture
+
+### 4.1 Overview
+
+Skills follow the [Agent Skills](https://agentskills.io) open standard:
+declarative `SKILL.md` files that any compatible agent (Claude Code, Gemini
+CLI, Cursor, Copilot, Codex) can discover and use.
+
+```
+skills/
+├── bqx-shared/SKILL.md                       # Auth, global flags, security rules
+│
+├── bqx-datasets/SKILL.md                     # Service: dataset operations
+├── bqx-tables/SKILL.md                       # Service: table operations
+├── bqx-jobs/SKILL.md                         # Service: query execution
+├── bqx-routines/SKILL.md                     # Service: UDFs, remote functions
+├── bqx-models/SKILL.md                       # Service: ML models
+├── bqx-connections/SKILL.md                  # Service: external connections
+│
+├── bqx-analytics/SKILL.md                    # Service: Agent Analytics SDK
+├── bqx-analytics-evaluate/SKILL.md           # Helper: run evaluations
+├── bqx-analytics-trace/SKILL.md              # Helper: retrieve traces
+├── bqx-analytics-drift/SKILL.md              # Helper: drift detection
+├── bqx-analytics-views/SKILL.md              # Helper: manage event views
+│
+├── bqx-ca/SKILL.md                           # Service: Conversational Analytics
+├── bqx-ca-ask/SKILL.md                       # Helper: ask questions in NL
+├── bqx-ca-create-agent/SKILL.md              # Helper: create data agents
+│
+├── bqx-query/SKILL.md                        # Helper: shortcut for bqx jobs query
+├── bqx-schema/SKILL.md                       # Helper: inspect table schemas
+│
+├── persona-agent-developer/SKILL.md          # Persona: agent developer workflows
+├── persona-data-analyst/SKILL.md             # Persona: SQL analyst workflows
+├── persona-sre/SKILL.md                      # Persona: SRE/on-call workflows
+│
+├── recipe-eval-pipeline/SKILL.md             # Recipe: CI/CD eval gate setup
+├── recipe-quality-dashboard/SKILL.md         # Recipe: Looker dashboard via remote fn
+├── recipe-error-alerting/SKILL.md            # Recipe: CQ + AI.GENERATE_TEXT alerting
+├── recipe-drift-monitoring/SKILL.md          # Recipe: weekly drift detection
+├── recipe-self-diagnostic-agent/SKILL.md     # Recipe: agent self-correction loop
+└── recipe-ca-data-agent-setup/SKILL.md       # Recipe: CA data agent creation
+```
+
+### 4.2 Example Skills
+
+#### Service Skill: `bqx-analytics/SKILL.md`
+
+```markdown
+---
+name: bqx-analytics
+version: 1.0.0
+description: "BigQuery Agent Analytics: Evaluate, trace, and monitor AI agent sessions."
+metadata:
+  category: "analytics"
+  requires:
+    bins: ["bqx"]
+  cliHelp: "bqx analytics --help"
+---
+
+# analytics
+
+> **PREREQUISITE:** Read `../bqx-shared/SKILL.md` for auth, global flags,
+> and security rules.
+
+```bash
+bqx analytics <command> [flags]
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `doctor` | Run diagnostic health check on BigQuery table and configuration |
+| `evaluate` | Run code-based or LLM evaluation over agent session traces |
+| `get-trace` | Retrieve and display a single session trace |
+| `list-traces` | List recent traces matching filter criteria |
+| `insights` | Generate comprehensive agent insights report |
+| `drift` | Run drift detection against a golden question set |
+| `distribution` | Analyze question distribution patterns |
+| `hitl-metrics` | Show human-in-the-loop interaction metrics |
+| `views` | Create per-event-type BigQuery views (18 event types) |
+
+## Helper Skills
+
+For common tasks, use the shortcut helper skills:
+
+| Helper | Description |
+|--------|-------------|
+| [`bqx-analytics-evaluate`](../bqx-analytics-evaluate/SKILL.md) | Quick evaluation commands |
+| [`bqx-analytics-trace`](../bqx-analytics-trace/SKILL.md) | Trace retrieval and analysis |
+| [`bqx-analytics-drift`](../bqx-analytics-drift/SKILL.md) | Drift detection workflows |
+| [`bqx-analytics-views`](../bqx-analytics-views/SKILL.md) | Manage per-event-type views |
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--project-id TEXT` | GCP project ID [env: `BQX_PROJECT`] |
+| `--dataset-id TEXT` | BigQuery dataset [env: `BQX_DATASET`] |
+| `--last TEXT` | Time window: `1h`, `24h`, `7d`, `30d` |
+| `--agent-id TEXT` | Filter by agent name |
+| `--format TEXT` | Output: `json` (default), `table`, `text` |
+| `--exit-code` | Return exit code 1 on evaluation failure |
+```
+
+#### Helper Skill: `bqx-analytics-evaluate/SKILL.md`
+
+```markdown
+---
+name: bqx-analytics-evaluate
+version: 1.0.0
+description: "Evaluate AI agent sessions for latency, error rate, or correctness."
+metadata:
+  category: "analytics"
+  requires:
+    bins: ["bqx"]
+  cliHelp: "bqx analytics evaluate --help"
+---
+
+# analytics evaluate
+
+> **PREREQUISITE:** Read `../bqx-shared/SKILL.md` for auth and global flags.
+
+Evaluate agent sessions against a threshold. Returns pass/fail per session.
+
+## Usage
+
+```bash
+bqx analytics evaluate --evaluator=<TYPE> --threshold=<N> [flags]
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--evaluator` | Yes | — | `latency`, `error_rate`, `turn_count`, `token_efficiency`, `llm-judge` |
+| `--threshold` | Yes | — | Pass/fail threshold (ms for latency, 0-1 for rates/scores) |
+| `--criterion` | If llm-judge | — | `correctness`, `hallucination`, `sentiment`, `custom` |
+| `--custom-prompt` | If custom | — | Custom LLM judge prompt |
+| `--exit-code` | No | false | Return exit code 1 on failure (for CI/CD) |
+
+## Examples
+
+```bash
+# Check latency compliance (agent self-diagnostic)
+bqx analytics evaluate --evaluator=latency --threshold=5000 --agent-id=support_bot --last=1h
+
+# CI/CD gate: fail if correctness drops below 0.7
+bqx analytics evaluate --evaluator=llm-judge --criterion=correctness \
+  --threshold=0.7 --last=24h --exit-code
+
+# Custom evaluation
+bqx analytics evaluate --evaluator=llm-judge --criterion=custom \
+  --custom-prompt="Rate how well the agent handled PII. Score 0-1." \
+  --threshold=0.9 --last=24h
+```
+
+> [!NOTE]
+> This is a **read-only** command. Safe to run without confirmation.
+```
+
+#### Persona Skill: `persona-sre/SKILL.md`
+
+```markdown
+---
+name: persona-sre
+version: 1.0.0
+description: "On-call SRE workflows for monitoring and triaging AI agent issues."
+metadata:
+  category: "persona"
+  requires:
+    bins: ["bqx"]
+    skills: ["bqx-analytics", "bqx-ca", "bqx-query"]
+---
+
+# SRE / On-Call Engineer
+
+> **PREREQUISITE:** Load the following skills: `bqx-analytics`, `bqx-ca`,
+> `bqx-query`
+
+Monitor AI agent health, triage incidents, and validate fixes.
+
+## Incident Triage Workflow
+
+1. Check overall health:
+   `bqx analytics doctor`
+2. Look for error spikes:
+   `bqx analytics evaluate --evaluator=error_rate --threshold=0.05 --last=1h`
+3. Identify failing sessions:
+   `bqx analytics evaluate --evaluator=latency --threshold=5000 --last=1h --format=table`
+4. Inspect a specific failure:
+   `bqx analytics get-trace --session-id=<ID_FROM_STEP_3>`
+5. Ask follow-up in natural language:
+   `bqx ca ask "What tools failed most in the last hour?" --agent=agent-analytics`
+
+## Daily Health Check
+
+```bash
+bqx analytics doctor && \
+bqx analytics evaluate --evaluator=error_rate --threshold=0.05 --last=24h && \
+bqx analytics evaluate --evaluator=latency --threshold=5000 --last=24h
+```
+
+## Tips
+
+- Use `--format=table` for quick visual scans during incidents.
+- Pipe `--format=json` output to `jq` for scripted analysis.
+- Set `BQX_PROJECT` and `BQX_DATASET` env vars to avoid repetitive flags.
+```
+
+#### Recipe Skill: `recipe-eval-pipeline/SKILL.md`
+
+```markdown
+---
+name: recipe-eval-pipeline
+version: 1.0.0
+description: "Set up a CI/CD evaluation pipeline that gates agent deployment on quality metrics."
+metadata:
+  category: "recipe"
+  domain: "devops"
+  requires:
+    bins: ["bqx"]
+    skills: ["bqx-analytics"]
+---
+
+# CI/CD Evaluation Pipeline
+
+> **PREREQUISITE:** Load `bqx-analytics` skill.
+
+Set up a GitHub Actions workflow that blocks deployment when agent quality
+drops below thresholds.
+
+## Steps
+
+1. Install `bqx` in CI:
+   `npm install -g @bigquery/bqx`
+
+2. Authenticate with Workload Identity Federation:
+   ```yaml
+   - uses: google-github-actions/auth@v2
+     with:
+       workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+       service_account: ${{ vars.SA_EMAIL }}
+   ```
+
+3. Add evaluation gates:
+   ```bash
+   bqx analytics evaluate --evaluator=latency --threshold=5000 --last=24h --exit-code
+   bqx analytics evaluate --evaluator=error_rate --threshold=0.05 --last=24h --exit-code
+   bqx analytics drift --golden-dataset=golden_qs --min-coverage=0.85 --exit-code
+   ```
+
+4. Upload reports as artifacts:
+   ```bash
+   bqx analytics insights --last=24h > insights.json
+   ```
+
+> [!CAUTION]
+> Ensure the CI service account has `bigquery.dataViewer` and
+> `bigquery.jobUser` roles only. Never grant `dataEditor` to CI.
+```
+
+### 4.3 Skill Generation
+
+Like `gws generate-skills`, `bqx` auto-generates skills from the BigQuery
+Discovery Document:
+
+```bash
+# Generate all skills from BigQuery API + Agent Analytics commands
+bqx generate-skills --output-dir=./skills
+
+# Regenerate only analytics skills
+bqx generate-skills --filter=bqx-analytics --output-dir=./skills
+```
+
+The generator:
+- Fetches the BigQuery v2 Discovery Document
+- Creates one `SKILL.md` per API resource (datasets, tables, jobs, etc.)
+- Creates helper skills for common operations
+- Blocks destructive methods (delete, drop) in skill descriptions
+- Includes flag tables, usage examples, and cross-references
+
+### 4.4 Skill Distribution
+
+```bash
+# npm (all skills)
+npx skills add https://github.com/bigquery/bqx
+
+# Individual skill
+npx skills add https://github.com/bigquery/bqx/tree/main/skills/bqx-analytics
+
+# OpenClaw
+ln -s $(pwd)/skills/bqx-* ~/.openclaw/skills/
+
+# Gemini CLI
+gemini extensions install https://github.com/bigquery/bqx
+
+# Claude Code (auto-discover from project)
+# Just clone the repo — Claude Code reads SKILL.md files automatically
+```
+
+---
+
+## 5. Conversational Analytics Integration
+
+### 5.1 Why This Matters
+
+BigQuery Conversational Analytics lets users ask natural language questions
+over their data. Today it's only accessible in the BigQuery Cloud Console.
+`bqx ca` brings it to the terminal and to agents.
+
+### 5.2 Data Agent for Agent Analytics
+
+The SDK ships a pre-built data agent configuration with verified queries
+tuned for agent analytics:
+
+```bash
+# Create the agent-analytics data agent (one-time setup)
+bqx ca create-agent \
+  --name=agent-analytics \
+  --tables=myproject.analytics.agent_events \
+  --views=myproject.analytics.adk_llm_responses,myproject.analytics.adk_tool_completions \
+  --verified-queries=./deploy/ca/verified_queries.yaml \
+  --instructions="You help analyze AI agent performance. The agent_events
+    table stores traces from ADK agents. Key event types: LLM_REQUEST,
+    LLM_RESPONSE, TOOL_STARTING, TOOL_COMPLETED, TOOL_ERROR.
+    Error detection: event_type ends with _ERROR OR error_message IS NOT NULL
+    OR status = 'ERROR'."
+```
+
+#### Verified Queries (shipped with SDK)
+
+```yaml
+# deploy/ca/verified_queries.yaml
+verified_queries:
+  - question: "What is the error rate for {agent}?"
+    query: |
+      SELECT
+        COUNT(CASE WHEN ENDS_WITH(event_type, '_ERROR')
+                     OR error_message IS NOT NULL
+                     OR status = 'ERROR' THEN 1 END) AS errors,
+        COUNT(DISTINCT session_id) AS sessions,
+        SAFE_DIVIDE(
+          COUNT(CASE WHEN ENDS_WITH(event_type, '_ERROR')
+                       OR error_message IS NOT NULL
+                       OR status = 'ERROR' THEN 1 END),
+          COUNT(DISTINCT session_id)
+        ) AS error_rate
+      FROM `{project}.{dataset}.agent_events`
+      WHERE agent = @agent
+        AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+
+  - question: "What is the p95 latency for {agent}?"
+    query: |
+      SELECT
+        APPROX_QUANTILES(
+          CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64), 100
+        )[OFFSET(95)] AS p95_latency_ms
+      FROM `{project}.{dataset}.agent_events`
+      WHERE agent = @agent
+        AND event_type = 'LLM_RESPONSE'
+        AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+
+  - question: "Which tools fail most often?"
+    query: |
+      SELECT
+        JSON_VALUE(content, '$.tool') AS tool_name,
+        COUNT(*) AS error_count
+      FROM `{project}.{dataset}.agent_events`
+      WHERE event_type = 'TOOL_ERROR'
+        AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+      GROUP BY tool_name
+      ORDER BY error_count DESC
+      LIMIT 10
+
+  - question: "Show me the sessions with highest latency"
+    query: |
+      SELECT
+        session_id,
+        agent,
+        MAX(CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64)) AS max_latency_ms,
+        COUNT(*) AS event_count,
+        MIN(timestamp) AS started_at
+      FROM `{project}.{dataset}.agent_events`
+      WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+      GROUP BY session_id, agent
+      ORDER BY max_latency_ms DESC
+      LIMIT 10
+```
+
+### 5.3 Usage
+
+```bash
+# Natural language query via terminal
+$ bqx ca ask "What were the top errors for support_bot yesterday?" \
+    --agent=agent-analytics
+
+{
+  "question": "What were the top errors for support_bot yesterday?",
+  "sql": "SELECT JSON_VALUE(content, '$.tool') AS tool, error_message, COUNT(*) ...",
+  "results": [
+    {"tool": "database_query", "error_message": "Connection timeout", "count": 15},
+    {"tool": "search_api", "error_message": "Rate limit exceeded", "count": 8}
+  ],
+  "explanation": "The most common errors for support_bot in the last 24 hours were..."
+}
+
+# Compose with analytics commands
+$ bqx ca ask "Which agent had the worst performance today?" --agent=agent-analytics \
+  | jq -r '.results[0].agent' \
+  | xargs -I{} bqx analytics evaluate --agent-id={} --evaluator=latency --threshold=5000 --last=24h
+```
+
+---
+
+## 6. How the Three Domains Compose
+
+The power of `bqx` is that its three domains — BigQuery API, Agent
+Analytics, and Conversational Analytics — compose through Unix pipes and
+agent reasoning:
+
+### Scenario: Agent Investigates Its Own Performance
+
+```
+Agent thinks: "User asked a complex question. Let me check if I've been
+              performing well recently before I commit to an expensive
+              tool call."
+
+Step 1: Quick health check
+  $ bqx analytics evaluate --evaluator=latency --threshold=5000 --last=1h
+  → pass_rate: 0.70 (borderline)
+
+Step 2: Natural language drill-down
+  $ bqx ca ask "What's causing high latency in the last hour?" --agent=agent-analytics
+  → "The database_query tool has p95 latency of 12s due to 3 timeout events"
+
+Step 3: Check specific trace
+  $ bqx analytics get-trace --session-id=sess-042
+  → Shows TOOL_ERROR: "Connection timeout after 30s"
+
+Agent decides: Switch to cached data source for this query.
+```
+
+### Scenario: SRE Triages an Alert
+
+```bash
+# 1. What's the overall health?
+bqx analytics doctor
+
+# 2. Which agents are failing?
+bqx ca ask "Which agents have error rate above 5% in the last hour?"
+
+# 3. Deep dive into the worst one
+bqx analytics evaluate --agent-id=support_bot --evaluator=error_rate --last=1h --format=table
+
+# 4. Get the specific traces
+bqx analytics get-trace --session-id=sess-042 --format=tree
+
+# 5. Run raw SQL for custom analysis
+bqx jobs query --query="
+  SELECT event_type, COUNT(*)
+  FROM analytics.agent_events
+  WHERE session_id = 'sess-042'
+  GROUP BY event_type"
+```
+
+---
+
+## 7. Implementation Roadmap
+
+### Phase 1: Core CLI + Analytics (v0.1) — 4 weeks
+
+- [ ] Rust CLI scaffold with `clap` (auth, global flags, `--format`)
+- [ ] `bqx analytics` commands: `doctor`, `evaluate`, `get-trace`
+- [ ] `--exit-code` for CI/CD
+- [ ] JSON/table/text output formatting
+- [ ] Auth: ADC + service account + `bqx auth login`
+- [ ] npm distribution (`npx bqx`)
+- [ ] 5 core skills: `bqx-shared`, `bqx-analytics`, `bqx-analytics-evaluate`,
+  `bqx-analytics-trace`, `bqx-query`
+
+**Exit criteria:** `npx bqx analytics evaluate --last=1h --exit-code` works
+in GitHub Actions; 5 skills installable via `npx skills add`.
+
+### Phase 2: Dynamic BigQuery API + Skills (v0.2) — 4 weeks
+
+- [ ] Discovery Document fetching + caching
+- [ ] Dynamic `clap::Command` tree generation for BigQuery v2 API
+- [ ] `bqx generate-skills` command
+- [ ] Full skill set: 6 service, 6 helper, 3 persona, 5 recipe skills
+- [ ] Model Armor integration (`--sanitize`)
+- [ ] Gemini CLI extension registration
+
+**Exit criteria:** `bqx datasets list` works without any hardcoded command
+definition; `bqx generate-skills` produces valid SKILL.md files;
+`gemini extensions install` succeeds.
+
+### Phase 3: Conversational Analytics + Polish (v0.3) — 3 weeks
+
+- [ ] `bqx ca ask` — natural language query via CA API
+- [ ] `bqx ca create-agent` — create data agents
+- [ ] `bqx ca add-verified-query` — add verified queries
+- [ ] Ship `deploy/ca/verified_queries.yaml` with SDK
+- [ ] Remaining analytics commands: `insights`, `drift`, `distribution`,
+  `views`, `hitl-metrics`, `list-traces`
+- [ ] Completion scripts (bash, zsh, fish)
+- [ ] Documentation and examples
+
+**Exit criteria:** `bqx ca ask "error rate for support_bot?"` returns
+structured JSON with SQL and results; all analytics commands pass
+integration tests.
+
+---
+
+## 8. Relationship to Existing Tools
+
+| Tool | Role | Relationship to `bqx` |
+|------|------|----------------------|
+| `bq` CLI | Legacy BigQuery CLI | `bqx` is a successor, not a wrapper. Coexists — users can migrate gradually. |
+| `gcloud` | Google Cloud CLI | `bqx` handles BigQuery-specific workflows; delegates to `gcloud` for IAM, projects. |
+| `gws` CLI | Google Workspace CLI | Architectural template. Same skills format, same output patterns, different domain. |
+| `bq-agent-sdk` (from PRD) | Python CLI from current PRD | `bqx analytics` subsumes this. The Python SDK remains as a library; the CLI moves to Rust. |
+| BigQuery Console | Web UI | `bqx ca ask` brings CA to terminal; `bqx analytics` brings SDK to terminal. |
+
+---
+
+## 9. Open Questions
+
+1. **Language choice:** Rust (like `gws`) vs Go (like `gcloud`/`bq`)?
+   **Recommendation:** Rust — faster startup, smaller binary, proven by `gws`.
+
+2. **Naming:** `bqx` vs `bqai` vs `bq2`?
+   **Recommendation:** `bqx` — short, clearly extends `bq`, no conflict.
+
+3. **BigQuery API coverage scope:** Full Discovery Document or curated subset?
+   **Recommendation:** Start with curated (datasets, tables, jobs, routines,
+   models, connections); add more resources via `generate-skills` as needed.
+
+4. **CA API availability:** The Conversational Analytics API is in preview.
+   **Mitigation:** Phase 3 depends on API stability; Phase 1-2 deliver
+   value independently.
+
+5. **Relationship to `bq-agent-sdk` CLI in current PRD:**
+   **Recommendation:** The current PRD's Python CLI (§4) becomes a
+   stepping-stone. v1.0 ships as `bq-agent-sdk` (Python/typer); once `bqx`
+   reaches v0.2, analytics commands migrate to `bqx analytics` and the
+   Python CLI is deprecated.

--- a/docs/python_udf_support_design.md
+++ b/docs/python_udf_support_design.md
@@ -1,0 +1,586 @@
+# Python UDF Support Design
+
+**Status:** Proposal
+**Parent PRD:** [Unified Analytics Interface](prd_unified_analytics_interface.md)
+**Related:** [Remote Function Rationale](remote_function_rationale.md)
+**Date:** 2026-03-14
+
+---
+
+## 1. Executive Summary
+
+This document proposes adding a **second SQL integration path** for the
+BigQuery Agent Analytics SDK based on **BigQuery Python UDFs**, while
+**retaining the existing Remote Function path** as the primary
+full-fidelity interface.
+
+This is the right product shape.
+
+It is not the right engineering move to replace Remote Function with
+Python UDF. The two mechanisms solve different problems:
+
+- **Remote Function** is the right fit for the current multiplexed
+  `agent_analytics(operation STRING, params JSON) RETURNS JSON` contract.
+- **Python UDF** is the right fit for **typed, scalar, row-level or
+  vectorized analytical kernels** that run directly inside BigQuery.
+
+The recommended approach is:
+
+1. Keep **Remote Function** for the broad SDK surface area.
+2. Add **Python UDF** as an **independent, complementary interface**.
+3. Reuse SDK logic only where it can be expressed as **pure Python kernels**
+   over typed inputs.
+4. Do **not** attempt to force the current JSON-RPC-like remote function
+   contract into Python UDF as the primary design.
+
+---
+
+## 2. Why an Independent Python UDF Path Is a Good Approach
+
+Yes, keeping both is a good approach, but only if the two paths are
+deliberately separated.
+
+That separation matters because the platform contracts are different:
+
+- Python UDFs are **Preview / Pre-GA**.
+- Python UDFs implement a **scalar function in Python**.
+- Python UDFs do **not support `JSON`** types.
+- Python UDFs can use third-party packages and can access external services
+  only when created with a **Cloud resource connection**.
+- Python UDFs run on **BigQuery-managed resources**, which removes Cloud
+  Functions / Cloud Run deployment from the architecture.
+
+Official references:
+
+- BigQuery Python UDFs:
+  `https://docs.cloud.google.com/bigquery/docs/user-defined-functions-python`
+- BigQuery UDFs overview:
+  `https://docs.cloud.google.com/bigquery/docs/user-defined-functions`
+- BigQuery Remote Functions:
+  `https://docs.cloud.google.com/bigquery/docs/remote-functions`
+
+The product decision is therefore:
+
+- **Remote Function** remains the best interface for the current
+  operation-dispatch design.
+- **Python UDF** should be added only for the subset of SDK capabilities that
+  naturally map to typed UDF signatures and in-engine execution.
+
+---
+
+## 3. Platform Constraints That Shape the Design
+
+The design has to respect the current BigQuery Python UDF contract.
+
+### 3.1 Confirmed Python UDF constraints
+
+From the current BigQuery Python UDF documentation:
+
+- Runtime is limited to `python-3.11`
+- Python UDFs are **persistent only**; temporary Python UDFs are not supported
+- Python UDFs cannot be used in **materialized views**
+- Python UDF query results are not cached
+- `JSON`, `RANGE`, `INTERVAL`, and `GEOGRAPHY` types are not supported
+- Network access is blocked unless the UDF is created with `WITH CONNECTION`
+- PyPI packages and Cloud Storage Python libraries are supported
+- Vectorized UDFs are documented for Python but `OPTIONS(vectorized = true)`
+  is not yet supported in the Python UDF preview (only JavaScript UDFs)
+
+### 3.2 Consequences for this SDK
+
+These constraints drive several design decisions:
+
+1. The current Remote Function API cannot be ported as-is.
+   Reason: it depends on `JSON` input/output and a multiplexed
+   operation-dispatch contract.
+
+2. Full `Client` reuse is not the right goal.
+   Reason: `Client` is built around issuing BigQuery jobs, loading trace rows,
+   and assembling rich Python objects such as `Trace`,
+   [`EvaluationReport`](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py),
+   and [`InsightsReport`](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/insights.py).
+
+3. Python UDF support should be built around **small analytical kernels**,
+   not around a UDF that internally reimplements the whole SDK client.
+
+4. Complex outputs should use either:
+   - typed scalar return values, or
+   - `STRING` returns carrying JSON text when structured output is necessary.
+
+5. Session-level analytics will often require a **SQL + UDF split**:
+   SQL does the scan and aggregation; Python UDF does the reusable scoring or
+   parsing logic.
+
+---
+
+## 4. Product Positioning
+
+The SDK should expose two SQL-native paths:
+
+| Path | Best for | Contract shape | Infra model |
+|------|----------|----------------|-------------|
+| Remote Function | Full SDK access from SQL | Multiplexed, JSON-based | Cloud Function + BQ connection |
+| Python UDF | Direct typed functions in BigQuery | Scalar / vectorized typed UDFs | BigQuery-managed runtime |
+
+### 4.1 Recommendation
+
+Use this positioning:
+
+- **Remote Function** = broadest capability coverage
+- **Python UDF** = lowest operational friction for deterministic kernels
+
+This avoids a false choice. It also gives users a clean progression:
+
+1. Start with Python UDFs for lightweight scoring and canonical event logic.
+2. Move to Remote Function when they need richer objects, broader method
+   coverage, or JSON-based multi-operation dispatch.
+
+---
+
+## 5. What Part of the SDK Should Python UDF Support?
+
+The goal is not "all SDK features in Python UDF." That is not realistic under
+current BigQuery constraints.
+
+The right goal is:
+
+> Support as much of the SDK as possible by extracting the subset of logic that
+> is deterministic, pure-Python, typed, and meaningful at row or batch level.
+
+### 5.1 Strong fit: deterministic analytical kernels
+
+These parts of the SDK map well to Python UDFs:
+
+| SDK area | Current source | Python UDF fit | Design |
+|----------|----------------|----------------|--------|
+| Error detection | [event_semantics.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/event_semantics.py) | Strong | `BOOL` helpers such as `is_error_event` |
+| Tool outcome classification | [event_semantics.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/event_semantics.py) | Strong | `STRING` helpers such as `tool_outcome` |
+| Response text extraction | [event_semantics.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/event_semantics.py) | Good | parse-wrapper plus `STRING` extraction from a JSON-formatted `STRING` payload |
+| Latency scoring | [evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py) | Strong | `FLOAT64` score kernel |
+| Turn-count scoring | [evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py) | Strong | `FLOAT64` score kernel |
+| Error-rate scoring | [evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py) | Strong | `FLOAT64` score kernel |
+| TTFT scoring | [evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py) | Strong | `FLOAT64` score kernel |
+| Cost scoring | [evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py) | Strong | wider `FLOAT64` score kernel over token and pricing inputs |
+
+These kernels are exactly the kind of logic that benefits from direct SQL
+invocation with no external deployment surface.
+
+### 5.2 Moderate fit: session-level scoring via SQL pre-aggregation
+
+These capabilities can be supported, but not as a single "call the SDK"
+primitive:
+
+| SDK area | Python UDF fit | Required redesign |
+|----------|----------------|-------------------|
+| `Client.evaluate(CodeEvaluator, filters)` | Partial | SQL builds per-session summaries first; UDF computes scores from summary fields |
+| `Client.deep_analysis()` / question distribution | Partial | SQL does grouping / embeddings / top-k; UDF can help with categorization or normalization |
+| `Client.drift_detection()` | Partial | SQL computes set logic; UDF may help with text normalization or thresholding |
+| `Client.insights()` | Partial | Best split into SQL extraction + optional UDF post-processing; not a direct port |
+
+### 5.3 Weak fit or out of scope
+
+These SDK capabilities should remain Remote Function or Python-library-only:
+
+| SDK area | Why Python UDF is a poor fit |
+|----------|------------------------------|
+| `Client.get_trace()` / `get_session_trace()` | Rich trace reconstruction, nested objects, and event-row loading do not map cleanly to scalar UDFs |
+| `Client.list_traces()` | Returns collections, not scalar computation kernels |
+| `Client.doctor()` | Environment and schema diagnostics are not a natural UDF workload |
+| `ViewManager` | DDL management is not a UDF responsibility |
+| `ContextGraphManager` / GQL / audit export | Multi-table graph workflows and property graph DDL are outside UDF scope |
+| Memory service | Stateful retrieval and semantic search are not good scalar UDF targets |
+| Trial runner / eval suite / grader pipeline | Orchestration constructs, not in-query scalar kernels |
+
+---
+
+## 6. Recommended Design Principle
+
+The Python UDF path should not depend on instantiating the full
+[`Client`](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/client.py)
+inside the UDF body.
+
+Instead, the SDK should expose a new internal layer:
+
+```text
+bigquery_agent_analytics/
+  client.py               # BigQuery job orchestration
+  evaluators.py           # existing evaluator logic
+  event_semantics.py      # existing canonical predicates
+  udf_kernels.py          # new: pure functions reused by Python UDFs
+  udf_serialization.py    # new: STRING envelope helpers if needed
+```
+
+### 6.1 Why this layering is better
+
+It keeps the contracts clear:
+
+- `Client` remains the orchestration layer
+- Remote Function remains the broad SQL bridge
+- Python UDFs reuse only pure business logic that is stable and typed
+
+That is maintainable. Reusing the entire client inside a Python UDF is not.
+
+### 6.2 Extraction work is real, not free
+
+The current evaluator score math is not implemented as standalone top-level
+functions today. It lives inside factory-method closures such as
+`CodeEvaluator.latency()` and `CodeEvaluator.error_rate()` in
+[evaluators.py](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/evaluators.py).
+
+That means the first implementation step is a deliberate refactor:
+
+1. extract each `_score` closure into a top-level pure function in
+   `udf_kernels.py`
+2. update the existing evaluator factories to call those shared functions
+3. add parity tests proving exact behavior matches the current implementation
+
+Those parity tests must cover the existing edge cases, including the current
+"missing or non-positive input returns `1.0`" behavior.
+
+---
+
+## 7. Proposed Python UDF API Surface
+
+The recommended API surface is a **family of typed functions**, not a single
+multiplexed UDF.
+
+### 7.1 Tier 1: canonical event semantics
+
+These should be the first Python UDFs because they are simple, stable, and
+useful across many queries.
+
+```sql
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_is_error_event`(
+  event_type STRING,
+  error_message STRING,
+  status STRING
+) RETURNS BOOL
+LANGUAGE python
+...
+
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_tool_outcome`(
+  event_type STRING,
+  status STRING
+) RETURNS STRING
+LANGUAGE python
+...
+
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_extract_response_text`(
+  content_json STRING
+) RETURNS STRING
+LANGUAGE python
+...
+```
+
+`bqaa_extract_response_text` is not a direct lift of the current helper.
+The existing
+[`extract_response_text()`](/Users/haiyuancao/BigQuery-Agent-Analytics-SDK/src/bigquery_agent_analytics/event_semantics.py)
+accepts a parsed Python `dict`. The Python UDF version therefore needs a thin
+parse wrapper that accepts `STRING`, calls `json.loads()`, then delegates to
+the shared extraction helper.
+
+### 7.2 Tier 2: code-evaluator score kernels
+
+These should map directly to the existing `CodeEvaluator` math:
+
+```sql
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_score_latency`(
+  avg_latency_ms FLOAT64,
+  threshold_ms FLOAT64
+) RETURNS FLOAT64
+LANGUAGE python
+...
+
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_score_error_rate`(
+  tool_calls INT64,
+  tool_errors INT64,
+  max_error_rate FLOAT64
+) RETURNS FLOAT64
+LANGUAGE python
+...
+
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_score_turn_count`(
+  turn_count INT64,
+  max_turns INT64
+) RETURNS FLOAT64
+LANGUAGE python
+...
+
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_score_cost`(
+  input_tokens INT64,
+  output_tokens INT64,
+  max_cost_usd FLOAT64,
+  input_cost_per_1k FLOAT64,
+  output_cost_per_1k FLOAT64
+) RETURNS FLOAT64
+LANGUAGE python
+...
+```
+
+`bqaa_score_cost` is the widest deterministic kernel in the first batch. It
+cannot reuse the simpler two- or three-argument signatures used by the other
+scoring functions because the current `cost_per_session()` evaluator depends on
+both token counts and pricing parameters.
+
+These kernels let users express session evaluation in plain SQL:
+
+```sql
+WITH session_summary AS (
+  SELECT
+    session_id,
+    AVG(latency_ms) AS avg_latency_ms,
+    COUNTIF(event_type = 'TOOL_STARTING') AS tool_calls,
+    COUNTIF(event_type = 'TOOL_ERROR') AS tool_errors,
+    COUNTIF(event_type = 'USER_MESSAGE_RECEIVED') AS turn_count
+  FROM `PROJECT.DATASET.agent_events`
+  GROUP BY session_id
+)
+SELECT
+  session_id,
+  `PROJECT.UDF_DATASET.bqaa_score_latency`(avg_latency_ms, 5000.0) AS latency,
+  `PROJECT.UDF_DATASET.bqaa_score_error_rate`(
+    tool_calls, tool_errors, 0.1
+  ) AS error_rate,
+  `PROJECT.UDF_DATASET.bqaa_score_turn_count`(turn_count, 10) AS turn_score
+FROM session_summary;
+```
+
+### 7.3 Tier 3: vectorized scoring envelopes
+
+Where row-wise scalar UDFs become too slow or repetitive, add vectorized Python
+UDFs that accept a batch of typed columns and return one score column.
+
+This is the right place to support:
+
+- batch latency scoring
+- batch cost scoring
+- batch normalized labels from free-text fields
+
+### 7.4 Tier 4: optional STRING-envelope functions
+
+For outputs that need richer structure, allow a separate family of UDFs that
+return `STRING` containing JSON text:
+
+```sql
+CREATE FUNCTION `PROJECT.UDF_DATASET.bqaa_eval_summary_json`(
+  avg_latency_ms FLOAT64,
+  tool_calls INT64,
+  tool_errors INT64,
+  turn_count INT64,
+  threshold_ms FLOAT64,
+  max_error_rate FLOAT64,
+  max_turns INT64
+) RETURNS STRING
+LANGUAGE python
+...
+```
+
+This is acceptable as a secondary pattern, but it should not become the
+primary API style.
+
+---
+
+## 8. What Not to Do
+
+These anti-patterns should be explicitly avoided.
+
+### 8.1 Do not build a Python UDF clone of the Remote Function
+
+Avoid:
+
+```sql
+-- Not recommended
+CREATE FUNCTION fn(operation STRING, params STRING) RETURNS STRING
+```
+
+Why this is the wrong default:
+
+- it recreates a JSON-RPC envelope without JSON type support
+- it loses type safety
+- it is harder to document and optimize
+- it hides which inputs are actually required
+- it becomes a second dispatch surface to maintain
+
+### 8.2 Do not call BigQuery recursively from inside the UDF as the main model
+
+The Python UDF should not become a wrapper that:
+
+1. accepts a session id
+2. creates a BigQuery client
+3. submits another BigQuery job
+4. waits for the result
+5. returns a string
+
+That would be operationally fragile, hard to reason about, and contrary to the
+point of in-engine computation.
+
+### 8.3 Do not promise full SDK parity
+
+Python UDF should be documented as a **subset interface**. If the docs imply
+"everything the SDK can do is now callable directly as a Python UDF," the docs
+will overpromise and drift.
+
+---
+
+## 9. Proposed Repository Layout
+
+If this proposal is accepted, the implementation should add a separate deploy
+surface:
+
+```text
+deploy/
+  remote_function/
+  python_udf/
+    register.sql
+    generate_sql.py
+    README.md
+examples/
+  python_udf_evaluation.sql
+  python_udf_event_semantics.sql
+src/bigquery_agent_analytics/
+  udf_kernels.py
+  udf_sql_templates.py
+tests/
+  test_udf_kernels.py
+  test_udf_sql_generation.py
+docs/
+  python_udf_support_design.md
+```
+
+### 9.1 `udf_kernels.py`
+
+This module should contain only:
+
+- pure functions
+- typed inputs and outputs
+- no BigQuery client creation
+- no file IO
+- no environment-dependent behavior
+
+That gives one source of truth for both Python and SQL-facing implementations.
+
+---
+
+## 10. Coverage Matrix
+
+This is the realistic support target.
+
+| SDK capability | Remote Function | Python UDF | Recommended path |
+|----------------|-----------------|------------|------------------|
+| Trace reconstruction | Full | No | Remote Function / Python SDK |
+| Deterministic score math | Full | Full | Both |
+| Canonical event predicates | N/A | Full | Python UDF |
+| Session-level eval from pre-aggregated SQL | Good | Good | Both |
+| LLM judge | Good | Maybe, but not preferred | Remote Function or BigQuery SQL AI |
+| Insights extraction | Good | Partial | Remote Function or SQL AI pipeline |
+| Drift detection | Good | Partial | Remote Function plus SQL primitives |
+| Context graph / GQL / audit | Full | No | Remote Function / Python SDK |
+| View creation | No | No | CLI / Python SDK |
+| Health diagnostics | No | No | CLI / Python SDK |
+
+### 10.1 Important implication
+
+Python UDF should be described as:
+
+> "Fastest path for deterministic, typed analytics inside BigQuery."
+
+Remote Function should still be described as:
+
+> "Broadest SQL interface for SDK capabilities."
+
+---
+
+## 11. Recommended Rollout Plan
+
+### Phase U1: design-safe core extraction
+
+- Add `udf_kernels.py`
+- Move reusable evaluator math into standalone pure functions
+- Move reusable event semantic helpers into a UDF-safe layer
+- Add unit tests proving parity with existing `CodeEvaluator` behavior
+
+### Phase U2: Tier 1 and Tier 2 UDFs
+
+- Register event semantics UDFs
+- Register deterministic score UDFs
+- Publish example SQL for session scoring
+- Document region-replication guidance for utility datasets
+
+Note: BigQuery UDFs are region-scoped. The BigQuery UDF docs recommend
+maintaining UDFs in each region, or using dataset replication for utility
+datasets.
+
+### Phase U3: vectorized UDFs (deferred)
+
+- **Deferred**: BigQuery Python UDF preview does not support
+  `OPTIONS(vectorized = true)`. The option is currently only available
+  for JavaScript UDFs. Vectorized Python UDFs will be added when
+  BigQuery extends `vectorized` support to the Python runtime.
+- When available: add batch-oriented UDFs where scalar calls become
+  inefficient; benchmark against pure SQL expressions and Remote
+  Function equivalents.
+
+### Phase U4: selective structured `STRING` envelopes
+
+- Add JSON-string return helpers only where the structure is worth the extra
+  parsing overhead
+
+---
+
+## 12. Documentation Positioning
+
+The docs should say this explicitly:
+
+- Python UDF support is **complementary**
+- Remote Function support remains **first-class**
+- Python UDF support is aimed at **deterministic and typed kernels**
+- Complex, orchestration-heavy, or JSON-heavy SDK features remain better served
+  by Remote Function or direct Python usage
+
+Recommended wording:
+
+> The SDK supports two SQL-native execution paths. Use Remote Function for the
+> broadest method coverage and JSON-shaped outputs. Use Python UDFs for direct
+> in-BigQuery execution of deterministic analytical kernels with typed inputs.
+
+---
+
+## 13. Concrete Recommendation
+
+Yes, adding independent Python UDF support is a good approach.
+
+But only under these conditions:
+
+1. Remote Function stays in place as the full-surface SQL bridge.
+2. Python UDF support is positioned as a **parallel subset interface**.
+3. The Python UDF API is **typed and function-family-based**, not a second
+   JSON-RPC dispatcher.
+4. The implementation reuses **pure kernels**, not the full `Client`
+   orchestration layer.
+
+If those constraints are followed, Python UDF support improves the SDK:
+
+- less deployment overhead for deterministic SQL-native users
+- better fit for direct BigQuery evaluation patterns
+- no damage to the existing Remote Function design
+
+If those constraints are not followed, Python UDF support will become a second,
+worse Remote Function implementation.
+
+---
+
+## 14. Proposed Next Step
+
+The next step should be a narrow implementation plan, not immediate broad
+feature parity.
+
+Recommended first cut:
+
+1. Event semantics UDFs
+2. Deterministic score kernels for `latency`, `error_rate`, `turn_count`,
+   `ttft`, and `cost`
+3. Example SQL showing session pre-aggregation plus UDF scoring
+4. Benchmark and doc comparison versus Remote Function
+
+That is the highest-confidence path to "support as much as possible" without
+building the wrong abstraction.

--- a/docs/remote_function_rationale.md
+++ b/docs/remote_function_rationale.md
@@ -1,0 +1,251 @@
+# Why the SDK Needs a BigQuery Remote Function Interface
+
+**Status:** Proposal
+**Parent PRD:** [Unified Analytics Interface](prd_unified_analytics_interface.md)
+**Date:** 2026-03-06
+
+---
+
+## 1. The Problem
+
+The BigQuery Agent Analytics SDK has 16+ analytical capabilities — trace
+retrieval, latency evaluation, LLM-as-judge scoring, drift detection,
+insights extraction — but every one requires writing Python code. This
+locks out the largest user group in the data ecosystem: **SQL analysts**.
+
+```
+Today:
+  Analyst → "I need agent quality metrics in my dashboard"
+          → Files ticket to Python engineer
+          → Engineer writes notebook, exports CSV
+          → Analyst imports into Looker
+          → 3-day turnaround, stale by arrival
+
+With Remote Function:
+  Analyst → SELECT agent_analytics('analyze', JSON'{"session_id":"s1"}')
+          → Scheduled query materializes nightly
+          → Looker reads table directly
+          → 10-minute setup, always fresh
+```
+
+### Who is blocked today
+
+| User | What they need | Why Python-only blocks them |
+|------|---------------|---------------------------|
+| **Data analysts** | Agent quality dashboards in Looker | Cannot run Python in BigQuery console |
+| **BI engineers** | Scheduled quality reports | Cannot add Python dependencies to scheduled queries |
+| **Data scientists** | Batch evaluation of 10K sessions | SDK works per-session; SQL can fan out natively |
+| **On-call SREs** | Ad-hoc investigation in BigQuery | Switching to a notebook during an incident adds friction |
+
+---
+
+## 2. The Solution: One Multiplexed Remote Function
+
+Deploy the SDK as a Cloud Function, register it as a BigQuery Remote
+Function, and expose all operations through a single SQL-callable endpoint:
+
+```sql
+agent_analytics(operation STRING, params JSON) RETURNS JSON
+```
+
+### Architecture
+
+```
+┌─────────────────┐     ┌──────────────────────┐     ┌─────────────┐
+│   BigQuery      │────▶│  Cloud Function       │────▶│  BigQuery   │
+│   SELECT fn()   │     │  (SDK Core)           │     │  (queries)  │
+│                 │◀────│  handle_request()      │◀────│             │
+│   Returns JSON  │     └──────────────────────┘     └─────────────┘
+└─────────────────┘
+```
+
+BigQuery sends batched rows via HTTP POST. Each row is an
+`[operation, params_json]` tuple. The function dispatches to the
+appropriate SDK method and returns JSON results. BigQuery handles
+retry (HTTP 408/429/5xx) and batching automatically.
+
+### Supported Operations
+
+| Operation | What it does | Example params |
+|-----------|-------------|----------------|
+| `analyze` | Trace metrics (spans, errors, latency) | `{"session_id": "s1"}` |
+| `evaluate` | Code-based evaluation (latency, error rate) | `{"session_id": "s1", "metric": "latency", "threshold": 5000}` |
+| `judge` | LLM-as-judge scoring | `{"session_id": "s1", "criterion": "correctness"}` |
+| `insights` | Intent/outcome/friction extraction | `{"session_id": "s1"}` |
+| `drift` | Golden-set coverage analysis | `{"golden_dataset": "golden_qs", "agent_filter": "bot"}` |
+
+---
+
+## 3. Concrete User Journeys
+
+### Journey 1: Nightly Quality Dashboard
+
+Priya (data analyst) creates a scheduled query — no Python needed:
+
+```sql
+-- Runs nightly, materializes agent quality scores
+CREATE OR REPLACE TABLE `project.analytics.daily_quality` AS
+WITH recent AS (
+  SELECT DISTINCT session_id, MIN(timestamp) AS ts, ANY_VALUE(agent) AS agent
+  FROM `project.analytics.agent_events`
+  WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+  GROUP BY session_id
+)
+SELECT
+  session_id, ts, agent,
+  JSON_VALUE(r, '$.error_count') AS error_count,
+  CAST(JSON_VALUE(r, '$.avg_latency_ms') AS FLOAT64) AS avg_latency_ms,
+  JSON_VALUE(r, '$.tool_call_count') AS tool_calls
+FROM recent,
+UNNEST([`project.analytics.agent_analytics`('analyze',
+  JSON_OBJECT('session_id', session_id))]) AS r;
+```
+
+She connects Looker to `daily_quality` — dashboard shows latency trends,
+error rates, and tool usage by agent. Total setup: **~30 minutes**.
+
+### Journey 2: LLM-as-Judge at Scale
+
+Score every session for correctness, surface the worst ones for review:
+
+```sql
+SELECT session_id,
+  CAST(JSON_VALUE(j, '$.score') AS FLOAT64) AS score,
+  JSON_VALUE(j, '$.feedback') AS feedback
+FROM (
+  SELECT DISTINCT session_id
+  FROM `project.analytics.agent_events`
+  WHERE agent = 'support_bot' AND timestamp >= '2026-03-01'
+) s,
+UNNEST([`project.analytics.agent_analytics`('judge',
+  JSON_OBJECT('session_id', s.session_id, 'criterion', 'correctness'))]) AS j
+WHERE CAST(JSON_VALUE(j, '$.score') AS FLOAT64) < 0.7
+ORDER BY score ASC;
+```
+
+### Journey 3: Weekly Drift Alert
+
+Scheduled query detects when production questions drift from the golden set:
+
+```sql
+SELECT
+  JSON_VALUE(d, '$.coverage_percentage') AS coverage_pct,
+  JSON_QUERY(d, '$.uncovered_questions') AS gaps
+FROM UNNEST([`project.analytics.agent_analytics`('drift',
+  JSON_OBJECT('golden_dataset', 'project.analytics.golden_questions',
+              'agent_filter', 'support_bot',
+              'start_date', '2026-03-01', 'end_date', '2026-03-06'))]) AS d;
+```
+
+If coverage drops below 85%, a BigQuery alert triggers a Slack notification.
+
+---
+
+## 4. Deployment & Security
+
+### One-Time Setup (Platform Engineer)
+
+```bash
+# 1. Deploy Cloud Function
+gcloud functions deploy bq-agent-analytics \
+  --gen2 --runtime python312 --region us-central1 \
+  --entry-point handle_request --source ./deploy/remote_function/ \
+  --trigger-http --no-allow-unauthenticated
+
+# 2. Create CLOUD_RESOURCE connection
+bq mk --connection --location=US --connection_type=CLOUD_RESOURCE \
+  --project_id=PROJECT analytics-conn
+
+# 3. Grant connection SA → Cloud Run Invoker
+CONNECTION_SA=$(bq show --connection --format=json PROJECT.us.analytics-conn \
+  | jq -r '.cloudResource.serviceAccountId')
+gcloud functions add-invoker-policy-binding bq-agent-analytics \
+  --region=us-central1 --member="serviceAccount:${CONNECTION_SA}"
+
+# 4. Register the remote function
+bq query --use_legacy_sql=false '
+CREATE FUNCTION `PROJECT.analytics.agent_analytics`(
+  operation STRING, params JSON
+) RETURNS JSON
+REMOTE WITH CONNECTION `PROJECT.us.analytics-conn`
+OPTIONS (
+  endpoint = "https://us-central1-PROJECT.cloudfunctions.net/bq-agent-analytics",
+  max_batching_rows = 50
+)'
+```
+
+### Least-Privilege IAM
+
+| Service Account | Roles | Scope |
+|----------------|-------|-------|
+| Cloud Function runtime SA | `bigquery.dataViewer`, `bigquery.jobUser` | Analytics dataset + project |
+| BQ Connection SA (auto-created) | `run.invoker` | The Cloud Function |
+
+The Cloud Function SA only needs read access to `agent_events`. It cannot
+write data or modify schemas.
+
+### API Contract
+
+- **Versioning:** Responses include `_version: "1.0"`. v1.x is additive-only.
+- **Partial failure:** If 1 of 5 batched rows fails, the other 4 succeed.
+  Failed rows return `{"_error": {"code": "SESSION_NOT_FOUND", ...}}`.
+- **Idempotency:** All read-only operations (`analyze`, `evaluate`) are
+  naturally idempotent. `judge` is non-deterministic (LLM output varies).
+
+---
+
+## 5. Cost & Performance
+
+### Cost per 1K Sessions
+
+| Component | Cost | Notes |
+|-----------|------|-------|
+| BigQuery scan | ~$0.03 | ~6 MB/session, $6.25/TB on-demand |
+| Cloud Function | ~$0.01 | 256 MB, ~500ms/invocation |
+| LLM calls (`judge` only) | ~$1.25 | Gemini 2.5 Flash, ~600 tokens/call |
+
+A nightly evaluation of 1K sessions costs **< $0.05** without LLM,
+**~$1.30** with LLM-as-judge. Partitioning `agent_events` by timestamp
+reduces scan cost by 90%+.
+
+### Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| `analyze` p95 latency | < 5 seconds |
+| `evaluate` p95 latency | < 5 seconds |
+| `judge` p95 latency | < 15 seconds (LLM-bound) |
+| Cold start | < 3 seconds (Cloud Function gen2) |
+| Availability | 99.5% (Cloud Function + BQ connection) |
+
+### Why Not Just Use Continuous Queries?
+
+Continuous Queries (`APPENDS()` + `AI.GENERATE_TEXT`) are excellent for
+real-time per-row processing, but they **cannot** use `JOIN`, `GROUP BY`,
+aggregations, or user-defined remote functions. The SDK's analytical
+operations — trace assembly, drift detection, batch evaluation — require
+cross-row logic that only Remote Functions can provide in SQL.
+
+| Need | Remote Function | Continuous Query |
+|------|----------------|-----------------|
+| Aggregate session metrics | Yes | No (no GROUP BY) |
+| Compare against golden set | Yes (JOIN) | No (no JOIN) |
+| Batch evaluate 10K sessions | Yes | No (per-row only) |
+| Real-time error classification | No (batch) | Yes |
+
+The two paths are complementary, not competing.
+
+---
+
+## Summary
+
+| Without Remote Function | With Remote Function |
+|------------------------|---------------------|
+| SQL analysts file tickets for Python engineers | SQL analysts self-serve with `SELECT agent_analytics(...)` |
+| Dashboard data is days stale | Scheduled queries materialize nightly |
+| Batch evaluation requires notebooks | `SELECT ... FROM sessions` fans out natively |
+| Drift detection is a manual Python script | Scheduled query alerts automatically |
+| 3-day turnaround for quality reports | 30-minute setup, always fresh |
+
+The Remote Function is the bridge between the SDK's analytical depth and
+BigQuery's reach. It turns every SQL user into an agent analytics user.

--- a/examples/ci_eval_pipeline.sh
+++ b/examples/ci_eval_pipeline.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example: CI/CD evaluation pipeline using bq-agent-sdk CLI.
+#
+# This script runs multiple evaluations and gates the build on their
+# results.  Use it in GitHub Actions, Cloud Build, or any CI system.
+#
+# Prerequisites:
+#   pip install bigquery-agent-analytics
+#   export BQ_AGENT_PROJECT=my-project
+#   export BQ_AGENT_DATASET=agent_analytics
+#
+# Usage:
+#   bash examples/ci_eval_pipeline.sh
+#
+# In GitHub Actions:
+#   - name: Run agent evaluation gate
+#     env:
+#       BQ_AGENT_PROJECT: ${{ secrets.BQ_PROJECT }}
+#       BQ_AGENT_DATASET: ${{ secrets.BQ_DATASET }}
+#     run: bash examples/ci_eval_pipeline.sh
+
+set -euo pipefail
+
+echo "=== Agent Evaluation Pipeline ==="
+echo ""
+
+# Step 1: Health check
+echo "--- Step 1: Health check ---"
+if ! bq-agent-sdk doctor --format=text; then
+  echo "FAIL: Health check failed. Aborting pipeline."
+  exit 2
+fi
+echo ""
+
+# Step 2: Latency evaluation (last 24h)
+echo "--- Step 2: Latency gate ---"
+bq-agent-sdk evaluate \
+  --evaluator=latency \
+  --threshold=5000 \
+  --last=24h \
+  --exit-code \
+  --format=text
+echo ""
+
+# Step 3: Error rate evaluation
+echo "--- Step 3: Error rate gate ---"
+bq-agent-sdk evaluate \
+  --evaluator=error_rate \
+  --threshold=0.1 \
+  --last=24h \
+  --exit-code \
+  --format=text
+echo ""
+
+# Step 4: Cost evaluation
+echo "--- Step 4: Cost gate ---"
+bq-agent-sdk evaluate \
+  --evaluator=cost \
+  --threshold=2.0 \
+  --last=24h \
+  --exit-code \
+  --format=text
+echo ""
+
+# Step 5: Generate insights report (informational, does not gate)
+echo "--- Step 5: Insights report ---"
+bq-agent-sdk insights --last=24h --format=text || true
+echo ""
+
+echo "=== All evaluation gates passed ==="

--- a/examples/cli_agent_tool.py
+++ b/examples/cli_agent_tool.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example: ADK agent that uses bq-agent-sdk CLI for self-diagnostics.
+
+This shows how an agent can call the SDK CLI as a tool to inspect its
+own traces, run evaluations, and generate insights — enabling
+self-monitoring and adaptive behavior.
+
+Prerequisites:
+    pip install bigquery-agent-analytics google-adk
+
+Usage:
+    export BQ_AGENT_PROJECT=my-project
+    export BQ_AGENT_DATASET=agent_analytics
+    python examples/cli_agent_tool.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from google.adk import Agent
+
+
+def run_bq_agent_sdk(command: str, args: dict) -> dict:
+  """Run a bq-agent-sdk CLI command and return parsed JSON output.
+
+  Args:
+      command: CLI command name (e.g. "doctor", "evaluate", "insights").
+      args: Dict of CLI arguments (keys without leading dashes).
+
+  Returns:
+      Parsed JSON output from the command.
+  """
+  cmd = ["bq-agent-sdk", command, "--format=json"]
+  for key, value in args.items():
+    flag = key.replace("_", "-")
+    if isinstance(value, bool):
+      if value:
+        cmd.append(f"--{flag}")
+    else:
+      cmd.append(f"--{flag}={value}")
+
+  result = subprocess.run(
+      cmd,
+      capture_output=True,
+      text=True,
+      check=False,
+  )
+  if result.returncode == 0:
+    return json.loads(result.stdout)
+  return {"error": result.stderr.strip(), "exit_code": result.returncode}
+
+
+# -- Agent tool definitions --
+
+
+def check_health() -> dict:
+  """Check SDK connectivity and data health."""
+  return run_bq_agent_sdk("doctor", {})
+
+
+def evaluate_recent_sessions(
+    evaluator: str = "latency",
+    last: str = "1h",
+    limit: int = 50,
+) -> dict:
+  """Evaluate recent sessions with a given evaluator."""
+  return run_bq_agent_sdk(
+      "evaluate",
+      {
+          "evaluator": evaluator,
+          "last": last,
+          "limit": limit,
+      },
+  )
+
+
+def get_insights(last: str = "24h") -> dict:
+  """Generate an insights report over recent traces."""
+  return run_bq_agent_sdk("insights", {"last": last})
+
+
+def get_session_trace(session_id: str) -> dict:
+  """Retrieve the full trace for a specific session."""
+  return run_bq_agent_sdk(
+      "get-trace",
+      {"session_id": session_id},
+  )
+
+
+# -- Example agent setup --
+
+
+def create_self_monitoring_agent():
+  """Create an ADK agent with self-monitoring tools."""
+  agent = Agent(
+      model="gemini-2.0-flash",
+      name="self_monitoring_agent",
+      instruction=(
+          "You are an agent that can monitor your own performance. "
+          "Use the available tools to check health, evaluate recent "
+          "sessions, get insights, and inspect specific traces. "
+          "When asked about your performance, use these tools to "
+          "provide data-driven answers."
+      ),
+      tools=[
+          check_health,
+          evaluate_recent_sessions,
+          get_insights,
+          get_session_trace,
+      ],
+  )
+  return agent
+
+
+if __name__ == "__main__":
+  agent = create_self_monitoring_agent()
+  print("Self-monitoring agent created with tools:")
+  for tool in [
+      check_health,
+      evaluate_recent_sessions,
+      get_insights,
+      get_session_trace,
+  ]:
+    print(f"  - {tool.__name__}: {tool.__doc__}")
+  print()
+  print("Example usage:")
+  print("  result = check_health()")
+  print(
+      '  result = evaluate_recent_sessions(evaluator="error_rate",'
+      ' last="24h")'
+  )

--- a/examples/dashboard_v2.ipynb
+++ b/examples/dashboard_v2.ipynb
@@ -1,0 +1,2344 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "license",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:41:45.045707Z",
+     "iopub.status.busy": "2026-04-11T06:41:45.045553Z",
+     "iopub.status.idle": "2026-04-11T06:41:45.048984Z",
+     "shell.execute_reply": "2026-04-11T06:41:45.048431Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#      https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-links",
+   "metadata": {},
+   "source": [
+    "# Dashboard V2 — Agent Analytics\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/colab-logo.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/github-logo.png\" width=\"32\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/main/examples/dashboard_v2.ipynb\">\n",
+    "      <img src=\"https://www.gstatic.com/images/branding/product/1x/google_cloud_48dp.png\" alt=\"Vertex AI logo\" width=\"32\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/bigquery/import?url=https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb\">\n",
+    "      <img src=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTW1gvOovVlbZAIZylUtf5Iu8-693qS1w5NJw&s\" alt=\"BQ logo\" width=\"35\">\n",
+    "      Open in BQ Studio\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "description",
+   "metadata": {},
+   "source": [
+    "A self-contained notebook that queries BigQuery directly with raw SQL.\n",
+    "No SDK imports — all logic lives in SQL + pandas/matplotlib.\n",
+    "\n",
+    "**Architecture**: 2-layer SQL\n",
+    "- **Layer 1** (cells 2-8): Canonical base temp tables that extract typed columns once.\n",
+    "  Rules copied from the ADK plugin schema, `views.py`, `event_semantics.py`, and `evaluators.py`.\n",
+    "- **Layer 2** (cells 9+): Chart queries that only read from Layer 1 temp tables.\n",
+    "  No `JSON_VALUE`/`JSON_QUERY` in chart cells.\n",
+    "\n",
+    "**Source-of-truth hierarchy**:\n",
+    "1. ADK plugin schema (`bigquery_agent_analytics_plugin.py`) — columns, types, JSON structure\n",
+    "2. SDK semantic mirrors (`views.py`, `event_semantics.py`) — per-event extraction, event families\n",
+    "3. SDK aggregation patterns (`evaluators.py`) — session rollups, token COALESCE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "## Cell 0: Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-0-deps",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:41:45.051022Z",
+     "iopub.status.busy": "2026-04-11T06:41:45.050916Z",
+     "iopub.status.idle": "2026-04-11T06:41:48.187666Z",
+     "shell.execute_reply": "2026-04-11T06:41:48.187125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dependencies loaded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess, sys\n",
+    "\n",
+    "# Install dependencies (non-fatal for managed environments)\n",
+    "subprocess.call(\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"-q\",\n",
+    "     \"--break-system-packages\",\n",
+    "     \"google-cloud-bigquery\", \"pandas\", \"matplotlib\", \"db-dtypes\"],\n",
+    "    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,\n",
+    ")\n",
+    "\n",
+    "import os\n",
+    "from google.cloud import bigquery\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=UserWarning, module=\"google\")\n",
+    "\n",
+    "print(\"Dependencies loaded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "config-header",
+   "metadata": {},
+   "source": [
+    "## Cell 1: Configuration + Filter Block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-1-config",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:41:48.189567Z",
+     "iopub.status.busy": "2026-04-11T06:41:48.189394Z",
+     "iopub.status.idle": "2026-04-11T06:41:50.295558Z",
+     "shell.execute_reply": "2026-04-11T06:41:50.294475Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session  : ChoKGHRlc3QtcHJvamVjdC0wNzI4LTQ2NzMyMxABGiRmNjNhOTk0Yy0yZGYxLTRjY2QtODk4Zi1lYjJiMzY0YTc2NDA=\n",
+      "Project  : test-project-0728-467323\n",
+      "Location : (auto)\n",
+      "Dataset  : agent_analytics\n",
+      "Table    : agent_events\n",
+      "Time     : last 720 hours\n",
+      "WHERE    : timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 720 HOUR)...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------- Configuration (user-provided) ----------\n",
+    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"test-project-0728-467323\")\n",
+    "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
+    "TABLE_ID   = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
+    "TABLE_REF  = f\"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`\"\n",
+    "LOCATION   = os.environ.get(\"BQ_LOCATION\") or None  # e.g., \"us-central1\", None = auto\n",
+    "\n",
+    "# ---------- Required filters (top-level, every query) ----------\n",
+    "TIME_RANGE_HOURS   = 720         # default: last 30 days\n",
+    "AGENT_FILTER       = None        # e.g., \"my-agent\" or None for all\n",
+    "USER_ID_FILTER     = None\n",
+    "SESSION_ID_FILTER  = None\n",
+    "TRACE_ID_FILTER    = None\n",
+    "\n",
+    "# ---------- Advanced filters (drill-down, opt-in) ----------\n",
+    "EVENT_TYPE_FILTER      = None    # list of event types, e.g. [\"LLM_REQUEST\",\"LLM_RESPONSE\"]\n",
+    "INVOCATION_ID_FILTER   = None\n",
+    "SPAN_ID_FILTER         = None\n",
+    "TOOL_ORIGIN_FILTER     = None\n",
+    "LABEL_FILTERS          = None    # dict, e.g. {\"env\": \"prod\"}\n",
+    "SESSION_META_FILTERS   = None    # dict, e.g. {\"customer_id\": \"abc\"}\n",
+    "\n",
+    "# ---------- BigQuery client with session ----------\n",
+    "client = bigquery.Client(project=PROJECT_ID, location=LOCATION)\n",
+    "\n",
+    "# Create a session so CREATE TEMP TABLE works across cells\n",
+    "_session_job = client.query(\n",
+    "    \"SELECT 1\",\n",
+    "    job_config=bigquery.QueryJobConfig(create_session=True),\n",
+    ")\n",
+    "_session_job.result()\n",
+    "SESSION_ID = _session_job.session_info.session_id\n",
+    "print(f\"Session  : {SESSION_ID}\")\n",
+    "\n",
+    "def _job_config():\n",
+    "    cfg = bigquery.QueryJobConfig()\n",
+    "    cfg.connection_properties = [\n",
+    "        bigquery.query.ConnectionProperty(\"session_id\", SESSION_ID)\n",
+    "    ]\n",
+    "    return cfg\n",
+    "\n",
+    "def run(sql):\n",
+    "    \"\"\"Execute SQL within the BQ session and return a DataFrame.\"\"\"\n",
+    "    return client.query(sql, job_config=_job_config()).to_dataframe()\n",
+    "\n",
+    "def execute(sql):\n",
+    "    \"\"\"Execute SQL within the BQ session (no result needed).\"\"\"\n",
+    "    client.query(sql, job_config=_job_config()).result()\n",
+    "\n",
+    "def where_clause():\n",
+    "    \"\"\"Build WHERE clause from all active filters.\"\"\"\n",
+    "    conds = [\n",
+    "        f\"timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {TIME_RANGE_HOURS} HOUR)\"\n",
+    "    ]\n",
+    "    if AGENT_FILTER:\n",
+    "        conds.append(f\"agent = '{AGENT_FILTER}'\")\n",
+    "    if USER_ID_FILTER:\n",
+    "        conds.append(f\"user_id = '{USER_ID_FILTER}'\")\n",
+    "    if SESSION_ID_FILTER:\n",
+    "        conds.append(f\"session_id = '{SESSION_ID_FILTER}'\")\n",
+    "    if TRACE_ID_FILTER:\n",
+    "        conds.append(f\"trace_id = '{TRACE_ID_FILTER}'\")\n",
+    "    if EVENT_TYPE_FILTER:\n",
+    "        types = \",\".join(f\"'{t}'\" for t in EVENT_TYPE_FILTER)\n",
+    "        conds.append(f\"event_type IN ({types})\")\n",
+    "    if INVOCATION_ID_FILTER:\n",
+    "        conds.append(f\"invocation_id = '{INVOCATION_ID_FILTER}'\")\n",
+    "    if SPAN_ID_FILTER:\n",
+    "        conds.append(f\"span_id = '{SPAN_ID_FILTER}'\")\n",
+    "    if TOOL_ORIGIN_FILTER:\n",
+    "        conds.append(f\"JSON_VALUE(content, '$.tool_origin') = '{TOOL_ORIGIN_FILTER}'\")\n",
+    "    if LABEL_FILTERS:\n",
+    "        for k, v in LABEL_FILTERS.items():\n",
+    "            conds.append(f\"JSON_VALUE(attributes, '$.labels.{k}') = '{v}'\")\n",
+    "    if SESSION_META_FILTERS:\n",
+    "        for k, v in SESSION_META_FILTERS.items():\n",
+    "            conds.append(f\"JSON_VALUE(attributes, '$.session_metadata.state.{k}') = '{v}'\")\n",
+    "    return \" AND \".join(conds)\n",
+    "\n",
+    "print(f\"Project  : {PROJECT_ID}\")\n",
+    "print(f\"Location : {LOCATION or '(auto)'}\")\n",
+    "print(f\"Dataset  : {DATASET_ID}\")\n",
+    "print(f\"Table    : {TABLE_ID}\")\n",
+    "print(f\"Time     : last {TIME_RANGE_HOURS} hours\")\n",
+    "print(f\"WHERE    : {where_clause()[:120]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "layer1-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Layer 1: Base Tables\n",
+    "\n",
+    "Canonical extraction CTEs. Each cell creates a `CREATE TEMP TABLE` with typed columns.\n",
+    "Chart cells (Layer 2) only reference these temp tables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell2-header",
+   "metadata": {},
+   "source": [
+    "### Cell 2: `filtered_events` — master filtered event stream"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-2-filtered",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:41:50.298254Z",
+     "iopub.status.busy": "2026-04-11T06:41:50.298069Z",
+     "iopub.status.idle": "2026-04-11T06:41:56.350076Z",
+     "shell.execute_reply": "2026-04-11T06:41:56.348840Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "filtered_events: 148 events across 6 sessions\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 2: filtered_events\n",
+    "# Sources: plugin schema (columns), event_semantics.py:136-159 (families), event_semantics.py:128 (error)\n",
+    "where = where_clause()\n",
+    "sql = f\"\"\"\n",
+    "CREATE TEMP TABLE filtered_events AS\n",
+    "SELECT\n",
+    "  -- identity / grouping (plugin schema)\n",
+    "  timestamp,\n",
+    "  event_type,\n",
+    "  agent,\n",
+    "  session_id,\n",
+    "  invocation_id,\n",
+    "  user_id,\n",
+    "  trace_id,\n",
+    "  span_id,\n",
+    "  parent_span_id,\n",
+    "  -- event routing\n",
+    "  status,\n",
+    "  error_message,\n",
+    "  is_truncated,\n",
+    "  -- event family (event_semantics.py:136-159)\n",
+    "  CASE\n",
+    "    WHEN event_type = 'USER_MESSAGE_RECEIVED' THEN 'user'\n",
+    "    WHEN event_type IN ('INVOCATION_STARTING','INVOCATION_COMPLETED') THEN 'invocation'\n",
+    "    WHEN event_type IN ('AGENT_STARTING','AGENT_COMPLETED') THEN 'agent'\n",
+    "    WHEN event_type IN ('LLM_REQUEST','LLM_RESPONSE','LLM_ERROR') THEN 'llm'\n",
+    "    WHEN event_type IN ('TOOL_STARTING','TOOL_COMPLETED','TOOL_ERROR') THEN 'tool'\n",
+    "    WHEN event_type = 'STATE_DELTA' THEN 'state'\n",
+    "    WHEN event_type LIKE 'HITL_%' THEN 'hitl'\n",
+    "    ELSE 'other'\n",
+    "  END AS event_family,\n",
+    "  -- canonical error flag (event_semantics.py:128)\n",
+    "  (ENDS_WITH(event_type, '_ERROR')\n",
+    "   OR error_message IS NOT NULL\n",
+    "   OR status = 'ERROR') AS is_error,\n",
+    "  -- cross-cutting filter dimensions (plugin schema: attributes JSON keys)\n",
+    "  JSON_QUERY(attributes, '$.labels') AS labels,\n",
+    "  JSON_QUERY(attributes, '$.session_metadata') AS session_metadata,\n",
+    "  -- raw JSON (used by downstream base cells only, never by chart cells)\n",
+    "  content,\n",
+    "  attributes,\n",
+    "  latency_ms,\n",
+    "  content_parts\n",
+    "FROM {TABLE_REF}\n",
+    "WHERE {where}\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n, COUNT(DISTINCT session_id) AS sessions FROM filtered_events\")\n",
+    "print(f\"filtered_events: {count['n'][0]:,} events across {count['sessions'][0]:,} sessions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell3-header",
+   "metadata": {},
+   "source": [
+    "### Cell 3: `llm_events` — typed LLM extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-3-llm",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:41:56.352543Z",
+     "iopub.status.busy": "2026-04-11T06:41:56.352369Z",
+     "iopub.status.idle": "2026-04-11T06:42:01.619774Z",
+     "shell.execute_reply": "2026-04-11T06:42:01.618052Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "llm_events: 48 events (24 responses)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 3: llm_events\n",
+    "# Sources: views.py:78-98 (per-event), evaluators.py:682-712 (token COALESCE)\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE llm_events AS\n",
+    "SELECT\n",
+    "  timestamp, agent, session_id, invocation_id, user_id,\n",
+    "  trace_id, span_id, parent_span_id,\n",
+    "  event_type, status, error_message,\n",
+    "  (ENDS_WITH(event_type, '_ERROR') OR error_message IS NOT NULL OR status = 'ERROR') AS is_error,\n",
+    "  -- LLM_REQUEST fields (views.py:80-84)\n",
+    "  JSON_VALUE(attributes, '$.model') AS model,\n",
+    "  JSON_QUERY(attributes, '$.llm_config') AS llm_config,\n",
+    "  -- LLM_RESPONSE fields (views.py:89-98)\n",
+    "  CAST(JSON_VALUE(content, '$.usage.prompt') AS INT64) AS usage_prompt_tokens,\n",
+    "  CAST(JSON_VALUE(content, '$.usage.completion') AS INT64) AS usage_completion_tokens,\n",
+    "  CAST(JSON_VALUE(content, '$.usage.total') AS INT64) AS usage_total_tokens,\n",
+    "  JSON_VALUE(attributes, '$.model_version') AS model_version,\n",
+    "  -- latency (views.py:93-96)\n",
+    "  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms,\n",
+    "  CAST(JSON_VALUE(latency_ms, '$.time_to_first_token_ms') AS FLOAT64) AS ttft_ms,\n",
+    "  -- token extraction: 3-way COALESCE (evaluators.py:682-712)\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.prompt_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.prompt') AS INT64),\n",
+    "    CAST(JSON_VALUE(attributes, '$.input_tokens') AS INT64)\n",
+    "  ) AS prompt_tokens,\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.candidates_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.completion') AS INT64),\n",
+    "    CAST(JSON_VALUE(attributes, '$.output_tokens') AS INT64)\n",
+    "  ) AS completion_tokens,\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.total_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.total') AS INT64),\n",
+    "    COALESCE(\n",
+    "      CAST(JSON_VALUE(attributes, '$.input_tokens') AS INT64), 0\n",
+    "    ) + COALESCE(\n",
+    "      CAST(JSON_VALUE(attributes, '$.output_tokens') AS INT64), 0\n",
+    "    )\n",
+    "  ) AS total_tokens\n",
+    "FROM filtered_events\n",
+    "WHERE event_family = 'llm'\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n, COUNTIF(event_type='LLM_RESPONSE') AS responses FROM llm_events\")\n",
+    "print(f\"llm_events: {count['n'][0]:,} events ({count['responses'][0]:,} responses)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell4-header",
+   "metadata": {},
+   "source": [
+    "### Cell 4: `tool_events` — typed tool extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-4-tool",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:01.622630Z",
+     "iopub.status.busy": "2026-04-11T06:42:01.622434Z",
+     "iopub.status.idle": "2026-04-11T06:42:06.267905Z",
+     "shell.execute_reply": "2026-04-11T06:42:06.265200Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tool_events: 50 events across 4 distinct tools\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 4: tool_events\n",
+    "# Sources: views.py:105-126 (per-event typed extraction)\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE tool_events AS\n",
+    "SELECT\n",
+    "  timestamp, agent, session_id, invocation_id, user_id,\n",
+    "  trace_id, span_id, parent_span_id,\n",
+    "  event_type, status, error_message,\n",
+    "  (ENDS_WITH(event_type, '_ERROR') OR error_message IS NOT NULL OR status = 'ERROR') AS is_error,\n",
+    "  JSON_VALUE(content, '$.tool') AS tool_name,\n",
+    "  JSON_VALUE(content, '$.tool_origin') AS tool_origin,\n",
+    "  JSON_QUERY(content, '$.args') AS tool_args,\n",
+    "  JSON_QUERY(content, '$.result') AS tool_result,\n",
+    "  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms\n",
+    "FROM filtered_events\n",
+    "WHERE event_family = 'tool'\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n, COUNT(DISTINCT tool_name) AS tools FROM tool_events\")\n",
+    "print(f\"tool_events: {count['n'][0]:,} events across {count['tools'][0]:,} distinct tools\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell5-header",
+   "metadata": {},
+   "source": [
+    "### Cell 5: `session_rollups` — per-session aggregation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-5-session",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:06.271245Z",
+     "iopub.status.busy": "2026-04-11T06:42:06.270992Z",
+     "iopub.status.idle": "2026-04-11T06:42:11.113316Z",
+     "shell.execute_reply": "2026-04-11T06:42:11.112639Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session_rollups: 6 sessions\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 5: session_rollups\n",
+    "# Sources: evaluators.py SESSION_SUMMARY_QUERY pattern\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE session_rollups AS\n",
+    "SELECT\n",
+    "  session_id,\n",
+    "  ANY_VALUE(agent) AS agent,\n",
+    "  ANY_VALUE(user_id) AS user_id,\n",
+    "  MIN(trace_id) AS first_trace_id,\n",
+    "  MIN(timestamp) AS start_ts,\n",
+    "  MAX(timestamp) AS end_ts,\n",
+    "  TIMESTAMP_DIFF(MAX(timestamp), MIN(timestamp), MILLISECOND) AS duration_ms,\n",
+    "  COUNT(*) AS total_events,\n",
+    "  COUNTIF(event_type = 'LLM_REQUEST') AS llm_calls,\n",
+    "  COUNTIF(event_type = 'TOOL_STARTING') AS tool_calls,\n",
+    "  COUNTIF(event_type = 'TOOL_ERROR') AS tool_errors,\n",
+    "  COUNTIF(event_type = 'LLM_ERROR') AS llm_errors,\n",
+    "  COUNTIF(event_type LIKE 'HITL_%') AS hitl_events,\n",
+    "  COUNTIF(event_type = 'USER_MESSAGE_RECEIVED') AS turn_count,\n",
+    "  COUNTIF(event_type = 'STATE_DELTA') AS state_deltas,\n",
+    "  COUNTIF(is_error) > 0 AS has_error,\n",
+    "  COUNTIF(content_parts IS NOT NULL AND ARRAY_LENGTH(content_parts) > 0) > 0 AS has_multimodal,\n",
+    "  COUNT(DISTINCT invocation_id) AS invocation_count,\n",
+    "  COUNT(DISTINCT trace_id) AS trace_count,\n",
+    "  ANY_VALUE(labels) AS labels,\n",
+    "  ANY_VALUE(session_metadata) AS session_metadata\n",
+    "FROM filtered_events\n",
+    "GROUP BY session_id\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n FROM session_rollups\")\n",
+    "print(f\"session_rollups: {count['n'][0]:,} sessions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell6-header",
+   "metadata": {},
+   "source": [
+    "### Cell 6: `hitl_events` — typed HITL extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-6-hitl",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:11.115962Z",
+     "iopub.status.busy": "2026-04-11T06:42:11.115783Z",
+     "iopub.status.idle": "2026-04-11T06:42:16.813117Z",
+     "shell.execute_reply": "2026-04-11T06:42:16.812276Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hitl_events: 0 events\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 6: hitl_events\n",
+    "# Sources: plugin schema + views.py:151-186 (raw fields),\n",
+    "#          event_semantics.py:126,131,151-157 (hitl_type, is_completed)\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE hitl_events AS\n",
+    "SELECT\n",
+    "  timestamp, agent, session_id, invocation_id, user_id,\n",
+    "  trace_id, span_id, event_type,\n",
+    "  -- event_semantics.py classification\n",
+    "  CASE\n",
+    "    WHEN event_type LIKE 'HITL_CREDENTIAL%' THEN 'credential'\n",
+    "    WHEN event_type LIKE 'HITL_CONFIRMATION%' THEN 'confirmation'\n",
+    "    WHEN event_type LIKE 'HITL_INPUT%' THEN 'input'\n",
+    "  END AS hitl_type,\n",
+    "  event_type LIKE '%_COMPLETED' AS is_completed,\n",
+    "  -- views.py per-event typed extraction\n",
+    "  JSON_VALUE(content, '$.tool') AS tool_name,\n",
+    "  JSON_QUERY(content, '$.args') AS tool_args,\n",
+    "  JSON_QUERY(content, '$.result') AS tool_result\n",
+    "FROM filtered_events\n",
+    "WHERE event_family = 'hitl'\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n FROM hitl_events\")\n",
+    "print(f\"hitl_events: {count['n'][0]:,} events\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell7-header",
+   "metadata": {},
+   "source": [
+    "### Cell 7: `multimodal_parts` — content_parts unnest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-7-multimodal",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:16.815696Z",
+     "iopub.status.busy": "2026-04-11T06:42:16.815508Z",
+     "iopub.status.idle": "2026-04-11T06:42:21.446270Z",
+     "shell.execute_reply": "2026-04-11T06:42:21.445378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "multimodal_parts: 162 parts across 2 mime families\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 7: multimodal_parts\n",
+    "# Sources: plugin schema (content_parts RECORD at :1594)\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE multimodal_parts AS\n",
+    "SELECT\n",
+    "  fe.timestamp,\n",
+    "  fe.agent,\n",
+    "  fe.session_id,\n",
+    "  fe.event_type,\n",
+    "  fe.event_family,\n",
+    "  fe.is_truncated,\n",
+    "  cp.mime_type,\n",
+    "  REGEXP_EXTRACT(cp.mime_type, r'^([^/]+)') AS mime_family,\n",
+    "  cp.storage_mode,\n",
+    "  cp.uri,\n",
+    "  cp.text IS NOT NULL AS has_inline_text,\n",
+    "  cp.part_index\n",
+    "FROM filtered_events fe, UNNEST(fe.content_parts) AS cp\n",
+    "WHERE fe.content_parts IS NOT NULL\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n, COUNT(DISTINCT mime_family) AS families FROM multimodal_parts\")\n",
+    "print(f\"multimodal_parts: {count['n'][0]:,} parts across {count['families'][0]:,} mime families\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell8-header",
+   "metadata": {},
+   "source": [
+    "### Cell 8: `trace_rollups` — per-trace aggregation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-8-trace",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:21.449839Z",
+     "iopub.status.busy": "2026-04-11T06:42:21.449579Z",
+     "iopub.status.idle": "2026-04-11T06:42:26.384847Z",
+     "shell.execute_reply": "2026-04-11T06:42:26.382638Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trace_rollups: 10 traces\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 8: trace_rollups\n",
+    "# Sources: plugin schema (trace_id, span_id, parent_span_id)\n",
+    "#          labels/session_metadata: pass-through from filtered_events\n",
+    "sql = \"\"\"\n",
+    "CREATE TEMP TABLE trace_rollups AS\n",
+    "SELECT\n",
+    "  trace_id,\n",
+    "  ANY_VALUE(session_id) AS session_id,\n",
+    "  ANY_VALUE(agent) AS agent,\n",
+    "  MIN(timestamp) AS start_ts,\n",
+    "  MAX(timestamp) AS end_ts,\n",
+    "  COUNT(*) AS total_events,\n",
+    "  COUNT(DISTINCT span_id) AS span_count,\n",
+    "  MAX(CASE WHEN parent_span_id IS NULL THEN span_id END) AS root_span_id,\n",
+    "  COUNTIF(is_error) > 0 AS has_error,\n",
+    "  ANY_VALUE(labels) AS labels,\n",
+    "  ANY_VALUE(session_metadata) AS session_metadata\n",
+    "FROM filtered_events\n",
+    "WHERE trace_id IS NOT NULL\n",
+    "GROUP BY trace_id\n",
+    "\"\"\"\n",
+    "execute(sql)\n",
+    "count = run(\"SELECT COUNT(*) AS n FROM trace_rollups\")\n",
+    "print(f\"trace_rollups: {count['n'][0]:,} traces\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "layer2-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Layer 2: Dashboard Charts\n",
+    "\n",
+    "Every chart query reads only from Layer 1 temp tables.\n",
+    "No `JSON_VALUE`, no `JSON_QUERY`, no raw `content`/`attributes`/`latency_ms`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "chart-helpers",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:26.387951Z",
+     "iopub.status.busy": "2026-04-11T06:42:26.387703Z",
+     "iopub.status.idle": "2026-04-11T06:42:26.400289Z",
+     "shell.execute_reply": "2026-04-11T06:42:26.399672Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Chart styling helpers\n",
+    "def fmt_ax(ax, title, xlabel=\"\", ylabel=\"\"):\n",
+    "    ax.set_title(title, fontsize=12, fontweight=\"bold\")\n",
+    "    ax.set_xlabel(xlabel)\n",
+    "    ax.set_ylabel(ylabel)\n",
+    "    ax.grid(axis=\"y\", alpha=0.3)\n",
+    "    # Auto-format x-axis for time series\n",
+    "    if hasattr(ax, 'get_xlim'):\n",
+    "        try:\n",
+    "            ax.xaxis.set_major_formatter(mdates.DateFormatter(\"%m-%d %H:%M\"))\n",
+    "            plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha=\"right\")\n",
+    "        except Exception:\n",
+    "            pass\n",
+    "\n",
+    "def kpi_row(labels, values):\n",
+    "    fig, axes = plt.subplots(1, len(labels), figsize=(3 * len(labels), 1.5))\n",
+    "    if len(labels) == 1:\n",
+    "        axes = [axes]\n",
+    "    for ax, label, val in zip(axes, labels, values):\n",
+    "        ax.text(0.5, 0.55, f\"{val:,.0f}\" if isinstance(val, (int, float)) else str(val),\n",
+    "                ha=\"center\", va=\"center\", fontsize=22, fontweight=\"bold\",\n",
+    "                transform=ax.transAxes)\n",
+    "        ax.text(0.5, 0.15, label, ha=\"center\", va=\"center\", fontsize=10,\n",
+    "                color=\"gray\", transform=ax.transAxes)\n",
+    "        ax.axis(\"off\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "def time_plot(df, x_col, y_cols, title, ylabel, kind=\"line\", stacked=False, labels=None):\n",
+    "    \"\"\"Plot time series that handles single-point data gracefully.\"\"\"\n",
+    "    if df.empty:\n",
+    "        print(f\"No data for: {title}\")\n",
+    "        return\n",
+    "    fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "    if len(df) == 1:\n",
+    "        # Single data point: use bar chart instead of line/area\n",
+    "        colors = plt.cm.tab10.colors\n",
+    "        x_label = str(df[x_col].iloc[0])[:16]\n",
+    "        if isinstance(y_cols, list):\n",
+    "            bar_labels = labels or y_cols\n",
+    "            for i, col in enumerate(y_cols):\n",
+    "                ax.bar(i, df[col].iloc[0], label=bar_labels[i], color=colors[i % len(colors)])\n",
+    "            ax.set_xticks(range(len(y_cols)))\n",
+    "            ax.set_xticklabels(bar_labels, rotation=45, ha=\"right\")\n",
+    "        else:\n",
+    "            ax.bar([x_label], df[y_cols].iloc[0])\n",
+    "        ax.set_title(f\"{title} (single time bucket: {x_label})\", fontsize=12, fontweight=\"bold\")\n",
+    "    else:\n",
+    "        if kind == \"area\":\n",
+    "            if isinstance(y_cols, list):\n",
+    "                ax.stackplot(df[x_col], *[df[c] for c in y_cols],\n",
+    "                             labels=labels or y_cols, alpha=0.7)\n",
+    "            else:\n",
+    "                ax.fill_between(df[x_col], df[y_cols], alpha=0.7)\n",
+    "        else:\n",
+    "            if isinstance(y_cols, list):\n",
+    "                for i, col in enumerate(y_cols):\n",
+    "                    lbl = labels[i] if labels else col\n",
+    "                    ls = \"--\" if i >= 2 else \"-\"\n",
+    "                    ax.plot(df[x_col], df[col], label=lbl, linewidth=2 if i < 2 else 1, linestyle=ls)\n",
+    "            else:\n",
+    "                ax.plot(df[x_col], df[y_cols], marker=\"o\", markersize=3, linewidth=2)\n",
+    "        fmt_ax(ax, title, ylabel=ylabel)\n",
+    "    ax.set_ylabel(ylabel)\n",
+    "    ax.grid(axis=\"y\", alpha=0.3)\n",
+    "    if isinstance(y_cols, list) and len(y_cols) > 1:\n",
+    "        ax.legend(loc=\"upper left\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel1-header",
+   "metadata": {},
+   "source": [
+    "## Panel 1: Token / Cost"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-9-token-kpi",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:26.402876Z",
+     "iopub.status.busy": "2026-04-11T06:42:26.402735Z",
+     "iopub.status.idle": "2026-04-11T06:42:29.231801Z",
+     "shell.execute_reply": "2026-04-11T06:42:29.231279Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3kAAACMCAYAAADBR2DiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJXFJREFUeJzt3QncVdP+x/FVipIm0ohKc1KGMpRISoMhRIZQUoZCrqnI5dZ1RZd75d5cDYhbopApcyo0yliiFA2STE3GDOf/+q7/az93n33WPmef85zn6bH7vF+v53V1zn722Wd396/1W+u31iqVSCQSBgAAAAAQC6V39AUAAAAAAPKHJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKkzI6+ACTbtm2bmTNnjlm0aJF59913zapVq8yGDRvMd999Z3bZZRdTuXJl06hRI3PEEUeY3r17m4MOOij0FtarV8+sWbMm51tct25ds3r16tD3N2/ebB577DHz4osvmmXLlpnPP//cfP/996Z06dJmjz32MPvtt59p0aKF6datmznttNPMbrvtlvbz9B3ffvtts3jx4oKflStXmkQikXRcnz59zMSJEyN9B13T7Nmz7f1cunSp+fTTT83XX39tr7N8+fKmatWq9hqPOeYYc+6555o6depEvDsAsrV+/Xr7vCl2BEV9rjdt2mT++9//mueee8589NFH5ssvvzRlypQxNWrUMK1btzYnn3yyOeOMM+xrubruuuvM3//+d+d7iiGKrZnMnz/fPP744+bNN9+0cUzf+eeffza777672XPPPW0cb9eunenVq5dp3rx5ztcK7Oz0jL3xxhvmvffeMx9//LH9N/7bb7+1z9yuu+5q2yN6Zg844ADTpUsXc8opp2Rsj6Rrp7Rs2dLGgSC1I9TeSBf/9L7aNmozqW2n6/zmm2/M77//bmNDzZo1TePGjc3RRx9tTj/9dNsOi0rnnTRpkpk3b55tu+n7V6hQwcZGxRp97xNPPNGUKlUq8jmXLFlipk2bZs+5YsUKG39//PFHU65cOVOlShXTsGFDc/jhh5uePXuaww47LPJ5UUwSKDFGjRqVKFu2rDKayD89e/ZMfPnll87z1a1bN6tzBX/0+2HGjx+fqFKlSuRz1a5dOzFjxoy037906dKRztWnT59I97NHjx5Zfd9dd901MWzYsMSvv/4a6fwAstOtW7dCPdcTJkxI7Lnnnhmf5WbNmiXmzp2b01+Pfi9dLPr000/T/v6GDRsSnTp1ihx3SpUqlejdu3di27ZtOV0vsDPTc5Nt20btkenTp+f0eZdccknoeY855pi0v6v2WjbXWaZMmcSgQYMSP//8c9rzrl+/PtG9e/dI5zzssMMSS5cuzfg9t27dmjjrrLNsfIp6vV26dEls3Lgx63uKokOSV4IMHjw4p2RMDZqvv/4670levXr1nNd577335nQ+NZxeeeWV0O8f9TxRk7xWrVrldJ29evXK4m8NQBTqGCrMcz18+PCsnuPy5csnXnjhhaz+cn744YdEo0aN0p43XZKnBmfDhg1zijsdO3ZM/Pbbb/yfCSjiJE8/Sl6efPLJrO71yy+/nPac+U7yvJ/TTjst9JyKR3Xq1MnqfOooW7hwYeg51dHdrl27nNuj33//fVb3FUWHOXklnMozVcqj4fYwH374obnmmmtSXldJwaGHHprxp2nTps7zdu7cOeU1DdOrlMlFw/c61/77729LS4NUjjBkyBATlco+y5Yta/JJpRAq2ahUqVLoMVOnTjUPPvhgXj8X2JmtXbvWXH311Tn//owZM8zNN9/sjBFNmjSxpeGuWHXmmWfaku2orr/+elvulavRo0fb0kyXWrVq2VJVlTi5vPrqq7YEFUDuKlasaGNCq1atbFwIa0OoX/lPf/pTynSQMFu3bjUXXnhh3v5qVE6uUky101Sema5N8sQTT9hpPK42lUo6VQYapHJU3Ydq1aqlvKcSUZVXbtmyxfl5jzzyiJk7d67zPZ1PcWzvvfcObY/ef//9od8FxawIE0jkOJK39957J2644YbE22+/nfj9998L3l++fHloGZDKPDdv3pzTPR8xYoSzl+ujjz6K3JN17rnnJn3+J598EjqS9t133zmvQz3oKg+44447ErNnz7blAuoZy7bH3+N9vnqW7r777sSaNWtSvktYr3ubNm2yvo8AUimGBeOWSqOjPtfbt29P7LPPPinH77///okPP/yw4LhnnnkmUa5cuZxH5ufMmZNUmuS6xkwjea7e70qVKiVeffXVpF7y0aNHO899zTXX8H8hIMvR9/PPPz8xderUxGeffZby/qZNmxJ33XVX6FSYFStWRPqcfv36ZYxhmUbybrvtNnst77zzTuKXX35Jek+j+DNnzrTtFdd1qk0YpO/sOva8885LKv9WbFRlQ/C4K664wnmdKh93tTEfffTRpDap/uy6r6effnqke4qiR5JXgtx0002JkSNHJn788cfQY9TgadGihfPBVtKSrZ9++ilRo0aNlHOddNJJzuMnT57s/GzXvMCwAKQ5K1EVJslTacS0adPSHqNk1NUwVGMvUx08gMzuueeepGera9euWT3XYXHkxRdfTDl26NChznktmWKOOp6UNPpLy//2t79lneS5Sj0HDhzoPLZ58+Ypx1588cUZ7yeA7F100UXO5znK3N3nnnsu6XdatmyZOPvss7NO8qKYN2+e8zoHDBiQcqzrGlSK6SqXvPbaa1OOrVixonMucOfOnVOO1Zw/F9dcQM3NQ8lAuWYJMnz4cDN06FBb9hhGpQdaVdNFK0plS6vUbdy4MeV1V/mnVK9ePbSUIchVCqDVLMPOkW9a+VOlDOnUr1/frogVpA4QlTQAyN0nn3xirr322oI/q1RxwoQJWZ1jypQpKa+pVMhVTn7OOeekvPbrr7/aEux0dI26Vo9KS9u2bWuy5YptrtioMiutpBwUVjoPoHD0zIWVUaejFSr79++f1AZ76KGH7KqdO/o6ly9fnvKaSim1SmeQVmQPUgxylYhHjWNh7TziWMlBkvcHFFa7nSlYuRKZf/zjHymvaxlcLd/romV499prr5TXlXhqiV1tTaCgOH36dDNs2LCU46644go7j6ak30/Vy7tq2QFEjy8XXHCBjQmef/3rX1lvU7JgwYKU1w4++GDnMuCav6ytUYIWLlwYev6ZM2eae++9N+kcf/3rX00uevTokfLaww8/bO644w47N1BbKGgZct2XdevWJR2nuKptXADkj+LPPffc45xnr/lw6uhN5/LLL0+a13vTTTfZ+X5FES+17crFF18cObZoO4fCcsVG12dpiwqtx6CtGbZv326359Kfg3P3NBfwkksuKfR1IU929FAisqeypuDw+G677Zb45ptvsjrPs88+6ywLUHlUOk888UTofJV0P6r/znZ7gsKUa0ah+vL69eunfEbr1q3z9hnAzkhzT/zP1Kmnnpr1c60ycFcs6d+/f+jn+ssuvZ8DDjjAeeyWLVsS++23X1Jp5+LFi+17s2bNyrpcU+XvRx11VNaxUdfw1ltvZXmHAfhp3YJDDz3U/hx88MGJBg0a2Gfa9cyprHHRokVpb6BW3wzO1ffm0rnaYdmUa55zzjkF16r4pLm7YfHhz3/+s/Mcrliz11572XmKQUOGDHGeW6WZrnbRGWeckXUc0z11ldFjxylZQyrISJv/Pvroo84yJW2wm40777wz5TWtjKmNy9M59dRT7UpwWpkziu7du9seKq0851p1c0fS5suuTU3VewcgN1qhUitV+ssr/aNlUYWVoKeLda5Kg7DzXHXVVXblT88NN9wQOa65qBdbI4M6rzZgzkTlq3fddZfdcPiQQw7J+XMBGPPDDz+Yt956y/688847ZtWqVbZc20/TYbTqrjYOb9OmTeht0wbl/lE1/Z5GA1Xlkw8ffPBBwbXqv13lkIpFKjUfMWKE8xwdOnRwXvfAgQOTKihUkqkqChfXtBRVSaideeuttzrjqSvuabqRVtY8/vjjMx6P4kOS9weiuXNKsH766aek11VWeMstt2R1LgXAWbNmpbyuJYWjJGIq29Rnqtwhk5deesk2ZDS8X5KovFTlo0Ht27cPnfcIIPOckr59+9otDDz/+c9/cpqLG7bEtxoVYVzvqYQ86IUXXjD33XdfUgnojTfeaApLc3VUxnTZZZdljKW6LsXGadOmFfpzAWTWrFkz07FjR1O7du20xw0aNChpvQK1d/S7xUUdQFovQNNnwgwYMMBZnq7OayVnul5tv3XCCSfYBNglbK6dEj3dA8Uy1xw/P5WhjxkzxibBv/32W8bvhmK0A0cRkYVVq1YlGjdunDI8vvvuu9vVmLKlUgHXUHuUTSzXrVvnLBNQWYS2JNh3332TliL3fqpWrVpQCrWjyzWff/75xB577JFybq2O51opFEA0o0aNSnqmtAJcrs/1/PnznWVBN954Y1bbGKicPbisun8DYZWfL1myJOmYXMo1vdVEFZdd8VUralaoUMF5Xi0D71+eHEB2tDVB1NJCPYtaXdtFq3L7j1V7R1sc+BW2XDNsi6ngj7Y+mDhxYuh5JkyYkHVZZXClUJfHH3/cxqzg8Sor1b2rXLlyaPmnytZRMpDk/QEsXLgwUb169ZSHSY0F//5LUa1du9ZZpz5s2LCMv6vldl3JpubI+PfJW7lyZaJt27Ypx9WrVy+rAFAUSd748eOd318JnmufHQDRLFu2LGlLklq1ajnnCkd9rnU+V0PiuuuuC70GzacNHq9tYvyUUPnf19Y1QbkkeePGjUs5vmbNmknb26ixqERQ2zQEjx07dmza+wsgGs2d09Yp2v5A84Fdz3KTJk1StqzauHFjolq1akntLLVnggqb5HnUsaO5wZqTe/PNN9ttDYLnVae59tALo62t0s3p0486tV37Anfo0MHZCR6MT7oP2hcvmAy7Oq2uv/76rO8DigZJXgn39NNPO3uFNbl2wYIFOZ3z6quvdvZ0f/HFFxl/V5t5Bn9X+/a5FlTRiJ9ro8xHHnlkhyV5msDsCoCHHHKIDe4AcqfOHv9zpcWdXAq78MqFF14Yeg2uhZT8C6+oI8f/3hFHHOGMX9kmeVrsQNUKweODDSPPpZdemnJs06ZNQ78XgNypY8j1PGskzO+WW25Jen/MmDHO8+UryXONRroWttNoYjrqTFMVRceOHe2ggNpeShi1sIsqHz7//PNEp06dUs7bt2/flHMpDgWPu/32252fq9eDxyrh1J7O2PFI8kowBZdddtkl5QHS6nFaRSoX6jFy9fikW63Or3379im/O2jQoNDjXRv+XnXVVcWe5CnguIKyfrp16+bcEBRAdsKesWx/6tatW3DO2rVrR1oRTpSs+UcSvZ/evXsXHKMkLR/XqJ8HHnig4LzqaXcd89VXX2W1ybtiNID8Uieu63nT1BU/jablKz7kSm2S4LnUFnStmhmVKqhco27BJFdTg1zf5c0333SeVyuUuo5///33c75W5A8Lr5RASr6HDBliJ70GJ7FqQ0vtG9W4ceOczq2NiIMTbTXBVpv/RrFhw4aU11z7VaV7Lx97u2RD31crfLr2ydHqWc8880yklfAAFL/DDz/cuXCU4mSQVqkLLkwVdo58c8XGdPEx7HX/qngA8iNs8ZCvvvrqD3Gtagtu2rQp53NqA/dgbNGexccdd1yRxLHibufBjSSvhNEqRdoOYdSoUSnv9ezZ025doOXIc6GlhLWNQZBWXmratGmkc1SuXDnltddee82uqBekDUS1lHpQrtefi88++8wcddRR5pVXXkkJTLfddptd1r2kbesA4H8UD11bImjV3qApU6akvKYlz88444wiv6Wu2CiuVYxl9uzZKa8pLmm1ZADRLFq0KNJxrq2nirM98t5779n2XSaKbWrnRY0NrrZX0MqVK83QoUOdm57Xq1cv73GsuNt5CJefDT+QF+qlOeWUU2zSFKR9l+644460o2aZaJlu/55QnmuuuSbyObTMuPZ18Xv//fftvixKTCtVqmRf095z559/vtm+fXvKOTQaWRx0XRrBW79+fcoS6+rV6tWrV7FcB7CzqF+/fqR95pYvX57S06slv70Gh395czVE9tlnH9th46eYM2PGjIIOKo3I//Of/3R2jtWsWTPp+Y9yjdu2bTMrVqxIef3AAw+02ySIv9F10EEH2fgcHGEcPHiw/W7HHntsQaNMWze49g3UXnlly5bNeG0A/jdKf+SRR5qzzz7bdOvWzTRo0CCpnaR94O6///7Q7VHatm2b9GfFnijxYfXq1XZPOj9VBDVp0sR5vGKTtm3R9kzaCkuf4d/+QCN13h6brhE7He/FneB2CY899phtb3Xt2tVuveDRyJ06vpTgBffD07luuummlPM1bNjQfo9gfNY+eIrviqee6dOn29eDtF2O9lzGjldKNZs7+iLw/y666CIzfvz4lNuhRkmLFi0i/b5+wrRu3TolQdNmoFF7wmTu3Ll2ZMxFjRM10tRbtW7dOmc5ld7Xhu6uvaxOPvlkO/qXTWPQc9JJJ5mbb7456TWVtLpGEtUwq1u3boZvaszYsWMLtTEyABO6ie+cOXOSXuvTp49tsLg8++yz9hkPUrlRo0aN7J58rg4s9UovW7Ys455YYT3UXmLmpw6sYPzxaCPgl19+2fme4pb2rNJ1hpUyKeaki+EAkgU7vitWrGhq1aplSx61D6Wet7DRLj2P2sC7atWqWd9W7QUanAKife3CRraCx6uCaN9997Ux6pdffrFJY9hedjJ58mRnVYOm4Gi/PI86xBRrdC7FquBm8P6k88orr8yqLSq63jp16ti2mmv/Ubn++uvtRurY8RjJK0Fco16ipCmYnLkEEyQ/BR7XObIZxfM2QVdg0Aa+QQpUrqTKU65cOdujFraRsUbeomyYrt6zYA+aKwkOu58qh9BPlJ58ADveiSeeaP7yl7/YHz813tQR5KJecpVo5ZLg5UobAitGuub5uOKWn0Yh+vfvX8RXCMSb/t2O8m+3kkGNcuWS4OWDRu6U2EWh9RlcCZ6LKh6CVQ/BpHjEiBGhCZ6MHDnSloyuWrUq5b0tW7bYnzCqRhg2bFika0XRY07eTuLOO+9MeS049B6VeoBUmpnNYiUqqVIPt6tnHAAy0Uj9uHHjIjXKvHjTpUuXYr2xGlV84403QqsdXDRnUCWdKn3SyCSA6HJ5Zjp37mzmz59frO2RXOb+a1ROHeP//ve/83INKiV96qmnQktXPRoJVBxzVU+ko1JUlZxWqFChkFeKfGEkbyegnm7NXQlST06ui45ce+21pl+/frYWXA/10qVL7apMqgFX0NXcPJVEag6f5tSosaXGDADkSmVJ6piaNGmSjWkqtdKomWKLSq9UXq14o/m2OyreqEz89ddft40kJW6LFy+2FQ7q/dbKn2oAqWS8efPmpn379uass86KVD4OIJWef7VBlLRpcRONjuk1lSuqfaPOaMUGJTiav6dpIXr2iptKsS+44AK75oKqqhQTtF6ASrc1qqe4oFJIzYnTvF+N7Hfs2NE5D89PcxFVPqlqLa28rnaYKpV0Xs3P03fXvEOdT0lb1Daf5jE//fTT5t1337XtPJ1bbUnNF1R5vMph1eGmDjXNiVQca9asWZ7uFvKFOXkAAAAAECPUhgAAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOQBAAAAQIyQ5AEAAABAjJDkAQAAAECMkOShxJs4caJ54YUXdvRlACgGmzdvNsOHDzdffPFFoc6zevVqe56ffvrJxPl7AiiZ9Hx/9NFHeT8vsQNRlYl8JIrFk08+ad577z3736VLlzaVK1c2rVq1Mu3bt7d/LmnUkHrwwQfNkCFDTLly5TJ+Jxd9xyuvvLIIrxKA33fffWdee+018/HHH5tt27aZChUqmJo1a5rDDz/c7L///n/IjiBdf9euXQte23fffc3VV19tdttttyJtxKVzzDHHmA4dOhTZ5wMo2udUCdXo0aPNxRdfbGNMvhA7UBxI8kqghg0bmh49ephff/3VNsKee+45m+Ap0Qv67bffzC677GJKMjW8OnXqVPDnO++8034/fU8pVarUDrw6YOeiRsv9999vO2U6d+5satSoYePIqlWrbKy57LLLTBwoLu6xxx5F+hlKIj1Lly41s2fPTrp/u+66a5F+PoA/5nNaEq8J8UOSV8IbJ23atLHD/StWrLBJnkbFVH5Uu3Zt8+abb5oyZcqYwYMHm40bN9qSxs8++8yULVvWNGvWzHTp0qUgUHi/V6dOHbNw4UKbQB555JH2nK+88op555137O8de+yx5uCDD07qwerZs6f9nQ0bNpg999zTdO/e3dSrV8++r1E8uf322+3/atTxlFNOSfo+rhE+veZ9R40GPvzww/Y7lC9f3p6jY8eOoSOXuhdPPPGEvY6WLVuaLVu2mJdeesk2UpUw1q1b1yaWVapUSfru++23n5k/f75t0B5wwAH2GC9B1r1csGCBPZeuTcf26tUrb3+nQEkxY8YM+7/9+/dPakhUr1694NkXPQvPP/+8+eSTT+xzpU6Zbt26FTy3apQoNmn0T//9448/2mdXx+g5008ikbDvH3300Uk92Hp29Rzr2df5lGw2b9489Jq//PJL8/LLL5s1a9bYa27QoIGNb7vvvrt9vvW6fhSnRDHRi0/+KoNly5bZa/3222/t5x522GGmbdu2BZ9z1113mUMPPdS+r2P1e7p2vebiTyK9z/Be03fXaOlbb71lfvjhB1OtWjXb2eV1bgX9/vvv5plnnjHr1q0z5513nq1w0P2dM2eO+eqrr0zFihXt/dX1eLFR9/Kkk06ynYErV640lSpVMscff7xp0qSJfV9/J/o7VGzcvn27ff+oo45K+nsG4q4wz6naQDJ27Fj7v2pf9O3b16xfv968+uqrtl2kZ1ejfIpJtWrVKvJrCiJ2IAxJ3h+Aki/9Y+359NNPbQmSGgKif7wnTZpky5MGDBhgvv/+e/P000/bXnl/wqXf0z/yClBqSOgY/a+Clhp8H3zwgXn22WdtA0rHedS4UvDae++9bcNtypQpthGlY5QITZ061fZA6ZqUdGZj69atNsFT4+XUU081X3/9tW3o6Dyu8oklS5bYa1Ti2bhxY5uw6bvvs88+5oILLrCNn9dff92+dumllxYkcV5jsk+fPrYB99hjj9mgrMbb559/bhtC+nzdQ93rtWvX5vR3BZRk+v+2kgF1orh6ir3GhhoZjzzyiD1G8UKNCMUTPTf6s2fTpk32fOeee659rqZNm2Zf22uvvZLijEpA9Yx6Zs2aZRst6mhRKbfOq+dVMSZIHTRK1g455BAbh3755RfbMaXP0vOsc3zzzTc2SVUnlSj5U5Lnp+dcn6PSrBYtWthrU8KrYw866KCC4xTjdB51gCnR0zGKkWpoZUOdRjrXiSeeaGONOtIUOwcOHGjvj5863R5//HF7zYpjKp9V0qoEVt9Pn6/7q9gn/tioJFD3Uomyklx1gKn8XR1mus9KEHv37m2/p86h+wcg2nOqttGECRNse0sxxmtTqN3ldWopXuockydPNpdffnmhS8SJHciXkjfJCwUUONSLrkaURs78Sd/JJ59sA45+lPiokaCETn+uX7++7Sl///337dwbj/7RV0BSY0U9uQpg+gdfjRn9t3p4FcCCCY5GE9XLrgaYAqEaggqESqh0TlGjRElU2Ly8MBpBU7Ko69V1NW3a1DZgvFEAv0WLFtkG19lnn20TPFFiquN0P1R2pmtUKahGIZTYeXRd3mfodxs1amSTXtGxaszqdY3+qSdOow9A3KiRL5kSFsUdjayfdtpptmpACZo6QZR4qAfb4z17eu40eqQ4pYRLiYk/zvifRVE8UdKm95Rw6jP0fLvodT2Txx13nD2n/lvPuM6pz9KzrbiluKgYpB9XFYAaToqNSvL0uUrsNJI3b968pOMUGxTzVLXQrl07mxwFrz8KxTD9vhJKXbeSMDUidR1+aiyqo0s99kpaFUu95E2/r+usWrWq7XxT8qnefT81NA888EB7vbpHOp/3d6TYps/U/VVsU7LtjfIByPyces+j4oBii9fmUSxRJZF+R/FPI+pqTylGFhaxA/nCSF4JpDKmW2+91faeqxGlf8D9PbdKZvzz8DT6paDk75nXiJR+V40grwRACaB//pte9/ecq2GkQKaRQD+dy3+MGgz6zHzQeXR+/3Xpz2qoaJRPJUuiHnVdV79+/WzJqUcr06nhOnLkyKTzKunV62oYed/d3/DTd1cJmKjho8+5++67bTmEfkflrmo0AnES7DhJ91zqmfCeP1GsUEKl97xnUImDv9faS7CCcSZdTBElkUoqXfS6OmQUE4P0jAdHxcJoRCuY4Og61JhTrPXig2KFR9/Ddf2Z/Pzzz3ZBm+D31J+D31MjeOroOv/885Nijo7TaKMqE/x/f4ptakx6x+rfA4/+DdDfh3e9rVu3tpUWKilTXFMnWvCagJ1VNs9pkDrQVa6ppE7Pm2KInkt1rBTXNRE7kAlJXgmkHqITTjjBJnKahxHslc41+XD1brsWbYnaECxO6r1XQ0UjiEoyvUakkkH9WSMOQUpYw767ft/7nmoUaeUs9dZr7orm7KgXXaWv2Y5MAiWZlxDlq5PGFVNcrxUmpugZV3LmX7zJUxQLqxR3TFTHkqoxNJ9asd//vdW5pw6nIH9ZfLrr1aikSjc1Z0+jsw899JAdpdS8PQC5Uym1yt9VtaDOMD2T9913n51CUlyIHciEcs0SSEmcSm8UOKJsm6ByAY1oqVHgUQ+wEpmovdzpqPHhUW+V5rZ45V5eA0Ov50Ln0bX6G1H6s3qk/fMCVa6kUqbly5fb+XP+5E+jlSqp0D3z/2SToOk+a0RPpRqXXHKJnRvjlXMCcaFSIzUMVCbtjxceb085PZfqkfb3SmskTO+75s0VJqaIygvDSkhVpaBRd40aBp9xr3pBcShTDNJ1K7b46c+KkfnenkYdR+qgc31e8P4p6VKZpeYB+ctCFduUjAe/s36yWZFYsVEln+oI05zGYLknsLOK8pyGtXF0jMq91ZHizdVTyXVxXJOH2IFMSPJiQHXh6kVSz5IaQ0pOlAjp9Xz0dKtB+OGHH9oGh+bEqaHnrc7mlXOpxFQlC66GYzoKUirL1PXq/FpNTiNpWvkz2JBRY0yJnq7F2xxd31EjdlokQmUTWvRBDSWdT+eNQteuBQuUKCu500IQSjrzkSADJY3mpur/31pMQGXQ6iRRAqdnQD3Rog4PlQFqEQ+NoCsJmz59ul0ARCPnhaXP1ai8PluLg+j8ajC56HX1mKs0ScepRFPzlJ966qmChpcSQL2n51cNLdfIm2KKYqNG6fW57777rp3v519dM5903rlz59rl0RXbtFiMYoxrvq9e09xEJXrenGitoql51YqHiuv6O9K5VCIWle6tYqrumc6hEb18JOlAXGR6TtVJovaVYo5KNL2OMHW26PnUc6lOK8XKbBeey/Wa/IgdSIdyzZiM/Gl1OyU+48ePT9pCIR/Uy6yAoyCjwHbWWWcVlEJqtE0lRTNnzrSNLtcWCuno98855xy7gue9995rRxqUQPqXXPdTb7/mrmi1PSWB+o5ajU5BUHNPVM+uc6rsKeoKVxrxU+KoxpTmuyi50+qd/rk5QFxoVPyiiy6yc7209YgaLnqelbypTFz0bOk5V2fJAw88kLSFQj4oZqgBo04j9VrreQtLPvS+5uLqGdequXpGldRpjpnXEaRGkTq5xowZY9/X6r9BGhk7/fTT7XOu5cl1Xi1k4l9ZM5/U+FKDUPdYHWD6flo0Kqzz6IgjjrDJqVboUzzX/dbxulbFX40UeIvZRKXfUWxW8qt/F7Q1jO41gGjPqUb5FffUOaTYoWdIKwdrwSmtdjtu3Djb5lA7SefIB2IH8qVUoiROwEKJ4O2Tp/lqKpkCgMLS3m5nnnmmXQQEAAAUDco1AQAAACBGSPIAAAAAIEYo1wQAAACAGGEkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAGKEJA8AAAAAYoQkDwAAAABihCQPAAAAAEx8/B8JuTyFK42OWgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 900x150 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 9: Token KPI cards\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  COALESCE(SUM(prompt_tokens), 0) AS prompt,\n",
+    "  COALESCE(SUM(completion_tokens), 0) AS completion,\n",
+    "  COALESCE(SUM(total_tokens), 0) AS total\n",
+    "FROM llm_events\n",
+    "WHERE event_type = 'LLM_RESPONSE'\n",
+    "\"\"\")\n",
+    "kpi_row(\n",
+    "    [\"Prompt Tokens\", \"Completion Tokens\", \"Total Tokens\"],\n",
+    "    [df[\"prompt\"][0], df[\"completion\"][0], df[\"total\"][0]],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-10-token-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:29.233099Z",
+     "iopub.status.busy": "2026-04-11T06:42:29.232998Z",
+     "iopub.status.idle": "2026-04-11T06:42:31.440202Z",
+     "shell.execute_reply": "2026-04-11T06:42:31.439703Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYOJJREFUeJzt3Qd0FNX3wPEbIKETepPeexGkiCBNUBAFQYpKE0QQVECqIE1pIgoqgoIUFZUiKAI/ilTpghTpgvQWFAihl+z/3Kez/9nNJiSQTNr3c86ezc6+nZ2dmd3M3LnvPj+Xy+USAAAAAAAAwEFJnHwzAAAAAAAAQBGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAKAOMbPz8/c8uXLF9uLAsjq1avd+2S7du3i7Bq5evWqZMuWzSzn8OHDo/z6mjVruj/n0aNHxQlDhgxxv+f06dPFSbHxeaNC9zVr+XQfjA26Xqxl0PUFIPK/xxkyZDDfnTFjxrDaAESIoBQA3CcNGlknLPe6xdZJVUyeRHsHKOwncHpLyH7++Wd59tlnJUeOHBIQECAZM2aUGjVqyCeffCI3btyQuCyh7re67oOCgiRFihTy6quvSmK3Y8cO833VW3zajonFuHHj3Nsnun6TdL8vW7asZMmSxfwu5cmTR15++WU5duyYz9f88ssvUrduXQkMDJRUqVLJww8/LJMmTZLQ0FCPdmvWrJE333xTKlasKNmzZzfz1t++Fi1ayK5du3zO2+VyyVdffWV+F9OnTy8pU6aUvHnzSvPmzWX37t2R/lyXL1+Wvn37SsGCBSV58uQm8PzSSy/J4cOHI3zd7NmzPX7L+vXrF+n3jOr7vvXWW1K1alX3ukmTJo2ULl1a+vfvLxcvXoz0e549e1Y6d+4suXPnNvPR+y5dusi5c+fCDdiGd4vKfrVt2zbz/yxTpkzm97NEiRIycuRIuXXrVpi2N2/elBEjRpg22lZf07hxY/n999892qVOnVpeeeUV87cGpa5cuRLp5QGQCLkAAPclb968Lv0Zjcxt1apVkZ6v9Rqdf1wzePBg9/K1bdvW47kjR454fOaE6NatW65WrVpFuK3Lli3rOnXqlCuh7LeXLl1y/frrr+Z28OBBV1x0+/ZtV7Zs2cwyt2zZ8r7msWvXLvfnvHHjhsvp79O0adOidd46P2ve+j5x4fNGhf6+3M/vZ3Sy/6Y9/vjjMfY9jA5FixYN93ucKVMm16FDhzzaT5061eXn5+ezfYcOHTza1q9fP9x5p0iRwrVhwwaP9nfu3HE1b9483Nd8/fXXkfpMwcHBrjJlyvicR4YMGcw+7Ms///zj/j2wbn379o30uozq+yZNmjTcz1qqVCnXzZs37/mex48fd+XKlcvnPPLkyeM6efKkz+9GeLf33nsvUp916dKlroCAAJ/zqFevntmW9t/ZOnXq+GybPHly1y+//OIx7wMHDrif/+STTyK1PAASJzKlAOA+zZ07V3799Vf3Ta+SWj7++GOP58qXL896TgDefvtt+e6778zfeuX/3XffNdkGU6ZMMVkJaufOndK0adMw2QZO0ivcd+7ciZb9VrMoHnvsMXMrXLiwxEX/+9//3NkEuu7vh2Y2WJ9TMyMSusT2eRODMmXKmAys5cuXm/t06dKZ6f/8848MGzbM3e7MmTPy+uuvm2ymZMmSyYcffijff/+9PPTQQ+b5L7/8UhYtWuQx7wIFCpgMmWXLlpnfO82UUpoZ6p2F9MEHH5hMJVW0aFGTfaXLpNN69erlfu29aLaPlYmlGVc//vijOwtSM5A6dOjg83WauaS/B5rJcz+i+r5PPfWU+e3UbLWlS5ea97doVtiqVavu+Z6aiXby5Enz93PPPSc//fSTuVfHjx+X7t27u9sOGDDA43dab/oemqFl0cyne7l+/bq0b9/enRE1cOBA+eGHH6RUqVLmsW5r3XaWzz77TFasWGH+1jbaVl9jZVBpBpfeW4oUKSIlS5Y0fzvdPRlAPBPbUTEASCjsV769r+zrlde3337bVaxYMXNlOU2aNK5KlSq5Jk2a5AoNDb1nppRegbSuZmbMmNG1c+dOMz0kJMRkQZQsWdLMN23atOaK/uLFiyO84r9lyxZXzZo1XSlTpjRXlAcMGOC6e/dujGVKzZ0711WtWjVXunTpXP7+/uY99XGfPn3cn//KlSuuzp07uypUqODKmjWraaftq1Sp4poyZUqYZbl27ZrrzTffdGXOnNmVOnVqV6NGjcwyhJeBoO+j2QGPPvqoWU+6vvRq+Lhx4yL12U+fPu1xRXn69Okez//555+uZMmSuZ//4YcfzPTSpUubx3o1/fz58x6veeKJJ9zt9+zZ456+du1a83n0s+l6yJcvn6tHjx6uCxcueLzefsVct3nPnj1d2bNnNxkQui4edL9VOs3XNvd+79dff93sm5pJ0LVrV5N9c+zYMfM5dPuEt5896HZR7du3N8uhn1szu+z+/vtv16uvvmqyDXRd6nevcOHCJqNq9erV7nb6vbA+j7Xu7ud7c/ToUdezzz5rPnOWLFlcb7zxhtm2vjJuIsqU0u+4LqNuT13unDlzmgyWEydOPFA2nJU1FZnPu3LlStfDDz9stkn58uXd+8dnn33myp8/v8mO0O22Y8eOMMvw119/uTp27GjWu35vdF1o9szevXsjtU3t+9fy5ctdQ4YMMZkkuizVq1d3bdu2LdzPHN58vPfvjRs3upo1a+bKkSOH+3fpqaeecm3fvt3n+rB89dVX7iwj/W5qlosKCgoy39NChQqZz5w+fXpXgwYNzPv4ymDzdbP42j4RWbZsWZhp+h2y5lG8eHH39NGjR7un63fD8t1337mnP/300+7pK1asMFkydj/++KO7rX4fLNevXze/Azpd16d+/+6HZhfp+rO+1/r7a/1e6P9R6723bt3q8TrdV6z31u9eVDOl7vd9vWnGrNV2zpw5EbY9c+aMK0mSJKZtYGCgWYdK7/Wx9f/j7Nmz4c5D/8f62lcj+g2fNWuWe7pmw1l0f7Vnell0H7Km2/dpeyadLodd9+7d3c9Z3xMA8EZQCgCiSXgn9xpIsB/Met+8uxt5B6X04FdP1q0DVutgWE++rYCHr9uECRPc87SfXOkJmJ5EeLefPHlyjASl9MTfOuD2dbNOdvTAPKKTtaFDh3q8n574e7fJnTu3+4TI++S0TZs24c67RYsW9/zsGhiz2mugwPskTTVt2tTdpnXr1mbaqFGj3NO++OILjy4mVhBLT/gtuh3CW1/aRccemLKfcBcoUMCjrZNBqYIFC4ZZVv38Gri41372oNtFFSlSxL0c3mrXrh3u/DWoZLlXkCYy35uLFy/6DAjZT1AjE5TSIJ8GfHwts+57GvCJ6aDUQw89ZAJA9tfq5+/Vq1eYeWpgxv590ICRdWLvfdOg4ObNm++5Te37l6+uVBqw1u5Bvj5zePOx798aCA2v25W1LXwFpRYtWuT+3mqQzNoWGoANr/uVBrx++umnGA1K+aLLas2jYsWK7ukaKLamz5gxwz1dP4M1XbdfROyBVg2e2wNY1nQNuut3WC8ypEqVylWrVi3XunXrIrXsug9Z89HfEV9BaL199NFH7ulXr151/w5qIMj+/YpsUOp+3tdOLxTNmzfP/d3R77G9650vegHDmq+uIzt9bD03f/78cOdh/52bPXt2pH7D9UKCr/+v+l3WfdZ6Tv/n6P8r+/5s79anr7We0wtFdhrAtZ7ToCcA+EL3PQBwoMvX/v373V1m5s2bZ7o/6Mg0SrtNzJo1y+dr//zzT9M1ICQkxKTmL168WCpUqOBO4f/jjz/M3w0aNDDdLbSwrNUdq0ePHnLixIkw89SuG1rQVrsHvPHGG+7pn3/+eQx8+n8L8Fpd2bT7h6b/62fWtH8tlmoVRddCu9rFRLt4aLcB7Y6g7awuY1os1epmoM/r8ivtoqHdT7SLhRb4vXDhgs8ua7purO4k2gVPl6tKlSpmmq7/8LaBZe/eve6/teuCdnvxVq5cuTDtX3jhBfdn1OWw6PJaXey0gK46deqUdOvWzayvtGnTmuLd2h1Eu1ioAwcOmP3Jl7/++stszyVLlphtqa93ihbo/eKLL8x+nSTJv4cWX3/9tekeotvQXnTXvp9Fx3bRdajfE1WoUCGP5/R7Y3Wd0a6ICxYsMF39tEuKdvPTYryRFZnvzfvvv+8uKq3dOfWzT5s2zd0tJzKuXbsmbdu2Nd1gdB/TkQR1f+/Tp497Xb/22msRzkPXq30/0f3H6uajha8jQ/dFLYKtvyu1a9c203R7atesjh07ysKFC6VYsWLuQQ50P1UaV9flv3TpknmsXZl0+UePHi1JkyY1BY91ef6Nv0fOoUOHZPz48eY7o8W2rULUWkj6fuhn0wLSd+/eNY+1UPP8+fPNetPizFpk2peNGzfK888/b/Y5/Z1duXKl5M+f3zyn28Tazm3atDHfw4kTJ5rf7du3b5v1riOS6W+1d7dZezes6KTdqyz6f8RiH21RC3hbsmbN6v5bt19ERbrDm7f9d1K77On3Vwcg0P1av4u1atWKVHe28JbRezmPHDni/vudd94xv4O6PZs1a3bP94iu91X6m6K/8/q7q93utFujdnnU9WR1i4zu97To8YXuiypnzpzSpEmTe3zKiN9Xf3d08A57O3tbLW6u3+XILKP9N9m+bwCAXdgjagBAtNHggv2k+ttvv3XXa9ATPK3rofRkXEcystOTt/r168v58+dN/SI9CXz00Ufd89V5KT2B6tmzp6kLozVE9IBYaz9oAEcDPPb6FlZ7PVDWg9Cnn37aBBL0hEFP/GKCv7+/+28NMOnoUHpQq59XazJZdNk1cKC1ObZv325OiKyTRmt96MG31k3Rk1NL165dTQBO6UmydaJs980333i0z5Url/lba4Ns2rTJ3cZ7G9jpSbBFg1++2KcHBwebex1BSeuS6AhWejKmn0sDklaASoM4rVq1Mn/PmTPHXZNDT6qsIJeexOt+pNtJ95UJEya4gz8WDX7piXts0Hoo1khLH330kezZs8f8rQEVXacagBg7dqwJEtn3s+jYLhqEtAIcVqDXfnKlJ4r6fObMmc0Jku6DOj2qI/RF5ntj3y91G2k7pdtUR9WKDA3g6HdePfHEE2bfUY0aNTLfZysA9Pfff5vP5IsGbuwjnGmATGtHRYX+5sycOdN8L/VzWie9Oi8NQOp63bdvn/Tu3dtMt9aD1lSz3lv3Xw0QKP3tqlSpkgns6MmpjtZlBdjvRb/fViBQA9laq0ZpkF4DPvbfmMiwf890uTQgZQmvJpkG+HV76rrQ9a615KyAue6DuixKg03Wd0F/63Ub6vy1rpMGqnT+ehJvr+Pla9s86IiJkydPlqlTp5q/NThi/z+gwTGLPQDnHYzTdt7fKaWf9b333jN/a/DC/jtuBSMt+tvWunVrE6TW3y7dXvr/Sn/jdRv89ttvYeav6yO8ZfR+bLXbunWr+f3TGnj63YtIdL5vRLS9/X9YeB70PfX/vaVTp05hLpjUrFnTZxA4Ku9rf31UltG+/+hvFgD4QlAKAGKQnlxaV5s1E8gKSCk9QbMcPHgwzGv1JEZvSovWPv744x4Hd9Z8NfikGQ2+6EmjNw3aWFdFNbChB416ouV9MuGLlfGjvA9y7Y/t7V588UUTqNATAc0yUHpSVq1aNZNdYC27ZpDdq0i1tYx6NdxSuXJl99+abaOfx/sKv3392rNc7rWu7KyiwcoKGnizT9eTI4tmQmlQSk/INHChV7KtgrGahWIV/rUvp2bY6M2bBrtOnz7tDuBYNGgRW+z7sv0Ku5XVovuDTteglH0/i47tYue9T2pgRU+KNbiiWRsa0NAAhhbf1fWlJ+r27RSRyHxvwtsvdbj4yLKvE83q0puvz6kB2qgGmqJCv0vWPm/fphpIsr7f9qCYtR7sy79jxw6pXr16uNs1skEp+7rUQJD1HddsFP0u5M2bN0qfzb6MDRs2jNRr7NtW9yergLMVkLP2Pc1ki+gzO0GDM1agXoNkGgyz7+f2DEF7YWorE9VXO4sGZjUArm01C0wvltjXvz3YpsEKDY7pfHSdaCBefwN1v9D/bfp74Gtd6boMbxm9l9Nqp78fGgDSbEXNFrpX1mN0va9Fg6/6/133S/1t14sr+h3V33oNwOrFmPDc73taQSAr21R/2zQoFVlReV/7b2tUljEqGZEAEi+67wGAQ+yBGl+PvdnT40eNGuUeXSwqfF1Z9ZVNEln2LmHeVz3tj+3t9EB927Zt5qRBTy715Ei7c2j2gGaCbdiwwbT79NNP3a/RUXw0Y0S7s2imgcXXiHb3Wo+Rda8r3xrQsGgmiK/R7TRLxFd7zXqyTtb0xEy7kVkH8hq0i45l9e724ST7Ca89g8seyIup7aIBE2sf8NXdSAN72sXumWeekYIFC5oTVz0p1uyOiDKwHvR7E137ZXgik6nh5DaN6snngyy/r3Vrn2bPTomu7Az777F2Pb6f5Y/pbWZlJ+pIbbo9NEtTg+Heo2bmy5fP/bf9/4oG1Czp06cPs8/PmDHDfGf0t0uf199o74CrNQqp0oxYK0ihASx97Cvz1JfwltF7Oa3ukxqcVJoBqfuC3oYOHepup91HdZp+96PzfS0a/NMgsQa79SKSZof5ypaOzve0AqRWVq4GwCI7smFE76v/26wLYlY7e1t9zv7/L6JltP8mh5fZCQAEpQAgBml3Lj14t05IrG5NavPmze6/re4odpoJY13t1joNekXfOqnRgzvrhEEP9vWK83+DV7hvemLmK9PmQbMnLBpM0i51FqumjLJ3odNl0awCvXqvXbI0o8LquqYH7FaXJ63zYtFaShqM0q419ukWDS5Y7N0wtOaSr8CEff1qFzrvdaW3w4cPR/jZtRaM1U1BD8K1K4p3JoW9+5bVbUnpPmBlZGi3Hx1y3crksWeH2Zdz8ODBPpdT9wH7dnAqCBITomO7aHDIOun21QVVn9fsAa0Fpc/r/mF1g9WT6ugMFIS3X2qXtftZJ1qbKbx9QAO6EbEHknwFc2OKffk1uzO85Y9K98ktW7a4/9ZtaNWN03pyVlaMPYhmnSTr7+L69esjXEar2929aGan9V3VbavBGSv4pd1Cre+f7gN6wu79mTWQozXzYnL79O3b1wTMlH4n1q1b5/N/iz3Dzroo4L2femfhaZc47Uasn1kzXbV7oa8MQJ1mrQsNXmg2odJtbm03zejRII4GOnztH9bFDGubap026/+APm917VXhZaVFJDrfV7vh+2L/Pb5XFrL+Hln7g3Zr1AxApff62AqK+lrf9q572gU6KsLbD3T/toJOuj70WEOD/8WLFzfT9Lnwft+8t4f9N9l+oQYA7Oi+BwAxSA80W7ZsaYqgWlkxGmzQE2O9t1g1hbxpUWE9qNPiz5ptpN3fNMtGT7T1NXpAqoGhevXqmUwkDVZpsV3N5NHucFpTROtJRBftaqZXu/VkQw+0tSD1s88+a65Sa80Qi73IrHan0BMYDcroVXS9cm4PYFldAbQLiNWtZtCgQeakW+fpqziqBnysg3HNsNIAns7bftJnp+vdKoyuV7C1SLyetGl3Oy2SrcWctVivfZt40yvQWoRci6orrRF0/Phxc6KgdX4088Y6kNfubPaglNWFT7eJnpyuXbvWTNPsHXtWma63fv36mXWi2XF6YqPz1xM7DUxq4EZPgrQrWkIQHdvFChjovqPrSLMG7AEKDRJoMEG7z2gAQ7P0rGK8eqKp6zoqBc8jotvc2l91X9FtqNtOP1dkaTBWg9m6DrRbjp4M6jQNBuh+pkEWzci7V9Fge5aLdt/S2lQaxNHBFiLbZfF+6HrWE1n9DdIsHS36rb9bGojQ5dcAk2ZJRlRE25t2/9VMQP2OayaQRfcNq56UBoasTEV9T93m+vvhKyCgy2N9z3R9alt9jQaH9Lul+5N3BqN+F3V++p3XE3LdN7VYutbX0m2ky6IBLg2i6vda66Lpd1sDGxpY0O++nrxbGSe6faz9UIPw2pVRt4tuH6W/27r+lLazZ6qEV9dNu4xZQfCRI0eaZdWb0m1vdafV75r+VmqgSAPkehFBvxu9evVyz89eA03Xv9aBUprxqfPWgJ8GvbwDHLqN9Ldb9zn9rdOAsP726bqzskN1XWlAPiJ6AUCLw+t76/dU/9/p8ul614sPSj+P1QVU/2d4Z1/pMlj/a+rUqWNqgt2r6HhU31f/v+mFBt2H9LdL9xPtvmf/f6gDJEREA3T6f1S/F/r7pe+py6AXlazPpFlQ3tmw1m+B0u+cVX/Om/7/1QLzVqB7+vTp5m/N6tLtrv+/NUCvv1P6uXRd+toP9G/dz5TWTdN9SLsm6muV/h+26uhZrKCa0u8VAPjkc0w+AECU2Ycktw89rkMpFytWLNwhwFu2bOkKDQ11t7em6/zUlStXXOXKlXNPf/nll93Dz5cuXTrC4cWt5fA1tLmv5Y6MWbNmhTuUut4qVarkun79urv9u+++G27bJEmSuIcI1yG8vZ/XYbUrVKjgc70+++yzYdrrMPYZM2b0+XnatGkT4brS4cPv5datW67mzZtHOJ9SpUq5Tpw4Eea1N27cMMOs29suWLAgTLvJkyeb9RLe/O3bL7zh7qNjv73XcOLhvXd4Q9mHt59Fx3b5+eef3e3nzp3r8VxE+2r9+vUjXO6ofm/0O2mfbt3KlCnjcz72IeunTZvmnr5o0SIzlHx4y239NkTk/PnzPudhbauofN7w9gFdZl/badu2bWH2de/bvdj3r8KFC4d5fZo0aVz79u1zt1+6dGmYNsmSJXMVKlTI534a0ffM2ha+1seZM2dcuXPndk8fOnSomX7s2DFXrly5IvzM9u/DW2+9FeF3O7zvUXh87XcR7TNTp051+fn5+WzboUMHj7b2ZYnM9jx8+LAre/bsPttly5YtUp9HBQcHe3x37Dfdv3bt2hXh6+3fr759+0bqPaP6vvb38HV77LHHzP+Nezl+/Hi4+0+ePHlcJ0+eDPOaF154wd1m4sSJ4c47vO+v9b0JCAjw+b716tVz3blzx9329u3brjp16vhsq781v/zyS5j3LlmypHm+YsWK91wHABIvuu8BQAzTq+ia9q/Dl2u3K73SrJkZjzzyiBkyXEfRi6jrlbbVYrJWNxXNftIrmXo1XK+8a4aOZifolWctpq5XazXjRruXaSZTdGvevLm5QqvZBrpMmrWlXQj1avCIESPMVVm9Km/v9qZddaxuANoNQdeJZnfpVWzr6qkus9b+0eXX1+v60Svd9uLwdvr5NDtMM7f0c2smlmYgWV1hvK/Eaz0UzTzRLkWakaBXxPWqvl5B1wwDLbp+L5qVofVB9Iq2XmXWK9c6TbeFfg6tJaKZIN5FyJVud6vQu9LlfvLJJ8O069ixo/kcOoqizl/Xr95r9pUOeW7vrpEQRMd20fWo2QZKM1LsdJ/UzA3dJroN9KbfQx01Tkdhi066H2h2i2bK6D6p21iXX7/nFp1+L/qd0dHENKNFl1v3Mc2C1NHsNGMlMsut7bU7qY5oea+slOimvwVau0czK3TkN92mum70u6zTrCL/kaXZkNo1TbMVdftpVo5mDdq7CevviX7/rO2s3xf774uv75nWrLN/z7RbmmbxWKNe+qL7mf4eWxmOmsWnv8m6z2pWiO5Xulz6G6Zt9G/NwtIMV63xZNHXaRaR/obGRtdb7Yqn60e/Z7qcuo/ovqL7qmZ/PQjd5vo7qNk+us103ern1HWuGb/3yvqy1y/TbaTrVGsV6X6k20gLrWu2mpVVFt2i8r7626Pb1xoYQP+/6fdef890v9V9PTKjQ+q+ofPW/5WazaWv0Xt9rOvSO8NLMymtbvD6vpqNdj/0e6Nd9/T/mf5/1u+OdtPT303N0LbXUtPtqBljmq2o+7W21f/l+nun89B9yU6zV62SBVonEgDC46eRqXCfBQAgjtJ/X94nczrakVX3okyZMh6Fx5GwaSFj7ZKlJ9cnTpzwKKoc2/uldt/Vrl5KA6laXw0AErI+ffrImDFjTHdk7YIaXd2kASQ8ZEoBAOIlrfOhtU30KrIGIbSuhX00taiMrIb4T2s4aTaD1tyyarjFBs3Y08wZzRDQ4veaBWYVn1bslwASOq1XNnnyZHdwioAUgIiQKQUAiJe0O4B2/fJFRwDSIJW9GyHgBO2apMWtfdHuQFoYGQAAAP8iUwoAEC9pDQytYWHVddK6GlpDS7tGaR0PAlKIDVo3R0fn0vosWoNFu65onSIdZZCAFAAAgCcypQAAAAAAAOA4MqUAAAAAAADgOIJSAAAAAAAAcFwy598yYQoNDZXTp09L2rRpwwwFDQAAAAAAkFi4XC4JCQmRnDlzSpIk4edDEZSKJhqQyp07d3TNDgAAAAAAIF47ceKE5MqVK9znCUpFE82Qsla4jgAFAAAAAACQGF2+fNkk7lixkvAQlIomVpc9DUgRlAIAAAAAAImd3z3KG1HoHAAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA46gp5bC7d+/K7du3nX5bxDJ/f39JmjRpbC8GAAAAAABxBkEph7hcLjl79qxcunTJqbdEHJM+fXrJnj37PQu9AQAAAACQGBCUcogVkMqaNaukSpWKwEQiC0heu3ZNgoKCzOMcOXLE9iIBAAAAABDrCEo51GXPCkhlypTJibdEHJMyZUpzr4Ep3Q/oygcAAAAASOwodO4Aq4aUZkgh8bK2PzXFAAAAAAAgKOUoagklbmx/AAAAAAD+H5lSAAAAAAAAcBw1pRDGrpOMEBgTXHduSdDF69Jx3mo5FXKXPQ8AYtHRUQ1Z/wAAALGMoFQsy9dvUZw+AH+nx2uyYO535u9k/v6SI2cuebpZS+nYrackSxa3dp/fNq6Tjs0bya+7j0q6wMDYXhwAAAAAABCBuBVVQJxUrWYdGTZ2gty6dVPWrVwuIwb2Fv9kyaRDt54e7W7fuiX+AQGxtpwAAAAAACD+oKYU7ikgILlkzppNcubKI83bdJDKj9WU1cuXmCyq7h1elMkffyB1KxSXZ2o+Ytr/uW+PdGzxjFQqlENqlC4gw/p2l2tXr7jnZ71uyidjpVb5IvJYybwyadz7cufOHfnwvXekeqn88sQjJeXHWTPdrzl14riUzZ1B/vfTD9KmcT15pFB2ea5OVdm6cb37ec2SUtVL5TNt9X0AAAAAAEDcRFAKUZYiRQq5ffuW+Xvz+rVy9K9DMunbefLJtO/l2rWr0uWlZpIuML3MXLhCxkyaLpvWrZaRA/t4zGPLhl8l6NxZmTZ3kbz1znCZOHakvN6upXndNz//Is+/1F7e7d9Dzp055fG6j4YPkjadusms/62RshUqyRsvt5JLFy9I9pwPydgvvjJtflrzm6zYtl/6DB3J1gUAAAAAII4iKIVIc7lcsunX1bJh7Uqp9Gh1My1lqlQy5P2PpVDR4ub2vx/nys2bN+S9cROlcLESUrlaDen/7vuycN4s+ed8kHtegenTS79hoyVfwcLSpOVL5v7G9WvS8fW3JG/+gtKhWw/x9w+Q37ds8liGlu1ekboNnpEChYvKgBFjJU3atDL/+68ladKkEpg+g2mTMVMWk9mVNh11pQAAAAAAiKsISuGe1q5YKlWK5jJd5rq2eV7qN2oinXv2M89p4MleR+qvPw9KkRKlJFWq1O5p5SpWltDQUDl6+E/3tIJFikmSJP+/+2XKnMXMy6JBpvQZMsiFf/72WJayD//bRVBpofUSZcqb9wQAAAAAAPELhc5xT488Wl0GDB8r/gH+kiVbDo9R91KmTHV/O14yf4/Hfn5+ZnQ/72mu0FC2EAAAAAAACRCZUrgnDTzlyV9AcjyU2yMg5UuBwkXk4N7dpraUZcfWzSYrSrvoPahd27e6/9bC6Pv+2GHeU/n/F9QKDb37wO8DAAAAAABiFkEpRKsGTZ6X5MlTmJHv/ty/1xQ0H/VOX3n6uRaSKUvWB57/rBlTZMX/FsqRQwdlxMBecjk4WBq3eMk8p0Ezza5a+8tS0+3PPuIfAAAAAACIWwhKIdqzqiZ+M1eCL12UF5+uI71ebSuVH3tc+r/3frTM/81+g2XqZ+Pk+frVZftvm2X81G8lQ8ZM5rlsOXJKl579ZfyooVK7fJEwI/4BAAAAAIC4w8+lQ6rhgV2+fFkCAwMlODhY0qVL5/HcjRs35MiRI5I/f35JkSJFnF/bu05ekrjm1Inj0uDRsjJryVopVrK0xEeuO7ck6PRJGbIqSE6F0MUQAGLT0VEN2QAAAACxECOxI1MKAAAAAAAAjiMoBQAAAAAAAMdFPJQaEEc8lDuP7DxxMbYXAwAAAAAARBMypQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUQrx16sRxKZs7g+zf88cDzee3jevMfC4HB0fbsgEAAAAAgIglk1g0cuRImTdvnuzfv19Spkwpjz76qIwePVqKFi3qblOzZk1Zs2aNx+teffVVmTRpkvvx8ePHpUuXLrJq1SpJkyaNtG3b1sw7WbL//3irV6+Wnj17yp49eyR37twycOBAadeuncd8J0yYIGPGjJGzZ89K2bJl5ZNPPpFKlSrF6DqQIYExO3+P97q/oMvfQedk8idj5deVyyTo7BnJmCmzFC1ZWl7q0EUqP/a4xCcdnn/aLHufISPd08pVqCQrtu2XtOnSxeqyAQAAAACQmMRqppQGm7p27SqbNm2S5cuXy+3bt6VevXpy9epVj3avvPKKnDlzxn17//333c/dvXtXGjZsKLdu3ZINGzbIjBkzZPr06TJo0CB3myNHjpg2tWrVkh07dkj37t2lY8eOsnTpUnebWbNmmaDV4MGD5ffffzdBqfr160tQUJAk9myklg1qyZYNv0rPAcNk7vL18tnXc+WRqtVlxMDekhD4BwRI5qzZxM/PL7YXBQAAAACARCNWg1JLliwx2UolS5Y0QSANJmnW07Zt2zzapUqVSrJnz+6+pbNltCxbtkz27t0r33zzjZQrV06eeuopeffdd03WkwaqlGZV5c+fX8aOHSvFixeXbt26SbNmzeSjjz5yz+fDDz80wa/27dtLiRIlzGv0fadOnSqJ2YgBb5lgzcyff5G6DZ6RfAUKSaGixaVNp67y9U/LTZszp07Imy+/IFWK5pJHi+eR3l3ayz/n/z+YN/HDUdK8fnWZ//03Ur9yKdNu+NtvmYDitInjpfbDRaVmucIy+eMPPN5bu9TN/upLea11M6lUKIc0qFZOli/6KcLl/XP/XtNe36NW+SLy9puvysUL/5jn3unxmmzdtF5mfjnJzFtvGnTz1X3vl8ULpEmdqlKxYDZ5qmoZmfH5px7vo9OmfDJWBr3VTaoWy20+19yZ06NlnQMAAAAAkBjEavc9b8H/BQUyZszoMX3mzJkm6KQBqUaNGsk777xjAkZq48aNUrp0acmWLZu7vWY4aXc+7apXvnx506Zu3boe89Q2mjGlNHilgbD+/fu7n0+SJIl5jb7Wl5s3b5qb5fLly+Y+NDTU3Oz0scvlct/snMzN8X7v8FjLFHzxoqxfvUJe7zNQUqdKHaZdYGCg+WzdO7woKVOllmlzFsqdu3dkxIDe0ue1l2XqnIXutieOHZX1q3+RiV/PlRPHjshbndvJyePHJF+Bgqbdzq1bZFCvblKlek0pU76i+3UTPhghb/YfLH2HjpKFP8ySvl07SKEixaRA4aLu5fT776ZBpVdaPivPtWwtfQaPkBs3bsi4EUNMkOzLWQuk79CRcuzIISlUtIR0fevfbZ0hU2Y5c/K4x3z27tphXtOlRz+p/0wTs2zDB/SSDBkyyrPNX3Av21dfTJCuvd6WV7r1lOWLfzKBtopVqkn+goUjXLd+4pIkErltAQCIGd7/qwEAAOD8sVacCUqZ4Eb37lKtWjUpVaqUe/oLL7wgefPmlZw5c8quXbukb9++cuDAAVOLSmn9J3tASlmP9bmI2mgg6fr163Lx4kWTteOrjda78kVrVg0dOjTM9PPnz5tgiJ12S9TPd+fOHXOz8xfneL93eFIk/ff+wIm/TCCrSJEi7mne1q9bY7KTVm7aITkeymWmffDJRGlQs6oc/ON3KVPuYUnmJ+IKDZXRH30iadKklZLFi8mcR6vLkcN/ytSZs00AsHiRwiZravvGX6VSxf8PSj3V6Fl58aU25u9i/QbI5nWrZfaML2TIyLGS/L9lCkjy7zJP/WqylCxVRvoO+P+um/qeNSqWkjNHD0n+goUkeUCApEmVUnLl+P9tra+3PrfeZk6ZIFUfe1zefOvf7onFCheSY4f2y4zPP5EWrV5wB5cer/OEtHu5o3lc+PXu8s2UibJj06/ms/hyN1TEP4lLCqYTCUxGUAoAYlNi754PAAAQk0JCQuJXUEprS+3evVvWrVvnMb1Tp07uvzUjKkeOHFKnTh05fPiwFCxYUGKLZlVpDSqLBri0gHqWLFk8uhcqDVLpBtHC6/bi606L7HvfuPvv/c27/wZObt/9/2ne9h88KNlyPiQZsudyt8lVsJikDQyU/QcOSpHSD8sdl0jO3HkkWcq07jbpM2eR/EmSyC1XEpH/pmXMnEWCzv/t8V4ly1fyeFy6/CNyYO8fZtrN/6bfCv13+fbs2S2bNvwqZQv9GxyzO3TkiOTIV0hCXWKWxz5Pfb31uQPuivz550GpVa+B5/tWqCLTp0ySq7fuStKkSU2eU8FiJW1t/CRTlqxyzmv57VyhIrdD/eTwZZHTIdSvAoDYlDVrVjYAAABADEmRIkX8CUppjaeFCxfK2rVrJVeusAEFu8qVK5v7Q4cOmaCUdunbsmWLR5tz586Ze33Ourem2dto8EhH/dMgg958tbHm4S158uTm5k2zfvTmPU3rMlm32BLZ97ZyePLkK2hec+TwwXA7m1nT7/W8BsTsbfzET5Il8/ec5ucnoa7QMPPy9di62R9fu3pFHq/7pHTvPyTMcmTOls1jPr7+ts8zMm18Lr921Qzz7t7L7SehjnbcBAB48/5fDQAAAOePtWL1iEy7hmlAav78+bJy5UpTjPxedPQ8pRlTqmrVqvLHH394pOHrSH4acNKC5VabFStWeMxH2+h0FRAQIBUqVPBoo8EFfWy1SYwCM2SQRx+vLd/P+FKuXfMcEVH+q+FUoFAROXf6lJw9fdI9/fDB/RKizxUu+sDLsOv33zwfb99q3tOX4qXKmvfWrKw8+Qt43FL9VxMrmX+A6aoZEZ3/9t82e0zbsXWT5M1f0AQvAQAAAADAg0sS2132tID5t99+K2nTpjW1n/SmdZ6UdtHTkfS0CPnRo0dlwYIF0qZNG6lRo4aUKVPGtKlXr54JPrVu3Vp27twpS5culYEDB5p5W5lMnTt3lr/++kv69OljakR99tlnMnv2bOnRo4d7WbQr3uTJk2XGjBmyb98+Uyj96tWrZjS+xOzt9z6Q0NC78mKjumZEumNHDstffx6QmVM/lzaN65nC5IWKlZD+r3eSfX/slD+2b5OB3buYgt8ly5Z/4PfX0fZ01L6jfx2Sz8aOlN07tknLdq/4bNuibUcJvnRR+nXrKLt3/C4njh4xhdrf6dnVHYh6KHces4w66p6Oyuer+FqbTt1ky/o18vm4MeZ9F8z5Tr6fPkXavvr6A38eAAAAAAAQB7rvTZw40dzXrFnTY/q0adOkXbt2JoPpl19+kXHjxpkAkdZsatq0qQk6WTRzRbv+aRBJs5pSp04tbdu2lWHDhrnbaAbWokWLTBBq/PjxpovglClTzAh8lhYtWpgi5YMGDTKBsXLlysmSJUvCFD9PbHLlzSffL14tkz8ZK2PfHSjng85JhoyZpUTpsjJgxFjTZW38lzNl1Dt9pX2zhiZFr1rNOtJv2Ohoef8uPfvJkgXzZMTAXpI5azYZ9ekUKVikmM+2WbPnkBnzl5gR9zq/9JzcvnlLcuTKLdUer+NOHWzzajd5p8dr8lztKnLjxnVZvGFnmPkUL11WxkycJhPGjpQvPh4jWbJmk9fe6u8x8h4AAAAAAHgwfi7tQ4cHpoXOAwMDJTg42Geh8yNHjpjgWGSLfcWmXScvSVxQNncG+WjyN1L7yYaSELju3JKg0ydlyKogORUScRdCAEDMOjoqYfxvAQAAiG8xEjuqfAIAAAAAAMBxBKUAAAAAAACQuGpKARHZeeIiKwgAAAAAgASKTCkAAAAAAAA4jqAUAAAAAAAAHEdQykGhoaFOvh3iGjPQpUvushsAAAAAAEBNKScEBARIkiRJ5PTp05IlSxbz2M/PL87ufq47t2J7ERIc1907cv3yRbl47Y78fe1ubC8OAAAAAACxjkLnDtCAVP78+eXMmTMmMBXXBV28HtuLkODcDQ2VXWdvyPe7Q+SOJkwBAAAAAJDIEZRyiGZH5cmTR+7cuSN378btTJmO81bH9iIkKKEukau3QiXklkuIRwEAAAAA8C+CUg7SLnv+/v7mFpedConbQTMAAAAAABD/UegcAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAADAcQSlAAAAAAAA4DiCUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA4whKAQAAAAAAwHEEpQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAiSsoNXLkSHnkkUckbdq0kjVrVmncuLEcOHDAo82NGzeka9eukilTJkmTJo00bdpUzp0759Hm+PHj0rBhQ0mVKpWZT+/eveXOnTsebVavXi0PP/ywJE+eXAoVKiTTp08PszwTJkyQfPnySYoUKaRy5cqyZcuWGPrkAAAAAAAAiVusBqXWrFljAk6bNm2S5cuXy+3bt6VevXpy9epVd5sePXrIzz//LHPmzDHtT58+Lc8995z7+bt375qA1K1bt2TDhg0yY8YME3AaNGiQu82RI0dMm1q1asmOHTuke/fu0rFjR1m6dKm7zaxZs6Rnz54yePBg+f3336Vs2bJSv359CQoKcnCNAAAAAAAAJA5+LpfLJXHE+fPnTaaTBp9q1KghwcHBkiVLFvn222+lWbNmps3+/fulePHisnHjRqlSpYr873//k6efftoEq7Jly2baTJo0Sfr27WvmFxAQYP5etGiR7N692/1eLVu2lEuXLsmSJUvMY82M0qytTz/91DwODQ2V3Llzy+uvvy79+vW757JfvnxZAgMDzTKnS5dO4rN8/RbF9iIAABCjjo5qyBoGAACIIZGNkcSpmlK6sCpjxozmftu2bSZ7qm7duu42xYoVkzx58piglNL70qVLuwNSSjOcdAXs2bPH3cY+D6uNNQ/NstL3srdJkiSJeWy1AQAAAAAAQPRJJnGEZiZpt7pq1apJqVKlzLSzZ8+aTKf06dN7tNUAlD5ntbEHpKznreciaqOBq+vXr8vFixdNN0BfbTQzy5ebN2+am0XnZX0OvcVnSSTOJM8BABAj4vv/agAAgIRwrBVnglJaW0q7161bt07iAy3SPnTo0DDTtcugFmePz4pnICgFAEjYqBkJAAAQc0JCQuJPUKpbt26ycOFCWbt2reTKlcs9PXv27KZrndZ+smdL6eh7+pzVxnuUPGt0Pnsb7xH79LH2a0yZMqUkTZrU3Hy1sebhrX///qYwuj1TSmtQaQ2s+F5Tat9Fv9heBAAAYpTWsAQAAEDMSJEiRdwPSmmNdS0kPn/+fFm9erXkz5/f4/kKFSqIv7+/rFixQpo2bWqmHThwQI4fPy5Vq1Y1j/V++PDh5oqndYCpI/lpYKhEiRLuNosXL/aYt7ax5qFdBPW99H0aN27sTjXTxxow8yV58uTm5k1rUektPgsVglIAgIQtvv+vBgAASAjHWsliu8uejqz3008/Sdq0ad01oLRCu2Yw6X2HDh1MRpIWP9dAkwaxNJikI++pevXqmeBT69at5f333zfzGDhwoJm3FTTq3LmzGVWvT58+8vLLL8vKlStl9uzZZkQ+i75H27ZtpWLFilKpUiUZN26cXL16Vdq3bx9LawcAAAAAACDhitWg1MSJE819zZo1PaZPmzZN2rVrZ/7+6KOPTIRNM6W0sLiOmvfZZ5+522q3O+3616VLFxOsSp06tQkuDRs2zN1GM7A0ANWjRw8ZP3686SI4ZcoUMy9LixYtTD2oQYMGmcBWuXLlZMmSJWGKnwMAAAAAAODB+bm0Dx0emNaU0syu4ODgeF9TKl+//88gAwAgITo6qmFsLwIAAIAk9hgJBRUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAADAcQSlAAAAAAAA4DiCUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA4whKAQAAAAAAwHEEpQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUAgAAAAAAQNwPSs2YMUMWLVrkftynTx9Jnz69PProo3Ls2LHoXj4AAAAAAAAkQFEOSo0YMUJSpkxp/t64caNMmDBB3n//fcmcObP06NEjJpYRAAAAAAAACUyyqL7gxIkTUqhQIfP3jz/+KE2bNpVOnTpJtWrVpGbNmjGxjAAAAAAAAEjsmVJp0qSRf/75x/y9bNkyeeKJJ8zfKVKkkOvXr0f/EgIAAAAAACDBiXKmlAahOnbsKOXLl5eDBw9KgwYNzPQ9e/ZIvnz5YmIZAQAAAAAAkNgzpbSGVNWqVeX8+fPyww8/SKZMmcz0bdu2SatWrWJiGQEAAAAAAJDYM6V0pL1PP/00zPShQ4dG1zIBAAAAAAAggYtyUEpdunRJtmzZIkFBQRIaGuqe7ufnJ61bt47O5QMAAAAAAEACFOWg1M8//ywvvviiXLlyRdKlS2cCURaCUgAAAAAAAIiRmlJvvfWWvPzyyyYopRlTFy9edN8uXLgQ1dkBAAAAAAAgEYpyUOrUqVPyxhtvSKpUqWJmiQAAAAAAAJDgRTkoVb9+fdm6dWvMLA0AAAAAAAAShSjXlGrYsKH07t1b9u7dK6VLlxZ/f3+P55955pnoXD4AAAAAAAAkQFHOlHrllVfkxIkTMmzYMHn++eelcePG7luTJk2iNK+1a9dKo0aNJGfOnKZI+o8//ujxfLt27cx0++3JJ5/0aKN1rLTwuhZdT58+vXTo0MHUu7LbtWuXVK9eXVKkSCG5c+eW999/P8yyzJkzR4oVK2baaLBt8eLFUfosAAAAAAAAiMGgVGhoaLi3u3fvRmleV69elbJly8qECRPCbaNBqDNnzrhv3333ncfzGpDas2ePLF++XBYuXGgCXZ06dXI/f/nyZalXr57kzZtXtm3bJmPGjJEhQ4bIF1984W6zYcMGadWqlQlobd++3R1k2717d5Q+DwAAAAAAACLHz+VyueQ+3bhxw2QWRQfNgpo/f74JBtkzpXSEP+8MKsu+ffukRIkS8ttvv0nFihXNtCVLlkiDBg3k5MmTJgNr4sSJMmDAADl79qwEBASYNv369TPz3L9/v3ncokULEyDToJalSpUqUq5cOZk0aVKkll+DX4GBgRIcHGyytuKzfP0WxfYiAAAQo46OasgaBgAAiCGRjZFEuaaUZkONGDHCBGvOnTsnBw8elAIFCsg777wj+fLlM9lG0Wn16tWSNWtWyZAhg9SuXVvee+89yZQpk3lu48aNpsueFZBSdevWlSRJksjmzZtNd0JtU6NGDXdAyirWPnr0aLl48aKZr7bp2bOnx/tqm/CCYermzZvmZl/hysoai8+SyH3HKQEAiBfi+/9qAACAhHCsFeWg1PDhw2XGjBmmLpPWl7KUKlVKxo0bF61BKe2699xzz0n+/Pnl8OHD8vbbb8tTTz1lgkhJkyY12U8asLJLliyZZMyY0Tyn9F5fb5ctWzb3cxqU0ntrmr2NNQ9fRo4cKUOHDg0z/fz58yaDLD4rnoGgFAAgYQsKCortRQAAAEiwQkJCYiYo9dVXX5l6THXq1JHOnTu7p2ttKKs7XHRp2bKl+28tPl6mTBkpWLCgyZ7S949N/fv398iu0kwpLaKeJUuWeN99b99Fv9heBAAAYpT3RS0AAABEn8iWeopyUOrUqVNSqFAhn6lZt2/flpik3QQzZ84shw4dMkGp7Nmzh7nSeefOHTMinz6n9F67GdpZj+/Vxnrel+TJk5ubN+06qLf4LFQISgEAErb4/r8aAAAgIRxrRfmITAuL//rrr2Gmz507V8qXLy8xSYuX//PPP5IjRw7zuGrVqqYQuo6qZ1m5cqUJkFWuXNndRkfkswfMdKS+okWLmq57VpsVK1Z4vJe20ekAAAAAAACIflHOlBo0aJC0bdvWZExp8GfevHly4MAB063PPnpdZFy5csVkPVmOHDkiO3bsMDWh9KY1m5o2bWoylrSmVJ8+fUyWlhYhV8WLFzd1p7S2lRZe18BTt27dTLc/HXlPvfDCC2Y+Wuuqb9++snv3bhk/frx89NFH7vd988035fHHH5exY8dKw4YN5fvvv5etW7eabooAAAAAAACIfn4ulyvKVa01U2rYsGGyc+dOE1h6+OGHTbCqXr16UZqP1oaqVatWmOka9Jo4caI0btxYtm/fbrKhNMik83/33Xc9ipJrVz0NRP38888mPUyDWB9//LGkSZPG3WbXrl3StWtX+e2330z3v9dff90EqOzmzJkjAwcOlKNHj0rhwoVNIfcGDRpE+3CH8UG+fotiexEAAIhRR0c1ZA0DAADEkMjGSKIclNIudLly5fL53KZNm6RKlSqSGBGUAgAg/iAoBQAAEPsxkijXlNJsJc1O8rZ+/XrTlQ4AAAAAAAC4lygHpTQTSgNTISEh7mlaSFy7ug0ePDiqswMAAAAAAEAiFOWg1JQpUyRPnjzSqFEjuXnzpqxatcoUB9caUz169IiZpQQAAAAAAEDiDkppMXEdnc7f319q164tzzzzjIwcOdKMYAcAAAAAAABERrLINNLR67wNGTJEWrVqJS+99JLUqFHD3aZMmTKRemMAAAAAAAAkXpEKSpUrV078/PzEPlCf9fjzzz+XL774wvyt0+7evRuTywsAAAAAAIDEEpQ6cuRIzC8JAAAAAAAAEo1IBaXy5s0b80sCAAAAAACARCNSQSlvhw8flnHjxsm+ffvM4xIlSphC5wULFozu5QMAAAAAAEACFOXR95YuXWqCUFu2bDFFzfW2efNmKVmypCxfvjxmlhIAAAAAAACJO1OqX79+0qNHDxk1alSY6X379pUnnngiOpcPAAAAAAAACVCUM6W0y16HDh3CTH/55Zdl79690bVcAAAAAAAASMCiHJTKkiWL7NixI8x0nZY1a9boWi4AAAAAAAAkYJHuvjds2DDp1auXvPLKK9KpUyf566+/5NFHHzXPrV+/XkaPHi09e/aMyWUFAAAAAABAAuHncrlckWmYNGlSOXPmjMmU0pH3xo4dK6dPnzbP5cyZU3r37i1vvPGG+Pn5SWJ0+fJlCQwMlODgYEmXLp3EZ/n6LYrtRQAAIEYdHdWQNQwAABDLMZJIZ0pZsSsNOmmhc72FhISYaWnTpo2OZQYAAAAAAEAiEaXR97yzoAhGAQAAAAAAIMaDUkWKFLln97wLFy7c14IAAAAAAAAg8YhSUGro0KGmTyAAAAAAAADgWFCqZcuWkjVr1gd6QwAAAAAAACBJZFdBYh1VDwAAAAAAALEYlLJG3wMAAAAAAAAc674XGhr6wG8GAAAAAAAARClTCgAAAAAAAIguBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAADAcQSlAAAAAAAA4DiCUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAEldQau3atdKoUSPJmTOn+Pn5yY8//ujxvMvlkkGDBkmOHDkkZcqUUrduXfnzzz892ly4cEFefPFFSZcunaRPn146dOggV65c8Wiza9cuqV69uqRIkUJy584t77//fphlmTNnjhQrVsy0KV26tCxevDiGPjUAAAAAAABiNSh19epVKVu2rEyYMMHn8xo8+vjjj2XSpEmyefNmSZ06tdSvX19u3LjhbqMBqT179sjy5ctl4cKFJtDVqVMn9/OXL1+WevXqSd68eWXbtm0yZswYGTJkiHzxxRfuNhs2bJBWrVqZgNb27dulcePG5rZ79+4YXgMAAAAAAACJk59L05HiAM2Umj9/vgkGKV0szaB66623pFevXmZacHCwZMuWTaZPny4tW7aUffv2SYkSJeS3336TihUrmjZLliyRBg0ayMmTJ83rJ06cKAMGDJCzZ89KQECAadOvXz+TlbV//37zuEWLFiZApkEtS5UqVaRcuXImIBYZGvwKDAw0y6hZW/FZvn6LYnsRAACIUUdHNWQNAwAAxJDIxkiSSRx15MgRE0jSLnsW/UCVK1eWjRs3mqCU3muXPSsgpbR9kiRJTGZVkyZNTJsaNWq4A1JKs61Gjx4tFy9elAwZMpg2PXv29Hh/bePdndDu5s2b5mZf4So0NNTc4rMkEifilAAAxJj4/r8aAAAgIRxrxdmglAaklGZG2elj6zm9z5o1q8fzyZIlk4wZM3q0yZ8/f5h5WM9pUErvI3ofX0aOHClDhw4NM/38+fMe3Qvjo+IZCEoBABK2oKCg2F4EAACABCskJCR+B6Xiuv79+3tkV2mmlBZRz5IlS7zvvrfvol9sLwIAADHK+6IWAAAAoo8OIhevg1LZs2c39+fOnTOj71n0sdZ6stp4X+m8c+eOGZHPer3e62vsrMf3amM970vy5MnNzZt2HdRbfBYqBKUAAAlbfP9fDQAAkBCOteLsEZl2udOg0IoVKzyykbRWVNWqVc1jvb906ZIZVc+ycuVK03dRa09ZbXREvtu3b7vb6Eh9RYsWNV33rDb297HaWO8DAAAAAACA6BWrQakrV67Ijh07zM0qbq5/Hz9+3IzG1717d3nvvfdkwYIF8scff0ibNm3MiHrWCH3FixeXJ598Ul555RXZsmWLrF+/Xrp162aKoGs79cILL5gi5x06dJA9e/bIrFmzZPz48R5d7958800zat/YsWPNiHxDhgyRrVu3mnkBAAAAAAAg+sVq9z0N/NSqVcv92AoUtW3bVqZPny59+vSRq1evSqdOnUxG1GOPPWaCR/a+iTNnzjTBozp16pj0sKZNm8rHH3/sMWLfsmXLpGvXrlKhQgXJnDmzDBo0yMzT8uijj8q3334rAwcOlLffflsKFy5sRt4rVaqUY+sCAAAAAAAgMfFzuVwMtRYNtGuhBsCCg4PjfaHzfP0WxfYiAAAQo46OasgaBgAAiOUYSZytKQUAAAAAAICEi6AUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA4whKAQAAAAAAwHEEpQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAADAcQSlAAAAAAAA4DiCUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA4whKAQAAAAAAwHEEpQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOi9NBqSFDhoifn5/HrVixYu7nb9y4IV27dpVMmTJJmjRppGnTpnLu3DmPeRw/flwaNmwoqVKlkqxZs0rv3r3lzp07Hm1Wr14tDz/8sCRPnlwKFSok06dPd+wzAgAAAAAAJEZxOiilSpYsKWfOnHHf1q1b536uR48e8vPPP8ucOXNkzZo1cvr0aXnuuefcz9+9e9cEpG7duiUbNmyQGTNmmIDToEGD3G2OHDli2tSqVUt27Ngh3bt3l44dO8rSpUsd/6wAAAAAAACJRTKJ45IlSybZs2cPMz04OFi+/PJL+fbbb6V27dpm2rRp06R48eKyadMmqVKliixbtkz27t0rv/zyi2TLlk3KlSsn7777rvTt29dkYQUEBMikSZMkf/78MnbsWDMPfb0Gvj766COpX7++458XAAAAAAAgMYjzmVJ//vmn5MyZUwoUKCAvvvii6Y6ntm3bJrdv35a6deu622rXvjx58sjGjRvNY70vXbq0CUhZNNB0+fJl2bNnj7uNfR5WG2seAAAAAAAASGSZUpUrVzbd7YoWLWq67g0dOlSqV68uu3fvlrNnz5pMp/Tp03u8RgNQ+pzSe3tAynreei6iNhq4un79uqRMmdLnst28edPcLNpehYaGmlt8lkRcsb0IAADEqPj+vxoAACAhHGvF6aDUU0895f67TJkyJkiVN29emT17drjBIqeMHDnSBMm8nT9/3hRgj8+KZyAoBQBI2IKCgmJ7EQAAABKskJCQ+B+U8qZZUUWKFJFDhw7JE088YQqYX7p0ySNbSkffs2pQ6f2WLVs85mGNzmdv4z1inz5Oly5dhIGv/v37S8+ePT0ypXLnzi1ZsmQxr43P9l30i+1FAAAgRumIvAAAAIgZKVKkSHhBqStXrsjhw4eldevWUqFCBfH395cVK1ZI06ZNzfMHDhwwNaeqVq1qHuv98OHDzdVQ6+Bz+fLlJmhUokQJd5vFixd7vI+2seYRnuTJk5ubtyRJkphbfBYqBKUAAAlbfP9fDQAAkBCOteL0EVmvXr1kzZo1cvToUdmwYYM0adJEkiZNKq1atZLAwEDp0KGDyVZatWqVKXzevn17E0zSkfdUvXr1TPBJg1g7d+6UpUuXysCBA6Vr167ugFLnzp3lr7/+kj59+sj+/fvls88+M90De/ToEcufHgAAAAAAIOGK05lSJ0+eNAGof/75x3SLe+yxx2TTpk3mb/XRRx+Z6JtmSmnRcR01T4NKFg1gLVy4ULp06WKCValTp5a2bdvKsGHD3G3y588vixYtMkGo8ePHS65cuWTKlClmXgAAAAAAAIgZfi6Xi6rW0UBrSmn2VnBwcLyvKZWv36LYXgQAAGLU0VENWcMAAACxHCOJ0933AAAAAAAAkDARlAIAAAAAAIDj4nRNKQAAAMDDkEBWCAAgYRsSLIkFmVIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAADAcQSlAAAAAAAA4DiCUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCAAAAAACA4whKAQAAAAAAwHEEpQAAAAAAAOA4glIAAAAAAABwHEEpAAAAAAAAOI6gFAAAAAAAABxHUAoAAAAAAACOIygFAAAAAAAAxxGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKS8TJkyQfPnySYoUKaRy5cqyZcsW57cKAAAAAABAAkdQymbWrFnSs2dPGTx4sPz+++9StmxZqV+/vgQFBcXeFgIAAAAAAEiACErZfPjhh/LKK69I+/btpUSJEjJp0iRJlSqVTJ06Nfa2EAAAAAAAQAKULLYXIK64deuWbNu2Tfr37++eliRJEqlbt65s3LgxTPubN2+amyU4ONjcX7p0SUJDQyVeu3k1tpcAAIAYpf+vEU/d9IvtJQAAIGZdiv/HKZcvXzb3LpcrwnYEpf7z999/y927dyVbtmweK0gf79+/P8yKGzlypAwdOjTM9Lx58z7IdgMAAA7IMI7VDAAA4qhRGSShCAkJkcDAwHCfJyh1nzSjSutPWTQ76sKFC5IpUybx8+MKHoCoXUXInTu3nDhxQtKlS8eqAwAAcQbHKQDuh2ZIaUAqZ86cEbYjKPWfzJkzS9KkSeXcuXMeK0gfZ8+ePcyKS548ubnZpU+f/r42FgAoDUgRlAIAAHERxykAoiqiDCkLhc7/ExAQIBUqVJAVK1Z4ZD/p46pVq0Z55QMAAAAAACB8ZErZaHe8tm3bSsWKFaVSpUoybtw4uXr1qhmNDwAAAAAAANGHoJRNixYt5Pz58zJo0CA5e/aslCtXTpYsWRKm+DkARCftCjx48OAwXYIBAABiG8cpAGKSn+te4/MBAAAAAAAA0YyaUgAAAAAAAHAcQSkAAAAAAAA4jqAUAAAAAAAAHEdQCgAAAAAAAI4jKAUAAAAAAADHEZQCgBjC4KYAAAAAED6CUgAQQ/z8/Mz98ePHWccAACBOCA0Nje1FAAA3glIAEM3mzp0rixYtMn/36tVL+vbtK9evX2c9AwCAWA9IJUny7yng3r17ZefOnWwRALGKoBQARKObN2/KihUrpFGjRtKsWTOZNGmS9OvXT1KmTMl6BgAAscoKSPXp00eefvppqVy5sjz77LOybNkytgyAWOHnougJAES7okWLyuHDh2X8+PHStWtXuXv3riRNmpQ1DQAAYjVD6scffzQXzMaOHSv+/v4ycOBASZMmjXTr1k2ee+45tg4ARxGUAoBodvXqVWnbtq35e8GCBTJv3jxzNVIPCLXOlFVrCgAAwElLliyRVatWSY4cOaR79+5m2smTJ81xix6nvPHGG9KkSRM2CgDHEJQCgGi8+min2VF61fHLL790B6YsBw8elCJFirDuAQCAI86fPy9lypSRc+fOmeOTjz/+2P2cBqbatWtn/m7fvr28+OKLbBUAjiAoBQDRFJD66quv5MSJEyYTqnHjxqYLn9IDv2nTpsm3334rTzzxhDnYy5w5s6k3BQAAEBO0Sot3dvb+/fvlhRdekGTJksmYMWPk8ccfdz936tQpadCggdSoUUM++eQTNgoARxCUAoBoONjT2gyffvqpPPbYY7Jt2zbJlSuXPP/889K7d293QVGtL1W6dGlTDP2PP/4wdRwAAABi8qJZSEiIpEqVSm7fvi0pUqQwxyAtWrSQggULmhGC9djFnk2VKVMmnxngABATCEoBwAM6fvy4ueqoBUN1FJs7d+5Ir1695LfffpPmzZub+gwavFq5cqUEBQWZYJUWPdd2eqUSAAAgJgJS77//vqkh9c8//0ipUqVMHSntwrdz505p1aqVFCpUyASmqlWr5jEPBmgB4BSCUgDwAPRgT0exSZ06tXz//ffm6qK6fPmyCUYdOHBA1q1bF2bkPQ72AABATBowYIB8/vnnMmjQIDly5Ijs27dPNm3aJMuWLZNKlSrJrl27TO2otGnTmpICGqwCAKcRlAKAB6AHdpolpSnx69evN1chrSuUhw4dMsXM9QqlvWYDAABATDp27Jg0atRI3nvvPXnmmWfc095++22Tua0XzLT73o4dO0xtqa+//pouewBiBZ2FASCSNNjkrV69ejJ//nzTPW/48OFy4cIF90HdrVu3pECBAqaOAwAAQEzQmlBTp071mHblyhUz0m9gYKB7Wp48eUz2lNa9XL16tamNWa5cOZk5c6Y5dvF1nAMAMY1iJgAQxfoMa9askUuXLpnRadKnTy/Vq1eXH374wYy4d+3aNVOj4aGHHpLRo0eblPiHH36YdQwAAKKdZmrrKL9NmjTxmJ4/f36pWLGiLF26VB555BFzgUwvoBUrVszUtDx8+HCYkfkobg4gNpApBQCR+bH8LyClxUD1wO+VV14xI+l98803JkBVp04d+emnn0w6vHbn++6770x9KS12rvWktIYUAABAdNKRfFu2bCnJkyc3GdtaP0ppEErrRmmZgdmzZ7uPQ27cuCEpU6aUbNmysSEAxAkEpQAgAprabt3v3bvXZEktWLDAFAutX7++DBkyxASgLl68KLVr1zZFzzNkyGAO/j777DMzuh5FzQEAgBMBKq0hNWrUKPP4gw8+MLUtx40bJ88++6wJWD355JNmMJauXbuyQQDECQSlACCCLntWavv169fNCHs6ZLLeNAvqyy+/NDWl9KBPR97TjCntyqdXJL/99lt58803JSQkJMzIewAAAA9i69atZkAVK4t7+fLl0qNHD5kwYYKpG/Xuu++aLG+tF9WpUydTW2rLli1SokQJ2b59u/uiGQDENkbfA4B70GwoTX+3RtNbuHChqSVlee211+SXX34xB32vvvqqqSOlBUQ1c0qf+/TTT1nHAAAgWujxiGY+aekArWWpRc537txpygroICuTJ0+WN954wxy/vPPOO+7X6XMBAQHmb60rpYEpAIhtBKUAwIt21bMypPQK4+uvv25S3jXQtHnzZmnfvr25GpklSxb3a7S4uV5xnDVrlvu1v/76q2mjRUUBAACiy7Rp06R///4mS3vOnDnSqFEj9/GLFZjq3r27yZjq169fuMc5ABDbCI8DgBfrQE1HrNm2bZtJhdegkx7cvf322yZrSrvkafe8zJkzm7ZaV8rq7mcd7GlXPgAAgOhi1anMkyePyczWzO0VK1ZI4cKF3RfBNBtKB2TRYxEdmU9HBG7dunWY4xwAiAsISgGAD5s2bTI1Gk6cOCFVq1Z1Tx8xYoS5/9///mcOCrV7XtasWc00rd2ggSmGVAYAANHJOr6w6lRqfUsddGX69Onm4plmR+nFsqJFi7oDU1pSQEfZ065+ABBXUegcAHyoUqWKtG3b1oykpynwQUFBHoGpp556yhQ6/+mnnzx/VJPwswoAAKKP/YLXkiVLTKkAHVBFa0J17NjRXCDbuHGjCU4dOHDAtGvWrJmsW7dOmjZtatppDSkAiIuoKQUg0fPObrI//uSTT+Sbb76RMmXKmGCUvY7UF198IR06dGB0PQAAEOM0g1vrR+XIkUPOnz9vsqG+/vprKV++vEyaNMkUPPf39zfHMceOHTM3fQwAcRlBKQCJmj0A9fnnn5vhkvVqonbZ69y5s5k+fvx4c1WyZMmSYQJT9voOAAAAMUEvhOlIelrvsly5cjJ37lxp3ry5KSdQv35900an7dmzRy5cuCBjx451Z0gxyh6AuIygFAD8d/VRR7LRbnk3btwwB3YtWrQwVx7TpUsnH374ofz444+mftSUKVNMYVEAAIDoprWiihcvHuY4JUWKFDJ06FBzoUzrRY0aNcpcQLt8+bI5VvFGQApAfEDxEwCJntZh0C568+bNkxkzZpiDvfXr18vixYulZ8+eZv3ofd26dc1oe74O/AAAAB6UZjhpZvavv/7qMX3nzp2mmLken+jIeiNHjjQBKR3xd8yYMabcgDcypADEBwSlACTKLnt2mhmlB27WiDV6ZVELnWvdhpkzZ8ry5cvN9EGDBsnEiRPdo+wBAABEJx1BT7vlaYFye2Cqffv2pqterVq1TPZ2ly5dzPSQkBDZvn27nDt3jg0BIF4iKAUg0bFqSPXq1ctkSGXPnl1Onz4t27ZtM9Ot+lB6pVKLiQYHB7tf6+fnZ65KMsoeAACIbnqRTC+IafCpSZMmsnbtWjNd60jlyZPHHJtkypTJTDt48KC0atXKBKSGDBnCxgAQLxGUApBoaEFyy6JFi+S7776TnDlzSr58+cxB3fDhw83BnwaeVOrUqSVlypQmCGVnPQ8AABDd9OKYBqZq165tAlNr1qwx2dwDBgwwgalu3bqZC2pa+1IvnG3YsMEEs+zHOQAQX1DoHECi8/PPP8vChQulUKFC0rt3bzNt1apV8umnn8r+/ftNrQatHaXDLAcFBcnWrVsZXQ8AAMT4SMDemjVrJitXrpT58+fL448/LmfOnDHHJrt27ZKCBQtK5cqVzTEKRc0BxFcEpQAkeOvWrZPNmzebv9OkSWMCUlqnoUePHjJ48GB3u02bNpkR9nR0vcKFC5uR9nQUPn9/f3P10erWBwAAEN0Bqe+//16OHj1qLoxVqFBBypcvb6ZrfSm9eKbHKDVq1AgzD45RAMRnBKUAJGgaYHr77bcld+7ccujQIdNVT1PgL126JMeOHTNd+B5++GGP1+hzGohKlSqV6arH1UcAABDdtDyAVRKgf//+ZgS9ihUryu7du6VAgQKm655OV88//7wpMaDd+nQ0YABIKKgpBSBBB6S6du1quuVptpSmvuvVxwsXLsizzz4r2bJlk2HDhpkUeOvgUK9Ypk+f3tSTsoqaM6QyAACIblZASoNQWjdKR/tdvXq1GU2vZs2aJlt73Lhx7iyqMmXKmJH3ACAhIVMKQIKkB3VaIFRHoxk0aJD7auSoUaPks88+k3379smSJUtk4sSJkjZtWhOcKl26dGwvNgAASERGjhxpCpXrMYoGnjRLW504cUKGDh1q7vWimk7XbnrajhGAASQkZEoBSJAeeugheeyxx+T333/3GFFPD+T0duPGDVOjQYuaX7161WRUHT58OLYXGwAAJCI6mp6OCKwZ3fbjEC070KZNG5M9tXfvXjNNa1vqMYxmdQNAQkFQCkCCpIXKv/zyS7l586YMHz5c/vzzTzN6jWZNaep7pkyZTDsdTvmFF14wxUTz588f24sNAAASKF/BpBdffFEWLFhg6llOmDBBTp065X5OSw7o8Yx3ZhSZUgASErrvAUjQNBj15ptvyrlz5+SPP/6QadOmmQNATYFX3iPqRTQsMwAAwP2wH1/oCMCapa0j7GXIkMHUrpw1a5a0atVKWrZsKc2aNZOcOXPKu+++a4JUmvXNsQmAhIqgFIBEEZjq3LmzBAUFmeLnlStXNtO1zpSyuvYBAADEpD59+shXX30lISEhppZlx44dzcWylClTyuzZs01QSrVr105u374t06dPNxfQ9GKa94U0AEgISAcAkOBp6vvnn38uuXLlMoXP169f7w5GEZACAAAxxboApvc62q8OxPLTTz/Jzp07JV++fKbUwKRJk+T69evSvHlz05VPaabU2LFjTSBKs6wISAFIqAhKAUgUChUqJB9//LE5qOvevbs5MAQAAIgpGkyyLn7duXNH0qRJI+XKlZNHHnnEHJdMnTpVihcvbrru6cUzDUw9/fTTMnPmTBkxYoSMGTNGzp49S9c9AAlastheAABwMmNKD/C0C1+pUqVY8QAAIMZYdaC0NtTixYtNMXPNgLKmp0qVSj799FPp1q2bzJkzx3Tp0+59WlsqICBAnn/+eUmRIoUMHTqUwBSABIuaUgASLYqaAwCAmDy+0JpQOuDKgAEDZPny5bJ7925p3bq1GRnY39/ftLl27ZqpK5UlSxaZOHGiu6uedvPTC2olSpRgIwFIsAhKAQAAAEA0W7hwoSkXULRoUWnatKnpnqdZU6tWrZKaNWuav3XkPXXz5k0TpNJglhY113vqXgJIDKgpBQAAAADRaOvWrdKzZ08ZPXq06YKndIS9fv36Sa1atUzB88GDB5taUyp58uQmEGUVNScgBSCxICgFAAAAANFIu9117dpVAgMDZfLkye7p6dKlk/79+0udOnXk+++/N3UuPU7O/uv2BwCJBd33AAAAACCaalRaj69cuSJfffWVTJgwQapWreoRgLp8+bJ899130rFjR3cNKQBIjAhKAQAAAMADBqQ0I+qPP/6Qv//+W5o1ayaNGzeW27dvm2DU559/LpUrV/bImrJoDSkCUwASK/JDAQAAAOB+Tqb+C0j17t3bjLB37tw5kyH1/PPPS48ePSQ4OFhefvll6dSpk/z+++8mWOWNgBSAxOzf4R4AAAAAAFG2Zs0amTlzpixatEgeeeQRM2327NnSpUsXSZ06tYwYMUJat24tISEhcuDAgTDd/QAgMSMoBQAAAACRtHPnTjl69KhkzpxZqlWrJjdu3JBUqVJJrly5TFc8DTg1b97cTNeaUS1atJCyZctK9+7dzUh8OrIegSkA+BchegAAAACIBM2IateunUydOtVkRlnd744dOyb//POP+fvWrVtm+jPPPCM5c+aUQ4cOmccpU6Y0ASmXy0WmFAD8h0wpAAAAALgHHUmvc+fOJiD15JNPSvr06c30WrVqScOGDeWll16SefPmSYECBcx0DU4FBASY7Cg7DUwBAP7F6HsAAAAAEIE9e/aYbnjaBU+75Fk060mDTFpXavTo0bJ//34ZPny4mfb111/L2bNnZcuWLRQzB4BwkCkFAAAAABE4deqUXLt2TWrUqOEORCnr/vHHH5cMGTLIpEmTpFu3bpInTx556KGHZNOmTSYgpbWmGGUPAMIiKAUAAAAAEdi2bZsZPa9IkSLmsT0wZRUt9/f3l65du8oHH3wgt2/flnTp0pk2d+7ckWTJOO0CAF8odA4AAAAAEShUqJBcvXpVli1bFqYulAak1PTp02X8+PGSPHlyCQwMdI+yR0AKAMJHUAoAAAAAIlChQgVTtPyLL76Q48ePu6drxpS6fPmyHD58WEqXLu3RTc8KWAEAfONXEgAAAAAioCPqab2ohQsXSv/+/WX79u1mumZDnT59Wlq2bGmKmnfp0oX1CABRwOh7AAAAAHAPWqx82rRp8tprr0m2bNmkVKlSpntecHCwuV+/fr2pK0VRcwCIPIJSAAAAABBJO3bskKlTp8qBAwckd+7cUr58eencubPptkdRcwCIGoJSAAAAAPCAyJACgKgjKAUAAAAAUaAFzu0j8AEA7g+FzgEAAAAgCghIAUD0ICgFAAAAAAAAxxGUAgAAAAAAgOMISgEAAAAAAMBxBKUAAAAAAADgOIJSAAAAAAAAcBxBKQAAAAAAADiOoBQAAAAAAAAcR1AKAAAAAAAAjiMoBQAAAAAAAMcRlAIAAAAAAIDjCEoBAAAAAABAnPZ/B83t51Tx1rwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 10: Token usage over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "  COALESCE(SUM(prompt_tokens), 0) AS prompt,\n",
+    "  COALESCE(SUM(completion_tokens), 0) AS completion\n",
+    "FROM llm_events\n",
+    "WHERE event_type = 'LLM_RESPONSE'\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"prompt\", \"completion\"],\n",
+    "          \"Token Usage Over Time\", \"Tokens\", kind=\"area\",\n",
+    "          labels=[\"Prompt\", \"Completion\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cell-11-agent-tokens",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:31.441769Z",
+     "iopub.status.busy": "2026-04-11T06:42:31.441671Z",
+     "iopub.status.idle": "2026-04-11T06:42:33.836102Z",
+     "shell.execute_reply": "2026-04-11T06:42:33.835525Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxQAAAGGCAYAAADissfwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAALEtJREFUeJzt3Qe0VNW9P/ANgigiKKIisXdRsXeNPfZubKzYxRp7w4aaWGM06lOfJU8TY6xLLFGMvcb6rFiwoRhrREWxA/Nfv/3+M2vu5V4ubPEC934+aw33zpwzZ87Zs+9wvmeX6VCpVCoJAACgQMeSJwEAAAgUAADAT6KFAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFABMk+aff/7UoUOHfJtWrbPOOrVjeOedd6b07gAUESiAdq3+pLSl24MPPjjF9vO6665rsC8bb7xxmtp98cUX6eSTT863q666Kk3Ldt9994muJ3G8bUHU9+oxxd/JhP52puTfBjDldZrSOwBAy6699toG9++777706aefpl69ek3VgeKUU07Jv6+99tr5pByAtkegANq1m266KX333Xe1+7/+9a/TRx99lH+/4IIL0nLLLVdbtvTSS0+xE/O77rqrwWNjxozJ+77ffvtNkX1qb44//vi099571+6ffvrpaciQIfn3PfbYI+255561ZfPOO+8U2UeAKUWXJ6BdW3HFFdOaa65Zu3Xp0qVBgKhfFl074sRyiSWWSDPOOGOaeeaZ0yqrrJIuvfTSVKlUGmy3vqvIG2+8kTbffPPUrVu33KJw4IEHpq+//nqi9/Hmm29OP/zwQ/59p512atANqikvvvhiWnfddVPXrl3T3HPPnVsJ7r333to+NW4p+M9//pMOP/zwtMgii+Tjn3XWWdNmm22WnnjiiWa7wMQ2/vnPf6aVVlopzTDDDPkkOgJYVSxfYIEFavcfeuih2nNj3ED49ttv01FHHVV73Zlmmik/Z9ttt02DBw9OkyJaa3bbbbe87z169Ej9+/dPn3zySV721Vdf5W1X34/692rs2LFp9tlnz8tmm2229OOPPza5/djH+rowxxxz1JbFsdcvm2eeedJll12WVl111VxHonwWX3zxdNxxx6VRo0a1eCzvv/9+mm+++fI+TTfddOmvf/1rfjz2+8orr0xrrLFG6t69e66DyyyzTDr//PPTuHHjmu2OFAH5N7/5TS6b2J8dd9wxffbZZ+nn8sILL6Stttoql1Hnzp1zuS677LI5/I4YMaK23plnnpnrQtTROJaor3379k0nnHBC+uabb8bb7sUXX5wWWmihvO7KK6+c7r///gZd0Rp3u3rkkUfSlltumd/f6aefPtetqOeff/75z3bs0G5VAKiZb7754mwz3x544IHa45999lll8cUXry1rfNtpp50alGL18VlmmaUy55xzjrf+xhtvPNGlvsEGG9Se98ILL1SWXXbZ/HvHjh0r77//foN133777fyajV9vmWWWqf2+22671dZ/9913K3PPPXeTx9S5c+fKrbfeWls3yqO6LMopXr/xc+655568brxGc2W19tpr53X23HPPZtfp37//JL1X/fr1G28b8dh333033v488sgjtW08/PDDtccHDBgw0e9J/fYGDRpUe3zcuHG5LjR3XFGHoi5VRVlUlw0fPjwvW3LJJfP9Dh06VC677LLaurvuumuz291xxx2bLZsFF1ywqHwbv98T87fy6aefVmafffZm97NaP8Jiiy3W7Hrrrrtug9c699xzm6yfffv2bfLv9fLLL2+yfsYtXrf+PQB+Oi0UABMhri6/9tprtZaLaDW44oor8lXfamvB9ddf32R3pbgCe8stt6QLL7wwX4UN0YXp9ttvb/F1P/744/TAAw/UrpL369cvbb/99vl+XJVu/JrRghKvGWLduNIfV7Bff/31Jrd/wAEHpH//+9/591133TXv1yWXXJJbU+JqfXTlaao15d13301bbLFFPob6VpNoranux4033lh7PK5QxxXjuEU5hFtvvTX/jKvx0X3r7rvvTn/+85/zflTLdWKNHj06l0UM/q6OK4mWmmgpCHvttVdt3Wuuuab2+2233Vb7feedd04/1Q033FBrOYpjiNeP9yDeixB1KOpSU6LFJlqyXn755Xz/T3/6U9pnn33y71E+1ZaKxRZbLI+pibKPVpAQx95U/atu929/+1u+wh9X6kPs48S0lkyqxx9/PLd4VcvznnvuyXX/nHPOyeNoosWlKlosrr766nTnnXfm1oV4LzbddNO8LOr8v/71r/x71Odotaivs3fccUf+O3jllVeabOE56KCD8t9HtMhEfYvWtOiaFoYNG9bsewAUmgyhBKDNaOqq69ixYyuzzjpr7fGXXnqptv6FF15Ye3yrrbaqPV5/RfSNN96oPX788cfXHo8r9C2p3/7AgQPzY6+99lrtsZVXXrm2buxnt27dmtzPY489drwWipEjR+ar4PFY796985X76m2bbbaprX/TTTeNd8V6jjnmqF39/+ijj2qPR+tJVVxxb9wqUS9es9p68txzz9W2V/Je1V/5jqvT1cfXW2+92uOLLrpofmy22War/PDDDw2ukvfp0yeX309todhyyy1rj8d7VxXvRfXxqEvRktG4hWLFFVes/X7WWWc1eL2oW9VlF1xwQe19qj/WzTffvMmyGTx4cO3xaBmrPv78889P9haKu+66q/bY0UcfXRkxYkTtWBsbOnRobs2JFrJobWjcknD++efn9a6//vraYyussELt+T/++GOD1rXqPpx33nm1x/bYY49aWUVrVNeuXfPjPXr0mKT3G5gwLRQALYgrrtV+19HCsNRSS9WWRV/uqqZaAXr27JkWXnjhJtd/++23J2l2p2rLRFyhrg4Qf+qpp2rbiTEDcaW+qf1cbbXVxtv2m2++WRtPEP3s11prrdqtfgzDq6++Ot5z48p4dbxJ9JGvqraOTIxqq0H0uY/B7zHOIfrQRz/3Dz/8ME2KGMvSUhlXB06PHDkyt8TE2Ja4Wh1iXEHHjj/9v8T6OlC/T/FeVFunoi5Vr+LXe+aZZ2pX9o8++uhmt3vwwQfX3qdqC0Zz71OIloGqSXmv6r/fo/EYocaPVcsu9ila0sLZZ5+dx5fEmJYYK3H55ZfXxnpEC9fqq6+eW0qihaypsSvV/at/D+vLtFOnTnkMT2P1ZRVjTqpl9ctf/rI2NiNaZz744IMJHj8w8QQKgEnQ+EvUJvVL1SZl/RjAGl1IqlZYYYXaANSXXnppgoOzJ+eXvTXV5am+S1Kc2E3oxLM5v/vd73Jgipm1IiTFPsdJ8XnnnZd+9atf5ZmsSjR37DFou7qv0QWo2uUq7LLLLmlKq3YHiu500TVsUjU30L/0vYruQvWD3hurf6y6boSmxx57LJ166qlpvfXWS717986D4mNQ/oABA3LICH/5y1/Sl19+WQu70S0qjrk+SDUeaN4a9RooI1AAtCBmiZlllllqJyHVPu7hySefrP2+6KKLjvfcmE0nWgKaWn/BBRec4OtGUJiYE/RqoIhZdaondrGf9Ves64NJVbScVE/QYvacOIGP16u/xexScXJYov6Kf1MnhyHGX8S4gxhbECee1VaYoUOHNjvuoynRUtNSGcfJbbWPfow/qLb+RDnEbF+TQ30dqN+nOJ7q1fE4wY861ViMM4gy+/777/MsSfXvX/12Y3xB4/cpbm+99VaanKKlofoexr5HUKh69NFHa8cTQajaKhH7Ecd24okn5u9KiZamaGGIMTnVsFQd51AV4xnieGOGrKbGdUTdrHr66adrv0d9rb/fVFkNGjSoybKKv48IscDk4XsoAFoQJ1Vx4vvf//3f+X5MSRonKtF1JX62NKg3rn7HoNLo2hEDbaviJGpiuzvF8+ecc84Gy//whz/kVoxorYjBqdFdKAZK//3vf8/LY6rQOLGLdWJgdlPdsTbZZJM8KDZORmOKzeiGFKEkuqQ899xz+QQwwkhT35Tckvor47GPcRU6BkxHN5i4xfSn0dUpuij94he/yIGifpBtnFhPrH333TedccYZ+TtFYkB4c2UcxxeDf2Og8rPPPjvZBmPXv9fVgd4nnXRS7hYWx1z9gr9q96qmrrRvvfXW+SQ5ptKNuhXfhh5T984111y5zlVbVOJ9jWOMk/joOhVdt2KQcryX9fXxp4p6sNFGG9W+byPKMgbMh+oA8RDrVANDDKSOLlnbbbdd3r849hgcXw0f1fc0BuJXxXTDMVg8gmAMym9sww03zC0fsY0IaYceemh+zRjQXZ1QoF6E0mOPPTa/VkxNG2UdrSDx/OHDh+dAFu9/DBgHJpMWxlgAtCvNTRsbA5hbmja2fvBp9fGePXs2OS3rhhtu2Oxg1cYDr2MAdFMDSA899NDaOieccMIEp42tn1Z1YqeNrd5icHXjQbr126g/3saDd2MQbePtVQcxL7TQQs2+ZkwHOmbMmIl+rxZZZJHxtrHUUktVvv322wbPiYG81cHg1dsrr7xSmVQTmjY2pnAtnTY27L333rXHYsD6qFGjWpw2tvF+1JdNc/tdX7+bM2zYsDyIvbnX7NWrV+X111+vrR+Dnye0j2eccUat3lUHSNff1lhjjSaPp7lpY+v/Jid22tjmJgkAyunyBDAR4mp+XC0eOHBg7ipR/SK2GBQa06xGq0BTV53jKm/0DY+Wg1g/thPTZcaV/wn1B69vnYgvmWtqwHBss3G3p/jyruivHoNg4wvV4up2tG7E1fKq6uDgEC0F0RIRV8Xjy9fiObHP8XtcjY6r7fFFbaXiOOJKe1PTwEZZxlXvuFod+xRfghYtIVE+8aVl9VOMtiSmHd1hhx3yF77F/keLUnyZXxxPvRhDEGMpquKL4eKLCieXeE+jLkRrVrS8xHsedSW64cRV86hDLU2JG/Vp/fXXrw1Yj6v9MWg5xh1Ey0AMso6BznFVP96/WDeu8sd0qpNb7HfUj/gyxugaFscSt2h9iMdiWbW7U3X9Y445Jg/ajxa1KO9ovYi/k4suuigvC7HfMU1wlFF8UV10a4ppbeu/jbzeYYcdlp8f9Ttef/nll8+tMlFPm6rXsZ2HH344f0lidT/iZ7xetNrFawGTT4dIFZNxewDUDR6Nk+V33nmnVcskPtYbh5U4mT3rrLPy7+eee24+QWuv4kSzOvNRlEnjGZWY+jRVp2N8T4Sc9957Ly+L7l/1s1gBrccYCoA2JqbjPOSQQ/JV3BBTpMYV7BCtAHHVtj2KfvMxs1C0AIRoAZkaZneiZdHqE4PCY0awCBExzXHMGBVhImywwQbCBExBAgVAGxPdauLWWFzFjSlZ6wfEticxaDm6g9V/L0V8izlTv+jyFUGwGgbrxexdTT0OtB5jKADamN/+9repX79+uZ99tEj06dMn98OPk+no997excxDMStU/YxbTN2itS3qcIy9iDEUMe5iySWXzGN/YpxJ/dSyQOszhgIAACimhQIAACgmUAAAAMUMym7Dxo0blz744IM8J/uE5rsHAID6qZq/+uqrPAavqe9BakygaMMiTPyUL6QCAKD9eu+99yZqNjyBog2LlolqZYhvjwUAgJbEd/bERenquWRLBIo2rNrNKcKEQAEAwKSY2C7zBmUDAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABTrVP5UphVLDfpn6til65TeDQAAJsE7Z26WpgVaKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABA+wsU77zzTurQoUN6/vnnJ8v2rrrqqjTLLLNMlm0BAEB7MUmBYp111kmHHnroz7c3AABA+22hqFQqacyYMZNzkzThhx9+UC4AAExbgWL33XdPDz30UDr//PNzV6O4RTeh+DlkyJC0wgorpC5duqRHH300vfXWW2mrrbZKc845Z+rWrVtaaaWV0r333lvb1nHHHZdWWWWV8V5jmWWWSaeeemrt/hVXXJGWWGKJNMMMM6TFF188XXzxxUUH+eCDD+b9vOOOO1K/fv3y9lZdddU0dOjQZp/T0jGE+eefP51++ulpzz33TDPPPHOad95502WXXTZet6ybb745rbvuuqlr1675GB9//PEG24kyW2uttdKMM86Y5plnnnTwwQenr7/+usHr/O53v0u77rpr6t69exowYEBROQAAwBQLFBEkVltttbTPPvukDz/8MN/i5Dcce+yx6cwzz0yvvvpqPmEfPXp02nTTTdN9992XnnvuubTxxhunLbbYIo0YMSKv379///TUU0/lk/aql19+Ob344otpl112yfevueaadNJJJ6XTTjstbzdO3E888cT0l7/8pfhgjzrqqPTHP/4xPf3002n22WfP+/Tjjz82uW5Lx1AV21txxRXzOgcccEDaf//907Bhwxqsc/zxx6cjjzwyj/dYdNFF084771xryYkyiG1vt912+fivv/76HDAOOuigBts455xzchiJ14lyAACAaSpQ9OjRI00//fT5Knvv3r3zbbrppsvLolVhww03TAsttFDq2bNnPvHdd99901JLLZUWWWSRfHU9lt122215/SWXXDKv8/e//722/QgQ0Wqx8MIL5/uDBg3KJ+vbbrttWmCBBfLPww47LF166aXFBxvbjP1ceumlczD5+OOP0+DBg5tct6VjqIrQEUEi9vuYY45JvXr1Sg888ECDdSJMbLbZZjlMnHLKKendd99Nb775Zl52xhln5IAVY1PidVZfffV0wQUXpL/+9a/pu+++q21jvfXWS0cccUTeh7g15fvvv09ffvllgxsAAEz1YyjiCn3jq/txEh3dlWLmpOgyFK0M9Vf34yS6Gihi7MW1116bHwvR3Seu3O+11175udXb73//+watGpMqWliqIvgstthieb+aMjHHEKJFpiq6N0XQ+uSTT5pdZ6655so/q+u88MILuetY/XFutNFGady4cWn48OHNlnFTIpxE8Kveqi1IAADwc+k0OTYy00wzNbgfJ+L33HNP7qYTV+5jbMD222/fYDBxdPuJK/rPPvts+vbbb9N7772Xdtxxx9rJfLj88svHG2tRbRX5uU3MMYTOnTs3uB+hIsJAc+vE8lBdJ441WkJi3ERjMSajuTJuysCBA9Phhx9eux8tFEIFAAA/p0kKFNHlaezYsS2u99hjj+VB3Ntss03tpDkGKNebe+6509prr527OkWgiK5Ic8wxR14WA6H79OmT3n777VqrxeTwxBNP1E7SP//88/T666/nFojSY5gcll9++fTKK6/Uunr9FDEoPm4AADBVBoqYbejJJ5/MJ9bRNafxlfiqGAsQMxvFIOa4Ih+DiJtaN8JCjGuIq/7nnXdeg2Ux1iCu2kfXnRi0HOMDnnnmmRwE6q/CT4oY6zHbbLPlwBIDpWO8w9Zbb/2TjuGnilaamHEqBmHvvffeuSUiAka0jvzXf/3XZH89AACYYmMoohtQdDnq27dvniWp8XiCqnPPPTfNOuuseYBxnJDHmIC4Et9YdCEaOXJk+uabb8Y7sY+T65g29sorr8yDqKM1I8YaxADtUjET1SGHHJKnuP3oo4/S7bffnltdfsox/FQxviKm443Wkpg6drnllsuzW0ULDQAATO06VGJEdBsX30MR3wMRrRsxwLq9iDEUeXD2oTekjl26TundAQBgErxz5mZpSp5Djho1Kn8HWqt+UzYAANC+tIlAsd9++zWYdrX+FssAAICpeNrYKS0GW8f4jqZEM03MHtUOenYBAECraxOBIgJDdcpZAACg9bSJLk8AAMCUIVAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAAAgUAABA69NCAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAAAgUAAAAK1PCwUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAU61T+VKYVQ0/ZKHXv3n1K7wYAAG2QFgoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUKxT+VOZ2lUqlfzzyy+/nNK7AgDANKJ67lg9l2yJQNGGjRw5Mv+cZ555pvSuAAAwjfnqq69Sjx49WlxPoGjDevbsmX+OGDFioioDPy3JR3B77733Uvfu3RXlz0hZtx5lrazbIvVaWbdFX07m85BomYgw0adPn4laX6Bowzp2/L8hMhEmnOS2jihnZa2s2xr1Wlm3Req1sm6Luk/G85BJuRhtUDYAAFBMoAAAAIoJFG1Yly5d0qBBg/JPlHVboV4r67ZIvVbWbZF63X7KukNlYueDAgAAaEQLBQAAUEygAAAAigkUAABAMYGiDbvooovS/PPPn2aYYYa0yiqrpKeeempK79JU7eSTT04dOnRocFt88cVry7/77rt04IEHptlmmy1169Ytbbfddunjjz9usI34EsHNNtssde3aNc0xxxzpqKOOSmPGjGmwzoMPPpiWX375PHBq4YUXTldddVVq6x5++OG0xRZb5C/IiXK95ZZbGiyPoVwnnXRSmmuuudKMM86YNthgg/TGG280WOezzz5L/fv3z/NrzzLLLGmvvfZKo0ePbrDOiy++mNZaa61c5+MLfs4+++zx9uXGG2/M72uss/TSS6c777wztaey3n333cer5xtvvHGDdZR1y84444y00korpZlnnjn/rW+99dZp2LBhDdZpzc+Mtvx5PzFlvc4664xXr/fbb78G6yjrll1yySWpX79+te8yWG211dKQIUNqy9Xp1ivrdaa1Oh2Dsml7rrvuusr0009f+Z//+Z/Kyy+/XNlnn30qs8wyS+Xjjz+e0rs21Ro0aFBlySWXrHz44Ye123/+85/a8v32268yzzzzVO67777KM888U1l11VUrq6++em35mDFjKksttVRlgw02qDz33HOVO++8s9KrV6/KwIEDa+u8/fbbla5du1YOP/zwyiuvvFK58MILK9NNN13lrrvuqrRlURbHH3985eabb45JICqDBw9usPzMM8+s9OjRo3LLLbdUXnjhhcqWW25ZWWCBBSrffvttbZ2NN964sswyy1SeeOKJyiOPPFJZeOGFKzvvvHNt+ahRoypzzjlnpX///pWhQ4dWrr322sqMM85YufTSS2vrPPbYY7m8zz777Fz+J5xwQqVz586Vl156qdJeynq33XbLZVlfzz/77LMG6yjrlm200UaVK6+8Mte1559/vrLppptW5p133sro0aNb/TOjrX/eT0xZr7322vm46+t1fCZUKeuJc9ttt1XuuOOOyuuvv14ZNmxY5bjjjsufkVH2QZ1uvbJeexqr0wJFG7XyyitXDjzwwNr9sWPHVvr06VM544wzpuh+Te2BIk5Ym/LFF1/kP/Qbb7yx9tirr76aT9gef/zxfD/+mDt27Fj56KOPautccsklle7du1e+//77fP/oo4/OoaXejjvumP/DbC8an+SOGzeu0rt378of/vCHBuXdpUuXHApCfBDG855++unaOkOGDKl06NCh8v777+f7F198cWXWWWetlXU45phjKosttljt/g477FDZbLPNGuzPKqusUtl3330rbVFzgWKrrbZq9jnKuswnn3ySy/uhhx5q9c+M9vZ537isqydfhxxySLPPUdbl4nP1iiuuUKdbsaynxTqty1Mb9MMPP6T//d//zd1Gqjp27JjvP/7441N036Z20c0muoosuOCCuXtNNCeGKM8ff/yxQZlGt5l55523VqbxM7rQzDnnnLV1Ntpoo/Tll1+ml19+ubZO/Taq67Tn92X48OHpo48+alAuPXr0yM2u9WUb3ZxWXHHF2jqxftTrJ598srbOL3/5yzT99NM3KNvoGvH555/X1lH+/9cEHs3jiy22WNp///3TyJEja2WmrMuMGjUq/+zZs2erfma0x8/7xmVddc0116RevXqlpZZaKg0cODB98803tWXKetKNHTs2XXfddenrr7/O3XHU6dYr62mxTneapLWZJnz66ae5ctZXshD3X3vttSm2X1O7OIGNvoVxkvXhhx+mU045JffHHzp0aD7hjRPVOKltXKaxLMTPpsq8umxC68QHwLfffpvHD7Q31bJpqlzqyy1OgOt16tQpn1DUr7PAAguMt43qsllnnbXZ8q9uoz2I8RLbbrttLqu33norHXfccWmTTTbJ/3lMN910yrrAuHHj0qGHHprWWGON/B9/aK3PjAjL7enzvqmyDrvsskuab7758gWhGEt1zDHH5IsJN998c16urCfeSy+9lE9qY7xEjP0ZPHhw6tu3b3r++efV6VYq62mxTgsU8P/FSVVVDJSKgBF/zDfccEO7PNGnbdppp51qv8fVrajrCy20UG61WH/99afovk2rYuB1XHh49NFHp/SutNuyHjBgQIN6HRM8RH2O0Bz1m4kXF9UiPERL0E033ZR222239NBDDynCVizrvn37TnN1WpenNiiax+JKY+PZROJ+7969p9h+TWviyuKiiy6a3nzzzVxu0TT4xRdfNFum8bOpMq8um9A6McNDew0t1bKZUH2Nn5988kmD5TGTRcxGNDnKvz3/XUT3vvjMiHoelPWkOeigg9I//vGP9MADD6S555679nhrfWa0p8/75sq6KXFBKNTXa2U9caJlLWYDWmGFFfIMW8sss0w6//zz1elWLOtpsU4LFG1QVNConPfdd1+DZuK4X983jwmLKUnjSkBcFYjy7Ny5c4MyjabHGGNRLdP4Gc2X9Se+99xzT/7DrTZhxjr126iu057fl+h6Ex9c9eUSzbExNqK+bOPELPp6Vt1///25Xlc/ZGOdmDI1+q3Xl21cAYruTtV1lH9D//73v/MYiqjnynrixZj3OMGNLgpRFxt3t2utz4z28HnfUlk3Ja76hvp6razLRH36/vvv1elWLOtpsk5P0hBuphkxDVjMknPVVVflWVsGDBiQpwGrnw2Aho444ojKgw8+WBk+fHieXjSmYosp2GJGkep0eTFV4f3335+ngFxttdXyrfEUbr/61a/y1IYxLdvss8/e5BRuRx11VJ7x5aKLLmoX08Z+9dVXeVq7uMXHzrnnnpt/f/fdd2vTxkb9vPXWWysvvvhinoWoqWljl1tuucqTTz5ZefTRRyuLLLJIg2ljY1admDb2N7/5TZ52L/4GoqwbTxvbqVOnyjnnnJPLP2b2amvTxk6orGPZkUcemWcZinp+7733VpZffvlclt99911tG8q6Zfvvv3+e6jg+M+qndfzmm29q67TWZ0Zb/7xvqazffPPNyqmnnprLOOp1fI4suOCClV/+8pe1bSjriXPsscfm2bOiHOOzOO7HbHp33313Xq5Ot05ZvzkN1mmBog2L+YbjP7OYXzimBYv5+2leTKU211xz5fL6xS9+ke/HH3VVnNwecMABeVq3+APdZptt8n9q9d55553KJptskr//IMJIhJQff/yxwToPPPBAZdlll82vEx8QMb96WxfHHCe3jW8xhWl16tgTTzwxB4L4YFt//fXzvNz1Ro4cmQNEt27d8rR4e+yxRz5BrhffYbHmmmvmbcR7GEGlsRtuuKGy6KKL5vKP6fRiHvD2UtZxAhb/+cR/OhGk5ptvvjzneOP/OJR1y5oq47jV/z235mdGW/68b6msR4wYkU+0evbsmf/24ztq4gSqfs7+oKxbtueee+bPhahH8TkRn8XVMBHU6dYp6xHTYJ3uEP9MWpsGAADA/zGGAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAoA2o0OHDumWW26Z7Nt955138raff/75yb5tgGmdQAHAZBcn3xO6nXzyya1+8v5T9gmA5nWawDIAKPLhhx/Wfr/++uvTSSedlIYNG1Z7rFu3bq1eslPjPgG0BVooAJjsevfuXbv16NEjtwBU788xxxzp3HPPTXPPPXfq0qVLWnbZZdNdd91Ve+4CCyyQfy633HL5eeuss06+//TTT6cNN9ww9erVK29z7bXXTs8++2yr7FNjY8eOTXvuuWdafPHF04gRI/Jjt956a1p++eXTDDPMkBZccMF0yimnpDFjxtSeE693xRVXpG222SZ17do1LbLIIum2226rLf/8889T//790+yzz55mnHHGvPzKK6+cxJIHaH0CBQCt6vzzz09//OMf0znnnJNefPHFtNFGG6Utt9wyvfHGG3n5U089lX/ee++9uVXh5ptvzve/+uqrtNtuu6VHH300PfHEE/mEe9NNN82P/9z7VO/7779Pv/71r3OXrEceeSTNO++8+eeuu+6aDjnkkPTKK6+kSy+9NF111VXptNNOa/DcCBk77LBDfo3Y9wgQn332WV524okn5ucOGTIkvfrqq+mSSy7J4QlgqlcBgJ/RlVdeWenRo0ftfp8+fSqnnXZag3VWWmmlygEHHJB/Hz58eCX+e3ruuecmuN2xY8dWZp555srtt99eeyyeN3jw4J9tnx555JHK+uuvX1lzzTUrX3zxRW3deOz0009v8Pyrr766MtdcczXYtxNOOKF2f/To0fmxIUOG5PtbbLFFZY899mhx3wGmNlooAGg1X375Zfrggw/SGmus0eDxuB9X5Sfk448/Tvvss09umYguS927d0+jR4+udTlqjX3aeeed09dff53uvvvuvA9VL7zwQjr11FPzOIzqLfY1Wli++eab2nr9+vWr/T7TTDPlY/jkk0/y/f333z9dd911ubvV0Ucfnf71r3/9pOMCaC0CBQDThOjuFN2MontSnGzH77PNNlv64YcfWm0foptSdFd6/PHHGzwewSa6M8U+VW8vvfRS7jIVYyqqOnfu3OB5Ma5i3Lhx+fdNNtkkvfvuu+mwww7LAWf99ddPRx55ZCsdGUA5gQKAVhNX5Pv06ZMee+yxBo/H/b59++bfp59++trA58brHHzwwfmkfskll8yDpz/99NNW2aeqaEU488wz8/iKhx56qPZ4DMaOGaMWXnjh8W4dO078f7UxIDuC09/+9rf0pz/9KV122WU/+fgAfm6mjQWgVR111FFp0KBBaaGFFsrde2Imo7iif8011+TlMeNSzHIUsyzFrEtxhT+6F0VXp6uvvjqtuOKKuZtSbCfWa419qvfb3/42h53NN988D6Bec8018xS0cT8GaG+//fY5REQ3qKFDh6bf//73E7UPsY0VVlghh6UY+P2Pf/wjLbHEEpPl+AB+TgIFAK0qWhlGjRqVjjjiiDx+IFoBYvrUCAz5P6ZOndIFF1yQxyTESfZaa62VHnzwwfTnP/85DRgwILcGzDPPPOn000+fbF2CWtqnxg499NDcVSlaSyL4xKxQEQBin88666zctSmmlN17770neh+iZWbgwIH5i/0iKMVxx5gKgKldhxiZPaV3AgAAmDYZQwEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAUqn/Bx2rNiOoTCjrAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 11: Top agents by token usage\n",
+    "df = run(\"\"\"\n",
+    "SELECT agent, COALESCE(SUM(total_tokens), 0) AS total\n",
+    "FROM llm_events WHERE event_type = 'LLM_RESPONSE'\n",
+    "GROUP BY agent ORDER BY total DESC LIMIT 10\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    ax.barh(df[\"agent\"].fillna(\"(unknown)\"), df[\"total\"])\n",
+    "    ax.set_title(\"Top Agents by Token Usage\", fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Total Tokens\")\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No agent token data.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cell-12-user-tokens",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:33.837495Z",
+     "iopub.status.busy": "2026-04-11T06:42:33.837393Z",
+     "iopub.status.idle": "2026-04-11T06:42:36.221254Z",
+     "shell.execute_reply": "2026-04-11T06:42:36.220702Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxQAAAGGCAYAAADissfwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKw9JREFUeJzt3Qe4VNW9P+4FoigqKFZQLNh77xr1okHsvV577MbeG2psscR21avRQK6a2K5ixWuJBQ222LBhQ9FERbEgFlSY3/Nd+c/85xwOcFggBzzv+zwDZ/bes2fNmn3m7M9eZdpUKpVKAgAAKNC25EEAAAACBQAAMEm0UAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQKAKWaDDTZIbdq0ybf33ntvmqz5vfbaq/YaHn300ZYuDkCLEyiAVmGhhRaqnQRO6DalTxLj+arPHeUcX9mdwDbf6aef3uz3PELCL0GEtPrXNb5A17dv3xYpI/DLI1AAAADF2pU/FGDacdttt6Xvv/++dn+HHXZIH3/8cf75sssuSyuttFJt3XLLLdciZZya/fDDD6lt27apXbtp58/GPvvskzbaaKPa/T/96U+pT58++edevXqlk046qbZunnnmaZEyAvwSaKEAWoVVV101rbvuurVb+/btGwSI+nXRHeTkk09OSy21VJppppnSrLPOmtZYY4109dVXp0ql0mC/9V2V3nrrrbT55punWWaZJc0555zpkEMOSd98883P9ppeeumltNVWW6W55547TT/99GmOOeZIK664YjrwwAPT0KFDG2w7YMCAtOWWW6a55porzTDDDGnhhRdORx11VPriiy/GOT6gf//+6eijj05dunRJM844Y/rwww/TmDFj0tlnn52WXXbZXDexfIEFFkibbbZZuu666yaq/N9++206/PDDc/lnnnnmXHfvvPNOXhfPs+CCC+ZyxLqRI0c2eGwEwFgXAWfYsGFN7j/KVf++xv2qeM76dYsttlgOnRtuuGGabbbZ8vHRvXv3dOihh6aPPvpogq9lxIgRaeWVV67V3VlnnVVbd+edd+ZgM/vss+f9LrHEEumMM85I33333Ti7I7388svpt7/9bS5n1HMEoPfffz/9nF2ldt1119S1a9d8LEUdLL300mnvvffOZamK97hnz565LuN9ifc/6i7K+tlnn42136jTOFZiu/j/lltuadAVrXG3q3iuXXbZJR9zcZzON9986Te/+U0+9oCpWAWgFVpwwQUjGeTbI488Ulv++eefV5Zccsnausa3nXfeucF+qstnm222yjzzzDPW9ptssskEyxLPX90+ytWcsn722WeVueaaa5zlfPDBB2uP/+Mf/1hp27Ztk9stscQS+TVX7bnnnrV13bt3b7DtkCFDKmeeeeY4n3OdddaZ4Gtdf/31a9svv/zyY+1jvvnmy68t9O7du7b8+uuvr+1j6NChteW//vWvK81Vv794nfWOO+64cb6ueeedt/Luu+82WUfxfnz//feVDTfcsLbs5JNPrm176qmnjnO/6623XmXUqFFN1k3jum9u/cZ7VP+Y8dV/nz598rIff/yxsvjii4+znHH8VPXs2XOc2y211FKV7777rrbt//7v/1batGkz1nYrrLDCWGUI9913X6V9+/bNeg+AqYsWCoA60Q3mjTfeqLVc3H777enaa6/NV5fDTTfdlG6++eax6uzLL79M888/f+rXr1+6/PLLU4cOHfLy+++/P919992TvY4HDhyYPv300/xzXNF98MEH83NfeOGFaf3110/TTTddXvfPf/4zX2WPK/7R0hJl+7//+7985TkMHjy4Qdefeu+++2467LDD8muI1pl4fFxtD3EF+4YbbkgPPfRQ+p//+Z/cKhJXlSfGv/71r9wF6dZbb82tAdXynnPOOfnnKGN1YPGNN95Ye9xdd91V+zle+6R6+umn0/nnn59/jivpUYfxHNFaEaJr3MEHH9zkY6Ned9ttt/TII4/k+9HqU22dePbZZ9Pvfve7/HPUTVzdj7qM1pxqq9HFF1/c5H7jvf3v//7vXMdR1+HJJ59Mr776aprc4nh/880388/RkhJlvOeee/KxEi0j9a15O+20U+46du+99+YJAuL/PfbYI697/fXX8+9LGD16dDriiCNqLXrRxTC2jeMpWtaaaq3ac88906hRo3KrU7SCPfDAA+m4446b4HsATAVaOtEAtISmrvqPHj26Mvvss9eWDxo0qLb95ZdfXlu+1VZb1ZbXX0V96623asvjKnV1+T777DPZWyjuv//+2rK4uh5X7ceMGTPWYy+++OLadnvvvXdlwIAB+fb4449XOnTokJd36tQpv/bGV9933XXXsfa35ppr1loSBg4cWPnmm28qE6P+Cnn9le9oUam/Ol+18cYb52Xt2rWrfPLJJw2uksfV7C+//HKSWygOO+yw2vKjjz66tvzTTz+tXTGPK+3Dhw8fq45WXXXV2s8HH3xwg+c7/PDDa+tOOumkWt3ffffdteXLLrtsk3UT71vVgQceWFver1+/yd5C8cYbb9SW7b777pV33nmndjw0FsfZfvvtV1l44YWbbE048sgj83ZPP/10g9aFH374YaxjqL4Md9xxR21Zr169anUVt4UWWqj2HsR7Akx9tFAA1F0Vro4piBaG6PNdtfrqq9d+rl7Nrde5c+e06KKLNrl9XOkfn/rpPRuP0Wi8LAZGh/XWWy/3XQ9xdT36tHfq1Cn3w//jH/+Yr5w3Lmu0BsTj4varX/0qXxUOX331VW4taGyLLbYYa9m+++5ba0lYa6218niReN0HHHBAk/UyPjEupan6iv781ddcfb6ffvoptwzFWIrq1Lmbbrppfs2Tqr7c9WWKcTDVlpMoz9tvvz3WY5977rn8/zrrrJP+67/+a5z7jVaXat3X12u1NayxaGWqirEx9S1h49N4qtjGx1NTx1IcR1GucP3116dFFlkkv6/x/l5wwQW51SB8/fXXae21187H15AhQ2rL61XLV3/Mx9iSGJdRFfttrL6uYuxOta7iVv2+kij7uOoLaFkCBUAzTsyamtN/fCZm++hKVNXUwNb6ZdVtI/BEF5gzzzwz/cd//Eead9558wnfY489lvbff/9aF57mamrweFMzH8UA2Tjh23333XPgioGzMZD6mmuuySfBEzrhndj62nrrrXNYC9H9J7rjVE9kYxDxz21C72O1a9nf//73POB4YkVQaurEvNrFLtTPrNVU4BzXsdTU8dTUsRTB4r777ksXXXRR2mSTTXI4jQHjTz31VO5yFAPnwx133FEbHL3kkkvmgNe421Y1yE7K7874/JyTHADlBAqA/0/MgFTtrx4nLvX91aOffdXiiy8+Vp19/vnnDa5g129fvco9LnGFuHq1OFoNIihUPfHEE7WWhDh5rbZKxIlllPfUU09NDz/8cJ6JKK4Kx5XlUO3LXl/W3r1758c1vsVrjZmHmnMiGNvHSWeMmxg0aFBuMYi+8tV+7nFi3VzPPPNMk/VV/SK/EP33//M//7O2/SWXXFI7Ga6ORZhU9XVUX6bhw4fXZp2K8tS3QFVFX/8YdxH1EmMAItA1td9oHRpX3dePUZhUEb7iuKiKcQhVMUtUjJmpilAQohxx3MT4jwiLsV3MnBUzgdUfS9EqVRUzmO244455hqz66ZiropWj6oUXXshjKurH/zRWX1dRj+Oqq5hhCpj6TDsTigP8zOKkfuedd86DYUMMto2T8OgGFf9PaCBwXDE/5ZRT8lXc6olviKldxydOjuNEKU7mqttXB7rGiXtVbFMNDHHiHgNct9tuuxwyontOTLlZDR/Vq97bb799OuGEE/L98847L58YR5eT2C66rcRg4rgaHYO6myP2F+WNrigxCD2usFe7/dQ/b3OceOKJ+ep7TD8aP4+rvqLbU3xXSKiGrWi5iOlUJ4d4P6v7j25LMXVq1Gm8h9XXE3VfbSmpF12k4j2KwcqxbZQrQuAyyyyTj4dLL700b3fkkUfm0Ln88svnVpwIKnGyH1PjxiDnySneo6uuuir/HK1VcazEe/bXv/61dmIfU8LGtMjVoBCDsSMgxPJomYpjozrov1oHUdaqKHME5QjR9VPk1ndz6tatW/rggw9yd7o4nuP3KSYEiJaPxjbeeOMchOI5oz6jrmNZlDe6PMX7HoO5X3vttclaV8Bk0tKDOACmpmljY+DthKaNrR/8XF3euXPnyvzzzz/W9jGouKnB0o0NHjy4Msccc4zzeeecc87Km2++Wds+BquOa9u4nXvuuc2aNjZuMVB3XFOiNtajR49x7iemzZ3QIOn6QcGLLbbYWPvo0qVLZdiwYWM9rn7wc9xiitGJ9XNNGxvOOuus2rJu3bpVPvzwwwlOG9u4HPV1E4Ormyp3/TSr4xIDl5uadrZ6i8H4TzzxRG37Dz74YLxlPOCAA/J2I0aMyO9PU9PZNvV6xjVt7HLLLdfk67n33nvHOW3suCYsAKYOujwB1Ikro3EFNa6YRzeg6I4SV9BXW221fNX3L3/5S5NdgeIKcPQnjwG3sX3sJ6ZSje4izelDHl0+omtIdCWJrjXxvHGLK+WxLNZVuztVtz/++OPTmmuuma8ox5X+aL2Icl5xxRV5Xf24h8cffzxtu+22tW3j/xgIHV2mrrzyymYfAzF1Z1yNrw7cjX3Fl4/F1ee4Mj8xg6Rjuti4gh6Djqtf3hblrO+yU1UdnB2iNSauXk9Ov//97/MYiBgH0rFjxzyIOLpeRd0///zzte4/4xJfhBhddUJclY/XEoPdY4xLTMEa3cTidcZ+o76iq1C0GMUX3E1uUT8xZW20TEVLSdRtjHWJFob44sJoUYpB5FVxrEYLXLz2mN42yhiPidaUaH2I6WOrx3i0ZMWYnXjv43XE64tbU+J4izqNVo94/mgRid+fHj161LapTq9cHWQfZYvxOdH6FeWI1xJf1hjdseJ4AaZObSJVtHQhAKZV1bAQJ2vV2WiY/OKbv6tdbg466KCJCkG0jDi9aCpMRwiujpmJsBbfeg5M27RQADDViv77MTi6OsYhVMeXMHWLFrsYnxLjJmKgd4yBiBafapiIFsAVVlihpYsJTAYGZQMw1Yrvt/jzn/9cux9dneIKN1O/mEI2vlk+bo1F96m+ffvWZjcDpm1+kwGY6sXYjBi7ceONN7Z0UWimmAUqpvyN8TYxViLGBMX4oOiyFq0VgiH8chhDAQAAFNNCAQAAFBMoAACAYgZlt6AYsBbfIBqD05ozTz0AAEyJaZ+//vrr1LVr12ZNniBQtKAIE926dWvJIgAAQJPiizrjiyYnRKBoQdEyUX2z4ptZAQCgpY0YMSJf9K6eq06IQNGCqt2cIkwIFAAATE2a2yXfoGwAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGLtyh/K5LJs7/9Lbdt3UKEAAGTvnbdZmlZooQAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAALRsoNthgg3TEEUdMjl0BAADTEC0UAABAMYHiZ/Ljjz/+XLsGAIBpN1B88803aY899kizzDJL6tKlS7rooosarB81alQ65phj0nzzzZdmnnnmtMYaa6RHH320tr5v375pttlmS/fcc09aYoklUocOHdL222+fvv322/TnP/85LbTQQmn22WdPhx12WBo9enTtcV988UV+3lgXj+nVq1d66623mlXm008/Pa244ooNll1yySX5uaqijKuvvnouc5RvnXXWSe+//35t/Z133plWXnnlNOOMM6bu3bunM844I/3000+19W3atElXXXVV2nLLLfM+zj777ImsWQAAaAWB4thjj02PPfZYPsF+4IEH8on4888/X1t/6KGHpoEDB6abbropvfzyy2mHHXZIm2yySYOT/wgPl112Wd7m/vvvz/vYZptt0n333Zdv119/fbr66qvTbbfdVnvMXnvtlZ577rl011135f1XKpW06aabTpaWgAgGW2+9dVp//fVzmWP/+++/fw4JYcCAATnMHH744em1117LZYtg1Dg0RHCJ1zFo0KC0zz77THK5AABgatduYjYeOXJkuu6669INN9yQevTokZdFq8L888+ffx46dGjq06dP/r9r1655WbRWRGiI5eecc05eFiEgruYvssgi+X60UESI+OSTT3LLx9JLL5023HDD9Mgjj6Sddtoph5EIEk8++WRae+2182NuvPHG1K1bt9SvX78cWibFiBEj0ldffZU233zzWpmWWmqp2vpojTjhhBPSnnvume9HC8Xvfve7dNxxx6XevXvXttt1113T3nvvPc7nidabuNU/LwAAtJpA8c4776Qffvghd2Oq6ty5c+66FOLKfHRTWnzxxRs8Lk6i55hjjtr96LJUPXEP88wzT+5+FGGiftmwYcPyz6+//npq165dg+eN/cXzxrpJFa8hWkB69uyZNt5447TRRhulHXfcMXfpCi+99FIOM/UtEvE6v//++9zaEq8nrLrqquN9nnPPPTeHEwAAaJWBojktGNNNN136xz/+kf+vVx8Wpp9++gbromtRU8vGjBkzWcrVtm3b3EWqXuOuUtGCEuM2ojXl5ptvTqecckp68MEH05prrplfVwSBbbfddqx9x5iKqhg7MT4nnnhiOuqooxq0UEQrCwAATKsmKlBEq0Kc+D/99NNpgQUWqA2WfvPNN/P4g5VWWilfuY+WhfXWW2+yFTK6H8U4h3jeapen4cOHp8GDB+fuURMy11xzpY8//jiHiuq4iBdffHGs7aL8cYsT/7XWWiv95S9/yYEiBmPHcy266KKT9Drat2+fbwAA0CoDRbQy7LvvvnlgdnQ5mnvuudPJJ5+cWwBCdHXabbfd8gDmmP0pTs4//fTT9PDDD6fll18+bbbZZkWFXGyxxdJWW22V9ttvvzwgetZZZ81jGmImqVjenC/ei3Kcf/75ebxGtEL0798/dezYMa8fMmRIuuaaa/IMTTH2I8JDjNuI1xFOO+20PL4iQlQ8Pl5vdIN65ZVX0llnnVX0mgAAoFXO8nTBBRfk1octttgijzVYd9110yqrrNKg61CciB999NF5jEPMnvTss8/WWjRKxX7jeeLEPloPorUhZoRq3FVqXC0cV155ZbriiivSCiuskJ555pk8WLwqxkC88cYbabvttsuhKGZ4OuSQQ9IBBxyQ18fYipjmNma1Wm211XKrxcUXX5wWXHDBSXpNAAAwrWtTaTy4gCkmxlB06tQpdTviltS2/b8HdgMAwHvnlfXsmZznqDELarVHz/j4pmwAAKDYLyJQxLdmx/iOpm7V774AAACm8mljW8q1116bvvvuu3F+xwQAAPDz+EUEipjtCQAAmPJ+EV2eAACAliFQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAAAIFAAAwJSnhQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAQKAAAACmPC0UAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAEAABQTKAAAgGICBQAAUKxd+UOZXF45o2fq2LGjCgUAYJqjhQIAACgmUAAAAMUECgAAoJhAAQAAFBMoAACAYgIFAABQTKAAAACKCRQAAEAxgQIAACgmUAAAAMUECgAAoJhAAQAAFGtX/lAmVaVSyf+PGDFCZQIAMFWonptWz1UnRKBoQcOHD8//d+vWrSWLAQAAY/n6669Tp06d0oQIFC2oc+fO+f+hQ4c2681i8ibvCHIffPBB6tixo6qdQtR7y1Dv6r21ccyr99ZkxM9wThMtExEmunbt2qztBYoW1Lbtv4ewRJhwUtsyot7VvXpvLRzv6r21ccyr99ak42Q+p5mYi90GZQMAAMUECgAAoJhA0YLat2+fevfunf9H3bcGjnn13po43tV9a+OYb7313qbS3PmgAAAAGtFCAQAAFBMoAACAYgIFAABQTKBoQVdccUVaaKGF0owzzpjWWGON9Mwzz7RkcaYpp59+emrTpk2D25JLLllb//3336dDDjkkzTHHHGmWWWZJ2223Xfrkk08a7CO+UHCzzTZLHTp0SHPPPXc69thj008//dRgm0cffTStvPLKeaDToosumvr27Ztak8cffzxtscUW+Yttoo779evXYH0MwTrttNNSly5d0kwzzZQ22mij9NZbbzXY5vPPP0+77bZbnht7ttlmS/vuu28aOXJkg21efvnltN566+XfhfhynvPPP3+sstx66635PY5tlltuuXTfffel1lz3e+2111i/A5tsskmDbdT9xDn33HPTaqutlmadddb8mbD11lunwYMHN9hmSn62tKa/Ec2p+w022GCsY/7AAw9ssI26nzhXXXVVWn755WvfX7DWWmul/v3719Y73lum3jeYFo/1GJTNlHfTTTdVZphhhsqf/vSnyquvvlrZb7/9KrPNNlvlk08+8XY0Q+/evSvLLLNM5aOPPqrdPv3009r6Aw88sNKtW7fKww8/XHnuuecqa665ZmXttdeurf/pp58qyy67bGWjjTaqvPDCC5X77ruvMuecc1ZOPPHE2jbvvvtupUOHDpWjjjqq8tprr1Uuv/zyynTTTVe5//77W817FPVy8sknV26//faYvKFyxx13NFh/3nnnVTp16lTp169f5aWXXqpsueWWlYUXXrjy3Xff1bbZZJNNKiussELlqaeeqgwYMKCy6KKLVnbZZZfa+q+++qoyzzzzVHbbbbfKK6+8UvnrX/9amWmmmSpXX311bZsnn3wy1/3555+f34tTTjmlMv3001cGDRpUaa11v+eee+a6rf8d+Pzzzxtso+4nTs+ePSt9+vTJx+GLL75Y2XTTTSsLLLBAZeTIkVP8s6W1/Y1oTt2vv/76uR7qj/n4/KhS9xPvrrvuqtx7772VN998szJ48ODKSSedlD9b430IjveWqff1p8FjXaBoIauvvnrlkEMOqd0fPXp0pWvXrpVzzz23pYo0zQWKOEltypdffpl/MW+99dbastdffz2flA0cODDfj1++tm3bVj7++OPaNldddVWlY8eOlVGjRuX7xx13XA4t9Xbaaaf8h681anxSO2bMmMq8885bueCCCxrUffv27XMoCPEhFo979tlna9v079+/0qZNm8o///nPfP/KK6+szD777LV6D8cff3xliSWWqN3fcccdK5tttlmD8qyxxhqVAw44oNIajCtQbLXVVuN8jLqfdMOGDct1/9hjj03xz5bW/jeicd1XT7IOP/zwcT5G3U8e8Xl87bXXOt5bqN6n1WNdl6cW8MMPP6R//OMfuXtIVdu2bfP9gQMHtkSRpknRtSa6g3Tv3j13qYnmvxB1++OPPzao3+gqs8ACC9TqN/6PbjPzzDNPbZuePXumESNGpFdffbW2Tf0+qtt4j/5tyJAh6eOPP25QR506dcpNpvX1HN2cVl111do2sX0c708//XRtm1/96ldphhlmaFDP0d3hiy++8F6MRzRnR1P3EksskQ466KA0fPjw2jp1P+m++uqr/H/nzp2n6GeLvxFj133VjTfemOacc8607LLLphNPPDF9++23DY55dV9u9OjR6aabbkrffPNN7oLjeG+Zep9Wj/V2E/0IJtlnn32WD6D6AyHE/TfeeEMNN0OctEZfwDiR+uijj9IZZ5yR++C/8sor+SQ3Tk7jRLZx/ca6EP83Vf/VdePbJn5hv/vuuzxmoDWr1lNTdVRfh3HCW69du3b5JKF+m4UXXnisfVTXzT777ON8L6r7aI1ivMS2226b6+6dd95JJ510UurVq1f+QzDddNOp+0k0ZsyYdMQRR6R11lkn/0EPU+qzJYJ0a/4b0VTdh1133TUtuOCC+UJSjLs6/vjj84WH22+/Pa9X92UGDRqUT2RjvESMC7rjjjvS0ksvnV588UXHewvU+7R6rAsUTJPixKkqBjZFwIhfvltuuaXVn+jTOuy88861n+NKVfweLLLIIrnVokePHi1atl+CGHgdFyieeOKJli5KqzOuut9///0bHPMxGUQc6xGo49inTFyYi/AQrUK33XZb2nPPPdNjjz2mOluo3pdeeulp8ljX5akFRBNWXEFsPDNI3J933nlbokjTvLhiuPjii6e3334712E05X355ZfjrN/4v6n6r64b3zYxI0Nrb52or6fxHcfx/7Bhwxqsj1koYvahyfFe+H35/0XXv/hsid8BdT9pDj300HTPPfekRx55JM0///wNjvkp8dnSmv9GjKvumxIXkkL9Ma/uJ160usUMQKusskqebWuFFVZIl156qeO9hep9Wj3WBYoWOojiAHr44YcbNPHG/fr+czRfTEMayT1SfNTt9NNP36B+o6kwxlhU6zf+j+bG+pPdBx98MP+iVZscY5v6fVS38R79W3S1iQ+d+jqKptQYG1Ffz3HyFf00q/72t7/l4736ARnbxBSp0Te9vp7j6k10d/JeNM+HH36Yx1DE74C6LxPj3+OENroexHHauCvelPpsaY1/IyZU902Jq7uh/phX95MujrVRo0Y53luo3qfZY32ih3EzWcRUXTEbTt++ffNsLPvvv3+eqqt+xD7jdvTRR1ceffTRypAhQ/KUojF1WkyZFjODVKe6iykH//a3v+WpHddaa618azzl2q9//es8RWFMozbXXHM1OeXasccem2dyueKKK1rdtLFff/11npIubvFx8Yc//CH//P7779emjY3j9s4776y8/PLLedahpqaNXWmllSpPP/105YknnqgstthiDaaNjZlzYtrY3XffPU+ZF78bUe+Np41t165d5cILL8zvRczy9UufNnZ8dR/rjjnmmDyzUPwOPPTQQ5WVV1451+33339f24e6nzgHHXRQngY5Plvqp2v89ttva9tMqc+W1vY3YkJ1//bbb1fOPPPMXOdxzMdnTvfu3Su/+tWvavtQ9xPvhBNOyDNpRZ3GZ3jcj1n4Hnjggbze8T7l6/3tafRYFyhaUMwJHH+YYg7gmLor5umneWLqsy5duuS6m2+++fL9+CWsihPagw8+OE/DFr9Q22yzTf7jVO+9996r9OrVK3/nQYSRCCk//vhjg20eeeSRyoorrpifJ36hY5701iRef5zMNr7FlKXVqWNPPfXUHAjiQ6lHjx55Tu16w4cPzwFilllmyVPa7b333vmEuF58h8W6666b9xHvZwSVxm655ZbK4osvnt+LmAov5vBurXUfJ1nxhyT+gESwWnDBBfP84Y3/CKj7idNUfcet/vd+Sn62tKa/EROq+6FDh+YTqs6dO+fPifg+mzhRqp+bP6j7ibPPPvvkz484xuLzJD7Dq2EiON6nfL0PnUaP9Tbxz8S3awAAABhDAQAATAKDsgEAgGICBQAAUEygAAAAigkUAABAMYECAAAoJlAAAADFBAoAAKCYQAHAVKtNmzapX79+k32/7733Xt73iy++ONn3DdDaCBQATFCcfI/vdvrpp0/xk/dJKRMAk0+7ybgvAH6hPvroo9rPN998czrttNPS4MGDa8tmmWUWZQJopbRQADBB8847b+3WqVOn3AJQvT/33HOnP/zhD2n++edP7du3TyuuuGK6//77a49deOGF8/8rrbRSftwGG2yQ7z/77LNp4403TnPOOWfe5/rrr5+ef/75KVKmxkaPHp322WeftOSSS6ahQ4fmZXfeeWdaeeWV04wzzpi6d++ezjjjjPTTTz/VHhPPd+2116ZtttkmdejQIS222GLprrvuqq3/4osv0m677ZbmmmuuNNNMM+X1ffr0cbQBvzgCBQCT5NJLL00XXXRRuvDCC9PLL7+cevbsmbbccsv01ltv5fXPPPNM/v+hhx7KLR233357vv/111+nPffcMz3xxBPpqaeeyifcm266aV7+c5ep3qhRo9IOO+yQu2QNGDAgLbDAAvn/PfbYIx1++OHptddeS1dffXXq27dvOvvssxs8NkLGjjvumJ8jyh4B4vPPP8/rTj311PzY/v37p9dffz1dddVVOTwB/OJUAGAi9OnTp9KpU6fa/a5du1bOPvvsBtusttpqlYMPPjj/PGTIkEr8uXnhhRfGu9/Ro0dXZp111srdd99dWxaPu+OOO362Mg0YMKDSo0ePyrrrrlv58ssva9vGsnPOOafB46+//vpKly5dGpTtlFNOqd0fOXJkXta/f/98f4sttqjsvffeEyw7wLROCwUAxUaMGJH+9a9/pXXWWafB8rgfV+XH55NPPkn77bdfbpmILksdO3ZMI0eOrHU5mhJl2mWXXdI333yTHnjggVyGqpdeeimdeeaZeWxI9RZljRaWb7/9trbd8ssvX/t55plnzq9h2LBh+f5BBx2Ubrrpptzd6rjjjkt///vfJ+l1AUytBAoAWkR0d4puRtE9KU624+c55pgj/fDDD1OsDNFNKborDRw4sMHyCDbRnSnKVL0NGjQod5mKMRVV008/fYPHxbiKMWPG5J979eqV3n///XTkkUfmgNOjR490zDHHTKFXBjDlCBQAFIsr8l27dk1PPvlkg+Vxf+mll84/zzDDDLWBz423Oeyww/JJ/TLLLJMHT3/22WdTpExV0Ypw3nnn5fEVjz32WG15DMaOWawWXXTRsW5t2zb/T2cMyI7gdMMNN6RLLrkkXXPNNZP8+gCmNqaNBWCSHHvssal3795pkUUWyd17YiajuKJ/44035vUx41LMchSzLMWsS3GFP7oXRVen66+/Pq266qq5m1LsJ7abEmWq99vf/jaHnc033zwPoF533XXztLhxPwZob7/99jlERDeoV155JZ111lnNKkPsY5VVVslhKQZ+33PPPWmppZaaLK8PYGoiUAAwSaKV4auvvkpHH310Hj8QrQAxfWoEhvyHpl27dNlll+UxCXGSvd5666VHH300XXfddWn//ffPrQHdunVL55xzzmTrEjShMjV2xBFH5K5K0VoSwSdmhYoAEGX+/e9/n7s2xZSyv/nNb5pdhmiZOfHEE/MX+0VQitcdYyoAfmnaxMjsli4EAAAwbTKGAgAAKCZQAAAAxQQKAACgmEABAAAUEygAAIBiAgUAAFBMoAAAAIoJFAAAQDGBAgAAKCZQAAAAxQQKAACgmEABAACkUv8P1R7VGK6WOqkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 12: Top users by token usage\n",
+    "df = run(\"\"\"\n",
+    "SELECT user_id, COALESCE(SUM(total_tokens), 0) AS total\n",
+    "FROM llm_events WHERE event_type = 'LLM_RESPONSE'\n",
+    "GROUP BY user_id ORDER BY total DESC LIMIT 10\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    ax.barh(df[\"user_id\"].fillna(\"(unknown)\"), df[\"total\"])\n",
+    "    ax.set_title(\"Top Users by Token Usage\", fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Total Tokens\")\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No user token data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel2-header",
+   "metadata": {},
+   "source": [
+    "## Panel 2: Usage Volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "cell-13-usage-kpi",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:36.222975Z",
+     "iopub.status.busy": "2026-04-11T06:42:36.222853Z",
+     "iopub.status.idle": "2026-04-11T06:42:39.694967Z",
+     "shell.execute_reply": "2026-04-11T06:42:39.694409Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABdIAAACMCAYAAAB4SluHAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAHkhJREFUeJzt3QeQnWX1P/An9B566GDovVfpHaSKFAE10kFBREYQf4Coo4goMuNQpffee6+GDhJ6r6H33vKf7/ufu3Oze/fd3fTsfj4zO2TfW/YmmRzOc97znKffsGHDhhUAAAAAAKClCVpfBgAAAAAAFNIBAAAAAKALOtIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACoMVHdg9BT7733XrnwwgvLddddV4YMGVLeeuut8tlnn5UZZpihzDjjjGWuueYqK6ywQtlwww3L8ssvX/r16+cPGeixZ599ttx///1tXw8++GD5+OOPOzzvhRdeKPPMM0+33/f9998vZ5xxRrn66qvLk08+WcWwiSaaqAwYMKAst9xyZbPNNitbb711dQ1AjALGN8mXbrvttnLvvfeWhx9+uDz33HNl6NCh5ZNPPikTTjhh6d+/f5l//vnLSiutVHbYYYey1FJLjdDPyfstscQSVS7W3hprrFFuvfXWUfC7AXqbUR2jBg0aVE477bQef46895lnnjkSvxN6q37Dhg0bNrY/BOO/b7/9thxxxBHlb3/7W/nwww+79ZoEw1lmmWW0fzagd/nTn/5UDjnkkG49tyeF9JNOOqn89re/rW4I1ll44YXLf/7zn7LKKqt0632BvkWMAsZVf//738vvf//78vXXX3f7NVtttVU59thjy0wzzdSjn7XnnnuW4447ruVjCunAmIpRCumMaka7MEruGG666abloIMO6nYRHWBkbtyNan/84x/LLrvs0mURPZ544omy7rrrVjtvANoTo4Bx1WuvvdajAlVcdNFFVeH73Xff7fZrbrzxxk6L6ABjO0bByLA3nZGSDQ3bbbddueaaa1o+Pv3005fZZput+vXbb79d3nzzTX/iwCg36aSTli+//HKEXnvVVVeVQw89tMP1CSaYoNo2+Pnnn5eXX355uMdybdttty2PP/54W4wDEKOA8U3GJMw+++xVEaqztVqaCPbff/9yyimndPl+H330Udl5551HwycF+qJRHaNi2WWX7fI5AwcO7PFnpW/Qkc5IOfroo6tZwu2luJ55Vgl2jz76aPX1xhtvlHfeeadceumlVXI1ySST+NMHemzqqacuq6++etlvv/3K2WefXZ5++ulOb+Z1JR0Pe+yxR8vE6bHHHqvmpL/00kvliiuuKJNNNtlwz8kOnF//+tf+BgExChivZARCdhPnjJmcD5OcJ2u1p556qtp118pZZ53Vrd3HyY2aGxCs+YBxKUZF81lbnX1lxzK0YkY6I+yLL76oDg9Np3mzgw8+WNABxqgcWLXWWmv1eEb6BRdcULbZZpsO1zO2Zf311x/u2u9+97ty+OGHD3cth46+8sorznsAxChgnJcdeJNPPnnZd999OzQINDcZLLPMMmXIkCEdHrvhhhs6LWJFGhs23njjtu9z2Oiiiy5azjnnnOGeZ0Y6MKZiVKsZ6Y6KZGToSGeEJSFqX0RfYIEFWo5IABgXtV/YNTog1ltvvQ7Xt99++w7Xvvnmm3L++eePts8H9G1iFDAqHXbYYeXAAw/stEAVE088cdlhhx1aPpbdxZ354IMPqvNmmt/n9NNP15EOjBMxCkYVhXRG2PXXX9/h2tZbb10eeOCBanRLZgvnbuKUU05Z5p133rLjjjuWa6+91p84MM4YPHhwh2tLL7106devX4friyyySBXT2rvnnntG2+cD+jYxChgbpplmmpbXZ5111k5fs/fee5fXX3+97ftDDjmkLLnkkqPl8wF924jEqGbrrLNOGTBgQHWjL++VsZ5bbbVVOf7448unn346ij8tvY1COiPsrrvu6nAt889XXHHFcvLJJ5dnn322Gv/y2Wefleeff76aWbXRRhtVQcuho8DYlh01Q4cO7XA9I6tamXDCCVsmZ4888sho+XxA3yZGAWPLvffe2/Jg98UXX7zl8y+77LJy5plntn2//PLLV12lAONCjGrv5ptvLm+99VY1Jubjjz+uxoFefPHF1dlZc845Z3UOF3RGIZ0R8t1335VXX321w/UcAtGdoLXmmmtWh0YAjC2dbf2bfvrpO33NDDPM0O33ARgZYhQwNuSg9fPOO6/liLtWOdK7775bdt9997bvM5Ih84hzjgzA2I5RPZU6VUbH/POf/xzp96J3UkhnhINLVwc05E5evjoLfjnRHWBs6exU93QzdKbVY5kJCjCqiVHAmJZdw1tuuWW1q7jZjDPOWP785z+3fM0vfvGL4XYb53kLL7zwaP+sQN8zIjGqVWNURnZm/HDdDb/999+/Zec7KKQzQtoHrmZzzDFHNSf95Zdfrr7y61xr74wzziivvfaavwFgnFJ3k9AJ78DYJkYBo0NGca6++upVw1OzKaaYolx++eVlttlm6/CaCy+8cLjO0FVXXVWzFDDOxKjGLpnMP89OmVdeeaXa8ZdJChlF/Pnnn5dTTjml5WuTb+XwU2hPIZ1RerhD5E7gMsss0/Z9ft3q7mDGw9xwww3+BoCxon///i2vf/XVV52+5ssvv+xwbdpppx2lnwsgxChgTEnX5corr1yefvrp4a5POeWU5corr6weay/zhffcc8/hnnvqqaeWCSZQYgDGfoxqOOaYY6qbfj/96U87NHimI33QoEHltttuqwry7d10001VsR2a+b8cI2TqqacuE088ccvH1l577Q7X1lprrZbPffHFF/0NAGNFtgC2klmfnWn1WGfvAzAyxChgTLjiiiuqtVoK4+3HH6SI1Nk67sQTTxzuLIcjjjiiGpUAMC7EqIbu3Nybb775yhZbbNGyiUrNivYU0hlhiy66aMvrM888c4drAwYM6HZ3J8CYMNNMM7XcxpeRVK18++23ZejQoR2uL7XUUqPl8wF9mxgFjG7p1My84c8++2y46wMHDix33313WXHFFTt97ddff91hVnq/fv06fGWcQnvp/mx+DsCojlE9Nffcc7e87jws2lNIZ4R1FrTa3ymM5gNouiq6A4zNOPbQQw+1nEGcWXqtzocYlQkcQFfxRYwCRlbynAMOOKAqfqdRoNlKK61UBg8eXBZYYAF/0ECfiVEvvfRSy+vTTz/9KP05jP8U0hlh22yzTcvrN998c4drt9xyS8vnKkABY9P222/f4Vq2KV9//fUdrp9zzjkdrmWu3tZbbz3aPh/Qt4lRwKiWHcGJLRnF0l4O5MtaLjtiAMb3GHXWWWdV89HrDmqPHDx6ySWXdLieGezzzDNPDz49fcFEY/sDMP7KLKpFFlmkPP7448NdP/jgg8sSSyxRll566bbOqf/7v//r8PoEJIV0YGzafPPNq0NnXn311eGu77XXXuWqq64qCy20UNtsvqOOOqplMjfLLLOMsc8L9C1iFDAqvf/++9Uc4Ntvv73DY/vtt1858sgjuz1qJePxll122S6fl/nC7c+YmWqqqcqCCy7Yg08O9AWjMkbFM888Uw477LCqe32nnXYqm222WbW+a7zHN998UxXbDzrooJaHim6yySZl0kknHcnfFb1Nv2Fd3ZqBGnfeeWdZY401ynfffdfhsTnnnLP67yuvvNLyteedd16nXe0AncnJ7H/4wx+Gu/bxxx93OMU9Fl988TLJJJMMdy1F8VlnnXW499t0001bHkwz//zzV0lVq7np/fv3r24ktpqzDvRdYhQwrtptt92qQ0LbS6FoscUW69br89UTgwYN6jAnPevHW2+9tUfvA/R+ozpGZc2YQnr7NVzWb1999VW1xmt/3kPzzxwyZEh1ECk005HOSFl11VWrLs199923w3aZzgroceCBByqiAyMko1ceeOCBbj330Ucf7fKQ43QaJMlqX5zPDcKnnnqq5ftOPvnk1c1ARXRAjALGFykctZLcqDu51euvvz4aPhXAmItRH374YfVVZ+KJJ67WeorotGJGOiNtn332KWeffXYZMGBAl8+dZpppygknnFD++te/+pMHxhmHHnpoFZumm266Lp+b7YA33HBD2WCDDcbIZwMQowAAeia7k3va+LTkkkuWu+66qxqvB63oSGeU2G677aquzjPOOKPa0pwtMG+//Xb12AwzzFAFo/XWW6/a2petNADjml133bWaeX7mmWdW89GfeOKJKo7lQNHcKMwc0CRUGUmVawBiFADAuClruy233LIMHjy4Gid13333VeNAhw4dWj755JNqlGfqUwMHDizLL7989fyMnoI6ZqQDAAAAAEANo10AAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIZ7V588cVy2GGHlS+++MKfNgDAaHDrrbeW4447zp8tMF7HrksvvbSce+65Y/UzAeO+MRkrUs968sknq19/8MEH1fdvvPHGGPnZjHsmGtsfgDHn008/Lbfcckt55plnql9PNtlkZZZZZimrr756mWuuuUbbz51zzjnLb37zmzLppJOOtp8B9F5JVOqsscYaZc011xxjnwfofQux3OzfbrvtyvgUF7fddtuy0EILtV1bZZVVygorrDBWPxcw7sSuf/3rX2WllVaqvtpLIejoo48u/fr1K/vuu2+ZZppp2h77+OOPy1FHHVWGDRtWfvWrX5Vpp52208/w3nvvlTvuuKM899xz5bPPPitTTz11mWOOOcrKK69cZptttlH0OwXGR+PCGi5x7MEHHywPPfRQeeutt8oEE0xQpp9++rLEEkuUZZddtkw88cSj9efTOymk9yHnn39++fbbb8sWW2xRpptuuqqY/vzzz5fPP/98tP7cCSecsEw11VSj9WcAvVduxDUMGTKk6lz65S9/2XZtkkkmGS5ZyleSJIC+JLGwOR4CdCWF70ceeaSsttpqbdfyfQrrH374Ye1rX3/99XL66aeXmWeeuWyyySZlxhlnLF999VXVtXn99deXQYMG+QuAPqwna7jR5ZJLLilPPPFE1Ty60UYblSmnnLLqJL/nnnuqm4TNDQnQXQrpfUS6FV5++eXys5/9rMwzzzzVtQSO2WeffbjnJOl56qmnyjfffFN1EWywwQZV13ok4Fx33XVV0hQzzDBDlTTleelquOaaa6qfkWJ93nu99dYr888/fzXa5bTTTisHHHBA1QUfjz/+eBVI08WQIns6qNJJ1dxBkTuEeTzPzesS/HIt8jPyWRIUcyMg75HHmpNAoHdovhHXiCGNa434sv3221c7bt58883yk5/8pFoAJp69+uqr1aJupplmKuuss04ZOHBg23slzuU1SexyYzGvWXXVVcsyyyxTPZ6uhRtuuKG89NJLVaI377zzVjFxiimmqB5PbLrtttuqOJVuhsTKdIUpZMH469RTTy0DBgwoE000UdXBlGaA5ZZbrq1j6qKLLqpu1v3oRz9qe01ykn/84x9VfFhyySWr2JLYkdjy5ZdftuVTzTlX4suNN95YxZdI/Nh8882rLqnXXnut3HzzzWXo0KHlu+++qx7L62eddda2HCnOO++86r/9+/evOkqTV6WAtccee1TX8zlvv/328sADD1SdoilyrbvuumW++eYbriN1m222Kffee28VL5Pb/eAHP6h2Ezae01l+B4z/ErMefvjh4dZQ+T7XEz86k/iSjvjErJ///OdVZ3tDYlbzSM/Ew8Smjz76qMrfFl988aoTNfG1O+Rb0PvWcF3lKJF13bXXXlvlJ1lrLbzwwlU+1N211mOPPVYeffTRDjv4ksssuOCCVY4WXeVdXUk9KrlSduZk3dlYUy699NLd/JNifKOQ3se6lJLEZLtdFojtXXDBBdX1HXbYoRrDkqCWLoO99967TD755OXiiy+ugkkWWEmWUlhvdH1effXV1QIrnQf5OW+//XanAS6F+AsvvLBKoBZbbLHyyiuvlKuuuqoqTi211FJtz/vvf/9b1lprrSqxSwKV58w999xVkM0dxBT8s5DNAjKJWVddE0DvddNNN1XFney2SbxKPEgitvbaa1cLtXRXnXPOOVUXRGJGZAGY+LPhhhtWCdP7779fJXKRBWAK9CmqJ5H6+uuvq6JX4mRuSGbbcwpqSfiS1CURS6EJGP8lXmQUwi677FIt3hIrUljOzbQUgBIHslBq5DlZOCVGNBZpKRrlRn92AGaxdtddd5Uzzzyz7LPPPlV8Ss6Sgn0aGxJPknMlfmTxFnnvFLHSOZWFZvKhs846q8rH8txdd921HHnkkVXhPXGuuYDVbPDgwdVr0/SQGJdtzYmDe+21V1Uwb8jiMfEz1/LrxLZ81uR4PcnvgPFPiklZ8yUGZdRn/pui0AILLFBbSM86MPHghz/8YcsY1CiaReJW4mG631MYu+KKK6pr3//+97v8fPIt6J26ylGSCyV3Sv6VvCdNT5dffnmVlySedEeK6HmvVl3niVuNONVV3tWVNGYlHqaOlppWmqySF9J7KaT3EVkMZcGVxCXJUgriKUqnkJ3OqyRNuRO3//77txXZ119//arwniJ2ur1TmErXeArZ0bwIy2MpJuW9IsWsuqD5ve99ryqkN94ngefuu+8erpCebqfll1+++nUSrbwu3af5+fl5eV0SvgTButl9QO+XbtEUuRpSrGrspokU1BPPcgMuO2Defffdqksh3euNLvXmuJXuzMTJdLE3JIZmZmhem4QrRa/EvUb8acQ/YPyWf8uNDvTkGokHL7zwQhVjUrhOITmF8iy6Ggu1FKOy2EpsuP/++6tFXqNre9NNN61G6aXDPfnMfffdVz13q622auvIbM6pkiM1y+sPP/zwqns9xa1sS44sAOtG52UhmJ+XXC9SLE8elXwqTRENmWWc9438vo855phqEdjIt7qb3wHjn8Sg3CBMESvrqvw3s4O76hZPjIjGurBOdhU3JGdKHpUdO90ppH/yySfyLeiFuspRkltlh1/yqcYN/I033rgqtqeRqTujgxNruhOjusq7upJcKevOxrkQalO9n0J6H7LIIotUgSABIR1Wzz77bNUltdlmm1ULv3wdccQRw70mwauRKGWhlUL8//73v6rwlPfLdr5YccUVq47xLBQTiPJYZ0WlFM2z4GyWO40JmilMNbrcM2+vIcXyBMvciYwU3M8444zy73//u1rU5vfVXEQD+pb2B1olnmXMQQ5XTjdTYkviWWPnSjqpEldyQ7GVdEylcPaXv/ylw2OJiYk3iXXHHntsFYMaMTEFfGD81px/RLooG/lHcpT8W88CL4X0xJrcoEtRPLKzJfGmMRolUpDKWJd33nmnLf4k9nRWqErhKJ3hydfyc/N+6Wzqyc677JJJ7Gv+HJHvE9+aNedrjYVpfm4Wnz3J74DxU8YPnHzyyVXzQBqodt5557YdMp1J12Z3pWieG5LJnxqNCN3p8ozEG/kW9C7dyVGSM6U43bwLLo8n9qRAPirP4BvZvCsjAHMeYUbDZI2YDvj2vzd6F4X0Pibd5vnHna90hGd7TIpN+cefYNTqUJjGlpd0KaVj4emnn66K8HldFo7pVMr4g7xnilbZ4nznnXdWHe1ZgI2oVgvMRtKWTtGcIp+fl8VdtlmnkJU5n0Df037UQOajJzakuyE3/DJXr3HgcrQab9UsC73c8EvHQ3uJlSmmpZs9o2ES87JATAKWURA6NmH8Vpd/RLo1M5oli638+088aZ7p2ZXEozoZJZPRChk7lVFUef+TTjqpLX6Nzt9vY0RD4/c7OvI7YNySYnVunGWsU/6bm4m54VensYsmxa66OcLJkzIeNOvIxMkU0FNYTzdqd8i3gBGVONVoYhideVd2IOasmkZtKuORM1kh+RK90/9v/aXPygF8KRglAcqduCQrKTo1fzUO1msEo3Smp4CUAnoOo2lI0ElBPoc55DnZwtzZz0xS1Szf570b3ejdkUQsW4HSUZ9Z6Y2DRwESU9It2hhJkOJ3Ds1ryLUUihoH/bWXDogcBpitee1jYqNon4JTtkHnLIfdd9+9KkZlfAzQu6XLKAdJpRiUzvR0aTeK0bmRll835zlZiGV8XvKfSJEqsaezBVpemxFUWZjluXm/xvkNDcmX6jpGkyOlk75VvtX4HN3V3fwOGH9lt2/GKnT3cLzkSYklKYi36k5vHDaamJNcKuNdsnsw672enmsl34LepTs5Sm7q5YZealXNjyceNI/Dq5NaUbrXW63PErea41RXeVdXMnYvcTTnRuR8rYxTpvfSkd5HJBCkazvJUQpIKQTl0M+MdknXZbq5szA899xz2w6cynabdJ+nEJWAlsOzslhMMpSDsrIozGOR05TTZZDXJSAlEetsoZZF2Iknnlhuu+22tsNG083ZPK+zK0naUhjLDYAE02xDzPfNB9sAfVcK3kmaGmOkcghM80IvcSzJzmWXXVYdLJO4mIVdOkwXXXTRKplKsSjdWTkbIiNbsiU5c9UzNy/xszEzOYlTxmU1TpwHer/s0MsiKQu0HBjakPwqRefkTIkbKUIn18oW4UaBKvEleU/iy6qrrlotKBNDMv4lMSTxK2P0UnTK9ue8V/tdNIlhiUG5mZcFX6uxUold2T2Y4n6KXml+yKI0i7zu6kl+B4x5iRHtu8cbsSeyZmv/eOOxZjkPK/lPd9dSWX/l7Jh0Xp5yyilltdVWq+JXY9xVujKz07lROM+Nx8S0dGz2pOkgsVG+Bb1PVzlKdv/l8XSLZ0dL1mjXXHNNdb27Y10S0xJvkm/lZl7WbWkSTbNUxgonH8sYlu7kXXWyzkxdKkX4jBJNnJMr9W4K6X1EFnZZoCVgpBiULqZ0U2XLbhKfJEPbb799NZoghaUEqgSozPBMkSidT+n2vuSSS6rHEoASdNKJGXm/nKCcZC0Lwiy6cieulQSZdJAnMOY0+NyNzPs0HzTand9PDifNAjafLUEvn7/VqfFA35P4k1iWbXmJVznMJolRs9y8u+mmm6r5v4lvWVimqBWJSzvttFO58cYbqxPjkxSlcJUELHEmcS4dpYmped88lu17jcMFgd5fSL/jjjuquNF+DmZGQuXGXXKmxIfkKDvuuGNbsTsxKcX3LNQyIiYxJYvIFMUjO+2uvPLKcsIJJ1S5WuYWZ1xVs8SbXMsNv8SrbCluL+NXUvzO85K7ZVH34x//uNudXD3N74AxLze3jj/++OGu5aZd4kij+aj9GJUtt9yyLd40ZD3VvAu5O7K23G233apYmHO00lCQ9WNiYiNOpKFhpZVWquJIduEkT0pBK+vA7pBvQe/UVY6SMXjJnXJDP02Y+T5NnD3JQZJfZRRxGh9ykHJiVWMCQ3YuN87Y607eVScNDVlTZvdzPmfia+PsHHqnfsN6clIIAAAAAAD0MWakAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUEMhHQAAAAAAaiikAwAAAABADYV0AAAAAACooZAOAAAAAAA1FNIBAAAAAKCGQjoAAAAAANRQSAcAAAAAgBoK6QAAAAAAUDr3/wAVaO3XgLO3dQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1500x150 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 13: Usage volume KPI cards\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  COUNT(*) AS sessions,\n",
+    "  COALESCE(SUM(trace_count), 0) AS traces,\n",
+    "  COALESCE(SUM(invocation_count), 0) AS invocations,\n",
+    "  COALESCE(SUM(llm_calls), 0) AS llm,\n",
+    "  COALESCE(SUM(tool_calls), 0) AS tools\n",
+    "FROM session_rollups\n",
+    "\"\"\")\n",
+    "kpi_row(\n",
+    "    [\"Sessions\", \"Traces\", \"Invocations\", \"LLM Calls\", \"Tool Calls\"],\n",
+    "    [df[\"sessions\"][0], df[\"traces\"][0], df[\"invocations\"][0],\n",
+    "     df[\"llm\"][0], df[\"tools\"][0]],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "cell-14-sessions-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:39.696560Z",
+     "iopub.status.busy": "2026-04-11T06:42:39.696441Z",
+     "iopub.status.idle": "2026-04-11T06:42:41.950269Z",
+     "shell.execute_reply": "2026-04-11T06:42:41.949828Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQJVJREFUeJzt3QecFPX9P/7PHQjYaApWrNhrYu8aW9SosddorIktKtHYYiEW1Bg1UaPGxJqoaFTs2JHYYu+xk2giCirNAvqF/T3e8//PPvaOu+PugFnYez4fj4W93dmZz8zOzt289v35TF2pVColAAAAAChQfZELAwAAAIAglAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlALoQM4444xUV1eX3a699tpqN4dm/Pvf/y6/T5tuuuksu51KpVJaZZVVsnYecsghbX79T3/60/J6Dhs2LBUh9vt8mfF5KFI11nd2PD7kbVhiiSWq1gaY3cTxeLnllss+O0cccUS1mwPQakIpgBngv//9b3ZSHidRXbp0ST169Ej9+/dP22+/ffrNb35jG88A//jHP9Kee+6Z+vXrl7p27Zp69uyZ1l577XT22Wen8ePHz9LbOIKl/ER7WrfZKSwcPHhwev3117P7xxxzTOroIkyMYCduQ4YMqXZzaCQ+W/n7M3bs2OnePo8//ng6+uij05prrpkWXHDB7Ni/0EILpT322CO9+uqrTb7mhRdeSDvuuGOab775Urdu3dKKK66YBg0alL799tsG07300kvpxBNPTOuvv35aZJFFsnn36dMn+50Sx8Lm3H333emHP/xhNv84Ti666KLZa4YPH97q9Zo0aVI655xzsrZFG2NeP/7xj9OLL77Y4uueeeaZ1KlTp/KxLI7XbdGW5Z577rnZcXXhhRfO1nPOOefMApkjjzwy+33cWvG744QTTkhLL710Np8FFlgg7bvvvun9999vNrBt7hahc2u99957aZ999smWF8uN5Uc7mvpdNmXKlHT55Zen733ve2muuebK/r7YYost0iOPPNJgumhD7I/hz3/+c/roo49a3R6AqioBMF1GjhxZWmihhUpxSG3q1qlTp1lmC//nP/8p/eMf/8hun376aWl2cdxxxzW7feO22GKLld54443SrGqTTTZpsf2Vt2uuuaY0ceLE8vv06quvlmZVa6yxRtbmddddt12vf+edd8rrOXbs2FIRYvvm2/r000+fofN+7LHHyvPef//9Z4n1bYvYHpX7YbXkbVh88cVn2udwxIgR0z2/rbfeutnPcbdu3UpPPfVUg+kfeOCBUpcuXZqcfquttir93//9X3nan/3sZ83Ou76+vnTbbbdN1Z5f/vKXzb7mzDPPbNU6fffdd6XNN9+8yXl07dq19PDDDzf5ukmTJpVWWmmlBtPvsccerd6WbV3u0ksv3ey6xu/jzz77bJrLHDduXGnVVVdtch69evVqcOyt/Gw0dzv44INbta4vv/xyqUePHk3OY/XVVy+NHz++wfRxLGlq2rq6utJ1113XYNp4bWyveD72B4DZgUopgOl0ySWXpJEjR2b3N99883T77benBx98MP3pT39KBx98cOrVq9css40XW2yxtOGGG2a3vn37ptnBZZddli644ILsfnwL/8tf/jI99NBD6W9/+1vWdSx8+OGHWTXAl19+WbV2xrfZEydObHYfieqG/Lb66quXnzv55JMbPLfttttm35zn71O+jrOa1157Lav6CLvssku75rHMMsuU1zO+/a91HW19O4Kllloqq+6JY35Up0SlVIhjQVQ65b755pt0wAEHlCuifv3rX6fbbrstrbzyytnP8forrriiwbyj+uqUU05J999/f7rxxhuzSqD8WDNgwICpqhZ/97vfZfejsurCCy9MDzzwQLaM0047LavcbY0//vGP5QqcaFu8PtqaVzJFNVD831hUe73xxhtZhVN7tHW58Rk6//zzs4rE+H1w1llnpTnmmCN7Ln4f//3vf5/mMqP6Ka9o23jjjbN5/exnP8t+HjNmTDrooIPK0x544IENjtP5rbKLaVR1tUbsB+PGjcvuH3rooenOO+/Mlh9efvnlBtXVd911V7ruuuuy+1EVdvPNN6eLLroode7cOeuuF930Pv300/L08847b1ZFFeJ35P/93/+1qk0AVVXtVAxgdvfDH/6w/M1lU1UtX3311VSPjRo1qnTssceW+vfvn31z3rNnz9K2225bevrpp6ea9oorrsgqUuaee+5s2oUXXjj7Rvm8884rTzN58uTSWWedlX1THd/Qxzel/fr1y+b55z//uVWVEC+88EJp1113LS2wwAKlOeaYI/t/l112KT3//PMtVprccMMN2XKjbcsss0xp8ODBDaaPb6zjW/+oZor5zjPPPNl0e+65Z2nYsGEtbttvvvmm1KdPn/LyzjjjjAbPf/HFF9k32vnzv/vd77LHt99++/JjL774YoPXHHLIIeXn7r333vLjr7zyStamBRdcMGtnbOeDDjqo9NFHHzV4feU2/Mtf/pJVIMS6RfVCVMq0tWKjqYqUqOLIn49pm1p2vK+xPaK98847b9b2MWPGlD7//PPSvvvuW+revXu2bWLbx3ZsbMiQIdl+FPtevHfLLrtsNr+vv/66VeswcODAclti21WKeUR1W75/zzXXXKUllliitNNOO5Vuv/32JisAKrddZaVMVBfF+xn7f3PrE/vYfvvtl61zVCD85Cc/KY0ePbrJipuWKqU++OCDrNoh3s9od+x7u+++e+nNN9+crmq4vGqqNesb23KjjTYqzTnnnKXllluudOutt2bTxP8rrrhi1q6o7njkkUem67jSlMbHh0svvTSrSInjyfe///3Sgw8+2KrKo5aOM7EtYzvk23j++ecvbbbZZg0qYZp63+L5vMqod+/e5X1uwoQJ2fLyY198FqJd9913X5MVbE3d8rY39/40J96DqPBp/LnK5xHvYS6Oi/njUWGVi/cmf3zllVcuPx7VdI1/d0SFTWW7K6tdY9+Ix2IbxGemvVZYYYXy/Cv3m8qqsL///e8NXhNVqvHexPr++te/blelVHuW29iOO+5Ynva3v/1ti9NGZVd8PvKKo48//jh7fMqUKaXll1++PJ/Gv/8a/87Mp1tyySWz38PTOob/85//LD8e6xzLC7H8aEdepfXtt99mj2+zzTbl6W+66aYmK+kuuOCCBu26+OKLy88NHz68xe0AMCsQSgFMp9122638B+AOO+yQnUzEH7wtdaFbdNFFmzw5ijDkzjvvLE97/fXXN3sitcgii5Sn+81vftPsdBtssME0TxZjmbHs1rSp8qR+qaWWmmr6CGfeeuut8vQ/+MEPmm3bKaec0uK2jRPRfNo46YnApaUuK3EyH26++ebyYyeffHJ52ugek4dcffv2LZ9Qxgls3uWh8S1CnwgrmtqGjde/yFCqqe4rEZCuvfba09zOp556arPvSWzDlvbfXHQ3yk+CG5+YH3jggc3Of5999ilPN62QJkKm+eabr8X1iZO3Nddcc6ppVltttTaFUnGCmZ+kNr5FkBonk619T9sbSsXyG69vnKhWnujntwhfIpRtz3GlOZX7V1PdmmI+lSe5bQ2lhg4dmgUXTbWx8r1o/L5FMBDrG49F6JgHBdEFcpVVVml2u1922WUzNZRqSgQ0+TwicMsdddRR5ccj0M3FZ6fy2Fv5njYWIVVluyOQC++//375se9973tZ8B6/H+KzGceDu+66q1Vtj+Nr5Xtd2Z2wMoQ++uijy49HELPeeuuVg6DKz1drQ6n2LLdxCB7vV+UXGC2FSU0FSpUOOOCA8nMXXXRRs/OoPM6df/75rTqGxxcn+eOxnErRjvy5l156KQus4hiYPxaf8Vx028sfjzCuUnxG8+cGDRrU4nYAmBXovgcwnfJS+bzUfqONNspK6KN7QXSn+OqrrxpMf/jhh5cHYt1vv/3S0KFDs0FM55lnnvTdd99l3QTy10RZf4hS/ejaEd0boiQ/urAtueSS5Xnm08Xg33/961/Tww8/nK6//vr085//vNydpDmxrOimEMsOhx12WLrvvvuydoZ4PJ5vvB7hgw8+yJ675557sq6LedeS6MYSJkyYkB577LHsfgzSGtsnuqLEukSXr7nnnrvFtr355psNuh727t17qmkqu8Ll0++www7ZexCiG0jlwMSjR4/O7sdgxLFdv/7667T//vtnXUPi5xg4PbrS/OpXv8qm++STT8rboqn1j8Fq77333mx7R7eZIgfVju4r0W0nX9fYl2IbxPaPfSp35ZVXlu8/99xz6cwzz8zux77xl7/8JXvddtttlz0WXVKie8i0/Otf/8r+X3zxxbPtVinfH+O56EYT2zOWE/t7W7qzxqC/MbhzvId5mxuvzzXXXJOef/757H7MO9b9lltuKXePaY3IQWIfyAe/js9XtPm8887LuoxGt9DocvP/5SWp2S6af/jDH8o/b7PNNuUuPtEFqzVi+dHFLz4n+SDRsczomhSDY8fnLI4r+WcrunS157jSGtEVK7oRxTK33nrr7LGYT3sHtI/PWbQrurGFOE7GvhvrGl3RmjsWvPvuu9m2jPWNdYlj0xprrJE9F9s1upGG6Paafw6j21s49thjs8Ge49jTuNvsrbfeWn5/pnWMbIvK4020u/LzmovBrXPx2ak8rlVO19K8Y/vF9mh8nIwB0q+66qr0v//9L+tC+Oyzz2b7TvxemJbKZccg47Hv5yq7e48YMaJB9+qnn346e09ie7dHe5YbYh+Pwb1j8O/NNtssO7bHe3/11VeX95HWLLPy/ZjWMnPRve+mm27K7keXxfh8tUZblhvLqBz4vHL6ltpY2VWzct8AmFU1/CsSgDaLUCaubBRhUS7GDXnyySezW5wYRhAQJ8xffPFFdlIV4o/nuGJfPobGlltume644470+eefZ39sR2iTj5ERV16KPzTjKk/du3dPe++9d4M25NPFiV1cxWfVVVfN/lD/yU9+Ms32x8n3Z599lt2PP+RjbI/8hOqf//xnNm5QPB/jdjQeM2O11VYrB1Dzzz9/eUyQuLJQfsIVJw1xYh3PxzrESXc8no/d0ZLKP8gjnGhK5eN5EBFXYtp5552zsTjefvvt7MQ1xmaqHGckwqR8/fOgKt6DfGyPGKMqwo04iYixWWIbxDpU2mCDDVp1sjczRKh2/PHHZ/fjRDxOyEOcGOZjoVx66aVZuBBtj20T4xhV7qcRtCy77LLZ/Qgw83nEOsWVoFqS7zNNhUz5/hghaeyPK6ywQjZOVmtP3CrFiV+ECfF+RtvfeuutButTeZW7CFHydY/PSVyFrDVeeeWV8lUEY1n5fh5XPosrPMZJd5zcxVXAmjvZjf0rPruVJ415gNQW8V7GZySCkhg/JsRn+YYbbsjCxwh1nnjiiQafs7YeV1ojQrFTTz01ux/rEePZRLAU2yCCnrgKZlvE52zUqFHZ/QjU43gS+0T+WWtKhIERiMXnMz7TEZDFe5KH33koF8fHCLZifvG+x74Sx7E4DsdnOELGxuN4xbG0cjyg/Op803P1y3gPIkAMETRVBqmVgWC0t1Llz80Fh3EcPuqoo7L7sZ6VwXHjKwnGFyVxHIjjVgSlcfyN7RPHjPhs5vtPpbXWWqvNbYyx/GJMvDieR+hcGSY1ZUYttyWxfrFvTMv0LjPC8Dxgjc9KhGmVYt9qKsRuy3IbL7vy+ZbaWHlMzo/TALMyoRTAdIo/xOMkPk4Y4tv3Rx99NDvJzf8wjktL//a3v80Gw42TyPwP1ajAiW+7W6pCidAgqgniZDCvyIpLfG+yySZZxUKcWIU4EY/Lcce34+utt14WBMUAvFG9FCdkefDQlHfeead8f5111mnwXJyQ54NZV06Xi3bkKv8oz0+S4kRyr732ysKEOAmNS33HScNKK62UnYhG21oa8DlOMHN5cNRY5eOV84rLeucDxEYYFcuMk/MQ4Vi+rpXrFVVccWss3rMIQxqHDD/60Y9StcR7k6ustMj3iVAZosV7Etuncn1jn4xbY7GurdXUiVfsj1FxFp+DqFKJz0jsgxESRZDW2sqUeP8rq1sa72OxPlGt1tT+G5+D1qrcJjHQcEufy2lVYEyPCPEikGr8nsYA13k1XOP3NLT1uNIaldsytnO0IapwQmzztoZSlds4jmV5INWSCNLyoO/iiy9ucLyJk+2oJAkRPlVWrLZ3nadHVDHFlwXRlqhgigAtKgVzlZVgjQcKzwc/bzxdZZgTlYwR0kcAFEFt5X7YeFtGIBf7UXyxEO2K3wtxnIxBveN1Te0fUW3T1jbGQO4RHJ500knZFxTTMqOWm1t33XWzSrfYLvEFSlQ2RmAaFxiJqqKWjs/T837EZ61yUPoYbLy12rLcxsuO6fOB5FtqY0sVnQCzIt33AGaQOImLq8RFJcHHH3+cfVufi8faIv/mc6uttsqqraLyIU7uo2IiuuhEyBMnaPkJefwRHmFKVEZFdUR8ixphWFwBMKZr/E16a0W41ZLKb2Qru3BV/lEc3yhHd6voUhdVM5MnT85O/KOKIL65b0mEWLn4Vj4/Ca0UwUdT0//gBz/IqjvyUCpO7OKEvbJKqi2a+sa8cfeLIlUGcPX19U0Gee09UYkrNjV1ha1KeTjS1HsS722cOO+2225ZmBH7UYQDUd0R+3RrrwjVuAqruX2stfvr9GpL97dZ7T2d3vY3tW0rH4vP9YyuzqisvDn33HMbXGVsVnnPQoTfcSyLoCCCxagKaxyKVlZlVa5HfBYqK+waV2/FvKJaLIKXCJ/iWLbTTjs1mCa6NlfKw7B4fyrDw8rK06ZULjvaVPk5zY+dIe86Hr/n8ivvxbLiFl+k5OILlXissppxRiw3F9s6viiIrpsDBw5sUN1Z2bV1WstsvF+1tMwQX7BEt9L8y4HKLwKmpS3LjeNf5We/cvqW2lh5TG5c3QswKxJKAUyn6LoX3xY3DitijJrGJ2xRoZOfyEVAE398//8XnSjf4sQmvyR0/BwnNxEuRbAV46rkl/2O6qnojpNPF1Uo0fUnuqpFe/KxX+KP16eeeqrZ9ldWUcX4I5Uqf26p2qolESTkl72Oio74gznvghMnXC2dNEb3uPyP6tgu0R2tUoRtMX5IrrJ7YZzU5+PyRNervFtNXkXV1HrFe9b4/YhbtDEfV6fIEGRmqFzfCAybW99pVbJEl7zwn//8p8mQKbZ9dJ2KqqvYb3fdddfs8egm11TVXXvF5ygX3WRz0eWuPdskQtzmtsm0upxWBkmt6UI0o7T1uNIalZ/96CoZ3WBzUYXZOETLT5JjveOkvaVtHGPeVVZ6NCeqQvNxiqKiJqqF8uNFHBfy0DIqk2Ifa7zOcdyNfXxmvj8xplIEMbGs6LI5bNiwJqv0KqssK4/Hsc/mn5/4QqEyiI3KzqgojWN9VMNE99oYH6qxqFKqrJaJAD/ENsjHGQt5QNXU/h1hSVTn5Z/raFNzn6fmKvGmZUYtN+8219LxeFpfxMS2zvffOIZFNVnexqg6bmld8y7uba2SarwfxLrlwXIsP3/fYh+Iyt5Yn/gd2NR+09L7kXfrbfxFDcCsSvc9gOkUgVGcLERVSJzQRnVOfKNZ2S0qxs0I8cd3dKmIsUeikimqh6KrU3TNiT+Mo3vM7bffnv3BGX+s/+IXv0gjR47MxoWJE4oIeKK7Qi6vZokT/phH/HEaJ3Lxh30++HPldE2JypXoFhXfUMdrjjzyyOzkL9qYzyNOAKMN7REnyTGOTZw4xbaJcWXygVnjD/JoW3ODHEdXhdNOOy3bDiG+DY+Tz2hzdEeJ6okYTyfE9orwq1KETxdeeGF2Pz9Rjoq2yoFgY71iXKqYX4R68R7FY3GSGeNJRaVaVGPVyoCx0cXo97//fXY/Tvhj+8UYZHESF/tkBIVRaVEZ9jUlTpZi2nj/Ytyqyu478VxU9kUVQQz+Hu9Z5fabVhVWW0QQmY+nFPtKdBmN/WlaY2JVirbHSWoEZjEYfgzIHZ/n6Goa+0AENBEQNFUVVqkyUIjKvKhejM9lBDKVAxPPaG09rrRGVLotv/zy2fsYYXAeBsXPebhR+TmK7stRsRnd1poKHeMzG9sg//zHz3Gsic94bKs4BuVjpFWK6tM4yb777ruzrsTxvsTg6HEsjK7BERBECB/zi+NEHKsiiIn3MtY59uNNN910qvcnBgOPCpvYX/JKl5/+9KflLr9xgYb8dc2Jyr8YqylEiBsVQ7GvV46dlIcQES7F8S+qi+JzE4O0R1e62GdzMa5bLrqCx/rFcSjCidNPPz1bRuW84/dKPBbbMKpk8y5lEZTElxKxnDyUin288v1qTrTh6KOPzu5HhW4EmfGFSMwrxO+XvFtcvH+NxxmMz0o+AHjsK/FZivHWZuRyowIrunPG9ol9NNY/776X+/73v9/i8qKaOMa4i/cwfg/FvI477rjsd3kewMZ+0bi7bgRHsY+H2Neaq/aN40ZewRR/F0RYGeKYGNslPpOxnAi6Y73iy6Y8oIrPbj4uX2yXvEt5dHePfSEC4BjDKw9kK79kCXk321AZagHMsqp9+T+A2V1c4r6ly40vuOCCpZEjR7bq0u2NL1F+0EEHNTtNXFo9LgUeNt9882anW2CBBbJLp7d0qfYhQ4Y0uCx5S5eTr7zkd+Vl3Ju7BHanTp2abdvWW2/dqm18zDHHtLi9+vXrV3rttdeafO0KK6zQYNo//OEPU01z7733lrp27drs/PNL07e0Ddsitk9L82huWza37OYuZV+5nHyfCqeeemqL2zPmNy2xvfPpL7jgggbPLb300s3Oe8UVVyxf8r25dje13Ztbn2+//ba05pprTrWcVVddtcn5NLf/xiXie/bs2eJ2mZbvvvsu+7w3fl3+XrVlfZvbB+J1Tb1PbTmuNKdy/1pmmWWmen3nzp0btPvNN98s1dfXTzXd8ssv3+R+et999zX7Oat8Lxpvjy+//LK0+uqrlx8/8MADs8fHjBlTWmWVVVpc58r2XnLJJS1+tpt7f5pTuT+2Zp954IEHSl26dGlyuq222qr8uWjclta8n59//nlpueWWa3K6eeaZp/Tss8+WWiP24eZ+n8R79/DDD7f4+srP1x577NGqZbZ1uZXLaOoW+98XX3wxzWWOGzeuwXGi8hbHgldffXWq15x88snlaU444YRm593c5ze89NJLpR49ejS53NjPx48f32D65vaFurq60nXXXTfVsrfbbrvs+TgWVe5TALMq3fcAplN8g33++edn39RHVVBUacS3sHH/sMMOy6qN8kuU5+N/xDeZURWQf8sbFQ1xP75VjiqAvBIhxj6KLmUxLk90NYgxVqLaIL6djoqpvBtNXA4+vrGNZcY3p1FFEBUq8fr4Zr2lwcRDdAmJKoqouIr5x+ujeijGxYouA1F50V5RMRZd3+Kb7vhWP26xPrH+UQ3QGvFtdnzTHFUSsV7xLXJss/gWO8YvigF8o9KlKZXfIsd65V36KkXFRLxPUW0Q7Yz5x7fgMch2VEK0tp2zi6hCiG/7o8tnVKjE+sZ2jaqOqD6LirRpie2dV5hERUqlGPg49qmouIpx0GL+UaET3/rHhQCmdZWutoh5RzfWeO9i/JW4RdVDDPCcizZMS1RWxFhn0cb4XMVnOMasifWMx/IrS7Yk9q/4/MZ2zAcmL0pbjiutEe9hHNfifYttEdUdsc9UVg9Fl6sY3y4qcGKa2FbRZbO56pGo5opqp8rPWex/Mc+WuoTFMTWWnY8RF9VPUWEU708ct+IYEJVAUfUU73UM8h3HsqjYicGwc1GVEhV0sa0qu/IVJX5HxPE0qqaiaiuOhbEN4xgZlWDT87mIarmYd1RIxecutm0cw+N4F93h8mrd1uzDUS0UFyqIfSfaGPOO3wEx/7h4xszQluXGexpVsXl3x9husS9EFWxsy6jWauqqoI3FsSJ+j8ZnJqqaYh+O339RTRrbrHGFV3Q5zSuUYv+prGxri/i9EvOP5cTyYrmx/F/96ldZpWbjY0fs79FNNF4Xn+tod2yPqP6Nz3alqNSL7rH5774ZeawFmFnqIpmaaXMHAGpWdKPJQ77owlet8UviT5nG43tFUBUhSIgT2xjTDKCWRXfW6L4ZoV4Mxt7Wq2QCVINKKQCgXXbfffdyhVpUs1VLVBNecsklWaVTjKEU4z9VVjFM6yqPALO7COfz8QJjfDeBFDC7UCkFAMzWovtXdHtpSgRS0Y1rdrxSIgBArXP1PQBgthZjSMUVJ+NqVnEVwRiTJcYYiqupxZgrAikAgFmTSikAAAAACmdMKQAAAAAKJ5QCAAAAoHCz9ZhSU6ZMSR9//HE2doTxIgAAAABmjauCTpgwIS288MKpvr6+NkOpCKRc7hQAAABg1vPRRx+lRRddtDZDqaiQyleye/fu1W4OAAAAQIc3fvz4rIgoz21qMpTKu+xFICWUAgAAAJh1TGuoJQOdAwAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAHS+U+t///pf23XffNN9886U555wzrbLKKun555+vdrMAAAAAmIk6pyoaM2ZM2mCDDdJmm22W7r///tSnT5/07rvvpl69elWzWQAAAADUcih13nnnpX79+qVrrrmm/NiSSy5ZzSYBAAAAUOvd9+6666605pprpt122y317ds3fe9730tXXXVVNZsEAAAAQK1XSn3wwQfp8ssvTwMGDEgnn3xyeu6559IvfvGL1KVLl7T//vtPNf2kSZOyW278+PHZ/1OmTMluAAAAAFRXazOaulKpVEpVEuFTVEo99dRT5ccilIpw6umnn55q+jPOOCMNHDhwqsffeeedNO+886ZacNB1z1W7CQAAAEAV/GX/tWpiu0+YMCEtu+yyady4cal79+6zZqXUQgstlFZcccUGj62wwgrptttua3L6k046KauqqqyUijGpYoD0llZydvKvMXXVbgIAAABQBX379q2J7d6tW7dWTVfVUCquvPf2229PVfW0+OKLNzl9165ds1tj9fX12a0WTElCKQAAAOiI6msk22jtelR1bY899tj0zDPPpHPOOSe999576cYbb0x/+tOf0hFHHFHNZgEAAAAwk1U1lFprrbXSHXfckW666aa08sorpzPPPDNdfPHFaZ999qlmswAAAACYyarafS/86Ec/ym4AAAAAdBy10VkRAAAAgNmKUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAAOhYodQZZ5yR6urqGtyWX375ajYJAAAAgAJ0TlW20korpYcffrj8c+fOVW8SAAAAADNZ1ROgCKEWXHDBajcDAAAAgI4USr377rtp4YUXTt26dUvrrbdeGjRoUFpsscWanHbSpEnZLTd+/Pjs/ylTpmS3WlCfStVuAgAAAFAFU2ok22jtelQ1lFpnnXXStddem5Zbbrk0cuTINHDgwLTRRhul119/Pc0777xTTR+BVUzT2OjRo9PEiRNTLVihl1AKAAAAOqJRo0alWjBhwoRWTVdXKpVmmRRk7NixafHFF08XXnhhOuigg1pVKdWvX780ZsyY1L1791QL+p98X7WbAAAAAFTBe+dsWxPbPfKaXr16pXHjxrWY11S9+16lnj17pmWXXTa99957TT7ftWvX7NZYfX19dqsFU1JdtZsAAAAAVEF9jWQbrV2PWWptv/zyy/T++++nhRZaqNpNAQAAAGAmqmooddxxx6XHH388/fvf/05PPfVU2mmnnVKnTp3SXnvtVc1mAQAAADCTVbX73n//+98sgPr8889Tnz590oYbbpieeeaZ7D4AAAAAtauqodTNN99czcUDAAAAUCWz1JhSAAAAAHQMQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAAOm4ode6556a6urp0zDHHVLspAAAAAHSEUOq5555LV155ZVp11VWr3RQAAAAAOkIo9eWXX6Z99tknXXXVValXr17Vbg4AAAAAHSGUOuKII9J2222Xtthii2o3BQAAAICCdE5VdPPNN6cXX3wx677XGpMmTcpuufHjx2f/T5kyJbvVgvpUqnYTAAAAgCqYUiPZRmvXo2qh1EcffZSOPvro9NBDD6Vu3bq16jWDBg1KAwcOnOrx0aNHp4kTJ6ZasEIvoRQAAAB0RKNGjUq1YMKECa2arq5UKlUlBRkyZEjaaaedUqdOncqPTZ48ObsCX319fVYRVflcc5VS/fr1S2PGjEndu3dPtaD/yfdVuwkAAABAFbx3zrY1sd0jr4lxw8eNG9diXlO1SqnNN988vfbaaw0eO+CAA9Lyyy+fTjjhhKkCqdC1a9fs1liEWHGrBVNSXbWbAAAAAFRBfY1kG61dj6qFUvPOO29aeeWVGzw299xzp/nmm2+qxwEAAACoLbURwQEAAAAwW6nq1fcaGzZsWLWbAAAAAEABVEoBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAMPuGUmPHjp1RswIAAACgxrUrlDrvvPPS4MGDyz/vvvvuab755kuLLLJIeuWVV2Zk+wAAAACoQe0Kpa644orUr1+/7P5DDz2U3e6///60zTbbpOOPP35GtxEAAACAGtO5PS/65JNPyqHUPffck1VKbbXVVmmJJZZI66yzzoxuIwAAAAA1pl2VUr169UofffRRdn/o0KFpiy22yO6XSqU0efLkGdtCAAAAAGpOuyqldt5557T33nunZZZZJn3++edZt73w0ksvpf79+8/oNgIAAABQY9oVSl100UVZV72oljr//PPTPPPMkz0+cuTIdPjhh8/oNgIAAABQY9oVSs0xxxzpuOOOm+rxY489dka0CQAAAIAa165QKrz77rvpscceS6NGjUpTpkxp8Nxpp502I9oGAAAAQI1qVyh11VVXpcMOOyzNP//8acEFF0x1dXXl5+K+UAoAAACAGR5KnXXWWenss89OJ5xwQnteDgAAAEAHV9+eF40ZMybttttuM741AAAAAHQI7QqlIpB68MEHZ3xrAAAAAOgQ2tV9r3///unUU09NzzzzTFpllVWyq/FV+sUvfjGj2gcAAABADaorlUqltr5oySWXbH6GdXXpgw8+SEUYP3586tGjRxo3blzq3r17qgVLnHhvtZsAAAAAVMG/z92uJrZ7a/OadlVKjRgxYnraBgAAAEAH164xpSpFoVU7iq0AAAAA6MDaHUpdf/312XhSc845Z3ZbddVV0w033DBjWwcAAABATWpX970LL7wwG+j8yCOPTBtssEH22BNPPJF+/vOfp88++ywde+yxM7qdAAAAAHT0UOqSSy5Jl19+edpvv/3Kj+2www5ppZVWSmeccYZQCgAAAIAZ331v5MiRaf3115/q8XgsngMAAACAGR5K9e/fP91yyy1TPT548OC0zDLLtGeWAAAAAHQg7eq+N3DgwLTHHnuk4cOHl8eUevLJJ9MjjzzSZFgFAAAAANNdKbXLLrukf/7zn2n++edPQ4YMyW5x/9lnn0077bRTe2YJAAAAQAfSrkqpsMYaa6S//vWvM7Y1AAAAAHQIrQ6lxo8fn7p3716+35J8OgAAAACYrlCqV69e2ZX1+vbtm3r27Jnq6uqmmqZUKmWPT548ubWzBQAAAKADanUo9eijj6bevXtn9x977LGZ2SYAAAAAalyrQ6lNNtmkyfsAAAAAUMjV94YOHZqeeOKJ8s+XXXZZWn311dPee++dxowZ055ZAgAAANCBtCuUOv7448uDnb/22mtpwIABadttt00jRozI7gMAAADADOm+VynCpxVXXDG7f9ttt6Xtt98+nXPOOenFF1/MwikAAAAAmOGVUl26dElff/11dv/hhx9OW221VXY/BkLPK6ha4/LLL0+rrrpq6t69e3Zbb7310v3339+eJgEAAABQ65VSG264YdZNb4MNNkjPPvtsGjx4cPb4O++8kxZddNFWzyemPffcc9MyyyyTSqVSuu6669KOO+6YXnrppbTSSiu1p2kAAAAA1Gql1KWXXpo6d+6c/v73v2fVTossskj2eFQ5/fCHP2z1fKLbX3T3i1Bq2WWXTWeffXaaZ5550jPPPNOeZgEAAABQy5VSiy22WLrnnnumevyiiy5qd0MmT56cbr311vTVV19l3fiaMmnSpOyWy7sKTpkyJbvVgvpUqnYTAAAAgCqYUiPZRmvXo12hVAxoPsccc6RVVlkl+/nOO+9M11xzTTb4+RlnnJGNOdVacfW+CKEmTpyYVUndcccd5UHUGxs0aFAaOHDgVI+PHj06e30tWKGXUAoAAAA6olGjRqVaMGHChFZNV1eKwZzaaK211konnnhi2mWXXdIHH3yQjf+00047peeeey5tt9126eKLL271vL799tv04YcfpnHjxmXdAf/85z+nxx9/vMlgqqlKqX79+qUxY8ZkA6XXgv4n31ftJgAAAABV8N4529bEdo+8plevXlnW01Je065KqRjQfPXVV8/uR5e7jTfeON14443pySefTHvuuWebQqmoqurfv392f4011siCrd///vfpyiuvnGrarl27ZrfG6uvrs1stmJLqqt0EAAAAoArqayTbaO16tGtto7gq7x/48MMPZ4OVh6ha+uyzz9L0iPlWVkMBAAAAUHvaVSm15pprprPOOittscUWWVe7uAJfGDFiRFpggQVaPZ+TTjopbbPNNtnA6dHfMKqthg0blh544IH2NAsAAACAWg6lonvePvvsk4YMGZJOOeWUcve7GBNq/fXXb9MAXvvtt18aOXJk6tGjR1p11VWzQGrLLbdsT7MAAAAAmE20a6Dz5sQV8Dp16pRdma+ogbMizJrWwFmzkyVOvLfaTQAAAACq4N/nblcT2721eU27R9AaO3ZsdqW86IL3xRdfZI+9+eabNXP5QgAAAABmse57r776atp8881Tz54907///e90yCGHpN69e6fbb789ffjhh+n666+f8S0FAAAAoGa0q1JqwIAB6YADDkjvvvtu6tatW/nxuArf8OHDZ2T7AAAAAKhB7QqlnnvuufSzn/1sqscXWWSR9Mknn8yIdgEAAABQw9oVSnXt2jUbtKqxd955J/Xp02dGtAsAAACAGtauUGqHHXZIv/nNb9J3332X/VxXV5eNJXXCCSekXXbZZUa3EQAAAIAa065Q6ne/+1368ssvU9++fdM333yTNtlkk7T00kuneeaZJ5199tkzvpUAAAAA1JR2XX2vR48e6aGHHkpPPPFEdiW+CKjWWGON7Ip8AAAAADBDK6WefvrpdM8995R/3nDDDdPcc8+d/vjHP6a99torHXrooWnSpEltmSUAAAAAHVCbQqkYR+qNN94o//zaa6+lQw45JG255ZbpxBNPTHfffXcaNGjQzGgnAAAAAB01lHr55ZcbdNG7+eab09prr52uuuqqNGDAgPSHP/wh3XLLLTOjnQAAAAB01FBqzJgxaYEFFij//Pjjj6dtttmm/PNaa62VPvrooxnbQgAAAAA6digVgdSIESOy+99++2168cUX07rrrlt+fsKECWmOOeaY8a0EAAAAoOOGUttuu202dtQ//vGPdNJJJ6W55porbbTRRuXn40p8Sy+99MxoJwAAAAA1pHNbJj7zzDPTzjvvnDbZZJM0zzzzpOuuuy516dKl/PzVV1+dttpqq5nRTgAAAAA6aig1//zzp+HDh6dx48ZloVSnTp0aPH/rrbdmjwMAAADADAulcj169Gjy8d69e7dndgAAAAB0MG0aUwoAAAAAZgShFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAA0LFCqUGDBqW11lorzTvvvKlv377pxz/+cXr77ber2SQAAAAAaj2Uevzxx9MRRxyRnnnmmfTQQw+l7777Lm211Vbpq6++qmazAAAAAJjJOqcqGjp0aIOfr7322qxi6oUXXkgbb7xx1doFAAAAQA2HUo2NGzcu+793795NPj9p0qTslhs/fnz2/5QpU7JbLahPpWo3AQAAAKiCKTWSbbR2PTrPSg0+5phj0gYbbJBWXnnlZsegGjhw4FSPjx49Ok2cODHVghV6CaUAAACgIxo1alSqBRMmTGjVdHWlUmmWSEEOO+ywdP/996cnnngiLbrooq2ulOrXr18aM2ZM6t69e6oF/U++r9pNAAAAAKrgvXO2rYntHnlNr169sh5xLeU1s0Sl1JFHHpnuueeeNHz48GYDqdC1a9fs1lh9fX12qwVTUl21mwAAAABUQX2NZButXY+qhlJRpHXUUUelO+64Iw0bNiwtueSS1WwOAAAAAAWpaih1xBFHpBtvvDHdeeedad55502ffPJJ9niPHj3SnHPOWc2mAQAAADATVbUu7PLLL8/6F2666aZpoYUWKt8GDx5czWYBAAAAMJNVvfseAAAAAB1PbYygBQAAAMBsRSgFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQMcKpYYPH5623377tPDCC6e6uro0ZMiQajYHAAAAgI4QSn311VdptdVWS5dddlk1mwEAAABAwTqnKtpmm22yGwAAAAAdizGlAAAAAOhYlVJtNWnSpOyWGz9+fPb/lClTslstqE+lajcBAAAAqIIpNZJttHY9ZqtQatCgQWngwIFTPT569Og0ceLEVAtW6CWUAgAAgI5o1KhRqRZMmDCh9kKpk046KQ0YMKBBpVS/fv1Snz59Uvfu3VMt+NeYumo3AQAAAKiCvn371sR279atW+2FUl27ds1ujdXX12e3WjAlCaUAAACgI6qvkWyjtetR1VDqyy+/TO+991755xEjRqSXX3459e7dOy222GLVbBoAAAAAM1FVQ6nnn38+bbbZZuWf8655+++/f7r22mur2DIAAAAAajaU2nTTTVOpZGBvAAAAgI6mNjorAgAAADBbEUoBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAAAdM5S67LLL0hJLLJG6deuW1llnnfTss89Wu0kAAAAA1HIoNXjw4DRgwIB0+umnpxdffDGtttpqaeutt06jRo2qdtMAAAAAqNVQ6sILL0yHHHJIOuCAA9KKK66YrrjiijTXXHOlq6++utpNAwAAAGAm6Zyq6Ntvv00vvPBCOumkk8qP1dfXpy222CI9/fTTU00/adKk7JYbN25c9v/YsWPTlClTUk2Y9FW1WwAAAABUwdixY2tiu48fPz77v1Qqzbqh1GeffZYmT56cFlhggQaPx89vvfXWVNMPGjQoDRw4cKrHF1988ZnaTgAAAICZrdfFtbWNJ0yYkHr06DFrhlJtFRVVMf5ULqqjvvjiizTffPOlurq6qrYNAGB6v1Hs169f+uijj1L37t1tTABgthUVUhFILbzwwi1OV9VQav7550+dOnVKn376aYPH4+cFF1xwqum7du2a3Sr17NlzprcTAKAoEUgJpQCA2V1LFVKzxEDnXbp0SWussUZ65JFHGlQ/xc/rrbdeNZsGAAAAwExU9e570R1v//33T2uuuWZae+2108UXX5y++uqr7Gp8AAAAANSmqodSe+yxRxo9enQ67bTT0ieffJJWX331NHTo0KkGPwcAqGUxRMHpp58+1VAFAAC1qq40revzAQAAAMAMVtUxpQAAAADomIRSAAAAABROKAUAAABA4YRSAAAAABROKAUAzJIGDRqU1lprrTTvvPOmvn37ph//+Mfp7bffbjDNxIkT0xFHHJHmm2++NM8886Rddtklffrpp+XnX3nllbTXXnulfv36pTnnnDOtsMIK6fe///1Uy5o0aVI65ZRT0uKLL55d/W6JJZZIV1999TTbeNlll2XTduvWLa2zzjrp2WefbXK6uK7MNttsk+rq6tKQIUOmOd9XX301bbTRRtl8o+3nn39+g+dvv/32tOaaa6aePXumueeeO7t68Q033DDN+Q4bNix9//vfz9axf//+6dprr23wfKxLtLHxLbbx9LQ33HrrrWn55ZfPpllllVXSfffdN832AgC1TSgFAMySHn/88SwMeeaZZ9JDDz2Uvvvuu7TVVlulr776qjzNsccem+6+++4s8IjpP/7447TzzjuXn3/hhReyQOuvf/1reuONN7Lg6aSTTkqXXnppg2Xtvvvu6ZFHHkl/+ctfsuDrpptuSsstt1yL7Rs8eHAaMGBAOv3009OLL76YVltttbT11lunUaNGTTXtxRdfnIU7rTF+/PhsPSMgi/b/9re/TWeccUb605/+VJ6md+/e2bo8/fTTWSB0wAEHZLcHHnig2fmOGDEibbfddmmzzTZLL7/8cjrmmGPSwQcf3OA1zz33XBo5cmT5Fts97LbbbtPV3qeeeioLBw866KD00ksvZQFj3F5//fVWbRMAoDbVleKrOwCAWdzo0aOzgCnCp4033jiNGzcu9enTJ914441p1113zaZ56623smqoCGvWXXfdJucTQde//vWv9Oijj2Y/Dx06NO25557pgw8+yMKe1orKqKjkygOuKVOmZFVCRx11VDrxxBPL00UA9KMf/Sg9//zzaaGFFkp33HFHFsg05/LLL88Cp08++SR16dIleyzmFxVWsX7NiQqoCJ3OPPPMJp8/4YQT0r333tsgCIr1Hjt2bLYNmhLB1T333JPefffdZkO11rR3jz32yMLEmFcu3p+o8LriiiuaXScAoLaplAIAZgsRQoU8OIqqnKie2mKLLcrTRPewxRZbLAulWppPZfh01113ZV3hosvZIosskpZddtl03HHHpW+++abZeXz77bfZ8iuXXV9fn/1cueyvv/467b333lk3vwUXXLBV6xmvj9AtD3hCVGBFBdeYMWOmmj6+X4wqr3g+XtfSfCvbm8+3uW0V6xgVZgceeGCDQOqnP/1p2nTTTdvU3rYuGwDoGDpXuwEAANMSVUhRtbPBBhuklVdeOXssr8yJcZUqLbDAAtlzTYluZNHtLiqGclEh9cQTT2RjHUUV02effZYOP/zw9Pnnn6drrrmmyfnENJMnT86W1XjZldVM0b1w/fXXTzvuuGOr3+Ro+5JLLjnVfPPnevXqVQ7XIkSL8bA6deqU/vjHP6Ytt9yyxfk21d7ofhcBXIy5VSkqnaKKKkKoSlHtFe9HW9rb3LKbe58AgI5BKAUAzPKiy110O4vwqL3i9REOxRhQMQZSLgKWqAT629/+lnr06JE9duGFF2ZdAiPoiW53MUh57sorr8zGZZqWqMCKLoIxhlJzVlpppfSf//wnux8Dhd9///2tXp8YAD66Bn755ZdZpVSMb7XUUks1qGKaHjG+Vqz3wgsvPNUA9AAAM4JQCgCYpR155JHZWETDhw9Piy66aPnx6A4XXcyimqeyWiquvte4q9ybb76ZNt9883TooYemX//611NV/kTFUR5IhRiXKrrF/fe//8269kX4U1nhE1evi+qkyiv9NV52BFLvv//+VJVccYXACKDiSnhxBbroghjySqV4fVPzzZ+r7C4YV9ALMTZTjJMVgVFzoVRz8+3evftUVVIRlD388MPZVf6mpTXtbW6a1nZpBABqkzGlAIBZUoRCEUhFl7oIeBp3EVtjjTXSHHPMkVUJ5WIcow8//DCtt9565cfiqntR2bT//vuns88+e6rlRJfAuGpfVBzl3nnnnSz0iRAsApsIf/JbVChFt8FYfuWyo+Iqfs6XHYN9x5XxItDKb+Giiy4qdwuMK9bl841gLMTrI4DLw6oQV8GLqwHmXfeaEsuPrnzNiflWtjefb+W2ykX7YlD5GDh9WlrT3rYsGwDoQOLqewAAs5rDDjus1KNHj9KwYcNKI0eOLN++/vrr8jQ///nPS4sttljp0UcfLT3//POl9dZbL7vlXnvttVKfPn1K++67b4N5jBo1qjzNhAkTSosuumhp1113Lb3xxhulxx9/vLTMMsuUDj744Bbbd/PNN5e6du1auvbaa0tvvvlm6dBDDy317Nmz9MknnzT7mvjT64477mhxvmPHji0tsMACpZ/85Cel119/PVvOXHPNVbryyivL05xzzjmlBx98sPT+++9ny77gggtKnTt3Ll111VXNzveDDz7I5nP88ceX/vWvf5Uuu+yyUqdOnUpDhw5tMN3kyZOzbXrCCSc0OZ8TTzwxa1tb2vvkk09m7Yt2xrJPP/300hxzzJG9PwBAxyWUAgBmSRHgNHW75pprytN88803pcMPP7zUq1evLAjZaaedstApF+FHU/NYfPHFGywrgpItttiiNOecc2YB1YABAxqEX8255JJLsgCnS5cupbXXXrv0zDPPTHOdphVKhVdeeaW04YYbZqHXIossUjr33HMbPH/KKaeU+vfvX+rWrVu27hHERRg0LY899lhp9dVXz9q71FJLNdiWuQceeCBr59tvv93kPPbff//SJpts0qb2hltuuaW07LLLZsteaaWVSvfee+802wsA1La6+Kfa1VoAAAAAdCzGlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAAonlAIAAACgcEIpAAAAAFLR/h8t2Chw1Mp4YgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 14: Sessions over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(start_ts, HOUR) AS hour, COUNT(*) AS sessions\n",
+    "FROM session_rollups GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", \"sessions\", \"Sessions Over Time\", \"Sessions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cell-15-calls-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:41.951701Z",
+     "iopub.status.busy": "2026-04-11T06:42:41.951598Z",
+     "iopub.status.idle": "2026-04-11T06:42:44.324908Z",
+     "shell.execute_reply": "2026-04-11T06:42:44.324433Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUi1JREFUeJzt3Qd4FOX6//87IUAACb2IdKSpgKiIBRUFRcCOnaOgCB4UUFBBBKWp2MWCciwUCyIWsFeOAh5BRUUOKhxAFJEuJQiGlvyvz/P9z/4mYZNsQpgteb+ua6/szs7uPjszO5m5537uJykrKyvLAAAAAAAAgAAlB/lhAAAAAAAAgBCUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAHJDJkydbUlKSu40cOTKqS7Nnz56htnz++eeh6d60+vXrR7V9iUDL0FuesezGG290bWzatKllZWXF/Db966+/hj6zffv2Vlx/w+Hot+y1T7/xaNF68dqh9QUgMr1793a/mxYtWhR4fwwg8RGUApAQdCIV6UmL/6TaH7jI60RIt4oVK9rff/+dbZ5du3ZZtWrVss334YcfWjROkvK76cQzlixdutQFDpo1a2aHHHKIpaWluQPWG264wb755huLF7/88ov179/ffY9y5cq5m+7369fPPRcvv5v8btEMBhTUqlWr7LnnnnP3BwwYEPMBtKDWtW7jxo2LdlMQ5n+Nt34WLlx4wMtn2bJl7r30/6Fu3bpWunRpq1SpknXo0MHeeuutsK9Zt26d/fOf/7Q6depYqVKl3N++ffva+vXrs823du1au//++61Tp07WoEEDK1OmjJUvX95OPPFEmzRpUq5tWrx4sf3jH/+www47zLWnevXqdsopp4R+p5F69dVX7eSTT3b/M3TT/enTp+f5mq1bt1qtWrVC+7KaNWsW6DML8rkzZsyw8847zx1n6H+BlmXt2rXtkksusa+++iriz8vMzLSnn37aWrdubWXLlrUKFSpYx44dbdasWXkep4S7FeRiTHp6ug0ZMsQaNWrk1lONGjXceluxYkXY+T/99FPXLrVP7TzmmGNswoQJrv1+N998c2g7yG99ASiGsgAgAYwYMUKX3tytR48eec5br1690LyfffZZrvPpOW8+7zZlypRs87zyyiv7zfPBBx9kBeW0007b7/Nzu02aNOmgtEHv632G1kMknnjiiayUlJRc29qqVatCtUXrPty69aZp3Rel1157LSs1NTXX76HnNE88/G7yu3m/q2+++SZr7ty57harbrnlFtfmUqVKZW3btq3Ar1+/fn3oO/72229ZQVi5cmVoWet3XdTy+g1E4/sWhH9fnN/+Paj9rdbXwfgdFsV+euzYsXn+lh999NFs869atSqrdu3aYeetW7du1urVq/P8n+e/3XTTTfu154033nC/xXDzd+jQoUj2V2PGjMn1ddddd122eWvUqBHxZxb0c3v16pXrvPqfN3v27AL/L/PfkpKSsh2HhDtOyXk7/PDDI/pM7StbtmwZ9j0qVaqUtWjRomzzT5w40bUn3PxaDjmdeOKJ7rljjz02ovYAKD7IlAKAAsh5VffZZ58t0oyVgmYzPfHEEzZ37tzQ7eijjw49d8cdd2R7rkuXLhYLXn/9dZdZtHfvXvf4rLPOsmnTprkrwBMnTnTtjIfMlu+//966d+9uGRkZ7rGujr/zzjvudv7557tpek5XmYsi++FA7NixI+z0a6+9Nts2cs0114Se69y5c7bnhg0b5qYfd9xx1q5dO3eLRdquXnrpJXf/zDPPdBl4BaUsDu87KtMk0RW371scKHPlpptucvujN99809q2bRt6Tr9l/z5B861evdrdv+iii1w2lf56WYdelosnNTXVevXqZW+88Ya9++672f63PP7449kyRHX/qquust27d7usqsGDB7s26XWPPPKIy5aKhPahY8aMcfeVmaX/Fbrpvvc/dNGiRfu9TplEzz//vGtzYRT0cxs3bmxDhw51mVX6n6ZjBGWHefsmZT/l5+2337YpU6a4+8rw0v/HRx991FJSUlzXN2UYexlsyqTy76e924UXXhh6vwsuuCCi7+r/LqeeeqrNnDnTrr/+evd4y5Ytbp37M+b0f1ztUbu0LtVO77tqmb/33nvZ3t/bpr799luXMQUAIdGOigFAPGRKlS9fPnR/6dKl7vnly5eHrhL6ny9MppTX/gO9Su6/kp/zvXbt2pV13333uSyksmXLZpUpU8ZdFdVVdT2X07fffpt18cUXu6vKJUuWdH+7deuWtWDBgkJnSu3Zs8ddeffm1/tnZmbuN99PP/0Uuj9jxoysc889N6t+/fpZhxxyiGuL3qNnz577ZSsUJFNq3759WXfffXfWkUce6TKaSpcunVWnTp2sLl26ZD333HNZ+VGbvPc9/fTTs30P3dc073nNKw8//HBo2iOPPJLt/V5++eXQc7fddlto+oYNG7IGDhzornYr26BixYqujfPmzcszm0TZCVrXek2kGWyR/I78v5/cPnv69OlZzZo1c9tYu3bt3BV2Le9Ro0Zl1apVy00/++yzs3799df93v+HH37Iuvzyy7Nq1qzp1rXm11X333//PaLvoEwEry2PPfbYfs9PmDDBXakvV66cWzZ6f2Vr3H///flu0/7fl9rZr1+/rGrVqrntJ9z38b7zYYcd5r5z+/bts77//vuwGTd5ZUpt377dtcPbVrW/0Tzvv//+AWV5eL+HSL6vfvfdu3d3v0HtCzSftnMtB30vtUu/n3DLfPfu3W7bP+aYY9y+R7fjjz8+68UXX8yKRM7ta9asWVlt2rRxv1ntF3Jm/uSWeZRXxtWff/6Zdfvtt2c1b97crSst49atW7usznDLw1tvyiLy9mnJycmhLBYtG2WSnHTSSe69tHy0vx03bpzbLjx5Zbh4bS9oNqqyGfV9/DZt2pQtO/Wrr75y09euXevarWkVKlTI+vvvv910/dVjTS9RokTWunXrQvvmnL/FjIwMt0147/3qq6+GnrvhhhtC0yNd3+H07ds39D76nxUuK0y/Rz99B+039dy9995bqEypwnxuTto+vXm7du2a72d27tw5NL8y0zzXX399aPpDDz2U6+u1PqpWrRraJlesWJHvPlzHAPrf4mVjrVmzJrQda1/u3w+I9pfeNLUrXCbdOeeck+1zFy5cGHpu9OjR+S4HAMUHQSkACeFgB6Xatm2b1aJFi2wBgyFDhrjHTZs2zXayEotBKR2knnrqqbme/Og5f2DqrbfecgGBcPNqup73FOSEac6cOaF5dbD8yy+/5Pud/AfiOW86uVDXo8IEpXRQnNv7nnzyyXm2aefOndm6o7z77rv7zfPOO++Ente8OkHSgb53AqiTVb8LL7wwW8BD1JUqt241OdeDf3tt0KBBtm4VQQalcn62bgow9e7dO9/lrCCLAg3hvq/eI5LtxX/ymbOL4QsvvJDrOlfgyBNJkKZhw4b5fp8BAwbsN49O9BVIiTQotXXr1tC+J9xt/PjxgQSlGjVqtN/r+/fvHzqR9d8++eSTbAEpBf1ya8PgwYPzXaf+7UtBo3D7Jn/AoKBBKXVf8wfL/Tf/usgZlNq8ebMLFOqxtvlnnnkmNO/VV1+d63e+7LLLQvPlNo+/7YXpIh2OAqje+yxevNhNU/Dam6ZAup8/sK6LA3lRkDDc/lCBSm8fqK5ujRs3dr9x/X3ggQeyBejy4v8N+LvA+YPQObt9e/+jFQjy/74KEpQqzOf6t30F8bSvjySY5AWB0tLSQvP7u9Mq4OlNP//883N9D/9+ThcwItmH6yKUfx/ud80114Se8wLA/osy/u6Eaq83XfuGnBelvP17p06d8lwOAIoXuu8BQISuu+469/eFF16wnTt3hrra+VPaY5WKG8+ZM8fdVwHbqVOn2iuvvBLqqqPn1D1A1K1D32nPnj3usYrdvv/++64AuWi6ns+tS1hefvjhh9B9pfmrUG5+1L3vX//6l+vyoa4YKiR/yy23uOfUhaGghXI9XsFfFbBXdy8VbNW6VbHfQw89NM/XLl++3HVH8fi7TYabpnn1Gr3vGWec4abNmzfP1qxZ4+5rWXoF8lXsvWXLlu6+lrnXrebqq69286j7hwrtaj2o+1249bBy5UrXze61115zXTAi7SJTFPTZKoqurhv6Ll4RZXVjUbcWFQJW8Vz5z3/+Yz/++KO7r99Ujx493OAB6g5yzz332Mcff+y6+3jv4W2Defn5559D9w8//PCw61zvr2K86l7z8ssvu+0pkm3Rb+PGje49tO1oG8r5fVTIX91rJTk52e666y63DR9//PEFGrlNXa3++9//uvvqJqXlqu3UK9Y8cOBA+/3333N9vddF06PXeV181JU2Utu3b3f7jHvvvTc0Td9P76d1qv2ER79Xz2OPPRYqznzCCSe4efW5GhVRHnjggQIVgNb6VdFoLQd9d3/Xo02bNllhaLtSNzXRPvGZZ55xvzW1TfvLcDToxTnnnBNa39rHaoQx0ffTOhJ9Ty03rXt9f1HXLt0kZ7dZf7frouxyrffTNisqfN28eXN3378ter9Lf7dO/+86N3pO3ZlF+yZvf/PXX3+Ftk3tA++8805XhF2/cf3Vb9vrHpaf3NqZWxvVnocffth1s4uky1xRfa7XbVtd0FXk/IgjjrAvv/zSdV3U9qquknlRNzkVGy/oZ/o99dRTofvq6heJgm4HkSwXFZjX9/Fov1uvXj13/6effoqoXQCKh5RoNwAA4oVqA+kgWoGQPn36uL8lS5Z0J9I5ayfkR6MizZ49e7/pOjnxn6DovYti1DwFofwHrDqZ8k4gzj33XHdfJ04adUeBAO/k7thjjw0d4KrGkE4eVQ9Cz3/yyScR16rwbNu2LXRftTIiXVYKUKhmhU4cc46AuGDBAisMrTvRCEkaaUiBII0epPon+fGfNIhGYMwp5zTvu6sOlQJgSpJQTRbV5dD2430vPS+bN292wUDRib93wnvUUUe5Wkk6uf/zzz/dyXO3bt2yfZbWq6ZXrlzZgqaTeAUKFYjRicdtt93mputE1Qto6PuPHz/e3Vew7sgjj3TbnXfSrO+nmiai7VOjNekk6KOPPnLbXtWqVXP9fH9gQiOOhVvnOllUwEqBO9WcuvLKKwv8PUePHh06of7iiy9cgMr/fRQA84Y+V32XUaNGufsatUsB2ZzbcTgawcr77arNgwYNciNiqc2qz6Lfpk72tXy8QG1OCrL460Tp9YWpB3b33Xfb5Zdf7u5rPSrgIFqPCrTqPb2Tfy0Dj1ffS9R+b91pO1egzpvHX/MoL/ouCviUKFHCBW2+/vprFwxUoOODDz6I6Pfr5/+d6T31u/ECNhphLjcKEnv7Ho1Gp1Eew31nBQU0+poomD9//vzQPJdddplbbvo9+GsS5Vw/CvIeyOiXCiR4+xUFS1T3Sb9P8Qe1tY35+R/ndhFC+yD9H/BqBI4dOzZUx01BCT8FJLQfVz0iba9aZ9pXaBkpiK/gq/9/hDRp0sQFOnJrZ7g27tu3z11EUpvuu+8+t0/KKxBcVJ+bFwVktOy9fUJucr5XQT9TwThvG2vYsKGdffbZ+80TblkUdDuIZLl48/n3w979wgaQASQmglIAECGd4OvkXyeJyq7wilv7rwzGqv/973+h+/6TP2Vt5Jwnt3m9+RWUyjlfQYrverwsobzo5ELDTXtX4cPJeeITKe8E8Y8//nDDmeuEQQfxGjZdJ0w6KclNzuLZCqZ4BV7908J9d21DysxQUMIr+u5lrKgNXoBEJ/beCYyyhHLLdvJnBnkU+IhGQMoLZHonvP42KADk8QeVvPXn354UXNAtJy2PJUuWRBxUyXkCqICvMlSUlaXtShQwOO2001wxZ38b86PXeKpUqbLf9/EXe/b/jnRS1qxZszy3aY9O3LxMAwWfvDZHsg0UNf++Qt/BC0p5yyzcOs25Xi+99NIDbr8+T8Ejf7sUlMq5zCOl35k3fL1+/15AKj9eQOqKK64IZfOF+87+YFXQ68z7HAV5tZ/zMte8CxFeUN6jIJGfPxvUP59HwSW9t5ctpqBjv379sgVAc2b9ecWutc50IUSUSaeglPaFOS/WTJo0yQXk9PnK1svZznBtVJHt7777zu0H/Rl8uSmqz/V/b2WmaX4tf2XcKWNMATnt4x966KFc25LzvfQeXpH2/NaHeMF+0Xf39sX5Keh2kNv8/nnDtTO/oByA4onuewBQiC58uT0u7Kh5XnZUzhHzvBHPDpaCjnJ3oKPitWrVKnRfJ0n5dWPSiYt38q6ubxqRSF0NvZMZ8U4oC0rrzsusUPaRrvCuWLHCdd1RwCGvYJeybPxXhMONrufvquhl5oi6kyiY6WXYKIvBy9RQdlBu3YVyE+6Kec7uF0HyBx79J0S5jYJX0JOU/LIS/MERf9cRryuotillnWnUKmXGqXukgsxa5wUJaviv/isLIq/vc7BHkyxMV9qDuV6Lep3mJdyy9U9TYNtTlNkZXmBMI9v5u0fG0jrTvlPbtfa1WiYKWCgA46eufB5vRDePguGenN1bf/vtNxco9wJSt99+u+su56dgrX5jHq/rVs77OTNPw8mtneHa6F3w0G9d26q+u7/9er2m5RxV8EA/16P3VuBcFzgUpPNG0suZtZzbfsX/m4r0M0X/s7z/jeouqK67kSrodhDJclG35pzZqt4+Oa9sVwDFD0EpACgAdSXzggvqRqKT3MJQrR1vCHb/MOxe1w3vpsdFwZ/1o+4uHn8tF2+e3ObN+TivTKLcKCPJ+64KJulEJq8sAu/qviiDSF1miqo+kk6c1bVBXYHUfUOZH95Jig6sVQckNzrg96971ePyn4jrvlejy+sG5B+S3OtKo2WgLmDeCaq6iHq0nXkn1+peqK4o//8AJaGbrkqrG1nQQZCDwb89qdtqzu+qm5ZTXl2qxJ/p4u9GJnoPbYMKPCqTQhkQ3om0sqe8ul5FQevM880332Q7KVO2VyR04uad1KlLptqbc5ko6KKsjvx420Rhg7hFsV4V9Au3Xr2aU5FQpqb/O/j3Ycp0yhlA858kh1u/+p15QTa1L9J1o2wXvU5ZIueff362zCf/d/7ss8/CfmcFwMMF+Ypq/Wj/dfrpp7uMTQVNtZ8LV5PtpJNOCn2+gliqhyT6610QUABOvxuP6qVpP+x9B3XZ0y0nva//dV7drpz3vUC8agbmXE5et0V/dqR/36zafJ7C/m8oqs/VPtrrxpjb/ji/zF7NqwyvSD/TT139tR8TdbUtSLasLsx4vxsFHL3/vVoWXndA/+dGslxyZrSqDqK33lVrCwA8dN8DkHB00hIu2KF6STmv2nkFbf10YqOaUbkdMCrLSQdp6kYSaWp8tCmgs2jRIndf9Tt0cqvv4l9O6oYiCrboCrdqhaiLiq70du3a1WXzeF1WdLKsbhsFpZMjncx53XjUlUq1PJQpphpMOhhWVzYdEOuEyH81XfWXdJCrk/rcglkFcfHFF7usJR1kqwuXTib89alydmHISYWVVeNIB9o6qVa3FHUJ1HJV9xHvRFtZUprXT8EwbxmrNpfX5UNt8uiEQnW8tNx18qfsKr2/2qzlpOWjLA2dBPivWscrbU/aBnQSrRNofX9NU9BFGXXKelD2WX4Fcv0ndAo8+U/e1JXK63KkE2Ftj/4sl/zWeUEoUKF9jlc7bMyYMXbMMce47lOR1JMS7V/0u1TtKAVN9dvUd9DvTxleixcvdtvAxIkTXcA8L9r3qX6SskiUGabfljLqiirwnRsFYL2sQdWyU1c3/d60HhQAUu0tdZeNtGaStn0FLbVP02/M67qn349XP8df4F5dphTQU4BSyykn73emum7a1nR/+PDhbvtQFpC2oRdffHG/13l1lFQzTfskfbb+LyijU9/ZK6qvTExlvGo5a9tWgW99lj5nxIgRbh7//yVtK8pGUf2zNm3auO+lYIOXTavX5Nyf5KQMTLXHC3Yr2K59hKb7L4woCKF6ddpWVaNO+2Jtb8qwUaDTy2BSTTQv+1IBKWV0btiwIbR+tV/2v7dXj0mUlejtC1UbUPs9BQq13YqC9fr/kh+9jwroK2inmmZqj/a1Xp06Bc68unv67t7gAx5t+/oNivahCuYrW7IoP1e/SQX5dPFE3RG1P1NXTtUc82gfkB8NtuF1X9ZvQ5+nZab/K6Lt2X8BQ7Sf8Rd0z6vAubYF/Y6813n/p7TevQss2g5uvfVWt61qnYuOedQ929uutQy1jald6pKsOpF6jf97+Gnf7e1j/ftpAPh/Y4ECQBzLa9jznEOv+4dDzmsIcP/w4W3bts3z8/1DhX/wwQeFbr9/+PLC8LfD/14ZGRlZp5xySq7f+dRTT83atWtXaP6ZM2eGHXZdN01/6623QvMWZrjyJ554IislJSXX9nhDbO/duzerZcuW+z1/8sknhx2yXcO8e9O1/jzeNK17T17D1GvI8K1bt+b7PV555ZWs1NTUXN9Hz02bNi3sa/v27Ztt3osuumi/eTS8du3atSParnMb7r6wv6Pc3iPccOK5fXZu24b/c/zb6XvvvRcaMjzczb/+cqNhx2vWrOnmP+ecc7I916tXr1zfu0yZMlkrVqzIs93+35e33PP6PgMGDNjvczTcu38Zeu/jH7Lev01v2bIl27D04W7+bT033bp12+913roq6PcNtw1IuPWk/Upev7VI9nv+7athw4ZZycnJ+73H3XffHZp/9+7dWXXr1t1vnubNm4fdTvP6nfnXRbjlcd1112Xbb23bts1Nv/rqq/P8zv7lvGjRoqykpKRcf9sF3cdG8v/Qv82sWrUq1++v5bh69erQvP62RLo+L7300lznfeqpp/L9PpF8rzFjxuT5Wv/vS/v3goj0c/2fEe5Wvnz5rK+++iqiz/T/L/PftJ1MmTJlv/k//vjjiI9Xcvv9atsN9/9Wt4oVK7rt1G/ixIlht1vdtK/N6cEHHww9v3jx4oiWA4DiIT4u8QMADoiutisjRyMRaZQ5dT/TFWpdLVe3C4185q+RpCvnysBR5o6ueCujRFd9lQ2kVH2vJlJhKftKXeZUiFVDpqvuiK7+6mqrstSUweZdhdaVWrVHV/XVBg2prRGbDpS6smj0K3Wz0mfrO6pYua7866q/vwtQbtRFQtkqei9lB2i56qb7mqbvqM8IJ+eV7pyPRV0dlRGlbAwtG60zXeXXfV2Nf/vttwtcgyqWaTQ1ZavpKryyaZQtoqwgZR2oiPJrr72W73toPXrLUtu8V6RYtG6VZaNtTutX25e2b2W9KGPK6/5VVJSlo6wWZRBo3SlrS925/Jkx/po74SjjQ79FZXmoJpu2L71GmTf6faqGzAknnJBvW5588kmXoRhupMiDSfsVZaNqxDcVJdf2q2WhbCBlyCjLQpk4kdIy1HavLBft15TxpS6Y/vp72m5mzpzpuo7p87UtafRDtSEc73emLC7vd6Z9grY7f/ZiOMpOUe0gUUaYBjJQ9qTqCCnjTzWdtK2pHfoczat2+LvSaT+sedX1NGdx8CBoH6IupupKrH2glp/+6rG6bOccxKGglJmnDBx9T28fpq6FygaKpBC5R7+ladOmufWqAtq66b4ybpXddrBE+rnaV2kb0u/R+7+p36pG41QtL2Ur+wcMyIuy+lQDTNuglpnqTGnb0T5N+/6cvFFy88uSyos+Q/tB/b/R71PbrL6HshK1fWj9+Sl7T9nCapfWqfZN+l3qN+H9D/fzsuOUcaVlAgCeJEWmQo8AAADinEa6Uhcu1dzSyVpBTnyLkg6xctb3UpdNBSdU+0UBJz2Ol27AAFAY6gqrulWiYF5uI3ECKJ44CgIAAAlFmR/eyJjjxo2L2jDkqp82dOhQV/dIgTJl4CnzxitGfMkllxCQApDwtB8WZVtpvwcAfmRKAQAAHKRuP+o2Fo66aqmrjAo/AwAAFFdkSgEAABwEGhFPdZNUk0f1WVSnSDVXNGqVavUQkAIAAMUdmVIAAAAAAAAIHJlSAAAAAAAACBxBKQAAAAAAAAQuxRJcZmamrVmzxsqXL7/fsMwAAAAAAAAoWhr9ePv27VarVq08RxtO+KCUAlIaGhoAAAAAAADB+f3336127drFNyilDClvQaSlpUW7OQAAAAAAAAktPT3dJQh5MZliG5TyuuwpIEVQCgAAAAAAIBj5lVGi0DkAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMAlfE2pSO3bt8/27NkT7WagEEqWLGklSpRg2QEAAAAAEEeKfVAqKyvL1q1bZ1u3bo32usABqFixotWsWTPfImoAAAAAACA2FPuglBeQql69upUtW5agRhwGFXfu3GkbNmxwjw899NBoNwkAAAAAAMR6UGrs2LH25ptv2pIlS6xMmTJ20kkn2f33329NmzYNzdO+fXubPXt2ttddf/31NmHChCLpsucFpKpUqXLA74fo0LYjCkxpXdKVDwAAAACA2BfVQucKNt144402f/58++STT1xNp7POOst27NiRbb7evXvb2rVrQ7cHHnigSD7fqyGlDCnEN28dUhcMAAAAAID4ENVMqQ8//DDb48mTJ7tMl2+//dZOPfXUbAEH1Qs6WKhDFP9YhwAAAAAAxJeoZkrltG3bNve3cuXK2aa//PLLVrVqVTvqqKNs6NChroYQAAAAAAAA4lfMFDrPzMy0m2++2U4++WQXfPJceeWVVq9ePatVq5YtWrTIhgwZYkuXLnW1qMLZtWuXu3nS09ND769bzs9UoWzvhmCNHDnS3nrrLfv+++/d42uuucbV+JoxY0aB38tbh+HWMwAAAAAACE6k5+UxE5RSbanFixfbF198kW16nz59QvdbtGjhRlfr0KGDrVixwho1ahS2ePqoUaP2m75x40bLyMjINk31h7Sg9u7d626exnd+bEFaNuasAs3fq1cvF7x54403wj7fuHFj69+/vw0YMGC/53799Vdr0qSJJScnu2V42GGHhZ5Tva6GDRu6AvD/+9//rH79+rm2Yfny5XbffffZrFmz3LJV0PD444+3gQMH2rHHHhvR9/CCgt6y9wJK/nURKb1Gr/3zzz+tZMmSBX49AACIkqmXsegBAPBc+aolgu3bt8dPUKpfv3727rvv2pw5c6x27dp5ztu2bdtQUCRcUErd+wYNGpQtU6pOnTpWrVo1S0tLyzavglRaUCkpKe4WLQX9bAWUdMvrdbk9701TMGrq1Kluefm7SWr6qlWr8lwmCxYssI4dO7qMNo2C2KxZM7cclfWkTLbPP/884u+hWlDe50TyvXKj1+i1GkUxNTW1wK8HAABRkr6IRQ8AgKd6dUsEkZ6XRzUopSwZZfSou5YCGQ0aNMj3NQsXLnR/lTEVTunSpd0tJy/gES4o4t2ipbCfndfrcvtO3rQePXq4wvJ33HFH6Dk91vQxY8bk+nqtM3WzUzbW3Llzsy3T1q1buy6Y3usUoNK6Xb16tStU3717d7vrrrtCmUzefDk/x3v8+uuvu6w3BSBV7F7vr8BXuXLlcv2+4dYzAACIZXS7BwAgJEHOZyM9L0+Odpe9l156yWXslC9f3tatW+duf//9t3te3csUINFofOp29vbbb9vVV1/tRuZr2bJlNJse98477zzbsmVLqLuk/urxueeem29Q8Mcff7Rbbrkl7EZWsWLF0H2tUwW6fvrpJ3vsscfs2WeftUcffTSi9qkr4RVXXGHXXnut/fzzzy5oedFFF1H7CwAAAACABBHVTKmnn37a/W3fvn226ZMmTbKePXtaqVKl7NNPP7Vx48bZjh07XDe8bt262fDhw6PU4sShbKV//OMfNnHiRGvXrp37q8f51WNatmyZ+6sue/nxryfVp7r11ltt2rRpNnjw4IiCUqoTpUCUCt17NcUAAAAAAEBiiHr3vbwoCDV79uzA2lPcKAvppJNOsnvvvddee+01mzdvXr5FxgsySuGrr75qjz/+uMt4++uvv9x756zrlZtWrVq5gvYKRHXq1MnOOussu/jii61SpUoRfz4AAAAAAIhdidFZEYWigI8yntRNrnnz5q5weX40cp8sWbIkz/kU4FINqS5durgi9t9//70NGzbMdu/eHVHbSpQoYZ988ol98MEHdsQRR9gTTzxhTZs2tZUrV0b47QAAAAAAQCwjKFXMKVtK9Zr0NxJHH320CxI9/PDDlpm5f2HSrVu3ur9ffvml63anQNRxxx3nCqP/9ttvBWqbCpeffPLJrti5glrqzqnC6QAAAAAAIP5FtfseCm/btm2hkQg9VapUcV0e5Y8//tjvea82k1/v3r3tkksuyVagPL9AkWp+dezY0U455RQXdFK2lbrnvfPOO/bxxx+7LpcKQq1atcrVkGrTpo299957BQooffXVVzZr1izXba969eru8caNG11GFwAAAAAAiH8EpeKUsptat26dbVqvXr3sueeec/cfeughd/N78cUXXVFzv5SUFKtatWqBPvv444+3BQsW2D333OOCWps2bbJDDz3U1adSUXpvdL+BAwdav379bNeuXda1a1e78847beTIkRF9hmpPzZkzx71fenq6C6gpO6tz584FaisAAAAAAIhNSVkFqVwdhxTQqFChgsssyllkOyMjw9UoatCggaWmpkatjThwrEsAAOLUyArRbgEAALFj5DZL9FiMH5lScWbR6v+r2YTssvbutg1b/rbr3vzc/ti+j8UDAMXEr/d1jXYTAAAAUEgUOgcAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZRCNncOvMFu7tU9kKXSqk4l+/eH77n7f/y+yj1e8uN/WSMAAAAAABQDKdFuQEwaWSHgz9sW8awK3OTlnwOHWN9Bt9vBlJWVZW9MnWIzpr1kK/63xFJSSlideg2t60WXWrfuPaxMmbIH9fMBAAAAAED8IygVZ2Z9uyR0/6N3ZthTD99rb33+TWha2XLlDnob7rjpevv3B+9a7wG32NAxD1ilKlXtfz8ttpeef9pq1a5rZ5zd9aC3AQAAAAAAxDe678WZqtVrhG6HlE+zpKSk0OPKVavZC88+ZWe2OdKOa1TDLu10iv3ns0+zvX7Zzz/adZedZ8cffqid2qKhjR5ys+3c8VfEn69A2PszXrP7nnzOrut/ix119DF2WJ26dnqnLvbcq29bm5PaufkWL/zOrr/yQjutZSM7+Yi6du3FXe3n//4Q8eekb91qQ/v3tvatDndtPfeUY23mqy8XYEkBAAAAAIBYRlAqgbz8/AR78ZknbdDw0fb6x1/YiaedYQN6XWm/rVzhnt+5c4f1/cfFllahor387ix7cMJkm//F5zZ2+OCIP0MBqfqNGrsgVE4KkJVP+7+ujzt2/GXnXny5TX7zA3vxrU+sboNGdmOPS23HX9sj+pwnH7rHVixbauNfeM1mfPaVDbv3YatYuXLE7QQAAAAAALGN7nsJZMq/nrRr+t5knc/v5h4PvGOUffPlF/byc0/bHfc8ZB/MfN127cqwu8c9bWXL/l83P3W/G3DNFXbzHSOtSrXq+X7Gql9/sfoND893vrYnn5rt8V33j7N2R9a3BfP/Y6d1PDvf16/7Y7U1O7KlHdmqtXusbCwAAAAAAJA4CEoliL+2p9vG9Wvt6ONOyDa99XFtbenPi939X5b9z5occVQoICVHH9fWMjMz7dcVyyIKSqnIeST+3LjBnnzwHlsw7wvb/OdG27cv0zL+3umCTZG49Opr7ZY+PWzJ4h/sxFNPt9M7dXVtBQAAAAAAiYHueyiQeg0a2coVy/Kdb/jAG2zpj/+1waPG2pQZH9n0D+dYxUqVbc+ePRF9TrvTz7QP5i+yf1x3g21Yv876XH6BPTzmTtYWAAAAAAAJgqBUglDR82o1DrWFC+Znm/79gq+sYeOm7n7Dxk3cKHmqLeVZuOArS05OdnWiItH5govtt1+W22cfvR82i2p7+rbQ+15xbR875Yyz7PCmza1U6VK2ZfOfBfpOlatUtfMuucLGPv6M3TbyXntj6pQCvR4AAAAAAMQuglIJpOc/+9ukpx+zD99+03XHGzd2pC396b/Wvdc/3fNdLrzESpdOtTsH3mDLlvxkX3851+67c4idc9FlEXXdk07nXuhut/e7zp574mH78Yfvbc3qVTb70w+tzxUXuBpWUrdBQ3v3jen2y7Kltuj7BTa0fx9LTS0T8XcZ/9C9LvC1auUvtnzpzzZn1kfW4PAmhVwyAAAAAAAg1lBTKoFcee31rraUurmpjlOjxk3t8eenui53UqZMWXv6pdft/pFDrfs5HSy1TBnr2OU8u/WuuyP+DI2wd9+Tz9nrL0+2ma++bM8+8YilpJSwuvUb2TkXX24nnXaGm2/kg0/YmCE32+Wd21uNWofZgCF32iN3R979rmTJUvb4/aNtze+rrHRqqh1z/Il2//jnC7FUAAAAAABALErKirRydZxKT0+3ChUq2LZt2ywtLS3bcxkZGbZy5Upr0KCBpaamWjxYtHprtJsQk7L27rYNa1bbyM822B/b90W7OQCAgPx6X1eWdbwbWSHaLQAAIHaM/L+SOIkci/Gj+x4AAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlzCwzMzP4JY+i5QaRzLJ9rEoAAAAAAOJCihVjpUqVsuTkZFuzZo1Vq1bNPU5KSrJYlrV3d7SbEHOy9u21v9O32Jade23Tzn3Rbg4AAAAAAIhAsQ5KKSDVoEEDW7t2rQtMxYMNW/6OdhNizr7MTFu0LsOmLd5ue5UwBQAAAAAAYl6xDkqJsqPq1q1re/futX37Yj/L5ro3P492E2JKZpbZjt2Ztn13lhGPAgAAAAAgfhT7oJSoy17JkiXdLdb9sT32A2cAAAAAAAD5odA5AAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAoXkGpsWPHWps2bax8+fJWvXp1u+CCC2zp0qXZ5snIyLAbb7zRqlSpYocccoh169bN1q9fH7U2AwAAAAAAIM6DUrNnz3YBp/nz59snn3xie/bssbPOOst27NgRmmfgwIH2zjvv2GuvvebmX7NmjV100UXRbDYAAAAAAAAOUIpF0Ycffpjt8eTJk13G1Lfffmunnnqqbdu2zZ5//nmbOnWqnXHGGW6eSZMmWfPmzV0g64QTTohSywEAAAAAABC3QamcFISSypUru78KTil7qmPHjqF5mjVrZnXr1rV58+aFDUrt2rXL3Tzp6enub2ZmprvFu2TLinYTAACIGYnwvx2UOAUAICRBjm0iPUZLiaUG33zzzXbyySfbUUcd5aatW7fOSpUqZRUrVsw2b40aNdxzudWpGjVq1H7TN27c6OpTxbvmlQhKAQDg2bBhAwsj3qW1jHYLAACIHRsS49hm+/bt8RWUUm2pxYsX2xdffHFA7zN06FAbNGhQtkypOnXqWLVq1SwtLc3i3c9bkqLdBAAAYoa6/SPOpS+KdgsAAIgd1RPj2CY1NTV+glL9+vWzd9991+bMmWO1a9cOTa9Zs6bt3r3btm7dmi1bSqPv6blwSpcu7W45JScnu1u8yzSCUgAAeBLhfzsSo5sCAABFIjm5WB2jRfXbZmVluYDUjBkz7N///rc1aNAg2/PHHnuslSxZ0mbNmhWatnTpUlu1apWdeOKJUWgxAAAAAAAAikJKtLvsaWS9t956y8qXLx+qE1WhQgUrU6aM+9urVy/XHU/Fz9X9rn///i4gxch7AAAAAAAA8SuqQamnn37a/W3fvn226ZMmTbKePXu6+48++qhL++rWrZsbVa9Tp0721FNPRaW9AAAAAAAASICglLrvRVIca/z48e4GAAAAAACAxJAYFbQAAAAAAAAQVwhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAULyCUnPmzLFzzz3XatWqZUlJSTZz5sxsz/fs2dNN99/OPvvsqLUXAAAAAAAACRCU2rFjh7Vq1crGjx+f6zwKQq1duzZ0e+WVVwJtIwAAAAAAAIpeikVR586d3S0vpUuXtpo1awbWJgAAAAAAACR4UCoSn3/+uVWvXt0qVapkZ5xxht19991WpUqVXOfftWuXu3nS09Pd38zMTHeLd8mWFe0mAAAQMxLhfzsocQoAQEiCHNtEeowW00Epdd276KKLrEGDBrZixQq74447XGbVvHnzrESJEmFfM3bsWBs1atR+0zdu3GgZGRkW75pXIigFAIBnw4YNLIx4l9Yy2i0AACB2bEiMY5vt27fHf1Dq8ssvD91v0aKFtWzZ0ho1auSypzp06BD2NUOHDrVBgwZly5SqU6eOVatWzdLS0ize/bwlKdpNAAAgZiibGnEufVG0WwAAQOyonhjHNqmpqfEflMqpYcOGVrVqVVu+fHmuQSnVoNItp+TkZHeLd5lGUAoAAE8i/G9HYnRTAACgSCQnF6tjtLj6tqtXr7Y///zTDj300Gg3BQAAAAAAAAcgqplSf/31l8t68qxcudIWLlxolStXdjfVhurWrZsbfU81pQYPHmyHH364derUKZrNBgAAAAAAQDwHpRYsWGCnn3566LFXC6pHjx729NNP26JFi2zKlCm2detWq1Wrlp111lk2ZsyYsN3zAAAAAAAAkOBBqd9//92SkpKsdu3a7vHXX39tU6dOtSOOOML69OkT8fu0b9/esrJyH03uo48+KkzzAAAAAAAAEOMKVVPqyiuvtM8++8zdX7dunZ155pkuMDVs2DAbPXp0UbcRAAAAAAAACaZQQanFixfb8ccf7+5Pnz7djjrqKPvyyy/t5ZdftsmTJxd1GwEAAAAAAJBgChWU2rNnT6iu06effmrnnXeeu9+sWTNbu3Zt0bYQAAAAAAAACadQQakjjzzSJkyYYHPnzrVPPvnEzj77bDd9zZo1VqVKlaJuIwAAAAAAABJMoYJS999/v/3rX/9yhcqvuOIKa9WqlZv+9ttvh7r1AQAAAAAAAEU6+p6CUZs2bbL09HSrVKlSaLpG3itbtmxh3hIAAAAAAADFSKGCUlKiRIlsASmpX79+UbQJAAAAAAAACS7ioFTr1q0tKSkponm/++67A2kTAAAAAAAAElzEQakLLrjg4LYEAAAAAAAAxUbEQakRI0Yc3JYAAAAAAACg2CjU6HsAAAAAAABAIJlSKmoeaU2pzZs3H0ibAAAAAAAAkOAiDkqNGzfu4LYEAAAAAAAAxUbEQakePXoc3JYAAAAAAACg2Ig4KJWbjIwM2717d7ZpaWlpB/q2AAAAAAAASGCFKnS+Y8cO69evn1WvXt3KlSvn6k35bwAAAAAAAECRB6UGDx5s//73v+3pp5+20qVL23PPPWejRo2yWrVq2QsvvFCYtwQAAAAAAEAxUqjue++8844LPrVv396uueYaO+WUU+zwww+3evXq2csvv2zdu3cv+pYCAAAAAACgeGdKbd682Ro2bBiqH6XH0q5dO5szZ07RthAAAAAAAAAJp1BBKQWkVq5c6e43a9bMpk+fHsqgqlixYtG2EAAAAAAAAAmnUEEpddn74Ycf3P3bb7/dxo8fb6mpqXbzzTfbbbfdVtRtBAAAAAAAQIIpVE2pgQMHhu537NjRlixZYt9++601btzYWrRoUZTtAwAAAAAAQHHPlNKIe0cccYSlp6dnm64C5x06dLDLL7/c5s6dW9RtBAAAAAAAQHEOSo0bN8569+7tipvnVKFCBbv++uvtkUceKcr2AQAAAAAAoLgHpVRH6uyzz871+bPOOst14wMAAAAAAACKLCi1fv16K1myZK7Pp6Sk2MaNGwvylgAAAAAAACiGChSUOuyww2zx4sW5Pr9o0SI79NBDi6JdAAAAAAAASGAFCkp16dLF7rzzTsvIyNjvub///ttGjBhh55xzTlG2DwAAAAAAAAkopSAzDx8+3N58801r0qSJ9evXz5o2beqmL1myxMaPH2/79u2zYcOGHay2AgAAAAAAoDgGpWrUqGFffvml9e3b14YOHWpZWVluelJSknXq1MkFpjQPAAAAAAAAUGRBKalXr569//77tmXLFlu+fLkLTDVu3NgqVapU0LcCAAAAAABAMVXgoJRHQag2bdoUbWsAAAAAAABQLBSo0DkAAAAAAABQFAhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAAKB4BaXmzJlj5557rtWqVcuSkpJs5syZ2Z7Pysqyu+66yw499FArU6aMdezY0ZYtWxa19gIAAAAAACABglI7duywVq1a2fjx48M+/8ADD9jjjz9uEyZMsK+++srKlStnnTp1soyMjMDbCgAAAAAAgKKTYlHUuXNndwtHWVLjxo2z4cOH2/nnn++mvfDCC1ajRg2XUXX55ZcH3FoAAAAAAAAkfE2plStX2rp161yXPU+FChWsbdu2Nm/evKi2DQAAAAAAAHGcKZUXBaREmVF+euw9F86uXbvczZOenu7+ZmZmulu8S7asaDcBAICYkQj/2xGz10gBAAheZmaxOkaL2aBUYY0dO9ZGjRq13/SNGzcmRC2q5pUISgEA4NmwYQMLI96ltYx2CwAAiB0bEuPYZvv27fEdlKpZs6b7u379ejf6nkePjz766FxfN3ToUBs0aFC2TKk6depYtWrVLC0tzeLdz1uSot0EAABiRvXq1aPdBByo9EUsQwAAPAlybJOamhrfQakGDRq4wNSsWbNCQSgFmDQKX9++fXN9XenSpd0tp+TkZHeLd5lGUAoAAE8i/G9HYnRTAACgSCQnF6tjtKgGpf766y9bvnx5tuLmCxcutMqVK1vdunXt5ptvtrvvvtsaN27sglR33nmn1apVyy644IJoNhsAAAAAAAAHKKpBqQULFtjpp58eeux1u+vRo4dNnjzZBg8ebDt27LA+ffrY1q1brV27dvbhhx9GnAYGAAAAAACA2BTVoFT79u0tKyv3wt1JSUk2evRodwMAAAAAAEDiSIzOigAAAAAAAIgrBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIXEwHpUaOHGlJSUnZbs2aNYt2swAAAAAAAHCAUizGHXnkkfbpp5+GHqekxHyTAQAAAAAAkI+Yj/AoCFWzZs1oNwMAAAAAAADFpfueLFu2zGrVqmUNGza07t2726pVq6LdJAAAAAAAACRyplTbtm1t8uTJ1rRpU1u7dq2NGjXKTjnlFFu8eLGVL18+7Gt27drlbp709HT3NzMz093iXbJlRbsJAADEjET4346Yv0YKAEBwMjOL1TFaTAelOnfuHLrfsmVLF6SqV6+eTZ8+3Xr16hX2NWPHjnXBq5w2btxoGRkZFu+aVyIoBQCAZ8OGDSyMeJfWMtotAAAgdmxIjGOb7du3x39QKqeKFStakyZNbPny5bnOM3ToUBs0aFC2TKk6depYtWrVLC0tzeLdz1uSot0EAABiRvXq1aPdBByo9EUsQwAAPAlybJOampp4Qam//vrLVqxYYVdddVWu85QuXdrdckpOTna3eJdpBKUAAPAkwv92JEY3BQAAikRycrE6Rovpb3vrrbfa7Nmz7ddff7Uvv/zSLrzwQitRooRdccUV0W4aAAAAAAAADkBMZ0qtXr3aBaD+/PNP1/2uXbt2Nn/+fHcfAAAAAAAA8Sumg1LTpk2LdhMAAAAAAABwEMR09z0AAAAAAAAkJoJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABC4uglLjx4+3+vXrW2pqqrVt29a+/vrraDcJAAAAAAAAiRyUevXVV23QoEE2YsQI++6776xVq1bWqVMn27BhQ7SbBgAAAAAAgEQNSj3yyCPWu3dvu+aaa+yII46wCRMmWNmyZW3ixInRbhoAAAAAAAAKKcVi2O7du+3bb7+1oUOHhqYlJydbx44dbd68eWFfs2vXLnfzbNu2zf3dunWrZWZmWtzbtSPaLQAAIGbo/zvi3K6kaLcAAIDYsTUxjm3S09Pd36ysrPgNSm3atMn27dtnNWrUyDZdj5csWRL2NWPHjrVRo0btN71evXoHrZ0AACA6Ko1jyQMAgARyXyVLJNu3b7cKFSrEZ1CqMJRVpRpUHmVHbd682apUqWJJSVyJA1A0Uf86derY77//bmlpaSxSAAAQ1zi2AVDUlCGlgFStWrXynC+mg1JVq1a1EiVK2Pr167NN1+OaNWuGfU3p0qXdza9ixYoHtZ0AiicFpAhKAQCARMGxDYCilFeGVFwUOi9VqpQde+yxNmvWrGyZT3p84oknRrVtAAAAAAAAKLyYzpQSdcXr0aOHHXfccXb88cfbuHHjbMeOHW40PgAAAAAAAMSnmA9KXXbZZbZx40a76667bN26dXb00Ufbhx9+uF/xcwAIiroIjxgxYr+uwgAAAPGIYxsA0ZKUld/4fAAAAAAAAEARi+maUgAAAAAAAEhMBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAMJgYFIAAAAAOLgISgGALwi1cOFCW7VqlSUlJbFcAABA3B/bbNq0yXbv3h3t5gBAWASlABR7OmhTEGrmzJnWpUsXmzBhgm3fvr3YLxcAABDfxzbvvvuu/fOf/7T33nvP9u7dG+1mAcB+CEoBKLYyMzPdXx20vf/++3bllVfa6NGjbcCAAVa+fPloNw8AAKBQdGwzY8YMu/TSS+24446zli1bWkpKyn7HQAAQbUlZFE4BUMy8/fbb1qJFC2vQoIE7KFNKe8+ePa1hw4Z277332s6dO23NmjU2bdo0a968uR1zzDFuXgAAgFi0bds2q1ChQujxsmXLXPb37bffbr169XLHO/v27bMffvjBGjVqZJUqVXLTkpPJUQAQXeyFABQr3333nQ0bNsyGDh1qv//+uzsY00HaypUrbcuWLfbnn3/abbfdZtddd509++yzduONN9qUKVPca4nhAwCAWPP888+7i22//PJLaJq66qWmplqrVq3cxbdx48bZ6aefbueff761adPGVq9eTUAKQEwgKAWgWFHWk2orrF+/3l09/PXXX61cuXLWv39/F3xSttTatWvdVcXffvvNevToYZ999pk7uKP4OQAAiDXnnHOOy5K6+OKLbcWKFW6ajlkUlBo1apQ7tpkzZ46deeaZLgu8ZMmS9uqrr0a72QDg0H0PQLHwr3/9yzIyMuymm25yj59++ml75ZVXrE6dOq7LXr169eynn35yAakOHTqEUtoVrFIGla5Cli5dOtpfAwAAwJk/f741bdrUdcXbuHGjnXXWWS77+6233nJlB1TkXKMKlyhRwq6++mo77LDD3OuUMXXVVVfZtddey5IEEHUEpQAkvM2bN9stt9xic+fOtSFDhljv3r1DgampU6da3bp1bcyYMe5Koufnn3+2l156ycaPH+9ep7R4AACAaFM5gW+++cZOOOEEu+eee+yGG25wmVJeYGrPnj0uIFW/fv1sr1M3vrvvvtsmTpxos2fPdrWlACDaCEoBKBaWLFliEyZMsA8//NAGDRpkffr02S8w5WVMLViwwB555BF3dVHZVKrHAAAAEEseeughVyNTganrr78+W2BKZQeUMeVdcHv55ZddOYL33nvPjTjcunXraDcfAJz/Ny4oACSwZs2aWd++fV23PAWcRIEpTRMFn+644w574IEH3NDJmq4rjOreBwAAECu8EgO33npr6K8oMFWtWjX7+OOPXWDqwgsvtBkzZrjAlKZXrVrVZUg1adIk2l8BAELIlAKQ8FRfQfUUvG55yo7SAVvOjKnp06db+fLl7amnnrLatWtHudUAAAB5B6ZEF9sUmLrvvvv2y5iS119/3XXVU/e9UqVKsUgBxBQypQAkdM2FnCPmNW/e3B2w6bmcGVN///23ffrpp4yyBwAAYpoXkBJdZFOQavDgwftlTLVp08YVNdfoewSkAMQiMqUAJHRA6vPPP3dXCDXynrrweSnuixcvtmeeecYdsGnadddd56Zv3brVKlasGOXWAwAAhD+20THM+vXr3bFNp06dLCUlJVRjSoEpf8bUpk2bLD09PdtgLgAQS8iUApCQdNCmOgo9e/a0Sy65xHXhU0Hzr776yl577TU76qijXIaUuvWpllTJkiWtR48eBKQAAEDMBqR0bKPR9mrWrOlKEnTt2tUGDBhgp512WujCm45rdu7c6TKoVEdKNwCIVQSlACSk7777zm677TZ78MEHXfBp+fLl1q5dOzcKX8eOHV03PQWmFIhSOrueAwAAiEUKSM2aNct69+7tMqGU4T1v3jw7+eSTXcaURtvr0KGDC0wpIDVu3Djr379/tJsNAPmi+x6AhCj0qUwoHZCVLl3aTX/zzTftgw8+sGeffdZ+++03O+OMM6x9+/YuIKWUdqW7K2NKKPwJAABisYi5R3Uvhw8f7o5z7r33XluxYoWdffbZ1rp1a3chTjWk7r77bheYks2bN1vlypWj9A0AIHIEpQDE/UGbsqDGjx9vv/zyi+uupyGQ5YcffrAWLVrY+eefb5UqVbIXXnjBtm/f7q4qqh5Dly5d7N133w1bEB0AACBaxzZr1qyxL7/80j3WRTUFnVQn87DDDrMaNWq4i2ytWrWy5557zubOnWtnnnmmnXjiiXbXXXfZ6aefzrENgLiRPQQPAHF20LZo0SJ3VVCZUt26dQsNfyw6WFu3bp3LlOrevbubpgCUriq+9NJLLpAlBKQAAECsHNvowpkyul988UWbP3++lS1b1h2r6KJakyZN7LPPPnPHM8OGDXOv++uvv+z444+3PXv2WKNGjdw0jm0AxAtqSgGISzpoW7lypct2uvLKK+2BBx4IPefPfNKB3K5du2zatGkuSKUaC//973/d/LrSCAAAEG06dtGxjYqXq2h53759bciQIVa+fPnQPKqBKX/++acLRKlLn6i2lC7Qaf7U1NSofQcAKAy67wGIO17QSbUT5syZ42pDadjjcFRnatKkSTZ69Gj3Onn77bftmGOOCbjVAAAAuduxY4f94x//cCMBq1ueRgiWnGUGli5daqeccorVqlXLypQp4wJZs2fPdhffACDeEJQCELeU2q4aC+qKl1POAzh14Vu2bJk1b97c1WMAAACIJRs2bHBd9EaMGOGCUzmpVIEXqNJowlOmTHHHOldddZU7vgGAeET3PQBxS4EnDYMcjheQuuaaa+ziiy+2rl27Wr169QJuIQAAQGRUlmD9+vV2xBFHhLK9U1L+3+maF5DSxTiVLhg7diyLFkDco9A5gLhVs2ZN+/rrr10GlMfroid//PGHq7dQtWrVKLUQAAAgMg0bNnR1o1555RX3WAEp/3GNvPHGGzZ16lQ3mjAAJAKCUgDijneANnz4cFfE/KabbnJXFjVqjTKk9FeeeeYZ122PDCkAABDrxzYanEWZ3dOnTw8FpnKOovfdd9+50gUlS5aMUksBoGhRUwpA3FJtBV0tHDBggLVs2dL69etnHTt2tO+//94VM1eB87lz57rnAAAAYt1XX33lakSVLl3aHd/07t3bTV+zZo09+uijro7UZ599ZkceeWS0mwoARYKgFICY5BXzTE9Pt7S0tDxHqvn888/t1ltvtV9++cX27NljjRo1sho1athTTz1FQAoAAMQMZUEpg7tt27a5zqOR9G655RZXzFwj6iUnJ7sg1fLly23mzJl29NFHB9pmADiYCEoBiFmLFy+2du3a2ZgxY6x///55zqtg1Pz5823Tpk3u6qHqSFWuXDmwtgIAAORl6dKlLguqSpUqds8999gxxxyT6+jBqpf55Zdf2kcffeQu0p100knWuXNnq1+/PgsZQEIhKAUgZt1xxx123333uSuEDz30kN18881h5/MPkQwAABCrXn/9dXvuuedcTaiRI0fascceG+0mAUBUUegcQMy66KKLrEuXLtarVy/XPe/+++8POx8BKQAAEMu8QVguvvhi69Onj2VkZLig1Lfffpvra/wj7+UchQ8AEgVBKQAxIdzBVvPmzW3z5s1WsWJFmzZtmg0bNswefPDBqLQPAACgsJT1vXfv3tBFt+uvvz7fwJR/5L2co/ABQKIgKAUg6tT9TgdbKmruV65cOVdz4eOPP7bDDz/cHnvsMbv99ttdVz4AAIB4uvDmz+xWxpQCU3///Xe+GVMAkMgISgGIOh2k/fjjj1atWjV3gPbkk0+GnmvRooUbSU/P33jjjfbII4/YkCFD3F8AAIBY5hUunzVrluu216NHD5f5rQtyCkwNGDDABaZGjBhBYApAsURQCkBMmDFjhhtBT1cK33jjDWvZsqVNmjTJTdMBnA7WtmzZYjfddJMLWqnG1BNPPBHtZgMAAORKAamZM2da165dbdeuXe42ceJEa9Omjf3000923nnnWd++fV2QauDAgbZw4UKWJoBihaAUgJigbnm33HKLLV682G677TZXb0FXFRWc+uGHH9xVRD0WHbw988wz1rFjx2g3GwAAIFcbN260u+66y0aPHm0vvPCCq5Gp7G+56qqr3N9u3bq5+1WrVrUqVaqwNAEUKwSlAMSElJQUe+CBB+yKK66wnj172qmnnmrPP/+8Cz4pULVz504rU6ZMaP7rrrvOFUIHAACIVcqA2rFjh7Vu3do9VgZ45cqV7aOPPrLVq1fbvffe66ZfeeWVLmhVp06dKLcYAIJFUApATKW4q8ueUtwvuOAClxl14YUX2ksvveQCU5oOAAAQLxSAUpe9OXPmuMclS5Z0o/ApI+roo4+2TZs2heY95JBDothSAIgOglIAApOZmen+bt++3XXH849I46fA1CWXXGKXXnqpffDBB1axYkU77LDDWFMAACAm6XjGO87xK1WqlN1www2urpRqSXnZ4cnJyS5ApZv3egAojpKy2AMCCNDatWtdwEld9Lp37+665Hkj0+TUq1cvVwB98uTJrhAoAABArFAQSsEldcnzgkuffvqpu6C2bNkyVyvqpJNOcqMLDx482ObOneuyvlXk/IsvvnDd9b7++mtr2rRptL8KAEQNQSkAgTv77LNt3bp1rrC5hkPOKzClGgtKeV+6dKmVK1eOtQUAAGImIKWi5Ro1WMXMdSFNxy3K9NZFOB3rKNv70UcftcMPP9zVytQIwmlpaVa+fHl3v1WrVtH+KgAQVQSlAARa7LNEiRLuvg7YNBTykCFDQoEp7wBPdNVxyZIl1qhRI0tPT7eaNWuypgAAQNR5xysaHVgFzFWsvE+fPm5UYGWCDxgwwM2n2pgKRK1Zs8Z13WvYsKF7rQqf6/VcbAMAakoBCJACUgpMyfTp0+2II46w+++/315//XU3up4XkNq9e7f985//dN33FJwiIAUAAGIpIKULayeeeKLLkLr99tvdcYwyo/w1MDt06GDXXnutrV+/3hYuXOim6bXKkiIgBQD/h0LnAA6KnMU+vcfhAlP33Xefvfnmm6Hi5+rWN23aNBs/frxVqFCBNQQAAGImIKURgU877TSrX7++jRw5MvScLqIpMOU9FmVP6Vjm3XffjWrbASBWEZQCcHB2LsnJtmrVKnv88cdDj3MLTB155JEuMKX7ypBSqrsKgKoQKAAAQCx12Wvbtq0dddRRtm3bNrvpppvc83Xr1rVjjz3WRo0aZfPmzQtlf6tmZtWqVV05AgDA/lLCTAOAA6ag01NPPeWKfu7atctuu+22UGBKfxWY2rt3rxsWWcEoFQa95ppr7JBDDrH//Oc/rkYDAABALNCxy4IFC9xoesOGDbPhw4e7i2i6r2MeFS1/9tlnXf0ojRh86623WvXq1V1WlUbde+ihh6L9FQAgJhGUAnBQKOjUv39/y8jIcKPSKBiloub+wJQCUl7x86lTp1rt2rXt6quvdlcfAQAAYonqRvXt29dGjBjhHl922WXurwJTosDUe++9Z/369bN33nnH1ZJSjanZs2dbs2bNotp2AIhVjL4H4KBSbYV77rnHvvnmG7vwwgtdYEq8wJSKmmvUmsaNG1v37t1ZGwAAIOapW15SUpIbIVh1MBWYUpBKgSnZuHGju+imC3BpaWnRbi4AxCwypQAcVCr6qQM1BabUlU8HcRqlRgEpFTZXervS3b1RaQAAAGKdAlKigNPll1/u7ut4R4Goxx57zKpVqxblFgJAfCAoBSDQwNTMmTPdgZxqTGnalClTbP78+W4UPgAAgHjjBaZ0wa1Pnz5WtmxZGzt2bLSbBQBxge57AALvyvfdd9+5dPcVK1a4UfaOOeYY1gIAAIhrGo1PF99OPPFEa9KkSbSbAwBxgaAUgMADU3fccYcLRr322mvWqlUr1gAAAEioWlMAgMgQlAIQOBX/VKHzGjVqsPQBAAAAoJgiKAUAAAAAAIDAJQf/kQAAAAAAACjuCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAAGBB+/8Ab8ebNCZymb0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 15: LLM + Tool calls over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "  COUNTIF(event_type = 'LLM_REQUEST') AS llm_calls,\n",
+    "  COUNTIF(event_type = 'TOOL_STARTING') AS tool_calls\n",
+    "FROM filtered_events\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"llm_calls\", \"tool_calls\"],\n",
+    "          \"LLM + Tool Calls Over Time\", \"Calls\", kind=\"area\",\n",
+    "          labels=[\"LLM Calls\", \"Tool Calls\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel3-header",
+   "metadata": {},
+   "source": [
+    "## Panel 3: Reliability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "cell-16-error-kpi",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:44.326476Z",
+     "iopub.status.busy": "2026-04-11T06:42:44.326364Z",
+     "iopub.status.idle": "2026-04-11T06:42:47.139370Z",
+     "shell.execute_reply": "2026-04-11T06:42:47.138760Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAACMCAYAAACK5iZjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAEvdJREFUeJzt3QlsFGUfx/GnQIEC5WhBCkJpkZsSFdAiagBRoCBySkAhICDIDWkkngET0VcSUAOBcIVgOCMgIGJFIQiioJRLzgqWU+S+CuXsvPk/yW5md2fbZwp1t/D9JA27czwzO+87j7955plnIizLshQAAADyVCTvRQAAAEBwAgAAcIEWJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJwAAAEMEJ9yzjIwMNX78ePXMM8+oqlWrqhIlSqiKFSuqRo0aqeHDh6sNGzZwlIFCLtTn+fbt29XYsWNVkyZNVOXKlVXx4sX1v40bN1Zvv/22Sk9Pd13myZMn1WeffaZatmypqlevrkqWLKkqVKig6tWrp/r376++/fZbZVlWnuVcuXJFffrppyo5OVmVK1dO71uVKlVUp06d1OrVq432Zfbs2SoiIkL/VatWTZeJMGUB+XTz5k1r9OjRVrFixaRmyfUvJSXFOnHiBMcaKGRCfZ5fvnzZ6t27txUREZHrtmW+LCfL5yUnJ8eaMGGCVapUqTx/U7Nmzax9+/YFLSsjI8NKSEjItYx+/frpbQZz+vRpq0KFCt7lly9fnu/jhYJHcEK+ZGdn60oyr0rH/lezZk0rMzOTIw4UEqE+z8+fP281bdrU1fZleVkvGAkwAwYMcFVmbGystX379oCy7ty5YzVs2NC7XFRUlDVjxgzr119/1SHOXsbEiROD7lOvXr28y3Xu3Pm+HDsUHIIT8iU1NdWxgpGKQyqSmJgYx/nJycnW3bt3OepAIRDq87xbt26O5UdHR1tJSUlW2bJlHed37949aJlTpkxxXCcyMtKqX7++FRcX5zhfWpWysrJ8ylq5cqXPMuPHj/fOk99vb4mqVKmS4zFJS0vzLiO/h5b58Edwgmt//vmnVbRo0YCKpX379tbFixf1Mrdv37bGjRvnWAFNmzaNow6EuVCf52vWrHEsV1qLrl27ppe5fv26NXDgQMflZH1/Z86cscqUKePYSuUJLNIiNWvWLMdbg2PHjvUpT77b50tLk92bb77pM3///v0+8+V3JCYmeudPnTr1no4Z/hsEJ7g2dOjQgAqldOnSjs3j0j/Af1m5UgUQ3kJ9nktA8y+zRo0aus+VnXyPj48PWLZDhw4BZcrtMv/lJCAdOHAgYNmePXs63rK7ceOGdxn/0Hbw4EGfMt59912f+Zs3bw4avOQY0hpfOPBUHdw+TKAWL14cML1du3YqJiYmYPprr70WMG3v3r1q9+7dHHkgTIX6PL948aJKS0sLmN69e3f9xJqdfJfp/mR9Kcdu0aJFAcvJU3l169Y1+k3nz59XP/zwg/e7/7GQ+Xbnzp3z+W5fXo7N5MmT9efIyEg1a9YsVaQI/0kuDPhfCa789ddf6sKFCwHT5RFhJ02bNnWcvnXrVo48EKZCfZ7/8ccfKicn5562f/fuXbVt2zbv9+zsbMcgdy+/6bnnnvOZZw9VEj5/+ukn7/dKlSqpOnXq6M/y2wYNGqTu3Lmjv8twCklJSY7bQ/ghOMGVXbt2OU6Pj493nC7jkbgpB0Dohfo8L4jt79mzR4cp0zLj4uJUsWLFci2zffv2qmHDht7vEydOVDNnzlRbtmxR/fr1U5mZmd55MgaVp0Vp2rRp3gBWu3Zt9eGHHzruA8JT4P8rgFz4Nz17ODXfi9jYWFflAAi9UJ/nBbF9t2XKQJQyGObZs2eDllm0aFH1zTffqDZt2qgjR47oVq3BgwcHlCUhKjU11Tvo5vvvv++dN2PGDD3wJgoPWpzgyuXLlx2nyyjCbqZfunSJIw+EqVCf5wWxfbdlBpvn/5ukxWjnzp1qwoQJ6qmnnlLR0dG6pUpGNe/YsaNatWqVmjt3rg5iYsSIEd5RwSVQtWrVSn8+duyYGjNmjKpfv74qXbq0KlWqlB7BfOTIkTqUIXzQ4oT7IthrCUxeVwCgcAj1eV4Q289tXdNy5TUr7733nv7LjYQoaaHy9HmaNGmS/rx27Vr16quvBrxm5eDBg/pPgtfXX3+tO+cj9GhxgitSQTi5deuW4/SbN286Ti9fvjxHHghToT7PC2L7bssMVm5+f1NWVpZ+p5/H559/rm8THj16VD8V6AlN0sol78kbMGCA9xaerCvBipan8EBwgivyUk8n/o/h5jU9WDkAQi/U53lBbN9tmfLkm9Otxvz+pg8++EAdP35cf27btq16/fXX9Wdpdbp69ap3uQULFqg5c+bol/7Onz/fO13Ck2f4AoQWwQmuPPHEE47T5f68E09FYVoOgNAL9XleENuXx/2dnpILVuapU6e8wwWY7FtuZFiEqVOn6s/Sd2n69OmOQxhIv6iuXbt6v8tnmeYht/QQegQnuFKrVi3Hp1DS09Mdlw82PTk5mSMPhKlQn+cyhpI8sXYv25f17WM0RUVFqUaNGt1Tmfn5TTIEgozZ5BkKYfz48SoxMdExuCUkJHg7kQv5XKNGDcdlEToEJ7giJ3KvXr0CpstVk9OAeU4j9cqVn1MFBuDBPs/lKTIp2/7XsmXLgHVlGACnjtDLli1Tt2/fDuijJNP9paSk6HLyGg18+/btugO2yW+SYQ9k6AE3vvjiC7Vjxw5va5U8OWdnD0oynIE/+zT7sggdghNce+uttwKuBq9du6b69Onj7RMgTdzjxo3TA8H5GzZsGEcdCHOhPs+d1peO1EOGDPGGCfl36NChji0xTuv37dtXlSlTJmB679699fhKnifp5PUnS5YsCVhu4MCBuQ5f4LS/cnyEHEsp1/92ob1F6dChQ7ovk4f0fTp8+LDjsgihUL8sD4VTamqq4xvJo6Ki9Ms9Y2JiHOcnJyfzIkvgIT3P+/btG7BsixYtgm6/W7dujuVHR0dbSUlJ+l+n+d27dw9a5pQpUxzXiYyMtBo0aGDFxcU5zk9ISLCysrLy/aLi0aNHOy4j0+3bGTZsmD528jd8+HCfeWPGjHG1fRQMghPyJTs720pJSXGsYIL9JSYmWpmZmRxx4CE9z90Gp/Pnz1tNmjRxtX1ZXtYLJicnx+rfv7+rMmNjY6309HRXx27JkiXe9ePj44OGrqNHjwYEQPletmxZn2ny/dixY672AQWDW3XIFxlfZMWKFXpUW6cnVfxJf4VNmzbpzo8ACodQn+fSQX3dunX60f28+vfIfFlu/fr1QV+j4llOHvX/+OOP9RNueZHO4Bs3blSNGzc23m+5lTlq1Cjvd3k3nYwG7kTelbd06VI94rj9Fp19MEyZJwNgVq9e3XgfUHAiJD0VYPl4CGRkZOjxRuRRWRmgTTqPSj+CKlWqqBYtWqgePXo4dgAF8HCd59I5fN68eT7TZN0NGzbkuX3pxL1w4UIdpKQ/koQTGdRSXvDbunVr3Znd/hSdCSnnq6++Umlpabp/kbyHTp6+kyEAmjdvrrp06aJfm+K2U7b0D5N30Ak5Lk79pfxJPy0Zp0n2RT7Lf5olVMmYT/KeO/o3hQ+CEwAAgCFu1QEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOAEAABgiOMGVjz76SB04cICjBgB4KBUL9Q4g/wEmNy1atFAtW7Z0nHfp0iX15ZdfqsGDB6u4uLj7+j/BihUr1K5duwKmP/bYY6p37973dVsAwle41gVHjhxR8+bN834vVaqUqlq1qnrxxRdV5cqVjcvZuXOnSktLU++8804B7SnCFcGpkEpNTfV+3rNnj9qwYYMaPny4d1rx4sVDtGdK1apVS3Xq1MlnWtGiRYMuf/fu3YD5TtNM5Hc9AA9XXSD1ZYkSJdTVq1fVjz/+qBYuXKhGjhxJ/YE8EZwKqTJlyng/lyxZ0meaZVlq48aNKj09XV2/fl1VrFhRX01JJSaktUnMmDFD/1ujRg3Vr18/dfLkSbV+/Xp16tQplZOTo1uj2rZtq6pUqeJq36Sysu+fU2tZ+/bt1aFDh1RmZqZq3ry5ni63AJ9++mm1adMm3So2btw4dfnyZfX999+rv//+W0VEROjfkJKS4i1fAqPTevv27VM///yzunDhgoqMjNS/pWfPniENlMDDJhzqgmBKly6t605ZPzk5WS1evFidO3fO2+r022+/6ValixcvqqioKFWnTh310ksv6TpEWq1Wrlzp/Q32Vv47d+7oelQuaG/cuKEeeeQRXf8mJCTc12OL0CE4PYC2bNmiT/qXX35ZB4YdO3aoRYsWqaFDh6rY2Fg1cOBANXv2bNWnTx99Unuuym7duqUef/xxXRlJ+JIyFixYoEaMGKGvzO4nCTWtW7dW7dq1U0WKFNH7KCFn//79qkePHnqa7INUZlJRSbCTMLdmzRq1dOlS/d3Dfz25gly2bJmurOrXr69u3rypjh07dl/3H0D41wUmJNzs3btXf7a3UEk4k32qUKGCDk/fffedbpnq0KGDql69ur6otLf0ey7KZL8kgHXr1k1FR0frMDd//nw1ZMgQXf+i8CM4PYAk8Dz77LMqKSlJf5erJLlCkkAlJ71caXnu7duvBhMTE33K6dixo/rf//6njh49qq+2TGVkZKhPPvnEZ9rzzz+v/zxk35588smApvXOnTt79+/w4cPq9OnTatSoUapcuXJ6WpcuXdS0adN069ijjz7quJ6nxUxCU/ny5fU0N30XANwfoa4LcjN58mT97+3bt/W/devW1a3zHs2aNfN+lnrkhRdeUKtXr9Z1qAQs/5Z+Ia1i0ko1ZswYHZqEtKJJi5pMl4CIwo/g9ICR1hVpcZErIjv5LhVPbrKysnQTswSla9eu6fAhlYpUBm5IAJPKxU6auu2kM6Y/qZzsFZ5ctUkl6akoRaVKlXSFJfM8laX/ehKSZB+mT5+um/Nr1qypGjRoELAPAApWqOuC3Lzxxhv6Nv6JEyfUL7/8ErCfcktQpkv5Uq9KfSi34aROlPWcSB0rrWNTpkzxmS6BTi5U8WAgOMHnKZjs7GzdPC0VVLFixdScOXP0Se+GVCoxMTG5LuPU1yhYZWSyPTtpopfbkMePH9dXqr///rsOhHKLUprdAfw3Ql0X5EbqAgle0sokF4py20/ClJD+UdJZvGnTprqlScKe3O5ftWqVrg+DbUe6O8gtvkGDBgXcKqR/5YODcZweMNIXSZqIJTTYyXe5QrPfx5crKP9lpGNl7dq1vX2fpHN5qEiFJq1d9havs2fP6j4Jnt8SjFRe8fHxqlWrVnrYBfktjD8FFE73UheYkHrvzJkzun+U+Oeff3TLkfRjqlatmu6bJC35dlKnyDJ28iCNTJMgJoHR/pdbJ3kULrQ4PYDknrp0WpQrKukcLvfW//33X9W1a1c9X5qypTVJ7ruXLVtWf5YrLzm5d+/erZvOpWlaOkLKPLfkikxu+9nJ1Zfbpmq5xSa33ZYvX65bwSToSQdNeQrQqXnfQ5re5QkdGS9Gfqt89zxdCOC/E+q6wJS0IDVu3FjXm/Xq1dN1oWxj69atuu+TtDZt27bNZx25LSgtTHJLT+pZKUMCVqNGjXTrfZs2bfR0qXtkGdl/N31FEb4ITg8gebRWrsTWrl2rr3zkiqxXr17eJzqk4pIn5+RpFqkopGVGnkx55ZVXdOfHmTNn6kAlHRmlDLckkE2aNMlnmmzbPs6UCWk1kiEE5BHkuXPn+jyCnFerm/TTks7wEgClgpNKTFrSAPx3Ql0XuG11kjpDhjJp2LChrjM2b96s1q1bpwOa1IcSiOz9Rps0aaJv8UkXB89wBDJulQwHI3XnlStXdEiUVitC04MjwvJvawQAAIAj+jgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAYIjgBAAAoM/8HTw6pGLYrchUAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x150 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 16: Error KPI cards\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  COUNTIF(is_error) AS total_errors,\n",
+    "  SAFE_DIVIDE(COUNTIF(is_error), COUNT(*)) AS error_rate\n",
+    "FROM filtered_events\n",
+    "\"\"\")\n",
+    "rate_pct = f\"{df['error_rate'][0] * 100:.2f}%\" if df['error_rate'][0] else \"0.00%\"\n",
+    "kpi_row([\"Total Errors\", \"Error Rate\"], [df[\"total_errors\"][0], rate_pct])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cell-17-errors-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:47.141102Z",
+     "iopub.status.busy": "2026-04-11T06:42:47.140987Z",
+     "iopub.status.idle": "2026-04-11T06:42:49.355343Z",
+     "shell.execute_reply": "2026-04-11T06:42:49.354075Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No errors found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 17: Errors over time by event family\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(timestamp, HOUR) AS hour, event_family, COUNT(*) AS errors\n",
+    "FROM filtered_events WHERE is_error\n",
+    "GROUP BY hour, event_family ORDER BY hour\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    if len(df[\"hour\"].unique()) == 1:\n",
+    "        fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "        ax.bar(df[\"event_family\"], df[\"errors\"])\n",
+    "        ax.set_title(f\"Errors by Event Family (at {str(df['hour'].iloc[0])[:16]})\", fontweight=\"bold\")\n",
+    "        ax.set_ylabel(\"Errors\")\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "    else:\n",
+    "        pivot = df.pivot_table(index=\"hour\", columns=\"event_family\", values=\"errors\", fill_value=0)\n",
+    "        fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "        pivot.plot.area(ax=ax, alpha=0.7, stacked=True)\n",
+    "        fmt_ax(ax, \"Errors Over Time by Event Family\", ylabel=\"Errors\")\n",
+    "        ax.legend(loc=\"upper left\", fontsize=8)\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "else:\n",
+    "    print(\"No errors found.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "cell-18-tool-errors",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:49.358277Z",
+     "iopub.status.busy": "2026-04-11T06:42:49.358056Z",
+     "iopub.status.idle": "2026-04-11T06:42:52.869401Z",
+     "shell.execute_reply": "2026-04-11T06:42:52.868956Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No tool errors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 18: Tool errors by tool name + origin\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  COALESCE(tool_name, '(unknown)') AS tool,\n",
+    "  COALESCE(tool_origin, '(default)') AS origin,\n",
+    "  COUNT(*) AS errors\n",
+    "FROM tool_events WHERE is_error\n",
+    "GROUP BY tool, origin ORDER BY errors DESC LIMIT 15\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    labels = df[\"tool\"] + \" / \" + df[\"origin\"]\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    ax.barh(labels, df[\"errors\"])\n",
+    "    ax.set_title(\"Tool Errors by Name + Origin\", fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Errors\")\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No tool errors.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "cell-19-llm-errors",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:52.871055Z",
+     "iopub.status.busy": "2026-04-11T06:42:52.870925Z",
+     "iopub.status.idle": "2026-04-11T06:42:55.022684Z",
+     "shell.execute_reply": "2026-04-11T06:42:55.022059Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No LLM errors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 19: LLM errors by model\n",
+    "df = run(\"\"\"\n",
+    "SELECT COALESCE(model, '(unknown)') AS model, COUNT(*) AS errors\n",
+    "FROM llm_events WHERE is_error\n",
+    "GROUP BY model ORDER BY errors DESC LIMIT 10\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    ax.barh(df[\"model\"], df[\"errors\"])\n",
+    "    ax.set_title(\"LLM Errors by Model\", fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Errors\")\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No LLM errors.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel4-header",
+   "metadata": {},
+   "source": [
+    "## Panel 4: Performance — Latency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "cell-20-llm-latency",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:55.024688Z",
+     "iopub.status.busy": "2026-04-11T06:42:55.024558Z",
+     "iopub.status.idle": "2026-04-11T06:42:57.203301Z",
+     "shell.execute_reply": "2026-04-11T06:42:57.202807Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVoVJREFUeJzt3Qm4jfX+///3ZpvLPB9DigzZKDI0ODqJpCIqmkgkDg1UhgZDnXJSQmU45SSnk5KKMkQiGkxFsilSKfkZy5jM1v96ff7fe517bWsPtu3ew3o+rmtda7g/6173tO697/d6f96fuFAoFDIAAAAAAAAgQLmC/DAAAAAAAABACEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQCAdImLi3O3c845J/zaa6+9Fn59yJAhmbple/Xq5ZajevXqFgqFTum9mbEeP//8c/gzmzVrZkHKSvstmoULF4aX784778y05dB+8ZZD+wtA2tx9993ue5OQkHDK52MAORtBKQA4BbpYS+uFkS7Uvba6oErLxZZuRYsWtYMHD0a0OXz4sJUqVSqi3Zw5c1JdXn/7jLyA0nbQbdSoUZZTaf/6t59uuXLlsuLFi9uVV15p7733nuV006dPD+/r7HYBvmnTJpswYYJ7fN9997n9F+ti4XubXenvgLd/Vq1addrz27Bhg5uXgmiVKlWyfPnyWbFixdy56/3334/6nm3btlmPHj2sYsWKljdvXnffs2dP2759e0S7rVu32jPPPGMtW7a0KlWqWIECBezss8+2Jk2a2MSJE5NdpjVr1tjtt99uf/nLX9zylC5d2i6//PLw9zStpkyZYpdeeqmdddZZ7qbHb7/9dorv2bNnj5UvXz58Li9btuwpfeapfO60adPs+uuvd/8DFCpUyG3LChUq2E033WTLli1L8+edOHHCxo0bZxdeeKEVLFjQihQpYs2bN7f58+en+D9EtJv/h4PU7Nu3z/r372/nnXee209lypRx++3HH3+M2v7jjz92y6Xl03JedNFFNn78eLf8fg888ED4OEhtfwGIMSEAQJoNHjxYP++5W+fOnVNsW7ly5XDbTz75JNl2mua1826TJk2KaPPmm2+e1ObDDz9MdXn97Tdu3Jhhe9qbp9Yxp9L+TbrNk96GDh0aysn82yDaMfzZZ5+525dffhl+beLEieH36PuSWR588EG3DHnz5g3t3bv3lN+/ffv28Pr98ssvoSDoO+ptu7/+9a8ZPv+UvreZsb6nwn+eTO3ceyZpv5yJc6r/b4u+Q6dr2LBhKZ67Ro4cGdF+06ZNoQoVKkRtW6lSpdDmzZtT/Hvkv91///0nLc+7777rvovR2l955ZXp2k5Jb08++WSy7+vWrVtE2zJlyqT5M0/1c7t27Zps2/j4+NCiRYtO629QXFxcxP8I0f6HSHqrWrVqmj5T58o6depEnUexYsVCq1evjmj/6quvuuWJ1l7bIakmTZq4afXr10/T8gCIDWRKAUAWlPSX41deeSXTlgVmXbp0sc8++8xlp7Vp0ya8SZ588kmXNZCRDhw4kG02+WWXXeZuDRo0sKzk2LFj9t///tc9vuqqq6xw4cKnPA9lcXjrp0yTnC7W1jcWKHPl/vvvtxkzZrjMzkaNGoWnPfrooxHnGrXbvHmze9yuXTuXTaV7L+vQy3Lx5M+f37p27WrvvvuuzZw506655prwtBdeeMF++umn8HM9vuOOO+zIkSMuq6pfv35umfS+559/3mVLpYUyyHTOFWVmvfrqq+6mx6LMsNWrV5/0PmUS/fvf/3bLnB6n+rnVqlWzgQMHuswqZTXp77eyw7xzk7KfUvPBBx/YpEmT3GNleL311ls2cuRIi4+Pd13f1DXZy2BTJpX+PiW93XDDDeH5tW3bNk3r6l+Xpk2bumzZe+65xz3fvXu32+ce/e2799573fJoubQvtZzeumqbz5o1K2L+3jG1YsUKlzEFAE5mR8UAIDs505lSZ599dvjx+vXr3fQffvgh/Eukf3pGZkolJiaGbr311lDNmjXdr6H6NbdUqVKha665JuJX3ZR+LfZnXxw5ciQ0YsSI0EUXXRQqWLCguzVs2DD0+uuvJ7uMev/3338fuu6660KFChVyy3HPPfeEDh48eNJ7Jk+eHGrWrFmoaNGi7td3vff2228P7dmzJzRhwoTwPAcNGhTxvunTp4en9e7dO82/UvszfrQ8BQoUCE977733wtN27NgR6tOnj/tVWsul5dM2XLJkSYpZH8oiqFu3rnuP/7P0vhtvvDFUrly5UJ48edyv+61atQp9/fXXJ62Xsg287XH++eeHhgwZEvrzzz+TzfL45ptv3DbQfs6fP3/o6quvDv38888nZexEu3nHc7R9n1Km1E8//eQyFpR5oeXUZ998882hb7/9NqLd8ePHQ//4xz9CF1xwgVu2fPnyhSpWrOi2pfZvanTMesswevTok6aPHz/e/VKv40zLUb58ebf9nnnmmVTXI63b0L8uyqj7y1/+4o4bHbfaf9EyblLKlNq/f79bDm+b6FygNrNnz051e6Tle5uW9f3qq69Ct912W+iss85yx6LanThxwm0HrZeWS/sp2jY/lXNCNEm/M/Pnzw9dfPHF7tg455xzTsr8SS7zKKWMq99//z00YMAAdx7UvtI2vvDCC0Mvvvhi1O3h7TdlEemY1mu5cuUKZ7Fo2yiT5JJLLnHz0vZRFsqoUaPcceFJ6bvmLfupZiAqe1Hr4/fbb7+5c7s3n2XLlrnXt27d6pZbrxUpUiR8ztW9nuv13Llzh7Zt2+Ze1/f1119/jZj3oUOH3DHhzXvKlCnhaX//+9/Dr6d1f0fTs2fP8HyUCRYtKyzpeV3roPOxpj399NPpypRKz+cmpePTa9u6detUP1Pnea+9MtM8+pvovf7cc88l+37tj5IlS4aPyR9//DHZ/088hw8fdn9D9Jr+59iyZUv4OK5Ro0bEeUB0vvRe03JFy6S79tprIz531apV4WlPPPFEqtsBQGwgKAUAWSgo1ahRo1BCQoJ7/PDDD7vp/fv3d8+rV68ecUGUkUGplLpj6B/aBQsWpPniVhefusBPrl2/fv2iLmPhwoVDJUqUOKn9o48+GtH+rrvuSnbeWkddvOuiOVqXBf97Fy9enK6glHj/uOv21ltvudfU5Sm57i8KKL3//vtR93mVKlUiuj94n6WLWV0IpnShKo8//niy2+Pyyy93Fxoe//Fz7rnnntT+0ksvPWNBqRUrVkRsN/9N+8u7QBZdrCT32d4ypsR/8anuaH7/+c9/kp23AkeprUdat6HnvvvuO6mNLvQVSElrUErBVu+8EO02ZsyYQIJS55133knvv/fee6Pu13nz5oXncarnhGj83xkFjfSdSjoff8DgVINS6r7mBZaS3vz7ImlQateuXS5QqOf6Hr/88svhtp06dUp2nTt06BBudyaCUslRANWbz5o1a9xrCop7r11xxRUR7fXcmzZt2rQU560godd25syZ4dcVqNRrCgCrq1u1atVcMFH3w4cPjwjQpcT/HfD/WOIPQiu47+f9/VQgyP/9OpWgVHo+13/sK4inwGRagkleEEh/D732/u60Cnh6r7dp0ybZefjPcwrmJxUtKKVztP/vkl+XLl3C07wAsH5A8l7zdyfU8nqv69zgd/ToUbfvNa1ly5YpbgcAsYPuewCQxXTr1s3d/+c//7E///zTjYol/rT5jKbRyUaMGOFS9RcsWOC6HKiLgYqcqljpsGHDXLu77rrLdQvwqFis11XgnXfeca+NHj06XIi1cePGruirpukzZPjw4VGLvaq4qoq5qzuI11VC/vWvf4Ufa5q6TUju3LntoYcestmzZ7ttpW5aKuiqArQ333yza/PDDz+EP0vr4XUlUNFXFeU9Veruom2horkejSQkf//738PdXzp16uS6+mkbanmOHj3qtl20rnkbN2503d+mTp3qtr+6svy///f/XIHh48ePh7teeNtRIxipcK58+eWX4W1Vrlw5111Cn9u6dWv3mvaLunxEs3PnTleMVt3cVFxfvvjiC1u7dq2bl97bqlWriC453r5Wd5FToevuzp07h7fbgw8+aB999JErlqz9+Mcff7gukt6ITF4hZi2Xlk+FdLWPVYRZy5aa7777Lvy4atWqEdO8eau7idZfx+obb7zhlklFm09FSttQ1q9fby+++KJ7rCL5gwYNct2WGjZseEqF49XVKjEx0T1WNykdx9oeXrHmPn362K+//prs+9PyvU2L/fv325tvvmlPP/10+DWtn+an41PHbLTvbXrPCSntXxWN1nbQuvu7Hv3222+WHvr+qpuaqPviyy+/7L5LWjYV/I5GA1Jce+214f2tAvL6forWT/tItJ7abtr3Wn9R1y7dRPtBx7/nkUceCe8ff7e406X56Zj1zoE1a9Z0j/3HoopaJ+3W6T9XJUfTvv76a/dY5zyvS56+296xqe57jz/+uCvCrsE7dK+ufF73sNQkt5zJLaOWR3/X1M0uLV3mMupz5dChQ+7vkc7VtWrVssWLF7uuizpe1VUyJeomp7+Hp/qZfmPHjg0/Vle/tDjV4yAt20XnfK2PR+fdypUru8fffvttmpYLQAzI7KgYAGQnQWRKqcuF90uiusroXlkBKkR8pjKljh075rqU6JdudTNJWrhUXenSWjBZvxh7099+++1w8WR/9ou/q4P/c/zd0vzdBZQpIvpl2Htt4MCBya7PF198EZHJ4XWF815TF52MKHR+ww03uLbaZ942K1u2bHiddVMbr/0777xz0j5XllDSbjb+rh76hT05KijstXvkkUfCnzljxozw67Vr1w639x8//u5OPXr0CL+uroDRtkG0YzjacRAto0P71XutXr16EdvHK3zr7xbSuHHjcOaS9tuBAwdCp8Lf9UXdWPw6duzoXlf3sY8//jjZIuhpyRxKbRv6u7e0b98+3FbZNf4uoCllSimLRN8/L9NEy+xtO3+3qNSyL1L73qZlff1ZQF42om7qSic7d+6M2M/pPSdE4//OKKNJ5yyPstO8acoQOdVMKX3/vO5ryk5M2p3Uz789GjRoEH7s7/qZ9Fz1wgsvhNf5lVdeidq1KaMLnSelrrNexpLOVR988EF4mn8/KLvL74477ki1kLi6BfqLY/u7O6qbn/+cqWNPmVkvvfRS+O+c/9yvQtr+84Nu+tsn3j7STevjUdc073XtP9Hxoa6i/kzClDKlMupz/d0Gk/690N/Wvn37uuyplChrz/8+ZU559F3zZy5Gs3LlyohszrRmovmzq5o2bRoxzZ+R6xUw92eKetnUos/zL3/Srp76P0ev6xwIABKf2UExAECk4sWLW/v27W3y5Mkug0M0vLT/18eM1rdvX5cJkxx/ZlBqvv/++/BjL2MppUwWj4pR16tXL/y8RIkSEZ+vor3+eStDITmXXHKJ1ahRw9atW+eyEZQtpMKxnltuucVOh4b5Vuaal0GmjCwvy0fDqidXuDfaemtYce1zP/96ellP0fjbKXvFn8Hi0TaI5q9//Wuy2zqj+ZdTRYNT2j7169d323bp0qUuY0wZbco4OPfcc91w9spoOv/889P82d5+8SgjRceEshA1jLlouHZtDxVzPpWi7altQ3+xZ3+R6WLFirnj08ssSYkyf7xMA2WaeMuclmMroynDy78OyoIRb5uVLFky6nGU3nNCcvR5yrDzL5cy1JJu87TS99cbvl7HmZdBlJqvvvoqfD5Rxo+ff53vu+++TNtn3ucok1TfJy9z7brrros4n3mUweSnYy5aO3+xa83byxbT35LevXuHpyvbNmnWn1fsWvtMGWSiTDqd/1U4e9GiRRHvmThxot15553u85Wtl3Q5oy2jskZXrlzpzq/+DL7kZNTn+tdbmWlqr+2vjDtljKkYuM5nzz33XLLLknRemodXpD21/SFjxowJP9a6K0szLU71OEiuvb9ttOVMek4GALrvAUAW7sKX3POMpH8g1VXFS63/5z//aZ988on7h9q7yMzofyKjdWPTRa6flsWTns/3ujvu2LHDdRXzglIXXHCB1alTJ12j7+kiSiMGKUigC7uCBQue9non7SaR0TTaU9ILjKTb+3S3dUbxto+O9w8//NCN2FW7dm3XBebHH390x6kCQakFzvzBEX/XEWnRooXbj+pmpW6I2ofqdqkAsOZ9KkGNU9mGuhA9k4IYtVGBYY//Qjfa6IanehydzvJH27b+17xusJLe7n3ReIExjWzn7x6ZlfaZAp86rhWQ0jZRwEIBGD915fN4I7p5FGT3JO3e+ssvv7gAsxeQGjBggOsu56dgrf886XXdSvrY310tOcktZ7Rl3LJli7vXd13Hqtbdv/x6v15LOqrg6X6uR/PWSJYKpCtI542kJ/rBKbXziv87ldbPFJ0bvUCfuguq625anepxkJbtom7NSf+2e+dk/3kaQGwjKAUAWVCzZs3CtXBU30QX0mfK77//7upfSN26da1///7u85UxsGvXrqjv8S74vOwCP38Wiy7w/29QjYibV1/mVPnnnXSo6aRU1ylPnjzu8VNPPRW+cEpPlpT2gS4wlIGloJY3X4/2lbdNzjvvPBcISrrOCv498cQTabqg9q+namYlx99Ov+pH29a68E2arZBW/sBDtH2dVv7l1AVycsvp1ZbR86uvvtrV5FEtJWXkeBePuuBRfZaU+DNdlAXjp3kr+0oBLmVSKAPCu5BW9pTqCGUUHQse1f/yX5Qll8GWlC7cvIs61erR8ibddgq6aP+nJqXv7ZmU0ecEDSfvXwd/PSqdt5IG0PwXydH2r76/3rGu5UvrvlG2i96noG+bNm0iMp/866wgf7R1VqA1o79rfvqeXHHFFa6OlIKm+j6pdlZSOq95n68glvf3QPdeNp8CcP46fKqXpoCUtw7KGvUyR/00X//7vLpdSR97dbsWLlx40nZStpLoHOxfN8+SJUvCj5PLwkxNRn2uzv26pXSeTy2orrbK8ErrZ/qpBqXOY9KxY8eTsnBToh8AvO+NAo5eZp22hTJXk35uWraLv42ovqK331VrCwCE7nsAkE66MNIvw0kpqJP0l0GvaK6fLp66d++e7D+lKiCsfwTVVSWt6fcpUVFp/4WaqKuUugqqa4AuQBQA0LIqe0cFtJO7ONL6KWClX6OVYaJfvPWeatWq2W233WbffPNNuIudurWoe5S6eehiT4Wm1QXL+4f/VNx+++3hQtXqDqF//nXRpcCaik2r6LT367u6O+rzVVTZ69rj/aOe0fSPv4qCK4CkizR1t1Smlgrs6p97Xdgpm0L/rPt/XU6Oijjr2NLFrpZd+0hBNu2PefPmuQsWbedbb73VZWyJCuhqnygLTBc9Wg5liGl7eMXhT5X/ONb21YWpbkkvNFKjYKcueJRlpi4yWheto4J7Kpa7fPlyt5+8X9BvvPFGt+108aNjR/vZ6yol0TK//PwXdAo8+S/e1JXK63KkC2FdrPuzXFKb96lQoELnA13UeQX8L7roIrfPVCQ7LfTdVyBVhYsVnFOAWuugYJUyvLRNdWxpHyuYnJKUvrdnUkafE/SdUuF8Hf8KZnnfbwVfFcxMWuBeXaYU0FOAMtp3wfv+KtCtAJ8eP/bYY+74UDBbx9Drr79+0vs0AIGOzYcfftgdu/psnbNVjF/r7J2rlPGnbmvazgoQqcC3PkufM3jw4JO+azpWlI2i78fFF1/s1kvBBq8Yut6jou4p+fzzz93yeNlYCurq3KPX/YM06G+CCtXrWNV3cO/eve54U4aNAp1eBtMNN9wQzupUQKpp06YuC9Xbvzon+OetoJzX5VxZiV7QUT8QKHtKgUIdt6K/Pyl1U/ZoPiqgr/OguiprefS30uu2rHOTV2he6+4NPuDRse8NDKHzi34kSMugDafyufpOKsinc5y6I2rwDnXl1N9fj84BqdGgDsoWFX039HnaZuqWKDqe9ffQT+cZf0H3lAqc61jQ98h7nygjVftd3d31mo4DDSaiY1X7XPT/iP5v8I5rbUMdY1oudUkuX768e49/PfxU3Nw7x/rP0wBiHKW1ACDtUhpaPWnRYn+h82g3r5Bx0kLnKTmdQufRbl6h3169ep00TcN1ly5dOvzcT0Wbk5vX4cOHUxz+PWkhX38B3OTW1V+kPaUC5EmLuWtYcv/0hg0bprrNon1OWoZg1zDYFSpUSNOxkdyw9H4qiOwvsJvc9vMXoE1pH6e0TZMrsuwvmO6/pbTvkiuYreHGNTx4SsvqSen4UYFir/B9cjTsuArOJy0mLSrSm9y8VXhXxYtTWo9T3Yb33XffSZ+j4d7954eUCp3L7t27I4alj3ZLaTCFtHxvT3V9ow0pn9wxcarnhGj83xkVWI723fjHP/4Rbq9i0iqInrRNzZo1o343Uvr++vdFtO3RrVu38Gsq6u4Vz1fR8JTW2b+dVWg76QAT/s9Ibv+czt8q/zGj4trJrb+24+bNm8Nt/cuS1v158803J9t27Nixqa5PWtYruULsnpQKnWfU5/o/I9pNxc6XLVuWps9M7m+djpNJkyad1P6jjz5K8/8SyX1/dez6i9b7bzp/6zj1e/XVV6Met/6C6H7PPvtsePqaNWvStB0A5Hx03wMAuG4o+iVdv/DrF1hl+uiXbdWkiOall15yBYv1K3BS+rVVWWEqnK4CxPpFWr+E65d//RquX1T1q3t6KWNAWQvqBqZf+fV56l6nX+uTZqjp13L9cptRBc5TomVQRpSyJvSLsdZZ667H+tVcNa2SG1o+GtVVUgaPigLrl3ll9CjzQNkV/oLw+qV65syZbl2VgaDsir/85S8uc0H1wYYOHZrudVJWi44NdUPz10xKD2UHqMi5fjlXlqD2mzIZlEGl1/zdt9TFqEOHDu5zdTzqs7VO2sfKxkia8ZeU2ntZBMos84oUi+ahLJvq1au7+SjLQdtVWS/a3l73r4yiLB1lteg41DGhrC115/Ifq6nVJtN2UpadsjyUdabvpd6jzBtllamGTOPGjVNdlpS+t2dSRp8TtA31fVKWi7KIlPGlLpjKRvLoezB9+nTXdUyfr8wsfReSG9DB+/4qi8v7/urY03dN2zglyk5R7SBRRpgyG9VNSXWE1GUu6blKbbUc/q50ylpSW3U9TW9329Ohc5O6mKoLrb5r3nlEz5XJqMenQ5l5ysDRenrnRmW5KhsoLYXIPfouvfXWW26/qoC2bnqswQuU3XampPVzlcGoY0jfR51XdC7Sd1XdvlXLa/Xq1REDBqREWX2qAaZjUNtMdaZ07Oicpr8pSSmbMi1ZUinRZ+g8qL9j+n7qmNV6KCtRx4f2n5+y9+bOneuWS/tU5yZ9L/Wd8GpV+nnZccq40jYBAIlTZIpNAQDIqbxuKOoGpa4VCrwh59NIV+rCpVpeulg7lQvfjKR/s5LWDVN3UwUnVPtFASc9z4guugCQVakrrH6EEAXzkhuJE0Ds4T8gAECOo0CA6u8oa8EriK4aQgSkYocyP7xRK0eNGpVpowoq02zgwIGu7pECZcr0UuaNV4xYtbUISAHI6XQeFmVb6bwHAB4ypQAAOY6KZ/uHy1amyqeffnrKBbqBjOj2k1wXSnXVUlcZdbsEAACIRWRKAQByLNULUu2gyZMnE5BCptCIeKqbpJo8qs+iOkWquaJaYKrVQ0AKAADEMjKlAAAAAAAAEDgypQAAAAAAABA4glIAAAAAAAAIXHzwH5kznThxwrZs2WJnn332SUM/AwAAAAAAxIpQKGT79++38uXLpzjSMEGpDKKAlIafBgAAAAAAgNmvv/5qFSpUyJpBqXHjxrmbhu6WCy64wAYNGmStWrVyzw8dOmQPPvigvfXWW3b48GFr2bKljR071sqUKROex6ZNm6xnz572ySefuBFtOnfubMOGDbP4+P+t2sKFC61v3762du1aFzh67LHH7M4774xYljFjxtizzz5r27Zts7p169qLL75oDRs2TPO6KEPK2+CFCxc+7W0DAAAAAACQHe3bt8/FX7xYSZYMSila9s9//tOqVavmUrsmTZpkbdq0sa+//toFqPr06WOzZs2yqVOnWpEiRax3797Wrl07++KLL9z7jx8/7oZZLlu2rC1evNi2bt1qnTp1sjx58tjTTz/t2mzcuNG16dGjh73xxhs2f/5869atm5UrV84FuWTKlCkuaDV+/Hhr1KiRjRo1yk1bv369lS5dOk3r4nXZU0CKoBQAAAAAAIh1camUN4oLKRqUhRQvXtxlLN14441WqlQpmzx5snss69ats5o1a9qSJUuscePG9uGHH9q1117rus552VMKLPXv39927txpefPmdY8V2FqzZk34Mzp27Gh79uyxOXPmuOcKRF188cX20ksvhetDKaJ377332oABA9IcBVTgbO/evQSlAAAAAABAzNqXxhhJlhl9T1lP6qZ34MABa9Kkia1YscKOHj1qzZs3D7epUaOGVapUyQWlRPcJCQkR3fmU4aSVV1c9r41/Hl4bbx5Hjhxxn+VvoyJceu61AQAAAAAAQMbK9ELniYmJLgil+lGqCTVt2jSrVauWrVq1ymU6FS1aNKK9AlCq+yS69wekvOnetJTaKHB18OBB2717twuIRWujzKzkqMaVbh7Nz8uy0g0AAAAAACAWnUhjXCTTg1LVq1d3ASildL3zzjuuUPmiRYssq1Mx9aFDh570uroNKsCW0o5REAzJy507d4pDRgIAAAAAgKxr//792SMopWyoqlWrusf169e3L7/80kaPHm0dOnRwXetU+8mfLbV9+3ZX2Fx0v3z58oj5abo3zbv3XvO3UZ/GAgUKuACIbtHaePOIZuDAga44etLK8qqDFa2/pEp3aZ5aH6RO+1zZaqkVRQMAAAAAAFlL/vz5s0dQKlomkbrFKUClUfQ0Wl779u3dNI2Gt2nTJtfdT3T/1FNP2Y4dO8Kj5M2bN88FhdQF0Gsze/bsiM9QG28eCorps/Q5bdu2DS+Dnmu0v+Tky5fP3ZJShk+0LB+NDKhsMAVaChYsSLAlGQre/fnnn26fKiClURIBAAAAAED2kdbeT5kalFK2UatWrVzxcqV2aaS9hQsX2ty5c12V9q5du7psJI3Ip0CTRsNTMEkj70mLFi1c8OmOO+6w4cOHu/pRjz32mPXq1SscMOrRo4cbVa9fv35211132YIFC+ztt992I/J59BnqNtigQQNr2LChjRo1yhVc79KlS4asp7rrKUNKgbMSJUpkyDxzMmWwiRdsVCYbAAAAAADIWTI1KKWgQ6dOnVwWkYJQderUcQGpq666yk0fOXKki64pU0rZUxo1b+zYseH3K1gxc+ZM69mzpwtWFSpUyAWXnnjiiXCbKlWquABUnz59XLfAChUq2IQJE9y8POoqqFpQgwYNcoGtevXq2Zw5c04qfp5eGkVQlCGFtPG2lbYdQSkAAAAAAHKeuJD6S+G0qaaUAmvqope0ppQKn2/cuNEFyNLarzLWsc0AAAAAAMh5MRI/hjgDAAAAAABA4AhKAQAAAAAAIHBZbvS9WHPOgP8VXD/Tfv5n6wyf55133mmTJk2KeE31ulSTy7Nr1y5XpH7GjBnhGmGq73XWWWdl+PIAAAAAAIDsgaAUTtvVV19tEydODD/3Rj703Hbbba6Y/bx581zhco1q2L17dzfaIgAAAJDVJUxKyOxFABBDEjsnWqwgKIUUNWvWzGrXru0ev/7665YnTx432qFGOIyLiwsHocqWLRv1/d99953Lmvryyy+tQYMG7rUXX3zRrrnmGnvuueesfPny7AEAAAAAAGIQNaWQKnXPi4+Pt+XLl7tud88//7xNmDAhPH3hwoVWunRpq169ugtY/f777+FpS5YssaJFi4YDUtK8eXPXjW/ZsmVsfQAAAAAAYhSZUkhVxYoVbeTIkS4zSoGnxMRE9/zuu+92XffatWtnVapUsR9//NEeeeQRa9WqlQtG5c6d27Zt2+YCVhEHXXy8FS9e3E0DAAAAAACxiaAUUtW4ceNwVz1p0qSJjRgxwo4fP24dO3YMv56QkGB16tSx8847z2VPXXnllWxdAAAAAAAQFd33kKHOPfdcK1mypP3www/uuWpN7dixI6LNsWPH3Ih8ydWhAgAAAAAAOR9BKaQqae2npUuXWrVq1Vz3vKQ2b97sakqVK1cunFW1Z88eW7FiRbjNggUL7MSJE9aoUSO2PgAAAAAAMYqgFFK1adMm69u3r61fv97efPNNN3re/fffb3/88Yc9/PDDLkj1888/2/z5861NmzZWtWpVa9mypXtvzZo1Xd0p1Z9SofQvvvjCevfu7br9MfIeAAAAAACxi5pSSFWnTp3s4MGD1rBhQ5cdpYBU9+7d7dChQ7Z69Wo3Op+yoRRkatGihT355JOWL1++8PvfeOMNF4hSjSmNute+fXt74YUX2PIAAAAAAMQwglKZ7Od/trasLk+ePDZq1CgbN25cxOsFChSwuXPnpvp+jbQ3efLkM7iEAAAAAAAgu6H7HgAAAAAAAAJHUAoAAAAAAACBo/seUrRw4UK2EAAAAAAAyHBkSgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMDFB/+RiDCkSHAbZMjeDJ/l9u3brX///vbRRx/Znj17rGnTpvbiiy9atWrVwm0OHTpkDz74oL311lt2+PBha9mypY0dO9bKlCmT4csDAAAAAACyBzKlkG6hUMjatm1rP/30k73//vv29ddfW+XKla158+Z24MCBcLs+ffrYjBkzbOrUqbZo0SLbsmWLtWvXji0PAAAAAEAMI1MKKWrWrJnVrl3bPX799dctT5481rNnT3viiSdsw4YNtnTpUluzZo1dcMEFrs24ceOsbNmy9uabb1q3bt1s79699u9//9smT55sf/vb31ybiRMnWs2aNd17GzduzB4AAAAAACAGkSmFVE2aNMni4+Nt+fLlNnr0aHv++edtwoQJriue5M+f/38HVK5cli9fPvv888/d8xUrVtjRo0dd9pSnRo0aVqlSJVuyZAlbHwAAAACAGEWmFFJVsWJFGzlypMXFxVn16tUtMTHRPf/mm29ccGngwIH2r3/9ywoVKuRe37x5s23dutW9d9u2bZY3b14rWrRoxDxVT0rTAAAAAABAbCJTCqlSFzsFpDxNmjRxXfeUFfXee+/Z999/b8WLF7eCBQvaJ598Yq1atXLTAAAAAAAAkkOmFE5L/fr1bdWqVa521JEjR6xUqVLWqFEja9CggZuu+lJ6XSPz+bOlNGqfpgEAAAAAgNhEOgtStWzZsojnKlBerVo1y507d/i1IkWKuICUMqi++uora9OmTThopeLo8+fPD7ddv369bdq0yWVcAQAAAACA2ESmFFKlAFLfvn3tnnvusZUrV9qLL75oI0aMcNOmTp3qglGqLaVaU/fff7+1bdvWWrRoEQ5Wde3a1b1fXfwKFy5s9957rwtIMfIeAAAAAACxi6AUUtWpUyc7ePCgNWzY0GVHKfDUvXt3N00FzRVwUne8cuXKubaPP/54xPtV/Fw1ptq3b+9G7GvZsqWNHTuWLQ8AAAAAQAyLC4VCocxeiJxg3759LitItZWUDeR36NAh27hxo1WpUsXy589v2UmzZs2sXr16NmrUqEA/NztvMwAAAOQsCZMSMnsRAMSQxM6JlpNjJH7UlAIAAAAAAEDgCEoBAAAAAAAgcNSUQooWLlzIFgIAAAAAABmOTCkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAALEVlBo2bJhdfPHFdvbZZ1vp0qWtbdu2tn79+og2zZo1s7i4uIhbjx49Itps2rTJWrdubQULFnTzefjhh+3YsWMn1Ua66KKLLF++fFa1alV77bXXTlqeMWPG2DnnnGP58+e3Ro0a2fLly8/QmgMAAAAAAMS2TA1KLVq0yHr16mVLly61efPm2dGjR61FixZ24MCBiHZ33323bd26NXwbPnx4eNrx48ddQOrIkSO2ePFimzRpkgs4DRo0KNxm48aNrs0VV1xhq1atsgceeMC6detmc+fODbeZMmWK9e3b1wYPHmwrV660unXrWsuWLW3Hjh0BbQ0AAAAAAIDYERcKhUKWRezcudNlOilY1bRp03CmVL169WzUqFFR3/Phhx/atddea1u2bLEyZcq418aPH2/9+/d388ubN697PGvWLFuzZk34fR07drQ9e/bYnDlz3HNlRilr66WXXnLPT5w4YRUrVrR7773XBgwYkOqy79u3z4oUKWJ79+61woULR0w7dOiQC4xVqVLFZWEhdWwzAAAAZBUJkxIyexEAxJDEzomW3aUUI/GLtyxECyvFixePeP2NN96w//73v1a2bFm77rrr7PHHH3dd9WTJkiWWkJAQDkiJMpx69uxpa9eutQsvvNC1ad68ecQ81UYZU6IsqxUrVtjAgQPD03PlyuXeo/dGc/jwYXfzb3AvmKWbn54r9ufdkDpvW0XbngAAAECQclGKF0CATuSAa+C0rkN8VlpgBYkuvfRSq127dvj1W2+91SpXrmzly5e31atXu6wn1Z1677333PRt27ZFBKTEe65pKbVRIOngwYO2e/du1w0wWpt169YlWw9r6NChJ72u7Cxl+fipW6LWT3Wukta6umjyRRaUlbeuzPB5bt++3R555BH7+OOPXebZ5ZdfbiNHjrRq1aqF2/z4449uv6l7pQJ56qKpzLek29tP20nb7Pfff7c8efJk+HIDAAAAaVUt/n//2wLAmbYjB5QR2r9/f/YKSqm2lLrXff755xGvd+/ePfxYGVHlypWzK6+80gU6zjvvPMssyqpSDSqPAlzq7leqVKmo3fe0Q+Lj490ts2T0ZyuT6aabbnJBo+nTp7v1fv75561Vq1YuS61QoUKuPpjqealG1/z58937VO+rXbt2LgtNGWnJLaumlShRgi6PAAAAyFQbjm1gDwAITOnSpbP91k5r6aIsEZTq3bu3zZw50z799FOrUKFCim1V+0l++OEHF5RSl76ko+Qpe0c0zbv3XvO3URClQIECljt3bneL1sabR1IaxU+3pBRISRpo0XP/6IGZJT2frZpeXuba66+/7gJQ6hr5xBNPuH2gIvUKJl5wwQXhel7aZm+99ZYrJq/sqJ9//tm+/vrrcLBOxeiLFStmn3zyyUndKv3Lqlu07QkAAAAE6YRl/640ALKPXDngGjit65Cpa6pMGwWkpk2bZgsWLHCFwFOj0fNEGVPSpEkTS0xMjEhv00h+CoDUqlUr3MbL0vG30euiYuj169ePaKOuY3rutYllCiIpc0nBv9GjR7tsqAkTJoRravkjoDrwFKzzMt7URsElfwBP7dUuaVYcAAAAAACIHbkyu8ueCphPnjzZzj77bFf7STfVeRJ10XvyySddEXJl23zwwQfWqVMnNzJfnTp1XBvVJ1Lw6Y477rBvvvnG5s6da4899pibtxcI6dGjh/3000/Wr18/VyNq7Nix9vbbb1ufPn3Cy6KueK+88ooLwHz33XcuG0hdz7p06WKxTt0SVSeqevXqdtttt7kRCfW8Ro0aVqlSJdeVUXW5VDD+mWeesc2bN9vWrVvdexs3buy68amm1J9//um26UMPPeRqeHltAAAAAABA7MnUoNS4cePciHvqIqbMJ+82ZcqUcAaTCmgr8KQAyIMPPmjt27e3GTNmhOehbnfq+qd7ZTXdfvvtLnCl7mUeZWDNmjXLZUepttGIESNcpo9G4PN06NDBnnvuOVfvqF69ei4ja86cOSkW444VCiz5u/5pO2/YsMFlO6ng/Pfff+9GTNSIiOqSp5pSXqqeamxNnTrV7bOzzjrLDQmpgugXXXRRjkhJBAAAAAAA6ROf2d33UsvQWbRoUarz0eh8s2fPTrGNAl+qa5QSdSXUDWmnbo8K4Cm4qEwpBaFU96tBgwbhNgoqKuvtt99+c90AixYt6upOnXvuuWxqAAAAAABiFKkqSNWyZcsinqu4ebVq1Vx2mkcZUApIKYPqq6++sjZt2pw0n5IlS7qAlOqHqQbY9ddfz9YHAAAAACBGZYnR95C1bdq0ydXcuueee2zlypX24osvui6Qoq55CkaptpQKzt9///3Wtm1blx3lmThxotWsWdO1W7JkiWujel6qUQUAAAAAAGITQSmkSjW6VHy+YcOGLjtKQaXu3bu7aSpWroDV9u3bXT0wtX388ccj3r9+/XpXDH3Xrl12zjnn2KOPPhpRZB4AAAAAAMSeuFBqhZ2QJvv27XNd2FRbqXDhwhHTDh06ZBs3bnQF1/Pnz5+ttqhqcanw+6hRowL93Oy8zQAAAJCzJExKyOxFABBDEjsnWk6OkfhRUwoAAAAAAACBIygFAAAAAACAwFFTCilauHAhWwgAAAAAAGQ4MqUAAAAAAAAQOIJSAAAAAAAACBxBqQCdOHEiyI/L1thWAAAAAADkbNSUCkDevHktV65ctmXLFitVqpR7HhcXF8RHZzuhUMiOHDliO3fudNtM2woAAAAAAOQ8BKUCoOBKlSpVbOvWrS4whdQVLFjQKlWq5LYdAAAAAADIeQhKBUQZPwqyHDt2zI4fPx7Ux2ZLuXPntvj4eLLJAAAAAADIwQhKBUhd9vLkyeNuAAAAAAAAsYy+UQAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAIitoNSwYcPs4osvtrPPPttKly5tbdu2tfXr10e0OXTokPXq1ctKlChhZ511lrVv3962b98e0WbTpk3WunVrK1iwoJvPww8/bMeOHYtos3DhQrvooossX758VrVqVXvttddOWp4xY8bYOeecY/nz57dGjRrZ8uXLz9CaAwAAAAAAxLZMDUotWrTIBZyWLl1q8+bNs6NHj1qLFi3swIED4TZ9+vSxGTNm2NSpU137LVu2WLt27cLTjx8/7gJSR44cscWLF9ukSZNcwGnQoEHhNhs3bnRtrrjiClu1apU98MAD1q1bN5s7d264zZQpU6xv3742ePBgW7lypdWtW9datmxpO3bsCHCLAAAAAAAAxIa4UCgUsixi586dLtNJwaemTZva3r17rVSpUjZ58mS78cYbXZt169ZZzZo1bcmSJda4cWP78MMP7dprr3XBqjJlyrg248ePt/79+7v55c2b1z2eNWuWrVmzJvxZHTt2tD179ticOXPcc2VGKWvrpZdecs9PnDhhFStWtHvvvdcGDBiQ6rLv27fPihQp4pa5cOHCZ2gLAQAAAAhawqQENjqAwCR2Tsz2WzutMZIsVVNKCyvFixd39ytWrHDZU82bNw+3qVGjhlWqVMkFpUT3CQkJ4YCUKMNJG2Dt2rXhNv55eG28eSjLSp/lb5MrVy733GsDAAAAAACAjBNvWYQyk9St7tJLL7XatWu717Zt2+YynYoWLRrRVgEoTfPa+ANS3nRvWkptFLg6ePCg7d6923UDjNZGmVnRHD582N08mpe3HroBAAAAyBlyZa3f8gHkcCdyQEwhreuQZYJSqi2l7nWff/65ZQcq0j506NCTXleXQRVnBwAAAJAzVIuvltmLACCG7MgBta3379+ffYJSvXv3tpkzZ9qnn35qFSpUCL9etmxZ17VOtZ/82VIafU/TvDZJR8nzRufzt0k6Yp+eq19jgQIFLHfu3O4WrY03j6QGDhzoCqP7M6VUg0o1sKgpBQAAAOQcG45tyOxFABBDSpcubdld/vz5s35QSjXWVUh82rRptnDhQqtSpUrE9Pr161uePHls/vz51r59e/fa+vXrbdOmTdakSRP3XPdPPfWUiyR6O04j+SkwVKtWrXCb2bNnR8xbbbx5qIugPkuf07Zt23CqmZ4rYBZNvnz53C0p1aLSDQAAAEDOcMKyf1caANlHrhwQU0jrOsRndpc9jaz3/vvv29lnnx2uAaUK7cpg0n3Xrl1dRpKKnyvQpCCWgkkaeU9atGjhgk933HGHDR8+3M3jsccec/P2gkY9evRwo+r169fP7rrrLluwYIG9/fbbbkQ+jz6jc+fO1qBBA2vYsKGNGjXKDhw4YF26dMmkrQMAAAAAAJBzZWpQaty4ce6+WbNmEa9PnDjR7rzzTvd45MiRLsKmTCkVFteoeWPHjg23Vbc7df3r2bOnC1YVKlTIBZeeeOKJcBtlYCkA1adPHxs9erTrIjhhwgQ3L0+HDh1cPahBgwa5wFa9evVszpw5JxU/BwAAAAAAwOmLC6kPHU6bakops2vv3r3UlAIAAABykIRJCZm9CABiSGLnRIuVGEn276gIAAAAAACAbIegFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAA2SMoNWnSJJs1a1b4eb9+/axo0aJ2ySWX2C+//JKRywcAAAAAAIAcKF1BqaefftoKFCjgHi9ZssTGjBljw4cPt5IlS1qfPn0yehkBAAAAAACQw8Sn502//vqrVa1a1T2ePn26tW/f3rp3726XXnqpNWvWLKOXEQAAAAAAADlMujKlzjrrLPv999/d448++siuuuoq9zh//vx28ODBjF1CAAAAAAAA5DjpypRSEKpbt2524YUX2vfff2/XXHONe33t2rVWuXLljF5GAAAAAAAA5DDpypRSDakmTZrYzp077d1337USJUq411esWGG33nprmufz6aef2nXXXWfly5e3uLg41xXQ784773Sv+29XX311RJtdu3bZbbfdZoULF3bF1rt27Wp//PFHRJvVq1fb5Zdf7jK5Klas6OpfJTV16lSrUaOGa5OQkGCzZ88+xa0CAAAAAACAM5oppeDPc88954I9O3bssA8++MC9Xr9+/VOaz4EDB6xu3bp21113Wbt27aK2URBq4sSJ4ef58uWLmK6A1NatW23evHl29OhR69Kli6tvNXnyZDd937591qJFC2vevLmNHz/eEhMT3edpHdROFi9ebLfccosNGzbMrr32Wvfetm3b2sqVK6127dqnvH0AAAAAAACQsrhQKBSyUzRnzhzr1KmTqyuV9O3KZjp+/PipztK9b9q0aS4Y5M+U2rNnz0kZVJ7vvvvOatWqZV9++aU1aNAgvGzqTrh582aXgTVu3Dh79NFHbdu2bZY3b17XZsCAAW6e69atc887dOjgAmQzZ84Mz7tx48ZWr149F8hKCwW/ihQpYnv37nVZWwAAAAByhoRJCZm9CABiSGLnRMvu0hojSVf3vXvvvdduuukm27Jli504cSLilp6AVEoWLlxopUuXturVq1vPnj3DBdZlyZIlLuPJC0iJMqJy5cply5YtC7dp2rRpOCAlLVu2tPXr19vu3bvDbfQ+P7XR6wAAAAAAAMgi3fe2b99uffv2tTJlytiZpK576tZXpUoV+/HHH+2RRx6xVq1auWBR7ty5XfaTAlZ+8fHxVrx4cTdNdK/3+3nLrWnFihVz90nXRc+9eURz+PBhd/NHAcULzgEAAADIGXKl77d8AEiXEzkgppDWdUhXUOrGG290GUznnXeenUkdO3YMP1bx8Tp16rjP1GdfeeWVlplUf2ro0KEnva7i74cOHcqUZQIAAACQ8arFV2OzAgjMjh07sv3W3r9//5kLSr300kuu+95nn33mgkV58uSJmH7ffffZmXDuuedayZIl7YcffnBBqbJly560s44dO+ZG5NM00b0yu/y856m18aZHM3DgQJct5s+U0sh+pUqVoqYUAAAAkINsOLYhsxcBQAwpnaRHWHaUP3/+MxeUevPNN+2jjz5yH6KsJRUp9+jxmQpKqXi5akqVK1fOPW/SpIkrhL5ixYrwyH8LFixwaWKNGjUKt1Ghc43M5wXPNFKfalSp657XZv78+fbAAw+EP0tt9HpyNApg0pEARfWsdAMAAACQM5yw7N+VBkD2kSsHxBTSug7pWlMFedR1TVXUf/75Z9u4cWP49tNPP6V5Pn/88YetWrXK3UTv1+NNmza5aQ8//LAtXbrUfYaCRm3atLGqVau6IuRSs2ZNV3fq7rvvtuXLl9sXX3xhvXv3dt3+NPKe3Hrrra7IedeuXW3t2rU2ZcoUGz16dESW0/333+9G7RsxYoQbkW/IkCH21VdfuXkBAAAAAAAg46UrKHXkyBHr0KHDaUfvFPi58MIL3U0UKNLjQYMGuULmq1evtuuvv97OP/98F1RSNpS6DPozlN544w2rUaOG6853zTXX2GWXXWYvv/xyeLqGIFRWlwJeev+DDz7o5t+9e/dwm0suucQmT57s3le3bl175513bPr06Va7du3TWj8AAAAAAABEFxcKhUJ2ivr06eNqJ2k0PPyvppQCYMoeK1y4MJsFAAAAyCESJiVk9iIAiCGJnRMtVmIk6aopdfz4cRs+fLjNnTvXjYiXtND5888/n57ZAgAAAAAAIEakKyiVmJgY7nK3Zs2aiGn+oucAAAAAAABAhgWlPvnkk/S8DQAAAAAAAHCy/ziDAAAAAAAAyHYISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIGLD/4jAQBAmgwpwoYCEJwhe9naAIBAkSkFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAACIraDUp59+atddd52VL1/e4uLibPr06RHTQ6GQDRo0yMqVK2cFChSw5s2b24YNGyLa7Nq1y2677TYrXLiwFS1a1Lp27Wp//PFHRJvVq1fb5Zdfbvnz57eKFSva8OHDT1qWqVOnWo0aNVybhIQEmz179hlaawAAAAAAAGRqUOrAgQNWt25dGzNmTNTpCh698MILNn78eFu2bJkVKlTIWrZsaYcOHQq3UUBq7dq1Nm/ePJs5c6YLdHXv3j08fd++fdaiRQurXLmyrVixwp599lkbMmSIvfzyy+E2ixcvtltuucUFtL7++mtr27atu61Zs+YMbwEAAAAAAIDYFBdSOlIWoEypadOmuWCQaLGUQfXggw/aQw895F7bu3evlSlTxl577TXr2LGjfffdd1arVi378ssvrUGDBq7NnDlz7JprrrHNmze7948bN84effRR27Ztm+XNm9e1GTBggMvKWrdunXveoUMHFyBTUMvTuHFjq1evnguIpYWCX0WKFHHLqKwtAABO25AibEQAwRmyl62djIRJCWwbAIFJ7JyY7bd2WmMk8ZZFbdy40QWS1GXPoxVq1KiRLVmyxAWldK8ue15AStQ+V65cLrPqhhtucG2aNm0aDkiJsq2eeeYZ2717txUrVsy16du3b8Tnq03S7oR+hw8fdjf/BpcTJ064GwAAp4/SjwACxP+wycrF+RhAgE7kgPNxWtchywalFJASZUb56bk3TfelS5eOmB4fH2/FixePaFOlSpWT5uFNU1BK9yl9TjTDhg2zoUOHnvT6zp07I7oXAgCQboXrsPEABGfHDrZ2MqrFV2PbAAjMjhxwPt6/f3/2DkpldQMHDozIrlKmlIqolypViu57AICMsW81WxJAcJL82Iv/2XAscrAlADiTSueA87EGkcvWQamyZcu6++3bt7vR9zx6rlpPXpukEcRjx465Efm89+te7/HznqfWxpseTb58+dwtKXUd1A0AgNOX/VO3AWQj/A+brBOcjwEEKFcOOB+ndR2y7Jqqy52CQvPnz4/IRlKtqCZNmrjnut+zZ48bVc+zYMEC13dRtae8NhqR7+jRo+E2GqmvevXqruue18b/OV4b73MAAAAAAACQsTI1KPXHH3/YqlWr3M0rbq7HmzZtcqPxPfDAA/aPf/zDPvjgA0tMTLROnTq5EfW8Efpq1qxpV199td199922fPly++KLL6x3796uCLraya233uqKnHft2tXWrl1rU6ZMsdGjR0d0vbv//vvdqH0jRoxwI/INGTLEvvrqKzcvAAAAAAAAZLxM7b6nwM8VV1wRfu4Fijp37myvvfaa9evXzw4cOGDdu3d3GVGXXXaZCx75+ya+8cYbLnh05ZVXuvSw9u3b2wsvvBAxYt9HH31kvXr1svr161vJkiVt0KBBbp6eSy65xCZPnmyPPfaYPfLII1atWjU38l7t2rUD2xYAAAAAAACxJC4UCoUyeyFyAnUtVABs7969FDoHAGSMIUXYkgCCM2QvWzsZCZMS2DYAApPYOTFmYiRZtqYUAAAAAAAAci6CUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOCydFBqyJAhFhcXF3GrUaNGePqhQ4esV69eVqJECTvrrLOsffv2tn379oh5bNq0yVq3bm0FCxa00qVL28MPP2zHjh2LaLNw4UK76KKLLF++fFa1alV77bXXAltHAAAAAACAWJSlg1JywQUX2NatW8O3zz//PDytT58+NmPGDJs6daotWrTItmzZYu3atQtPP378uAtIHTlyxBYvXmyTJk1yAadBgwaF22zcuNG1ueKKK2zVqlX2wAMPWLdu3Wzu3LmBrysAAAAAAECsiLcsLj4+3sqWLXvS63v37rV///vfNnnyZPvb3/7mXps4caLVrFnTli5dao0bN7aPPvrIvv32W/v444+tTJkyVq9ePXvyySetf//+Lgsrb968Nn78eKtSpYqNGDHCzUPvV+Br5MiR1rJly8DXFwAAAAAAIBZk+UypDRs2WPny5e3cc8+12267zXXHkxUrVtjRo0etefPm4bbq2lepUiVbsmSJe677hIQEF5DyKNC0b98+W7t2bbiNfx5eG28eAAAAAAAAiLFMqUaNGrnudtWrV3dd94YOHWqXX365rVmzxrZt2+YynYoWLRrxHgWgNE107w9IedO9aSm1UeDq4MGDVqBAgajLdvjwYXfzqL2cOHHC3QAAiIHfjgDkJPwPm6xcnI8BBOhEDjgfp3UdsnRQqlWrVuHHderUcUGqypUr29tvv51ssCgow4YNc0GypHbu3OkKsAMAcNoK12EjAgjOjh1s7WRUi6/GtgEQmB054Hy8f//+7B+USkpZUeeff7798MMPdtVVV7kC5nv27InIltLoe14NKt0vX748Yh7e6Hz+NklH7NPzwoULpxj4GjhwoPXt2zciU6pixYpWqlQp914AAE7bvtVsRADBKV2arZ2MDcc2sG0ABKZ0Djgf58+fP+cFpf744w/78ccf7Y477rD69etbnjx5bP78+da+fXs3ff369a7mVJMmTdxz3T/11FMuyujt1Hnz5rmgUa1atcJtZs+eHfE5auPNIzn58uVzt6Ry5crlbgAAnL7sn7oNIBvhf9hkneB8DCBAuXLA+Tit65Cl1/Shhx6yRYsW2c8//2yLFy+2G264wXLnzm233HKLFSlSxLp27eqylT755BNX+LxLly4umKSR96RFixYu+KQg1jfffGNz5861xx57zHr16hUOKPXo0cN++ukn69evn61bt87Gjh3rugf26dMnk9ceAAAAAAAg58rSmVKbN292Aajff//ddYu77LLLbOnSpe6xjBw50kXflCmlouMaNU9BJY8CWDNnzrSePXu6YFWhQoWsc+fO9sQTT4TbVKlSxWbNmuWCUKNHj7YKFSrYhAkT3LwAAAAAAABwZsSFQqHQGZp3TFFNKWVv7d27l5pSAICMMaQIWxJAcIbsZWsnI2FSAtsGQGASOyfGTIwkS3ffAwAAAAAAQM5EUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAAQuPviPRFZ3zoBZmb0IAGLIz/9sndmLAAAAACATkCkFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AqiTFjxtg555xj+fPnt0aNGtny5cuD3ysAAAAAAAA5HEEpnylTpljfvn1t8ODBtnLlSqtbt661bNnSduzYkXl7CAAAAAAAIAciKOXz/PPP2913321dunSxWrVq2fjx461gwYL26quvZt4eAgAAAAAAyIEISv2fI0eO2IoVK6x58+b/2zi5crnnS5Ysyaz9AwAAAAAAkCPFZ/YCZBW//fabHT9+3MqUKRPxup6vW7fupPaHDx92N8/evXvd/Z49e+zEiROWrR0+kNlLACCG6LyJZByOY9MACA7n42SFDoY4EgEEZk8OOB/v27fP3YdCKZ8/CUql07Bhw2zo0KEnvV65cuX0zhIAYlKxUZm9BAAA55/F2BAAkAUU65lzzsf79++3IkWKJDudoNT/KVmypOXOndu2b98esYH0vGzZsidtuIEDB7qi6B5lR+3atctKlChhcXH8so3Yoih4xYoV7ddff7XChQtn9uIAQEzjnAwAWQPnY8SyUCjkAlLly5dPsR1Bqf+TN29eq1+/vs2fP9/atm0bDjTpee/evU/acPny5XM3v6JFi2bcHgSyIQWkCEoBQNbAORkAsgbOx4hVRVLIkPIQlPJR5lPnzp2tQYMG1rBhQxs1apQdOHDAjcYHAAAAAACAjENQyqdDhw62c+dOGzRokG3bts3q1atnc+bMOan4OQAAAAAAAE4PQakk1FUvWnc9AMlTV9bBgwef1KUVABA8zskAkDVwPgZSFxdKbXw+AAAAAAAAIIPlyugZAgAAAAAAAKkhKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAovIPzMkgnQCQefzn4BMnTrArACCTcD4GMl78GZgngBxgz549VrBgQTt+/Li7BwBkjh07dliePHksb968dtZZZ7EbACCTbN++3Z2P4+PjrUiRIuwHIAOQKQXgJK+//rq1bt3aGjZsaM2aNbM5c+bYgQMH2FIAELBJkyZZ8+bNrXHjxlazZk3717/+Zb/88gv7AQAy4XzcqlUru/LKK935+Nlnn7UNGzawH4DTFBeiXw4An2nTptmtt95qzzzzjHu+atUq90f4kUcesbvvvtsqVarE9gKAAMyaNctuuukmGzlypJUrV86WL19ur7zyil133XXWs2dPq1+/PvsBAALw3nvv2V133eXOx7Vq1bIvvvjCHnroIWvTpo09/PDDdskll7AfgHSi+x4AR/HpuLg4mzFjht1+++123333hbdMgwYNbPDgwXb06FF78MEHrVSpUmw1ADjD5+P58+fbtddea/fcc497/frrr7eEhAQbNmyYvfDCCzZgwAD3az0A4Mw5duyYTZkyxXr16mVdunRxrzVq1MgWLVpkn376qevOp67VderUYTcA6UD3PQAR9u3b5+pIyZEjR9z93//+d3vyySdt9OjRNnv2bPcaxXYB4MxQQMo7z+qc7F0USYcOHeyxxx6zzz77zN59913OxwBwhun/4p9++skKFy7snh88eNDdV6hQwXXlUxbrhx9+6F6jExJw6ghKAYi4CKpXr57rwqdCjiqqq+wo6dGjh/Xp08elKGtarlycPgDgTFIXEf0Sv3btWldU1/uh4MYbb7QHHnjAnn76afv55585HwPAGZQvXz6rW7eujR071nbu3GkFChSw999/33WnVne++++/355//nn7/fffw/9PA0g7riqBGPfBBx+4X3g8Sk1W95D27dvbb7/95lKSDx06FP6FXhdGFNkFgDPDy4iS7t27u8EmrrnmGjcCn34oOHz4sJt22223WfHixS0xMZFdAQBn+Hw8cOBAq1y5spUpU8Yuvvhiu/nmm23cuHH2l7/8xS6//HL3/7FGrgZw6ghKATFs/PjxLtDk/fouxYoVc3Wj1G1Ef3B37dpl+fPnd9PUX75QoUKZuMQAkDNNnTrV1SpREOrxxx933fNE3aZV5Fz1S5QVpV/sRT8WFCxY0P1iDwA4M+djdZdeunSpnXfeebZw4UKbMGGCy4xasmSJde3a1bXfvXu3C1ZxPgbSh9H3gBilYcV79+5t//3vf11gKmnfeaUla6jbX3/91XURUcbU66+/7lKT9YeY7nsAkDF0HlYxc13o6KJGI54q+KQBJ/T6t99+67JYv/rqK+vXr5+dffbZNnfuXJc9pUzX3LlzsysA4Ayej1VfVedh0Q+3+j9Y/y+rvpS6VKvN9OnT6b4HpANBKSAGqTiuhhlX4ElDi6t447x589x9jRo13DRlRem5RnnSCFDKoNKv9ao3pQCV/hBzIQQAp0eB/3bt2rkaUeqSJxs2bHD1/XTe1YWRavmpG8nQoUNtwYIFrpBupUqV3A8FnI8B4Myfj0uUKOGCVY8++qh7XTVXZ86caS+//LJ739dff+3Ox17ACkDaxZ9CWwA5wJ9//ul+yalSpYr7NefHH3+0tm3buiCULnpUsFF1pjTaXu3atV0Rx23btoW77uk9aqe+8wCA07d//36rWLGiCzbpQkfdRJo2beoucN577z1r3Lixq1mi87IypdSlWudgzscAENz5WCNQ67HOx3pesmRJa9Kkic2YMcOdk/n/GEgfwrhAjFENksGDB9tVV13l+snXr1/fWrVq5bKmvvzyS1u2bJnrO//SSy+F36N+8gpK6QJIvwARkAKAjKGsUwX+161b586xKmaujNRNmza5LCl10dP52aNzsS6G1FYXTZyPASCY87Gm+c/HCk4NGjTInYf1Xs7HQPrQfQ+IEV46sXevdGTVitIfUN2XKlXKXeDoj7BSkR966CH7/vvvXUCK4W0B4Mydj0eMGOG66GmUPQWd3n77bZelqiK6Gmb8zTffdIXPFYyi2zQAZP75WP8/E4QCMgb9b4AY4O/frjpRKtx47rnn2pgxY2zt2rUu/ThpFz/1ny9dujQBKQA4g+djdYvu3Lmz1a1b142Iql/mP/roI2vevLn7oUC/zJctWzY8CioAgPMxkJMQlAJyOF3UeBdAAwYMcGnHO3futAsuuMBdCN11113htsqIOnz4sH388cdWs2ZNCjUCwBk8H6u+n0Y0rVWrlhvV6Z133okIWh06dMhWrVplderUYT8AAOdjIEciKAXkYP6Lm7feessNa6tf4vfs2eMypHr06OHqleji6MCBA66elAqd//LLL+5iSbwufQCAM3M+XrNmjRvpSQNPDBw40P04oBp/Q4YMse3bt7viupyPASBjcD4GshaCUkAO5l0ALVy40ObPn+9GbWrTpk14dBENKa6AVLVq1axBgwbuAihfvny2cuXKcNFG6pcAwJk/H1euXNmdj88//3xr3bq1+5GgfPny9uGHH3I+BoAMxPkYyFoodA7kcKpHctlll7mMqP79+9ujjz4anrZ7927XfU9D377wwgtutBFdEOmPNcPaAkDmnY/1vGjRoi5TlfMxAHA+BnKq//9nOwA5lgrkvvfee65oue6//vrr8LRixYpZiRIl3Eh8UqNGjfAIJIwoAgCZdz7WcwWk1IWa8zEAcD4GciqCUkAMUJFcXQCpO96oUaNc4Vyvy8h3333nfpmPltYMAMjc8zE1/QDgzOB8DGQNdN8DYoh+lb/99ttt165droaUhh7fuHGjLV261D2mqDkAcD4GgFjC/8dA5iIdAoghF154oU2ZMsUKFChge/futauuusoVNVdA6ujRo/wiDwCcjwEgpvD/MZC5CEoBMaZ27dqu68iRI0dcQOqHH35wr+fJkyezFw0AYgrnYwDIGjgfA5mH7ntADKcq9+jRw84991wbPHiwK3IOAOB8DACxiv+PgeCRKQXEcKrySy+9ZFu3brUiRYpk9uIAQMzifAwAWQPnYyB4ZEoBMe7QoUOWP3/+zF4MAIh5nI8BIGvgfAwEh6AUAAAAAAAAAkf3PQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAALCg/X8PLPon0UDsVQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 20: LLM latency p50/p90/p99 over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "  APPROX_QUANTILES(total_ms, 100)[OFFSET(50)] AS p50,\n",
+    "  APPROX_QUANTILES(total_ms, 100)[OFFSET(90)] AS p90,\n",
+    "  APPROX_QUANTILES(total_ms, 100)[OFFSET(99)] AS p99\n",
+    "FROM llm_events\n",
+    "WHERE event_type = 'LLM_RESPONSE' AND total_ms IS NOT NULL\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"p50\", \"p90\", \"p99\"],\n",
+    "          \"LLM Latency Percentiles\", \"ms\",\n",
+    "          labels=[\"p50\", \"p90\", \"p99\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cell-21-tool-latency",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:57.204637Z",
+     "iopub.status.busy": "2026-04-11T06:42:57.204560Z",
+     "iopub.status.idle": "2026-04-11T06:42:59.363587Z",
+     "shell.execute_reply": "2026-04-11T06:42:59.363052Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARndJREFUeJzt3QeUVeW5MOCPjg2IgCKKNSRosEUDaIreKwmWm1gwlmg0SjQasScKNqLmxquJHcs1xRgjSiwxtms0WOKNiD12Y2yoiNgoUenzr/f7/33+M8PMMIPDhmGeZ62z5pxdzu579nn3+727XU1NTU0CAAAAgBK1L3NiAAAAABAEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAWomf/OQnqV27dvn129/+dlnPDm1csS+uv/76lW6xXxbdY39dlo444og8H5///OdTTU1Ns8ZdFsvx2muvVaa5/fbbpzItT9utPvfdd19l/r73ve8ts/mI7VLMR2wvoGkOOeSQfNxsuummzT4fAys+QSmAJogf3sWPkcW94gfU8qB6nlryB1T8aI3XBRdckFZU8cO37nZt3759Wn311dMOO+yQbrrpprSiu/nmmyvburX9AJ88eXL61a9+ld8fddRRefu1dW3huG2t4n9GsX2efPLJT/19L730Uv6uCKKtu+66qUuXLukzn/lMPnf96U9/qnecqVOnpsMOOyz169cvde7cOf89/PDD0zvvvFNruLfffjudffbZadiwYWmDDTZIK620UlpttdXSNttsk6688soG5+mZZ55J+++/f1p77bXz/Kyxxhrpq1/9auU4barx48enL3/5y2nVVVfNr3j/hz/8odFxpk+fnvr27Vs5l/fp06dZ02zOdP/4xz+mb33rW/maYZVVVsnrcp111knf/va306RJk5o8vYULF6bLLrssbbnllmnllVdO3bt3T0OHDk0TJkxoMGDb0Kv6xsHizJw5M5144olpo402yttpzTXXzNvt5Zdfrnf4v/zlL3m+Yv5iPr/4xS+myy+/PM9/tWOOOaayHyxuewFtUA0Ai7XeeuvFrb0mve69996lskbHjBlTmcaVV1652OGr5+nVV19tsfkovjPWyYrqwAMPXOx2Pv3002tWZNXroL59+oEHHsivRx55pNIt9stinNhfl5Xjjz8+z0Pnzp1rZsyY0ezx33nnncryvf766zVliGO0WHfbbbddi39/Y8ftslje5oj9r5j/2C+XldguS+Oc2txz++KcddZZjZ67zj///FrDT548uWadddapd9h111235s0336wMe+211zb63UcfffQi83PjjTfmY7G+4XfYYYclWk91X2eeeWaD433/+9+vNeyaa67Z5Gk2d7ojRoxocNiOHTvW3H///Z/qf1C7du1qrrrqqnqPjYZen/3sZ5s0zThXbrbZZvV+x2c+85map556qtbwv/nNb/L81Dd8rIe6ttlmm9xvq622atL8AG2HTCmAJrjhhhvSAw88UHlV32m96KKLavWLO5usOA466KC8Xe+888606667VrqfeeaZOWugJX300UeptfjKV76SX1tvvXVansyfPz/9/ve/z++//vWvp27dujX7OyKLo1i+yDRZ0bW15W0LInPl6KOPTrfeemvO7Bw8eHCl38knn1zrXBPDvfnmm/n9HnvskbOp4m+RdVhkuRS6du2aRowYkW688cZ02223pZ133rnW/8NXXnml8jnef/e7301z587NWVUnnHBCnqcY77zzzsvZUk0RGWRxzg2RmfWb3/wmv+J9iMywp556apHxIpPo17/+dZ7nJdHc6fbv3z+NHj06Z1ZFVtMvf/nLnB1WnJsi+2lxbrnllnTVVVfl95Hhdd1116Xzzz8/dezYMTd9i6bJRQZbXG9UX38Ur913373yfbvttluTlrV6Wb72ta/lbNkf/OAH+fOHH36Yt3kh/vcdeeSReX5ivmJbxnwWyxrr/Pbbb6/1/cU+9dhjj+WMKYCKZR0VA2jtmVN1s0jibuNJJ51UM2DAgJquXbvWrLrqqjWDBg2qufzyy2sWLly4yHdNmDChZuedd67p2bNnTadOnfId67hL+o9//KOUTKmnn3665jvf+U7NxhtvnO+Gxt3c3r1753mqvqvb2N3i6uyLuXPn1px77rk1X/ziF2tWXnnl/Irlv/rqqxucxxg/lveb3/xmzSqrrJLn4wc/+EHNJ598ssg448aNq9l+++1revToke++x7j7779/zfTp02t+9atfVb7ztNNOqzXezTffXOk3cuTIJt+lrs74iflZaaWVKv1uuummSr9p06bVHHvssfmudMxXzF+sw4kTJzaa9RFZBJtvvnkep3paMd6ee+5Zs9Zaa+X9Iu7u77TTTjVPPPHEIssV2QbF+vjc5z5X85Of/KTm448/bjDL4+9//3teB7GdYx/dcccda1577bVFMnbqexX7e33bvrFMqVdeeSVnLETmRcxnTHuvvfaqee6552oNt2DBgpqf/vSnNV/4whfyvHXp0qWmX79+eV3G9l2c2GeLebjwwgsX6R/HYdypj/0s5qNv3755/Z199tmLXY6mrsPqZYmMurXXXjvvN7HfxvarL+OmsUypWbNm5fko1slqq62Wh7njjjsWuz6actw2ZXkfffTRmv322y+fz2JfjOHifBbrIZYr5iu2U33rvDnnhPrUPWbinPmlL30p7xvrr7/+Ipk/DZ0rG8u4ev/992tGjRqVz4OxrWIdb7nlljUXX3xxveuj2G6RRRT7dHRr3759JYsl1k1kkmy77bb5u2L9RBbKBRdckPeLQmPHWjHvzc1AjOzFWJ5q7733Xj63F98zadKk3P3tt9/O8x3dunfvXjnnxt/4HN07dOhQM3Xq1Nw9jtc33nij1nfPnj077xPFd48fP77S74c//GGle1O3d30OP/zwyvdEJlh9WWF1z+uxDHE+jn4/+9nPlihTakmmW1fsn8Wwu+yyy2KnGef5YvjITCvE/8Si+y9+8YsGx4/t0atXr8o++fLLLzd4/VKYM2dO/h9SZGNNmTKlsh/HtUz1eSDE+bLoFvNVXybdf/zHf9Sa7pNPPlnpd8YZZyx2PQBth6AUQAsGpT744INaF3B1X/vss0+t77nkkksaTH+PHzIPP/zwUg9KNdYcIy5o77nnnib/uI0fn/EDv6HhTjjhhHrnsVu3bjkoV3f4k08+udbwBx98cIPfHcsYP97jR3N9TRaqx33wwQeXKCgVigv3eF133XW5WzR5aqj5SwSU/vSnP9X7w3iDDTaotf2LacWP2fgh2NgP1XDqqac2uD6++tWv5h8a9f2g3nDDDRcZ/stf/vJSC0o99thjtdZb9Su2V/EDOcSPlYamXcxjY6p/fEZztGq/+93vGvzuCBwtbjmaug4LRx111CLDxA/9CKQ0NSgVwdZNN920wfmOc0gZQamNNtpokfGPPPLIerfr3XffXfmO5p4T6lN9zETQKI6put9THTBoblAqmq8VgaW6r+ptUTcoFef7CBTG5ziOr7jiisqwBxxwQIPLvPfee1eGWxpBqYZEALX4nmeeeSZ3i6B40e3f/u3fag0fn4t+f/zjHxv97ggSFsPedtttle4RqIxuEQCOpm79+/fPwcT4e84559QK0DWm+hiovllSHYSO4H61E088sRIIqj6+mhOUWpLpVu/7EcSLwGRTgklFECj+HxbDVzenjYBn0X3XXXdt8Duqz3MRzK+rvqBUnKOr/y9VO+iggyr9igBw3EAqulU3J4z5LbrHuaHavHnz8raPfsOGDWt0PQBti+Z7AC3opJNOSi+88EJ+H0+ZiWYTUcg1isyGSG+PtP7wxhtvpGOPPTanv0cR7VNOOSWnu0dB1DBr1qxccHtpP6kmnk527rnn5lT9e+65Jzc5iCYGUeQ0ipWeddZZebiDDz44NwsoRBPGoqlANG8MF154YaUQ65AhQ3LR1+gX0wjnnHNOvcVeo7hq7969c3OQoqlE+O///u/K++gXzSZChw4d0o9+9KN0xx13pN/97ne5mVYUdI0CtHvttVce5p///GdlWrEcRVOCKPoaRXmbK5q7xLqIormF2Mbhhz/8YaX5ywEHHJCb+sU6jPmZN29eXnf1Nc179dVXc/O366+/Pq//aMry1ltv5QLDCxYsqDS9KNZjPMEoCueGRx55pLKu1lprrdxcIqa7yy675G6xXaLJR33efffdXIw2mrn16NEjd/vb3/6Wnn322fxdMe5OO+1UbxPV5jZPjf33wAMPrKy3448/Pt111125WHJsx3/961+5iWSxnxeFmGO+Yv6ikG5s4yjCHPO2OM8//3zl/Wc/+9la/YrvjuYmsfyxr15zzTV5nqJoc3M0tg7Diy++mC6++OL8Po7v0047LTdbGjRoULMKx0dTq6effjq/j2ZSsR/H+iiaEMc5JM4lDWnKcdsUcT669tpr089+9rNKt1i++L7YP2Ofre+4XdJzQmPbN86RsR5i2aubHr333ntpScTxG83UQjRfvOKKK/KxFPMWBb/r88knn6T/+I//qGzvKCAfx2eI5YttFGI5Y73Fto/lD/E/oPg/ENsh9v/q/yHF9qluFvdpxffFPlucAzfeeOP8vnpfjKLWdZt1Vp+rGhL9nnjiifw+znlFk7w4tot9M5rvnXrqqbkI+5w5c/LfaMpXNA9bnIbms6F5jPmJ/2vRzK4pTeZaarph9uzZ+f9RnKs32WST9OCDD+ami7G/RlPJxkQzufh/2NxpVrv00ksr76OpX1M0dz9oynqJc34sTyHOu+utt15+/9xzzzVpvoA2YllHxQBWlEypuOMbzc6K7tEsrhBNQOre4TzvvPMq3YYPH17r7mqfPn0q/YrmWksrU2r+/Pm5SUnc6Y7srLqZW7FMTS2YHHeMi/5/+MMfKsWTq7Nfqps6VE+nulladbZZZIqEWG9Ft9GjRze4PH/7299qZXIUTeGKbtFEpyUKne++++552GgmU6yz2G7FMscrhimGv+GGGxbJ1ogsobrNbKqbesQd9oZEQeFiuGguWkzz1ltvrXQfOHBgvVke1c2dDjvssEr3aArY1ELn9e0H9WV0xHYtum2xxRa11k9R+La6WciQIUMqmUux3T766KOa5qhu+hLNWKpFpmJ0j+Zjf/nLXxosgt6UzKHFrcPq5i3Vx3dk11Q3AW0sU6r6nBKZJjHPxbqrbha1uOyLxR23TVne6iygIhsxXtGULrz77ru1tvOSnhPqU33MREZTnLMKkZ1W9IsMkeZmSsXxVzRfi+zEus1Jq1Wvj6233rryvrrpZ91z1UUXXVRZ5l/+8pf1Nm1q6ULndUXT2SJjKc5Vt9xyS6Vf9XaI7K5q3/3udxdbSDyaBVYXx65u7hjN/KrPmbHvRWbW2LFjKxkz1ef+KKRdfX6IVxThD8U2ilcsTyGaphXdY/uF2D+iqWh1JmFjmVItNd3qZoN1/1/E/9bjjjsu/39vTGTtVY9X3eQ/jrXqzMX6PP7447WyOZuaiVadXfW1r32tVr/qjNyigHl1pmiRTR1ietXzX7ep5+DBg3P3OAcCFDou66AYwIoi7kIXdwXj0cgDBw6s9IvsiMI//vGPWn9DdRHaTp065WyU//mf/6kMt8UWWyy1+T7uuONyJkxDqjODFqd6mYqMpcYyWQpRjLp6GXv27Flr+lG0t/q7I0OhIdtuu20aMGBAzliLbITIForCsYV99903fRrxmO8o+FpkkEVGVpHlE49Vb6hwb33LHY8VX3311Wt1q17OIuupPtXDRfZKdQZLocjaq2u77bZrcF23tOr5jKLBja2frbbaKq/bhx56KGeMRUZbZBxsuOGG+XH2kdH0uc99rsnTrptlGBkpsU98/PHH+THmIR7XHusjijk3p2j74tZhdbHn6uM7siZj/ywySxoTmT/FOSUyTYp5bsq+1dKqz2GxDJEFE4p11qtXr3r3oyU9JzQkphcZdtXzFRlqddd5U8XxWzy+PvazIoNocR599NHK+SQyfqpVL/NRRx21zLZZMZ3IJI3jqchc++Y3v1nrfFaIDKZqsc/VN1x1sev47iJbLP6XjBw5stI/sm3rZv0Vxa5jm0UGWYhMujj/R+Hs+++/v9Y4V155Zc4YjulHtl7d+axvHiNr9PHHH8/n1+oMvoa01HSrlzsy02L4WP+RcRcZY1EMPM5nv/jFLxqcl7rfFd9RFGlf3PYIl1xySeV9LHtkaTZFc/eDhoavHra++Vzamd9A66T5HsBSEBeejX1u7vhLS1xARlOVIrX+v/7rv9K9996bL6iLH5ktfRFZXzO2onljIealsCTTL54SNG3atNxUrAhKfeELX0ibbbbZEj19L35ExRODIkgQP+wi8Phpl7tuM4mWFk97qvsDo+76/rTruqUU6+f73/9+DsjGE7sisBtNYF5++eW8n0YgaHGBs+rgSHXTkfCNb3wjb8doZhWB39iG0ewymvDFdzcnqNGcdbi0j+cyntoYgeFC9Q/d+p5u2Nz96NPMf33rtrpb0Qw2LGnzvvoUgbFool3dPHJ52mYR+Iz9OgJSsU4iYBEBmGrRlK9QPNGtEEH2Qt3mra+//noOMBcBqVGjRuXmctUiWFt9niyabtV9X91crSENzWd98zhlypT8N4712Fdj2avnP8aPbnWfKvhpp1uI744nWUYgPYJ0xZP0wrhx4xZ7Xqk+ppo6zRDnxiLQF80Fo+luUzV3P2jKeolmzXX/txfn5OrzNICgFEALiZpIRW2Z+MFRXKyH6popRaZHdcbHww8/XHkfNYiqsyiakxnSXO+//36ufxE233zzdOKJJ6btt98+Zwx88MEH9Y5T/OArsguqVc9r/MD/fw/UqPUq6ss0V/V3133UdF1R1ykyzsJ//ud/VrbFkmRJRY2Z+IERGVgR1Cq+t7puUbFONtpooxwIqrvMEfw744wzmvSDuno5o2ZWQ6qHi7v69a3r2A/rZis0VXXgob5t3VTV8xk/kBuaz6K2THzecccdc02eqKUUGTnFj8f4wRP1WRpTnekSWTDV4rsj+yoCXJFJERkQxQ/pyJ6KOkItJfaFQtT/qv5R1lAGW13xw634URe1emJ+6667CLrE9l+cxo7bpamlzwnxOPnqZag+t8Z5q24ArfpHcn3bN47fYl+P+Wvqtolslxgvgr677rprrcyn6mWOIH99yxyB1pY+1qrFcfJv//ZvOYM3gqZxPEXtrLrivFZMP/7vFP8P4m/xfygCcNV1+KJeWgSkimWIrNEic7RafG/1eEXdrrrvi7pd99133yLrKbKVQpyDq5etMHHixMr7hrIwF6elphvn/ng1dp5fXFA9ho0Mr6ZOs9pvf/vbfB4L++yzzyJZuI2JGwDFcRMBxyKzLtZFZK7WnW5T1kv1MMW1TbHdo9YWQEHzPYAWEhfgcSEYxY/Dfvvtl8aMGZN/hMbfQhEY2XPPPXMQKC7U4m57DBOFcOOuajSLKC7cIlj0aUVR6eofaiGaSg0fPjw3DYgfIBEAiB/rkb0TBbQb+nEUP5IjYBV3oyPDJO54xzj9+/fPy/z3v/+90sQumrVE86hYnvixF4WmowlWccHfHPvvv3+lUHU0h4iL//jRFYG1KDYd6724+x7FVmP6UVS5aNoTYvu0tLjwj6LgEUCKH2nf+ta3cqZWFNiNi/v4YRfbNy7Wq+8uNySKOEfWQfzYjXmPbRRBttged999d/7BEuv5O9/5Ts7YClFAN7ZJZIHFj56Yj8gQi/VRFIdvruo73LF+44dpvOr+0Fic2H/jB09kmUUTmViWWMYI7kWx3AjIxnYq7qDHcRHrLn78xL4T27loKhXqy/yqVv2DLgJP1T/eoilV0eQofgjHj/XqLJfFfXdzRKAiju/4UVcU8P/iF7+Yt1kUyW7qOSXOF1G4OIJzkekVyxDBqsjwinUa+1Zs4wgmN6ax43ZpaulzQhxTUTg/9v8IZhXHdwRfI5hZt8B9NJmKgF4EKOs7ForjNwLdEeCL9/HQidg/Ipgd+9DVV1+9yHjxAILYN3/84x/nfTemHT/eoxh/LHNxroqMv2i2Fus5AkRR4DumFdMp/i9UH2uxr0Q2ShwfX/rSl/JyRbChKIYe40RR98b87//+b56fIhsrgrpx7onu1Q9piP8JUag+9tU4BmfMmJH3t8iwiUBnkcG0++67V7I6IyD1ta99LWehFts3zgnV3x1BuaLgdWQlFkHHuEEQ2VMRKIz9NsT/n8aaKRfie6KAfpwHo6lyzE8EcIpmy3FuKgrNx7IXN4gKse8XD4aI80vcJGjKQxuaM904JiPIF+e4aI4YN6qiKWf8/y3EOWBx4qEORfP9ODZierHOolliiP05/h9Wi/NMdUH3xgqcx74Qx1ExXoiM1Nju0dw9usV+EA8TiX01tnnRdDauG4r9OtZh7GMxX9EkuW/fvnmc6uWoFsXNi3Ns9XkaQKFzgBYqdF4Uza0u0l33FYWWqwuXRhHWuoXFqwujPvzww5VhP02h8/peRaHfI444YpF+8bjuNdZYo/K5WhRtbui75syZ0+jj3+vOe3UB3Gp1H73elALkdYu5x2PJq/sPGjSoSdu27nSa8gj2eAz2Ouus0+hyF/PX0GPpq0VB5OoCuw2tv+oCtI1t48bWaUP7VXXB9OpXY9uuoYLZ8bjxeDx4Y/NaaGz/iQLFReH7hsRjx4sHBVQXkw5RpLeh747Cu1G8uLHlaO46POqooxaZTjzuvfr80Vih8/Dhhx/Weix9fa/6CtHX1dhx29zlre+R8g3tE809J9Sn+piJAsv1HRs//elPK8NHMekoiF53mI033rjeY6Ox47d6W9S3Pr7//e9XukVR96J4fhQNb2yZq9dzFNqu7/9AMY2Gtk9DqvfHpuwzUVy7oeWP9fjmm29Whq2el6Zuz7322qvBYS+99NLFLk9TlquhQuyFxgqdt9R0q6fR0P/0SZMmNWmaDf2vi/3kqquuWmT4u+66qzJMFBNvTEPHb+y71UXrq19x/o79tNpvfvObBq9fioLo1X7+859X+j/zzDNNWg9A26D5HkALirvucbd89OjR+VHgcZc7Cn3GHe+4ixn1JKpT+aM5RWS/xF3zGDcyN+JuY9xpjWYqMd7SFs1Q4k563OGPO7CR6RN3tqMmRX3Gjh2bCxbHXeC64m5rNJGJwulRgDjuSMed8LjzH3fD445q3HVfUpExEFkL0Qws7vLH9KJ5Xdytr1u7Iu6Wx7psqQLnjYl5iIyoyJqIO8axzLHs8T62ZdS0aujR8vWJukqRwRNFgePOfOwXkXkQ+0l1Qfi4U33bbbflZY0MhMiuWHvttXPmQtQHO/3005d4mSKrJfaNaIZWXTNpSUR2QBQ5jzvn0cQqtltkMkQGVXSrbr4Vx8Tee++dpxv7Y0w7lim2cWRj1M34qyuGL7II4tgqihSH+I7IsoljM74nshxivUbWS6zvovlXS4ksnchqif0w9onI2ormXNX76uJqk8V6iiy7yPKIrLM4LmOcyLyJrLKoIRMZlovT2HG7NLX0OSHWYRxPkeUS59fI+IommJGNVIjj4Oabb85Nx2L6kZkVx0JDD3Qojt/I4iqO39j34liLddyYOK9H7aAQGWGR2RjZr5HxGk3m6p6rYtiYj+qmdJG1FMNG09MlbW77acS5KZqYRhPaONaK80h8jkzGeP9pRGZeZODEchbnxshyjWygphQiL8SxdN111+XtGv9X4xXv4+EFkd22tDR1upHBGPtQHI9xXolzURyr0ew7ank99dRTtR4Y0JjI6osaYLEPxjqLOlOx78Q5Lf6n1BXZlE3JkmpMTCPOg/F/LI7P2GdjOSIrMfaP2H7VInvvz3/+c56v2KZxborjMo6JolZltSI7LjKuYp0AFNpFZKryCQBWIEUzlGgGFU0rIvDGii+edBVNuKKWV/xYa84P35YUl1h164ZFc9MITkTtlwg4xeemPiELoDWKprDFE4kjmNfQkziBtslVEAArlAgERP2dyFooCqJHDSEBqbYjMj8i2yxccMEFy+ypgpFpFlmTUfcoAmWR6RWZN0Ux4qitJSAFrOjiPBwi2yrOewDVZEoBsEKJ4tnVj8uOTJW//vWvzS7QDS3R7KehJpTRVCuaykSzSwCAtkqmFAArpKgXFLWDoo6XgBTLQjwRL+omRU2eqM8SdYqi5krUAotaPQJSAEBbJ1MKAAAAgNLJlAIAAACgdIJSAAAAAJSuY/mTXPEsXLgwTZkyJa222mqLPPoZAAAAoC2pqalJs2bNSn379m30acOCUi0gAlLx+GkAAAAA/q833ngjrbPOOqkhglItIDKkipXdrVu3lvhKAAAAgFZp5syZOXmniJc0RFCqBRRN9iIgJSgFAAAAkBZb4kihcwAAAABKJygFAAAAQOkEpQAAAAAonZpSJVmwYEGaN29eWZNrlTp16pQ6dOiwrGcDAAAAKIGg1FJWU1OTpk6dmqZPn760J7VC6NGjR+rTp89ii6EBAAAArZug1FJWBKTWWGONtPLKKwu2NBK8+/jjj9O0adPy57XWWmtpbxoAAABgGRKUWspN9oqAVM+ePZfmpFYIK620Uv4bgalYZ5ryAQAAwIpLofOlqKghFRlSNE2xrtTfAgAAgBWboFQJ1EeyrgAAAIDaBKUAAAAAKJ2gFAAAAAClU+h8GVl/1O2lTu+1/9qlRb/ve9/7XrrqqqtqdRs2bFi68847K58/+OCDdOSRR6Zbb701tW/fPg0fPjxdeOGFadVVV23ReQEAAABaH0EpltiOO+6YrrzyysrnLl261Oq/3377pbfffjvdfffduXD5QQcdlA499NA0btw4ax0AAADaOEEp6rX99tungQMH5vdXX3116tSpUzr88MPTGWecUSncHkGoPn361Dv+888/n7OmHnnkkbT11lvnbhdffHHaeeed0y9+8YvUt29fax4AAADaMDWlaFA0z+vYsWN6+OGHc7O78847L/3qV7+q9L/vvvvSGmuskT7/+c/ngNX7779f6Tdx4sTUo0ePSkAqDB06NDfjmzRpkrUOAAAAbZxMKRrUr1+/dP755+fMqAg8Pf300/nzIYcckpvu7bHHHmmDDTZIL7/8cjrppJPSTjvtlINRHTp0SFOnTs0Bq1o7W8eOafXVV8/9AAAAgLZNUIoGDRkypNJUL2yzzTbp3HPPTQsWLEj77LNPpfumm26aNttss7TRRhvl7KkddtjBWgUAAAAapfkeLWLDDTdMvXr1Sv/85z/z56g1NW3atFrDzJ8/Pz+Rr6E6VAAAAEDbIShFg+rWfnrooYdS//79c/O8ut58881cU2qttdaqZFVNnz49PfbYY5Vh7rnnnrRw4cI0ePBgax0AAADaOEEpGjR58uR03HHHpRdffDFde+21+el5Rx99dPrXv/6VfvzjH+cg1WuvvZYmTJiQdt111/TZz342DRs2LI+78cYb57pTUX8qCqX/7W9/SyNHjszN/jx5DwAAAFBTigYdcMAB6ZNPPkmDBg3K2VERkDr00EPT7Nmz01NPPZWfzhfZUBFk+sY3vpHOPPPM1KVLl8r411xzTQ5ERY2peOre8OHD00UXXWSNAwAAAIJSy8pr/7XLcr/7derUKV1wwQXpsssuq9V9pZVWSn/+858XO348aW/cuHFLcQ4BAACA1krzPQAAAABKJygFAAAAQOnUlKJe9913nzUDAAAALDUypQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAAStex/EmS/aR7uSviJzNa9OveeeeddOKJJ6a77rorTZ8+PX3ta19LF198cerfv39lmNmzZ6fjjz8+XXfddWnOnDlp2LBh6dJLL01rrrlmi84LAAAA0PrIlKLZampq0m677ZZeeeWV9Kc//Sk98cQTab311ktDhw5NH330UWW4Y489Nt16663p+uuvT/fff3+aMmVK2mOPPaxxAAAAQKYU9dt+++3TwIED8/urr746derUKR1++OHpjDPOSC+99FJ66KGH0jPPPJO+8IUv5GEuu+yy1KdPn3Tttdem73//+2nGjBnp17/+dRo3blz693//9zzMlVdemTbeeOM87pAhQ6x6AAAAaMNaXabUJZdcktZff/3UtWvXNHjw4PTwww83Onxk6QwYMCAPv+mmm6Y77rijwWEPO+yw1K5du3TBBRcshTlvfa666qrUsWPHvI4vvPDCdN5556Vf/epXuSleiHVaaN++ferSpUv63//93/z5scceS/PmzcvZU4XYDuuuu26aOHHiMlgaAAAAYHnSqoJS48ePT8cdd1waM2ZMevzxx9Pmm2+e6xRNmzat3uEffPDBtO+++6YRI0bkJmbR5CxekeFT1x//+MecwdO3b98SlqR16NevXzr//PPT5z//+bTffvulI488Mn8ugkujR49OH374YZo7d246++yz05tvvpnefvvtPO7UqVNT586dU48ePWp9Z9STin4AAABA29aqglKRqXPIIYekgw46KG2yySbp8ssvTyuvvHL6zW9+U+/wkd2z4447ph//+Me52diZZ56ZvvjFL6axY8fWGu6tt97KAZdrrrkmN1Pj/4omdpE5Vthmm21y073IirrpppvSP/7xj7T66qvnbXDvvfemnXbaKfcDAAAAWJxWE0GIbJxoElbdHCwCIPG5oeZg0b16+BCZVdXDL1y4MH33u9/NgauiPhKLt9VWW6Unn3wyP3kvsqPuvPPO9P7776cNN9ww94/6UrHNon/dp/ZFPwAAAKBt65haiffeey8tWLAgN/+qFp9feOGFeseJZmL1DV/dfCyanUXdpKOOOqrJ8xI1lYq6SmHmzJmVAFe8CvE+nlRXvKr9//yjctSdflNMmjSp1ngRzOvfv38OBhbdu3Xrlv9G1tSjjz6aC6FHv8hIi6yzv/zlL2n48OF5mBdffDFNnjw5Z2A1ND/Fuqq7LgEAAIDWoam/51tNUGppiMyraOIX9amqm6ktzllnnZVOP/30Rbq/++67afbs2ZXPUeg7NsT8+fPzq1rZjQTrTn9xIjAUAaRjjz02P00vanJFs8dzzjknf9cNN9yQevfunetORY2u448/Pn3rW9/KT9qL/qusskpuZhndu3fvnoNXxxxzTA5Ibb311g3OT3SPdRZZV5pSAgAAQOsza9asFSso1atXr9ShQ4fc/KupzcGie2PDP/DAA7lIehTtLkQ2VgRS4gl8r732Wr3fGwW+o+B6daZUBGciSFNkDoUIUMWGiEyseC1LzZ1+BOmiWWMsw5e//OW87iObrHhCYay3E044Ia/PtdZaKw976qmn1ppOrMNYl3vvvXfOLIumk/H0xMbmJfpFJlbPnj1rPd0PAAAAaB2a+nu+Xc2StOtaRgYPHpwGDRqULr744vw5MmoioDRy5Mg0atSoRYaPYMjHH3+cbr311kq3bbfdNm222Wa5SHpk4xRPiytE4CQCLJHlE0+da4oISkU20IwZMxYJSr366qtpgw02aHUBlu233z5tscUWObBUpta8zgAAAIDUYJyk1WZKhchOOvDAA3PzrwhORcDko48+ygGkcMABB6S11147N68LRx99dNpuu+3Sueeem3bZZZd03XXX5bpHV1xxRe4f2TjxqhZNxiKTqqkBKQAAAACar1UFpSLzKeo2nXbaablYeWTyxFPfimLmUQMpmn5VZ0WNGzcunXLKKemkk07KRbpvvvnmNHDgwGW4FAAAAAC0quZ7y6sVsfnesmKdAQAAQNtovvf/04oAAAAAoCSCUgAAAACUTlCqBPGUQKwrAAAAoJUWOm9tOnfunAuvT5kyJfXu3Tt/bteu3bKereVSlDabO3duLmQf6yzWFQAAALDiEpRaiiK4EkXO33777RyYYvFWXnnltO6669Z6iiIAAACw4hGUWsoi4yeCLPPnz08LFixY2pNr1Tp06JA6duwomwwAAADaAEGpEkSTvU6dOuUXAAAAAAqdAwAAALAMKNwDAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUrtUFpS655JK0/vrrp65du6bBgwenhx9+uNHhr7/++jRgwIA8/KabbpruuOOOSr958+alE088MXdfZZVVUt++fdMBBxyQpkyZUsKSAAAAALRdrSooNX78+HTcccelMWPGpMcffzxtvvnmadiwYWnatGn1Dv/ggw+mfffdN40YMSI98cQTabfddsuvZ555Jvf/+OOP8/eceuqp+e9NN92UXnzxxfStb32r5CUDAAAAaFva1dTU1KRWIjKjvvSlL6WxY8fmzwsXLkz9+vVLRx55ZBo1atQiw++9997po48+Srfddlul25AhQ9IWW2yRLr/88nqn8cgjj6RBgwal119/Pa277rpNmq+ZM2em7t27pxkzZqRu3bot8fIBAAAAtHZNjZO0mkypuXPnpsceeywNHTq00q19+/b588SJE+sdJ7pXDx8is6qh4UOssHbt2qUePXq04NwDAAAAUK1jaiXee++9tGDBgrTmmmvW6h6fX3jhhXrHmTp1ar3DR/f6zJ49O9eYiiZ/jUXy5syZk1/VEcAicyteAAAAAG3VwibGRlpNUGppi6Lne+21V4rWjJdddlmjw5511lnp9NNPX6T7u+++mwNbAAAAAG3VrFmzVqygVK9evVKHDh3SO++8U6t7fO7Tp0+940T3pgxfBKSijtQ999yz2LpQo0ePzgXXqzOlorZV79691ZQCAAAA2rSuXbuuWEGpzp07p6222ipNmDAhP0GvSAeLzyNHjqx3nG222Sb3P+aYYyrd7r777ty9bkDqpZdeSvfee2/q2bPnYuelS5cu+VVX1LiKFwAAAEBb1b6JsZFWE5QKkZ104IEHpq233jo/Ie+CCy7IT9c76KCDcv8DDjggrb322rl5XTj66KPTdtttl84999y0yy67pOuuuy49+uij6YorrqgEpPbcc8/0+OOP5yf0Rc2qot7U6quvngNhAAAAALS8VhWU2nvvvXPdptNOOy0Hj7bYYot05513VoqZT548uVY0btttt03jxo1Lp5xySjrppJNS//79080335wGDhyY+7/11lvplltuye/ju6pF1tT2229f6vIBAAAAtBXtaqKyN59K1JTq3r17mjFjhppSAAAAQJs2s4lxEgWQAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHUEpa666qp0++23Vz6fcMIJqUePHmnbbbdNr7/+ekvOHwAAAAAroCUKSv3sZz9LK620Un4/ceLEdMkll6Rzzjkn9erVKx177LEtPY8AAAAArGCWKCj1xhtvpM9+9rP5/c0335yGDx+eDj300HTWWWelBx54IC1NEQBbf/31U9euXdPgwYPTww8/3Ojw119/fRowYEAeftNNN0133HFHrf41NTXptNNOS2uttVYOtA0dOjS99NJLS3UZAAAAANq6JQpKrbrqqun999/P7++666709a9/Pb+PwM8nn3ySlpbx48en4447Lo0ZMyY9/vjjafPNN0/Dhg1L06ZNq3f4Bx98MO27775pxIgR6Yknnki77bZbfj3zzDOVYSLD66KLLkqXX355mjRpUlpllVXyd86ePXupLQcAAABAW9euJlKFmmm//fZLL7zwQtpyyy3TtddemyZPnpx69uyZbrnlljR69Oj07LPPLpWZjcyoL33pS2ns2LH588KFC1O/fv3SkUcemUaNGrXI8HvvvXf66KOP0m233VbpNmTIkLTFFlvkIFQset++fdPxxx+ffvSjH+X+M2bMSGuuuWb67W9/m/bZZ58mzdfMmTNT9+7d87jdunVrseUFAAAAaG2aGidpv6RN6LbZZpv07rvvphtvvDEHpMJjjz2WvvOd76SlYe7cufn7o3ldoX379vlz1LWqT3SvHj5EFlQx/KuvvpqmTp1aa5hYaRH8aug7AQAAAPj0Oi7JSPGkvV/84hfpqaeeyk3nIkMqbLXVVmlpee+999KCBQtyFlO1+BxZW/WJgFN9w0f3on/RraFh6jNnzpz8qo4AFplb8QIAAABoqxY2MTayREGpO++8Mx1wwAG5rlTd1n/t2rXLwaMVWRR0P/300xfpHpljalEBAAAAbdmsWbOWXlAqajh9+9vfzk+tq5tltLT06tUrdejQIb3zzju1usfnPn361DtOdG9s+OJvdIun71UPE3WnGhJ1s6LgenWmVNS26t27t5pSAAAAQJvWtWvXpReUiqBNBGXKCkiFzp075+aBEyZMyE/QK9LB4vPIkSPrHSfqXkX/Y445ptLt7rvvzt3DBhtskANTMUwRhIoAUzyF7/DDD29wXrp06ZJfdUWNq3gBAAAAtFXtmxgbWaKg1J577pnuu+++tNFGG6UyRSDswAMPTFtvvXUaNGhQuuCCC/LT9Q466KDcP5oUrr322rl5XTj66KPTdtttl84999y0yy67pOuuuy49+uij6Yorrqg0NYyA1U9/+tPUv3//HKQ69dRT8xP5isAXAAAAAC1viYJSY8eOzc33HnjggbTpppumTp061ep/1FFHpaVh7733znWbotlgFCKP7Kaob1VkbE2ePLlWNG7bbbdN48aNS6eccko66aSTcuDp5ptvTgMHDqwMc8IJJ+TA1qGHHpqmT5+evvKVr+TvbGqqGQAAAADN166mbqXyJvj1r3+dDjvssBy46dmzZ844qnxhu3bplVdeSW1JNPnr3r17mjFjhppSAAAAQJs2s4lxkiXKlDr55JPz0+dGjRqlhhIAAAAAzbZEVbnnzp2bm9Ip6g0AAABAaUGpKDY+fvz4JZogAAAAACxR870FCxakc845J/35z39Om2222SKFzs877zxrFgAAAICWDUo9/fTTacstt8zvn3nmmVr9qoueAwAAAECLBaXuvffeJRkNAAAAAJa8phQAAAAAfBqCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKVrNUGpDz74IO23336pW7duqUePHmnEiBHpX//6V6PjzJ49Ox1xxBGpZ8+eadVVV03Dhw9P77zzTqX/3//+97Tvvvumfv36pZVWWiltvPHG6cILLyxhaQAAAADatlYTlIqA1LPPPpvuvvvudNttt6W//vWv6dBDD210nGOPPTbdeuut6frrr0/3339/mjJlStpjjz0q/R977LG0xhprpN///vf5u08++eQ0evToNHbs2BKWCAAAAKDtaldTU1OTlnPPP/982mSTTdIjjzyStt5669ztzjvvTDvvvHN68803U9++fRcZZ8aMGal3795p3Lhxac8998zdXnjhhZwNNXHixDRkyJB6pxWZVTG9e+65p8nzN3PmzNS9e/c8zcjkAgAAAGirZjYxTtIxtQIRRIome0VAKgwdOjS1b98+TZo0Ke2+++6LjBNZUPPmzcvDFQYMGJDWXXfdRoNSscJWX331Rudnzpw5+VW9ssPChQvzCwAAAKCtWtjE2EirCEpNnTo1N7Or1rFjxxw8in4NjdO5c+cczKq25pprNjjOgw8+mMaPH59uv/32RufnrLPOSqeffvoi3d99991cxwoAAACgrZo1a9byH5QaNWpUOvvssxsdJprSleGZZ55Ju+66axozZkz6xje+0eiwUXfquOOOq5UpFcXSo7mg5nsAAABAW9a1a9flPyh1/PHHp+9973uNDrPhhhumPn36pGnTptXqPn/+/PxEvuhXn+g+d+7cNH369FrZUvH0vbrjPPfcc2mHHXbIhdNPOeWUxc53ly5d8quuaE4YLwAAAIC2qn0TYyPLNCgVmUXxWpxtttkmB5eiTtRWW22Vu0Uh8mijOHjw4HrHieE6deqUJkyYkIYPH567vfjii2ny5Mn5+wrx1L1///d/TwceeGD6z//8zxZbNgAAAABa+dP3wk477ZSznC6//PJcwPyggw7Khc/j6XrhrbfeytlOv/vd79KgQYNyt8MPPzzdcccd6be//W1uVnfkkUdWakcVTfYiIDVs2LD085//vDKtDh06NClYVvD0PQAAAIAV8Ol74ZprrkkjR47MgadIA4vsp4suuqjSPwJVkQn18ccfV7qdf/75lWHjaXkRfLr00ksr/W+44YZcnPz3v/99fhXWW2+99Nprr5W4dAAAAABtS6vJlFqeyZQCAAAAaF6cRFVuAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHStJij1wQcfpP322y9169Yt9ejRI40YMSL961//anSc2bNnpyOOOCL17Nkzrbrqqmn48OHpnXfeqXfY999/P62zzjqpXbt2afr06UtpKQAAAABoVUGpCEg9++yz6e6770633XZb+utf/5oOPfTQRsc59thj06233pquv/76dP/996cpU6akPfbYo95hI8i12WabLaW5BwAAAKBau5qampq0nHv++efTJptskh555JG09dZb52533nln2nnnndObb76Z+vbtu8g4M2bMSL17907jxo1Le+65Z+72wgsvpI033jhNnDgxDRkypDLsZZddlsaPH59OO+20tMMOO6QPP/wwZ2M11cyZM1P37t3zNCOTCwAAAKCtmtnEOEnH1ApEECmCREVAKgwdOjS1b98+TZo0Ke2+++6LjPPYY4+lefPm5eEKAwYMSOuuu26toNRzzz2XzjjjjPw9r7zySpPmZ86cOflVvbLDwoUL8wsAAACgrVrYxNhIqwhKTZ06Na2xxhq1unXs2DGtvvrquV9D43Tu3HmRjKc111yzMk4Elvbdd9/085//PAermhqUOuuss9Lpp5++SPd3330317ECAAAAaKtmzZq1/AelRo0alc4+++zFNt1bWkaPHp2b8+2///7NHu+4446rlSnVr1+/3FxQ8z0AAACgLevatevyH5Q6/vjj0/e+971Gh9lwww1Tnz590rRp02p1nz9/fn4iX/SrT3SfO3dufpJedbZUPH2vGOeee+5JTz/9dLrhhhvy56K8Vq9evdLJJ59cbzZU6NKlS37VFc0J4wUAAADQVrVvYmxkmQalIrMoXouzzTbb5OBS1InaaqutKgGlaKM4ePDgeseJ4Tp16pQmTJiQhg8fnru9+OKLafLkyfn7wo033pg++eSTyjhRSP3ggw9ODzzwQNpoo41aaCkBAAAAaJU1paKJ3Y477pgOOeSQdPnll+cC5iNHjkz77LNP5cl7b731Vn5y3u9+97s0aNCgXOV9xIgRuZld1J6KZnVHHnlkDkgVRc7rBp7ee++9yvSa8/Q9AAAAAFbAoFS45pprciAqAk+RBhbZTxdddFGlfwSqIhPq448/rnQ7//zzK8NGUfNhw4alSy+9dBktAQAAAACFdjVFISWWWBQ6j8ysGTNmKHQOAAAAtGkzmxgnUZUbAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABKJygFAAAAQOkEpQAAAAAonaAUAAAAAKUTlAIAAACgdIJSAAAAAJROUAoAAACA0glKAQAAAFA6QSkAAAAASicoBQAAAEDpBKUAAAAAKJ2gFAAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBAAAAUDpBKQAAAABK17H8Sa54ampq8t+ZM2cu61kBAAAAWKaK+EgRL2mIoFQLmDVrVv7br1+/lvg6AAAAgBUiXtK9e/cG+7erWVzYisVauHBhmjJlSlpttdVSu3btrDGgyXcPIpj9xhtvpG7dullrAMByxbUKsKQi1BQBqb59+6b27RuuHCVTqgXECl5nnXVa4quANigCUoJSAMDyyrUKsCQay5AqKHQOAAAAQOkEpQAAAAAonaAUwDLSpUuXNGbMmPwXAGB541oFWNoUOgcAAACgdDKlAAAAACidoBQAAAAApROUAgAAAKB0glIAAAAAlE5QCgAAAIDSCUoBtKCampp63wMALA+qr08WLly4TOcFoKNVANBypk+fnlZeeeW0YMGC/BcAYHkybdq01KlTp9S5c+e06qqrLuvZAdo4mVIALeTqq69Ou+yySxo0aFDafvvt05133pk++ugj6xcAWC5cddVVaejQoWnIkCFp4403Tv/93/+dXn/99WU9W0Ab1q5G+xKAT+2Pf/xj+s53vpPOPvvs/PnJJ5/MF34nnXRSOuSQQ9K6665rLQMAy8ztt9+evv3tb6fzzz8/rbXWWunhhx9Ov/zlL9M3v/nNdPjhh6etttrK1gFKJygF8ClEXL9du3bp4IMPTh06dMgXd4VLL700jRkzJo0YMSIdf/zxqXfv3tY1ALBMrlWOO+649Oabb6Y//OEPlX7jx49PZ511Vtp8883TqFGjcvYUQJnUlAJoATNnzkzdunXL7+fOnZvrNPzwhz9M7du3T8cee2y+yDvwwANzQdHoBgBQhghIhbgGieuVMH/+/NSxY8e0995755tqJ5xwQurfv3865ZRTXKsApfLLCKAFLvS22GKL3ITvnXfeyQGpefPm5e6HHXZYDkr9+Mc/zv0EpACAZWGTTTZJ999/f3r22WdzQCpuooU999wzHXPMMelnP/tZeu2111yrAKUSlAJYArfcckuuxVA44ogj0qabbpqGDx+e3nvvvfxUm9mzZ+d+cRcyLv4UEgUAyhQZUYVDDz00P4hl5513zk/gi5toc+bMyf3222+/tPrqq6enn37aBgJKJSgF0EyXX355DjQVdxjDZz7zmVw3KlLj99prr/TBBx+krl275n7xuOVVVlnFegYASnH99dengw46KAehTj311PTAAw/k7hdeeGEucj548OCcFdWlS5fcPW6krbzyymmllVayhYBSKXQO0Azx6OSRI0em3//+9zkwVW3BggXpT3/6U/r5z3+e3njjjZwGHxlTV199dXr//ffTxIkTpcQDAEtVXKP84Ac/SEcffXQOMsXTgCP4dNRRR+Xuzz33XM7wfvTRR3MtqdVWWy39+c9/ztlTkQUeNaYAyiIoBdBEN954Y36UcgSe4vHJr7zySrr77rvz3wEDBuR+kRUVn+NJNhMmTMgZVHFHMupNRYAqAlcu9gCApSFuiu2xxx65RlQ0yQsvvfRSrn0Z1yQRqIo6l9Gs7/TTT0/33HNPfjrfuuuum2+iuVYByiYoBdAEH3/8cb67+OCDD+bU93ia3m677ZaDUHFh9/e//z3tsssu6cwzz0wDBw7M40ydOrXSdC8KohdPugEAWFpBqa9//evpiiuuSF/96lfzg1fi2iOuUSLg9O6776Zzzjkn9wuzZs3K5QZiGNcqwLKgphRAE0SdhTFjxuQLvXhc8lZbbZV22mmnnDX1yCOPpEmTJqWHHnoojR07tjLOmmuumYNScZEXtaYEpACApSkysuOm2AsvvJCvP6KYeWRrT548OWdJRRO9uHYpxHVKBKti2MiYcq0ClE2mFEAjIpjUvn37yt9IgY9aUXHRFn979+6dL+LiYi7uSv7oRz9K//jHP3JAKroBAJR5rXLuuefmJnrxlL0IOv3hD39Iv/zlL9OIESPSeeedl6699tpc+DyCUUoKAMuadiQADSgu7kLUiYpioRtuuGG65JJL0rPPPpt69eq1SBO/qNmwxhprCEgBAKVfq0TJgAMPPDBtvvnm+WnBkSl11113paFDh+abaJFF1adPn8oTggGWNUEpgHrEhVtxkTdq1Kic6h51GL7whS/ki72DDz64MmxkRM2ZMyf95S9/ybWmivEAAMq6Vrn55pvz03432WST/HS9G264oVbQavbs2enJJ59Mm222mY0CLDcEpQDqqL6Au+666/KjlONu4/Tp03OG1GGHHZZrMsQF4EcffZTrSZ1//vnp9ddfzxeEoWjSBwBQ5rXKM888k5+89/LLL6fRo0fnG2dR//InP/lJeuedd9Idd9zhWgVYbghKAdRRXOTdd999acKECemEE05Iu+66a+UpNfHY5AhI9e/fP2299db5Iq9Lly7p8ccfz7WmosioGg0AwLK6VllvvfXytcrnPve5/OS9uIHWt2/f9D//8z+uVYDlikLnAPWImgtf+cpXckbUiSeemE4++eRKvw8//DA33+vXr1+66KKL8hNu4qIvLhDnz5/vyTUAwHJ1rRKfe/TokbO4XasAyxOFTwDqEUVAb7rpply0PP4+8cQTlX6f+cxnUs+ePfOT+MKAAQMqT73xKGUAYHm7VonPEZCK8gKuVYDliaAUQAOiEGhc5EVzvAsuuCAXBy3S4p9//vl897HWCVWBcwBgOb5WUe8SWN5ovgewGHHncf/9908ffPBBriEVj1d+9dVX00MPPZTfK2oOACxLrlWA1kqmFMBibLnllmn8+PFppZVWSjNmzEhf//rXc1HzCEjNmzfPXUcAYJlyrQK0VoJSAE0wcODAnB4/d+7cHJD65z//mbt36tTJ+gMAljnXKkBrpPkeQDPT4w877LC04YYbpjFjxuQi5wAAywvXKkBrIlMKoJnp8WPHjk1vv/126t69u3UHACxXXKsArYlMKYAlMHv27NS1a1frDgBYLrlWAVoDQSkAAAAASqf5HgAAAAClE5QCAAAAoHSCUgAAAACUTlAKAAAAgNIJSgEAAABQOkEpAAAAAEonKAUAAABA6QSlAAAAAEhl+z+ogbjIUJVByQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 21: Tool latency p50/p90 over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "  APPROX_QUANTILES(total_ms, 100)[OFFSET(50)] AS p50,\n",
+    "  APPROX_QUANTILES(total_ms, 100)[OFFSET(90)] AS p90\n",
+    "FROM tool_events\n",
+    "WHERE event_type = 'TOOL_COMPLETED' AND total_ms IS NOT NULL\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"p50\", \"p90\"],\n",
+    "          \"Tool Latency Percentiles\", \"ms\",\n",
+    "          labels=[\"p50\", \"p90\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel5-header",
+   "metadata": {},
+   "source": [
+    "## Panel 5: Performance — TTFT (Time To First Token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "cell-22-ttft",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:42:59.365070Z",
+     "iopub.status.busy": "2026-04-11T06:42:59.364963Z",
+     "iopub.status.idle": "2026-04-11T06:43:01.941448Z",
+     "shell.execute_reply": "2026-04-11T06:43:01.940887Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVT5JREFUeJzt3Qm8jeX6//Frs80yz8cQkSEbRYamo4g0EXVoIok4NFCmBkOdchqEMp1yKj+lpBlFUjSYypDNiVQkP2NmMlv/1/f+/551nrX32hPbs6fP+/Var73Xeu71zOvZ+7nWdV93TCgUChkAAAAAAAAQoFxBLgwAAAAAAAAQglIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAADkcM2bN7eYmBj32Lhxo3tNP73XND0jTZ8+3a1HbGys/fbbb2l6b0Ztx7nnnhtebpAy03FLird+2kcZZdiwYeH1eP311zNsPYCs5s0333Sfm/z589vmzZszenUAZAMEpQAg4Bugu+66K9U3s/Pnz0+ynaZ57fQoVqyYHT58OKLN0aNHrXTp0hHtZs+eneQ8dXPmb5vcQze82pbUttc+SLh90R4PPvhgqtr5H8ntp6S2qXDhwnbRRRfZ888/b8ePH7fsbOXKlW7/65HcvsqMTp06FT53brrpJqtSpYrldDqnveO5d+/ejF4dJAgKesfmww8/PON9s2/fPhszZozdeOONVqNGDStUqJB7XHjhhfbCCy/YiRMnEr1H1/2nn37a6tSp4wIHJUuWtHbt2tny5csj2h07dsz+9a9/2d/+9jerVauWFSlSxAoUKODeN2TIEDt06FDUdfrjjz+sf//+VrNmTddef3vq169vffv2TdO2LVu2zNq2bevWT+up5Y4YMcKtV3Kuu+66iGv52rVrz8py4+Pj7Y477rDatWu7bcyTJ4+VKlXKWrRoYVOnTk3TMj///HNr2bKlFS1a1AoWLOj+9kycONFd3/xS8/fO++IgJZr3hAkT3LmiZWrZWod58+ZFbf/zzz/b7bffbmXLlrV8+fLZeeedZwMHDrT9+/dHtNP5UqFCBXeePfXUU2naDwAQVQgAcNYNHTo0pEuuHl26dEm2bZUqVcJtv/zyyyTbaZrXzntMnjw5os1bb72VqM2nn36a5Dxfe+21RO2Tevz1r39125La9toHCbcv2uOBBx5IVTv/I7n9lJptatmyZejkyZOh7Mq/D7zj4Ldq1arQ119/7R5Hjhxxr23YsCHiWGeUGTNmhNdj9uzZaX6/tsfbNm1nUPznb3rT8fDmreOUGbY3Lbx11z7KDNdkfT7Si/+6nNK1PjUWLVqU7LWrbdu2Ee2PHz8eatGiRdS2+fLlC33++efhtlu3bk123hdffHHo6NGjEfNfu3ZtqEKFClHb586dO9XbNWfOnFDevHmjzqdVq1ahEydORH3fG2+8kaj9jz/+eFaWO2XKlGT3z9NPP52qZb766quhmJiYqPPo1q1bRNvU/L3bvHlzqpab1N9nrUvC/xVWrlwZKlq0aNT2DRo0CO3fvz+i/eDBg9007ctdu3alan0AIClkSgFANjJp0qSI56+88kqa3n/ttdfa119/HX488sgj4WkNGjSImPbSSy/Zo48+GvFamzZtwu27du0aMe3uu+9OtLwXX3wxoo0eDzzwgJv27rvvRrxerly5JN+nb4JTw9uGL774ImLb9C32+++/b+kpqSyDzCguLs4uu+wy99A35JnJa6+95n4WL17crrrqqjS/X9vjbZu2M7vLadubE6jbaseOHe2tt96yTz/91Dp37hye9tFHH9mXX34Zfj5+/PhwJkzdunXtvffes8cee8w9V2aLslv106PMG123lX03Z84ce+ihh8LTvvvuO9dVy6OsrFtuucW2bNninnfq1Mneeecd++yzz9zfmttuuy1V26OMXv198DKTtH5aT62vaH7KIoqWoaVMWq1z3rx507AHT2+5JUqUsO7du9uUKVPc3whta7NmzSL+DqVk69atdt999yky7Y6jstvefvtt+8tf/uKm//vf/7ZZs2aF2yf8e6jHE088EZ7eqFGj8HuT8/HHH9vkyZPd78pq0jJHjRrl1kHr0rt3b9u+fXu4vfaLsvKkR48e7ry64oorwpm2/nWQ9u3bu5/al2nNGgOARJIMVwEAskym1DnnnBP+fd26dW76zz//HP521j89uUyp5DJsUpMt4/9mNlpGTlq2L73el9w2NG/ePDzt/vvvD79+7Nix0MiRI0MXXXRRqGDBgu7RuHFj9815clkfykxR1lWhQoUilrVp06ZQ7969Q+edd57LVihWrFioadOmobfffjtiXj/88EOoU6dOoXLlyoXy5MnjMhL0Tfrvv/+e5Pmkb+FHjRrl5q1vrevVqxeaN29e1P2W8OEdo2iZN8llSh04cMC994ILLgjlz5/fnV9q88knnyTaP++++27o0ksvDRUpUsRtU9myZd3zAQMGhE6dOpXssVOWhuavdbjpppsSTdd5oKyQ4sWLh2JjY0OlSpVy2R06lnv37k12O9KyDz3Tp09326xjqJ/Tpk1LMuMmqUwpbbOWd8kll7j9pu3T8kaPHp1itl607Ej/Q9uamu2dNGlSaNiwYe480zronNuzZ4/LeLjjjjvcsdI+vffee0OHDx9OtB4ffvih2+86j7W/zj//fDe/P//8M5Qa/s+M1vfGG28MFS5cOFSyZMnQ3//+99DBgwejbnPCa6d/Pn7Kdhk3bpz7jGlbtI+rV68e6tGjR9T94R03fe6vueaa8Ovdu3cPn6NfffVV6IYbbnDnmM7jc889N9S3b9/Q7t27w/P0f44SPrx1T2sGoj77a9asSfT6hRdeGJ7PM888E369du3a4deVZeVp3bp1+HV9JkXZLwsXLkw073bt2oXb9urVK/z6O++8k2SGT1roc+PNR+sVLSusbt26id53++23u2k6jv7PV2ozpU53uX4rVqwIt9V1PiU6Nl57fZ6iZTFff/31yc5D06NdYxL+zfX/XWzTpk34dS3Lo3XwXn/++efda0uWLAm/pvPHO+e3bNkS/h9C1wN9Pvz0mqZdddVVKe4HAEgOQSkAyAZBqSZNmoTi4uLc7/3793fTBw4c6J7XrFkz4maJoNR/qeuLt1969uzpXtM/3kl1f9FDwRQ/73V1fdBNdcIbTt3ElChRItkbVVFAR8GOaO0UPPj111+jnk/VqlVL1F6BBu9mOb2DUgr2eOdatIeCAZ758+eHcuXKlWRbdTVKjm6YvbZPPvlkom5EBQoUSHLe69evT3Y70rIP5b333ovaBad+/fppCkp17tw5yXXu2LFjIEEpBd8SvlfBGAVeE77+6KOPRqzD448/nuTyL7/88kTdvaLx2utzUbFixajrcrpBKX1+/QGYhI9o+0PHTTfiXtBDjzvvvDMcJHzllVeSPI91ffXOk7MRlErKLbfcEp7P2LFj3WsKKnqvKXDm74o2fPjwRF2kk6K/IV7bhx9+OPy69on3uto0atTIBex1fVLwyv95Sc59990Xno/Wy6Prgdbbm+afn/5u6TUF6nUNOp2g1Oks16Nz4X//93/d34nUBpNEgUyvvb/L3G+//RZ+XcHdpGzcuDF87unvS8IgcbSglM5lBWO917Usj9YhYddPfQHjvda1a9eI+VetWjU8TX/L/BSM8oJzSXW3BIDUoPseAGQT99xzj/v5P//zP/bnn3+GR5Tq1q2bZVZXXnllmoqWpxd1Q1FXFX/Rd6+rk4oKe91fmjZtah988IHrSqiivvLss8/akiVLEs1TXR9y585tL7/8spu3jofum9XVZvfu3a6NuomoK4i6a6iQsArtio5Xly5dXLcada9Q8Vh1JRkwYICbvm3bNvv73/8edVt+/fVXV4xW3TVUbFgOHDgQ7lKhdfd3VfR3q4zWpTIl6rKpAsBed09ti845r3ulih3//vvv7vcZM2aEC/mq8LL2q7qRqNuMigunNDLdjz/+GP69evXqEdPmzp0bLuyvLp+at7b1H//4h+vikpZR71LahydPnnTdhv5/HMRcFyZt9/33328//PBDqpej9dO+Ep1P6o6lfaTzTKZNm+YeSVE3VR03dUP1j0zoHc/y5cunaj1UKFnnsZZ1zjnnuNf0WfjPf/7jugCrOLJHhbD93bmefPJJ97uWpa5Hep8KT4vWQV2EUkufCxVVVkFwdQdWMWZvXbRfToe6VOnzJ5qf1lfzU/eyiy++OMn39evXL9xVTcdX3UZz5cpl//u//2t9+vRx57H2ldZT89fnSNatWxf+fGmav0uXusV5x0afm/Si4vbqgiw6z1u3bu1+9xfA1rVF1yNPmTJlwr9v2LAhyXlr0Af/vvd3ydb54Xnuuefs+++/d9cuXZ90zmjwCz1PiX89dfw9uvapy1zCdgcPHrSePXuGuyeqYPfpSOtyPfp8al+q25y692mfX3/99e78P91l+o+HjueePXuivt9fDF3XaxVmT4nm5S9OntRyvfMgqXVMqn3Ca7K6qqd1VFQA8IuNeAYAyLI0SpCCGKoToZoQ+qnRghTs8NesyMkWLFgQNVhRuXJlu/POO93vb7zxRsSNqkZbEo1KpECS16ZJkyaJ5qPXr7766vBz1eLwAjga2Uo3khoN0QvoeBSA2rlzp/td7/dqedxwww2ujoluGnQjrJoq3vp4NIrUP//5T/e7bghV58UbSUkUoFm9enXEtqre0OnQzZEXqFFNF+0f1TDStqnGiG4YVWNE66zaNDr/PBo5TAEf3SyrPo4X3EiOttejmlJ+/nlXrVrVBbm8wFhaAwAp7UON1uUF2rQMBS+0fB3DpUuX2uLFi1O1HP+5pZouFStWDAeOvXmojfZPNLoZ17Hz35Tr+GqkyrTQ/DV6mihI5l0fFFD0gthjx461NWvWuGOggKuW6a8vpKDM+eef735XwMCbh9ZfAb7UUpDSu7lVcMMbzUuBKp3/aaWgr0cBMl0LEwbuExo3bpwLsIhGudN2egEdBf28Gkw333xzOCCo7VdQT+eLgouahwLbu3btirihT/hZ07HygpunQ4FYBc285egz6A8OeBLWXPI/T6renT7f2kfeaHYdOnSIqOPmH+lRn/uRI0e64KTWQUGJVatWueCfgsSbNm1yDz8FPHQdSOt66vOs+Wu79VlNTnouNykKViqQlXDkvGiSWmbC5atdwmuczjsv8KVl9urVK9H89eWT9wVUUuuf1HK9dqe7X/zrq+tEtWrVEq0fAKQGQSkAyCb0Ta9uIhQ08G4edYPl/6Yzs1FWQcIi5UEWZ9Y/+gosKMPByxj56aefIoa+TimDx6NvsP0BqYTzUhDLC0gl5G+nQsZ6JKQbWd0sJrzJ/etf/xr+3cu8SngDmV504+F9o6/gk4YXT27/KJCnwIBurnRDKTofL730Upf5ldT7o0l4I6+bU92s6uZcWUx66CZJ+1kZBd7yUiOlfahMKo+GcvcHxFT4OLVBKf9xVpZVas+t9Na4cePw7/4MEQW4PP7gp/aDglL+9Vfmmx4JeQGN1NCy/Rlw/vXy7/O08K+jsllSwwtIKWCkIJT/+Prnp+wpr/C+n4J2Kv7tBRnPFmXvKVCn4LroHH/mmWfC0wsVKhT+3V/MXLzi3gnb+TOkFJj3MvUuv/zycFafxz8Igv7WKLDqXRfuvfde97sKgiso9eqrr9rw4cMj3q8vSBRASct66nxSgFSfbV2nU5Jey/VT9quuewpMKyNs4cKFLmi6efNmlz2YnKSW6V9etGWKzkXvywplrCn4nhoJ56XlehlW0bbzdPfLmQRXAcCP7nsAkI0kzARIKjMgM4765j1Ot2tGWkbf++abb2z58uXuZltdVdKaaRLtm/Qggn/Rluv/tlrf3meGGwZvPdVdUVlGCsAoWKRju2PHDtclUl2OdHOXHH9gJGH3FmUsad7KytF5o2CS2qirloKJysBJrbTsw7R0C8ysozb6P2MKzHqU8RZNWs4ldY1NeGObWtH2rf81daOMlkV3prysKGUkqvtuZjxuOrcVxPUCUgr46gsIfxc9/3VMwVodC4+y0DwJgxtHjhxxmY5eQKpFixYuMO51p/RnWXqqVKkS9Xd/t7Gk+NfTPwKc1tefaaZ2Wm9lJGn79Zn3unn7u4vVrl07oktreizXr169ei5wrWxkdRv2AjwKZvqDlmlZpv94FCtWLFGWlCjz1OMFAFND8/J/lpNarnceJLWOSbWPdk1OmMELAGlBUAoAshHV9PAyD3QD0apVq4xepUzF6/6kTB1laHnZUX5elyQvW+P/BgWJeHg1p1K6ofbPS928krqR9rfTt/rRlqmbXq92TFr5Aw+p6XKSFN14eDdPhQsXdpkbCddTgQMvm0TPL7jgAnejr2wiBQFVV8lbD2UbJEc3mx6vK51H89bNsLrdKdCofevPWnj//fctvZx33nnh31esWBERHFm0aFGq5+M/zl9++WXU4/zLL78EdjzTyr/+OsZJnaf+jJqUakr5j6u/VpvXFcgfQPPfIPvrwSW1jqnttqyaUN5NtYKc6o4XbX5Dhw5Ncpu9mnNn49goUKCgiK4hom5c6qboD6B6mWfeZ0aBFv/nwX+eKgvKo3pNqgk2c+bMcAai9lu0zB1dNz3+LnL+3ytVquR+Dhs2LNF+8rqZ+bM9/YFpra8XSFNAO1qgJiXpuVyvZl1y1/qUMlKTWqb/eETrTq2u314bXX+uueaaZJeTcP38xyqp5XrngX/5mu4FoVVPzTu22ie6lvt5n12dK/7AJACkFd33ACBgyu4YNGhQotd1M5Twn3B1G0h486WbNX+dlIT/jKqLgwIA6orjv0FC6igDwStere4/qtOlbjlbt251XUk++ugjVy/prrvuSnFeqqGkmxzVdFIXH2UgaH66edR5oG+aVZdF3f7UtU9dNdRlRtP1moIfyt749ttv3Tr5Cw2nhf+80vmkmlX6tl+ZamnJTNP5dOutt7pv8HUzq6CnsqB0Q6+uLNpOBYPUhUYBUhXTVuF63fQqSKqbF68ItaSUUdOwYUO3nsrkUGabnwIHKgLcrl079w2+tsMr/pyaeaeFuuzpZlvdd9RNS8XrdZ5oW1LbdU/0Hp0/oq5S6n6oWjc67uvXr3fBAHXTUfAjtcdTNXzUBbVAgQIR3e/Ohttuuy2cSaT6UwoqKYtEN+YKpqk2mm5OdfzTMk8Vvtf5M3r06PDrXu0gHVuddwrw6PgqgKRgslcDLCFls3ifX62jMvNU4Fw32LqeRgsi6pqqAKk+nzpv9NlWVo4GYlAdKV2v9bqWqWusumyqlpQKPyu4qOCFMmgSHhtlZCrjSOur4JayKfV59jJOFGhKaWAHrb+CBzo/ROuofaZrgkefLS+LSfW91H1Ounfvbk888YT77OjYiK5lXrdGrbeuM945rGOpbrD+YJZXj8k7ZzWQgPbFe++95wIf2k/+bpzq1pcSdUGsUKGC+yxpvfQ50Gfdq9nnbYfoS5ZoxfO1XV6mzuDBgxMFTM50uaLPk4qcK2ij/atjoWufF6zSZ84fOI9G+0zrqsCl6kPVqlXLrcPDDz8cdZke1SjzKAiZVIamztXJkye733Uu6rrrzdPrBq6/V3q/grpejSp9qaDPitdtVl/SKOCuwv3qiqlzRH+bvACVas35u7V6gTNRFqw/Yw8A0ixVY/QBAM6If/jx5IZzF/9Q19Ee3jDi/qHSmzRpkuzy/UOVa2jt1NJQ6WkZvtw/PLW2ORr/9nlDWKfG6b4vrdugIe1btGiR7DHQPJMblt5v2bJlbsjv5IaJl1mzZoXy5cuX5DL98084nL3Hf074571z586o8/b2o//88M7DpIau37NnTyguLi7Z/ePN98knn0yyjYY5/+abb1I8Hh06dHDtixcv7oZu90yZMiXZdXjrrbeS3Y607sP33nsvFBMTk2g5/n3hn4//fPXr3Llzsuud1OfG76WXXkry/Ejr9kYbUj6pc0Ief/zxZNffv8+S4rUtWrRoqHTp0onmcfXVV7th7T233nproja1a9eO+tk4duxYqGXLlkmuX3L744033ohYt1WrVrnXX3nlFXe+JjVP/37WOVquXLkkrxlJHZ+k+M/H1JwzWn5S1y9dAz7//PNwW/+6pPZ4jhs3Lsm2nTp1ijhuyZkzZ04ob968UefTqlWr0IkTJ5J9v//z9eOPP6ZqmWldbkp/i7UvUuPVV1+Neu3Qo1u3bona7927N1SwYEE3vUCBAqFdu3YlOe+kPr8Jp/kfWpfJkydHtF2xYoU756O1b9CgQWj//v0R7b/77rvw9LFjx6ZqPwBAUvgKHQCABKMNKZtIRdj1DbKyHJSto+wGZfzom+abbropTVk2ytzQt93KyND8VUNE38D7h1tXtotqlOibdWUz6FtpZSCpVopGt1LR29Ol+SgTRN+G69v9M6F1V7aJRs9TJpjmp9ozyqZQVokymLRt3jbpW3evS4y+TVcWmDKslGXk72KSFI1yJsqKUCaAR9kqygjR/tX2ad7KllJWiWrjeCPopRfV3NGoghrlT8dQGRKq6aPMFU/CGjzRKKtB2XDKktH6al7KwtB8dM6pAHxKtE+VWan3BZ0NqawPdfVSdyLV8dJ5+pe//MVlkyiTKGGR6ZTOJXW91LyURadzQxkeyrbzZ4Yo+1NFvdVG+0yZal999VXUeWp9lCHifX6VEaLPrzJulDmUHP8Im8ps1OdT2XGqzafl6RxQ5pC6zemn5v/4449H1P7RtI8//tjtj2jdg882LV8ZdxrFUFk56kqp/apBL9SNy3++ng6dnzr+On+9favrgDLoNMBGamuu6Rqg9VH2kq4NWk99ppR1pTp/ZyvzJi3LVTaT2ut6rHb6rKr+krJFdT6k5rPqXcN0vdO+1zmha6auxSqaruy9hNTdUJl4omX5ByNIC2UsKuNKf0N0nFRnSuugrD59hvzURhlyysJTRp+2VX/zlNmrOmYJz2Wve7T2i9YRAM5EjCJTZzQHAACAs0TdttStaM2aNa6AuVeMOWj6dynaDbcCcF4tJHWTSjiaJABkJxqpUcE5dYPUly3+oCwAnA4ypQAAQKalTCCvxpLq2PiLKgdJGT3KCFDGg0b+UvabRsTyAlIqdK2MEQDIzpQxqoCUsqRU4w0AzhSZUgAAAClQQWoVvo5GXVtUONnrtggAAIDUIVMKAAAgBaoHptGqNDy7akcpS0B1itR9RVlTBKQAAADSjkwpAAAAAAAABI5MKQAAAAAAAASOoBQAAAAAAAACFxv8IrPvkNUaiULFTqMNGQ0AAAAAAJAThEIhO3DggFWoUMGNppwUglLpRAGpSpUqpdfsAAAAAAAAsrTff//dKlasmDmDUhMmTHCPjRs3uucXXHCBDRkyxNq0aeOeHzlyxB566CF7++237ejRo9a6dWsbP368lS1bNjyPTZs2uZFvvvzySytcuLB16dLFRowYYbGxsRHDOPfr18/WrFnjAkePPfaY3XXXXRHrMm7cOHvuueds27ZtVr9+fXvppZescePGqd4WZUh5O7xIkSJnvG8AAAAAAACyov3797v4ixcryZRBKUXL/vnPf1qNGjVcatfkyZOtbdu2tmLFCheg6tu3r82aNcumT59uRYsWtT59+lj79u3t22+/de8/efKkXXfddVauXDlbuHChbd261Tp37mx58uSxp59+2rXZsGGDa9OzZ0978803bd68eXbPPfdY+fLlXZBLpk2b5oJWEydOtCZNmtjo0aPdtHXr1lmZMmVStS1elz0FpAhKAQAAAACAnC4mhfJGMSFFgzKREiVKuIylm2++2UqXLm1Tp051v8vatWutdu3atmjRImvatKl9+umndv3117uuc172lAJLAwcOtJ07d1revHnd7wpsrV69OryMTp062d69e2327NnuuQJRF198sY0dOzZcH0oRvfvuu88GDRqU6iigAmf79u0jKAUAAAAAAHKs/amMkWSa0feU9aRueocOHbJmzZrZsmXL7Pjx49ayZctwm1q1alnlypVdUEr0My4uLqI7nzKctPHqque18c/Da+PN49ixY25Z/jYqwqXnXhsAAAAAAACkrwwvdB4fH++CUKofpZpQH3zwgdWpU8dWrlzpMp2KFSsW0V4BKNV9Ev30B6S86d605NoocHX48GHbs2ePC4hFa6PMrKSoxpUeHs3Py7LSAwAAAAAAICc6lcq4SIYHpWrWrOkCUErpevfdd12h8gULFlhmp2Lqw4cPT/S6ug0qwJbcgVEQDEnLnTt3skNGAgAAAACAzOvAgQNZIyilbKjq1au73xs2bGjfffedjRkzxjp27Oi61qn2kz9bavv27a6wuejn0qVLI+an6d4076f3mr+N+jQWKFDABUD0iNbGm0c0gwcPdsXRE1aWVx2saP0lVbpL89T2IGU65spWS6koGgAAAAAAyFzy58+fNYJS0TKJ1C1OASqNoqfR8jp06OCmaTS8TZs2ue5+op9PPfWU7dixIzxK3ty5c11QSF0AvTaffPJJxDLUxpuHgmJalpbTrl278DrouUb7S0q+fPncIyFl+ETL8tHIgMoGU6ClYMGCBFuSoODdn3/+6Y6pAlIaJREAAAAAAGQdqe39lKFBKWUbtWnTxhUvV2qXRtqbP3++zZkzx1Vp79atm8tG0oh8CjRpNDwFkzTynrRq1coFn+6880579tlnXf2oxx57zHr37h0OGPXs2dONqjdgwAC7++677YsvvrB33nnHjcjn0TLUbbBRo0bWuHFjGz16tCu43rVr13TZTnXXU4aUAmclS5ZMl3lmZ8pgEy/YqEw2AAAAAACQvWRoUEpBh86dO7ssIgWh6tWr5wJSV199tZs+atQoF11TppSypzRq3vjx48PvV7Bi5syZ1qtXLxesKlSokAsuPfHEE+E2VatWdQGovn37um6BFStWtEmTJrl5edRVULWghgwZ4gJbDRo0sNmzZycqfn66NIqgKEMKqePtK+07glIAAAAAAGQ/MSH1l8IZU00pBdbURS9hTSkVPt+wYYMLkKW2X2VOxz4DAAAAACD7xUj8GOIMAAAAAAAAgSMoBQAAAAAAgMBlutH3cppzB/234PrZtvGf16X7PO+66y6bPHlyxGuq16WaXJ7du3e7IvUzZswI1whTfa/ChQun+/oAAAAAAICsgaAUztg111xjr732Wvi5N/Kh5/bbb3fF7OfOnesKl2tUwx49erjRFgEAAIDMLm5yXEavAoAcJL5LvOUUBKWQrObNm1vdunXd71OmTLE8efK40Q41wmFMTEw4CFWuXLmo7//xxx9d1tR3331njRo1cq+99NJLdu2119rzzz9vFSpU4AgAAAAAAJADUVMKKVL3vNjYWFu6dKnrdvfCCy/YpEmTwtPnz59vZcqUsZo1a7qA1a5du8LTFi1aZMWKFQsHpKRly5auG9+SJUvY+wAAAAAA5FBkSiFFlSpVslGjRrnMKAWe4uPj3fPu3bu7rnvt27e3qlWr2i+//GKPPPKItWnTxgWjcufObdu2bXMBq4iTLjbWSpQo4aYBAAAAAICciaAUUtS0adNwVz1p1qyZjRw50k6ePGmdOnUKvx4XF2f16tWz8847z2VPtWjRgr0LAAAAAACiovse0lW1atWsVKlS9vPPP7vnqjW1Y8eOiDYnTpxwI/IlVYcKAAAAAABkfwSlkKKEtZ8WL15sNWrUcN3zEtq8ebOrKVW+fPlwVtXevXtt2bJl4TZffPGFnTp1ypo0acLeBwAAAAAghyIohRRt2rTJ+vXrZ+vWrbO33nrLjZ73wAMP2MGDB61///4uSLVx40abN2+etW3b1qpXr26tW7d2761du7arO6X6UyqU/u2331qfPn1ctz9G3gMAAAAAIOeiphRS1LlzZzt8+LA1btzYZUcpINWjRw87cuSIrVq1yo3Op2woBZlatWplTz75pOXLly/8/jfffNMFolRjSqPudejQwV588UX2PAAAAAAAORhBqQy28Z/XWWaXJ08eGz16tE2YMCHi9QIFCticOXNSfL9G2ps6depZXEMAAAAAAJDV0H0PAAAAAAAAgSMoBQAAAAAAgMDRfQ/Jmj9/PnsIAAAAAACkOzKlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4GKDXyQiDCsa3A4Zti/dZ7l9+3YbOHCgffbZZ7Z371674oor7KWXXrIaNWqE2xw5csQeeughe/vtt+3o0aPWunVrGz9+vJUtWzbd1wcAAAAAAGQNZErhtIVCIWvXrp39+uuv9tFHH9mKFSusSpUq1rJlSzt06FC4Xd++fW3GjBk2ffp0W7BggW3ZssXat2/PngcAAAAAIAcjUwrJat68udWtW9f9PmXKFMuTJ4/16tXLnnjiCVu/fr0tXrzYVq9ebRdccIFrM2HCBCtXrpy99dZbds8999i+ffvs3//+t02dOtWuuuoq1+a1116z2rVru/c2bdqUIwAAAAAAQA5EphRSNHnyZIuNjbWlS5famDFj7IUXXrBJkya5rniSP3/+/55QuXJZvnz57JtvvnHPly1bZsePH3fZU55atWpZ5cqVbdGiRex9AAAAAAByKDKlkKJKlSrZqFGjLCYmxmrWrGnx8fHu+Q8//OCCS4MHD7Z//etfVqhQIff65s2bbevWre6927Zts7x581qxYsUi5ql6UpoGAAAAAAByJjKlkCJ1sVNAytOsWTPXdU9ZUe+//7799NNPVqJECStYsKB9+eWX1qZNGzcNAAAAAAAgKWRK4Yw0bNjQVq5c6WpHHTt2zEqXLm1NmjSxRo0auemqL6XXNTKfP1tKo/ZpGgAAAAAAyJlIZ0GKlixZEvFcBcpr1KhhuXPnDr9WtGhRF5BSBtX3339vbdu2DQetVBx93rx54bbr1q2zTZs2uYwrAAAAAACQM5EphRQpgNSvXz+79957bfny5fbSSy/ZyJEj3bTp06e7YJRqS6nW1AMPPGDt2rWzVq1ahYNV3bp1c+9XF78iRYrYfffd5wJSjLwHAAAAAEDORVAKKercubMdPnzYGjdu7LKjFHjq0aOHm6aC5go4qTte+fLlXdvHH3884v0qfq4aUx06dHAj9rVu3drGjx/PngcAAAAAIAeLCYVCoYxeiexg//79LitItZWUDeR35MgR27Bhg1WtWtXy589vWUnz5s2tQYMGNnr06ECXm5X3GQAAALKXuMlxGb0KAHKQ+C7xlp1jJH7UlAIAAAAAAEDgCEoBAAAAAAAgcNSUQrLmz5/PHgIAAAAAAOmOTCkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAADkrKDVixAi7+OKL7ZxzzrEyZcpYu3btbN26dRFtmjdvbjExMRGPnj17RrTZtGmTXXfddVawYEE3n/79+9uJEycS1Ua66KKLLF++fFa9enV7/fXXE63PuHHj7Nxzz7X8+fNbkyZNbOnSpWdpywEAAAAAAHK2DA1KLViwwHr37m2LFy+2uXPn2vHjx61Vq1Z26NChiHbdu3e3rVu3hh/PPvtseNrJkyddQOrYsWO2cOFCmzx5sgs4DRkyJNxmw4YNrs2VV15pK1eutAcffNDuuecemzNnTrjNtGnTrF+/fjZ06FBbvny51a9f31q3bm07duwIaG8AAAAAAADkHDGhUChkmcTOnTtdppOCVVdccUU4U6pBgwY2evToqO/59NNP7frrr7ctW7ZY2bJl3WsTJ060gQMHuvnlzZvX/T5r1ixbvXp1+H2dOnWyvXv32uzZs91zZUYpa2vs2LHu+alTp6xSpUp233332aBBg1Jc9/3791vRokVt3759VqRIkYhpR44ccYGxqlWruiwspIx9BgAAgMwibnJcRq8CgBwkvku8ZXXJxUj8Yi0T0cpKiRIlIl5/88037Y033rBy5crZDTfcYI8//rjrqieLFi2yuLi4cEBKlOHUq1cvW7NmjV144YWuTcuWLSPmqTbKmBJlWS1btswGDx4cnp4rVy73Hr03mqNHj7qHf4d7wSw9/PRcsT/vgZR5+yra/gQAAACClItSvAACdCob3AOndhtiM9MKK0h06aWXWt26dcOv33bbbValShWrUKGCrVq1ymU9qe7U+++/76Zv27YtIiAl3nNNS66NAkmHDx+2PXv2uG6A0dqsXbs2yXpYw4cPT/S6srOU5eOnbonaPtW5Sljr6qKpF1lQlt+2PN3nuX37dnvkkUfs888/d5lnl19+uY0aNcpq1KgRbvPLL7+446bulQrkqYumMt8S7m8/7Sfts127dlmePHnSfb0BAACA1KoR+9//bQHgbNuRDcoIHThwIGsFpVRbSt3rvvnmm4jXe/ToEf5dGVHly5e3Fi1auEDHeeedZxlFWVWqQeVRgEvd/UqXLh21+54OSGxsrHtklPRetjKZbrnlFhc0+vDDD912v/DCC9amTRuXpVaoUCFXH0z1vFSja968ee59qvfVvn17l4WmjLSk1lXTSpYsSZdHAAAAZKj1J9ZzBAAEpkyZMll+b6e2dFGmCEr16dPHZs6caV999ZVVrFgx2baq/SQ///yzC0qpS1/CUfKUvSOa5v30XvO3URClQIECljt3bveI1sabR0IaxU+PhBRISRho0XP/6IEZ5XSWrZpeXubalClTXABKXSOfeOIJdwxUpF7BxAsuuCBcz0v77O2333bF5JUdtXHjRluxYkU4WKdi9MWLF7cvv/wyUbdK/7rqEW1/AgAAAEE6ZVm/Kw2ArCNXNrgHTu02ZOiWKtNGAakPPvjAvvjiC1cIPCUaPU+UMSXNmjWz+Pj4iPQ2jeSnAEidOnXCbbwsHX8bvS4qht6wYcOINuo6pudem5xMQSRlLin4N2bMGJcNNWnSpHBNLX8EVCeegnVexpvaKLjkD+CpvdolzIoDAAAAAAA5R66M7rKnAuZTp061c845x9V+0kN1nkRd9J588klXhFzZNh9//LF17tzZjcxXr14910b1iRR8uvPOO+2HH36wOXPm2GOPPebm7QVCevbsab/++qsNGDDA1YgaP368vfPOO9a3b9/wuqgr3iuvvOICMD/++KPLBlLXs65du1pOp26JqhNVs2ZNu/32292IhHpeq1Ytq1y5suvKqLpcKhj/zDPP2ObNm23r1q3uvU2bNnXd+FRT6s8//3T79OGHH3Y1vLw2AAAAAAAg58nQoNSECRPciHvqIqbMJ+8xbdq0cAaTCmgr8KQAyEMPPWQdOnSwGTNmhOehbnfq+qefymq64447XOBK3cs8ysCaNWuWy45SbaORI0e6TB+NwOfp2LGjPf/8867eUYMGDVxG1uzZs5Mtxp1TKLDk7/qn/bx+/XqX7aSC8z/99JMbMVEjIqpLnmpKeal6qrE1ffp0d8wKFy7shoRUQfSLLrooW6QkAgAAAACA0xOb0d33UsrQWbBgQYrz0eh8n3zySbJtFPhSXaPkqCuhHkg9dXtUAE/BRWVKKQilul+NGjUKt1FQUVlvf/zxh+sGWKxYMVd3qlq1auxqAAAAAAByKFJVkKIlS5ZEPFdx8xo1arjsNI8yoBSQUgbV999/b23btk00n1KlSrmAlOqHqQbYjTfeyN4HAAAAACCHyhSj7yFz27Rpk6u5de+999ry5cvtpZdecl0gRV3zFIxSbSkVnH/ggQesXbt2LjvK89prr1nt2rVdu0WLFrk2quelGlUAAAAAACBnIiiFFKlGl4rPN27c2GVHKajUo0cPN03FyhWw2r59u6sHpraPP/54xPvXrVvniqHv3r3bzj33XHv00UcjiswDAAAAAICcJyaUUmEnpMr+/ftdFzbVVipSpEjEtCNHjtiGDRtcwfX8+fNnqT2qWlwq/D569OhAl5uV9xkAAACyl7jJcRm9CgBykPgu8ZadYyR+1JQCAAAAAABA4AhKAQAAAAAAIHDUlEKy5s+fzx4CAAAAAADpjkwpAAAAAAAABI6gFAAAAAAAAAJHUCpAp06dCnJxWRr7CgAAAACA7I2aUgHImzev5cqVy7Zs2WKlS5d2z2NiYoJYdJYTCoXs2LFjtnPnTrfPtK8AAAAAAED2Q1AqAAquVK1a1bZu3eoCU0hZwYIFrXLlym7fAQAAAACA7IegVECU8aMgy4kTJ+zkyZNBLTZLyp07t8XGxpJNBgAAAABANkZQKkDqspcnTx73AAAAAAAAyMnoGwUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAICcFZQaMWKEXXzxxXbOOedYmTJlrF27drZu3bqINkeOHLHevXtbyZIlrXDhwtahQwfbvn17RJtNmzbZddddZwULFnTz6d+/v504cSKizfz58+2iiy6yfPnyWfXq1e31119PtD7jxo2zc8891/Lnz29NmjSxpUuXnqUtBwAAAAAAyNkyNCi1YMECF3BavHixzZ07144fP26tWrWyQ4cOhdv07dvXZsyYYdOnT3ftt2zZYu3btw9PP3nypAtIHTt2zBYuXGiTJ092AachQ4aE22zYsMG1ufLKK23lypX24IMP2j333GNz5swJt5k2bZr169fPhg4dasuXL7f69etb69atbceOHQHuEQAAAAAAgJwhJhQKhSyT2Llzp8t0UvDpiiuusH379lnp0qVt6tSpdvPNN7s2a9eutdq1a9uiRYusadOm9umnn9r111/vglVly5Z1bSZOnGgDBw5088ubN6/7fdasWbZ69erwsjp16mR79+612bNnu+fKjFLW1tixY93zU6dOWaVKley+++6zQYMGpbju+/fvt6JFi7p1LlKkyFnaQwAAAACCFjc5jp0OIDDxXeKz/N5ObYwkU9WU0spKiRIl3M9ly5a57KmWLVuG29SqVcsqV67sglKin3FxceGAlCjDSTtgzZo14Tb+eXhtvHkoy0rL8rfJlSuXe+61AQAAAAAAQPqJtUxCmUnqVnfppZda3bp13Wvbtm1zmU7FihWLaKsAlKZ5bfwBKW+6Ny25NgpcHT582Pbs2eO6AUZro8ysaI4ePeoeHs3L2w49AAAAAGQPuTLXd/kAsrlT2SCmkNptyDRBKdWWUve6b775xrICFWkfPnx4otfVZVDF2QEAAABkDzVia2T0KgDIQXZkg9rWBw4cyDpBqT59+tjMmTPtq6++sooVK4ZfL1eunOtap9pP/mwpjb6naV6bhKPkeaPz+dskHLFPz9WvsUCBApY7d273iNbGm0dCgwcPdoXR/ZlSqkGlGljUlAIAAACyj/Un1mf0KgDIQcqUKWNZXf78+TN/UEo11lVI/IMPPrD58+db1apVI6Y3bNjQ8uTJY/PmzbMOHTq419atW2ebNm2yZs2auef6+dRTT7lIonfgNJKfAkN16tQJt/nkk08i5q023jzURVDL0nLatWsXTjXTcwXMosmXL597JKRaVHoAAAAAyB5OWdbvSgMg68iVDWIKqd2G2IzusqeR9T766CM755xzwjWgVKFdGUz62a1bN5eRpOLnCjQpiKVgkkbek1atWrng05133mnPPvusm8djjz3m5u0FjXr27OlG1RswYIDdfffd9sUXX9g777zjRuTzaBldunSxRo0aWePGjW306NF26NAh69q1awbtHQAAAAAAgOwrQ4NSEyZMcD+bN28e8fprr71md911l/t91KhRLsKmTCkVFteoeePHjw+3Vbc7df3r1auXC1YVKlTIBZeeeOKJcBtlYCkA1bdvXxszZozrIjhp0iQ3L0/Hjh1dPaghQ4a4wFaDBg1s9uzZiYqfAwAAAAAA4MzFhNSHDmdMNaWU2bVv3z5qSgEAAADZSNzkuIxeBQA5SHyXeMspMZKs31ERAAAAAAAAWQ5BKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAskZQavLkyTZr1qzw8wEDBlixYsXskksusd9++y091w8AAAAAAADZ0GkFpZ5++mkrUKCA+33RokU2btw4e/bZZ61UqVLWt2/f9F5HAAAAAAAAZDOxp/Om33//3apXr+5+//DDD61Dhw7Wo0cPu/TSS6158+bpvY4AAAAAAADIZk4rU6pw4cK2a9cu9/tnn31mV199tfs9f/78dvjw4fRdQwAAAAAAAGQ7p5UppSDUPffcYxdeeKH99NNPdu2117rX16xZY1WqVEnvdQQAAAAAAEA2c1qZUqoh1axZM9u5c6e99957VrJkSff6smXL7Lbbbkv1fL766iu74YYbrEKFChYTE+O6Avrddddd7nX/45prrolos3v3brv99tutSJEirth6t27d7ODBgxFtVq1aZZdffrnL5KpUqZKrf5XQ9OnTrVatWq5NXFycffLJJ2ncKwAAAAAAADirmVIK/jz//PMu2LNjxw77+OOP3esNGzZM03wOHTpk9evXt7vvvtvat28ftY2CUK+99lr4eb58+SKmKyC1detWmzt3rh0/fty6du3q6ltNnTrVTd+/f7+1atXKWrZsaRMnTrT4+Hi3PG2D2snChQvt1ltvtREjRtj111/v3tuuXTtbvny51a1bN837BwAAAAAAAMmLCYVCIUuj2bNnW+fOnV1dqYRvVzbTyZMn0zpL974PPvjABYP8mVJ79+5NlEHl+fHHH61OnTr23XffWaNGjcLrpu6EmzdvdhlYEyZMsEcffdS2bdtmefPmdW0GDRrk5rl27Vr3vGPHji5ANnPmzPC8mzZtag0aNHCBrNRQ8Kto0aK2b98+l7UFAAAAIHuImxyX0asAIAeJ7xJvWV1qYySn1X3vvvvus1tuucW2bNlip06dinicTkAqOfPnz7cyZcpYzZo1rVevXuEC67Jo0SKX8eQFpEQZUbly5bIlS5aE21xxxRXhgJS0bt3a1q1bZ3v27Am30fv81EavAwAAAAAAIJN039u+fbv169fPypYta2eTuu6pW1/VqlXtl19+sUceecTatGnjgkW5c+d22U8KWPnFxsZaiRIl3DTRT73fz1tvTStevLj7mXBb9NybRzRHjx51D38UULzgHAAAAIDsIdfpfZcPAKflVDaIKaR2G04rKHXzzTe7DKbzzjvPzqZOnTqFf1fx8Xr16rllatktWrSwjKT6U8OHD0/0uoq/HzlyJEPWCQAAAED6qxFbg90KIDA7duzI8nv7wIEDZy8oNXbsWNd97+uvv3bBojx58kRMv//+++1sqFatmpUqVcp+/vlnF5QqV65cooN14sQJNyKfpol+KrPLz3ueUhtvejSDBw922WL+TCmN7Fe6dGlqSgEAAADZyPoT6zN6FQDkIGUS9AjLivLnz3/2glJvvfWWffbZZ24hylpSkXKPfj9bQSkVL1dNqfLly7vnzZo1c4XQly1bFh7574svvnBpYk2aNAm3UaFzjcznBc80Up9qVKnrntdm3rx59uCDD4aXpTZ6PSkaBTDhSICielZ6AAAAAMgeTlnW70oDIOvIlQ1iCqndhtPaUgV51HVNVdQ3btxoGzZsCD9+/fXXVM/n4MGDtnLlSvcQvV+/b9q0yU3r37+/LV682C1DQaO2bdta9erVXRFyqV27tqs71b17d1u6dKl9++231qdPH9ftTyPvyW233eaKnHfr1s3WrFlj06ZNszFjxkRkOT3wwANu1L6RI0e6EfmGDRtm33//vZsXAAAAAAAA0t9pBaWOHTtmHTt2POPonQI/F154oXuIAkX6fciQIa6Q+apVq+zGG2+0888/3wWVlA2lLoP+DKU333zTatWq5brzXXvttXbZZZfZyy+/HJ6uIQiV1aWAl97/0EMPufn36NEj3OaSSy6xqVOnuvfVr1/f3n33Xfvwww+tbt26Z7R9AAAAAAAAiC4mFAqFLI369u3raidpNDz8t6aUAmDKHitSpAi7BQAAAMgm4ibHZfQqAMhB4rvEW06JkZxWTamTJ0/as88+a3PmzHEj4iUsdP7CCy+czmwBAAAAAACQQ5xWUCo+Pj7c5W716tUR0/xFzwEAAAAAAIB0C0p9+eWXp/M2AAAAAAAAwMn64wwCAAAAAAAgyyEoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABC42+EUCAIBUGVaUHQUgOMP2sbcBAIEiUwoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAAJCzglJfffWV3XDDDVahQgWLiYmxDz/8MGJ6KBSyIUOGWPny5a1AgQLWsmVLW79+fUSb3bt32+23325FihSxYsWKWbdu3ezgwYMRbVatWmWXX3655c+f3ypVqmTPPvtsonWZPn261apVy7WJi4uzTz755CxtNQAAAAAAADI0KHXo0CGrX7++jRs3Lup0BY9efPFFmzhxoi1ZssQKFSpkrVu3tiNHjoTbKCC1Zs0amzt3rs2cOdMFunr06BGevn//fmvVqpVVqVLFli1bZs8995wNGzbMXn755XCbhQsX2q233uoCWitWrLB27dq5x+rVq8/yHgAAAAAAAMiZYkJKR8oElCn1wQcfuGCQaLWUQfXQQw/Zww8/7F7bt2+flS1b1l5//XXr1KmT/fjjj1anTh377rvvrFGjRq7N7Nmz7dprr7XNmze790+YMMEeffRR27Ztm+XNm9e1GTRokMvKWrt2rXvesWNHFyBTUMvTtGlTa9CggQuIpYaCX0WLFnXrqKwtAADO2LCi7EQAwRm2j72dhLjJcewbAIGJ7xKf5fd2amMksZZJbdiwwQWS1GXPow1q0qSJLVq0yAWl9FNd9ryAlKh9rly5XGbVTTfd5NpcccUV4YCUKNvqmWeesT179ljx4sVdm379+kUsX20Sdif0O3r0qHv4d7icOnXKPQAAOHOUfgQQIP6HTVIurscAAnQqG1yPU7sNmTYopYCUKDPKT8+9afpZpkyZiOmxsbFWokSJiDZVq1ZNNA9vmoJS+pnccqIZMWKEDR8+PNHrO3fujOheCADAaStSj50HIDg7drC3k1Ajtgb7BkBgdmSD6/GBAweydlAqsxs8eHBEdpUypVREvXTp0nTfAwCkj/2r2JMAgpPgy1781/oTkYMtAcDZVCYbXI81iFyWDkqVK1fO/dy+fbsbfc+j56r15LVJGEE8ceKEG5HPe79+6j1+3vOU2njTo8mXL597JKSug3oAAHDmsn7qNoAshP9hk3SK6zGAAOXKBtfj1G5Dpt1SdblTUGjevHkR2UiqFdWsWTP3XD/37t3rRtXzfPHFF67vompPeW00It/x48fDbTRSX82aNV3XPa+NfzleG285AAAAAAAASF8ZGpQ6ePCgrVy50j284ub6fdOmTW40vgcffND+8Y9/2Mcff2zx8fHWuXNnN6KeN0Jf7dq17ZprrrHu3bvb0qVL7dtvv7U+ffq4IuhqJ7fddpsrct6tWzdbs2aNTZs2zcaMGRPR9e6BBx5wo/aNHDnSjcg3bNgw+/777928AAAAAAAAkP4ytPueAj9XXnll+LkXKOrSpYu9/vrrNmDAADt06JD16NHDZURddtllLnjk75v45ptvuuBRixYtXHpYhw4d7MUXX4wYse+zzz6z3r17W8OGDa1UqVI2ZMgQN0/PJZdcYlOnTrXHHnvMHnnkEatRo4Ybea9u3bqB7QsAAAAAAICcJCYUCoUyeiWyA3UtVABs3759FDoHAKSPYUXZkwCCM2wfezsJcZPj2DcAAhPfJT7HxEgybU0pAAAAAAAAZF8EpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMBl6qDUsGHDLCYmJuJRq1at8PQjR45Y7969rWTJkla4cGHr0KGDbd++PWIemzZtsuuuu84KFixoZcqUsf79+9uJEyci2syfP98uuugiy5cvn1WvXt1ef/31wLYRAAAAAAAgJ8rUQSm54IILbOvWreHHN998E57Wt29fmzFjhk2fPt0WLFhgW7Zssfbt24ennzx50gWkjh07ZgsXLrTJkye7gNOQIUPCbTZs2ODaXHnllbZy5Up78MEH7Z577rE5c+YEvq0AAAAAAAA5RaxlcrGxsVauXLlEr+/bt8/+/e9/29SpU+2qq65yr7322mtWu3ZtW7x4sTVt2tQ+++wz+89//mOff/65lS1b1ho0aGBPPvmkDRw40GVh5c2b1yZOnGhVq1a1kSNHunno/Qp8jRo1ylq3bh349gIAAAAAAOQEmT5Tav369VahQgWrVq2a3X777a47nixbtsyOHz9uLVu2DLdV177KlSvbokWL3HP9jIuLcwEpjwJN+/fvtzVr1oTb+OfhtfHmAQAAAAAAgByWKdWkSRPX3a5mzZqu697w4cPt8ssvt9WrV9u2bdtcplOxYsUi3qMAlKaJfvoDUt50b1pybRS4Onz4sBUoUCDquh09etQ9PGovp06dcg8AAHLAd0cAshP+h01SLq7HAAJ0Khtcj1O7DZk6KNWmTZvw7/Xq1XNBqipVqtg777yTZLAoKCNGjHBBsoR27tzpCrADAHDGitRjJwIIzo4d7O0k1Iitwb4BEJgd2eB6fODAgawflEpIWVHnn3++/fzzz3b11Ve7AuZ79+6NyJbS6HteDSr9XLp0acQ8vNH5/G0Sjtin50WKFEk28DV48GDr169fRKZUpUqVrHTp0u69AACcsf2r2IkAglOmDHs7CetPrGffAAhMmWxwPc6fP3/2C0odPHjQfvnlF7vzzjutYcOGlidPHps3b5516NDBTV+3bp2rOdWsWTP3XD+feuopF2X0DurcuXNd0KhOnTrhNp988knEctTGm0dS8uXL5x4J5cqVyz0AADhzWT91G0AWwv+wSTrF9RhAgHJlg+txarchU2/pww8/bAsWLLCNGzfawoUL7aabbrLcuXPbrbfeakWLFrVu3bq5bKUvv/zSFT7v2rWrCyZp5D1p1aqVCz4piPXDDz/YnDlz7LHHHrPevXuHA0o9e/a0X3/91QYMGGBr16618ePHu+6Bffv2zeCtBwAAAAAAyL4ydabU5s2bXQBq165drlvcZZddZosXL3a/y6hRo1z0TZlSKjquUfMUVPIogDVz5kzr1auXC1YVKlTIunTpYk888US4TdWqVW3WrFkuCDVmzBirWLGiTZo0yc0LAAAAAAAAZ0dMKBQKnaV55yiqKaXsrX379lFTCgCQPoYVZU8CCM6wfeztJMRNjmPfAAhMfJf4HBMjydTd9wAAAAAAAJA9EZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBiw1+kcjszh00K6NXAUAOsvGf12X0KgAAAADIAGRKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUSmDcuHF27rnnWv78+a1Jkya2dOnS4I8KAAAAAABANkdQymfatGnWr18/Gzp0qC1fvtzq169vrVu3th07dmTcEQIAAAAAAMiGCEr5vPDCC9a9e3fr2rWr1alTxyZOnGgFCxa0V199NeOOEAAAAAAAQDZEUOr/HDt2zJYtW2YtW7b8787Jlcs9X7RoUUYdHwAAAAAAgGwpNqNXILP4448/7OTJk1a2bNmI1/V87dq1idofPXrUPTz79u1zP/fu3WunTp2yLO3ooYxeAwA5iK6bSMLRGHYNgOBwPU5S6HCIMxFAYPZmg+vx/v373c9QKPnrJ0Gp0zRixAgbPnx4oterVKlyurMEgByp+OiMXgMAgPPP4uwIAMgEivfKPtfjAwcOWNGiRZOcTlDq/5QqVcpy585t27dvj9hBel6uXLlEO27w4MGuKLpH2VG7d++2kiVLWkwM32wjZ1EUvFKlSvb7779bkSJFMnp1ACBH45oMAJkD12PkZKFQyAWkKlSokGw7glL/J2/evNawYUObN2+etWvXLhxo0vM+ffok2nH58uVzD79ixYql3xEEsiAFpAhKAUDmwDUZADIHrsfIqYomkyHlISjlo8ynLl26WKNGjaxx48Y2evRoO3TokBuNDwAAAAAAAOmHoJRPx44dbefOnTZkyBDbtm2bNWjQwGbPnp2o+DkAAAAAAADODEGpBNRVL1p3PQBJU1fWoUOHJurSCgAIHtdkAMgcuB4DKYsJpTQ+HwAAAAAAAJDOcqX3DAEAAAAAAICUEJQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAFH5B+ZkkE4AyDj+a/CpU6c4FACQQbgeA+kv9izME0A2sHfvXitYsKCdPHnS/QQAZIwdO3ZYnjx5LG/evFa4cGEOAwBkkO3bt7vrcWxsrBUtWpTjAKQDMqUAJDJlyhS77rrrrHHjxta8eXObPXu2HTp0iD0FAAGbPHmytWzZ0po2bWq1a9e2f/3rX/bbb79xHAAgA67Hbdq0sRYtWrjr8XPPPWfr16/nOABnKCZEvxwAPh988IHddttt9swzz7jnK1eudH+EH3nkEevevbtVrlyZ/QUAAZg1a5bdcsstNmrUKCtfvrwtXbrUXnnlFbvhhhusV69e1rBhQ44DAATg/ffft7vvvttdj+vUqWPffvutPfzww9a2bVvr37+/XXLJJRwH4DTRfQ+Ao/h0TEyMzZgxw+644w67//77w3umUaNGNnToUDt+/Lg99NBDVrp0afYaAJzl6/G8efPs+uuvt3vvvde9fuONN1pcXJyNGDHCXnzxRRs0aJD7th4AcPacOHHCpk2bZr1797auXbu615o0aWILFiywr776ynXnU9fqevXqcRiA00D3PQAR9u/f7+pIybFjx9zPv//97/bkk0/amDFj7JNPPnGvUWwXAM4OBaS866yuyd5NkXTs2NEee+wx+/rrr+29997jegwAZ5n+L/7111+tSJEi7vnhw4fdz4oVK7qufMpi/fTTT91rdEIC0o6gFICIm6AGDRq4Lnwq5KiiusqOkp49e1rfvn1dirKm5crF5QMAziZ1EdE38WvWrHFFdb0vCm6++WZ78MEH7emnn7aNGzdyPQaAsyhfvnxWv359Gz9+vO3cudMKFChgH330ketOre58DzzwgL3wwgu2a9eu8P/TAFKPu0ogh/v444/dNzwepSare0iHDh3sjz/+cCnJR44cCX9DrxsjiuwCwNnhZURJjx493GAT1157rRuBT18UHD161E27/fbbrUSJEhYfH8+hAICzfD0ePHiwValSxcqWLWsXX3yx/e1vf7MJEybYX/7yF7v88svd/8cauRpA2hGUAnKwiRMnukCT9+27FC9e3NWNUrcR/cHdvXu35c+f301Tf/lChQpl4BoDQPY0ffp0V6tEQajHH3/cdc8TdZtWkXPVL1FWlL6xF31ZULBgQfeNPQDg7FyP1V168eLFdt5559n8+fNt0qRJLjNq0aJF1q1bN9d+z549LljF9Rg4PYy+B+RQGla8T58+9sYbb7jAVMK+80pL1lC3v//+u+siooypKVOmuNRk/SGm+x4ApA9dh1XMXDc6uqnRiKcKPmnACb3+n//8x2Wxfv/99zZgwAA755xzbM6cOS57SpmuuXPn5lAAwFm8Hqu+qq7Doi9u9X+w/l9WfSl1qVabDz/8kO57wGkgKAXkQCqOq2HGFXjS0OIq3jh37lz3s1atWm6asqL0XKM8aQQoZVDp23rVm1KASn+IuRECgDOjwH/79u1djSh1yZP169e7+n667urGSLX81I1k+PDh9sUXX7hCupUrV3ZfFHA9BoCzfz0uWbKkC1Y9+uij7nXVXJ05c6a9/PLL7n0rVqxw12MvYAUg9WLT0BZANvDnn3+6b3KqVq3qvs355ZdfrF27di4IpZseFWxUnSmNtle3bl1XxHHbtm3hrnt6j9qp7zwA4MwdOHDAKlWq5IJNutFRN5ErrrjC3eC8//771rRpU1ezRNdlZUqpS7WuwVyPASC467FGoNbvuh7realSpaxZs2Y2Y8YMd03m/2Pg9BDGBXIY1SAZOnSoXX311a6ffMOGDa1NmzYua+q7776zJUuWuL7zY8eODb9H/eQVlNINkL4BIiAFAOlDWacK/K9du9ZdY1XMXBmpmzZtcllS6qKn67NH12LdDKmtbpq4HgNAMNdjTfNfjxWcGjJkiLsO671cj4HTQ/c9IIfw0om9n0pHVq0o/QHVz9KlS7sbHP0RViryww8/bD/99JMLSDG8LQCcvevxyJEjXRc9jbKnoNM777zjslRVRFfDjL/11luu8LmCUXSbBoCMvx7r/2eCUED6oP8NkAP4+7erTpQKN1arVs3GjRtna9ascenHCbv4qf98mTJlCEgBwFm8HqtbdJcuXax+/fpuRFR9M//ZZ59Zy5Yt3RcF+ma+XLly4VFQAQBcj4HshKAUkM3ppsa7ARo0aJBLO965c6ddcMEF7kbo7rvvDrdVRtTRo0ft888/t9q1a1OoEQDO4vVY9f00ommdOnXcqE7vvvtuRNDqyJEjtnLlSqtXrx7HAQC4HgPZEkEpIBvz39y8/fbbblhbfRO/d+9elyHVs2dPV69EN0eHDh1y9aRU6Py3335zN0videkDAJyd6/Hq1avdSE8aeGLw4MHuywHV+Bs2bJht377dFdflegwA6YPrMZC5EJQCsjHvBmj+/Pk2b948N2pT27Ztw6OLaEhxBaRq1KhhjRo1cjdA+fLls+XLl4eLNlK/BADO/vW4SpUq7np8/vnn23XXXee+JKhQoYJ9+umnXI8BIB1xPQYyFwqdA9mc6pFcdtllLiNq4MCB9uijj4an7dmzx3Xf09C3L774ohttRDdE+mPNsLYAkHHXYz0vVqyYy1TlegwAXI+B7Or/f20HINtSgdz333/fFS3XzxUrVoSnFS9e3EqWLOlG4pNatWqFRyBhRBEAyLjrsZ4rIKUu1FyPAYDrMZBdEZQCcgAVydUNkLrjjR492hXO9bqM/Pjjj+6b+WhpzQCAjL0eU9MPAM4OrsdA5kD3PSAH0bfyd9xxh+3evdvVkNLQ4xs2bLDFixe73ylqDgBcjwEgJ+H/YyBjkQ4B5CAXXnihTZs2zQoUKGD79u2zq6++2hU1V0Dq+PHjfCMPAFyPASBH4f9jIGMRlAJymLp167quI8eOHXMBqZ9//tm9nidPnoxeNQDIUbgeA0DmwPUYyDh03wNycKpyz549rVq1ajZ06FBX5BwAwPUYAHIq/j8GgkemFJCDU5XHjh1rW7dutaJFi2b06gBAjsX1GAAyB67HQPDIlAJyuCNHjlj+/PkzejUAIMfjegwAmQPXYyA4BKUAAAAAAAAQOLrvAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAgAXt/wHpIJsU4I867QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 22: TTFT p50/p90/p99 over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "  APPROX_QUANTILES(ttft_ms, 100)[OFFSET(50)] AS p50,\n",
+    "  APPROX_QUANTILES(ttft_ms, 100)[OFFSET(90)] AS p90,\n",
+    "  APPROX_QUANTILES(ttft_ms, 100)[OFFSET(99)] AS p99\n",
+    "FROM llm_events\n",
+    "WHERE event_type = 'LLM_RESPONSE' AND ttft_ms IS NOT NULL\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"p50\", \"p90\", \"p99\"],\n",
+    "          \"LLM TTFT Percentiles\", \"ms\",\n",
+    "          labels=[\"p50\", \"p90\", \"p99\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel6-header",
+   "metadata": {},
+   "source": [
+    "## Panel 6: Session Duration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "cell-23-duration",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:01.942915Z",
+     "iopub.status.busy": "2026-04-11T06:43:01.942801Z",
+     "iopub.status.idle": "2026-04-11T06:43:04.497243Z",
+     "shell.execute_reply": "2026-04-11T06:43:04.496754Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASLtJREFUeJzt3Qm4VWXZMP4HZFYBQQQVME1TDHHAVNKMFCU1xcTStM+xMF9nTJPKuTdsUHDWtMwszNTU17fUjBwLxQk1zaEccGCwFFAURNj/617ff+1vn8M5h8PhuM45+/x+17Wvs8/aa+/17DXtte51P/fqUCqVSgkAAAAACtSxyIkBAAAAQBCUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAJoZmeddVbq0KFD9vjlL39p/jazfN5+4hOfMG9bucMOO6y8vO69995WtwwfeeSRclv++te/rvT7W+J7jBw5sjzdV155JRWptSy3+kS78ja2lNjn522I3wKgcWIfnG87sW8G2g9BKaDNeP3119M3v/nN7MSjS5cuqVevXmnjjTdOe++9dzrnnHNaunmtUuUJbDxivvXr1y9ts8026Zhjjkl///vfU2tz6623Zidz8Sj6pHtlRJClct7mjx49eqRPf/rT6fTTT0/vvfdeqmaxfPJlFcutrYllFD7zmc+kHXfcMbV3bWXba4/mzZtXXjbNcbHjww8/TFdeeWX66le/mjbbbLPUs2fP1L1797T55punM844Iy1cuHC59yxbtixdfvnlaeutt872c/EbPGrUqDR16tTlxr3uuuvSoYcemu0L11prrdS1a9fs9/qEE05I//73v+tsU0zz3HPPTcOGDUurr7561qYhQ4ako446aqX2pf/85z/TwQcfnPr3759N95Of/GT6zne+kxYsWNDg+/7rv/6rxr78zjvvbPQ0V2a6cSxz5JFHZt+zb9++qVOnTtk8in3QpZdempYuXdroaT722GNpzJgx2ed069YtW34TJ07Mlm99Adv6HpUXDlbkhhtuyNq7xhprZI94/rvf/a7OcWfPnp2+9a1vpUGDBmXHIPH36KOPTnPmzKkxXnxG7ItDrINAO1ICaANmzZpVWnfddUux26rrsdpqq5Vai1dffbX0wAMPZI85c+a0aFs+//nP1zvP4tGhQ4fSGWecUWpNDj300HL77rnnnuVez+ftI488UmpJ0baG5m08tthii9K7775bqlaV8yCWW20vvPBCeXnNmzevPDx/zwYbbFBqKU8//XS5HVdccUWTPqMl1sXKbfrll19ul9tefWJ9ytvfUq655ppyG84888xm+9xY1vnnxjrQHL+pDe27PvOZz5QWL15c7/pR+3fk2muvrTFu165d6/3sDTfcsPSf//ynxvizZ88uffrTn673Pa+99lqjvteMGTNKvXr1qvMzttpqq9KCBQvqfF+s1/E9Kse/4447Gj0/V2a6Ma2G5v24ceMaNc277rqr1KVLlzo/Y/fddy999NFHdW4b9T0efPDBRk031uv6PuPcc8+tMe7MmTNLAwcOrHPcwYMHl15//fUa41955ZXl12MfDbQPMqWANuHiiy9Os2bNyp7vuuuu6fe//33605/+lH72s5+lb3zjG9lVxtZi8ODBaaeddsoe66yzTmotvvvd76b77rsvTZkyJe27777ZsIgPRJbZ5MmTP5Zpvv/++83+mfm83XbbbVNrMWDAgPTAAw9kV5p//OMfp86dO2fDn3766XTFFVc067TqymBorTbZZJPy8oqsitbkmmuuyf527NgxffnLX66adfHj1N6+b7WL7Jg99tgjy7y666670sknn1x+LbpP/eY3vyn//z//8z/p2muvzZ6vt9566be//W2aNGlSluUTvyOReVuZ+RKfHetK7P/uvvvuLAMqsmTCyy+/nC688MLluvo+88wz2fPdd989+52K98U0jzjiiCzzqDEOP/zwNH/+/Oz5uHHj0m233ZZ23nnn7P8ZM2bUmVW9ePHiLAs7vkdkGzXFykw3ssC+/vWvp5///OfZfI9x99prr/Lrv/jFL1a4n//ggw+yaeYZUd///vfTzTffnIYOHZr9H8dHlb89N910U/YbVfm46qqryq+vu+66abvttlvh94zvEssyrLnmmllb4xHPQ2TyPfXUU+XxIzMuMsPCfvvtl33X+BtmzpyZTjzxxBqfH8cmsU8Oyh9AO9LSUTGAxvjiF79Yvnr21FNPLff6woULlxs2d+7c0kknnVTaeOONs6uJvXv3Lu25556ladOmLTduZEoMHz68tPrqq2fjrrfeeqVdd9219KMf/ag8ztKlS0s/+MEPsqu53bp1y64EDxo0KPvMq6++us6riHHVvNJjjz1W2n///Uv9+/cvde7cOfs7duzY0qOPPtrg1fbrrrsum260bZNNNindcMMNK51VUbstJ598cvm1Nddcs/TOO++sMPulrgyX2m29/PLLS5/61KdKnTp1Kk9z/PjxpREjRpQGDBiQfYeYz1tvvXXpJz/5SWnJkiXLZQLU9cgzN+rLsomr+uedd15pyy23LPXo0aPUvXv30rBhw0oTJ05c7op/5VXjyBj4+te/nq0fa6yxRumrX/3qclfx61I5n2q35bDDDiu/ts8++5SHL1u2rPSLX/yi9NnPfjab57EeRRsnT56crV/1tTGy7/bbb79Sz549S5/4xCfK40Q7TzvttNKQIUOy7xufGfP14osvrvFZL730Uukb3/hGdmU65n+/fv2y7/nss882eb1rKAsvX2/qy7ypb759+OGHpfPPP7+0zTbbZMswHtttt13Wjrrmf2yja621Vraurb322ll2x/HHH18jK6s+ka0RbYj5VVfWQyy3mE/x2X369MnWq6OOOipbFg19j6Zsu/fee29p2223zfYpG220Ubb86su4aShT6tZbb83mSazLMb3YDs8666zS+++/3+C8WJVtr3Y7L7nkkuz1WHZ77LFHlinxwQcfZMulb9++DW5j999/f2nvvffOlmXsH2Ndj33422+/XWqMym3mrbfeKh1yyCHZvIjt5qCDDqqRudpQ5lFDGVdTpkwpjRw5sjyPY9zYf+TrXH3L7cgjjywPj9+MfJ/05JNPlg488MBs3xjfOX57YtzKzKD6MpRqt72+7aoukbnzt7/9bbnh++67b/lzjj766PLwWJb58Ouvv748PLaJfPhPf/rTGlk8tZ144onlcePzctOnTy8PHzVqVLafbIqHH364/DmxT8w/58033yxnQcX+IvYzlb73ve+Vs4sqt6/GZko1dbqV4ve3crnG+tuQ2I/k444ePbo8PI5v8uFDhw5t8DOOPfbYOtfVho5jYp3Ih8dvay6e58Pjc0P8tnbs2DEbFllksR8I8TfPKoss98iSqxSZZfFa7AuB9kFQCmgTvvKVr9Q4yY/099qBhkpx4lhfyngc+N92223lcX/1q1/Ve8C//vrrl8c755xz6h1vxx13XOHBXEwzpt2YNlWe2MSBWe3x40DvueeeW6WgVHQriwPl/PX8xH9VglK125pPs6GuHIcffvgqnxgvWrSotPPOO9f73nitcn2pPOmsa/4efPDBqxSUOuGEE8qvRUA1FyfJ9bXxgAMOqPEZ9bUxn1ac7EeQaUUnqhEIjRPousaLAEGcUDVlvWvuoFScsEVApb7PPPXUU8vjRhsiCFffuC+++GKDyy5OFvNxIwBQ6d///ncWjKrvs+++++4Gv8fKbrtxElnX9hFBsJUJSp1++un1tvlzn/tcg/vL5gpKffKTn1zuvRF0rQx01LeNXXXVVeUT2NqPTTfdtFGBqcptJqZbV1tiX9HUoNQRRxxR7zzKl0VdQakJEyaUh8U6np+c//GPf6x33xhBqggmf1xBqfqccsop5c/59re/nQ2LIEsE9vLhlYHZ6LaXDx8zZkyDn33ppZeWx42LM3WtuxHkiv11BNgjiBnrSezrGiMC2rV/V2oHoePxxBNPlIfHRa74/Y0LJbEMmxKUasp0czFvIwB19tlnNzqYFI477rjy+PHeXFzkqTzOqG+7ee+998rLNALvb7zxRo3X6zuOiS7p+fD77ruvPDyeV+67ws0331we9oUvfKHG58f/+Wu33HJLvdtZBLaA6qf7HtAmRDHVym4En/vc57J08egecP755y+X6h4FS/OU8UMOOSQrWBoFWqMg55IlS7LuAPl7Ip08RDeESHePoq3RbSG6Mmy44Yblz8zH6927d/r1r3+d/vznP6df/epXWQHPSH1vSEwrCpvGtEMU+fzjH/+YtTPE8Hi9rpT9l156KXvtf//3f7Oui3nB2auvvjqtipgXeap/npa/qqKto0ePzgomR9HTKHIbvve976Xrr78+Ww7RxS26X26//fblFP1YVjEPo0tBdCfJXXTRReWuBlFctz7R/fD+++/PnkcR1ej6EdOLrpQhXouuJvV1g4jledlll5W7l0TXlLwrxsqI5fLwww9n089tscUW5e4Tsb6ETTfdNGvf7bffnnbYYYdy4dh41CW6xVxwwQVZl4zohhli3YnuDyG+Z3Rljfkb3QdjHoQ4T41iw1EkOcQ6HZ/xox/9KK222mpZ8eDoAvJ/z2dXbr2LLrWxfHKx3PJlFct7ZUV3nrxgcsyTW265JZtnMa9CfK+YtyG69cRyy7uHxPti3B/84AdZ17IV3X3tH//4R/l5FF+uNG3atPTWW29lz7/2ta9l04r1+ac//Wn6/Oc/n823xmrMtjt+/Pis+1D4whe+kK0TZ599dtb1s7Giq1XepSa2o+gWFOtC3iUolkl963/+nqZue5X+9a9/pVNPPTXbV66//vrZsOjKE98/5l9sF1FMu/Y29sYbb6Rjjz02mzexX491K7o1xboZnn/++fJ631ixbsf2FPuXtddeu9yW2E6aIrpGRTelEOvAt7/97WwfHtv0brvtVu86F+t1FJ4O8bsVv1/RRSy6Nse2Gcs+fnv++7//O9s2Y/7lxaHz34fYnm688cbyZ2611VblZRPzqrnE71Csf7l8fXjnnXdqFOuOQt65yi7q0S2vIbHfr/3Z4dlnny0/j+Lrsb9+991303/+85/st3jEiBHLFcWuS2Vx/so21tfOWN+i+39875j/Tb2r5MpON3fggQdmXdXi5iNnnnlmNiyOaSrn08pOM9alPn361DlepfjNy5dpdF+OLpmNUd906/qeTZ0vlfvkynUDqF6dWroBAI0RJ3ZxoFpZ4yJqKcQthOMRAac4MYvaUm+//XZ2spDX+olaESECMHHyECe7cbAbJ21jx44t1/+JgEQcDMVJbdz156CDDqrRhny8qAcRd9WJO+fEHYj+z//5Pytsf5xs5HccGj58eBYAyQ/M40Q77qATr8cJcF7vKbfllluWT2Lj5Co/cY87/ayqymBaU4IwtW2wwQbZCWgcGFfaZZdd0k9+8pPsu8b3/Oijj8qvRUDk8ccfT/vss89ydbgioBPDVqQyCBTz9ktf+lI58BZ3ZwwRBIo7IdUW4+fzPE4YY72Iux/FAXXM+8Z49dVX6zwpjQBm1FrJTwJyMWzgwIHldfuhhx4qj3PAAQcs9zkRUMjX41C5jscJcrQ57lIVIiiYe/LJJ8t3WIwT2fx7fvazn83qh0QAJg76Y/7Herky610sm9iOcrHcGrOs6lM5fyJQkwcS4m5W+Z2YYpwIZubbYojAcdxxKrb10JiAWOXdv2rXo6v87AjuRVAsllUs38qaO42xonk4d+7cbBmEqJkTgYe4i1asvxE4i8BNY1TuFyOQ86lPfSp7HgHzP/zhD+V5V9f6n0+7qdtepVivIuCZ7/PiTmJ5cC+fd9HWaFPlNhbfOw/M7b///tm6mn+XCCxFACe23/i8vN7MikRwI7+YEUGHfPuJAONxxx2XVlbcTS4XgaMf/vCH5f/r+w2IAM8TTzyRPY/1Nr53/Gbk8ycPfsbvUl5/KPZXEdCPeROBuVhXozZb5XoZ9dnqWjZ1BZcbKw/QPPfcc9n/8dsY++1Q+2JJHryv/byhOkhR86gy6BwXi3J50DwXweVYL+LumHGxJIKW5513XrYfjG3mhRdeqDF+zI9YXyunX9mu+toZAcPp06dn7VnROtGc021ILOfG3H1vVaeZH4OE/DeqUn6nx8ZOt65pNrWNlfvk+u7UCFQXQSmgTYgT7zipigPHOIH5y1/+kp1wx4F0foU+gh5xohAnfPnBeVxtjqvTDWVLVJ745CcxcRIaWRFRhDMv6psHD+IAOa7cxknqRhttlGVAxAlXfiJYl8qD2TxDKBfBgQhK1R4vF+3IxQlrfQfyTRHfJdcchai/+MUvLheQioP+yADJs8Tqsqrfpb75W1m4ta55+3HO31jvIoshAnW1p3/88cevMIOnUh5Yy8U6nq/7sQ7mAanaKqcZJ3cNbQu1g1If53q3orbGberra2eIW6BH8CmCYrGNxiNOZGLZRxbkV77ylUZPt/aJfMyjCAK8+OKLWXZWPCJ7Z5tttskCZLEfaGxgZEXzMDKpchHorhwn9jGNDUpVzrvYB1YGTHJ5sOHjVLm9VWZrVBZGz4ONlfOhsv1RgD4vQl8pguZvvvlmOZi7IvXtByrn+cqobGMe9F6RCPaGWH8iIJUXg679eXfccUf2qGvdjOW2KsHexoh9cwTW8kzN2AbyrM78QkylCCDmBcHzQtt1jZeLrLLIaA6bbbZZFvyv/J2oLGIegc08sByBizzIHpnJIYLxeQZd5XYWGbiV08+DnLna7Yzsrwh6RRAoCn6vaJturulWiozIyIaLLLDI6Itp3HPPPdlxSOzjGyq63tRphgcffLBcjDyymSv3UysSnxdZbLWnW9c0m9rGVQmuAm2T7ntAmxInGtENJA724wQlv4tL5QlAY+VX5+JOP5FtFVfSo5tKXMmO7mRxRT8O1vKTmLiKHCcOcfAeWVdxwBzBsOgOEuM19WR9RV2NKq8aVh7Ir+qBW6Tu51k0Ic9OqGxP5RXbxlyxrJ2iH6JLZB6QipO5OPCObieVV8rzAEtzW9G8ba75m999Lx6RsRfBksjsa2ym1Yquatc1X5tTXdP9uNa75mhnzO8I5EbmT5ywRzAnTjIjYywCWisK5lQGRuJ9lWL7j/1B3C0rMkViWnESFneujLtqRZCqsVZmHjZmXV0VkZ1Y+8SwuVUGtitP8iPztC4ruy419c6Tdc3b+vZzzZmdkXf1jPUnz/ZrbXfbXLRoUfY7mgek4iJL/M7lGV35ely5DCu70sWFn1xld/d8v37UUUeVA1KRXRxBnOiuVinvZh3yIH7t55XdB+tT2f2udne/2u2MIGfM2/htimynWB/iEdt5LjKZI9u1OadbKbIwI0MuguiRVZe/HheL8u7oKzvN2M4rM1jr6pK4oiyppky3ru/Z1PlSuU+u3FcD1UtQCmgT4gAtaoTUPlGPmhy1TyyiC15+whHZB3GQ9v/f2KH8iKt0+S2a4//ISojgUgS24gQiP4iO7Kk40c3Hi0yguIIc9V6iPfntjOMA629/+1u97a/MoorMoUqV/zeUbdXc4iQp77IX3dzy+jOVJ5aVB475fFjZk7/KbKyorRIH+hFIqK9GSOXJbGODVfXN37wGUe1xmlve/SkekRVSmSVS1/TjanjtdTIeEeRszHyNdTyfTxE0rS8LpnKaETita5pxYhYnjk3RlGVVn8q2xneqq6159594Hies0aUnAoERRIhgYG5FNVkqM8tqd4ONz46T5siiiOnNmjUra09sI4357JUR+6dcLPvKk7G8W9/KzrvIMqpvOVdmpHzcy3NlVLY/auvU1/68vlhj1LcfiMzChvZzkUVSVyCoso15l8gVidqBeX2cCATE+lrX58XvWH3fOc8U+jiWTfyGxX4/ulznGYjx3WpnrsT+Z8cddyz/X/lbV7meVmZixu9uXMDJa3hFF7kISNUVYK/87LxOXu3neZ28ww47bLn5FJ8bKjPKol150DN+g/LPigBbXutwZTTndPN6eA1Z0UWuymlWLo/YD+bd4+PiWe3uydENMeqjhQg0Nqb8QGOmW9d6EFlv+Xob3VgjABrib96tNQK3cfxVqXKfHF2zgeqn+x7QJsSBbRwsxxXFOLmOopwR1KjspvKZz3wm+xsBgQh8REZOnOhFraLochNdJ6L2TxwMxYllHETFlbzoShUnnlHXIw58I6MhTnRzlbVO4jPigCu6kMSB36OPPrrceHWJbKzI5ogrmPGeKOobJwPRxvwz4opgtOHjEt2RIrgXGWZRnyW6UFR2I8gPXuOqZRxIxolPdJOMAsPxvStPqFZG5dXuCErFCVhciY96KXWpPIiOLptx0BqPhrqwRP2vvDtCXPmNwGKcSJ122mnlcaKuTUuKrl95sfw4EYguKtFNLOrKxLKJ9TvW27zgbUPydTyvzRPPo2ZLrL/PPPNMFlyNGjiRqRUnJpERFxkAkZ0W21B0WYmaNXHiHjXWamcLNVblsoqT+Viusa7ECXdlfaLGzp/okptn1EXdntjOYtuMoFvMu+gmGyeHsf5GBl7UyIr1NQIMsa7mVpQRFLXU4n1RYLd2hmWcaMU+IWrqxPKJ7TLWrQhQN+azV0YEv+LELaYZJ2pR+DimHW2KukKNFet/1McJJ510UlZzLLJS4sQ29oFRvyi2w7xQd32asu01h9i3xrYa8zb2M7HtxolqzPNYRhHEjRP5qLnXWBFojf1NzNfKOmMReAmRAZPvk+MkOOpvRdArMnHr8vWvf728/Ua2XOz/o1tyvD/mVayPlfu6EJ8f22gEZGIbi31prNPxWbGvj+Uf239c6IhtOobltbYiWy+2h7zQc+WyiYsiURsr1s3IMsozjfLgdbSjvgLXuZifMb28nl2sL3GRpTK4GwGk2AZCzJ+8i2FshzGtCOZFUf0QQdv4XrnYfvLfmNgvRX2i2DfVrscUYjvO50V871hu0Z7K7LL4vBWJbpqR7Ry/8VEcP9aB2JfERaY8UBTHArH/i/ldV/H/Sy65pHxxIN7fmGzXlZluvg7G+hfzP45BIgvs2muvLRf8jnm7opsLRJfuOA6K3/PYvmMdjy7YlfMslllt0VUx7zoXvwd5sL22WF5xXJAHumO/GyKjPOq1xfFBHH/FOhLtzY/FYn+R12+LLNP4rvEbExfA4jc4ulfH51UWWa8dqMwDVhFAzmsFAlWupW//B9AYcVvohm5ZHrfPrrx1cNyyeuDAgQ2+J7+Fd9wSvr5x4rbz//rXv7LxGrpdff/+/Uvz5s1r8FbKt956a41bNVc+Yvhtt91WHreu24qv6Dbmdam8vXVdjw4dOmS3467ta1/72nLjDhkypM5bjtfX1tzDDz+cTaf2dEeMGFHnfLr99tvrbGuurjbEbd7jtvf1fc+4xfjixYtXeMv3yluv33PPPQ3O23i9rrY05JBDDmlweVTOv/ra2Jh1vHLdeOyxx0q9e/ducLpNXe/i9uOx7dX+vHx51jc/65pvsXwa2sYqP/e6665rcLzrr79+hcvi5JNPzsbt2LFjae7cueXhDzzwQIOfPXHixAa/x8rOw2nTppW6dOmy3HSGDRtW5+dUbtP5PizEdtxQu2NZrEhTtr36vm99+8H61omrrroqWxb1tb8x+7vKbWaTTTZZ7jOGDh1a+uCDD8rjT5gwYblx1l133RrbS6XKttd+5MuirvkR3zPf98ffu+++Oxv+hz/8odS1a9d6P7P2fmX48OEN7jNWZn9UuT42dp2p7/vH/vzaa6+tMe6KPrv28ozfv06dOtU5buzbK/ffDXniiSdKvXr1qvNzttpqq9KCBQsafH/l9nXHHXc0aporO90V/S6feuqpjZrmXXfdVee+Ix6777576aOPPqoxfvw/ePDg8jjPPvtsvZ9d3/Zb+7Xaj3PPPbfGuDNnzqz3dyra8vrrr9cYf86cOeX9wLe//e1GzQeg7dN9D2gTInskrk5HxlF0eYnuBVHTKZ5HF4nINqq8ohZXjuNq2ymnnJIVVo2CoZHBEc/j6mBcwc27A0SGRmTvxFXyuHobV/oiyyOu3kbGVN7dIwqSxp3RYppxdTEyquK25/H+yBJZUaHwuGIY2VmRFRCfH++Pq8NRzyMyJSKj6+OW3y46rv7G1dyYR3k3xkpRoDsyamI+x/eKebaiGhcNXUWOK6VxVTyWQ3RhiGL1sSzrEleYI1sh5nPtoun1iW5JkUURWRZxhT1uOx/TimnGVfe4klz77j8tIa6GR1ZEZPvFfI02xboadVwuuuii8i3gGyNfxyOjKF/HY72M2mCxjuWiQHcUOY+r5rEuxzTjKn1kUMWwvEtcU8TyiW0pMmkqizg3RbQruojGfIh1Jj4vvlNkNEVWYWRkxFX1EFk0J5xwQvbdIlskttmYn5HFGLVxIuNoRfKixXHFP7JOcpHlFbWqIrslruDHd4z5GpmYcfe3+u5g11QxncgajG6fMQ8ic2Ly5MlZRkGusr5PfWI7jm5Y0cU4MnQiKyP2T7FsYrvIsx4a0pRtr7lEzb7Yx8T+MJ/v8TfWhehKWVkHpzGia1XUF4suSrEuxToRxbIri0dHVknUCYvtIfZ1sY+OTJ369uVRjDoyEGtvv/EbULubVKWRI0dm2SUhahhF1k9kQe25557Zb1dkTkYGVSyzWJ9jG447UMZ+slJkCMbybWhaH6fItIttINoX8zHmbey7Yt9bWSOwKeL3L5Z/Xscp5m38Jsd6uzL772hbZHtF9mD8zsb7Yh8S+8nIFl3V/VRzTDfWufi+kdEWv1X5thrrX+xP8ztYrkj8hsaxQ2RNxToRv4PRNTmylqJGVV7TLBf7h7w7YdTLq+8GGSsSWVRRty/2w7HdxCOex743MnYrxXFWzJc43ojvmH/X+D8ydeN5pdgX591T8+wsoPp1iMhUSzcCAKBocQIcgbAIfFTWHSpSHIbVVYstgih58enobpwH5ACqVeyLI4iVl2AA2gdBKQCgXYqTnzgJCpHtWFlwuShR+yeyPSNrLTL7ogZSZMhEhkgErCKzMcb5uDI8AFqDyFLM69dFFlVeJxSofoJSAAAtJAJOtW+JnosuQJEtFV2JAQCqkZpSAAAtJDKhop5S1AWL2lURiIpaM1GjJzK5BKQAgGomUwoAAACAwsmUAgAAAKBwglIAAAAAFK5TqnLLli1Lb775ZnbXmrpuuQwAAABA84m7CL/77rtpvfXWSx07dmy/QakISA0aNKilmwEAAADQrrz22mtp4MCB7TcoFRlS+Yzo2bNnSzcHAAAAoKotWLAgSxDKYzLtNiiVd9mLgJSgFAAAAEAxVlRGSaFzAAAAAAonKAUAAABA4QSlAAAAAChc1deUaqylS5emJUuWtHQzWrUuXbo0eCtHAAAAgMZq90GpUqmUZs+enebNm9fomdZeRUBqww03zIJTAAAAAKui3Qel8oDUOuusk3r06LHCyvDt1bJly9Kbb76ZZs2alQYPHmw+AQAAAKukU3vvspcHpPr27dvSzWn1+vXrlwWmPvroo9S5c+eWbg4AAADQhrXrAkF5DanIkGLF8m57EcwDAAAAWBXtOiiV02XPfAIAAACKJSgFAAAAQOEEpQAAAAAoXLsudF6fT5z2h0Kn98p5ezX7Zx522GHp2muvrTFs9OjR6c477yz///bbb6fjjjsu3X777aljx45p7Nix6cILL0xrrLFGs7cHAAAAoJKgVBX74he/mK655pry/127dq3x+sEHH5xmzZqV7r777qzo++GHH57GjRuXpkyZ0gKtBQDapbN6tXQLAKD1OGt+ak8EpdqokSNHpqFDh2bPr7vuutS5c+d09NFHp3POOadcuD2CUAMGDKjz/f/4xz+yrKlHHnkkbbvtttmwiy++OO25557ppz/9aVpvvfUK/DYAAABAe6OmVBsW3fM6deqUpk+fnnW7u+CCC9LVV19dfv3ee+9N66yzTtp0002zgNV//vOf8mvTpk1LvXv3LgekwqhRo7JufA8//HDh3wUAAABoX2RKtWGDBg1KkyZNyjKjIvD09NNPZ/9/85vfzLru7bfffmnDDTdM//rXv9J3v/vdtMcee2TBqNVWWy3Nnj07C1hVigBXnz59stcAAAAAPk6CUm3YDjvsUO6qF0aMGJHOP//8tHTp0nTggQeWh2+xxRZp2LBh6ZOf/GSWPbXrrru2UIsBAAAA/i/d99qJjTbaKK299trpn//8Z/Z/1JqaO3dujXE++uij7I589dWhAgAAAGguglJtWO3aTw899FDaZJNNsu55tb3++utZTal11123nFU1b9689Nhjj5XH+ctf/pKWLVuWtt9++wJaDwAAALRnglJt2MyZM9P48ePT888/n66//vrs7nknnHBCeu+999Ipp5ySBaleeeWVNHXq1DRmzJi08cYbp9GjR2fvHTJkSFZ3KupPRaH0v/71r+nYY4/Nuv258x4AAADwcVNTqg075JBD0gcffJC22267LDsqAlLjxo1LixYtSk899VR2d77Ihoog0+67757OPffc1LVr1/L7f/Ob32SBqKgxFXfdGzt2bLrooota9DsBAAAA7YOgVB1eOW+v1BZ07tw5TZ48OV1++eU1hnfv3j3dddddK3x/3GlvypQpH2MLAQAAAOqm+x4AAAAAhROUAgAAAKBwuu+1Uffee29LNwEAAACgyWRKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUrlPxk2wDzupV8PTmN/tHzpkzJ33nO99Jf/rTn9K8efPSzjvvnC6++OK0ySablMdZtGhROvnkk9Nvf/vbtHjx4jR69Oh02WWXpf79+zd7ewAAAAAqyZSqQqVSKe27777ppZdeSrfddlt64okn0gYbbJBGjRqVFi5cWB7vpJNOSrfffnu68cYb03333ZfefPPNtN9++7Vo2wEAAID2QaZUGzVy5Mg0dOjQ7Pl1112XOnfunI4++uh0zjnnpBdffDE99NBD6e9//3v69Kc/nY1z+eWXpwEDBqTrr78+feMb30jz589PP//5z9OUKVPSLrvsko1zzTXXpCFDhmTv3WGHHVr0+wEAAADVTaZUG3bttdemTp06penTp6cLL7wwXXDBBenqq6/OuuKFbt26lcft2LFj6tq1a3rwwQez/x977LG0ZMmSLHsqt9lmm6XBgwenadOmtcC3AQAAANoTmVJt2KBBg9KkSZNShw4d0qabbpqefvrp7P8nn3wyCy5NmDAhXXnllWn11VfPhr/++utp1qxZ2Xtnz56dunTpknr37l3jM6OeVLwGAAAA8HGSKdWGRRe7CEjlRowYkXXdi6yo3//+9+mFF15Iffr0ST169Ej33HNP2mOPPbLXAAAAAFqaTKkqNXz48DRjxoysdtSHH36Y+vXrl7bffvu07bbbZq9HfakYHnfmq8yWirv2xWsAAAAAHydpM23Yww8/XOP/KFC+ySabpNVWW608rFevXllAKjKoHn300TRmzJhy0CqKo0+dOrU87vPPP59mzpyZZVwBAAAAfJxkSrVhEUAaP358Ouqoo9Ljjz+eLr744nT++ednr914441ZMCpqS0WtqRNOOCHtu+++affddy8Hq4488sjs/dHFr2fPnum4447LAlLuvAcAAAB83ASl2rBDDjkkffDBB2m77bbLsqMi8DRu3LjstShoHgGn6I637rrrZuOefvrpNd4fxc+jxtTYsWOzO/aNHj06XXbZZS30bQAAAID2pEOpVCqlKrZgwYIsKyhqK0U2UKVFixall19+OW244YapW7duqS0ZOXJk2mqrrdLkyZMLm2Zbnl8AQCt1Vq+WbgEAtB5nzU/VHouppKYUAAAAAIUTlAIAAACgcGpKtVH33ntvSzcBAAAAoMlkSgEAAADQfoNS5513XurQoUM68cQTaxTWPuaYY1Lfvn3TGmuskd0lLu4mBwAAAEDb1iqCUo888ki68sor07Bhw2oMP+mkk9Ltt9+ebrzxxnTfffelN998M+23337NPv1ly5Y1+2dWoyq/USMAAADQnmpKvffee+nggw9OV111VfrBD35QHh63Dfz5z3+epkyZknbZZZds2DXXXJOGDBmSHnroobTDDjus8rS7dOmSOnbsmAW7+vXrl/0f2VrUHZB66623svnTuXNnswgAAABo20Gp6J631157pVGjRtUISj322GNpyZIl2fDcZpttlgYPHpymTZtWb1Bq8eLF2SO3YMGCcjZUXRlRG2ywQZo9e3Z64403mvmbVZ8I4K2//vpZYEp2GQDQTEcYZiQA5KqkJ1djYwYtGpT67W9/mx5//PGs+15tESiKzKXevXvXGN6/f//stfpMnDgxnX322csNjyyfqFFVl65du2bZPwItDVtttdXSwoULswcAQLPoWbN8AwC0a3Pnpmrw7rvvtu6g1GuvvZZOOOGEdPfdd6du3bo12+dOmDAhjR8/vkam1KBBg7LueT179my26QAA0AwWPGU2AkBunXVSNWhsnKfFglLRPW/u3Llpm222KQ9bunRpuv/++9Mll1yS7rrrrvThhx+mefPm1ciWirvvDRgwoN7PjayneNTV9SweAAC0JtXRTQEAmkXH6ohbNDb+0mJBqV133TU9/fTTNYYdfvjhWd2o73znO1l2U3Spmzp1aho7dmz2+vPPP59mzpyZRowY0UKtBgAAAKA5tFhQas0110xDhw6tMWz11VdPffv2LQ8/8sgjs654ffr0ybreHXfccVlAqjnuvAcAAABAO777XkMmTZqUpXxFplTcUW/06NHpsssua+lmAQAAALCKOpRKpVKqYlHovFevXmn+/PkKnQMAtDZn9WrpFgBA63HW/NSeYjHVUUELAAAAgDZFUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAED7CkpdfvnladiwYalnz57ZY8SIEemOO+4ov75o0aJ0zDHHpL59+6Y11lgjjR07Ns2ZM6clmwwAAABAWw9KDRw4MJ133nnpscceS48++mjaZZdd0pgxY9IzzzyTvX7SSSel22+/Pd14443pvvvuS2+++Wbab7/9WrLJAAAAADSDDqVSqZRakT59+qSf/OQnaf/990/9+vVLU6ZMyZ6H5557Lg0ZMiRNmzYt7bDDDo36vAULFqRevXql+fPnZ9lYAAC0Imf1aukWAEDrcdb8VA0aG4vplFqJpUuXZhlRCxcuzLrxRfbUkiVL0qhRo8rjbLbZZmnw4MENBqUWL16cPSpnRFi2bFn2AACgNVHiFADKqiRu0dj4S4sHpZ5++uksCBX1o6Ju1C233JI233zzNGPGjNSlS5fUu3fvGuP3798/zZ49u97PmzhxYjr77LOXG/7WW29l0wAAoBXpOaylWwAArcfcuakavPvuu20jKLXppptmAahI6brpppvSoYcemtWPaqoJEyak8ePH18iUGjRoUNYVUPc9AIBWZsFTLd0CAGg91lknVYNu3bq1jaBUZENtvPHG2fPhw4enRx55JF144YXpgAMOSB9++GGaN29ejWypuPvegAED6v28rl27Zo/aOnbsmD0AAGhNqqObAgA0i47VEbdobPylY2vsdxg1oSJA1blz5zR16tTya88//3yaOXNm1t0PAAAAgLarRTOloqvdHnvskRUvj/6Gcae9e++9N911111ZlfYjjzwy64oXd+SLrnfHHXdcFpBq7J33AAAAAGidWjQoNXfu3HTIIYekWbNmZUGoYcOGZQGp3XbbLXt90qRJWcrX2LFjs+yp0aNHp8suu6wlmwwAAABAM+hQKpVKqYpFofMIeEUhdYXOAQBambN6tXQLAKD1OGt+ak+xmFZXUwoAAACA6icoBQAAAEDhBKUAAAAAKJygFAAAAABtIyh15513pgcffLD8/6WXXpq22mqrdNBBB6V33nmnOdsHAAAAQBVqUlDqlFNOySqph6effjqdfPLJac8990wvv/xyGj9+fHO3EQAAAIAq06kpb4rg0+abb549v/nmm9OXvvSl9MMf/jA9/vjjWXAKAAAAAJo9U6pLly7p/fffz57/+c9/Trvvvnv2vE+fPuUMKgAAAABo1kypnXbaKeumt+OOO6bp06enG264IRv+wgsvpIEDBzblIwEAAABoR5qUKXXJJZekTp06pZtuuildfvnlaf3118+G33HHHemLX/xic7cRAAAAgCrToVQqlVIVi+6EvXr1SvPnz089e/Zs6eYAAFDprF7mBwDkzpqf2lMsptHd91amVpTgDwAAAAANaXRQqnfv3qlDhw6NGnfp0qWN/VgAAAAA2qFGB6Xuueee8vNXXnklnXbaaemwww5LI0aMyIZNmzYtXXvttWnixIkfT0sBAAAAaH9Bqc9//vPl5+ecc0664IIL0te+9rXysH322SdtscUW6Wc/+1k69NBDm7+lAAAAALTvu+9FVtS222673PAYNn369OZoFwAAAABVrElBqUGDBqWrrrpqueFXX3119hoAAAAANEv3vUqTJk1KY8eOTXfccUfafvvts2GRIfXiiy+mm2++uSkfCQAAAEA70qRMqT333DMLQO29997p7bffzh7x/IUXXsheAwAAAIBmz5QKAwcOTD/84Q+b+nYAAAAA2rEmB6XmzZuXddmbO3duWrZsWY3XDjnkkOZoGwAAAABVqklBqdtvvz0dfPDB6b333ks9e/ZMHTp0KL8WzwWlAAAAAGj2mlInn3xyOuKII7KgVGRMvfPOO+VH1JcCAAAAgGYPSr3xxhvp+OOPTz169GjK2wEAAABo55oUlBo9enR69NFHm781AAAAALQLTaoptddee6VTTjklPfvss2mLLbZInTt3rvH6Pvvs01ztAwAAAKAKdSiVSqWVfVPHjvUnWEWh86VLl6bWYsGCBalXr15p/vz5WVF2AABakbN6tXQLAKD1OGt+qgaNjcU0KVNq2bJlq9I2AAAAANq5JtWUAgAAAIAWCUrdd999ae+9904bb7xx9og6Ug888MAqNQYAAACA9qFJQalf//rXadSoUalHjx7p+OOPzx7du3dPu+66a5oyZUrztxIAAACAqtKkQudDhgxJ48aNSyeddFKN4RdccEG66qqr0j/+8Y/UWih0DgDQiil0DgDtttB5kzKlXnrppazrXm3Rhe/ll19uykcCAAAA0I40KSg1aNCgNHXq1OWG//nPf85eAwAAAICGdEpNcPLJJ2d1pGbMmJE++9nPZsP++te/pl/+8pfpwgsvbMpHAgAAANCONCkodfTRR6cBAwak888/P/3ud78r15m64YYb0pgxY5q7jQAAAABUmSYFpcKXv/zl7AEAAAAAhdSUeuSRR9LDDz+83PAY9uijjzblIwEAAABoR5oUlDrmmGPSa6+9ttzwN954I3sNAAAAAJo9KPXss8+mbbbZZrnhW2+9dfYaAAAAADR7UKpr165pzpw5yw2fNWtW6tSpyWWqAAAAAGgnmhSU2n333dOECRPS/Pnzy8PmzZuXvvvd76bddtutOdsHAAAAQBVqUlrTT3/607TzzjunDTbYIOuyF2bMmJH69++frrvuuuZuIwAAAABVpklBqfXXXz899dRT6Te/+U168sknU/fu3dPhhx+evva1r6XOnTs3fysBAAAAqCpNLgC1+uqrp3HjxjVvawAAAABoF5pUUypEN72ddtoprbfeeunVV1/Nhk2aNCnddtttzdk+AAAAAKpQk4JSl19+eRo/fnzaY4890jvvvJOWLl2aDV9rrbXS5MmTm7uNAAAAAFSZJgWlLr744nTVVVel733ve6lTp//XA3DbbbdNTz/9dHO2DwAAAIAq1KSg1Msvv1y+616lrl27poULFzZHuwAAAACoYk0KSm244YZpxowZyw2/884705AhQ5qjXQAAAABUsSbdfS/qSR1zzDFp0aJFqVQqpenTp6frr78+TZw4MV199dXN30oAAAAAqkqTglLf+MY3Uvfu3dP3v//99P7776eDDjoorb/++unCCy9MBx54YPO3EgAAAICq0qSg1AcffJC+/OUvp4MPPjgLSv39739Pf/3rX9PAgQObv4UAAAAAVJ0m1ZQaM2ZM+tWvfpU9//DDD9M+++yTLrjggrTvvvumyy+/vNGfE939PvOZz6Q111wzrbPOOtn7n3/++RrjRBfB6CrYt2/ftMYaa6SxY8emOXPmNKXZAAAAALTloNTjjz+ePve5z2XPb7rpptS/f//06quvZoGqiy66qNGfc99992UBp4ceeijdfffdacmSJWn33XevcQe/k046Kd1+++3pxhtvzMZ/880303777deUZgMAAADQlrvvRZe9yG4Kf/rTn7IgUceOHdMOO+yQBacaK+7WV+mXv/xlljH12GOPpZ133jnNnz8//fznP09TpkxJu+yySzbONddck93hLwJZMT0AAAAA2klQauONN0633nprVlfqrrvuyrKZwty5c1PPnj2b3JgIQoU+ffpkfyM4FdlTo0aNKo+z2WabpcGDB6dp06bVGZRavHhx9sgtWLAg+7ts2bLsAQBAm0/cB4DqtKw64haNjb80KSh1xhlnZHfci2DUrrvumkaMGFHOmtp6662b3OATTzwx7bjjjmno0KHZsNmzZ6cuXbqk3r171xg3ugvGa/XVqTr77LOXG/7WW29l9akAAGhFeg5r6RYAQOsxd26qBu++++7HF5Taf//900477ZRmzZqVttxyy/LwCFBF9lRTRG2puIvfgw8+mFbFhAkT0vjx42tkSg0aNCj169dvlbK4AAD4GCx4ymwFgNw666Rq0K1bt48vKBUGDBiQPSptt912TfqsY489Nv3v//5vuv/++9PAgQNrTCPu7jdv3rwa2VJx973a08517do1e9QWNa/iAQBAa1Id3RQAoFl0rI64RWPjLy36bUulUhaQuuWWW9Jf/vKXtOGGG9Z4ffjw4alz585p6tSp5WHPP/98mjlzZrnLIAAAAABtT5MzpZpDdNmLO+vddttt2d388jpRvXr1St27d8/+HnnkkVl3vCh+Ht3vjjvuuCwg1V7vvPeJ0/7Q0k0AgFbjlfP2aukmAADQFoNSl19+efZ35MiRNYZfc8016bDDDsueT5o0KUv7Gjt2bHZXvdGjR6fLLrusRdoLAAAAQBUEpaL7XmOKY1166aXZAwAAAIDqUB0VtAAAAABoUwSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKB9BaXuv//+tPfee6f11lsvdejQId166601Xi+VSumMM85I6667burevXsaNWpUevHFF1usvQAAAABUQVBq4cKFacstt0yXXnppna//+Mc/ThdddFG64oor0sMPP5xWX331NHr06LRo0aLC2woAAABA8+mUWtAee+yRPeoSWVKTJ09O3//+99OYMWOyYb/61a9S//79s4yqAw88sODWAgAAAFD1NaVefvnlNHv27KzLXq5Xr15p++23T9OmTWvRtgEAAADQhjOlGhIBqRCZUZXi//y1uixevDh75BYsWJD9XbZsWfZo6zqmUks3AQBajWr4bafVXiMFgOItW9aujtFabVCqqSZOnJjOPvvs5Ya/9dZbVVGLashaglIAkJs7d66Z0db1HNbSLQCA1mNudRzbvPvuu207KDVgwIDs75w5c7K77+Xi/6222qre902YMCGNHz++RqbUoEGDUr9+/VLPnj1TW/ePdzq0dBMAoNVYZ511WroJrKoFT5mHAJCrkmObbt26te2g1IYbbpgFpqZOnVoOQkWAKe7Cd/TRR9f7vq5du2aP2jp27Jg92rplSVAKAHLV8NtOdXRTAIBm0bFjuzpGa9Gg1HvvvZf++c9/1ihuPmPGjNSnT580ePDgdOKJJ6Yf/OAHaZNNNsmCVKeffnpab7310r777tuSzQYAAABgFbVoUOrRRx9NX/jCF8r/593uDj300PTLX/4ynXrqqWnhwoVp3Lhxad68eWmnnXZKd955Z6PTwAAAAABonVo0KDVy5MhUKtVfuLtDhw7pnHPOyR4AAAAAVI/q6KwIAAAAQJsiKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwglIAAAAAFE5QCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpQAAAAAonKAUAAAAAIUTlAIAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACFE5QCAAAAoHCCUgAAAAAUTlAKAAAAgMIJSgEAAABQOEEpAAAAAAonKAUAAABA4QSlAAAAACicoBQAAAAAhROUAgAAAKBwbSIodemll6ZPfOITqVu3bmn77bdP06dPb+kmAQAAAFDNQakbbrghjR8/Pp155pnp8ccfT1tuuWUaPXp0mjt3bks3DQAAAIBqDUpdcMEF6Zvf/GY6/PDD0+abb56uuOKK1KNHj/SLX/yipZsGAAAAQDUGpT788MP02GOPpVGjRpWHdezYMft/2rRpLdo2AAAAAJquU2rF/v3vf6elS5em/v371xge/z/33HN1vmfx4sXZIzd//vzs77x589KyZctSm7d4YUu3AABajfh9p41b3KGlWwAArce86ji2WbBgQfa3VCq13aBUU0ycODGdffbZyw3fYIMNWqQ9AMDHZ63J5i4AUEXOWytVk3fffTf16tWrbQal1l577bTaaqulOXPm1Bge/w8YMKDO90yYMCErjJ6L7Ki333479e3bN3Xo4Eoc0DxR/0GDBqXXXnst9ezZ0ywFANo0xzZAc4sMqQhIrbfeeg2O16qDUl26dEnDhw9PU6dOTfvuu285yBT/H3vssXW+p2vXrtmjUu/evQtpL9C+REBKUAoAqBaObYDm1FCGVJsISoXIejr00EPTtttum7bbbrs0efLktHDhwuxufAAAAAC0Ta0+KHXAAQekt956K51xxhlp9uzZaauttkp33nnncsXPAQAAAGg7Wn1QKkRXvfq66wEULboIn3nmmct1FQYAaIsc2wAtpUNpRffnAwAAAIBm1rG5PxAAAAAAVkRQCgAAAIDCCUoBAAAAUDhBKQAAAAAKJygFAAAAQOEEpYB2r/ImpG5ICgBUg8pjmmXLlrVoWwDq06neVwDaiXnz5qUePXqkpUuXZn8BANq6uXPnps6dO6cuXbqkNdZYo6WbA1AnmVJAu3bdddelvfbaK2233XZp5MiR6c4770wLFy5s6WYBADTZtddem0aNGpV22GGHNGTIkHTllVemV1991RwFWp0OJX1VgHbqlltuSQcddFD60Y9+lP0/Y8aM7CDuu9/9bvrmN7+ZBg8e3NJNBABYKX/4wx/SV77ylTRp0qS07rrrpunTp6errroq7b333unoo49Ow4cPN0eBVkNQCmh3IhbfoUOHdMQRR6TVVlstO1DLXXbZZenMM89MRx55ZDr55JNTv379WrStAAArc3wzfvz49Prrr6ff/e535dduuOGGNHHixLTlllum0047LcueAmgN1JQC2q0FCxaknj17Zs8//PDDrObCf/3Xf6WOHTumk046KTtgO/TQQ7PioDEMAKC1ioBUiOOWOMYJH330UerUqVM64IADsgtxp556atpkk03S97//fcc3QKvgLAtotwdtW221VdaFb86cOVlAasmSJdnwb33rW1lQ6pRTTsleE5ACANqKzTffPN13333pmWeeyQJSceEt7L///unEE09MP/zhD9Mrr7zi+AZoFQSlgHbjf/7nf7K6CrljjjkmbbHFFmns2LHp3//+d3aHmkWLFmWvxRXFOJBTFBQAaO0iIyo3bty47OYte+65Z3YHvrjwtnjx4uy1gw8+OPXp0yc9/fTTLdhagP9HUApoF6644oos0JRfLQxrrbVWVjcq0ty/+tWvprfffjt169Ytey1unbz66qu3YIsBABp24403psMPPzwLQp1++unpgQceyIZfeOGFWZHz7bffPsuK6tq1azY8Lr716NEjde/e3awFWgWFzoGqF7dBPvbYY9Ovf/3rLDBVaenSpem2225LP/nJT9Jrr72WpbRHxtR1112X/vOf/6Rp06ZJbwcAWp04rjnqqKPSCSeckAWZ4g7CEXw6/vjjs+HPPvtslhX+6KOPZrWk1lxzzXTXXXdl2VOROR41pgBamqAUUNVuvvnm7LbIEXiKWyG/9NJL6e67787+brbZZtlrkRUV/8ddaaZOnZplUMXVxag3FQGqCFw5cAMAWou4kLbffvtlNaKiS1548cUXs3qZcRwTgaqojRnd+s4+++z0l7/8Jbs73+DBg7MLb45vgNZCUAqoWu+//352pfBvf/tblsYed9Pbd999syBUHKQ9+eSTaa+99krnnntuGjp0aPae2bNnl7vuRUH0/K41AACtKSi12267pZ/97Gfpc5/7XHazljheieOaCDi99dZb6cc//nH2Wnj33XezEgUxjuMboDVRUwqoWlEz4cwzz8wO2uLWx8OHD0977LFHljX1yCOPpIcffjg99NBD6ZJLLim/p3///llQKg7YotaUgBQA0NpEFndcSHvuueeyY5YoZh4Z3jNnzsyypKKLXhzv5OLYJoJVMW5kTDm+AVoLmVJA1YlgUseOHct/I509akXFAVj87devX3ZAFgdmcYXx29/+dnrhhReygFQMAwBo7cc3559/ftZFL+6yF0Gn3/3ud+mqq65KRx55ZLrgggvS9ddfnxU+j2CUMgRAa6VPClBV8gO1EHWiovDnRhttlC699NL0zDPPpLXXXnu5Ln5Rf2GdddYRkAIA2sTxTZQZOPTQQ9OWW26Z3WE4MqX+9Kc/pVGjRmUX3iKLasCAAeW7CgO0VoJSQNWIg7D8gO20007L0tajpsKnP/3p7MDtiCOOKI8bGVGLFy9Of/7zn7NaU/n7AABa8/HNrbfemt0hePPNN8/urnfTTTfVCFotWrQozZgxIw0bNqyFWw6wYoJSQFWoPBj77W9/m90WOa4czps3L8uQ+ta3vpXVV4iDuYULF2b1pCZNmpReffXV7OAu5F36AABa+/HN3//+9+zOe//617/ShAkTsottUTPzrLPOSnPmzEl//OMfs/c5vgFaM0EpoCrkB2z33ntvmjp1ajr11FPTmDFjyneciVsgR0Bqk002Sdtuu212wNa1a9f0+OOPZ7WmomCoegsAQFs6vtlggw2y45tPfepT2Z334qLbeuutl+644w7HN0CboNA5UDWifsJOO+2UZUR95zvfSd/73vfKr73zzjtZ971Bgwaliy66KLtbTRzAxcHeRx995C40AECbP76J/3v37p1lfju+AdoCRVSAqhEFPX//+99nRcvj7xNPPFF+ba211kp9+/bN7sQXNttss/IdbNwWGQCohuOb+D8CUtFlz/EN0BYISgFVJYp6xgFbdMebPHlyVugzT3H/xz/+kV1JrKTAOQBQbcc3amQCbYXue0BViquIX//619Pbb7+d1ZCKWyW//PLL6aGHHsqeK/oJALQ1jm+AaiNTCqhKW2+9dbrhhhtS9+7d0/z589Nuu+2WFTWPgNSSJUtcQQQA2hzHN0C1EZQCqtbQoUOzVPcPP/wwC0j985//zIZ37ty5pZsGANAkjm+AaqL7HtAuUt2/9a1vpY022iideeaZWZFzAIC2zPENUA1kSgHtItX9kksuSbNmzUq9evVq6eYAAKwyxzdANZApBbQbixYtSt26dWvpZgAANBvHN0BbJigFAAAAQOF03wMAAACgcIJSAAAAABROUAoAAACAwglKAQAAAFA4QSkAAAAACicoBQAAAEDhBKUAAAAAKJygFAAAAACpaP8f5a4Y09f2dHYAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 23: Session duration p50/p90 over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  TIMESTAMP_TRUNC(start_ts, HOUR) AS hour,\n",
+    "  APPROX_QUANTILES(duration_ms, 100)[OFFSET(50)] / 1000 AS p50_sec,\n",
+    "  APPROX_QUANTILES(duration_ms, 100)[OFFSET(90)] / 1000 AS p90_sec\n",
+    "FROM session_rollups\n",
+    "WHERE duration_ms > 0\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"p50_sec\", \"p90_sec\"],\n",
+    "          \"Session Duration Percentiles\", \"seconds\",\n",
+    "          labels=[\"p50\", \"p90\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel7-header",
+   "metadata": {},
+   "source": [
+    "## Panel 7: Users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "cell-24-users-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:04.498929Z",
+     "iopub.status.busy": "2026-04-11T06:43:04.498822Z",
+     "iopub.status.idle": "2026-04-11T06:43:06.610460Z",
+     "shell.execute_reply": "2026-04-11T06:43:06.609933Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQjRJREFUeJzt3Qm8VGX9B/6HRcANMNkUUTRzyQUMldRM/YWRuZYWqQWZS2maSZaQJqIp5hYtGLnb4laZlZhrbiVlopaaaLnhxlayhAIG8399z/9/5j/33pm74PVc7uX9fr0GZs6cOec5653zmed5TqdSqVRKAAAAAFCgzkXODAAAAACCUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAqgBQYPHpw6deqUPVrbNddcU572WWedZbvQ4fbx1vTlL385K+PWW2+dSqXSan+svfjii+V57r333qlIq/u55b777iuX7/Of/3yblSO2S16O2F5A8xx77LHZcbPDDju0+HwMIJQC1khxYZZffMRjrbXWSr17907bbrtt+sxnPpNuv/32d22+8Zg8eXJqa3GhmpdnwYIFLb54jPCisUAjxu0Inn/++XTSSSelbbbZJq277rrZI56feOKJ2XvtaT9v7NGWYUBLzZo1K11xxRXZ86985SurfYBWhNXp3EJdcS7Mt8/jjz/+jlfPP//5z2xaEaJtuummqXv37mmDDTZIH/nIR9JvfvObqp+ZPXt2+tKXvpQGDRqUunXrlv1//PHHpzlz5tQZ7/XXX0/f+c530siRI9Pmm2+e1l577bT++uun3XbbLV199dU1y/Tkk0+mz372s2ngwIFZefr165f23HPP8nHaXDfeeGPaY4890nrrrZc94vlNN93U6Gfi79fGG29cPpcNGDCgRfNsyXx//etfp4MOOij7Wxd/C2JdbrLJJulTn/pU+stf/tLs+a1cuTL96Ec/SjvttFNaZ511Uq9evdKIESPSPffcU/Nvbq1Htb/FtSxatCiddtpp6b3vfW+2nfr3759tt+eee67q+HfffXdWrihflPMDH/hAmjp1alb+Sl/96lfL+0FT2wuggRLAGmjChAnxU16jjwMPPLC0aNGiOp/761//WnrwwQezx6rIp73ZZps1eG/OnDnlab/00kuld9tee+1VLs8LL7zQrM/ce++9jS5DDMvfj3Hbu1/84helHj161NxH4r0Ypz3v5/ljzJgxrbKPF+FrX/taVuZu3bqVFi5c2OLPF32shTjG8nUdx15rW53OLS1VeV7J98O2sCrnxJYeh1dfffU7nt6kSZMaPZa/+93v1hl/1qxZpU022aTquJtuumnplVdeKY97/fXXNzrtk08+uUF5fvWrX2XHYrXxP/KRj7TK+eqcc86p+bljjjmmzrj9+/dv9jxbOt+jjz665rhdu3Yt3X///c2aZ+zn1abRqVOn0rXXXlv12Kj12HLLLZs1zzhX7rjjjlWnscEGG5T+/ve/1xn/qquuyspTbfxYD/Xttttu2XvDhg1rVnkAckIpYI1U+SV0v/32yy7WfvOb35ROOumkOl+uDz744MIuHIvWUUOpZcuWld5+++13PJ1HH320zr5w0EEHlX73u99lj9gv8uHdu3cvPfbYY6W29N///rfq8Agg8jAiHkcddVSD/T5/PPvss6X2ILZtXHTGMuy///6l9qItQ6nVnVCq5aFUr169soAozkc333xzafjw4eV9YJ111qlzTvjEJz5Rfu+Tn/xk9rcu/s+HHXbYYXVCqQjbI3SIsOnWW28tffzjH68Tmjz33HPl8eN5zC/eW3vttUvf+MY3sjLF5y655JLSWWed1axlinNo586ds+msv/76WSASj3gew7p06VL629/+VnXfiTJV/njQklCqpfM9//zzS+PHjy/deOONpXvuuad0+eWXlwYOHFie92c+85km5xnrPx9/4403Lt1www1ZkBihVgxbb731SrNnz87GXbBgQZ3zdP6o3Kannnpqs5b1lFNOKX/mwx/+cOmWW24pffGLXywP22WXXcrjvvbaa6V11123HLbFtoxyVi5rbONKF154Yfm9J554otnbAEAoBZTW9FCq/i/z8YW68hfBu+++u2roUmnq1KnZr4PxJS6CjPiiGb8Qf+c732kwv/qP/CIyfkHPh8X41cKj+HJ84oknlvr27Zt9Cf/Yxz5WevHFFxss3/Tp07MLjY022qi01lprZV/SI4SIL+BN/fLaWEC1qqHU448/noU6Ue74gvue97ynNGTIkOwLcf2aGw888EBWS61Pnz5Z2QcPHpx9mf7Pf/5T85fm2267rTR27NjSgAEDsguUWIYVK1aUvv3tb5e22267bF1FeDRo0KDsAuuKK64oNSXKkE9/n332Ka1cubL8XjyPYfn7MW64+OKLy8PiS3yln//85+X3vv71r5eHz507N1u++LU79p3evXtnZYxtWGvdx7LHBWOsw/hM5f6yqvt9Y/t4/XnfdNNNpW222Sa7CP3Qhz6U/cIe63vixInZvh/Da+2bsQ/HhVtsq9i+MX5cAL/88svNWoaoiZCX5Xvf+16D95s6FlvzWMuXOS7UYpn33nvv7BirFvg2FkotXrw4K0e+r8YFcYwT+3VTWuvc8sgjj5SOPPLI7II4zhcxXuznsR5iuaJccfxUW+fLly/P9v0PfOADWUARj1133bX005/+tNQc9fevuNiPC+Q4ZuP4r1/zp1bNo8bCrX//+9+lcePGlbbddttsW8U63mmnnUo/+MEPqq6PfLtFLaKoTRTDIrzIa7HEuonwYvfdd8+mFesnaqFMnjw52y9yjZ1r87LX2j61RG3GWJ5K8+fPL4ca8fjLX/6SDX/99dfLoUsEWW+99VY2PP6P13nwkocg//jHPxoci0uXLi0HwfGIQCZ3wgknlIc3d3tXc/zxx5enE6FbtVphcTxWimWI82a8d955561SKLUq860v9s983OYE5fG3OB8/QsBcZUB00UUX1fx8bI/4+5jvk5UhYa1zePxYE39bYlj8jYzQKd+P41xeeR4Icb7Mh0W5qtWkO+CAA+rMN/7O5++dffbZTa4HgJxQClgjNXVxPmLEiKrV1Kt92fvJT35S86IjLlZb88Jxiy22aPD5PfbYo07Z40IpLjJqXQQVHUrFxVJc2Nea31133VX+fPzqnF9A1X9svfXWdYKpylCq/nqJZYgvxbXmWX+d1ffmm2/WqSVV/xfh+uFljBsXSPFFPy9/XKxWqvxlO//lPQK5Ws1qIrCJX9SrrfvNN9+8TrOKIkOp+vOORwRMxx57bJPrOUKWCBqqLW9M4/nnn29yGSovPus3MWzOsdiax9pXvvKVBuPEhX4EKc0NpaImxA477FCz3FOmTGl0fbTWueW9731vg89HzdH8QrbWMRuBVIR+tcoQNWeaUrl/RWgU+3796VQGBi0NpaL5Wh4s1X9Ubov6oVScbyIojNexz1922WXlcUePHl1zmUeNGlUer9Y47ySUqqXyPPvkk09mwyK8zodFkF6pMlj/9a9/3ei0IySsdj6MoDI/B0ZTt/e9733ZMR7/X3DBBXUCusZUHgOVTeAqQ+gI4Suddtpp5SCo8vhqSSi1KvOt3PcjxItzfXPCpDwE6tmzZ3n8yh9lIvBsTi3tyvNc/IDRnHP4jBkz6pzDK1XWoM0D4MofZSqbE0Z58+FxbqhfizU/v48cObLR9QBQSUfnAFVEp665pjqmzTuW7dq1a9YBaHRU+vOf/zx97WtfyzqKDV/4whfSgw8+WP5MdMQar+Pxy1/+stnbYN68edk8fvazn2Uds4c//elP6amnnsqev/rqq1nntStWrMheH3LIIVnHrDGPuDtOdMoaHavGfIcOHVqe7i9+8YtyeTbaaKNW3SemT5+elTscfvjh6a677kq33HJLuuiii9Jee+2VunTpUi57dB4eHahGx7o/+MEP0h133JGOOuqo7P1nnnkmffOb36w6j+hwPDq8jg7qf/zjH2efz7dLrKdYX9Fh609+8pOss9+mlvFf//pXWr58efl15bqqNizGjc/EdP/v//6vvNyvvfZa9nzJkiXlzvPj7kQ77rhj9vyEE05Ir7zySvZ89OjR2TjR+W10tPv2229n+018tr4XXngh7bzzztl2i3UZHQoXJeYdnaJPmzYtW5a8E+XLL788jR8/PtvfovPc+vvmm2++mcaMGZOWLVuWHSvnnntuuvPOO9M3vvGN8jRifTTl6aefLj/fcsstW3wsttaxFvtj7KOhc+fO6cwzz0y/+93v0q677tqiO7edfvrp6Yknnsief/zjH8/Wa+yneWfNp5xySnr55Zdrfr61zi2LFy9O119/fTrvvPPKw2L5YnqxTeO8kotjLPe9732v3DnzBz/4wfL5Ju6KGC644IIWdQAd2zc6jY71EMuei46958+fn1ZF7FfROX6IjsEvu+yy7FiLskWH39W89dZb6YADDihv7+hAPs6hIZYvtlGI5Yz1Fts+lj/vNDseIbZDfg4LcQ7Lt09s79YS08vPs9Hxddy0I1Tui/lxmYvOyCuP61rivcceeyx7Huem/Hzz3//+t7xvxjnwW9/6VtYJexzj8X8c21/84hebVf5a5axVxijPxRdfnJ3r45y5qlo637B06dKsg/H4e/r+978/PfTQQ1mH8LG/nnzyyY3O74033sg6G2/pPCtdeumlde5C2hwt3Q+as16ig/lYnlycdzfbbLPs+T/+8Y9mlQsgO39YDQANVYYWCxcubHQVxZ37QnxBjYvkCAt69uyZjjjiiPI4cSEUj1zc9eZDH/pQi1f92WefXf6S/8c//jG7aA4RiGy33XZZSBEXBGH33XfPLhBzhx56aPl5zDvuppOLMrfkDj4tka+fEBeAcREXdyuKL/URFuQqy37YYYeVQ5+4oIsLvAg14uJvypQpWQhQKdZ1XBxXm2/cISnuNBRBUNw96HOf+1yTZa68aAh9+/ZtME79Yfl+cuSRR2YBWFSS+NWvfpXduS8usOMiN38//Oc//0m33XZb9jwu/PML3u233z7tu+++2bb797//nV08V267/MIwhr/nPe9JRYttGHfUim0QFx5f//rXs+FxoZoHGrH8sZ0q980IoPKL5li+D3/4w9nzAw88MLtbU1wERQgZwUOfPn1qzr8ymIg7jrX0WGytYy0CsPzW55/4xCfSxIkTs+dx1664A1m+vRsTAex1111XLvPYsWOzc0OU+ZOf/GR28RkX+7F+Ko+VSq11bvn2t7+d3Xk0xHaMwCHEdoygNaaZX/zHOshFaJeL8ufbLvbzCOrycYYPH96scsSyROATYXWENg8//HAWBsa54fe//32zjt9KlcdZTDOOmzywiTvM1RIh8SOPPJI9j7vRRehdbZkjFIjzWTj66KPTn//85/I4o0aNytZbHA+5973vfQ22T4S87+TulxEk5OeVOK9+//vfL58jK0Pt2McqVb6uFn6HOAfFjxv/+9//steTJk3K9s9Q/66tEUhccskl2R38Yn+NbRbnilhHcT6P8LX+39OtttoqCzpqlbNaGeNHl2OOOSYr0/nnn5+dkxoLgltrvo2JQCbWfX5OqKX+tFo6zwjj8n1siy22SB/72McajFNtXbR0P2jOesnHqzwP589XNUAG1kxCKYAqotZOrjK8qaYyNIlbJ4e4SIlaQHGb5Lgwbi0xzdyGG25Yfp5fHDz77LPlYfvvv39qbfGlO1fty3flsPyiKMKKuBCLX86jZkI84tftuLV0XEjFhVyMW1n2uPV4tduPx4VF1D7KLwJzEWzUl18gxraMmm9R9vgSH7dNjwumuCipJb/oykWYEkFD/WGV8v0kAqSomRGhRNSoiFAqr7ESZcgDkriwz9dX1BKqVdupsmZQLoKPtgikwrBhw8rbtrIMlft5ZahUbd+McCEe9cX6mDlzZrNDlfr7YGsei00da1E7L1cZuMRF2TbbbFOuWdKYuHDLaxpE+JSXuTn7QGuLGl6Vy5CHUvk6q7ZN62/XT3/60++4/DG/vPZkXq4Ipeqv8+aK4yy/fX0c/3kg1ZQ8kIranXltvmrLXBlWFb3N8vlEyJv/zYpwvvJ8GKF8Lg/9c5W1QSvHy0W4FNPOa4tF6Bi1WSsD0Pq1/iJMDbHN4keEEDXpIpSKc+H9999f5zNxno9ALuYftfXql7NaGa+88sr06KOPZufByhp8tbTWfCuXO2qmxfix/uNvWtQYi0AuzvFRC7iW+tOKafTo0aPJeebysD/Estf/gaY5823OflBr/Mpxq5WzqVAOoBrN9wCqyC+CajXdqvTRj340Gz9qukTTuKiNE02yotlQXNiuyoVULZW/SMYvs0V/EYwwKVftl9DKYfm4sT5i/UTNk6hxEbWC4iIgLhKOO+647At9S1T7Bbl+c4QQv6TnNSui9lH8wvvcc89lTXdiu9T/lb9S1LKp/EW4WhPOv/3tb+Xnec2cfLkPOuigcg2bqMWQ19SI2kG1mgu90+UtSmVIW3lBVD/IW9V9s6laCZXhSGXTkdY+FltyrFWGte+G5tTUKHK7tvY2bUy1dVs5LG+q3Nq1M/Jg7Oabb67TPHJ12mYRfMZ+HYFUrJMILCKAqVRZA3bOnDl13oswPFe/eetLL72UBeV5IDVu3LisuVylCGvjGMvlTbfqP69f87SaWuWsVsa8WXQc67GvxrJXlj8+H8MiiG7N+eZi2hGcxw8cEdJde+215ffymo+NnVcqj6nmzjPE36w86IvmgtF0t7lauh80Z71Es+b6tVXzc3JjtV0B6hNKAdQTffTcd9995dfRBKMxcYEWNXEi7IhfbyNwyb+8R42NvC+hyoup/Jf71lZZ+ycPQmqpvPBsbnmixlP+uVi2yvAuApgYll/Qxbj5+ommbtHfSPxiHr++RzgQTdDyi776ZZ8wYUL2ufqPuNDL+6pp6sI1xo+mDdEUKJpvRM2P/CIlvlhHPyC1xBf+CDhy3/3ud+tciMfzGJaLZkD5r90hb0oT6zWagOUXqJ/97GfL40SIlZc7mhdGU5T6yxu/SkeY15zlXd1Vbt/oW6rW9m2sSVWorOlS2YyspcfiOxXbLPfXv/61zkVZ1PZqjrhwyy/q4niI8tZfJxG6VKs1WN+7fW5pznaN47rads37nGqOGTNm1FmGyv6ooqZT/QCt8iK52vaN4yw/Z0X5mrttorZLfC5qiRx88MF1aj5VLvO9995bdZkjAH8n59qmxPlrn332yWpsRmga57lqfbJFM+58/hFiRX9IIf7Pa/PF+bqyH8XoLy0CqXwZoslePOqL6VZ+Lu+3q/7zPIiPv6v111PebLGydmTluTn65sutat95rTXfOEfnzRhrnY8b+7EjHzdqeDV3npWuueaa8t/YaGrbktqy8cNMftxE4JjXrIt1kTcHrJxvc9ZL/Rqt0Q9ivt2jry2A5tJ8D1jjzZ07NwtUou+R6IQ7Lmhz0Qwimi80Jppv5M0c4st3XCBU/rJeWfU9LkBjPvFLb9TeiF+To9ZLHuC8U9FBcPyiHfOMwCiakkXfKHEhFMsWX4bzwKTyF87opDr6b4kwprEmTlELKEKDvOlVXKzF9EPe8W+IcfLQKb7QxjqKssRyxoX43//+9/KX68p+pPKyRz8h8eU9LnhivKhtFBd/0SQulqM5YnpR3viSHU244mIib5JTOd9aomPl6OMovmjHRXU0S4kmgVGuaD6SX2hHLakYt1KEYVGLIPpjycsbTT6iTLm4oNhvv/2y8DAu/qJ2VUw/yhwXDXHBGIFdXAS8W/19FSmOjwgn4yI69pVY/hgWoUv0gRL7a9Q+a6qD3MoLugieKi/eWnIsvlOx75922mnlvsPOOeecrElqNJ9qTn9S+UV9NA+LvqMiNI0gNJYhjpGo4fXkk09m+8BVV12V9t5770an9W6fW2qJ80leazA6Bo+mbnG8xXaIACj63ormss3tMyn2/Qgto5lrHGN58B3HT95/TmUH99FkKs41EVDGeqovP86iX7fY1+L5GWecke0fUQso9qGf/vSnDT6X96MUfaZF0Bjzjov36G8wljnvVD9qYkaztVjPsW9HM+WYV8wnwvX659rYV6I2SvR/tssuu2TLFWFD3hl6fKb++aS++HsV5cnD7gjb4xwRw3NxE4IIIaJmauyr0UddNH+O/S1q2ETQmddgij7R8tqXEUhFjc74u5hv3wgfKqed98cUolZifi6MmxfEeS+CwvzHhgjrm9OUPKYTHejH36ro0yzKE+favJ+6CM7yfvdi2fObD+Ri349jMMQ5NML8qC3ZmvONYzJCvvibFzWo43wWTTmjz7FcnAOaEjfbyP+GxrER84t1Fn9XQuzPlT9ghDjPVHbo3lgH57EvxHGUfy7/OxXbPf+BJfaDU089NdtXY5uH+NsfzbPz/TrWYexjUa5okrzxxhtnn6lcjkpx7s7PsZXnaYAm1bkXH8AaorHbqOePuM30okWLmrzV8tFHH11zGmuvvXbpueeeK4976KGHNhgnv3V5c27bnt9evrHbol9++eWlzp07N3oL8vCDH/yg5i3kG/PMM8+UNtxww5rL3KdPn9Kzzz5bHv/BBx9sdD1X3uq9sbLXv317rLd8eNwKvr7GblMftwxfsGBBk8t6/fXXl3r06FFzOvHeDTfcUPWzxx9/fJ1xP/nJTzYYJ26vvckmmzS6fvJtXut29y1Ruc/Umka1fbzWvGvts7X2zWnTppVvGV7t0Zz9L247PmDAgGz8Aw44oM57zT0WW+tY+8pXvtJgPnG798p1mE+n8pb1lfvxG2+8Uee29NUe1fbv+lrz3FJtHwjVttOyZcsaPdbqr7NqKvevLbbYouo54Nvf/nZ5/OXLl5c23XTTBuNsu+22VffTxo6zym1RbX0cc8wx5WFDhgwpLVy4MBs+evToRpe5cj3//e9/L3Xq1KnmsV1r+7yTv1+V+8ysWbNqLn+sx1deeaU8bmVZmrs9P/3pT9cc99JLL21yeZqzXOecc06jn608vuL83hLNnW/lPKo91l9//dJf/vKXZs2z8u9X5SP2k2uvvbbB+HfeeWd5nOHDhzc67VrHb+y7O+64Y9X59u7dO9tPK1111VVV99t4xLm2vgsvvLD8/pNPPtms9QAQNN8D+P9qLMSvq/ELcNQ2itt7x6OyD6Va4pfk+GU/mpXFL9Pxy2r8ihy/tEctjbzJSfjhD3+YdQZc7W5urSX6Uor5Rs2e+NU3aotEeeKX+8r+saJZWdT0iLtdNbez1BDrKGrxxC+1UWMhfumPR9QUiGHxXmXtjBg/5hO3S8/LE78ERy2B6AMl3qss+wMPPFCn7PF/dHYczf8qb4XdlGjKEk0vo5lVzC+mFZ2Vx/aKX/2b6sA+byIRtVViWrEcUZMsHvE8hkWzwFrNO+v/0l3/dYh1H+sramPEL9FRqyD2uXgev8b/9re/bXEfVKuzqI0XtdXiV/ioTRO1RaJWUOyX0Yly3IGxKbEd83UZtdDyTopbeiy2hqilE7VaogZBbLuotRU1+iprxlT2uVNN1PiI2nBRy2PIkCHZ/hWfiWMoatZFHzJx7DSliHNLNVEDI5rNxR3f4jiN/TfWRdQGihoyUcsiauI0V6zD2O+jlkucV6LGVzTBjNpIudhvopl11KSM+ce+FHc/jDJUkx9nUYsrP87inBD7XWXtxWqidkr0HRSiRljU+Izak9GPUNT4iz6dYl+LcsR8YtwoR2VTuqi1FONG09P6nYMXIc4h0cQ0zvlxDoz1F//H67i7Yf2bOLRU1MyLGjixnPk5LJoWRm2g5nREnotj6YYbbsi2a3SgHY94HjcviNpt75bmzjfOVbEPxfEY55U4F8WxGnfjjL68ogZw5Q0DGhO1+uLvX+yDsc6in6nYd+Kcltc+rlT5t6+xWlKNiXnEeTD+3sTxGftsLEfUSoz9I7Zfpai9F7WFo1yxTePcFMdlHBOVNcpzee24qHEV6wSguTpFMtXssQEA2ljc6SoC0ehzKy7WWnLh25riK1T9/r2iyWaEE9HsNAKneN2S0BegvYmmsNFvVYgwr9adOAGq8S0JAGhXouZH1KoLkydPbrPbkEdn2OPHj8/6PYqgLGrgRc2bvL+0qHUpkAI6ujgPh6htFec9gJZQUwoAYBWb/USzsWqiqVY0lYmOnwEAqE5NKQCAVRB3xIt+k6JPnuifJfopij5X4q5V0VePQAoAoHFqSgEAAABQODWlAAAAACicUAoAAACAwnVNa5iVK1em1157La2//voNbuMMAAAAwDsTd0devHhx2njjjRu9G/EaF0pFIBW3kgYAAADg3fPyyy+nTTbZpOb7a1woFTWk8hXTs2fPti4OAAAAQIeyaNGirEJQnsHUssaFUnmTvQikhFIAAAAA746muk3S0TkAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAALBmhVIPPPBAOvDAA9PGG2+cOnXqlG655ZYmP3PfffelD3zgA6l79+5pyy23TNdcc00hZQUAAACgg4RSS5YsSUOGDElTpkxp1vgvvPBC2n///dM+++yTHn/88fTVr341HXPMMemOO+5418sKAAAAQOvpmtrQfvvtlz2aa+rUqWnzzTdPF198cfZ62223TX/84x/Td7/73TRy5Mh3saQAAAAArLF9Sk2fPj2NGDGizrAIo2I4AAAAAO1Hm9aUaqnZs2en/v371xkWrxctWpTeeuuttPbaazf4zLJly7JHLsYNK1euzB4AAAAAtJ7m5i3tKpRaFZMmTUoTJ05sMHzevHlp6dKlqb07+tq/tnURAAAAgFZw5ZhdOsR6XLx4cccLpQYMGJDmzJlTZ1i87tmzZ9VaUmH8+PFp7NixdWpKDRo0KPXt2zf7XHv39Bud2roIAAAAQCvo169fh1iPPXr06Hih1G677ZZuu+22OsPuuuuubHgt3bt3zx71de7cOXu0dyuTUAoAAAA6gs4dIKdoyXK06dL+97//TY8//nj2CC+88EL2fNasWeVaTqNHjy6P/6UvfSk9//zz6Rvf+EaaOXNmuvTSS9NNN92UTjnllDZbBgAAAABark1DqUceeSTttNNO2SNEM7t4fuaZZ2avX3/99XJAFTbffPM0bdq0rHbUkCFD0sUXX5yuuOKK7A58AAAAALQfnUqlUimtQaJPqV69eqWFCxd2iD6lBo+b1tZFAAAAAFrBi+fvv0ZlLx2jsSIAAAAA7YpQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAWPNCqSlTpqTBgwenHj16pOHDh6eHH3640fEnT56ctt5667T22munQYMGpVNOOSUtXbq0sPICAAAA0M5DqRtvvDGNHTs2TZgwIT366KNpyJAhaeTIkWnu3LlVx7/uuuvSuHHjsvGffvrpdOWVV2bT+OY3v1l42QEAAABop6HUJZdcko499th01FFHpfe///1p6tSpaZ111klXXXVV1fEfeuihtMcee6Qjjjgiq1310Y9+NB1++OFN1q4CAAAAYPXSta1mvHz58jRjxow0fvz48rDOnTunESNGpOnTp1f9zO67755+9rOfZSHUrrvump5//vl02223pc997nM157Ns2bLskVu0aFH2/8qVK7NHe9c5ldq6CAAAAEArWNkBcoqWLEebhVLz589PK1asSP37968zPF7PnDmz6meihlR87kMf+lAqlUrpf//7X/rSl77UaPO9SZMmpYkTJzYYPm/evA7RF9W2GwilAAAAoCOYW6M7o/Zm8eLFq3cotSruu+++dN5556VLL7006xT9X//6Vzr55JPTOeeck771rW9V/UzUxIp+qyprSkUH6X379k09e/ZM7d3Tb3Rq6yIAAAAAraBfv34dYj3GzexW61CqT58+qUuXLmnOnDl1hsfrAQMGVP1MBE/RVO+YY47JXu+www5pyZIl6bjjjkunn3561vyvvu7du2eP+mLcauO3NyuTUAoAAAA6gs4dIKdoyXK02dJ269YtDRs2LN1zzz112hzG6912263qZ958880GCxbBVojmfAAAAAC0D23afC+a1Y0ZMybtvPPOWcflkydPzmo+xd34wujRo9PAgQOzfqHCgQcemN2xb6eddio334vaUzE8D6cAAAAAWP21aSg1atSorMPxM888M82ePTsNHTo03X777eXOz2fNmlWnZtQZZ5yROnXqlP3/6quvZv1CRSB17rnntuFSAAAAANBSnUprWLu36Oi8V69eaeHChR2io/PB46a1dREAAACAVvDi+fuvUdlLx+hBCwAAAIB2RSgFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAACseaHUlClT0uDBg1OPHj3S8OHD08MPP9zo+AsWLEhf/vKX00YbbZS6d++ettpqq3TbbbcVVl4AAAAA3rmuqQ3deOONaezYsWnq1KlZIDV58uQ0cuTI9Mwzz6R+/fo1GH/58uVp3333zd775S9/mQYOHJheeuml1Lt37zYpPwAAAADtMJS65JJL0rHHHpuOOuqo7HWEU9OmTUtXXXVVGjduXIPxY/h//vOf9NBDD6W11lorGxa1rAAAAABoX9oslIpaTzNmzEjjx48vD+vcuXMaMWJEmj59etXP/Pa3v0277bZb1nzvN7/5Terbt2864ogj0mmnnZa6dOlS9TPLli3LHrlFixZl/69cuTJ7tHedU6mtiwAAAAC0gpUdIKdoyXK0WSg1f/78tGLFitS/f/86w+P1zJkzq37m+eefT3/4wx/SkUcemfUj9a9//SudcMIJ6e23304TJkyo+plJkyaliRMnNhg+b968tHTp0tTebbuBUAoAAAA6grlz56aOYPHixat/871VSdqiP6nLLrssqxk1bNiw9Oqrr6YLL7ywZigVNbGi36rKmlKDBg3Kaln17NkztXdPv9GprYsAAAAAtIJ+VfrXbo/iZnardSjVp0+fLFiaM2dOneHxesCAAVU/E3fci76kKpvqbbvttmn27NlZc8Bu3bo1+EzcoS8e9UVTwXi0dyuTUAoAAAA6gs4dIKdoyXK02dJGgBQ1ne655546NaHidfQbVc0ee+yRNdmrbJv47LPPZmFVtUAKAAAAgNVTm0Zw0azu8ssvT9dee216+umn0/HHH5+WLFlSvhvf6NGj63SEHu/H3fdOPvnkLIyKO/Wdd955WcfnAAAAALQfbdqn1KhRo7IOx88888ysCd7QoUPT7bffXu78fNasWXWqfEVfUHfccUc65ZRT0o477pgGDhyYBVRx9z0AAAAA2o9OpVJpjbp9W3R03qtXr7Rw4cIO0dH54HHT2roIAAAAQCt48fz916jspWP0oAUAAABAu7JKoVT0ARX9OeW+8Y1vpN69e6fdd989vfTSS61ZPgAAAAA6oFUKpaJz8bXXXjt7Pn369DRlypR0wQUXpD59+mT9PQEAAABAq3d0/vLLL6ctt9wye37LLbekQw89NB133HFpjz32SHvvvfeqTBIAAACANcgq1ZRab7310r///e/s+Z133pn23Xff7HmPHj3SW2+91bolBAAAAKDDWaWaUhFCHXPMMWmnnXZKzz77bPr4xz+eDX/qqafS4MGDW7uMAAAAAHQwq1RTKvqQik7N582bl371q1+lDTfcMBs+Y8aMdPjhh7d2GQEAAABY02tK/e9//0vf//7302mnnZY22WSTOu9NnDixNcsGAAAAQAfV4ppSXbt2ze60F+EUAAAAABTWfO8jH/lIuv/++1dphgAAAACwSh2d77fffmncuHHpiSeeSMOGDUvrrrtunfcPOuggaxYAAACA1g2lTjjhhOz/Sy65pMF7nTp1SitWrFiVyQIAAACwhlilUGrlypWtXxIAAAAA1hir1KdUpaVLl7ZOSQAAAABYY6xSKBXN884555w0cODAtN5666Xnn38+G/6tb30rXXnlla1dRgAAAAA6mFUKpc4999x0zTXXpAsuuCB169atPHz77bdPV1xxRWuWDwAAAIAOaJVCqZ/85CfpsssuS0ceeWTq0qVLefiQIUPSzJkzW7N8AAAAAHRAqxRKvfrqq2nLLbes2gH622+/3RrlAgAAAKADW6VQ6v3vf3968MEHGwz/5S9/mXbaaafWKBcAAAAAHVjXVfnQmWeemcaMGZPVmIraUTfffHN65plnsmZ9t956a+uXEgAAAIAOZZVqSh188MHpd7/7Xbr77rvTuuuum4VUTz/9dDZs3333bf1SAgAAANChrFJNqbDnnnumu+66q3VLAwAAAMAaYZVqSr388svplVdeKb9++OGH01e/+tXsjnwAAAAA8K6EUkcccUS69957s+ezZ89OI0aMyIKp008/PZ199tmrMkkAAAAA1iCrFEo9+eSTadddd82e33TTTWmHHXZIDz30UPr5z3+errnmmtYuIwAAAAAdzCqFUm+//Xbq3r179jw6Oz/ooIOy59tss016/fXXW7eEAAAAAHQ4qxRKbbfddmnq1KnpwQcfzDo7/9jHPpYNf+2119KGG27Y2mUEAAAAoINZpVDqO9/5Tvrxj3+c9tprr3T44YenIUOGZMN/+9vflpv1AQAAAEAtXdMq2HvvvdP8+fPTokWL0gYbbFAeftxxx6V11llnVSYJAAAAwBqkRaFUBFCdOnVqMLxXr15pq622Sqeeemrad999W7N8AAAAAKzpodTkyZOrDl+wYEGaMWNGOuCAA9Ivf/nLdOCBB7ZW+QAAAABY00OpMWPGNPr+0KFD06RJk4RSAAAAALR+R+e1RE2pmTNntuYkAQAAAOiAWjWUWrZsWerWrVtrThIAAACADqhVQ6krr7wya8IHAAAAAK3Wp9TYsWOrDl+4cGF69NFH07PPPpseeOCBlkwSAAAAgDVQi0Kpxx57rOrwnj17pn333TfdfPPNafPNN2+tsgEAAADQQbUolLr33nvfvZIAAAAAsMZo1T6lAAAAAKA5hFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAArJmh1JQpU9LgwYNTjx490vDhw9PDDz/crM/dcMMNqVOnTumQQw5518sIAAAAQAcKpW688cY0duzYNGHChPToo4+mIUOGpJEjR6a5c+c2+rkXX3wxnXrqqWnPPfcsrKwAAAAAdJBQ6pJLLknHHntsOuqoo9L73//+NHXq1LTOOuukq666quZnVqxYkY488sg0ceLEtMUWWxRaXgAAAADaeSi1fPnyNGPGjDRixIj/v0CdO2evp0+fXvNzZ599durXr186+uijCyopAAAAAK2pa2pD8+fPz2o99e/fv87weD1z5syqn/njH/+YrrzyyvT44483ax7Lli3LHrlFixZl/69cuTJ7tHedU6mtiwAAAAC0gpUdIKdoyXK0aSjVUosXL06f+9zn0uWXX5769OnTrM9MmjQpa+ZX37x589LSpUtTe7ftBkIpAAAA6AjmNtG/dnvKb1b7UCqCpS5duqQ5c+bUGR6vBwwY0GD85557Luvg/MADD2yQvnXt2jU988wz6b3vfW+dz4wfPz7rSL2yptSgQYNS3759U8+ePVN79/Qbndq6CAAAAEAr6NevX4dYjz169Fj9Q6lu3bqlYcOGpXvuuScdcsgh5ZApXp944okNxt9mm23SE088UWfYGWeckSVw3/ve97Kwqb7u3btnj/qi76p4tHcrk1AKAAAAOoLOHSCnaMlytHnzvajFNGbMmLTzzjunXXfdNU2ePDktWbIkuxtfGD16dBo4cGDWDC+Stu23377O53v37p39X384AAAAAKuvNg+lRo0alfXvdOaZZ6bZs2enoUOHpttvv73c+fmsWbM6TFIIAAAAwP+rU6lUWqN6yo4+pXr16pUWLlzYIfqUGjxuWlsXAQAAAGgFL56//xqVvaiCBAAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAMCaGUpNmTIlDR48OPXo0SMNHz48PfzwwzXHvfzyy9Oee+6ZNthgg+wxYsSIRscHAAAAYPXT5qHUjTfemMaOHZsmTJiQHn300TRkyJA0cuTINHfu3Krj33fffenwww9P9957b5o+fXoaNGhQ+uhHP5peffXVwssOAAAAwKrpVCqVSqkNRc2oXXbZJf3whz/MXq9cuTILmk466aQ0bty4Jj+/YsWKrMZUfH706NFNjr9o0aLUq1evtHDhwtSzZ8/U3g0eN62tiwAAAAC0ghfP379DrMfmZi9tWlNq+fLlacaMGVkTvHKBOnfOXkctqOZ4880309tvv53e8573vIslBQAAAKA1dU1taP78+VlNp/79+9cZHq9nzpzZrGmcdtppaeONN64TbFVatmxZ9qhM6/IaWfFo7zqnNq3oBgAAALSSlR0gp2jJcrRpKPVOnX/++emGG27I+pmKTtKrmTRpUpo4cWKD4fPmzUtLly5N7d22GwilAAAAoCOYW6N/7fZm8eLFq38o1adPn9SlS5c0Z86cOsPj9YABAxr97EUXXZSFUnfffXfacccda443fvz4rCP1yppS0WdV3759O0SfUk+/0amtiwAAAAC0gn79+nWI9Vir4tBqFUp169YtDRs2LN1zzz3pkEMOKVfxitcnnnhizc9dcMEF6dxzz0133HFH2nnnnRudR/fu3bNHfdF3VTzau5VJKAUAAAAdQecOkFO0ZDnavPle1GIaM2ZMFi7tuuuuafLkyWnJkiXpqKOOyt6PO+oNHDgwa4YXvvOd76QzzzwzXXfddWnw4MFp9uzZ2fD11lsvewAAAACw+mvzUGrUqFFZ/04RNEXANHTo0HT77beXOz+fNWtWnYTtRz/6UXbXvsMOO6zOdCZMmJDOOuuswssPAAAAQMt1KpVKa1RP2dGnVK9evdLChQs7RJ9Sg8dNa+siAAAAAK3gxfP3X6Oyl47RWBEAAACAdkUoBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAAFE4oBQAAAEDhhFIAAAAArJmh1JQpU9LgwYNTjx490vDhw9PDDz/c6Pi/+MUv0jbbbJONv8MOO6TbbrutsLICAAAA0AFCqRtvvDGNHTs2TZgwIT366KNpyJAhaeTIkWnu3LlVx3/ooYfS4Ycfno4++uj02GOPpUMOOSR7PPnkk4WXHQAAAIBV06lUKpVSG4qaUbvsskv64Q9/mL1euXJlGjRoUDrppJPSuHHjGow/atSotGTJknTrrbeWh33wgx9MQ4cOTVOnTm1yfosWLUq9evVKCxcuTD179kzt3eBx09q6CAAAAEArePH8/TvEemxu9tI1taHly5enGTNmpPHjx5eHde7cOY0YMSJNnz696mdieNSsqhQ1q2655Zaq4y9btix75GKFhAULFmQBWLu3bElblwAAAABoBQsWLOgwoVRoqh5Um4ZS8+fPTytWrEj9+/evMzxez5w5s+pnZs+eXXX8GF7NpEmT0sSJExsM32yzzd5R2QEAAABa0waTO9b6XLx4cVZjarUMpYoQtbAqa1ZF7aj//Oc/acMNN0ydOnVq07IBADT318bo3uDll1/uEN0PAAAdW9SQikBq4403bnS8Ng2l+vTpk7p06ZLmzJlTZ3i8HjBgQNXPxPCWjN+9e/fsUal3797vuOwAAEWLQEooBQC0B43VkFot7r7XrVu3NGzYsHTPPffUqckUr3fbbbeqn4nhleOHu+66q+b4AAAAAKx+2rz5XjStGzNmTNp5553TrrvumiZPnpzdXe+oo47K3h89enQaOHBg1jdUOPnkk9Nee+2VLr744rT//vunG264IT3yyCPpsssua+MlAQAAAKDdhFKjRo1K8+bNS2eeeWbWWfnQoUPT7bffXu7MfNasWdkd+XK77757uu6669IZZ5yRvvnNb6b3ve992Z33tt9++zZcCgCAd090RTBhwoQGXRIAALRnnUpN3Z8PAAAAAFpZm/YpBQAAAMCaSSgFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgBAuzNp0qS0yy67pPXXXz/169cvHXLIIemZZ56pM87SpUvTl7/85bThhhum9dZbLx166KFpzpw55ff/9re/pcMPPzwNGjQorb322mnbbbdN3/ve9xrMa9myZen0009Pm222WXb3u8GDB6errrqqyTJOmTIlG7dHjx5p+PDh6eGHH646XtxzZr/99kudOnXK7ijclL///e9pzz33zKYbZb/gggvqvH/zzTennXfeOfXu3Tutu+662Z2Nf/rTnzY53fvuuy994AMfyJZxyy23TNdcc02d92NZooz1H7GO30l5wy9+8Yu0zTbbZOPssMMO6bbbbmuyvABA+yeUAgDanfvvvz8LQ/785z+nu+66K7399tvpox/9aFqyZEl5nFNOOSX97ne/ywKPGP+1115Ln/zkJ8vvz5gxIwu0fvazn6WnnnoqC57Gjx+ffvjDH9aZ16c//el0zz33pCuvvDILvq6//vq09dZbN1q+G2+8MY0dOzZNmDAhPfroo2nIkCFp5MiRae7cuQ3GnTx5chbuNMeiRYuy5YyALMp/4YUXprPOOitddtll5XHe8573ZMsyffr0LBA66qijsscdd9xRc7ovvPBC2n///dM+++yTHn/88fTVr341HXPMMXU+89e//jW9/vrr5Ues9/CpT33qHZX3oYceysLBo48+Oj322GNZwBiPJ598slnrBABovzqV4uc5AIB2bN68eVnAFOHThz/84bRw4cLUt2/fdN1116XDDjssG2fmzJlZbagIaz74wQ9WnU4EXU8//XT6wx/+kL2+/fbb02c+85n0/PPPZ2FPc0XNqKjJlQdcK1euzGoJnXTSSWncuHHl8SIAOuCAA9IjjzySNtpoo/TrX/86C2Rq+dGPfpQFTrNnz07dunXLhsX0ooZVLF8tUQMqQqdzzjmn6vunnXZamjZtWp0gKJZ7wYIF2TqoJoKrW2+9Nf3zn/+sGao1p7yjRo3KwsSYVi62T9Twmjp1as1lAgDaPzWlAIB2L0KokAdHUSsnak+NGDGiPE40D9t0002zUKqx6VSGT7/97W+zpnDR5GzgwIFpq622Sqeeemp66623ak5j+fLl2fwr5925c+fsdeW833zzzXTEEUdkzfwGDBjQrOWMz0folgc8IWpgRQ2uN954o8H48dtj1PKK9+NzjU23srz5dGutq1jGqGH2hS98oU4g9fnPfz7tvffeLSpvS+cNAHQcXdu6AAAA70TUQopaO3vssUfafvvts2F5zZzoV6lS//79s/eqiWZk0ewuagzloobUH//4x6yvo6jFNH/+/HTCCSekf//73+nqq6+uOp0YZ8WKFdm86s+7sjZTNC/cfffd08EHH9zsZY2yb7755g2mm7+3wQYblMO1CNGiP6wuXbqkSy+9NO27776NTrdaeaP5XQRw0edWpajpFLWoIoSqFLW9Ynu0pLy15l1rOwEAHYdQCgBo16LJXTQ7i/BoVcXnIxyKPqCiD6RcBCxRE+jnP/956tWrVzbskksuyZoERtATze6ik/Lcj3/846xfpqZEDaxoIhh9KNWy3XbbpZdeeil7Hh2F//73v2/28kQH8NE08L///W9WUyr6t9piiy3q1GJ6J6J/rVjujTfeuEEH9AAAzSWUAgDarRNPPDHri+iBBx5Im2yySXl4NIeLJmZRm6eytlTcfa9+U7l//OMf6SMf+Ug67rjj0hlnnNGg5k/UOMoDqRD9UkWzuFdeeSVr2hfhT2UNn7h7XdROqrzTX/15RyD13HPPNajJFXcIjAAq7oQXd6CLJoghr6kUn6823fy9yuaCcQe9EH0zRT9ZERjVCqVqTbdnz54NaklFUHb33Xdnd/lrSnPKW2uc5jZpBADaL31KAQDtToRCEUhFk7oIeOo3ERs2bFhaa621slpCuejHaNasWWm33XYrD4u77kXNpjFjxqRzzz23wXyiSWDctS9qHOWeffbZLPSJECwCmwh/8kfUUIpmgzH/ynlHjat4nc87OvuOO+NFoJU/wne/+91ys8C4Y10+3QjGQnw+Arg8rApxF7y4G2DedK+amH805aslpltZ3ny6lesqF+WLTuWj4/SmNKe8LZk3ANDBxN33AADak+OPP77Uq1ev0n333Vd6/fXXy48333yzPM6XvvSl0qabblr6wx/+UHrkkUdKu+22W/bIPfHEE6W+ffuWPvvZz9aZxty5c8vjLF68uLTJJpuUDjvssNJTTz1Vuv/++0vve9/7Ssccc0yj5bvhhhtK3bt3L11zzTWlf/zjH6Xjjjuu1Lt379Ls2bNrfia+lv36179udLoLFiwo9e/fv/S5z32u9OSTT2bzWWeddUo//vGPy+Ocd955pTvvvLP03HPPZfO+6KKLSl27di1dfvnlNaf7/PPPZ9P5+te/Xnr66adLU6ZMKXXp0qV0++231xlvxYoV2To97bTTqk5n3LhxWdlaUt4//elPWfminDHvCRMmlNZaa61s+wAAHZtQCgBodyLAqfa4+uqry+O89dZbpRNOOKG0wQYbZEHIJz7xiSx0ykX4UW0am222WZ15RVAyYsSI0tprr50FVGPHjq0TftXygx/8IAtwunXrVtp1111Lf/7zn5tcpqZCqfC3v/2t9KEPfSgLvQYOHFg6//zz67x/+umnl7bccstSjx49smWPIC7CoKbce++9paFDh2bl3WKLLeqsy9wdd9yRlfOZZ56pOo0xY8aU9tprrxaVN9x0002lrbbaKpv3dtttV5o2bVqT5QUA2r9O8U9b19YCAAAAYM2iTykAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAAKBwQikAAAAACieUAgAAACAV7f8BJxk151nPFwIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 24: Distinct users over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(start_ts, HOUR) AS hour,\n",
+    "       COUNT(DISTINCT user_id) AS users\n",
+    "FROM session_rollups\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", \"users\", \"Distinct Users Over Time\", \"Users\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "cell-25-top-users",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:06.612097Z",
+     "iopub.status.busy": "2026-04-11T06:43:06.611935Z",
+     "iopub.status.idle": "2026-04-11T06:43:08.814030Z",
+     "shell.execute_reply": "2026-04-11T06:43:08.813137Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top Users by Session Count:\n",
+      "  user_id  sessions\n",
+      "demo_user         6\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 25: Top users by sessions\n",
+    "df = run(\"\"\"\n",
+    "SELECT COALESCE(user_id, '(unknown)') AS user_id, COUNT(*) AS sessions\n",
+    "FROM session_rollups GROUP BY user_id ORDER BY sessions DESC LIMIT 10\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    print(\"Top Users by Session Count:\")\n",
+    "    print(df.to_string(index=False))\n",
+    "else:\n",
+    "    print(\"No user session data.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "cell-26-agents-users",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:08.816538Z",
+     "iopub.status.busy": "2026-04-11T06:43:08.816390Z",
+     "iopub.status.idle": "2026-04-11T06:43:11.315453Z",
+     "shell.execute_reply": "2026-04-11T06:43:11.315029Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKmZJREFUeJzt3QeUXMWZNuASkhBRgAAhRE4iRxEswmIwWBiMiQu2dAhLTksyOYkMywLGYAMmGAzGRJNsgoki5yiTczICk4yISv2fr7y3/57RjFJJGmnmec5pZqb79u3qe3tQvbfqq+lUq9VqCQAAoMB0JU8GAAAQLAAAgEnCiAUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAmKotvPDCqVOnTvk2Ndtxxx3r7Rw8ePAk3ffbb79d3/cPf/jDSbpvgElFsAA6XOd0XLdJ3SmcEFdddVWTtmy00UZpavfFF1+kY489Nt8uvfTSNK2L8994Djp37pxmmWWWtMgii6Sf/OQn6cILL0zffffdJH/dOHbVcYxj2tbHoGrLs88+O97PazxuEYZaC16xX6D96dLWDQDg/7vyyiubHI677747ffLJJ2muueaaag9TdIKPO+64/P26666bO5DtyejRo9PXX3+db9FZvv3229MZZ5yRbrrpprTkkkvWtzvyyCPTLrvskr9ffvnlJypY3Hffffn7OIazzz57/bF55503PfDAA/n72WabLU2JYFGd0wjlK6200mR/TWDaJ1gAHcJ1113X5Crzf/7nf6ahQ4fm788+++y08sor1x+bmE7hpOqgR6e10ciRI3Pb99hjjzZpU0fXq1evdO211+ZQ8dRTT+XPykcffZReeeWVPJr0zDPP1APAEksskW+TQ7du3dLaa689Wfbd0XzzzTdppplmautmQLtkKhTQIay66qq5Y1bdoqPWGCQaH4upGnH1eemll04zzjhjmnXWWdMaa6yRfve736VardZkv9XUjriq+9prr6Wf/vSnedpMjDDsvffeuUM6vq6//vo0fPjw/P3Pf/7zJtOjWvL888+n9dZbL3eS5p9//nyF+a677qq3qfnIwT//+c904IEH5s5vvP855pgjbbLJJunRRx9tdSpQ7ONvf/tbWm211dIMM8yQFlxwwdy5rsTjMUWoElfcm9cCfPvtt+nggw+uv+7MM8+cn7PlllumG264IU2IGL3ZYYcdctvjyv3AgQPTxx9/nB8bNmxY3nd1PhrP1ahRo9Lcc8+dH5tzzjnTiBEjJqhD379//3TEEUekJ598sj5iEKMXMXLReCxamk4X32+wwQapR48eqWvXrrkdq6++etpvv/3Sv/71r/rxrkYrQhyfxilFrdVYxJSi6v5LLrkknXXWWWnxxRfP7V5xxRXTPffcM8Z7eu+999I+++yTt4tzGseyX79+6eqrr86Px76q0YrwX//1X/XXmBxT3T799NMcnBdaaKE0/fTT59+3Pn36pF/84hdNjkl466230q677pq3jffYs2fPtO2226aXXnqpyXbRzsZpV+eff34eXYrjf8011+Rt/vznP+dzG+czXjdCZPx86KGHjvF7DoynGkAHtNBCC0XPId/uvffe+v2fffZZbamllqo/1vz285//vMl+qvtnn3322jzzzDPG9htttNF4t2mDDTaoP++5556rrbTSSvn76aabrvbBBx802fbNN9/Mr9n89VZcccX69zvssEN9+3feeac2//zzt/ieunbtWrvpppvq28bxqB6L4xSv3/w5d955Z942XqO1Y7XuuuvmbXbaaadWtxk4cOAEnasVVlhhjH3Efd99990Y7XnggQfq+7j//vvr9++2225jfb3m77+5E088sf74YostVr+/8bWrz9TLL79cm3HGGVt9/6+99lqT12vp9tZbb+Vb8+MaBg0aVL9/0UUXHeO5s846a/5MV5555plajx49Wnyd6vMytrZccsklYz12zdvdqPH4RLsr66+/fquvd+SRR9a3e+qpp1r8zMdtlllmqT322GP1baOdrR2XeGzw4MEtfq6r24gRI8b6PoGWGbEAaBBXpV9++eX6SEaMIlx00UX5qm41elBd2W0+jSlGDW688cZ0zjnn1KdaxNSmv/zlL+M8xjG95t57783fx5X9FVZYIW299db1Of7NXzNGVKoC39g2rvz/+te/Tq+++mqL+99rr73S+++/n7/ffvvtc7vOO++8PLoSV+932mmnFkdX3nnnnbTpppvm99A4ihKjN1U7YqpQJebiRy1A3OI4hKhFCHGVOaZ13XHHHeniiy/O7aiO6/j66quv8rGIK9JV3UmM3FxwwQX5+5133rm+7RVXXFH//uabb65/H1fCS8TV/cobb7yR29SaO++8M4/YhBihiJqZOAYnnnhiHkWLK+oxDS+OV2MdQxzT6jhGfcX4ePPNN/PV9nivMVpRjeL86U9/yt9Hvz+O+WeffZZ/Xm655dLll1+ebrnllnTMMcfkkZwQrxmjFI2/E1VbNt544zQpRfuqz30ch2j7bbfdlkcYttpqqzwCVbU9Rqqqz/wvf/nL/Dn6n//5n1xcH+cg2tzSSEMclxhxit/NGK1Ydtll8+c5fq/CySefnM9L/G4fddRRaZlllpnqVyCDqVYrgQOgw41YjBo1qjbHHHPU7x8yZEh9+3POOad+/2abbVa/v/nV50pcaa3ujyv249K4/8MPP7x+tbu6b/XVV69vG+2MK7QttfOwww4b4wr0p59+WuvUqVO+r1evXvlKfnXbYost6ttfd911efvGK+g9e/asjwYMHTq0fn+MplRau5peidesRlPiinm1v4k5V9VISbjwwgvr98dV70qfPn3yfXPOOWdt+PDh+b4ll1wy39e7d+98/EpGLF588cUm5/39999vdcTi/PPPr9931lln1T788MNWXzeOXWtX+8dnxKLxc3nVVVfV799///3zfXHsq/u6d+9e+/jjj1ttS+N+xzVKUTJi8c0339RHDjbccMN8bFsaLWhse3z2Gj/D/fr1qz/25JNPjjFiEeew+T4bf0+uvfba2ieffDLe7xFonRELgIYahM8//zx/HyMOcUW3EnPiKy2NCsT8+Ziz3tL2ccV0QlaDqkYqYk54VUj++OOP1/cTNQXVVfLm7Wy8ml55/fXX61dyo2B9nXXWqd8aaxyaz1MPP/jBD+r1KNUV7TAhy6FWowjPPfdcviodV6HjqnDUe3z44YdpQkSty7iOcYy+VHP3Y2Qmal+i2DrEfPzppiv7p++DDz5o8vPYVmnabLPN6sdt//33z6MP8VmJZWsbR3omhViRq9LSuWr83MZxjFqPyan56EHjz9U5iBqmagQpRnficxGf6ficxChK1KA0b3ssf9v4GX7kkUfG+hmOIvsuXZquVRO1OdXnOhZyiNGveeaZJ9f9RJ0SMHEEC4AWNJ8KMaFTIyZk+3fffbdJ56hv3771wtMhQ4aMtYh7Uk7ZaGkqVONUpcbO2YQUt55wwgk5OEUHLsJStDk6gL/61a/Sj3/847zy1cRo7b3HlJmqrX/84x/rU7HCgAEDUqmHHnqo/v1iiy2Wp5O1JgqCYzWpmKIUhcHR4Y/wGoFnm222abUwf2JMinNVKgqvGwvtGzX+3LhdFJ3H1Lqf/exn+XhGoX2Eh/jcRBAs/QxHYGguwnicl3333TeHrAiHEdgjaMe0qYcffniCXhf4N8EC4P/EFdxq6dDooLzwwgv1Y/PYY4/Vv48Va5qLeesxMtDS9osuuuhYj3F0Lsen81d1QmMlnKpjFu1svErbGFAqMZJSdcKj4xYd+Xi9xlusRnX88cdP1GehcQSgmrfeXNRnxPz2qF+JefXVqMzf//73VutCWhIjN+M6xtGZr2oBYi59NRoUxyHqGkpECDzzzDPrP4+r4xvHNmpLTj311FyjEJ3rJ554ov541PBMyHEs0fi5jePYvOPfaGLb0vh3PaIGohIjbI2d9aWWWqpJCNptt91yAIzfoQhea665Zn0f8RlvbHuMzDT//MYtttt9993HK4DG9lFrEXVJsSpajOpE7Uv1fqMeA5hw/o4FQENnKjrAUThaTZcYNGhQ7ujE13EV/8bV8Cj+jCLpWPazcTrM+E6Diuc3v8L6v//7v7lDG6MXL774Yp4uEgXVVVHudtttl44++ui8TXSUmqum3tx666252DiuDMf0pAgnUZwdf4shOrgRSmKZ1pIr5dHG6JTF1JJYmjZua621Vp7aElOX5ptvvhws4n1Uvv/++/F+reg4nnLKKflvkkTheGvHON5fFAJH4fTTTz890UXb0bYHH3ww/+2DCASx1O6XX36ZH4vAcNBBB43z3MbnafPNN89LyMaV8cYlYBvfe+NxjL/uHeEopgqVhqFKFHTHlfoIczHF6Ec/+lE65JBD8ucjrt7H57xaPrexLbEsa7Q9lmqNZYcbl2puLkalYkneEL8zERR69+6dQ0M1JStGbRqXzI2wG4Xa0b7YNkYOYlnZKgDEMWpseyxBG0Xo8VrRpliKN4JSjDZUUxnH5bTTTsvL/MZyy/EZjel5sazyxHwmgQZjqb8A6HDLzUah87iWmx09enR9++r+WMKzpeVcoyC1cfvmGgu0o1C6pcLiKL6ttjnqqKPGutxs43Ks47vcbPNi28bi5cZ9NL7f5kXNffv2HWN/VYFuLMna2msus8wytZEjR473uVpiiSXG2Mdyyy1X+/bbb5s8J4p1q6Lx6haFweNjXMu/Vu2Ic9eopeLtyy+/fKz7ufLKK1ss4G9+nMeneLuxyLq1czi2JVsbt3v++efrBf9jK8huLs5DLDTQ2vvt3Llz7ZprrmnynLivte379+8/Xm2vbpXG4u3GpW0rJ5xwQqv7iGLyBx98cKzvE2iZqVAADeLqbUyNOPzww/O0juoPusWV2lieNUYJWppaEVf/Y6pLjCTE9rGf+KNfMRIwtjqIxtGKuHraUmFx7LP5dKi4ghxXbuPKb/yRsygKjtGOKHitNP514bgqGyMT8YfqYhpKPCfaHN/H1d+4ur/AAgtM9Gch3kcUyba0fGwcyxhRiCv80aa4yhwjI3F84up9LBc6vuIqc9QmdO/ePbc/Rpii2DbeT6OYXhO1FpW44h1/8HBixPmLdkf7oyYkPgdRiN447ac1UUwfy8yussoqeRQn3muMWkTRcSyb27iEb4zGRC1GnKvSAvPWRDui7XvuuWeePhZ/GC6m/0WRfoxqVWLRgMsuuywfs7GNUDQX5yHOUSzhGq8V9SdxLmIkIkYYoj4lvjaKbaOuIZZrjteKWxzb+Kw2FrjH/qL2Ij43jW2PkYy4L5aMHV8xGhTHO54bn9k4L/E7G+c3Ri5ilA2YcJ0iXUzE8wBomL8dnc6YkjElxf++m4eWww47LK/tH6IW4IADDuiw5+n++++vr5QUxySm/QAw+aixAJhGRYFrdTU8xEpDUQMQYlQgls7siKKuIuogYmQhxNXoSbEaFABjJ1gATKNiylbcmotRjFjKNUZROqKY0hPTxBr/rkVMswFg8hIsAKZR//3f/5070LGyU6xaFMvlVnP6Yw5/Rxc1DbHaUOPysABMPmosAACAYlaFAgAAigkWAABAMTUW7djo0aPTP/7xj7zW+9jW0QcAgNaWNh82bFj+ezTj+hs7gkU7FqGi5A9eAQBAeO+998a5wp5g0Y7FSEX1QYi/UgsAABMi/i5QXKiu+pVjI1i0Y9X0pwgVggUAABNrfKbVK94GAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACjWpXwXTO2WG/S3NF23mdq6GQAATKS3T90kTe2MWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAACBYAAEDbM2IBAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACg4waLt99+O3Xq1Ck9++yzk2R/l156aZp99tknyb4AAKCjmaBg8cMf/jDtv//+k681AADANGmSjljUarU0cuTISblLWjB8+HDHBQCAaTNY7Ljjjum+++5Lv/71r/MUpLjF9KH4etttt6W+ffumbt26pQcffDC98cYbabPNNkvzzDNPmmWWWdJqq62W7rrrrvq+jjjiiLTGGmuM8RorrrhiOv744+s/X3TRRWnppZdOM8wwQ1pqqaXSueeeO1FvcvDgwbmdt9xyS1phhRXy/n7wgx+kv//9760+Z1zvISy88MLp5JNPTjvttFOaddZZ04ILLpguuOCCMaZrXX/99Wm99dZLM800U36PjzzySJP9xDFbZ5110owzzpgWWGCBtO+++6avv/66yeuccMIJafvtt0/du3dPu+2220QdBwAAaPNgEYGiX79+adddd00ffvhhvkUnOBx22GHp1FNPTS+99FLuuH/11Vdp4403TnfffXd65pln0kYbbZQ23XTT9O677+btBw4cmB5//PHcea+88MIL6fnnn08DBgzIP19xxRXpmGOOSSeddFLeb3Tgjz766PSHP/xhot/swQcfnM4444z0xBNPpLnnnju3acSIES1uO673UIn9rbrqqnmbvfbaK+25557plVdeabLNkUcemQ466KBcD9KnT5/0i1/8oj6yE8cg9r3VVlvl93/11VfnoLHPPvs02cfpp5+eQ0m8ThwHAACYJoPFbLPNlqaffvp81b1Xr1751rlz5/xYjDJsuOGGabHFFks9evTIHeDdd989LbfccmmJJZbIV9vjsZtvvjlvv+yyy+Zt/vSnP9X3H0EiRjEWX3zx/POgQYNyp33LLbdMiyyySP56wAEHpN/97ncT/WZjn9HO5ZdfPgeUjz76KN1www0tbjuu91CJ8BGBItp96KGHprnmmivde++9TbaJULHJJpvkUHHccceld955J73++uv5sVNOOSUHrahdiddZc80109lnn50uu+yy9N1339X3sf7666df/vKXuQ1xa8n333+fvvzyyyY3AACYZmos4op986v90ZmOaUyx0lJMJYpRh8ar/dGZroJF1GZceeWV+b4Q04DiSv7OO++cn1vdTjzxxCajHBMqRlwqEYCWXHLJ3K6WjM97CDFCU4lpTxG4Pv7441a3mXfeefPXapvnnnsuTylrfJ/9+/dPo0ePTm+99Varx7glEVIiAFa3akQJAAAmty6TYiczzzxzk5+jQ37nnXfm6TtxJT9qB7beeusmRccxHSiu8D/99NPp22+/Te+9917adttt6536cOGFF45Ri1GNkkxu4/MeQteuXZv8HOEiQkFr28Tjodom3muMjERdRXNRs9HaMW7J4Ycfng488MD6zzFiIVwAADDVBYuYCjVq1KhxbvfQQw/lYu8tttii3nmOQuZG888/f1p33XXzFKgIFjFFqWfPnvmxKJju3bt3evPNN+ujGJPCo48+Wu+sf/755+nVV1/NIxIT+x4mhVVWWSW9+OKL9SlgJaJ4Pm4AADBVB4tYneixxx7LHeyYstP8ynwlagViJaQodo4r9FFs3NK2ERqi7iFGAX71q181eSxqEeIqfkzpieLmqB948skncyBovCo/IaIWZM4558zBJQqqox5i8803L3oPpWLUJlaoimLtXXbZJY9MRNCI0ZLf/OY3k/z1AACgzWssYnpQTEVaZpll8qpKzesNKmeeeWaaY445ciFydMyjZiCuzDcXU4s+/fTT9M0334zRwY9Odiw3e8kll+Ri6xjdiFqEKOSeWLFy1X777ZeXxh06dGj6y1/+kkdhSt5Dqai/iGV8Y/QklpxdeeWV82pYMWIDAADTik61qJxu5+LvWMTfkYjRjijE7iiixiIXce9/TZqu20xt3RwAACbS26duktqyP/mvf/0r/z21KfaXtwEAgI6pXQSLPfbYo8lyrY23eAwAAJgGlptta1GUHfUfLYkhm1htqgPM+AIAgDbTLoJFBIdqqVoAAGDKaxdToQAAgLYlWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQIAABAsAACAtmfEAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAggUAAND2jFgAAADFBAsAAKCYYAEAABQTLAAAgGKCBQAAUEywAAAAigkWAABAMcECAAAoJlgAAADFBAsAAKCYYAEAABTrUr4LpnZ/P65/6t69e1s3AwCAdsyIBQAAUEywAAAAigkWAABAMcECAAAoJlgAAADFBAsAAKCYYAEAABQTLAAAgGKCBQAAUEywAAAAigkWAABAMcECAAAo1qV8F0ytarVa/vrll1+2dVMAAJgGVf3Iql85NoJFO/bpp5/mrwsssEBbNwUAgGnYsGHD0myzzTbWbQSLdqxHjx7567vvvjvODwLt68pChMn33nsvde/eva2bwxTivHc8znnH5Lx3TF+24b/tMVIRoaJ3797j3FawaMemm+7fJTQRKnQwO5445857x+O8dzzOecfkvHdM3dvo3/bxvUCteBsAACgmWAAAAMUEi3asW7duadCgQfkrHYfz3jE57x2Pc94xOe8dU7dppE/XqTY+a0cBAACMhRELAACgmGABAAAUEywAAIBigsU07re//W1aeOGF0wwzzJDWWGON9Pjjj491+2uvvTYttdRSefvll18+3XrrrVOsrbTNeb/wwgvTOuusk+aYY45822CDDcb5OaF9/L5XrrrqqtSpU6e0+eabT/Y20rbn/Isvvkh77713mnfeeXORZ58+ffx/vgOc97POOistueSSacYZZ8x/RO2AAw5I33333RRrL2Xuv//+tOmmm+Y/QBf/r77xxhvH+ZzBgwenVVZZJf+eL7744unSSy+dOk5DFG8zbbrqqqtq008/fe33v/997YUXXqjtuuuutdlnn7320Ucftbj9Qw89VOvcuXPttNNOq7344ou1o446qta1a9fakCFDpnjbmXLnfcCAAbXf/va3tWeeeab20ksv1XbcccfabLPNVnv//fedhnZ83itvvfVWbb755quts846tc0222yKtZcpf86///772qqrrlrbeOONaw8++GA+94MHD649++yzTkc7Pu9XXHFFrVu3bvlrnPO//e1vtXnnnbd2wAEHTPG2M3FuvfXW2pFHHlm7/vrrY0Gl2g033DDW7d98883aTDPNVDvwwANzf+6cc87J/bvbb7+91tYEi2nY6quvXtt7773rP48aNarWu3fv2imnnNLi9ttss01tk002aXLfGmusUdt9990ne1tpu/Pe3MiRI2uzzjpr7Q9/+IPT0s7Pe5zrNddcs3bRRRfVdthhB8GinZ/z8847r7booovWhg8fPgVbSVuf99h2/fXXb3JfdDjXWmstJ2calMYjWBxyyCG1ZZddtsl92267ba1///61tmYq1DRq+PDh6amnnsrTWirTTTdd/vmRRx5p8Tlxf+P2oX///q1uT/s478198803acSIEalHjx6TsaVMDef9+OOPTz179kw777yzE9IBzvnNN9+c+vXrl6dCzTPPPGm55ZZLJ598cho1atQUbDlT+ryvueaa+TnVdKk333wzT3/beOONnYx26pGpuD/Xpa0bwMT55JNP8j8W8Y9Ho/j55ZdfbvE5Q4cObXH7uJ/2e96bO/TQQ/M8zub/U6J9nfcHH3wwXXzxxenZZ5+dQq2krc95dCjvueeeNHDgwNyxfP3119Nee+2VLyTEH9aifZ73AQMG5OetvfbaMQsljRw5Mu2xxx7piCOOmEKtZkob2kp/7ssvv0zffvttrrVpK0YsoAM59dRTcyHvDTfckIsCaZ+GDRuWtttuu1y4P9dcc7V1c5hCRo8enUeoLrjggtS3b9+07bbbpiOPPDKdf/75zkE7FkW8MTJ17rnnpqeffjpdf/316ZZbbkknnHBCWzeNDsiIxTQqOgudO3dOH330UZP74+devXq1+Jy4f0K2p32c98rpp5+eg8Vdd92VVlhhhcncUtryvL/xxhvp7bffzquMNHY6Q5cuXdIrr7ySFltsMSepnf2ux0pQXbt2zc+rLL300vnqZkyxmX766Sd7u5ny5/3oo4/OFxJ22WWX/HOs+Pj111+n3XbbLQfLmEpF+9Krlf5c9+7d23S0Ivi0TaPiH4i4InX33Xc36TjEzzHHtiVxf+P24c4772x1e9rHeQ+nnXZavnp1++23p1VXXXUKtZa2Ou+xpPSQIUPyNKjq9rOf/Sytt956+ftYjpL297u+1lpr5elPVYgMr776ag4cQkX7Pe9RN9c8PFTh8t+1wLQ3/abm/lxbV49TtiRdLDF36aWX5uXGdtttt7wk3dChQ/Pj2223Xe2www5rstxsly5daqeffnpednTQoEGWm+0A5/3UU0/NSxded911tQ8//LB+GzZsWBu+Cyb3eW/OqlDt/5y/++67ecW3ffbZp/bKK6/U/vrXv9Z69uxZO/HEE9vwXTC5z3v8Wx7n/corr8zLkN5xxx21xRZbLK8EybRh2LBheUn4uEXX/Mwzz8zfv/POO/nxON9x3psvN3vwwQfn/lwsKW+5WSaJWLt4wQUXzB3HWKLu0UcfrT+27rrr5s5Eo2uuuabWp0+fvH0sVXbLLbc4E+38vC+00EL5f1TNb/GPEe37972RYNExzvnDDz+clxGPjmksPXvSSSflZYdpv+d9xIgRtWOPPTaHiRlmmKG2wAIL1Pbaa6/a559/3katZ0Lde++9Lf47XZ3n+BrnvflzVlpppfwZid/1Sy65pDY16BT/aetREwAAYNqmxgIAACgmWAAAAMUECwAAoJhgAQAAFBMsAACAYoIFAABQTLAAAACKCRYAAEAxwQKAKapTp07pxhtvnOjnH3vssWmllVaapG0CoJxgAUCxHXfcMQeGuHXt2jXNM888acMNN0y///3v0+jRo5ts++GHH6af/OQnEx1CDjrooHT33XdPsrM2ePDg/DpffPHFWLe79NJL0+yzzz7e7QToaAQLACaJjTbaKIeGt99+O912221pvfXWS/vtt1/66U9/mkaOHFnfrlevXqlbt24T/TqzzDJLmnPOOTvMWRs+fHhbNwFgvAgWAEwSERYiNMw333xplVVWSUcccUS66aabcsiIq/0tXd2PTvM+++yT5p133jTDDDOkhRZaKJ1yyin5sYUXXjh/3WKLLfJzqp+bT4WK0ZLNN988nX766Xk/ETr23nvvNGLEiPo233//fTr00EPTAgsskNu5+OKLp4svvjiHoAhAYY455sivE/sr8fnnn6eBAwemueeeO80444xpiSWWSJdcckn98ffeey9ts802efSjR48eabPNNsvtaP5+TjrppNS7d++05JJL5vvPPffcvK84TjEitPXWWxe1E2BS6zLJ9wgA/2f99ddPK664Yrr++uvTLrvsMsZxOfvss9PNN9+crrnmmrTgggvmTnfcwhNPPJF69uyZO+UxGtK5c+dWj+u9996bQ0V8ff3119O2226bw8euu+6aH99+++3TI488kl8v2vPWW2+lTz75JAeNP//5z2mrrbZKr7zySurevXsOAyWOPvro9OKLL+ZANddcc+X2fPvtt/mxCDv9+/dP/fr1Sw888EDq0qVLOvHEE/P7e/7559P000+ft4upXtGWO++8M//85JNPpn333Tddfvnlac0110yfffZZfj7A1ESwAGCyWmqppXKnuSXvvvtuvgq/9tpr59GCGLGoxBX/EFf2YyRkbGK04Te/+U0OH/F6m2yySe6cR7B49dVXc3CJTvoGG2yQt1900UXrz41RgxAhprUaigkR72nllVdOq666av65GmkJV199da45ueiii/L7DRGc4nWj1uPHP/5xvm/mmWfO21RBI4JZ3BfTymadddZ8nOI1AKYmpkIBMFnVarV6J7q5mPbz7LPP5uk+cUX+jjvumKjXWHbZZZuMaMToxccff5y/j/3HY+uuu26aEvbcc8901VVX5RGTQw45JD388MP1x5577rk8ghHhIGpF4hbB5rvvvktvvPFGfbvll1++HipCFMJHmIhAtN1226UrrrgiffPNN1Pk/QCML8ECgMnqpZdeSossskiLj0UtRkxLOuGEE/J0oag9mJjagViJqlEEmWo1qtKpTZWYmvT111+PscpVtZrUbLPNlr/GilfvvPNOOuCAA9I//vGP9KMf/SivZBW++uqr1Ldv3xx2Gm8xqjJgwID6PmN0olEEkaeffjpdeeWVOTQdc8wxeUrXuFayApiSBAsAJpt77rknDRkyJNcwjK3DHjURF154YZ4qFDUPUUNQBYZRo0YVtSGu/kcYuO+++1p8vBoZGNfrxKhKrG4VQaBRdPhDnz59mkzj2mGHHdIf//jHdNZZZ6ULLrigHqRee+21PO0qCsgbb1UwaU3UY8RUrtNOOy1PLYuC7zi+AFMLwQKASSJWXho6dGj64IMPcmf75JNPziseRV1AFE+35Mwzz8xX4V9++eV81f7aa6/N9RRVrUPUJ0StROw3VluaGLGP6OTvtNNOeTWqGCGJeoaouwgxxShGOP7617+mf/7zn3lUobXpVlEDEfuJNsV+br/99rTXXnvlYBSrYYUYTYjVsGLK0wsvvJD3u/TSS+fHYrWoKOiO4xLF11VbYhrY+++/3+p7iH1E4XmEmhgNueyyy3JYqlaMApgaCBYATBLRyY5pOtGRj1WOYoWm6AxHJ7u1FZ1iik9cgY9C59VWWy1fhb/11lvTdNP9+5+nM844Ixddx+pNJcXK5513Xp5iFSEgirujqDumNYUIBMcdd1w67LDD8jKusfxta2JEJWo1dt999xw0IhBESIhC68YRkMMPPzytsMIK6T/+4z/ye4+aizDTTDOl+++/P6+AteWWW+bAsfPOO+caixi5aU0ErSjgjlW24jnnn39+DmTRBoCpRadaVNUBAAAUMGIBAAAUEywAAIBiggUAAFBMsAAAAIoJFgAAQDHBAgAAKCZYAAAAxQQLAACgmGABAAAUEywAAIBiggUAAFBMsAAAAFKp/wccBxl6DYjHwgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 26: Top agents by distinct users\n",
+    "df = run(\"\"\"\n",
+    "SELECT COALESCE(agent, '(unknown)') AS agent, COUNT(DISTINCT user_id) AS users\n",
+    "FROM session_rollups GROUP BY agent ORDER BY users DESC LIMIT 10\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    ax.barh(df[\"agent\"], df[\"users\"])\n",
+    "    ax.set_title(\"Top Agents by Distinct Users\", fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Distinct Users\")\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No agent user data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel8-header",
+   "metadata": {},
+   "source": [
+    "## Panel 8: HITL / Orchestration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "cell-27-hitl-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:11.316939Z",
+     "iopub.status.busy": "2026-04-11T06:43:11.316844Z",
+     "iopub.status.idle": "2026-04-11T06:43:13.541111Z",
+     "shell.execute_reply": "2026-04-11T06:43:13.540383Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No HITL request events found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 27: HITL requests over time by type\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "       hitl_type, COUNT(*) AS requests\n",
+    "FROM hitl_events WHERE NOT is_completed\n",
+    "GROUP BY hour, hitl_type ORDER BY hour\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    if len(df[\"hour\"].unique()) == 1:\n",
+    "        fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "        ax.bar(df[\"hitl_type\"].fillna(\"(unknown)\"), df[\"requests\"])\n",
+    "        ax.set_title(f\"HITL Requests by Type (at {str(df['hour'].iloc[0])[:16]})\", fontweight=\"bold\")\n",
+    "        ax.set_ylabel(\"Requests\")\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "    else:\n",
+    "        pivot = df.pivot_table(index=\"hour\", columns=\"hitl_type\", values=\"requests\", fill_value=0)\n",
+    "        fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "        pivot.plot.area(ax=ax, alpha=0.7, stacked=True)\n",
+    "        fmt_ax(ax, \"HITL Requests Over Time by Type\", ylabel=\"Requests\")\n",
+    "        ax.legend(loc=\"upper left\")\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "else:\n",
+    "    print(\"No HITL request events found.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "cell-28-hitl-rate",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:13.543447Z",
+     "iopub.status.busy": "2026-04-11T06:43:13.543270Z",
+     "iopub.status.idle": "2026-04-11T06:43:15.699112Z",
+     "shell.execute_reply": "2026-04-11T06:43:15.697573Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No HITL events found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 28: HITL completion rate by type\n",
+    "df = run(\"\"\"\n",
+    "SELECT hitl_type,\n",
+    "       COUNTIF(NOT is_completed) AS requests,\n",
+    "       COUNTIF(is_completed) AS completions\n",
+    "FROM hitl_events\n",
+    "GROUP BY hitl_type\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    x = range(len(df))\n",
+    "    w = 0.35\n",
+    "    ax.bar([i - w/2 for i in x], df[\"requests\"], w, label=\"Requests\")\n",
+    "    ax.bar([i + w/2 for i in x], df[\"completions\"], w, label=\"Completions\")\n",
+    "    ax.set_xticks(list(x))\n",
+    "    ax.set_xticklabels(df[\"hitl_type\"].fillna(\"(unknown)\"))\n",
+    "    ax.set_title(\"HITL Completion Rate by Type\", fontweight=\"bold\")\n",
+    "    ax.legend()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No HITL events found.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "cell-29-invocations",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:15.701896Z",
+     "iopub.status.busy": "2026-04-11T06:43:15.701677Z",
+     "iopub.status.idle": "2026-04-11T06:43:17.858627Z",
+     "shell.execute_reply": "2026-04-11T06:43:17.857957Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXRBJREFUeJzt3Qd8U9X///EPyEaWyJZRka0CKqLgYstQQUURUIYCIoiAoiIbFERZiojinoALtyBTRBEZKuD2KwiyldGyR/N/vI+/m/9tSUtbSpK2r+fjkUebm5vk5Obm5uZzPudzsgUCgYABAAAAAAAAYZQ9nE8GAAAAAAAACEEpAAAAAAAAhB1BKQAAAAAAAIQdQSkAAAAAAACEHUEpAAAAAAAAhB1BKQAAAAAAAIQdQSkAAAAAAACEHUEpAAAAAAAAhB1BKQAAAAAAAIQdQSkACOHll1+2bNmyucvw4cPZRkiTChUqBPcjRI/OnTsH35dFixZZtHr77bddG3PkyGF//fVXqu67fv364Gu86qqrLLPv85F6vanhtU/bKFL0fea1Q99zAFLmjTfecJ+bPHny2N9//81mA9IRQSkACU5S9WMtK71uXSZNmhTppkSlY8eO2eTJk+3CCy+0008/3Z2IlSlTxurVq2d33323/fLLLwnW13b0tunJ0o8l77F2795tp/rHc/bs2S137txWokQJq1u3rt1///3uR+6pkp7bKj3Exsba6NGj7eKLL7bChQu7bVG2bFlr166dLV682KKZgkre+3iiSySDAakVHx8f3D/atGlj5cuXt6wuHMcFpI2Ol9578/7775/0ZtyzZ4898cQTdu2111qlSpUsf/787lK7dm2bMGGCHT169Lj7HDp0yB3Hqlev7r6vihYtaq1bt7ZVq1YlWO/w4cP27LPP2k033WRVq1a1ggULWt68ed39hg4davv27QvZpn/++ccGDBhgVapUcevrWFmzZk3r169fql7bypUr7brrrnPtUzv1vGPGjHHtSk7Lli0THM8Sfwen1/OuWbPGOnbsaNWqVXOvMWfOnHbmmWdao0aN7M0330zVc86bN88aN25shQoVsnz58tkFF1xgzzzzjDu++aXk+J3S72Q99tSpU92+oufUc6sN8+fPD7n+H3/8YR06dHDf//ruq1ixoj3wwAPue9FP+0vp0qXdfvbII4+kajsAOIEAgCxv2LBhAR0OdOnUqVOW2R7eay5fvvxxt23bti3w5Zdfustff/0VyIo6d+4c3EahLq+99lqC9bUdvdtO1pVXXhl8rHXr1gVOBX97Q11y5swZePbZZ9PtOVKyPBJ+/PHHQLly5ZLdFvfdd18gWi1cuDDZtvsv3mf9t99+C36+d+/eHYhGH330UbDds2fPTvX9Dx48GHyNq1evDoTLqdy3kzsuROr1ptd3TiS+71966aVT8jlMj/OIpUuXJvtZvu666xKsf+TIkUCjRo1Crps7d+7AvHnzgutu2bIl2ceuU6dO4NChQwke/5dffgmULl065PqnnXZail/XnDlzArly5Qr5OE2bNg0cPXo05P1ef/3149b/+eefT8nz6rs9ue0zevToFD3niy++GMiWLVvIx7j99tsTrJuS4/fff/+doufV/hfq/mrLK6+8kmDd77//PlCoUKGQ69eqVSsQGxubYP2BAwe627Qt//333xS1B8CJkSkFACEUL17cLrvsMncpV65chtxGXgZJWrLffv/99+DQDvWQqmdTvYzqJVVP8nnnnWeZyZNPPmkLFy50r/nKK690y44cOWI9evSwWbNmWWa1d+9ea9WqlW3YsMFdP/fcc+3111+3uXPn2n333WennXaaWz5u3DjX8xxJSWUvqDf8yy+/DF70XnpKliyZ4LZ33nnHLVfmhff5Vi96NHrppZfc3yJFiljDhg1TfX/1+HuvMbN9XkPJaq83K9Cw1ZtvvtmmT59un332md12223B2z744AN3zPY8/fTTwUwYHcfeffddGzx4sLuuzBZ9D+qvR9+NzZs3d8f8OXPm2L333hu8bfny5W6olkdZWW3btrXNmze768ogfeutt+zzzz+35557ztq3b5+i13PgwAHr0qVLMDNJ7VM71V7R4+m7NlSGVt++fV2bc+XKlYotmLbnPeOMM6xbt2722muvuUwnvdZLL700eLv/GJuULVu2uIxqxZv0Piq7bcaMGS7bWl544QX75JNPguv7j9PeZeTIkcHbL7roouB9k/Phhx/aK6+84v5XVpOec+LEia4NakuvXr1s27ZtwfW1XZSVJ927d3f71RVXXOGuf//99wnaINdff737q22Z2qwxAMlIQeAKQBbNlPIvV4/XxIkTAxUrVnQ9ROeff35g/vz5wXWvueaa4LqrVq1K8PjdunUL3vbJJ58El69cuTJw4403BkqUKOGyUvT3hhtuCKxYseK4NqoXb8qUKYFLLrkkULBgwUCePHkC55xzTqB79+7BddasWRNo3759oFq1aoEiRYoEcuTIEShWrFigRYsWgS+++CLk60oqk0I9yN4yre/3+++/uyyis846y7X7jDPOCDRv3jxBT2yonmNlO1x00UWu17Zs2bKBJ554IsH6+/fvdxkpel3axvny5QtUqFAh0KZNm8B7772XqvfU//xp6bWeMWNGsO39+/cPuc6+ffuO21ahLrJ3797AnXfeGbjwwgsDxYsXd9tN76Pez+eff/64Nid18WdHvP/++65nvHDhwm57Va5cOTB8+HC3HVOb0aHn9cTHx7v90rtN74F64f236/NQr169QIECBdy+qM/DpEmTAseOHUvyOdJ7W3neeeedQP369d063udI1++//37X1uSMHz8++Nzaj3fu3Jngdm1P73a15cCBA+5z6y279tprE6yvnmyvZ1zZBp7Dhw+757rgggvcfq3LxRdffFy2nfg/i8p4ady4cSB//vwuSyYl/PtQUhkp/p50/3vvv98PP/wQuPzyywN58+YNVKlSJfD222+7dfS3evXqIY+Dnu3btwf69esX/CxrH9VxSNkfKaEsDe1Xaos+/6Feo/Z97zh35plnuu3dp0+fYOaXPive6/Fvu9Qc1z16zTVq1HDHLv2dOXNmkhk3SWVKpeZzE+r1nui4kJLXq8+P9umSJUu6NrRr1y6wa9cul/HQsWNH9xnSNu3Ro4fb1xM72WOOf/9Se/X5Of300wNFixYN3HXXXe6zH+o1Jz6GJ7V/p+R7MtT7ps/n1VdfHVyu72zv2LF48WL3/a59TMcXHQ+1b/uPFf4MtsQXr+1JvT9J2bhxo8viTKx27drBxxk7dmxwub73veX+z1mzZs2Cy3WsFGW/fP3118c9duvWrYPr9uzZM7j8rbfeSjLDJzX0ufEeR+0KlRV27rnnHne/Dh06uNv0Pvo/XynNlErr8/p99913wXV1PD4RvTfe+vo8eaZPnx5c3qpVq2QfQ7eHOsYkdwzXuZi3XM/lURu85ePGjXPLli1bFlym/cfb5zdv3hz8HtPxQJ8PPy3TbQ0bNjzhdgCQMgSlAKQoKHX22Wcfd7Kpk3rvxNQfxHjooYcSnCQrMOT9qPV+3H/wwQfuBDfUSayW63aPTgj8J5ahfsgnPtlJfMmePXtgwYIFx72u1AaldBKj1x3qvjqJefrpp5P8caw2JL7P3Llzg+t37do1yXbppDScQSkFD73nLlOmjBs6oB/aoaQk0HKi4RIjRow4bpslF5QaMmRIkusokJB46EVqglKyYcOGBO+XhgR5brvttiSf++abb07yOdJ7W8miRYtC7lfexR9MC+Wyyy5Ldoiefqz7h3x4AQvvB6B+9PqHNyjQ6q3rBV31+U1qWI0uCp75ecs1pEI/1r3r4QxKKejgf27v8z148OBkj4Oi4b4KWKfk2JYU/WD27jNq1KjjhhEpUJbU9lTQXFISpDnRcV3efffdkENwatasmaqgVGo+N8m9p0kdF1LyehV8S3xfBWMUIE28fNCgQQnakB7HHH8AONQ+orakNSiV0u/JxEEp/RD3gh663HrrrcEg4XPPPZfk8UWBWm8/ORVBqaS0bds2+DhPPfVU8Djl/4z5h6LpeOndds899yT72AMGDAh5PNQ28ZZrHXUuKbCu4KaCV4mD+Um5++67Qx7HdZz2nw/5H++zzz5zyzR0UAHntASl0vK8Hu0LmzZtch0lKQ0mJe6o9A+Z0/HRf5xNyvr164P7no7FiYPEoY7h2pcVjPWW+0svqA2Jh376O2W6dOmS4PFjYmKCtykg56dglBecS2q4JYDUYfgegBT5888/XeFHpUarsKfExcUF05dVjLRAgQLuf6WFe7744gvbsWOH+19p+Eqh1jCc22+/3Q2Pkp49e9qnn35qd911l7uu5brdG66jVHGl14uKVo4aNcpmz57t0ubr1KkTfC4VHx0/frwrsrpgwQKXyq8hRxrWocKXKugpXbt2danhoYb4eMN7ksgsdaneet1y4403uvTzIUOGuELZul0p9hs3bjzuvpo565prrrGPPvrIpf57VGzVo7RxUUFjtUMp9Upx15AFDeEJJxW89t7PTZs2uaKnGtJ4zjnnuPT3H3/8MbhuixYt3LbTdvT4U/C9901p8N6QBw27UFq9hlHJ448/7tLhvaFYtWrVSjADmfdYpUqVckMrtA+IrmsbaX9QEVjvuZWufzJU5Ns/VEBp/KL35dVXXw3ubxpWovf0kksucctmzpzpLklJz20lem6vYKwK/Gqf17oanqEitieaAe2nn34K/u/f5v5hHNoWiddXUVg5ePCgffzxx8Hbvc+Phv15+7mKFXvDarSdNBxS62n7yWOPPWbLli077rk1pEKPM23aNPf5v+OOOyxcVERb21vHO+916PP98MMPu0LBes0aJpb4OCg6jnkzM+mzq31TxyFNFqBjm44/SQ1F9Pz888/B//WZ89PQSg3HkXvuucdtW21PtU1DXFIz692Jjuua7EDHtP/iIOaGMOmY16dPH/vhhx9S/Dwn+7lJyXEhJVQoWfubnss7vun90X79/PPPJxii6j82p/cxZ+fOna6osr6rNJmEPvNeW7Rd0iKl35OJ9e/fPzhUTe+vho3q+0zH/d69e7vji7aV2qnH13eg/Prrr/bQQw+5/3Wbf0iXhsV5782gQYMsPT+X+m4X7efNmjVz//sLYKuItzfsWPS95Vm3bl2Sj63Ppn/b6zWEOk7q+LtixQrbv3+/bd261e0zmu1R10/E3069/x6dF+lYm3g9Da++8847g8MT0zrUOLXP69HnU9tS34Ua3qdtruHe2v/T+pz+90Pv565du0Le318MXcdMFWY/ET2Wvzh5Us/r7QdJtTGp9RMfk3UcT+2sqACSkMogFoAsminlLyrqz4rq27dvyJ4rr9CsehG9Zd98841bpqFo3jINUfLTde+2WbNmuWX+HvnkCk+rx0pDQTSMRb39iXv3lXJ9ot5mT6hMKQ1L9Japh9Sf0q1hh95tGg6TuKdbWWIqxCtbt25NUEjTo8fUMr1e9cx566dUchlg/ktKi+xqyI6GloR6DA0ZUgZFagocq3BzkyZN3DAQFYZN/JgaLpWSgsbq7fZn5XnFjf2FoU80FOFEmVLiz554+OGH3TJ9DrxlTz75ZPC5lVEQqhc5rYXOU7qtHnzwweAyvV///PNPIDX0Pnr3VyHcUDQUKPF2+PPPP4Ofr+uvvz6Y4eX1bPszPvyfXw2D8bbZyJEjg8t79+4dXN//Oj///PNAaqVHppQuKoYuy5cvDy5TdoSXGabtnfg4qIwNb7vo8+y9Vl00DC/xMKKUDH1JXOT8mWeeCd6m4522eygpyRw60XHdP7wl8THPv1+cKFMqtZ+bpCR3XEjJ69Xwbk/Lli2Dy5UF5dHwRG+5NxQyvY45oTLaRFlZ3nJlzKYlUyql35P+7aGMH+9/DSX0v7/6HvNnkXivWcP59Dnwshm9rKr0LnSemIZIaiiv9xz33ntv8Da1yVuuSRv8XnjhheBtytgMRa/Bn8mn73M/f4adhrAqQ0vff/59XZ9FUXaO/3Ovi3cs8TJsdNFQVj8N6U+cmavhuLqu7DBPUplS6fm8nrp16ybYZ/VdpCGOSR1z/PxZmF6Wuret/Y+pYZqJ6dzHy7DXd4q+b1JCGc7+x/YPX1eWr7dc72fi7PShQ4cmeCxlP3q3JR5m/sADDwRv0zESwMnLkVSwCgD8vOLPXk+kxz8tt7JpvAKT6hmvUaNGsEi0epbq1q3r/v/tt9+C9/GW+TN0NG2xfz3/+uqlS67HN7kCnCc7hbi/HZrWWNMk+9vtZYj51/P3OCpjK7ntp+wwTTOsDARlBqiHsnLlynb11Ve7aahTmg2QXpQJpmwQZewok+3rr78OZomp8KuKmHpFP0/kvffesxtuuCHZdVL6/vi3r7KDdEkstVNlh6JMAY/XQ+1/bmWLnCjLJS1Ss62UsaQMDRXwVZaD18Nbv359l7GjabCTo6nQlbUhXkZjYv7l3naIiYmxevXq2VdffeWyMdRjrHZ7Pds6Fnj820xTaqd0m6lnvEmTJhYJmgbdy0zzZxIoy8fLsNEEAInfD00t7mUVKYvi8ssvP+l9xHs8jzK1lH3y77//uiwmXZRJqWOpMgq8/SA9juvKpErqmKfCx998802Kniccn5uU0HHa439flWHmSfy+ap9P72OOntufAedvl3+bp0ZKvyf9lPEjFSpUcJln/vfX/3jKnvIK7yfOZlTx77POOstOJX3vKNNYmdeifXzs2LHB2/Pnzx/831/MXLys0sTr+TOkbr311mCmnj6zXlafx/vuFh2blS3sFSDXZBiiguDKXHzxxRdtxIgRCe7fqVMnV1A9Ne3U/vTUU0+5z7Yy0U4kvZ7XT1mqyj5S9rcywnQOoOw+ZYIqezA5ST2n//lCPadoX/S+d5Sxpu+blEj8WHpeL8Mq1OtM63ZJfEwGcPIYvgcgRfzDx5TyHerLWTNEabYTLyi1ZMkS98PMP9znRFIz9CTxCYROoLz2Pfroo27Yk4YPeD8yTuWJxInanZLtp+EWGtaiE279+NVj6oeagg5NmzZ1gaDkeMMSE89C5h9KcaIhiolpmJl+RCrwoB/BOsH1Xqt+jHjv74no5NqjWZA0LE1t8QcdvIBGetC2SnySmRpK1/dmWkpqaFtSTjQ0Kz23lWZPUhBX75GCEvoBvX37dhcM1tAW/YhIjob4JR6i6KeAlX84qn99L/CkYSsKWnr7lU7gW7dunarXHGqb+YdPhJt/mIyGMvmDeKGk9thyon3EHxhJPLxFn0m95xp2p6CxgklaR59RBf00fDOlUnJcOtljc7g+N5F+X0/mmBNq2/qXaRilR4GQ9OINc9MwJg2zjcb3Tfu2guteQErnEhpe6h+ip6CaR99T/u9K/3dU4uCGhh+rY8ULSDVq1MjN8ucNp/T4Z+DV8PpQ//uHjSXF307/DHBqr9rtX0/t1nFer1+fee0PuviHi1WrVi1F302peV6/888/3wWudazXsGEvwKNgZqjOt5Q8p//9UPA/VGkCDVX0eAHAlNBj+T/LST2vtx8k1cak1g91TPYfqwGkHUEpAOlGJ/le/RXVYFCNE48/c0LZP55vv/02wWP4r3vr+df3TyHspxMrnWCKaqPoB5vqPJx99tnBTJCkTvpTGgzxt+O7775LcOLrr4njXy+1vKmm1Uuq3mFlK8natWtPeBKoE2dvSnT/tOj6ce9f7s8KSIp+pPjraIh60dXzqhPJUD+W/D/yEm9Tf9aRen0VYFGmjX+5X3KP5d++6r3/v0k7Elz0Q8nfu50aur+mB/d+kOqHh1f7xv/cCnqGeu7//e9/J3yO9NpWej5lJOoHpbJWlNnhBYf0uOrVTo4/eKRtmThbbcqUKcEe42LFirl2eBQ89TIr1Iu+ePHi4GP6e5b920xZIKG2mVdzKpxBkFNB2S9euytWrOiOEYlfq7Zn4mnGE9OPTY+yr/z0GNonFXhXsFJBCn/WgjLW0oteg/+Y5/+8L126NMWPE47PzamU3sccfSf531f/94e+sxIH0Pw/kBV8PFEbk/qeTEw1obwf1frOVKdIqMcbNmxYkq/Zqw13Kt4bBQoUFPHOC1R/8rXXXksQQPUyz7zPjD5z/s+Dfz/1Zy6qXpNqgnk18ZSBqO0WKnNHmaeeDRs2hPzfq703fPjw47aTOnPEq0Mn/g4Dtdc7n1BHQ1pqSKbn83o165I7Jp8oszmp5/S/H/51/J0j3jo6/ihTPKXUPv97ldTzevuB//l1u/edr+9a773VNtF3rJ/32dW+4g9MAkg7hu8BSFcKPk2YMMH9r541UQaHf6iCsn7Uu69AknrcVExVJ4fKtvCGE+hE2csM0WN6RXX79evnMkFUuFUnDsqO0smEilSqF0+BqTVr1rjlWqbso6ROkHWyoR8HyohRoVedXOg+3rCdxNQjqRNfZS9t2bLF9dgqk0U/KLxhirly5Trh0Kuk6GRKw/Y0lEOFRRWU8geGTibzJ7V00qX3ST3HGgqi160TNg1R9HoJlRXnLwau7ekVBFUw5cILL3Q/rBQc07b1gmpDhw51WTz6cZE48OV/LI8K9apAeN68eV1ArX379sFefe0Peg/Vo6uTZP2wVWaRnk/DGVJK+4xOaBWMUxFXfyF8Fc/3fgTpPfcK0mvIh4ZRaX/RUIPff//d/ahRZpp+xCUnvbaVijYvWrTIfX4UlNRJslfsOCX7TPfu3V1mll63Po/6Afjggw+6QKa2o167R6/JX2xWn2G9VhXJVqAhVADa22be51f70v333++G++gzpOCrtqeCgPosZXT6caxtomOZ9kVNAKFhuRrypwwHBXYUNNIxK3FWgp/2B+94tmrVqgS3KXCgIsAK/qkHX/uNV/w5vY8TGrKnH9vKltNxUoXb9X5qH0vp0L30/twkdVw4lU7FMUePqQkJNBRq0qRJweUKjojeWwV69P2l91cBJO1HCkaGkpLvycQUAFPgWsd57Tf6DCorp0GDBq5DRMcCLddz6vioIZvKjNSxS595BS+873n/e6MsaWUcqb0Kbul4omOMl3Gi44yOW8lR+xU80P4haqO2mYYMe3TM87KYVBBcw+ekW7duLvCrz47eG9ExxxvWqHbr/MLbh/VeahisP5jlPxfQPqtONm0LfQfqu1rbyT+MMyXf+xqCqO9NfZbULn0O9FnXcd7jFTbXOVOo4vl6Xd538MCBA48LmJzs84o+T+qIUdBG21fvhbKXvGCVPnP+wHko2mZqqwKX+k6tWrWqa8N9990X8jn9HSEeBSGT6pzQvuqVi9C+qE5I7zG174m+V3R/BXW94uyacML7jtK5ls65dFxW4X4NxdQ+ou89L0Cl47d/WKs/q1jntv6MPQAnIR3qUgHIAoXO/YVsT1TQ1Jsu3l/YNrH3338/wVTEyU2bruKr/gKniS+eXr16HXdbpUqVXJHxxOsmLk6e+PWEKnQuKmqpIuqh2qECx08//XSKtlOoQrWhpiv3LtWrV0/11MPe86el6OzcuXOTbEuofUJUeDbxOl7BYX9RaO+SJ0+eBIXt/QWnJ0+efNz6/m2V3PTsKX3N/oKxSe2HKiqdWHJT2yfeX5IqaJ5e22rUqFFJtkMFYpcsWXLC7aBJCfzFbkNd/BMa+M2cOTPBevqsaZpxv0OHDrkCwyndl0K93+EudO6/X1IFtJP6fKvg8FlnnZXs601cpDsU7/ikCRr821RFd5N77OnTpyfb7tQe11XQOfGkEbqcd955IR8nqX0+NZ+bpCR3XEjt601qH0iqmHp6HHO8dVUg3Cvk7L9ocgN/ceZbbrnluHX836/+/TSl35Ohtsfrr7+eoG3eRCUqRO9NXhDq4t/O2ke9yTpCfbaTen+S4t8fU7LP6PmTOs6oOPm8efOC6/rbktL3c8qUKUmu265duwTvW3I0oUSuXLlCPk7Tpk1P+D2fVKHz9HzeE303alukhIqqhzp26HL77bcft74mFvCK6OfNm9dNHJGUpD6/iW/zX9SWV155JcG6mlRG+3yo9TURjTexhcc/8YUK3gNIHwzfA5Du/JkSyjDxhvT5qTdYPbfqjVUvqtbT8CDVd1DKtTIMPOqlUs+XaiSpZ0s9XcoiUE+iekQ948aNc72dKgiudfQYGhakXr1QlCGiGix63pTyCrFrGJuyhNRu9RArxVw9kOrZSyv1emq7qMddNS30upVNoZ4/9ZSHs0dOvaTKHlNmhNL6lRWj16oMNr1WvR+JM1uU5aDMG/WGJu7d1PusKdbV86z3Tj34Goaixw5FPZYaTqJeWv+wEI96YDXsQm1R27St9H6oZ1e9+okLvqaEHkP7gnqJVTRfGXFeEVs/9c6qEK56+5Wlouw4tVM9+dpHVWD8RNJrWylTRG30hl5oH1G2jrLclM3iH8qQFGVnKVNMWYXqPVd2g7c9NURPvdBJTXevz5i/hoc+64mH1mj7qP3e51ePr9elrAlleKkHu02bNpZZaF9Qz7smJ1B2gF6rXrP+1+dJmWXeUJ/kdOnSxf1VVoQ/E03ZKsoIURaTPo96z7UfKqtEtXFCHW9Pho7JGlKsemJ6L5UhoZo+2t89iWvwhJIen5sTHRdOpfQ85mgItLIx9VjKbtRnVsd5ZdH5jwfKotRnUOtom2n/8YbJJpbS78mkMtm8rBkVL1fWmrLj7rjjDvd82geUOaTPtv7q8YcMGZKg9o9u076t7eFNBhBOen5l3GmyEH3WNJRS21XHKJ1T+PfXtND+qfdf+6+3bVUqQBl0+q5M6XBjHZvVHmUv6Zitduozpayrjz766JR9z6fmeZXNpPWVXab19FnVucgtt9zi9oeUfFa9Y5i+h7TttU/oXEyZSRru7dUA9dNwQ2XiiZ7LPxlBaihjURlXym7X+6TvKLVBWX36DPlpHWXIKQtP56J6rfpuUkav6pgl3pe94dHaLmojgPSRTZGpdHosAAAApAMN29Kwoh9//NEFz71izOGm08RQP7gVuPZqIWmYlH5sAkBmpZkaFZzTMEh1QPqDsgBODplSAAAAUUaZQF6NJdWx8RdVDidl9CgjQBkPqoulukWaEcsLSKnQtTJGACAzU8aoAlLKklKNNwDph0wpAAAAhKSC1Cp8HYqGtmjYsjc7JQAAQGqRKQUAAICQNEOb6gRqenbVjlKWgOoUafiKsqYISAEAgJNBphQAAAAAAADCjkwpAAAAAAAAhB1BKQAAAAAAAIRdDssCUyprpgQV4ww1pTEAAAAAAADSTyAQsLi4OCtdurSbVTjLBqUUkCpbtmykmwEAAAAAAJClbNy40c4666ysG5RShpS3IQoWLBjp5gAAAAAAAGRqsbGxLkHIi8lk2aCUN2RPASmCUgAAAAAAAOFxojJKFDoHAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYZfqaUil17NgxO3LkSKSbgSiRK1euZKetBAAAAAAAJyfLB6UCgYBt3brVdu/efZKbEpmJAlIxMTEuOAUAAAAAANJflg9KeQGp4sWLW758+U5YGR6ZX3x8vG3evNm2bNli5cqVY58AAAAAACCzBaUWL15sjz/+uK1cudIFAGbNmmWtW7dOkMU0bNgwe+6551zgqH79+jZ16lSrVKlSug3Z8wJSRYsWTZfHROZQrFgxF5g6evSo5cyZM9LNAQAAAAAg04lo0Zx9+/ZZzZo1bcqUKSFvf+yxx+zJJ5+0Z555xpYtW2b58+e3Zs2a2cGDB9Pl+b0aUsqQAvy8YXsKXAIAAAAAgEyWKdW8eXN3CUVZUpMmTbLBgwfbdddd55a9+uqrVqJECXv//fetXbt26dYOhuyBfQIAAAAAgPCK2ppS69atc/WeGjduHFxWqFAhq1u3ri1dujTJoNShQ4fcxRMbGxusE6SLn64r+OVdAI+3T4TabwAAAAAAQNJS+js6aoNSCkiJMqP8dN27LZQxY8bYiBEjjlu+Y8eO44b9afieNpTqBumSEaz/Z59lJk+Oe9Tmzf7EPpz3pUWTY0cO247YAzb2hS/sn/0ZY98AgKzohU51It0EAAAAJBIXF2cZOiiVVgMHDrT+/fsnyJQqW7asK1xdsGDBBOsqSKUNlSNHDnfxxAz8NKxtXjemRYrXPfh/JY4G97vL4mL32BMvvGEZxflli9ik5163hle3DC7r2L233dS5e/B1RYtAvNmR+Gz2v1izzXHMyAgA0UqTlQAAACC65MmTJ2MHpUqWLOn+btu2zUqVKhVcruu1atVK8n65c+d2l8SyZ8/uLomXqZ6Ud4mU1Dx34kGGGW3QYSBRm/PmP93y5o++1+G1M2DZLN4ISgFAtEr83Q4AAICMc44WtWdyMTExLjA1f/78BFlPmoXv0ksvjWjbos3tbVvZo0MfsImPDLXLz42xhhdUsakTHg3e/mDvO2xAz67HDV288vyK9tE7M9z1w4cOuce4qlYlq3NOSet0/dW29vtVCe7zx68/W+/ON1u9auXs0qplrfP1zW3j+nXuNq3bo30b95j1q5ezrje2tJ/X/BC8b/NLz3d/+3XraDXLFgleVztvanZ5cD0Np3xm0mPWpE4Nu6hiCXfbVwvnBW/ftHGDu/+8zz6y22+6xupWKm1tm15mP6z8NrjO5r832N1d2tll51awupXLWJtGl9qXCz5Pt+0NAAAAAABOXkSDUnv37rXvv//eXbzi5vp/w4YNLnuob9++9vDDD9uHH35oa9assdtuu81Kly5trVu3jmSzo9JH70y3vPny2+sfzbN+D42wZyc9ZksXL3S3tWjT1hbPm2379+0Nrv/1F/Pt4IEDwaF0E0cPs3mffmQPT3zaZny6yMqVP9t6drzB9uza5W7ftmWzCzTlypXbnpvxgU3/dKG1vrmjHTv2X72lffv22jU3trOX3/vMXvtgrpWLqWi9Ot1k+/b+N470jY8XuL8jx0+x+St/CV5P7I0XnrHXpj1l/QePtHc+X2KXXtnQ+tze3v5a978E6z312MPWqUdvmzlnsZU/+xwXePPqgo0ePMAOHzpsL739ib079yvrO3CY5cuX/xRsdQAAAAAAkFYRHb63YsUKa9CgQfC6VwuqU6dO9vLLL9v9999v+/bts+7du9vu3bvtsssus9mzZ6d4bGJWUqlqDbuz3wPu//IxFW36y8/Zsq++sEuvaGD1rmxkefPls/mzP7Zrbvhv1sLP3n/HrmxyteU/vYDt37/P3nrtRRs1fopd1qCJu33oY0/Y0ksX2ayZr1nnO/vYzFeet9MLFrSxU16wnDlzunUqnH1O8Pnr1r8iQXuGjp1kl9WoYCu++cqubHy1nVH0TLe8QMFCdmbxhMXr/V559inr0vMea37dDe66AmzLv15ibzw/1R56ZFxwvdt69LYrGjVz//fs/6Bd3+hS27j+T4s5p7Jt3fS3NW5xrVWqVsPdflb5Cum0lQEAAAAAQKYISl111VUWCCRdTUjZUiNHjnQXJK/y/wVgPMWKl7Cd//zj/lcR96atWtuns95xQSkFoRZ+/pmNnfK8u/3vv9bZ0SNHrFadusH7K/B0bq0L7M/ff3PXf/1pjV1w8aXBgFRi/+7Ybk89/oitWLrEdv67w44di7eDB/a7AFFK7Y2LtR3btlitiy5JsLz2RXXt15/XJny9Vf//6y1W/L/6Yzv/2eGCUu279rBHHrrXli5eYHUvu8oat7jGKlc7N8XtAAAAAAAAp17U1pRC6uRIFCxSQC8QHx+8riF83371hf37zw5bOOcTl21W/6rGKX783HnyJnu7ZgP89cc1dv+IMfbKrDn21uzFVrjIGa521Sl/vf9XKD7+/wKc199ym33y1XfW8vqb7fdffrJbWja0N1+adkraAQAAAAAA0oagVBZR66K6VqJ0GZvz0Sz7dNbb1qTldcGsp7PKx1jOXLns++XLgusrmPTjD99ZxUpVgplYq75dmmSQ6fsVy+yWrt3t8oZN7Zwq1SxX7ly2a+e/xwWS4uOPJdnG0wsUtGIlStn3K75JsPy7Fcvs7P9rR0qVLH2W3XRrV5v43Gt2W/de9t6br6Tq/gAAAAAAIBMP30N4tbjuRnv79Zdsw59/2HMzPwwuVxFwBXAmPDLMChUuYiXLnGUvT33SDb9r0+5Wt067zt1s+kvT7IFet9vtvfq5+lKrVy2382pdaBUqVrJyMWfbx+++ZTXOr21798bZxIeHWp5E2VWlzypny5Z84QJkKphesHDh49rY+c67beqEMS5QVrXGefb+W2+4oYNjJqc80+mx4QNdFpgKoMft2e1qUsWck7qgFgAAAAAAOLUISmUhGsL33OTxVvqssla7TsK6Tfc8OMzi4+NtUN873Ux61c+vZVNffzcYONJQvOdmfmATHh5mXdu2stNOO82qVD/Xav9f/afhj0+2UQ/0tXbNr3IZWX0eGGITHh6S4DnuHTLKxo8cbO9Nf9WKlyxlny1dfVwbVQ9KtaXGjxrialMpU+vJF950xdtT6tixYzZm8ADbtnWzK+Re/6pGNmDY6DRuNQAAAAAAcCpkCyRXaTwTiI2NtUKFCtmePXusYMGCCW47ePCgrVu3zmJiYjLMjH6r/94d6SZkCYGjh2375r9t+MLttiku6SGHAIDIWv9oS94CAACADBSL8aOmFAAAAAAAAMKOoBQAAAAAAADCjqAUAAAAAAAAwo6gFAAAAAAAAMKOoBQAAAAAAADCjqAUAAAAAAAAwo6gFAAAAAAAAMKOoBQAAAAAAADCjqAUAAAAAAAAwo6gFKLe8qVLrGbZIha7Z0+kmwIAAAAAANJJjvR6oExleKEwP1/qgi07//3Hnh432r5c8Ln9+88OK1iosFWudq716DvAate5xK2jIM7E5163hle3TNVjN7/0fOtwe0/reEdPOxkfvPWmDb23l/s/e/bslr9AASsfc45d3qipdejawwoULHRSj/34iIG25Me/TqqNAAAAAAAgcghKZUD3dr/Njhw5YqMmTrWzypW3f3fssG+/+sL27Npp0eT0AgXsg0XLLRAIWFzsHvt+5bf24lMT7YO33rBX3pttxUuWinQTAQAAAABAhDB8L4PRELZV3y61vgOH28X1LrfSZ5Wz82pfaLf37m9XNW0RzHaSft06uowp7/rG9evsnq7trUHtynZJlbOsfcuG9s2Xi4KPfXvbVrb57432+IiH3P108eg5O1/f3C4+p5Q1vbiGPTr0Adu/f1+ybc2WLZudWbyEFStR0s6uVMWub3ervfL+HDuwb59NHD0suF58fLy98NQEa16vpnv8tk0vs7mffJDkUD5lYMXFxgbbOHXCo+62j96dYbe0aGCXVi1rDS+oYg/2vsNlkgW33e7dNvDubnZVzXPc81xz+YX2/sw30vhOAAAAAACAk0FQKoPJlz+/5ct/ui2c84kdPnQo5DpvfLzA/R05forNX/lL8Pr+/XvtsoZNbNr0923m7C+s3lWNrE+XW2zLpo3u9gnTXrMSpUrbXfc+5O6nixfMuuvWtta4xbX29twl9tjTL9p3y7+xMYPvT3X7i55ZzFq0aWtfzJ1tx44dc8sUkPro3Zk2ePQEe2/+Uut4x1320D09bMXSr467f60LL7b7h49xWVheGzv16O1uO3rkqPUa8JC9PedLm/T867b57w02tP9dwfs+Ne4R+9/vv9qUV9+2WQuX2aDR463wGWek+jUAAAAAAICTx/C9DCZHjhw2asIUG3H/Pfb26y9ZtfPOtwvr1rerr7ve1ZWSM4qe6f6qbpMylTxVqp/nLp7eAwbZgtkf26K5n9ktnbtboSJF7LTTTrP8p5+e4H4vTJloLdrcGKwzVT6moj0w4lGXWTV49HjLnSdPql5DhYqVbN/eONu9a6cVKFDQnn9qok2bPstqXnixu/2s8hVc0OudN16yiy6tn+C+OXPlstMLFAxmYfm1adcx+L8e44ERY619q4a2f99eF8jbuulvq1rjfKtRs7Zbp0zZcqlqNwAAAAAASD8EpTIgZSxd3rCpG1K3etUK+2rRXHv5mSdt2GNP2nU3tU/yfgrOTJ0w1hVI/2f7Vjt69JgdOnjABWuS89tPa+23X360T2e9E1ymOlEadrdp419uaF6qBALujwJLG9b/aQcP7Lce7a9PsMqRI4ddACk1flr9vU2d+Khrr4Y5qn2yZdPfVrFyVbvptq52b/dO9svaH+zSKxpYg2YtrdZFdVPXdgAAAAAAkC4ISmVQyk5SYEUXzbo3fEAfmzphTLJBqfEPD7FvFi+y/oNHWbkKMZY7T167785Ormh6clQ76sYOna19lx7H3VaqzFmpbvuff/zmht8VLnKG/b1hvVv21Mszjyt8nit3rhQ/ptrYs+MNVu/KhjbmyWlWpOiZLhilZd7ru6xBE/vsm9W2ZMFcW/rlQuverrXd3OkOu3fIqFS/BgAAAAAAcHIISmUSylZSnSlPjpw5LT7+v5pNnu+XL7Nr27a3Rs1bBTOnVHfJL0fOXMFaT55q555vf/7+q5WLOfuk26nC45+9/47LUsqePbtVrFTFcuXObVs2bzxuqF5ScubMaceO/ZcF5Vn/x+9uOOA9A4dZydL/Bcp+XP3dcffV0MZr297iLm9f/JJNfGQYQSkAAAAAACKAoFQGo8DLfXd2ttY3d7DK1WpYvvwF7KfV37nhe97se6JZ+ZYt+cINT8uVK7cVLFzYysVUtPmzP7Irm1xt2bKZTXl8tMXH/zeUzn+/Vcu+tquvvd4Fi4qcUdS63HWP3XptUxs9eIBdf8ttljdfPvvzt19dttFDDz+eZFs1xO+f7dvc37jYPfbDyuWuqLlqQt3z4H+z7+U/vYB16t7bxo0YZIH4gNWuc4ntjYu171Yss9NPL+CCR4mVLlvOBdT0+ipXP9fy5M1rJcuc5epNTX9pmrXt2NX++PUnm/bEuAT3mzJutFU/r5Ybynf48CFbPH+OxZxTOR3eFQAAAAAAkFoEpTKYfPny23m1L7TXn59qf/+1zo4cOWolS5dxwaI7evcPrqchaeNHDrb3pr/qhsV9tnS13Tf0ERt2X2/r1LqZm3WuS897XMFxv173DbRRD/azVpdf4Gb3+2HjLldA/YW3P7bJjz1sXW5o4YJMZctXsGbXtEm2rXvj4qzRhVVd7SgN1yt/diW75sZbrMPtPVxgKvicAwa54XYqqK7hfCrQXu3cmnZH734hH1eBtrYdu9j9d3V1Qbo7+z1gPfs/aKPGT7EnHxtlb740zWV39R880u7p+v+HM+bMmcueHDvSNm/c4IY/XnDxpTZ2ygsn8W4AAAAAAIC0yhZQhCETi42NtUKFCtmePXusYMH/HwiRgwcP2rp16ywmJsbypHIGuUhZ/ffuSDchSwgcPWzbN/9twxdut01xCYczAgCix/pHW0a6CQAAAEhFLMYve5K3AAAAAAAAAKcIQSkAAAAAAACEHUEpAAAAAAAAhB1BKQAAAAAAAIQdQSkAAAAAAACEHUEpM4uPjw//lkd0c5NSBiw+U89NCQAAAABA5OSwLCxXrlyWPXt227x5sxUrVsxdz5Ytm0WzwNHDkW5C5hcI2NH9sRZ38JjtOkDAEgAAAACAUyFLB6UUkIqJibEtW7a4wFRGsH3XgUg3IQsIuIDU1BW77eAxUqUAAAAAADgVsnRQSpQdVa5cOTt69KgdO3bMot0d7y2KdBMyPQ3ZU4YUASkAAAAAAE6dLB+UEg3Zy5kzp7tEu01x0R84AwAAAAAAOBEKnQMAAAAAACDsCEoBAAAAAAAg7AhKAQAAAAAAIOwISgEAAAAAACDsojoopdnwhgwZYjExMZY3b16rWLGijRo1ygKBQKSbBgAAAAAAgMw6+97YsWNt6tSp9sorr1iNGjVsxYoV1qVLFytUqJD16dMn0s0DAAAAAABAZgxKff3113bddddZy5Yt3fUKFSrY9OnT7dtvv4100wAAAAAAAJBZg1L16tWzadOm2W+//WaVK1e2H374wZYsWWITJkxI8j6HDh1yF09sbKz7Gx8f7y4ZXXZj6CIAAJ7M8N0OAACQVc/Rojoo9eCDD7qgUtWqVe20005zNaYeeeQR69ChQ5L3GTNmjI0YMeK45Tt27LCDBw9aRletCEEpAAA827dvZ2MAAABEmbi4uIwflHrrrbfsjTfesDfffNPVlPr++++tb9++Vrp0aevUqVPI+wwcOND69+8fvK6gVtmyZa1YsWJWsGBBy+h+3pUt0k0AACBqFC9ePNJNAAAAQCJ58uSxDB+UGjBggMuWateunbt+3nnn2V9//eWyoZIKSuXOndtdEsuePbu7ZHTxRlAKAABPZvhuBwAAyKrnaFF9Jrd///7jXoiG8VE/AgAAAAAAIGOL6kypa665xtWQKleunBu+991337ki5127do100wAAAAAAAJBZg1KTJ0+2IUOG2F133eUKmaqWVI8ePWzo0KGRbhoAAAAAAAAya1CqQIECNmnSJHcBAAAAAABA5hHVNaUAAAAAAACQORGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYRX1QatOmTdaxY0crWrSo5c2b18477zxbsWJFpJsFAAAAAACAk5DDotiuXbusfv361qBBA/vss8+sWLFi9vvvv1uRIkUi3TQAAAAAAABk1qDU2LFjrWzZsvbSSy8Fl8XExES0TQAAAAAAAMjkw/c+/PBDu+iii6xt27ZWvHhxq127tj333HORbhYAAAAAAAAyc6bUn3/+aVOnTrX+/fvbQw89ZMuXL7c+ffpYrly5rFOnTiHvc+jQIXfxxMbGur/x8fHuktFlt0CkmwAAQNTIDN/tAAAAWfUcLUe0vwhlSo0ePdpdV6bU2rVr7ZlnnkkyKDVmzBgbMWLEcct37NhhBw8etIyuWhGCUgAAeLZv387GAAAAiDJxcXGnLih19tlnu6wlzYjnt3v3brvgggtchlN6KFWqlFWvXj3BsmrVqtm7776b5H0GDhzoMqv8mVKqS6Ui6QULFrSM7udd2SLdBAAAooaG9wMAACC65MmT59QFpdavX2/Hjh07brmGzW3atMnSi2be+/XXXxMs++2336x8+fJJ3id37tzuklj27NndJaOLN4JSAAB4MsN3OwAAQFY9R8uR2sLjnjlz5lihQoWC1xWkmj9/vlWoUMHSS79+/axevXpu+N5NN91k3377rU2bNs1dAAAAAAAAkHGlKijVunVr9zdbtmzH1XTKmTOnC0iNHz8+3RpXp04dmzVrlhuSN3LkSIuJibFJkyZZhw4d0u05AAAAAAAAEOVBKa96uoJDqil15pln2qnWqlUrdwEAAAAAAEDmkaaaUuvWrUv/lgAAAAAAACDLSFNQSlQ/ShdNxexlUHlefPHF9GgbAAAAAAAAMqk0BaVGjBjhajxddNFFVqpUKVdjCgAAAAAAADilQalnnnnGXn75Zbv11lvTcncAAAAAAABkcdnTcqfDhw9bvXr10r81AAAAAAAAyBLSFJS644477M0330z/1gAAAAAAACBLSNPwvYMHD9q0adNs3rx5dv7551vOnDkT3D5hwoT0ah8AAAAAAAAyoTQFpVavXm21atVy/69duzbBbRQ9BwAAAAAAwCkJSi1cuDAtdwMAAAAAAADSXlMKAAAAAAAACHumVIMGDZIdprdgwYKTaRMAAAAAAAAyuTQFpbx6Up4jR47Y999/7+pLderUKb3aBgAAAAAAgEwqTUGpiRMnhlw+fPhw27t378m2CQAAAAAAAJlcutaU6tixo7344ovp+ZAAAAAAAADIhNI1KLV06VLLkydPej4kAAAAAAAAMqE0Dd+7/vrrE1wPBAK2ZcsWW7FihQ0ZMiS92gYAAAAAAIBMKk1BqUKFCiW4nj17dqtSpYqNHDnSmjZtml5tAwAAAAAAQCaVpqDUSy+9lP4tAQAAAAAAQJaRpqCUZ+XKlfbzzz+7/2vUqGG1a9dOr3YBAAAAAAAgE0tTUGr79u3Wrl07W7RokRUuXNgt2717tzVo0MBmzJhhxYoVS+92AgAAAAAAIKvPvnf33XdbXFyc/fjjj7Zz5053Wbt2rcXGxlqfPn3Sv5UAAAAAAADIVNKUKTV79mybN2+eVatWLbisevXqNmXKFAqdAwAAAAAA4NRkSsXHx1vOnDmPW65lug0AAAAAAABI96BUw4YN7Z577rHNmzcHl23atMn69etnjRo1SstDAgAAAAAAIAtJU1DqqaeecvWjKlSoYBUrVnSXmJgYt2zy5Mnp30oAAAAAAABkKmmqKVW2bFlbtWqVqyv1yy+/uGWqL9W4ceP0bh8AAAAAAACyeqbUggULXEFzZURly5bNmjRp4mbi06VOnTpWo0YN+/LLL09dawEAAAAAAJD1glKTJk2ybt26WcGCBY+7rVChQtajRw+bMGFCerYPAAAAAAAAWT0o9cMPP9jVV1+d5O1Nmza1lStXpke7AAAAAAAAkImlKii1bds2y5kzZ5K358iRw3bs2JEe7QIAAAAAAEAmlqqgVJkyZWzt2rVJ3r569WorVapUerQLAAAAAAAAmViqglItWrSwIUOG2MGDB4+77cCBAzZs2DBr1apVerYPAAAAAAAAmVCO1Kw8ePBge++996xy5crWu3dvq1Klilv+yy+/2JQpU+zYsWM2aNCgU9VWAAAAAAAAZMWgVIkSJezrr7+2nj172sCBAy0QCLjl2bJls2bNmrnAlNYBAAAAAAAA0i0oJeXLl7dPP/3Udu3aZX/88YcLTFWqVMmKFCmS2ocCAAAAAABAFpXqoJRHQag6deqkb2sAAAAAAACQJaSq0DkAAAAAAACQHghKAQAAAAAAIOwISgEAAAAAACDsCEoBAAAAAAAg7DJUUOrRRx+1bNmyWd++fSPdFAAAAAAAAGSFoNTy5cvt2WeftfPPPz/STQEAAAAAAEBWCErt3bvXOnToYM8995wVKVIk0s0BAAAAAABAVghK9erVy1q2bGmNGzeOdFMAAAAAAACQDnJYlJsxY4atWrXKDd9LiUOHDrmLJzY21v2Nj493l4wuuwUi3QQAAKJGZvhuBwAAyKrnaFEdlNq4caPdc889NnfuXMuTJ0+K7jNmzBgbMWLEcct37NhhBw8etIyuWhGCUgAAeLZv387GAAAAiDJxcXEpWi9bIBCI2ijH+++/b23atLHTTjstuOzYsWNuBr7s2bO7jCj/bUllSpUtW9Z27dplBQsWtIzunIc+jXQTAACIGn+MbhHpJgAAACARxWJUE3zPnj3JxmKiOlOqUaNGtmbNmgTLunTpYlWrVrUHHnjguICU5M6d210SUxBLl4wu3rJFugkAAESNzPDdDgAAkFXP0aI6KFWgQAE799xzEyzLnz+/FS1a9LjlAAAAAAAAyDjoXgQAAAAAAEDYRXWmVCiLFi2KdBMAAAAAAABwksiUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNhFdVBqzJgxVqdOHStQoIAVL17cWrdubb/++mukmwUAAAAAAIDMHJT64osvrFevXvbNN9/Y3Llz7ciRI9a0aVPbt29fpJsGAAAAAACAk5DDotjs2bMTXH/55ZddxtTKlSvtiiuuiFi7AAAAAAAAkIkzpRLbs2eP+3vGGWdEuikAAAAAAADIrJlSfvHx8da3b1+rX7++nXvuuUmud+jQIXfxxMbGBu+vS0aX3QKRbgIAAFEjM3y3AwAAZNVztAwTlFJtqbVr19qSJUtOWBx9xIgRxy3fsWOHHTx40DK6akUISgEA4Nm+fTsbAwAAIMrExcWlaL1sgUAg6qMcvXv3tg8++MAWL15sMTExya4bKlOqbNmytmvXLitYsKBldOc89GmkmwAAQNT4Y3SLSDcBAAAAiSgWU6RIEVeGKblYTFRnSiledvfdd9usWbNs0aJFJwxISe7cud0lsezZs7tLRhdv2SLdBAAAokZm+G4HAADIqudoOaJ9yN6bb77psqQKFChgW7dudcsLFSpkefPmjXTzAAAAAAAAkEZR3b04depUl+p11VVXWalSpYKXmTNnRrppAAAAAAAAOAlRnSmVAcpdAQAAAAAAILNlSgEAAAAAACBzIigFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwIygFAAAAAACAsCMoBQAAAAAAgLAjKAUAAAAAAICwyxBBqSlTpliFChUsT548VrduXfv2228j3SQAAAAAAABk5qDUzJkzrX///jZs2DBbtWqV1axZ05o1a2bbt2+PdNMAAAAAAACQWYNSEyZMsG7dulmXLl2sevXq9swzz1i+fPnsxRdfjHTTAAAAAAAAkBmDUocPH7aVK1da48aNg8uyZ8/uri9dujSibQMAAAAAAEDa5bAo9s8//9ixY8esRIkSCZbr+i+//BLyPocOHXIXz549e9zf3bt3W3x8vGV4h/ZFugUAAEQNfb8DAAAgusTGxrq/gUAg4wal0mLMmDE2YsSI45aXL18+Iu0BAACnTpFJbF0AAIBoFRcXZ4UKFcqYQakzzzzTTjvtNNu2bVuC5bpesmTJkPcZOHCgK4zuUXbUzp07rWjRopYtW7ZT3mYAWSPqX7ZsWdu4caMVLFgw0s0BAAA4KZzbAEhvypBSQKp06dLJrhfVQalcuXLZhRdeaPPnz7fWrVsHg0y63rt375D3yZ07t7v4FS5cOCztBZC1KCBFUAoAAGQWnNsASE/JZUhliKCUKOupU6dOdtFFF9nFF19skyZNsn379rnZ+AAAAAAAAJAxRX1Q6uabb7YdO3bY0KFDbevWrVarVi2bPXv2ccXPAQAAAAAAkHFEfVBKNFQvqeF6ABBuGiI8bNiw44YKAwAAZESc2wCIlGyBE83PBwAAAAAAAKSz7On9gAAAAAAAAMCJEJQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAIBMxptkPS4uLtJNAYAkEZQCAAAAgEwWkMqWLZvNmTPHBg8ebF9//XWkmwQAIRGUAgBfb+KWLVts165dbBMAAJBhKSD13nvv2fXXX2/Fixe3M844I+R5DwBEGkEpAFme15v4wQcf2M0332zz5s0j1R0AAGRYP/zwg/Xp08emTJligwYNsqpVq7rl69evd3913hMfHx/hVgIAQSkACAakOnToYC1btrRLLrnEChQowJYBAAAZkjK/zzzzTGvbtq0dOXLEXn75ZWvYsKE1a9bMbrzxRrdO9uzkJwCIPI5EALK8TZs2uV7EMWPG2AMPPGAlS5a0vXv32oIFC1xPIwAAQEbgDctTwEnBqH79+lndunVt1qxZVqVKFXe+o/MbXQeAaJAj0g0AgEg77bTT7PTTT7eyZcvav//+a1OnTrW5c+fajz/+aEWLFrVHH33U2rRpE+lmAgAAJFmGQLy/TZs2tY4dO9qaNWtchlTnzp3t3HPPtT179rghfYULF2ZLAogK2QJUuQOQxW3dutVatWplBQsWtJUrV1qjRo3syiuvtPr169u9997rrg8dOjTSzQQAAAgZkPriiy9cYfP9+/fbBRdcYD179nS3Hz582HLlyhVcf/jw4fbaa6/ZokWLXGccAEQamVIAsuTJ2x9//GH79u1zs9HopGzGjBn2+eef20033WS33HKLFSpUyK2v2lLUXAAAANFI5zQainf77be7TrRSpUpZr169bOPGjfbQQw+5THB59913bf78+fb222+78x0CUgCiBUEpAFlyiuRu3bq51PXt27e7NPbbbrvNzjnnnOB6Bw4csJEjR9q3335rEyZMiGibAQAAQlm1apX17dvXRo8ebXfeeadt27bNZUKp9IBKEkycONHy5cvnCp8fPHjQFi9ebNWqVWNjAogaBKUAZKkMKfUcDhw40J281axZ0z755BPr0qWL7d6927p372558uSxV1991c3Gt2LFCpszZ45Vrlw50s0HAABZnFd1RX+9LO7169e72lEKSP3999922WWXWfv27V3WlLK/1QH3yCOPWO/evV2GeP78+SP8KgAgIYJSALIEBaSUtq5he5oOuUePHm75JZdc4oboaXYarXP33Xe7gqAbNmywsWPHJsieAgAAiFTHmoJKGo6n/5ctW+bOXxR8Kl++vJtpT51rOod58sknXUHzChUq2OOPP+7qTE2ePJmAFICoRFAKQJahmgtPP/201a5d22JjY11hc7n//vvd3wEDBtjevXtdJpXqMFBLCgAARJqCUJqUpV69evbyyy+7YXjXXnutqw1VvXp1u/DCC23Hjh1u6N5dd93lZhXOnTu3NW7c2Jo0aeJm3QOAaPVf3icAZAHqJRw0aJD98MMP9tlnnyW4TYGpBx980MaNG2e7du0iIAUAAKKGsqSaN2/uglG6TJ8+3a644orgkD5lSv3888/23XffuWxvDdnTjHzKpKpSpUqkmw8AScoW8I5kAJAJU92Vsn7o0CErUqRI8Db1Iqqn8Y033rA2bdokuJ+KghYtWjQCLQYAAPj/Jk2aZJ9++qnLiBLNnHfzzTdb3rx57aOPPnJD9eLj490lR44c9vzzz7shfDExMRYXF+fqYio7HACiGUEpAJk2IKUTNmVHqY5UnTp17Morr3QBKenZs6e98sorrqfxuuuui3STAQAAElBW9y233OKG4Ckg9b///c+++eYbW758uetc08Qsypo6duyYG7Inv//+u23evNnVxCxTpgxbFEDUIygFIMPzEj4ViPKfyLVu3drViSpVqpQrcv7XX3+5wNSECRPcOppCWcVAP/zwQ2vVqlXE2g8AABDq/GbhwoVuFj0Nw5s5c2Yw8KRzGXWsKeu7ZcuWwdqZGqqnOlMAkFEQlAKQ4e3evdtNeeydwB04cMBuvfVWq1y5so0ZM8Yt1yw006ZNsxkzZlivXr2sa9eubrnqSHXu3NmqVq0a0dcAAACQmM5rFixY4IbtqYbUe++955YrC3z8+PEuKDV69GjbtGmTTZkyxVavXu1m3QOAjIKgFIAMTSdgqrfwwQcfuNR1L1tKJ27nnXeeu92j+gpt27a1kiVLurR3AACAjBCYUsa3AlNXXXWVvfvuu275+vXr7dlnn7XXX3/dSpQo4f7XTHwAkJEQlAKQoaluVLVq1VztBBU01xTIKm5+5513WmxsrL300ktWqFCh4Gx6Dz/8sL3//vu2ePFiy5cvX6SbDwAAcFxdTK82lIqalytXznWozZs3z9q1a+dKEXiBKdm2bZsrdM5ELQAyov9+pQFABnXNNde4gJQKfzZt2tT1GirY1KNHD5dBpSCUhvd5VCRUs9LkzJkzou0GAAAIFZDSED3VkOrXr5916tTJFTufPXu2NW7c2N566y3XsaY6Ux5lSRGQApBR5Yh0AwAgNTTtsbKevBM3z969e12G1B133GHPPfec1a9f3524KdX9559/tiJFiliuXLnsnXfesa+++oqgFAAAiCo6r1m6dKndfvvtrlNNNTB1LqOgVPPmze3qq6+2Bg0auGUKWilgpZmEASAjY/gegAxHs+jt2rXLatWq5U7MlM6uIuYalqfZ9BS40kla+fLlbdmyZa7Wgu5TrFgx69+/v9WoUSPSLwEAACDI62wbN26cO3d5++23bcOGDW6onoJRU6dOdevt2LHDnc8oW0pD+jSpCwBkZGRKAchQJ2y6KPvp33//tW7dutnAgQNdZpS0bt3a3T558mTXe6h6UnXr1nXBK9WaOnLkCBlSAAAg4hJnfHv/61ylbNmytnXrVqtXr561bNkyOGmLhvBp1j1lhWtCFwDIDKgpBSDD0Ambhu6pfpSKmg8aNMiGDRtmXbt2Da7Tpk0bu/vuu9163bt3dzWmFJASFQEFAACIFGVzy9GjR93/69atcxOzeAoXLuxmCK5du7Y7p9GMejqn0boqQbBmzRoX0AKAzIKgFIAM5eDBg3bgwAF3Mqeinh9++KGtXLkywQmaTuL69OnjUtz1V+uKv0cSAAAgEnUxNemKiphfcMEFVqlSJbv00kvt3nvvdev07NnTZUft3LnTdbqpXmZcXJzriPv444/d/TQjHwBkFtSUApAh7dmzxwoVKmRVqlRxs+09//zz7uTOH3hSvQVNo1yhQoWIthUAAGRtXkBq9erVbuZgzaRXrVo1VxNq+vTpri6mipers02daipurk43DeVTJ5wCWR999JHLoAKAzISgFIAMU3dB9RWUKaWTswIFCrjb1IOoYFT+/PldivtFF11ko0aNsi1bttjTTz8d6aYDAIAszgtI/fDDD252YM2qN3LkyGB5AdXJnDVrlvXt29euu+46e+ONN9xy/VXGlAqbq76UOtoAILMhKAUgQwSk1HP40EMP2eHDh23fvn32yCOPWJMmTaxMmTIuMHXxxRe7gJWyor799lubP3++1alTJ9LNBwAAcLMAV6xY0QYPHmzDhw93pQVU69ILWGmInmbYU63MF1980WVKAUBWQE0pAFFNAalPP/3Ubr31VjejnobkaZY9zbr36quv2saNG93wvRUrVlj79u3tkksucYXQCUgBAIBooWF7Z555pv3666/uugJSCkwpICXKANfswipNoEla/ChsDiAzI1MKQFTbtm2b3XbbbXbVVVe5QJSG5WkaZBX53LBhgysM2rlzZ1dzQbweRwAAgGihSVpmz57tzlvOP/98V0NKjh07ZqeddlpwvXPPPdeaNm1qEyZMiGBrASB8+OUGIKqp3kK7du1cltT27dutYcOG1qBBA9fjeMMNN7i6UaolpWCVEJACAADRRp1pzZs3t3HjxrlzGM0ULApIebME//TTT3b66ae7IugAkFUQlAIQVbwUdc0yo+KehQsXdrPUlC5d2gWfypcvb2PHjnXr6H/55JNPLFeuXBFtNwAAQHLy5MljLVq0cIEpFT33AlMayievvPKKC1JpAhcAyCoISgGIuqLmSmlv1qyZmyJ5z549rgaDKFNKJ3TeyZuKgk6bNs3mzp3rZuQDAADIiIGpMWPGuELnupQsWTLSzQSAsPnvlx0ARAEFpObMmeMKlo8fP96luavgp0cnaTNmzLBBgwbZP//842bk69atWzBoBQAAEE0dbckFpuTBBx90HWuaSXjJkiWu3hQAZCUUOgcQNY4cOWIdOnRwwacnn3wyuNybNlnuv/9+V4tBBc3Vy8jJGwAAiPZgVKjlhw4dsnfffddlfT/xxBNWs2bNMLYUAKIDQSkAUTUzTZ06daxr167Wv3//BDPp6X/1IqoA6OHDh93JnYqgAwAARAMv8PTVV1/Z/Pnz3XlNjRo1rGPHjkne5+DBg65TrkCBAmFtKwBEC2pKAYiqmWnKlStnX3zxhcuOUkBKUyXLb7/95noSVWNKRc0JSAEAgGiigNR7771n1157rcvq3rVrl912223Wt29flxWV1FA+AlIAsjKCUgAiOsueMqCU+eTRidy6detswoQJ7jbNQiOvvvqqm5VGvYkAAADRRjMH33vvvTZixAh75513bOjQoZY/f353m78zzTsHAgBQ6BxABNPbZ8+ebW+88Yb9/vvv1qBBA7vuuuuse/fuLitKBc01q56G8+n2zz//3BYvXkxRcwAAEFXnM165gZ07d7q6mL1797b169fbZZdd5obuTZo0ya3//fffW61atZIsgA4AWRGZUgDCTidjmjlPQSj1INarV88++OADGzBggCv4qZn39L9m1VNdBtWR+vrrrykACgAAIkoBKFGZAS+4FBcX5/7qemxsrM2bN891trVs2dImT57sblu5cqWNHDnSdbwBAP4/Cp0DCHuvonoSFZC65ppr7IEHHgimvD/88MP2xx9/uBloLrjgArdcNaV0kucVPAcAAIikP//80z7++GPr06ePzZw50+688053HqOi5V26dLFvvvnGBaTefPPN4H00e7ACU1pfnW4AgP/8N8c6AISJAkzKjtq9e7cr7un1OlasWNHVXmjSpIl9+umnwaCUV1MKAAAgGkyfPt0ef/xxW7Fihb399tv29NNP2xlnnOFu03C9NWvWWMGCBV3ZAZ3zqFTBSy+9RBkCAAiBoBSAsFEWVKFChSxHjhxupr2NGzcGs6cUmIqJibHLL7/cli1bFqzPAAAAEE0GDRpka9eutddff93atm1rt9xyS/C2W2+91Q3hU7CqWbNmVrVqVdfBtmjRIjvvvPMi2m4AiEb84gNwyinAtGHDBle0XCdxRYoUsbvvvtvNsKcZ9XSy5gWg9uzZYxUqVCAgBQAAoo5mDFZnWs6cOV0pgm+//daefPJJ2759e3CdXr16uaCUhvG9//77buKWmjVrRrTdABCtyJQCcMop4FSuXDm76qqrbNSoUS44ddttt9lff/3lai/ohK5YsWL277//uuKgOokDAACINrly5XJ/NRxPnWoDBw60KVOmuEBV165d3fmM1yFHIAoAToxMKQCn3JEjR9xfnazt37/fvvvuO3d9yJAhNmPGDPv1119tzpw5tm7dOluyZIlVr16ddwUAAEQFBZzkxx9/dFlP6kBTZreMGTPGOnToYFOnTrUXXnjBncsMHz7cDdVT4XPvvgCA0Jh9D8Apo0yoUqVKBXsVlfJev359VzvqrbfeCq63b98+y5cvnx04cMD9BQAAiAYKKmmSllmzZlnPnj2tTJkyrjPt+uuvd8Eo1Y0STdaiGlMqbK7Mb61ft27dSDcfAKIeQSkAp4R6EzU0T6ntkydPdidxClB9+eWXbuie6i9cc801CU74AAAAos38+fPt5ptvtkceecR69OhhH374od10003WsGFDu+uuu6xVq1ZuPWVRKSP8/PPPdx1wAIATIygF4JSIi4tz6e2aBlmz6V144YVudporr7zSbr/9dtd7qF5FZtkDAADRSJ1mGoI3YMAAlwE1duxYNzyvSZMmVq1aNTeJS8GCBd1sfFdffXWkmwsAGRJBKQDpwst22rx5sxumpxn0PO+++659/fXXLjtKAalVq1bZypUr7bfffrOKFSvyDgAAgIjyOsmOHTvmsrxl69atVrJkSTcBS+HChV3Gt7KjatWq5epHffrppy5j6oILLnAFz5s3b867CACpRKFzAOlCASkFn5o2bepm1+vYsaObBlluuOEGGz9+vMuY0smeAli6eCd9AAAAkaSAlGpFqQNN3n77bRd82rZtm/tbtWpVN4xP640YMSJ4P03OcsYZZ7jC5gCA1MuRhvsAwHE9iz/99JP169fPXZTKrmKfqiWlYXy33nqrW1c9iU888YTFxsa6GfnKli3LlgQAAFFh4cKFdu+997qM7unTp7tsqBIlSgRn0NPELDqv2bJli5111lm2dOlSN2zvvvvuc+c+AIDUY/gegDQFoVRjIU+ePMGi5sqS0ux5mhpZfvnlFxs8eLCbgeaOO+5wM9T47w8AABBtQ/Y6d+5sr732msvy9s8ULMuXL7dOnTrZ6aefbjly5LC1a9fakiVLXGFzAEDa8MsQQOoOGtmz26ZNm9wMekpjl+7du9u4ceNs/fr1wfWU5j5y5EiX0v7yyy+73kbv/gAAANEQkNK5i85RlPUkWqaZ9t555x3X0bZnzx63XNlSKk8wZcoUa9GihV166aWuLAEBKQA4OWRKAUi1P//809WMUsBpwoQJ7kStW7duru7CpEmTEhT6/Pnnn61Pnz6WN29eN6SP9HYAABANAak1a9bYjTfeaDVq1LCuXbtaq1atguuo3IBKEjz88MPWu3fv4PmLhu6p4DkAIH0QlAKQJr///rs7SVNASiduOXPmdCnvClRpuQqee1Q4VFMpq/4CAABApKnMQL169axHjx529913W+nSpY9bRx1vqhelwFT79u1d59qzzz7ryhYUKFDATfICADg5BKUAnHRgSlTUXD2PypjStMn33HOPNW7cmK0LAACiiupiqgxB8eLF7amnngou1yQsyvrWhCyaVU8mTpzoamRWqVLFNmzYYLNnz7aLLroogq0HgMyFoBSAdA9M9ezZ0xUN1ZTJDRo0YAsDAICocfToUWvYsKHddNNNwXOYOXPmuIDTiy++aEWLFrXy5cvbggULXDbU4sWLbffu3a5+VIUKFSLdfADIVKg4DOCkVKpUKdjLqPR3zV6j6xqud84557B1AQBAVNm/f7/t2LHDVq9e7UoMqKC5Mrw3btxoo0aNcplRf//9t/Xv39+tf8UVV9i1115LQAoATgEypQCkW8ZU37597Z9//rE33njD9TCqzhQAAEC0URZUs2bNrEyZMrZz5057/PHHrVGjRq5DTcP4VPRcBc01gzAA4NTJcQofG0AWy5gaP368DRo0yHLlykVACgAARC0N39Nswtu3b3cdaWeeeWbwNmV9FypUyMqWLesmdBGKmgPAqUGmFIB0dfjwYReUAgAAyIjnMRrCp9pSixYtcp1uAIBTh0wpAOmKgBQAAMiIXn/9dVu+fLnNnDnTPvvsMwJSABAGBKUAAAAAZGkqeP7CCy9YkSJFbOHChVatWrVINwkAsgSG7wEAAADI8lRfKnfu3K6eFAAgPAhKAQAAAAAAIOyyh/8pAQAAAAAAkNURlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAEDYEZQCAAAAAABA2BGUAgAAAAAAQNgRlAIAAAAAAICF2/8DM+c7LiavPOsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 29: Invocations + state deltas over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(start_ts, HOUR) AS hour,\n",
+    "       SUM(invocation_count) AS invocations,\n",
+    "       SUM(state_deltas) AS state_deltas\n",
+    "FROM session_rollups\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "time_plot(df, \"hour\", [\"invocations\", \"state_deltas\"],\n",
+    "          \"Invocations + State Deltas Over Time\", \"Count\",\n",
+    "          labels=[\"Invocations\", \"State Deltas\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "panel9-header",
+   "metadata": {},
+   "source": [
+    "## Panel 9: Multimodal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "cell-30-multimodal-time",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:17.860278Z",
+     "iopub.status.busy": "2026-04-11T06:43:17.860176Z",
+     "iopub.status.idle": "2026-04-11T06:43:20.168642Z",
+     "shell.execute_reply": "2026-04-11T06:43:20.168041Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAANwRJREFUeJzt3QmYFNW99/H/sCM7KCCyKkRAFhWURVwQLgSVwNWr0aCCcsENwqIoJCyiKIsKCLK4ouaioklExSsGQUEDsioqKmBEIUFARUAxLEK/z++8b/Vb3dMz9MzpYXpmvp/nqWemq6qrTtf+P1tlRCKRiAEAAACAh2I+XwYAAAAAAgsAAAAAKUGJBQAAAABvBBYAAAAAvBFYAAAAAPBGYAEAAADAG4EFAAAAAG8EFgAAAAC8EVgAAAAA8EZggSLr6aeftoyMDDfcfffdSX/voosuin7vq6++snQUpK9+/fq5+v4777wTXUafPn2sqGI7FC061oPjXvs+VefTsdx2221u+aeffrpFIpE8WQdQENx3333uXKhRo4bt378/v5ODXCCwQNrQw31wA9fQpUuXTPOsXbs2Zh4NBw4cSGk6PvzwQ5cWDeGHCyQXbAVD8eLFrXr16ta9e/c83Y5adrC/tO8K08Othv79+2ea5y9/+UvMPDVr1oxOU7AbnhYWv4+WL1+eadnaX+F5hg8fnuU5Gj9Urlw5RwF9VsOePXusqNi6das98cQT7v/f//73mfZZsrRdg/Mg2e33zTff2MSJE61r167WoEEDK1u2rFWoUMHatWtnc+bMSfidffv22V133WWnnXaalS5d2j0AXnvttfaPf/wjZr69e/faww8/bL/5zW+sUaNGVq5cOTecddZZNnnyZPvll18SLv/rr7+2m2++2aVHy69WrZqde+65Nn78+Bxtj7feess6d+5slSpVshNOOMHOPvtsmz17th09ejTL7xw+fNhatmzpdX9Jdr3Lli2zK6+80ho2bGgVK1a0kiVLuvP40ksvtYULF+ZonfPmzbPzzjvPypcv7wb9/+KLL8bME39dyGpI1sGDB+3++++3pk2bWpkyZdx+6tmzp61bty7h/Lp39+jRw82n+fU97dNDhw7FzKd9r+Nw165d9sgjj+RoOyBNRIA0MWbMGGXVRYdixYpFvvrqq5h5brrppph5NPz73//O1frmzJkTXYbWfazxgY8++ijy7rvvuuHAgQORdBSkv169ern6/ttvvx1dRu/evY85/4UXXphpv4SHjIyMyNNPPx3J6+NG+y6VcrodUkHrCW+7ChUqRH766aeYebp27RozT40aNaLTtmzZEjMtLH6/3HDDDTHT//nPf0aKFy8eM89dd92V5TkaP1SqVOmYvy98fmU1/PDDD5H8sGnTpui5vWfPnpSdT9m5/fbb3bJLlSoV2bt3b66XEz4HdQwk4/nnn892PwwaNChmfqWvRYsWCeetUqWKuzYGVqxYke2ye/TokSk97733XqRixYoJ5z/ttNOS3hZPPfWUu+YkWk7fvn2z/N64ceO87i85We+9996b7faZO3duUuvM7pzUOrK6LiQaSpQokdQ6Dx8+HOnUqVPCZZQuXTry1ltvxcz/5ptvuuM70fxdunSJ/PLLLzHzX3PNNW5azZo13bpQsFBigbSlHJ4nn3wy+lnFos8995zlt+bNm1uHDh3coBw1xPrDH/5g7777rr322msu50z0bDZkyJBMuVM+ikox+Y8//uhyJMM5uosWLUrJspWrqeUHnnrqKTty5EhS3+3WrZvbz+EhpzmtZ555ZqZlaFCueX5QznpwbivHOa8p1/5//ud/3P//8R//4XKujzflHvft29eVgi1YsMAuueSS6LRp06bZl19+Gf2s0pCPPvrI/X/BBRfY/Pnz7aabbnKff/jhB7ecsBIlSthvf/tbe/755+2NN96w66+/PjrtlVdesbfffjv6WaUsysFXiYhKO5Vz/fLLL7tjasaMGS4nP9lSmIEDB7prjtav0pEXXnjBTjnlFDdd95TXX3890/c2btxo9957r9seuZHT9Wr8oEGD3LZZvHix/elPf7ImTZpEp0+fPv2Y61QJrdIsOmd0/moIzp/w/jr55JMTnmu33nprdHkqcUjGzJkzXZqlWbNm7tgZOXJktCRDpa76K//+97/thhtuiF77NZ/m1/fkb3/7myvRCbv88svd3x07duT4moI0kN+RDZAo50W5tPpbu3btyJEjR9z0J598MmZafI5SdrnLiXIcE5VMaHpWuTnBPIlyBsO5QZq+ZMmSyNlnnx0pU6ZM5KyzznJpk5kzZ0YaNGjgcnXat28f+fDDDzMdAJs3b4706dPH/faSJUtGqlatGunWrVumXCD59ttvI9ddd53L5VNusf7XuES/V7nRyqFWjmO1atVc7pRyGTt27Bh5+eWXU1ZiES41UIlTeBuuW7fO5b7ffPPNkVatWkWqV6/ufqPS37Zt28gTTzwRs9z47bp06VI3n7ZrfM5+/BCkQ9v4N7/5TeSkk05yv1nbs2XLlq706+uvv872d8Vvh8WLF0fOOecct//q168fmTJlSnRepT2Yd/To0THLmT9/fnTagAEDsl1n+HcFx3q7du2i00eNGpXpPMhNiUXw/UcffdRN03kWHP/hZWdVYpHbEpzwead9mp2hQ4e6366cS+V4litXzp1PDzzwQKaczPAxv379+sj5558fKVu2bOT000+PvPTSS24e/W3atKlbls4D7c+stn1wzsYvO5X7WsdzMO/DDz8cMy3Z8yR8jCYasiu9+PTTTyPbtm2LGadSWB1PwffnzZvnxh88eDBSuXJlN0658tu3b3fjjx49GmncuHF0/jVr1rjxWu6GDRsyrVP7L5h34sSJ0fGTJk1KmNOeU1pmsByd44lKZy677LKY7+g36HjRtPvvvz/h/SUv1htP1+Fg3jPOOOOY67zlllui848fPz46Xv8neww2b9484TGfXSlYkyZNouNVMpWoJPXPf/6zG6fjJxin6YlKtJo1axazXpVYBtNuvPHGY24HpBcCC6SN8EOLHqx1I9X/r7/+upvepk0b97l///5pHViccsop7sE3/F094Nxxxx2ZlqmH0/AD0sqVKzMFTsGgm7kCk4Bu9OGbdDCEqyqEf++xqiY888wzKQ8swjcIDe+//37km2++yTYdY8eOjX4/vF1r1aoVs12TCSy+++47F1BkNc+iRYuy/V3h7aCbaXBMhofghv7jjz9Gypcv78Y1bNgwZjm6OQbzL1++PNt1hn9Xv379ov/rIU1VBnR8xZ8HuQksgmUrUJI33njDfVZVKFXbSIfAQgFcVvsuvhpXMF4Pvwqc48+dkSNHZlqGzrXdu3fnOLBI1b4OP8Sq+lVYsueJT2CRFR0TwfcXLFjgxq1duzY6TpkjYdoXwbRwsJ3IlVdeGZ33kUceiY4PHuyD36aHTZ3vdevWjQwfPjzpB/zu3bsnvKYpEyF8jITNmjXLjVeGg67H4e2Xl+sN6Lz+8ssvIz179kw6IIgPChSkJgpY9ZuysmzZsuh8CrjjJbrXff/999Fxuh6GqzFpv8VXoxs4cGDCa7u2c/h6Gj4P5dRTT3XjlTGAgoWqUEhLahB42WWXuf/VsPHjjz+2lStXus///d//nWfr/fOf/+yq8gRUhBsUGd94441JLeNf//qXa7ynYu+LL744Whz84IMPurSrukHjxo2jDerefPNN97+eX7S+oGrKf/3Xf7lljBo1yooVK+amDx482LZt2+amq3HlBx984P5XgzgVgb/00kv2008/JUyXGgZOmDDBFUOrgaGqITzzzDN20kknuenjxo2zVFLjzT/+8Y/Rz6oeoN+tBo333HOPq4ajYnClQ1UGVA1FHnjggYRVprZv3261a9d2VUf+93//1xXba79om8VXw9KgKh0rVqywb7/91k275pprXBUiVd/QvrjwwgtdlYtkffbZZ66qhvaJqnUFVN3gu+++c40mr7rqKjfuiy++iB6vqtIXVIFQr0JqGJssNfxUY9fgPNDv1vGlbenbW1dwHq1evdqdX48//rj7rIa82s7HomMnvuFnTtO0dOnSTMtQRwABHT+qKqLqEGqk/9e//tXatGkTbaz8z3/+M9MyVaVGx9Krr75qV199tRunc0fHtxqP6vxTVSfRuZab6pWp2tc6pgJqxBuW7Hmi40PHu6qVBXQdCM4DVYHJiS1btkSvK/qd559/vvs/3AOers9h6qQh/P2saN8sWbLE/a99rWMt8Omnn0b/HzNmjH3yySeu4bQat+u6pX2XTI9ZWaUznEalQ1W3ROeTGqPrWqDqSjq3ciOn6w1fl7XOU0891V2b9P91112XVGP1ZNaZ3f5QlaZwz2TJCK9T953wNTTRerNKo35n1apVEy43fD5s2rQp6eqZSA+5O4OA40APPqpjqwcB9ZghLVq0sHPOOSfP1tm6dWt3QwvUrVs3+hCSLPVoMXfuXFdf+ueff47eSLWsxx57zN1Q9UAxbNiw6INJUF82uLnqZqMHHv1uPSBrvAICPUjorwIM1VEO6AEkeMBWzzyqrx1PDzpa7tSpU92DpB78wzfqzZs3u/rNvvW8lY7ww35A9Y+Deut6GFL9bT3A6EYbvnEoMPr888/dvg5TcKVjQV1yhilIiq8jHwiOG6lTp477rh6atQ9uv/32HP0u7b9nn33W3Ui1T1atWmV///vfXV1i1R/Xw4DqmCvAEx0DegjWfDt37nTjggfdnJ4HuumrDnZwfGj9OX1gjBecSwos9NCtNjHB+tavX2/pQIG5HqD14K7gLdyTkI5d9UCTKAjSftKxoG2kh/HgQV3bUPXPFei/9957MedfTqViX+s3BapUqRIzTedhsudJfJsQXcdy0zXu999/7wL2YDvr4Ta4HoTbNJUqVSrme+HPWbV90jZXYK51yNChQ2OCqXBPVtoW6lFK1A5Bv13BlYJFBRi6VgXbOXx+asgqnfFp1nxaj9oY6Lqn63GrVq2y3T6pXG9WdH3RkEwQlcw6s9of+h26l4jOCV2/4iXqzS+nx0Fuj5tgG2k76JgJBy1Ib5RYIG39+te/dg+D6gIw6DqvX79+lu708BrcjMM5MrppBd35nXjiiZluqMqZCedUhx+K1d1iIJgv3KgyHGyF5w2bMmWKy1FWLqbWmejGlRfdfOoGoVx9PSCKcp3VpalKD/RglSg3KlE69KAYH1Qci3JbgxzeSZMmuQcAPYApV1w59Nl1PRlPD2vh3Lnwdg72Rfv27aOlUWpwrd+mh6GASk1yqlevXu6hWNsqKN1K1XkQLEfnl84zBZ7aN7ltvB0uocpt4+2g0aoe0jt27OgCaDXiTNQ9aaLjRIF1sM/D55+OnaBRa6LzL6dSva/jz8fcnie5pcbHKsULGvvqwX/AgAHR6eoqNhA0zA2ESxjD8wVUMqTjJcgEUIChbm7Dwh1h3HLLLe5BV4MacQeC7+tdBzq3w0MQ5GWVzvhSUM0XBCvqOnfs2LHH3EapWm+Y1q/MJ5VInnHGGe67Ko1LlDkTL5l1JtofouufznlRo/pkO0zI6XGQ2+OG97kUXAQWSFvKoQ5fXNVbh/pLz0q4D+7wTTicK3g8hHMO9RsCWZUEJHMBzUn/4lnNG+5l5M4773S9euhBTr1cBXLyoJ2VoDqS3pGgHFVVRVLVhuChPNw3uQId3dw1f7iUJVE64qtfJEMP5CpVUImOcr/14KyHHFXB0fshFGzkVlbbOegZR/2wBw8uooeG+FKYZI8nVYsL9yajh7RUUK56+Ibeu3fvpKuCKAcx6EEpGIIH+pz8tvhlBMejeooJHnxULVLVwHSchHsWSnSc5MX5lxXffR0OcOKryOT2PMkN9TSmh+QNGza4z3p3yUMPPRQzT7gEJD7XXoFfQO+fCNPvUtVQnXNBoKzS2PhqiAr6A/Xq1Uv4v0oWjiWrdIbTqOBTGR6qXil6B4euFYne5aAS6GR6S8rJesOUQaEAWsdSUGoYBJbHeodGMuuM3x/B/VGl54Fwz1DHEl6nShLCAX+i9WaVRn0vKL2Kny98Pmh/qMoVCg4CC6Q1tWsIHg6uuOKKbF/AFX6gCF/gctpdXfhhJFU37mT86le/iv6vqg/hC3ZQhzs8n+rkBtasWZNw3jDVJRZdpJVbqAdtVbUIxqdKUB1J9cuVSxz/ABFen4IdPSgp9/dY6cjqQT67/aWHRrUhUTsVBVLKlVXpguqOBzfvZOkFT+Hlh7dzeF/owTcobVIOZ/CwlpvSikC4XZEeMnPSNiQ7yqVUd6CB+O5C81P4eFCVHAVTOq7iH2rzk+++DncvGl8lK6fnSW6vW+pmVUFF8II7betE9fvVPWhwjVUgEqRD59j7778fnS9okyHaVyoFUelTUBKh6miJgtega2pRu4pE/6sEW5Sj//86n4kOKhWVcFXI8Asg1d4qkNPqrYFUrldVw7K7xmnZxwqkkllneH8EFMAEbfUU1OhldclSKWBw3OoepaqU2a03qzTqe8E9TsdWfMAVnA+636XqeofjgzYWSGvKrVIf5goUwrm2iSiHRDdX3VRVtKyccz04qeFfToQvcApK1F+7SkuUk5qXfdurWogu2Gp/oQdg5ezpIVIPsGprEtRJVYAleqOt6vbL6NGjXc6aHphHjBiR5bZUHWHlEmmbKEdV9Zh3796dZ78pq3QE1bmUbjXgDLcfyKnw/lKdYR0HethT9TAFXHqbsbaZAh7lEKuqh9q+JCqaz44eppSj/7vf/c4FKSoJCapwqNpeOCdfOezaZ8E8uW1fEb5J62FPOZip7rxAdcv1wKZtk5MSB+XSB+0UwrTdU/F+l3BOtX67tr2O96A6WDrw3dfhh2m1Fwk/BOb0PAmfB6rmonY4uiaoCl92QYWub9qXomuOHgTD+1UPdvqduvYoo0dVKvXQq+DpjjvucI3VtRzRuoJ2Clqmfo+uOdKpUyd37oS3U9A+QXRcq1qRlj1r1qxoNbPwOw6Ca192VH1KJZSqs6/G2FpOrVq1XFoDQfUqlRbo98QLd86gKpzJVMHMyXqDkkeVwCsNagukB/1wKZHOyaBjjeyqMj766KPunqe3YKtUV8GJ/hc9kCeqNql7ajKNtlVlNChpUmPsoFRBv0NtX4I06Hfr+FWpmqjdU9D5iqrzaTuodEjTVV1Sx4iO6UTbJajiFzT+Dp8jKCDyu1sqIFFXluEuLhPJqjvA4I2d4SHc5/axupsVvQciUTeXQfeTybzH4ljdtma17px2N6uuBOPna9SoUcLfq77/4+c98cQTXXd+8b8nVd3NJqJ3CcSnQ91Kqr/++G2d1XYN09t+E73tVt9VF57ZdcUZ7vs9kfB2UPeHeht8/DL0tt546qIzPM+5554bSVa4y1N1g5mV8LbJTXez2XWjmdW5eKw3b4ePId/uZnUuxO9XfdZ7LRIda4mO+Zyel8l2N5uqfa0uN/WOjkTvOMjJeSLTp0/PNP+x3hSezFvQw9s4uzdvqyvV8Ju3j9UNbvy1T4YNG5blvMe6J6Tizds5PU981pvddlE3rK+88kpK37wd2LhxYzSN6ro6uzdbZ/Uei7x+83b42A+6O0bBQVUoFCqqMqCGgao3rtIFVVVYtmxZjpahnFt1+6dqQsrxO56Ue6UqN8qdVY6WqgwoJ1I54srtUVWCgHIQ1bBTuYyqP65BXWAm6skjyIVT7z/KCVV9YuVGqWRH7Q6OJ5U8KZdNueMqCVIOt0qGgjex5pRKktQLkEp74nPKlduqriTbtm3rcvO0PVWqo3Uq107TkqXcV9Wh13Gh9Wg7KocxUYNl7S/l0gV8qkEVVToXVBKg/avjRO0W1I1qly5dLJ347Gsdj0G7MZ3L4beg5/Q80RuwdTyrBCBcLSqVdI1ROw+VcqlkUNcglWaoJEJVW8LttXJDbZ7UjbF+q65RGtTblrqYzknJs9rmqWRLpSQqtdZ1XOetSkLCbQtSLSfrVbszVRNTaYVKWDWv9rWqI6qkVSXSyVBVLPV8pqqnuu9p0P/qUCB4G3aY0hK0K9Ixk5vudfUdlVSp+p9KZnQ9VBUppVnVnfT7w3TOarxKL3Q/0/y6XqtkRdWy4qs6BVVUdW8KlwajYMhQdJHfiQCAwkbVRvSuET3k6X0Lvt3DonDua1WBUber6iFH7xUIZx4ARY2q6qoamNqgqC2gOhpBwUKJBQCkiPJp9H4BvQcieFGaGt0SVBQ+qdrXeogK2s3oHTPk9aEoU5saBRUqCQt3d4yCgxILAEgRvT023L2jGlKqKl5ue6FB+mJfA0BmlFgAQIqpzrB6klF//QQVhRv7GgD+P0osAAAAAHijxAIAAACANwILAAAAAN5487aZe2ul3gqpfqfV2BIAAACAud7q9J4dvbPnWO/JIbAwc0GFuvwDAAAAkPi9O7Vr17bsEFiYuZKKYIPpzaIAAAAAzPbt2+cy4IPnZQKLYwiqPymoILAAAAAAYiXTXIDG2wAAAAC8EVgAAAAA8EZgAQAAAMAbgQUAAAAAbwQWAAAAALwRWAAAAADwRmABAAAAwBuBBQAAAABvBBYAAAAAvBFYAAAAAPBGYAEAAADAG4EFAAAAAG8EFgAAAAC8lfBfBFKh/vDX2ZAA8s1XEy5l6wMAvFBiAQAAAMAbgQUAAAAAbwQWAAAAALwRWAAAAADwRmABAAAAwBuBBQAAAABvBBYAAAAAvBFYAAAAAPBGYAEAAADAG4EFAAAAAG8EFgAAAAC8EVgAAAAA8EZgAQAAAMAbgQUAAAAAbwQWAAAAALwRWAAAAADwRmABAAAAwBuBBQAAAABvBBYAAAAAvBFYAAAAAPBGYAEAAADAG4EFAAAAgIIdWCxbtsy6d+9utWrVsoyMDJs/f37M9EgkYqNHj7aTTz7ZypYta507d7bNmzfHzLN7927r1auXVaxY0SpXrmx9+/a1n3766Tj/EgAAAKBoy9fAYv/+/dayZUubMWNGwumTJk2yadOm2ezZs23lypVWrlw569q1qx04cCA6j4KKDRs22KJFi2zBggUuWOnfv/9x/BUAAAAASuTnJujWrZsbElFpxdSpU23kyJHWo0cPN+7ZZ5+1GjVquJKNq6++2j777DNbuHChrV692lq3bu3mmT59ul1yySX24IMPupIQAAAAAEW4jcWWLVtsx44drvpToFKlStamTRtbsWKF+6y/qv4UBBWi+YsVK+ZKOAAAAAAUgRKL7CioEJVQhOlzME1/q1evHjO9RIkSVrVq1eg8iRw8eNANgX379qU49QAAAEDRkrYlFnlp/PjxrvQjGOrUqZPfSQIAAAAKtLQNLGrWrOn+7ty5M2a8PgfT9HfXrl0x03/55RfXU1QwTyIjRoywvXv3Rodt27blyW8AAAAAioq0DSwaNGjggoPFixfHVFlS24l27dq5z/q7Z88eW7t2bXSeJUuW2NGjR11bjKyULl3adU8bHgAAAAAU0DYWet/EF198EdNg+8MPP3RtJOrWrWuDBw+2cePGWaNGjVygMWrUKNfTU8+ePd38TZo0sV//+tfWr18/1yXt4cOHbcCAAa7HKHqEAgAAAIpIYLFmzRrr2LFj9PPQoUPd3969e9vTTz9td955p3vXhd5LoZKJDh06uO5ly5QpE/3O3LlzXTDRqVMn1xvUFVdc4d59AQAAAOD4yYjohRFFnKpYqRG32lvkV7Wo+sNfz5f1AoB8NeFSNgQAwOs5OW3bWAAAAAAoOAgsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAAAAgQUAAACA/EeJBQAAAABvBBYAAAAAvBFYAAAAAPBGYAEAAADAG4EFAAAAAG8EFgAAAAC8EVgAAAAA8EZgAQAAAMAbgQUAAAAAbwQWAAAAALwRWAAAAADwRmABAAAAoHAHFkeOHLFRo0ZZgwYNrGzZsnbaaafZvffea5FIJDqP/h89erSdfPLJbp7OnTvb5s2b8zXdAAAAQFGT1oHFxIkTbdasWfbII4/YZ5995j5PmjTJpk+fHp1Hn6dNm2azZ8+2lStXWrly5axr16524MCBfE07AAAAUJSUsDS2fPly69Gjh1166aXuc/369e3555+3VatWRUsrpk6daiNHjnTzybPPPms1atSw+fPn29VXX52v6QcAAACKirQusWjfvr0tXrzYNm3a5D6vX7/e3nvvPevWrZv7vGXLFtuxY4er/hSoVKmStWnTxlasWJFv6QYAAACKmrQusRg+fLjt27fPGjdubMWLF3dtLu677z7r1auXm66gQlRCEabPwbREDh486IaA1gEAAACgkJZYvPjiizZ37lx77rnnbN26dfbMM8/Ygw8+6P76GD9+vCvZCIY6deqkLM0AAABAUZTWgcWwYcNcqYXaSjRv3tyuu+46GzJkiAsMpGbNmu7vzp07Y76nz8G0REaMGGF79+6NDtu2bcvjXwIAAAAUbmkdWPz8889WrFhsElUl6ujRo+5/dUOrAELtMMLVmtQ7VLt27bJcbunSpa1ixYoxAwAAAIBC2saie/furk1F3bp17YwzzrAPPvjAJk+ebDfeeKObnpGRYYMHD7Zx48ZZo0aNXKCh917UqlXLevbsmd/JBwAAAIqMtA4s9L4KBQq33nqr7dq1ywUMN910k3shXuDOO++0/fv3W//+/W3Pnj3WoUMHW7hwoZUpUyZf0w4AAAAUJRmR8GusiyhVn1IjbrW3yK9qUfWHv54v6wUA+WrC/31fEAAAuX1OTus2FgAAAAAKBgILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA6RNY7NmzJ1WLAgAAAFAUAouJEyfavHnzop+vuuoqq1atmp1yyim2fv36VKYPAAAAQGENLGbPnm116tRx/y9atMgNb7zxhnXr1s2GDRuW6jQCAAAAKIyBxY4dO6KBxYIFC1yJRZcuXezOO++01atXpzSB//rXv+zaa691JSJly5a15s2b25o1a6LTI5GIjR492k4++WQ3vXPnzrZ58+aUpgEAAABAHgQWVapUsW3btrn/Fy5c6B7mg4f8I0eOWKr88MMPdt5551nJkiVdicinn35qDz30kFt/YNKkSTZt2jRXirJy5UorV66cde3a1Q4cOJCydAAAAADIXgnLhcsvv9x+97vfWaNGjez77793VaDkgw8+sIYNG1qqqC2HSkbmzJkTHdegQYPo/wpkpk6daiNHjrQePXq4cc8++6zVqFHD5s+fb1dffXXK0gIAAAAgxSUWU6ZMsQEDBljTpk1d+4ry5cu78d98843deuutliqvvvqqtW7d2q688kqrXr26nXXWWfb4449Hp2/ZssVVywpKTKRSpUrWpk0bW7FiRcrSAQAAACAPSiz00D548GArUSL26wMHDrTly5dbqnz55Zc2a9YsGzp0qP3hD39w7Td+//vfW6lSpax3794uqBCVUITpczAtkYMHD7ohsG/fvpSlGQAAACiKclVi0bFjR9u9e3em8Xv37nXTUuXo0aN29tln2/333+9KK/r372/9+vVz7Sl8jB8/3pVsBEPQEB0AAADAcQws1LYhIyMj03i1t1Dj6VRRT0+qbhXWpEkT27p1q/u/Zs2a7u/OnTtj5tHnYFoiI0aMcEFQMAQN0QEAAAAch6pQarQtCir69OljpUuXjk5Tb1AfffSRtW/f3lJFPUJt3LgxZtymTZusXr160YbcCiAWL15sZ555ZrRak3qHuuWWW7JcrtIdTjsAAACA4xhYqNpQUGJRoUIF996IgNo9tG3b1lVVSpUhQ4a4QEVVofSujFWrVtljjz3mhiDAUVuPcePGuR6qFGiMGjXKatWqZT179kxZOgAAAACkMLBQt68KKmT69OnR3qDyyjnnnGMvv/yyq7p0zz33uMBB3cv26tUrOo9eyrd//37X/mLPnj3WoUMH926NMmXK5GnaAAAAAPx/GZEgUshBg2o9tG/YsMGVEhQGqj6l0hi1t6hYsWK+pKH+8NfzZb0AIF9NuJQNAQDwek7OcePtYsWKRV+MBwAAAAC5CixkwoQJNmzYMPvkk0/YigAAAABy94K866+/3n7++Wdr2bKla7QdbsQtid5xAQAAAKDwylVgoQbUAAAAAOAVWPTu3Ts3XwMAAABQSOUqsAg7cOCAHTp0KGZcfvWsBAAAAKAANd7WeyMGDBhg1atXt3LlylmVKlViBgAAAABFS64CC72UbsmSJTZr1iwrXbq0PfHEEzZ27Fj3xutnn3029akEAAAAUPiqQr322msugLjooovshhtusPPPP98aNmxo9erVs7lz58a8GRsAAABA4ZerEgt1J3vqqadG21ME3ct26NDBli1bltoUAgAAACicgYWCii1btrj/GzdubC+++GK0JKNy5cqpTSEAAACAwhlYqPrT+vXr3f/Dhw+3GTNmWJkyZWzIkCHujdwAAAAAipYctbE4evSoPfDAA/bqq6+6Lma3b99uY8aMsc8//9zWrl3r2lm0aNEi71ILAAAAoOAHFvfdd5/dfffd1rlzZytbtqw9/PDDtmvXLnvqqadcw20AAAAARVOOqkKpJ6iZM2fam2++afPnz3dtKtQLlEoyAAAAABRdOQostm7dapdcckn0s0ouMjIyXJUoAAAAAEVXjqpC/fLLL66RdljJkiXt8OHDqU4XAABpo/7w1/M7CQCKsK8mXGqFLrCIRCLWp08f97btwIEDB+zmm2+2cuXKRcf99a9/TW0qAQAAABSewKJ3796Zxl177bWpTA8AAACAwh5YzJkzJ+9SAgAAAKBovSAPAAAAAMIILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAAQWAAAAADIf5RYAAAAAPBGYAEAAADAG4EFAAAAAG8EFgAAAAC8EVgAAAAA8EZgAQAAAMAbgQUAAAAAbwQWAAAAALwRWAAAAADwRmABAAAAwBuBBQAAAICiFVhMmDDBMjIybPDgwdFxBw4csNtuu82qVatm5cuXtyuuuMJ27tyZr+kEAAAAipoCE1isXr3aHn30UWvRokXM+CFDhthrr71mL730ki1dutS2b99ul19+eb6lEwAAACiKCkRg8dNPP1mvXr3s8ccftypVqkTH792715588kmbPHmyXXzxxdaqVSubM2eOLV++3N5///18TTMAAABQlBSIwEJVnS699FLr3LlzzPi1a9fa4cOHY8Y3btzY6tataytWrMhyeQcPHrR9+/bFDAAAAAByr4SluRdeeMHWrVvnqkLF27Fjh5UqVcoqV64cM75GjRpuWlbGjx9vY8eOzZP0AgAAAEVRWpdYbNu2zQYNGmRz5861MmXKpGy5I0aMcNWogkHrAQAAAFBIAwtVddq1a5edffbZVqJECTeogfa0adPc/yqZOHTokO3Zsyfme+oVqmbNmlkut3Tp0laxYsWYAQAAAEAhrQrVqVMn+/jjj2PG3XDDDa4dxV133WV16tSxkiVL2uLFi103s7Jx40bbunWrtWvXLp9SDQAAABQ9aR1YVKhQwZo1axYzrly5cu6dFcH4vn372tChQ61q1aqu5GHgwIEuqGjbtm0+pRoAAAAoetI6sEjGlClTrFixYq7EQr09de3a1WbOnJnfyQIAAACKlAIXWLzzzjsxn9Woe8aMGW4AAAAAkD/SuvE2AAAAgIKBwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAABQuAOL8ePH2znnnGMVKlSw6tWrW8+ePW3jxo0x8xw4cMBuu+02q1atmpUvX96uuOIK27lzZ76lGQAAACiK0jqwWLp0qQsa3n//fVu0aJEdPnzYunTpYvv374/OM2TIEHvttdfspZdecvNv377dLr/88nxNNwAAAFDUlLA0tnDhwpjPTz/9tCu5WLt2rV1wwQW2d+9ee/LJJ+25556ziy++2M0zZ84ca9KkiQtG2rZtm08pBwAAAIqWtC6xiKdAQqpWrer+KsBQKUbnzp2j8zRu3Njq1q1rK1asyHI5Bw8etH379sUMAAAAAIpAYHH06FEbPHiwnXfeedasWTM3bseOHVaqVCmrXLlyzLw1atRw07Jru1GpUqXoUKdOnTxPPwAAAFCYFZjAQm0tPvnkE3vhhRe8lzVixAhX+hEM27ZtS0kaAQAAgKIqrdtYBAYMGGALFiywZcuWWe3ataPja9asaYcOHbI9e/bElFqoVyhNy0rp0qXdAAAAAKAIlFhEIhEXVLz88su2ZMkSa9CgQcz0Vq1aWcmSJW3x4sXRceqOduvWrdauXbt8SDEAAABQNJVI9+pP6vHplVdece+yCNpNqF1E2bJl3d++ffva0KFDXYPuihUr2sCBA11QQY9QAAAAwPGT1oHFrFmz3N+LLrooZry6lO3Tp4/7f8qUKVasWDH3Yjz19tS1a1ebOXNmvqQXAAAAKKpKpHtVqGMpU6aMzZgxww0AAAAA8kdat7EAAAAAUDAQWAAAAADwRmABAAAAwBuBBQAAAAACCwAAAAD5jxILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAeCOwAAAAAOCNwAIAAACANwILAAAAAN4ILAAAAAB4I7AAAAAA4I3AAgAAAIC3QhNYzJgxw+rXr29lypSxNm3a2KpVq/I7SQAAAECRUSgCi3nz5tnQoUNtzJgxtm7dOmvZsqV17drVdu3ald9JAwAAAIqEQhFYTJ482fr162c33HCDNW3a1GbPnm0nnHCCPfXUU/mdNAAAAKBIKGEF3KFDh2zt2rU2YsSI6LhixYpZ586dbcWKFQm/c/DgQTcE9u7d6/7u27fP8svRgz/n27oBID+vfwUB12gARfUave//rTsSiRT+wOK7776zI0eOWI0aNWLG6/Pnn3+e8Dvjx4+3sWPHZhpfp06dPEsnAKSzSlPzOwUAgHS+Rv/4449WqVKlwh1Y5IZKN9QmI3D06FHbvXu3VatWzTIyMvI1bUBuchIUFG/bts0qVqzIBgSANMI1GgWdSioUVNSqVeuY8xb4wOLEE0+04sWL286dO2PG63PNmjUTfqd06dJuCKtcuXKephPIawoqCCwAID1xjUZBdqySikLTeLtUqVLWqlUrW7x4cUwJhD63a9cuX9MGAAAAFBUFvsRCVK2pd+/e1rp1azv33HNt6tSptn//ftdLFAAAAIC8VygCi9/+9rf27bff2ujRo23Hjh125pln2sKFCzM16AYKI1Xr0ztc4qv3AQDyH9doFCUZkWT6jgIAAACAwtzGAgAAAED+I7AAAAAA4I3AAgAAAIA3AgsAAIAcevrpp2PegXX33Xe7zmPyWv369V3vl0A6IrAA0tBFF11kgwcPTvtlAgD+rzvuuCPmnVqpDlwCq1evtv79+7PZkZYKRXezAAAA+al8+fJuyGsnnXRSnq8DyC1KLIA006dPH1u6dKk9/PDDlpGR4YavvvrKPvnkE+vWrZu7cekdLdddd51999137jvvvPOOewv9u+++G13OpEmTrHr16rZz584slwkAhZHeZdWhQweX41+tWjW77LLL7B//+IebpmufroEvvPCCtW/f3sqUKWPNmjVz18iArqma5/XXX7cWLVq4edq2beuuw1lJVBXqqaeesjPOOMO9y+Lkk0+2AQMGRKdNnjzZmjdvbuXKlbM6derYrbfeaj/99FN0/XrJ7969e6PXbC0/UVWorVu3Wo8ePdy9oWLFinbVVVe56358uv70pz+571aqVMmuvvpq+/HHH1OyrYEwAgsgzejhv127dtavXz/75ptv3FChQgW7+OKL7ayzzrI1a9a4m6ZuHLqBhKs5KdjQjeiDDz6wUaNG2RNPPOGCkETL1I0MAAqj/fv329ChQ931UtWTihUrZv/5n/9pR48ejc4zbNgwu/322931UtfH7t272/fffx+zHM3z0EMPuepHKinQPIcPH04qDbNmzbLbbrvNVVv6+OOP7dVXX7WGDRtGpytN06ZNsw0bNtgzzzxjS5YssTvvvNNNU8Cj4EGBQnDNVlWrePo9Cip2797tAqNFixbZl19+6V4cHKagav78+bZgwQI3aN4JEybkeLsCx6QX5AFILxdeeGFk0KBB0c/33ntvpEuXLjHzbNu2TS+3jGzcuNF9PnjwYOTMM8+MXHXVVZGmTZtG+vXrl+0yAaCo+Pbbb9318uOPP45s2bLF/T9hwoTo9MOHD0dq164dmThxovv89ttvu3leeOGF6Dzff/99pGzZspF58+a5z3PmzIlUqlQpOn3MmDGRli1bRj/XqlUr8sc//jHpNL700kuRatWqRT/HLz9Qr169yJQpU9z/f/vb3yLFixePbN26NTp9w4YNLu2rVq2KpuuEE06I7Nu3LzrPsGHDIm3atEk6bUCyKLEACoD169fb22+/Ha3Dq6Fx48ZuWlC8r6pQc+fOtb/85S924MABmzJlSj6nGgDyx+bNm+2aa66xU0891eX6qwpQUG0ooFKKQIkSJax169b22WefxSwnPE/VqlXt9NNPzzRPIrt27bLt27dbp06dspznrbfectNPOeUUVyqtEmeVmPz8889J/06lRaXP4RLopk2buipg4XTq92sdAVXLUhqBVKPxNlAAqN6tiuAnTpyYaZpuEIHly5e7vyoW16C6uwBQ1Oh6Wa9ePXv88cetVq1arsqQ2lEcOnTouKy/bNmy2U5XOw+1+7jlllvsvvvuc0HLe++9Z3379nVpPOGEE1KanpIlS8Z8VpuNcLUwIFUosQDSkEofjhw5Ev189tlnu3q4ynVSHd3wEAQPKrkYMmSIu5G2adPGevfuHXPjiF8mABRGyvXfuHGjjRw50pUINGnSxH744YdM873//vvR/3/55Rdbu3atmzerebSMTZs2ZZonEZUO6HqdVfezWpeuz2q/oUbhv/rVr1wJR1gy12ylZdu2bW4IfPrpp7Znzx5XcgEcbwQWQBrSDWnlypUuV0s9P6kBoEogVLSvRoQKIt58803Xa4huPBquvfZa69q1qxs3Z84c++ijj9xNK6tlklsFoDCqUqWK6wnqsccesy+++MI1ilZD7ngzZsywl19+2T7//HN3jVXgcOONN8bMc88997jgQL1BqXe9E0880Xr27JlUOtQbk67BaqCtqlnr1q2z6dOnu2nKFFIjcH1WY2v12DR79uyY7+uardJqrV/X7ERVpDp37ux6lurVq5db/qpVq+z666+3Cy+80FXtAo43AgsgDan3j+LFi7scJ/VEoqLxv//97y6A6NKli7uRqBco1aNVzyIqSv/666/t0UcfjVaP0k1VOXZqn5FomeG6xgBQWOiaqK5kVSqg6k8qyX3ggQcyzadekTS0bNnSVUNSr00KHOLnGTRokLVq1cp27Nhhr732mitJSIZKjdWz08yZM12Xs6r6pABDtE51N6vqrUqj2seNHz8+5vvqGermm292PTzpmq0uxOOpStMrr7zigqkLLrjABRpqVzJv3rwcbjUgNTLUgjtFywIAAEhrKrVt0KCB62Y2/r0TAb1HomPHjq4UI9HbrwEkRokFAAAAAG8EFgAAAAC8URUKAAAAgDdKLAAAAAB4I7AAAAAA4I3AAgAAAIA3AgsAAAAA3ggsAAAAAHgjsAAAAADgjcACAAAAgDcCCwAAAADeCCwAAAAAmK//AzNWZZWdYHC8AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 30: Content by mime_family over time\n",
+    "df = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "       COALESCE(mime_family, '(unknown)') AS mime_family,\n",
+    "       COUNT(*) AS parts\n",
+    "FROM multimodal_parts\n",
+    "GROUP BY hour, mime_family ORDER BY hour\n",
+    "\"\"\")\n",
+    "if not df.empty:\n",
+    "    if len(df[\"hour\"].unique()) == 1:\n",
+    "        fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "        ax.bar(df[\"mime_family\"], df[\"parts\"])\n",
+    "        ax.set_title(f\"Multimodal Parts by MIME Family (at {str(df['hour'].iloc[0])[:16]})\", fontweight=\"bold\")\n",
+    "        ax.set_ylabel(\"Parts\")\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "    else:\n",
+    "        pivot = df.pivot_table(index=\"hour\", columns=\"mime_family\", values=\"parts\", fill_value=0)\n",
+    "        fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "        pivot.plot.area(ax=ax, alpha=0.7, stacked=True)\n",
+    "        fmt_ax(ax, \"Multimodal Content by MIME Family Over Time\", ylabel=\"Parts\")\n",
+    "        ax.legend(loc=\"upper left\")\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "else:\n",
+    "    print(\"No multimodal content found.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "cell-31-truncation",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:20.170032Z",
+     "iopub.status.busy": "2026-04-11T06:43:20.169933Z",
+     "iopub.status.idle": "2026-04-11T06:43:25.298548Z",
+     "shell.execute_reply": "2026-04-11T06:43:25.298088Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW4AAAGGCAYAAADrbBjiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATztJREFUeJzt3QeYHVXZAOCTkEaABAiQEAgdgdBbKPJLixBFIAIaEKRFEAWkSUciIIaI9CqCgNID0hGkg/SqdFHA0DtJ6CX3f77jP/e/u7m72SSb7Ozu+z7PJLtz586dOffunW+++eacLpVKpZIAAAAAACiNrm29AQAAAAAANCRxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELzDDnnXde6tKlS55++ctfaulWsvvuu+c2XWqppVKlUtGudFpHH310/lvo379/+uijj9p6cwCAVhTnD8W5RJxXdFatcU710ksvVdex3nrrtfo2AjOOxC1Mp0UWWaR6EJzSdMcdd3S49o7gIaYTTzwxldmOO+442fvRvXv3NHDgwLTFFluk+++/f7rWH+9t0RaPP/54mlHGjRuXzj777Pzzz372s7wf0xoAFtv7wQcftOg5r7/+ehozZkzaeOON06KLLppmnXXWNMccc6S11lornXvuuXWfM2HChHTggQemxRdfPPXs2TMn2Lbbbrv073//u8Fy48ePTyeddFLabLPN0pJLLplmm222PK288srp+OOPT19++WXd9f/nP/9Ju+22W96eWH+/fv3SkCFD0ujRo6eqPW655ZY0dOjQ1Ldv39S7d++0yiqrpDPPPDNNmjSpyed88cUXacUVV2zwmfr0009nyOvedddd6Xvf+15aYoklUp8+ffJnd8CAAWmTTTZJN95441S95qWXXpq+/vWvp9lnnz1P8fNll13WZHDf3NRSn332Wfr1r3+dBg8enHr16pXfp+HDh6dHH3207vKPPPJI2nzzzfNysXw8L97Tzz//vMFy8d7H5/Ctt95Kp5566lS1AwAd2yuvvJJ22WWXHKv36NEjH2vjOLrpppumI488crLjXhEXXXXVVamzaxw377rrrpMtc8UVVzRYJuKS9qTeuUF8Tuaff/4cX91www1tvYkA/1UBpsvCCy8cJY8tmm6//fYO19rFvkU7NPbmm29W7r777jz95z//qbSlHXbYodn3pkePHpUHH3xwmtc/atSo6rrOPffcyoyy3377Vbd3/Pjx07yeddddt7q9L774Youec/HFFzfbhnvttVeD5WP7VlhhhbrLzjXXXJV//OMf1WXvu+++Zte9+eabT7Y9f/vb3yp9+vSpu/ziiy/e4rb4wx/+UOnSpUvd9YwcObLJ5/3qV7+abPlPPvlkhrzuUUcd1Wz7XHjhhVP9OW08xWsU4jMxpe+zbt26teg1v/jii8qGG25Ydx09e/as3HLLLQ2Wv+mmm/Lnu97yG220UeXLL79ssPw222yTHxswYEB+LQB4/fXXK/PPP3+Tx7BZZpmlQSNFjF48FjFjZ9c4bp5jjjkqH374YYNlNt544wbL9O/fv9W3Y0bG11M6N4jpsssuq5RB7HuxTdEm06I2tovzAKD9UHEL0+nyyy9Pd999d3Wqvdp88sknN3gsqgfr6ai3+M4333xpnXXWydNCCy2UymKnnXbK78fFF1+cFl544TwvKvl+97vfpTKLqtMLLrgg//zNb34zV17ObFH9OHLkyFxlcd1116Vvf/vbDT7vL7zwQvX3qFr5xz/+kX/+xje+kStYfvzjH+ff33///byeWt26dUsjRozI78tf/vKXtP3221cfu/rqq9Ptt99e/T2qhKMCNSp6Z5llllx5eeWVV+bq09NOOy1XSrS0injPPffMXU7E60d17yWXXJIWWGCB/Pg555yTrr/++sme99xzz6Wjjjoqt8e0mNrXjfl77bVXbptbb701/elPf0rLLLNM9fFTTjlliq8ZleCxzSEqpf/whz/kKX5u/H5FtUntd1cx/fSnP62uLypmW+L000/P2xyWW265/Nk57LDDqpW4UfES/4dPPvkk/30WlbWxXCwfzwt//etfc0VyraiYD2+88cZUVx8D0DHFcTGOtWHDDTdMf/7zn/Mx5Kyzzko/+tGP0lxzzdUm29VeY/6JEyfmO3Zq73i6+eabU0dRnBvcdNNN+bylEDFlR35fgXairTPH0JErcGsrbBtf5bzzzjsra665ZqVXr17VK/tNVa/Wq45svL6oFl1vvfUqs846a77ifeihh1a++uqrBuuJSrXTTjstv25UKsZrL7HEEpVdd921uswTTzxR+cEPflBZZpllclVkVNXNO++8lW9/+9t5m1tSuVdsf3NXh59//vnKjjvuWFlwwQUr3bt3r8w999yVb33rW5NV3zWugLjxxhsrq622Wq7UGzRoUOWkk06a6qvqtdty3HHHNajmqzV69OjctgsssEBuq2jbaJdo248++qi6XHNX6murA/7+979Xtt5661wZGPs8cODAXFn58ssvt2gfov2L9Tbe76iC2G233SqrrrpqZb755svrj/c43uuzzz67bnvWm5qrvn366acn29ZPP/00f96K51966aV5/meffVaZc84587yoKn3ttdfy/EmTJlWWXnrp6vIPP/xwnh/rfeqppyZ7zZVXXrm67JgxY6rzf/Ob39StFJ1asc5iPT/+8Y/rVhd/5zvfafCc2If/+Z//yY/9+te/nqaK22l53cauvPLK6rLLLrvsFF/zJz/5SXX5+GwX4udi/h577NHsOpZffvm632/NVXHH30wxPyqr61XqXH755XlefH6KefF4vYrs5ZZbrsHrvv/++9XHdt555ym2AwAd37Bhw6rHhto7fAq1cVzt8avxVFt9G1W8e+65Z2WxxRbLd4b07ds3P7dxVWZLYv6IzSLujFi2d+/eOa6NmDyOw2+//fZk2zt27Nh8rI/l4v84XjZXjTq9MWdt3BzVtvH/WmutVX38F7/4RYPH6lXcRrz0u9/9rrLGGmtUZp999rztSy21VOXggw+ufPDBB5O9ZuzT4MGD22Qfa88Nrrvuuur82N6peV+nZrtaes7V3DlVrLeYH8+L+Du88MILlU033TR/tmKdP/vZz3Kc3VTFbdwld8ghh+QYPfYn3q8hQ4ZUzjzzzPw+FrbYYovqOuJcLnz88cd5Pxv/vRxwwAHVZW+44YbJ2jzusIrPUZxnxXu+9tprVx5//PEWvXfQ2UjcQhskbuMAHgfFxkHhtCZu41awSCo2DjZ///vfV9fx+eefT3ZLU+3Uktvhu3btWrntttumO3H7wAMPNAj0aqdI8p1++ul1E42x3tiGxs+5+eabpzk4++1vf1udH4nkWhGsNbWP66+/fnW5ppapDTIjYImgpN4yEdhFgDUltUnC6H6iVpxMNLcdRxxxxGTtWW9qabcJtVZfffXq8yPYDY888kh13qKLLtpg+Z122qn62AknnNDsur/3ve9Vlz311FOr84vEabFvkcyLv6mFFlqoctBBB7U4gRpBbbGe888/vzo/uvYo5kcCutYZZ5yR56+44or51vza9puRr1t7ASY+L8OHD29xwrVx0rX2hKD2gkDsU1Puuuuu6nJxYtVYve+pd999tzovgvrabg7ifWvczUacEDf+zIZo5+KkIKb33nuvwWvHSXTjEywAOq/a+GGzzTbLcVOR1GqsJYnbOO5GvNbUcgceeOBUxfzNxeSRyKuNJ6644oq6XSvFMbtxvNlaMWdt3LzLLrtUf47kXxzLI9kWv0fxR73EbST7InnZ1D5GgrD2WB7J73r7WNvl1ozcx+LcIBL6cUG9mL/llltO1fs6NdvV0nOups6pIgFezIsuqYrPTMRecUGgubasTdzG+1BbVNF4ivexEHF7Mf9Pf/rTZPHh1772tcli9diXonu32jYvYrfaaZFFFtHtFdQhcQttkLiNKa6qX3DBBfkAH5Vz+Q9yGhO3MX3961+vXH311fmKajEvKlPrJSjj6mtUKUb1aiR3I/FWePTRR3MV6lVXXZUDhltvvTUnqoog5Jvf/GY1wRRBcG0wUvRn+9BDDzUZZEQgF0mfYv5WW21Vuf766/MV1yIpG1UM48aNq5tojL5Or7322gbBYKxjSmoDhUgcxnZecsklOdFX9HUWfabWiuAkgpJ4j+64447KNddck69mF+u555578nKxrtpkZFyxLtoi+vmNIDCudsdjcTX96KOPrvz1r39tcCU6KkOm5Ic//GF1+UjU1oqA6Mgjj8yBb6w72i32b8kll8zLx5XzOGGJCofYrpVWWqm6rqjiKLY3KminRgSgsU/FaxSBWZxkFOuPaoRacXJTPBaf16ZEJWW/fv3ychHMF1f2QzG/qSmqWGorBFqSzIy/h0IEv7XrK04uXnnllVzJHJ+Xolp4WhK3U/u6hdrq5uLzFJ+LiRMnTvE1ay+WPPvss9X5zzzzTHV+7FtTav/monK/sXrfU7UJ/PiOqJcAL06qGye0o8qjqX2P76la8X4Xn5PGfeAC0PlEpWfj2CDiy4iXIyau7a81KnJPPvnk6nJxB1gRF/3zn/+crII37nCLmPD4449vkLy7//77WxzzRz/3MUUMHDFm/L/99ttP1nd9HNNqk3CRkI5la+P92qRma8WctXFzHK+LO6D22WefvO/F+u+99966iduIQYv5UU161lln5X2vTR7GnWLFPhaJ4Jgi3oh9jNeaWftYb4okYvH+t+R9ndrtauk5V71zqhNPPLH6eyRIayvIo4Chdh+icvm8886rzDPPPHUTt/E+FPMjPv3zn/+cK8LjfSvmx/vZOK776U9/OtldZDG98847uWCoKCqKz069No8L8vHceL3az3hRBAL8P4lbaIPEbSQoaxMn1T/IaUzcRiD6xhtv5PnRPUIkZhtX7NVelY9gtikRPEUwEMncSPQ0vvodB/GWbHNTidsIUmoTOXFgL8RV7caVmLWJ2+gCoEgsxv4W8yMJOT3BWVzxjQCxsSeffDIHj0V3Do2fV9tdQXO3ctXe0l57MhBTBFRFwqnerXG14rnFeuolWCOhHUFeBGaRWGy8vXHr1vQMTtZYBGa1Afgpp5xSfeyPf/xjdf43vvGNBs8rbq9rbvCvuO1q6NCh1eViULZatfsXn8l4vZhqg8wIhEME3bVtXjtYXu3V/trKhvg7qm274va2SDDG7/vvv3912aYSt635uk0lbiO4j0rxCRMmTPH9qq1Wr634+Pe//93kYC2F+Hsr/gbie6Elr9e4CiMuktQ655xzGlSKhA022KA6L05oa9UG9Y0rzkeMGFF9LC6WANC5RTy77bbbNhn7xSCmtRdHmxucLCoYi3g4jrsR/zQeNLb27pGWxPxRoBCVrHFXUr0KzUhaFnepNRU3x4XxxrFna8WcjRO3ccE2fo4Ys6gWjpiodl9rE7dFvNQ4PozuAWrjt7jIXruPUclaO9BoJNpnxj7Wm6K7huIifUve16ndrqk556o9p1pllVWqy0Y3FI1jstouqmrPb6JYp3HiNuLO2tg53p9CvG+NBwmObS4GBi4SssUdYNFe8X+cj0QXfvWKNGrbvHZQ42OOOaY6P9oEaMjgZNAGllxyybTUUku12vqWXnrp1L9///xz165dqwMuxABOhX/+85/Vn7/zne80ua5999037b333umhhx7KAxH8Ny/1/2rXOS1qt2OVVVZJ3bt3r/4+ZMiQussV1lxzzdSzZ8/8c79+/Vptm8aNG9dgUK1i0IW11147Dxj1yiuvpC+++GKy57X0dWv3JQbd+p//+Z/q9NJLL+X50c7PPvtsi7e58fsSg25suummeaCId955J3311VfTvL0tEQN+rLvuutXBrOJzs8cee1Qfn2222ao/FwNPFYqBpxovV4jP3be+9a10yy235N9jELIxY8Y0WKb4HISf/OQn6Yc//GGeYpCyQvH8o48+ukGbxxSDcjW3nbXbWCwXg5pcc801afHFF09HHHHEFNuotV63Vrz+bbfdls4+++y07LLL5ueed955eVCNKWnJa9Z7P8Lvf//76t9ADBpXDGg2ra/Z1OtO6+em8d8DAJ1bDFwaA7ref//9ab/99ssDBEeMXPj3v/+djj322Bat6/nnn68eZyIGqI1BpxS71ov5I86JGDOOrS+++OJkx7vamK02Pm0cN6+11lozJeYM2267berdu3eOMWMAr7DLLrs0uXztdqyxxhrVn2Ow0VhPMVDt22+/3WAfV1pppTxoa732nZH7WAxOFrFjDAYbnnrqqXzO9Omnn7bofZ3a7ZrWc65HH300LxuxWAxk2zgmq23P1Vdfvdm2jPaP9yHE+1IMBtt4+WLf4u8qPrshzgFiULb77rsv9ejRozqA7b333punQux/PXEeUWjN8zroiCRuoQ0USdamNE66RZDUnMYj49YGPFMjEiMx2m6xjmOOOSbdfvvtOZCZZ555ZniCpEuXLi3ez9p9nNptGjVqVA6S//jHP+Yg/ssvv8yB0+OPP15d5vzzz08TJkyoBsZXXXVVbocDDjigusykSZNSa5rSiLTFexCKIKtw6qmnVn/ecccdc5Ixtveb3/xmq29vJLUjCIuANhx00EHpuOOOa7DMIossUv35zTffbPDYG2+8Uf150UUXbfBY7NfQoUPTnXfeWT1RuOiii3KgWGuhhRaq/rzwwgvX/bl4/5rT1HbWbuOcc86ZP3uvvfZa9WQvgtv4vDb+zM4666xp+PDhrfq6tSKIXn/99dPIkSPTtdde2yBxX+/EYmpfs/H7UXwfFd8LoQjMW6L2Nd999938t9bc6za1jfG8eH699db+PcT7URv8A9C5RdLwt7/9bU52xXF8iy22qD4W82Z07Fov5r/yyitzUUBRfHHppZfmmO2EE05oNmab0mu1ZszZWN++fdNWW21V/X2BBRbIF9lntOnZ56nZx4gr11lnnbThhhumE088Mb8vRaxy1113TfW53JS2a3rOuYqYOJK9hx9+eKu1ZePHm1r+G9/4RjU+jM9uxGtxYSTi0xCJ3JimlLhtrfM66AwkbqENNHUgjKAoRIKiqG6LK7RTe1W8nq997WvVn+PqbD3xukXyZ8UVV0wHHnhgWm+99dJiiy2W3nvvvWb3paVJwdrteOyxxxokch544IG6y80IcWU4KjSjerAIPn75y19WH3/11VerPx9yyCFp8803zwHd+PHj666vtoqjcVvU7ssOO+yQA5LGUwRxG2+8cbPbvMwyy1R//te//tXgsdrtPeWUU3LCNq6I185v6fY257nnnssBWCQvw+jRo/PUWFyxLz7PkegttiP2Napf6gVzEfjF1fcHH3ywWkn7pz/9qe6FiK9//esNKqbr/Txo0KD8f1SkNm7v4r2O97RQWx1QG3DWLjM1WvN1P/nkk2a/R2LdU0pUt+Q16wXXkSB++eWX888RlA8ePDi11Nxzz1393MbfelSVNPe6TW1jPK/4rojPVuOEdvH3EH9rjZP8AHQ+kWz78MMPJ0u2RRxWr1CiubhoiSWWqB5zI/6pvZA4pdi1XsxfG5vtvvvu6fvf/34+/tW7ABsVvrVxc+021x5HWzvmrOdHP/pRgyKB5o63tdtRxHXhySefTB9//HH+OY7l8847bz7PKEQRRe0+1rbvzNjHeuqdA9V7X6dmu6blnKsQ8XF8JsPpp5+ek761atvz4YcfbrYto/2jUCDEthVFGY2Xr9232lixuNgQRS6R7I51Rcx2zz33VJ83PUlu4L+mrSwPmCHiIPzII4/kJM0PfvCDfEUzDsj1bnufWtttt136+9//nn/eZ5990ltvvZVvn4ngMa74RvAXB9ZevXrlQOKJJ57I82PeUUcd1WRyL4KuCDCiiuHCCy/MFY/xnLiFqJ64BSoSOc8880y+3T4qKiP4i+AgKhCKpOqWW26ZZoYIlKK6NoKpuA09kuQReNRWbp588sl5m2IbzznnnLrrqU0kXXHFFbmCMG5nizaOJGoERnE7UlT5RjIr5sX7Gon5CG7ivXn66aeb3dbaZGVUidQGTrG9xW1McfU9gsJIeja1ztrtjVv1vv3tb+dq0dVWW63ZpG18JuOzE+K9ixONv/3tb9VlIkCbb775cnvtvPPOOaCLtt1mm23Sz3/+83zRINYT4rVWXXXV/HOsM/YnbkcMUfEQfwNF4FdUQxSVtnHyEN0OxLrPOOOMamXEmWeeWV2+JZ+hSN4feeSROViN9zbWM3DgwLythaL7hah2ra2GKcTfUyFuu2xJNyhT87pFZUv8Dcc2zD///DmRWlvlHEnq+Iw1J25p/N3vfpf/ln/961/nv9M48YifQ5yA1bvt8bTTTmtwgtmUOOEoKqXj1s+iKjb2o7jtMNYf+x2f36gKDwsuuGC1+5bo7iPaIb5P4vFDDz00f0ZqK0pq26W4pS5er/HfCACdV8SwEXNEd0txUTiOLXGBuDjmNb6NvDYuirgmbnWPW9CLuCbiqhtvvDHfsRWJ1jj2RxI34vRCxDotURtjRiwTiba4APmrX/1qsmWje4Q4xsdxP46NUXAQ8Vd0V1B7IbzQWjFnPRGnxcX6OE+oTeLWEzFcxNUhjuHRxVVUktZ2NTVixIgch8RxPuKcOCcp9jFinltvvbVBHDgj9zEu/Mf7Hu9vfG5qi2ZaWkwyNds1LedchbizKLYxupCLO46iwCRiqWizsNlmm+XzrBDdmEViN14nYqrG4oLF1ltvXY2f47MVdybGeuP/ep/tiEWLbY9EfJG4jfcytin+Topq56aqbYGp1KjPW2AmDE5WO5LnlEbAnX322fPgWM0NTtZ4fbXbUIjBDGoHe2o8FXbffffJHltyySXzwGCNl208oFjjQR3qDU4WYhCC2hHua6fobP/0009v0WARzQ2M1lhtZ/i12xI22WST6mM/+tGP8rwYRKoY5K12qh0koXY9MSJx40EFat+vGByg3uATU7MPMVhDDEwRy3/nO99p8NjYsWMnW2eMdLzqqqvW/TzWDjjQ0m2ofT+bmmoHZhs/fnyDwctqpxg4L9qs3vvc1NT4fYsBwppa9sADD6y0VAyCVe+9a27wtFpNDU7Wmq/bXLvEoGFXX311i16zdhC9xtNRRx012fLPPfdcdRtjxOfaAUMaa2rAu3hODD5W7zXjb+KWW25psJ6bbropD7hYb/mNNtooD4zR1GffSMQAhOYGJosp4qnXX3+9boxVL66JgTzrPV4v7phSzB+DSc0///zNxpi1Me8VV1xRN15Yfvnl68ZfrRFzNh6crClNDU4Wg47VDhzaeFp66aUbDA538cUX111uiSWWmCn72NS06aabTtW53NRs19Scc9U7p4rYuRg4Nv6/+eab8/wYPC9itnrrrrf9MfhevB9NbXMM1BzvZ60YeLh2mRhsLxxxxBEN5p933nlNtnnteUlT54zAf+kqAUokrl4ffPDB+cp+VD9usMEGua+j2tukplVUf0b1QFSPxpXS2WefPV8tjSrf2iq76Acs+nuNqr5YJq7axhXv2J56om/VqDyYUrVfrXj9qCyO24jiCnvcCh+VDsOGDctVdnEL0MwUg1YUoko1+rOKys7YltjW2Pd4D6KqoqkKg+WXXz5fXY9q4tqBswpR0Rq3K0WlZVwVj/cjKg+iAjkGJxg7duwUtzPaqbiaHoOQRd9Wheh3LKopo9I53teoIokr3rWDDNT68Y9/nKuNYz9rbw9sTX369Mmf3/333z9XIEcVbny2owojbqOKNpsev/nNb3K1dOxr9DkbU/RlF4ORNL5tbEoDUkTlSlT5RnVNvN/RV1dU8tb27drapuZ1o+ohKobi7zI+O7FsvNfR1218ruLvtCWiq4YYcC8qI2KAr5ji5+ij7LDDDpts+diWoq+x+MxMS//Z8ZyoDInB2qKyOP4+ogoltjm6Q4j9r7XRRhvl+VF9G98LsXz8XUWVVHTb0PjWzOjfNwwYMCB/hwBAHDcjTohjSsRwcbyLOCR+jjgzjp1x3Kg9VkWFaNxJVG8AzqiKjbtFooKxuKsq4py4EymOoVMTd8T6I46LOD9i7YiF426UmOqJfnkvu+yy3FVR7EMcE6P//9rjZzHgV2vFnNMrqi9jG6OSM2LpaP84nkf1aoyNENXCtVXOUfV58cUX532LfYy7l6IaOSpA65lR+xjbHe9J3BUWn5+pXc/UbNfUnnPVu9MpYv8QXezFnWZR0RsVudFVSNzNFJ+LiLniXK+pfYnH4/2Ic9Bo93if4v2K+DriwHgfG3cNUfRzG+LzW3RP1njAPBW30Dq6RPa2ldYFwAwWt8pFsj0GNYhE8sxOckOZRB9xcbIQ3cuMGTOmweCBANARxOl6vT5V47b0oh/SSCrHxV8AOh4VtwDtSCSpiqrfGPXWtTc6s6jkiaRtVHJHFRQAdDRx91L0MRp36cSAr1FVGX3OF0nbqJKMAa4A6JhU3AIAAEAJ3XHHHWn99ddvstuF6Norqm8B6JhU3AIAAEAJRf+6McZB9M8bfZZGH6TRbVZ0lxXVt5K2AB2bilsAAAAAgJJRcQsAAAAAUDIStwAAAAAAJdOtrTegI5g0aVJ67bXXcufwXbp0aevNAQDotCqVSpo4cWIaOHBg6tpVjUJBvAoA0P7iVYnbVhBJ20GDBrXGqgAAaAUvv/xyWnDBBbXl/xGvAgC0v3hV4rYVRKVt0eB9+vRpjVUCADANJkyYkC+oF/EZ/yVeBQBof/GqxG0rKLpHiKStxC0AQNvTfVX99hCvAgC0n3hVx18AAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAl062tNwAAAJg5lht1U+ras7fmBgD4Py8ds0kqKxW3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDLtLnF72mmnpUUWWST16tUrrbHGGunBBx9sdvmxY8empZdeOi+//PLLpxtuuKHJZXfbbbfUpUuXdOKJJ86ALQcAAAAA6ICJ20svvTTtu+++adSoUenRRx9NK664Ytp4443TW2+9VXf5e++9N22zzTZp5MiR6bHHHkvDhw/P05NPPjnZsldeeWW6//7708CBA2fCngAAAAAAdJDE7fHHH5922WWXtNNOO6XBgwenM888M/Xu3Tv94Q9/qLv8SSedlIYNG5b233//tMwyy6SjjjoqrbLKKunUU09tsNyrr76a9txzz3ThhRem7t27z6S9AQAAAABo54nbzz//PD3yyCNp6NCh1Xldu3bNv9933311nxPza5cPUaFbu/ykSZPSD3/4w5zcXXbZZWfgHgAAAAAAtEy31E6888476auvvkr9+/dvMD9+f/bZZ+s+54033qi7fMwvjBkzJnXr1i397Gc/a/G2fPbZZ3kqTJgwoZoEjgkAgLYhFgMAoKNoN4nbGSEqeKM7hegvNwYla6nRo0enI444YrL5b7/9dvr0009beSsBAGipiRMnaiwAADqEdpO4nWeeedIss8yS3nzzzQbz4/cBAwbUfU7Mb275u+++Ow9sttBCC1Ufj6re/fbbL5144onppZdeqrvegw8+OA+SVltxO2jQoDTvvPOmPn36TNd+AgAw7Xr16qX5AADoENpN4rZHjx5p1VVXTbfeemsaPnx49Va4+H2PPfao+5y11lorP7733ntX59188815foi+bev1gRvzYwC0pvTs2TNPjUWfuzEBANA2xGIAAHQU7SZxG6LKdYcddkirrbZaGjJkSK6K/eijj6pJ1u233z4tsMACuSuDsNdee6V11103HXfccWmTTTZJl1xySXr44YfTWWedlR/v169fnmp17949V+QutdRSbbCHAAAAAADtLHE7YsSI3I/s4YcfngcYW2mlldKNN95YHYBs3LhxDaos1l577XTRRRelww47LB1yyCFpySWXTFdddVVabrnl2nAvAAAAAACa16VSqVSmsAxTEH3c9u3bN40fP14ftwAAbUhc1ny7DNr7stS1Z++Z/K4AAJTXS8dsUtp4VYesAAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACXT7hK3p512WlpkkUVSr1690hprrJEefPDBZpcfO3ZsWnrppfPyyy+/fLrhhhuqj33xxRfpwAMPzPNnm222NHDgwLT99tun1157bSbsCQAAAABAB0jcXnrppWnfffdNo0aNSo8++mhaccUV08Ybb5zeeuutusvfe++9aZtttkkjR45Mjz32WBo+fHiennzyyfz4xx9/nNfzi1/8Iv//5z//OT333HNps802m8l7BgAAAADw/7pUKpVKaieiwnb11VdPp556av590qRJadCgQWnPPfdMBx100GTLjxgxIn300Ufpuuuuq85bc80100orrZTOPPPMuq/x0EMPpSFDhqT//Oc/aaGFFmrRdk2YMCH17ds3jR8/PvXp02ea9w8AgOkjLmu+XQbtfVnq2rO3jxkAwP956ZhNUlnj1W6pnfj888/TI488kg4++ODqvK5du6ahQ4em++67r+5zYn5U6NaKCt2rrrqqydeJRuvSpUuac845m1zms88+y1NtgxeJ5JgAAGgbYjEAADqKdpO4feedd9JXX32V+vfv32B+/P7ss8/Wfc4bb7xRd/mYX8+nn36a+7yN7hWay3iPHj06HXHEEZPNf/vtt/M6AABoGxMnTtT0AAB0CO0mcTujxUBl3//+91P0HHHGGWc0u2xU/dZW8kbFbXTZMO+88+oqAQCgDcWAtAAA0BG0m8TtPPPMk2aZZZb05ptvNpgfvw8YMKDuc2J+S5YvkrbRr+1tt902xeRrz54989RYdN0QEwAAbUMsBgBAR9Fusow9evRIq666arr11lsb9GEWv6+11lp1nxPza5cPN998c4Pli6Tt888/n2655ZbUr1+/GbgXAAAAAAAdqOI2RPcEO+ywQ1pttdXSkCFD0oknnpg++uijtNNOO+XHt99++7TAAgvkPmjDXnvtldZdd9103HHHpU022SRdcskl6eGHH05nnXVWNWm71VZbpUcffTRdd911uQ/dov/bueeeOyeLAQAAAABmtnaVuB0xYkQeAOzwww/PCdaVVlop3XjjjdUByMaNG9fg9ri11147XXTRRemwww5LhxxySFpyySXTVVddlZZbbrn8+Kuvvpquueaa/HOsq9btt9+e1ltvvZm6fwAAAAAAoUslRuNiusTgZH379k3jx483OBkAQBsSlzXfLoP2vix17dl7Jr8rAADl9dIxm5Q2Xm03fdwCAAAAAHQWErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAyErcAAAAAACUjcQsAAAAAUDIStwAAAAAAJSNxCwAAAABQMhK3AAAAAAAlI3ELAAAAAFAy3aZ3Be+880564IEH0ldffZVWX331NP/887fOlgEAAAAAdFLTVXF7xRVXpCWWWCIdccQRadSoUWnxxRdP5557bpqRTjvttLTIIoukXr16pTXWWCM9+OCDzS4/duzYtPTSS+fll19++XTDDTc0eLxSqaTDDz88J5xnnXXWNHTo0PT888/P0H0AAKC8dtxxxzR8+PDqz126dEnHHHNMg2WuuuqqPL9wxx135N8/+OCDuuv85S9/mVZaaaUGv8fyu+22W4PlHn/88Tz/pZdeyr/H//F7ven+++9v1f0GAKAdJ24//PDDBr9HwjYSpzE99thjOUl66KGHphnl0ksvTfvuu29OEj/66KNpxRVXTBtvvHF666236i5/7733pm222SaNHDkyb18E4DE9+eST1WV+85vfpJNPPjmdeeaZuXJ4ttlmy+v89NNPZ9h+AADQfkQBwJgxY9L777/f6us955xzWlQ0cMstt6TXX3+9wbTqqqu26vYAANCOE7cRHF599dXV37t169Ygafrmm2+mHj16pBnl+OOPT7vsskvaaaed0uDBg3OytXfv3ukPf/hD3eVPOumkNGzYsLT//vunZZZZJh111FFplVVWSaeeemq12vbEE09Mhx12WNp8883TCiuskP74xz+m1157LVdRAABA3JE1YMCANHr06FZtjKWWWiqtv/76LSp86NevX96G2ql79+7eHACADmyqErc33XRTOuuss9J3v/vdnNyMxOiIESNy4DjPPPOkgw46KJ1++ukzZEM///zz9Mgjj+TAudC1a9f8+3333Vf3OTG/dvkQ1bTF8i+++GJ64403GizTt2/f3AVDU+sEAKBzmWWWWdKvf/3rdMopp6RXXnmlVdcdXTBE92MPP/xwq64XAIBONjhZ9C17/fXXp4svvjitu+666Wc/+1n617/+lacYnKzoS3ZGiEHQ4jX69+/fYH78/uyzz9Z9TiRl6y0f84vHi3lNLVPPZ599lqfChAkT8v+TJk3KEwAAbWNGxWJRuBB91EaXXdG9QWuJu8G+//3vpwMPPDDdeuutTS639tpr56KF5roxa0m8CgBAB03cFqLf2G9961vp5z//eVpvvfVyFW7tYAsdXdwmF/37Nvb222/rGxcAoA1NnDhxhq07+rndYIMNcgzcmn71q1/lbr3++te/pvnmm6/JsR5imemNVwEA6MCJ2xtuuCE988wzeWCws88+O915551p2223zYncI488Ms0666wzZEOjK4a4TS360a0Vv0dXDfXE/OaWL/6PefPPP3+DZZpLRB988MF5kLTaCoZBgwaleeedN/Xp02ca9xAAgOk1o+7+Ct/4xjdyt1sRC+64446ttt7FF188j+MQ3Y41Vc0bseYSSyzR4nU2Fa8CANBBE7f77bdfuuCCC/IgCtGXbQSsv/jFL9Kjjz6aB/5aeeWV0wknnJCTuK0tBj2LwdHiFrLhw4dXb4WL3/fYY4+6z1lrrbXy43vvvXd13s0335znh0UXXTQnb2OZIlEbQe0DDzyQfvKTnzS5LT179sxTY3H7WuNb2AAAmHlmdCwWfdJG3BgDi7Wmww8/PCdwL7nkklZZX1PxKgAAHTRxe9555+VbuCKB+t5776U111wzJ24jqRqJ2+hC4cc//vEMSdyGqBrYYYcd0mqrrZaGDBmSTjzxxPTRRx+lnXbaKT++/fbbpwUWWKA64u9ee+2V++I97rjj0iabbJID4Rj4Ibp2CF26dMlJ3bg9bckll8yJ3NifgQMHVpPDAABQWH755fPdZieffHLdRnniiSfSHHPMUf094s24U21KYoyFiHWPPfbYuo+/++67k43BMOecc87QCmMAANpR4na22WZLL774Yk7cvvzyy5MFioMHD0533313mlFGjBiR+5GNioQIXKPa4cYbb6wOLjZu3LgGVRYxiMNFF12UDjvssHTIIYfk5OxVV12VlltuueoyBxxwQE7+7rrrrumDDz5I66yzTl6nIBgAgHqie7Doc7ap7hRqRVdfX375ZYsaMvrOPeOMM+qOmTB06NDJ5sWAwVtvvbU3CQCgg+pSqVQqLV34wgsvzP1vxdX9jz/+OJ1//vlp8803T51ddK/Qt2/fNH78eH3cAgC0IXFZ8+0yaO/LUteevWfyuwIAUF4vHbNJaePVqaq4jdvChg0bll544YVcvRoJXAAAAAAAWtdUJW5Dv3798gQAAAAAwIwxY4fdBQAAAABgqkncAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlEy7Sdy+9957adttt019+vRJc845Zxo5cmT68MMPm33Op59+mnbffffUr1+/NPvss6ctt9wyvfnmm9XH//73v6dtttkmDRo0KM0666xpmWWWSSeddNJM2BsAAAAAgA6QuI2k7VNPPZVuvvnmdN1116W77ror7brrrs0+Z5999knXXnttGjt2bLrzzjvTa6+9lrbYYovq44888kiab7750gUXXJDXfeihh6aDDz44nXrqqTNhjwAAAAAA6utSqVQqqeSeeeaZNHjw4PTQQw+l1VZbLc+78cYb07e//e30yiuvpIEDB072nPHjx6d55503XXTRRWmrrbbK85599tlcVXvfffelNddcs+5rRYVuvN5tt93W4u2bMGFC6tu3b37NqAgGAKBtiMuab5dBe1+WuvbsPZPfFQCA8nrpmE1KG6+2i4rbSLRG9whF0jYMHTo0de3aNT3wwAN1nxPVtF988UVerrD00kunhRZaKK+vKdFoc889dyvvAQAAAABAy3VL7cAbb7yRuzSo1a1bt5xgjceaek6PHj1ywrdW//79m3zOvffemy699NJ0/fXXN7s9n332WZ5qM+Vh0qRJeQIAoG2IxQAA6CjaNHF70EEHpTFjxjS7THRbMDM8+eSTafPNN0+jRo1KG220UbPLjh49Oh1xxBGTzX/77bfzgGgAALSNiRMnanoAADqENk3c7rfffmnHHXdsdpnFFlssDRgwIL311lsN5n/55Zfpvffey4/VE/M///zz9MEHHzSoun3zzTcne87TTz+dNtxwwzzY2WGHHTbF7Y4BzPbdd98GFbeDBg3Kferq4xYAoO306tVL8wMA0CG0aeI2Ep0xTclaa62VE7DRb+2qq66a58XgYXEr3BprrFH3ObFc9+7d06233pq23HLLPO+5555L48aNy+srPPXUU2mDDTZIO+ywQzr66KNbtN09e/bMU2PR525MAAC0DbEYAAAdRbvIMi6zzDJp2LBhaZdddkkPPvhguueee9Iee+yRtt566zRw4MC8zKuvvpoHH4vHQ4zONnLkyFwZe/vtt+ek70477ZSTtmuuuWa1e4T1118/d40Qy0XftzFFlwcAAAAAAG2lXQxOFi688MKcrI0uDaKSIqpoTz755OrjX3zxRa6o/fjjj6vzTjjhhOqyMZjYxhtvnE4//fTq45dffnlO0l5wwQV5Kiy88MLppZdemol7BwAAAADw/7pUKpVKze9Mg+jjNip8x48fr49bAIA2JC5rvl0G7X1Z6tqz90x+VwAAyuulYzYpbbzaLrpKAAAAAADoTCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBk2k3i9r333kvbbrtt6tOnT5pzzjnTyJEj04cfftjscz799NO0++67p379+qXZZ589bbnllunNN9+su+y7776bFlxwwdSlS5f0wQcfzKC9AAAAAADoQInbSNo+9dRT6eabb07XXXdduuuuu9Kuu+7a7HP22WefdO2116axY8emO++8M7322mtpiy22qLtsJIJXWGGFGbT1AAAAAAAdLHH7zDPPpBtvvDGdffbZaY011kjrrLNOOuWUU9Ill1ySk7H1jB8/Pp1zzjnp+OOPTxtssEFaddVV07nnnpvuvffedP/99zdY9owzzshVtj//+c9n0h4BAAAAADStW2oH7rvvvtw9wmqrrVadN3To0NS1a9f0wAMPpO9+97uTPeeRRx5JX3zxRV6usPTSS6eFFloor2/NNdfM855++ul05JFH5vW88MILLdqezz77LE+FCRMm5P8nTZqUJwAA2oZYDACAjqJdJG7feOONNN988zWY161btzT33HPnx5p6To8ePXLCt1b//v2rz4nk6zbbbJOOPfbYnNBtaeJ29OjR6Ygjjphs/ttvv5371QUAoG1MnDhR0wMA0CG0aeL2oIMOSmPGjJliNwkzysEHH5yWWWaZtN1220318/bdd98GFbeDBg1K8847bx48DQCAttGrVy9NDwBAh9Cmidv99tsv7bjjjs0us9hii6UBAwakt956q8H8L7/8Mr333nv5sXpi/ueff577rq2tun3zzTerz7ntttvSE088kS6//PL8e6VSyf/PM8886dBDD61bVRt69uyZp8ai64aYAABoG2IxAAA6ijZN3EaFakxTstZaa+UEbPRbG4OMFUnX6MMsBiurJ5br3r17uvXWW9OWW26Z5z333HNp3LhxeX3hiiuuSJ988kn1OQ899FDaeeed0913350WX3zxVtpLAAAAAIAO2MdtdGcwbNiwtMsuu6QzzzwzDzq2xx57pK233joNHDgwL/Pqq6+mDTfcMP3xj39MQ4YMSX379k0jR47MXRpEX7jRhcGee+6Zk7bFwGSNk7PvvPNO9fUa940LAAAAADCztIvEbbjwwgtzsjaSs3ELXFTRnnzyydXHI5kbFbUff/xxdd4JJ5xQXTYGItt4443T6aef3kZ7AAAAAADQMl0qRceuTLMYnCwqfMePH29wMgCANiQua75dBu19Weras/dMflcAAMrrpWM2KW28aiQtAAAAAICSkbgFAAAAACgZiVsAAAAAgJKRuAUAAAAAKBmJWwAAAACAkpG4BQAAAAAoGYlbAAAAAICSkbgFAAAAACgZiVsAAAAAgJKRuAUAAAAAKBmJWwAAAACAkpG4BQAAAAAoGYlbAAAAAICSkbgFAAAAACgZiVsAAAAAgJKRuAUAAAAAKBmJWwAAAACAkpG4BQAAAAAoGYlbAAAAAICSkbgFAAAAACgZiVsAAAAAgJLp1tYbAAAAzBxPHrFx6tOnj+YGAGgHVNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJSNwCAAAAAJSMxC0AAAAAQMlI3AIAAAAAlIzELQAAAABAyUjcAgAAAACUjMQtAAAAAEDJdGvrDegIKpVK/n/ChAltvSkAAJ1aEY8V8Rn/JV4FAGh/8arEbSuYOHFi/n/QoEGtsToAAFohPuvbt692/D/vvvtu/l+8CgDQfuLVLhXlCNNt0qRJ6bXXXktzzDFH6tKly/SvEKCNrvrFCf3LL7+c+vTp4z0A2qUIbSMIHjhwYOraVa9ghQ8++CDNNddcady4cRLadTgGNk/7aJ/p5TOkfXx+Zhx/X+2vjaYmXlVx2wqikRdccMHWWBVAm4sDWRkOZgDTSqXt5IqTgmgb3/FNcwxsnvbRPtPLZ0j7+PzMOP6+2lcbtTReVYYAAAAAAFAyErcAAAAAACUjcQtA1rNnzzRq1Kj8PwAdi+947ePz4+/Ld1B5+Y7WPj4//saaYnAyAAAAAICSUXELAAAAAFAyErcAAAAAACUjcQvQyd1xxx2pS5cu6YMPPmjrTQEAAAD+j8QtwFSKJGdz0y9/+cvStul6662X9t577wbz1l577fT666+nvn37ztDX3nHHHatt1L1797ToooumAw44IH366afTvQ8ANO20005LiyyySOrVq1daY4010oMPPtgpm2v06NFp9dVXT3PMMUeab7750vDhw9Nzzz3XYJk4Ju2+++6pX79+afbZZ09bbrllevPNN9tsm9vSMccck4/Ztcdc7ZPSq6++mrbbbrv8GZl11lnT8ssvnx5++OFqG1UqlXT44Yen+eefPz8+dOjQ9Pzzz6fO4Kuvvkq/+MUvcowX+7744ouno446KrdJZ2yfu+66K2266aZp4MCB+W/pqquuavB4S9rivffeS9tuu23q06dPmnPOOdPIkSPThx9+mDp6+3zxxRfpwAMPzH9fs802W15m++23T6+99lqnaZ+WfIZq7bbbbnmZE088sdO00V0taJ9nnnkmbbbZZvlcNz5LEQeMGzeuXR3XJG4BplIkOYspDoxxEKyd9/Of/7xBQPbll1+Wuo179OiRBgwYkA92M9qwYcNyG73wwgvphBNOSL/73e/SqFGjZvjrAnRWl156adp3333zd+2jjz6aVlxxxbTxxhunt956K3U2d955Zz45u//++9PNN9+cEwMbbbRR+uijj6rL7LPPPunaa69NY8eOzctHkmCLLbZInc1DDz2Uj9ErrLBCg/mdvX3ef//99PWvfz1fgP7LX/6Snn766XTcccelueaaq7rMb37zm3TyySenM888Mz3wwAM5URB/c1N7obo9GjNmTDrjjDPSqaeempMl8Xu0xymnnNIp2ye+W+I7Ny6e1dOStoiE21NPPZW/s6677rqcqNp1111TR2+fjz/+OB+z4kJA/P/nP/85X2iLBFytjtw+LfkMFa688sp8bIsEZmMduY0+mkL7/Pvf/07rrLNOWnrppfNdpv/4xz/yZyouZLer41oFgGl27rnnVvr27Vv9/fbbb4+SgsoNN9xQWWWVVSrdu3fP83bYYYfK5ptv3uC5e+21V2Xdddet/h4/77nnnpX999+/Mtdcc1X69+9fGTVqVIPnvP/++5Vdd921Mt9881V69uxZWXbZZSvXXnttfuydd96pbL311pWBAwdWZp111spyyy1Xueiii6rPjW2IbaudXnzxxeo2x7oLl19+eWXw4MGVHj16VBZeeOHKb3/72wbbEfOOPvroyk477VSZffbZK4MGDar87ne/a7at6rXBFltsUVl55ZWrv0/rPoQnnniiMmzYsMpss82W22e77barvP32281uE0BHN2TIkMruu+9e/f2rr77K37GjR4+udHZvvfVWPo7ceeed+fcPPvggH7fHjh1bXeaZZ57Jy9x3332VzmLixImVJZdcsnLzzTfn2CTilaB9KpUDDzywss466zTZdpMmTaoMGDCgcuyxx1bnRbtFzHbxxRdXOrpNNtmksvPOO08W62277baVzt4+8T1y5ZVXVn9vSVs8/fTT+XkPPfRQdZm//OUvlS5dulReffXVSkdun3oefPDBvNx//vOfTtc+zbXRK6+8UllggQUqTz75ZD5HO+GEE6qPdaY2SnXaZ8SIEfmcsCnt5bim4hZgBjjooIPyLYZRbdC4WqU5559/fr7aHlfd4yr8kUcema+OhkmTJqVvfetb6Z577kkXXHBBrvKI15hlllny43F1ftVVV03XX399evLJJ/OV1B/+8IfVW2JPOumktNZaa6VddtmlWh08aNCgybbhkUceSd///vfT1ltvnZ544onc9UNcmTzvvPMaLBcVJquttlp67LHH0k9/+tP0k5/8ZLJbTpsT23jvvffmit/CtO5D9M+7wQYbpJVXXjnfrnjjjTfmW1xiPwA6q88//zx/p8ftt4WuXbvm3++7777U2Y0fPz7/P/fcc+f/o62iCre2vaJKZ6GFFupU7RVVyZtsskmDdgjaJ6Vrrrkmxz7f+973cncbEXf8/ve/r7bRiy++mN54440GbRe350YXJZ3hMxTdb916663pn//8Z/7973//e/rb3/6W49fQ2dunVkvaIv6PW9vjM1eI5eN7PM4VOuN3dtwhGG0StM9/zw/jXGn//fdPyy677GRt1pnbaNKkSfmc8mtf+1quZI/v7Pj7qu1Oob0c17q19QYAdESRcP3mN7851c+LJG/RdcCSSy6ZbzWLADjWdcstt+QEZiSD4wAUFltssepzF1hggQbdNOy5557ppptuSpdddlkaMmRIDgYjSdq7d+/cNUJTjj/++LThhhvmZG2I14ok8bHHHpv7qS18+9vfzgnbEH1QRdcHt99+e1pqqaWaXHfcnhN9B0X3EZ999lkOGmIfp3cfYh1x8vTrX/+6Ou8Pf/hDTurGyUPRXgCdyTvvvJP7nOzfv3+D+fH7s88+mzqzOKGLvlvjtvflllsuz4skShxjiqRAbXvFY53BJZdckm9Ljq4SGtM+KXf1FF0BRPcjhxxySG6nn/3sZ/lzs8MOO1Q/J/X+5jrDZygKFyZMmJATH1FYEN8/Rx99dL5VO3T29qnVkraI/yPZVKtbt275YlNna68o7ojzjW222SZ3Uxe0z3+7J4nPRHwP1dOZ2+itt97KfflGodOvfvWr3FZR3BPdIMQ567rrrttujmsStwAzQO1VzanRuDo3Biso+iF8/PHH04ILLthkEjKC40hcRpIzBs6ISqtIjkaSc2pEYnjzzTdvMC9ObKM/33iNosK3dlvj6nckUqfUZ+L666+fT3iiP6JI9EbgEB3AT+8+REVHHIAjKVyvbyOJWwAaV5XGnR1RDch/vfzyy2mvvfbKd/rU9v9Hw4R/xHjFheK4aByfo+ijNBK3nV3EbxdeeGG66KKLcvVfxK5xgST63dQ+TKuoiIy76OJu+DiP4P+rReNuxLjYNjPGKmmP39chzmujH9uw0kor5Ts+4zs7Erftha4SAGaA6O6gwZdt164NRtQtgpDGYrCLWnEQLg46Mdpsc6IiNg7ecTU6kpgRLMdtIZH8nBGa29bm2mWJJZbInchHRWzconPOOedM9z7E1dQYUTSWr51iZN5vfOMb07mnAO3TPPPMky+2NR4dOX5v7s6Ljm6PPfbId4DEcSYuiBaiTeJ4E93vdMb2iiRAXIBdZZVV8oXVmGKglhg8KX6OCqTO3D7FBfXBgwc3mLfMMstURygv2qGz/s3F7dpRdRvdbS2//PL5Fu5ImIwePTo/3tnbp1ZL2qJeUUTctfbee+91mvYqkrb/+c9/8kWloto2dPb2ufvuu/P+x239xXd2tNN+++2XFllkkdTZ22ieeebJbTKl7+z2cFyTuAWYCeadd97cH2utSCxOjahwfeWVV6r9hjUWfd/GFcXtttsuJ0ajG4XGy8atIFHV2pw4mMW6Gq87qlaLatvWEMnsuM3wsMMOS5988sl07UOcZMZoqRGkRGK4dmqcRAfoLOL7MvoNjy53CnGBLX6P/sI7m7iAGknbGH37tttuS4suumiDx6Ot4qJkbXtF3+1xgtcZ2iu6SYq+7WsvgEZ1adzmXvzcmdunuAOpcX/+EacsvPDC+ef4TMXJfm0bRdcBcaG6M7TRxx9/nOO7WhE7Fhf2O3v71GpJW8T/kVCKiyqF+O6K9oy+OjtL0jYKMaLLuH79+jV4vLO3T1wY+cc//tHgOzuq2+MCSnQ119nbqEePHmn11Vdv9ju7vRz3dZUAMBPEwFlRTfrHP/4xHwRicLG4tS5usWupuJ0jqkeja4HohzaSktFHYVS6Dhs2LPeJe/nll+fbP+aaa668TFwtrL3KGInNCAhfeuml3K1AMSBLrbhKGwe5o446Ko0YMSJ3zB59yJ5++umptcXgHhFcnHbaablv22ndh7jlNQYHiX6vDjjggDzvX//6V+6r7+yzz27VhDNAexJ9ccYtypF0i77Co9ub6K5mp512Sp1NHCviFu6rr746zTHHHNX+66L/9LirJf4fOXJkbrM4jkRlV/S1HsftNddcM3V00SZFf7+FuPgZyZJifmdunxDVozEAV3SVEAmlGHvgrLPOylOImCy6Boj+FCOmieRcjBkQyZThw4enji7ufoo+baMCMLpKiAFsI5bbeeedO2X7xB1hEY/WDkgWybX4+4k2mlJbRDFFxPgxKG/c2h2JzLj4FBXNsVxHbp+obt9qq61yNwBxh0QUbRTf2fF4JOU6evu05DPUOJkdSci4IFCMOdLR2+jDKbRPnGfG+WycQ0eXfdHH7bXXXpvuuOOOvHy7Oe5XAJhm5557bqVv377V32+//fboD6Hy/vvvT7bs4YcfXunfv39efp999qnssccelXXXXbf6ePy81157NXjO5ptvXtlhhx2qv7/77ruVnXbaqdKvX79Kr169Ksstt1zluuuuqz4Wy88+++yV+eabr3LYYYdVtt9++zyv8Nxzz1XWXHPNyqyzzpq388UXX6y7zZdffnll8ODBle7du1cWWmihyrHHHttguxZeeOHKCSec0GDeiiuuWBk1alSTbRX7UbsthdGjR1fmnXfeyocffjjN+xD++c9/Vr773e9W5pxzzvzY0ksvXdl7770rkyZNanKbADqDU045JX+X9+jRozJkyJDK/fffX+mM4phRb4pjeeGTTz6p/PSnP63MNddcld69e+fjyuuvv17prBrHJtqnUrn22mtz/NWzZ88ca5x11lkN2izijl/84hc55otlNtxwwxy7dAYTJkzIn5f4vok4dbHFFqsceuihlc8++6xTtk8RYzeeiti+JW0RsfE222yTY+M+ffrk84CJEydWOnr7RHzf1Hd2PK8ztE9LPkON1TtH68htdHsL2uecc86pLLHEEvk7Kc5Xr7rqqgbraA/HtS7xT1snjwEAAAAA+H/6uAUAAAAAKBmJWwAAAACAkpG4BQAAAAAoGYlbAAAAAICSkbgFAAAAACgZiVsAAAAAgJKRuAUAAAAAKBmJWwAAAACAkpG4BQAAAAAoGYlbAAAAYKbYcccdU5cuXfLUo0ePtMQSS6Qjjzwyffnll9O1zuHDh7fqdgKUQbe23gAAAACg8xg2bFg699xz02effZZuuOGGtPvuu6fu3bungw8+eKrW89VXX+UEMEBHpeIWAAAAmGl69uyZBgwYkBZeeOH0k5/8JA0dOjRdc8016fjjj0/LL798mm222dKgQYPST3/60/Thhx9Wn3feeeelOeecMy87ePDgvJ6dd945nX/++enqq6+uVvLecccd6fPPP0977LFHmn/++VOvXr3ya40ePdq7DLQrKm4BAACANjPrrLOmd999N3Xt2jWdfPLJadFFF00vvPBCTtwecMAB6fTTT68u+/HHH6cxY8aks88+O/Xr1y8nZj/55JM0YcKEXMUb5p577ryeSPBedtllaaGFFkovv/xyngDaE4lbAAAAYKarVCrp1ltvTTfddFPac88909577119bJFFFkm/+tWv0m677dYgcfvFF1/k31dcccUGid/odiGqeAvjxo1LSy65ZFpnnXVyFW5U3AK0NxK3AAAAwExz3XXXpdlnnz0nYSdNmpR+8IMfpF/+8pfplltuyd0ZPPvss7mCNgYs+/TTT3OVbe/evfNzY0CzFVZYoUUDln3zm99MSy21VO5T9zvf+U7aaKONZsLeAbQefdwCAAAAM83666+fHn/88fT888/nbg6ij9q33347J1cjKXvFFVekRx55JJ122ml5+eivtra6tiUDkq2yyirpxRdfTEcddVR+je9///tpq622mqH7BdDaVNwCAAAAM00MPrbEEks0mBeJ2qi+Pe6443JftyH6p22JqML96quvJpvfp0+fNGLEiDxF0jYqb997773cBy5AeyBxCwAAALSpSORG1wmnnHJK2nTTTdM999yTzjzzzBY9N/rDjX5yn3vuuTxgWd++ffN6YuCylVdeOSeCx44dm/vAnXPOOWf4vgC0Fl0lAAAAAG0qBhs7/vjj05gxY9Jyyy2XLrzwwtzfbUvssssuuS/b1VZbLc0777w56TvHHHOk3/zmN3ne6quvnl566aV0ww03VKt5AdqDLpUYxhEAAAAAgNJwqQkAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAEpG4hYAAAAAoGQkbgEAAAAASkbiFgAAAACgZCRuAQAAAABKRuIWAAAAAKBkJG4BAAAAAFK5/C9InvuXcdL0EAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1400x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Cell 31: Truncation rate + storage mode breakdown\n",
+    "df_trunc = run(\"\"\"\n",
+    "SELECT TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,\n",
+    "       SAFE_DIVIDE(COUNTIF(is_truncated), COUNT(*)) AS truncation_rate\n",
+    "FROM multimodal_parts\n",
+    "GROUP BY hour ORDER BY hour\n",
+    "\"\"\")\n",
+    "df_storage = run(\"\"\"\n",
+    "SELECT COALESCE(storage_mode, '(unset)') AS storage_mode, COUNT(*) AS parts\n",
+    "FROM multimodal_parts\n",
+    "GROUP BY storage_mode ORDER BY parts DESC\n",
+    "\"\"\")\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "if not df_trunc.empty:\n",
+    "    if len(df_trunc) == 1:\n",
+    "        rate = df_trunc[\"truncation_rate\"].iloc[0] or 0\n",
+    "        ax1.bar([\"Truncation Rate\"], [rate * 100], color=\"red\", alpha=0.7)\n",
+    "        ax1.set_title(f\"Truncation Rate (at {str(df_trunc['hour'].iloc[0])[:16]})\", fontweight=\"bold\")\n",
+    "    else:\n",
+    "        ax1.plot(df_trunc[\"hour\"], df_trunc[\"truncation_rate\"] * 100, linewidth=2, color=\"red\")\n",
+    "        ax1.set_title(\"Truncation Rate Over Time\", fontweight=\"bold\")\n",
+    "        ax1.xaxis.set_major_formatter(mdates.DateFormatter(\"%m-%d %H:%M\"))\n",
+    "        plt.setp(ax1.xaxis.get_majorticklabels(), rotation=45, ha=\"right\")\n",
+    "    ax1.set_ylabel(\"%\")\n",
+    "    ax1.grid(axis=\"y\", alpha=0.3)\n",
+    "else:\n",
+    "    ax1.text(0.5, 0.5, \"No truncation data\", ha=\"center\", va=\"center\", transform=ax1.transAxes)\n",
+    "    ax1.set_title(\"Truncation Rate\", fontweight=\"bold\")\n",
+    "if not df_storage.empty:\n",
+    "    ax2.barh(df_storage[\"storage_mode\"], df_storage[\"parts\"])\n",
+    "    ax2.set_title(\"Storage Mode Breakdown\", fontweight=\"bold\")\n",
+    "    ax2.set_xlabel(\"Parts\")\n",
+    "    ax2.invert_yaxis()\n",
+    "else:\n",
+    "    ax2.text(0.5, 0.5, \"No storage mode data\", ha=\"center\", va=\"center\", transform=ax2.transAxes)\n",
+    "    ax2.set_title(\"Storage Mode\", fontweight=\"bold\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "drilldown-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Section 10: Trace Drill-Down\n",
+    "\n",
+    "**Separate section, different success criterion.**\n",
+    "\n",
+    "The aggregate dashboard answers \"how is the system doing?\"\n",
+    "The drill-down answers \"what happened in this specific trace?\"\n",
+    "\n",
+    "Set `SESSION_ID_FILTER` or `TRACE_ID_FILTER` above and re-run Layer 1 to scope the drill-down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "cell-32-session-list",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:25.300060Z",
+     "iopub.status.busy": "2026-04-11T06:43:25.299962Z",
+     "iopub.status.idle": "2026-04-11T06:43:27.480800Z",
+     "shell.execute_reply": "2026-04-11T06:43:27.479850Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recent sessions (6 shown):\n",
+      "      session_id          agent                         start_ts                           end_ts  duration_ms  total_events  has_error  has_multimodal  trace_count\n",
+      "e2e-a9b40dfdbe84 travel_planner 2026-04-03 07:44:09.959171+00:00 2026-04-03 07:44:56.141283+00:00        46182            33      False            True            3\n",
+      "e2e-054c12957ba3 travel_planner 2026-04-03 07:43:59.632517+00:00 2026-04-03 07:44:09.553076+00:00         9920            19      False            True            1\n",
+      "e2e-781fb52f3814 travel_planner 2026-04-03 07:43:46.386415+00:00 2026-04-03 07:43:59.242929+00:00        12856            21      False            True            1\n",
+      "e2e-3171eb36991f travel_planner 2026-04-03 07:37:14.206646+00:00 2026-04-03 07:37:40.342719+00:00        26136            33      False            True            3\n",
+      "e2e-f676e06a719e travel_planner 2026-04-03 07:36:54.241866+00:00 2026-04-03 07:37:13.697492+00:00        19455            19      False            True            1\n",
+      "e2e-125750c7b94d travel_planner 2026-04-03 07:36:20.755950+00:00 2026-04-03 07:36:53.834107+00:00        33078            23      False            True            1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 32: Session list\n",
+    "df = run(\"\"\"\n",
+    "SELECT\n",
+    "  session_id,\n",
+    "  agent,\n",
+    "  start_ts,\n",
+    "  end_ts,\n",
+    "  duration_ms,\n",
+    "  total_events,\n",
+    "  has_error,\n",
+    "  has_multimodal,\n",
+    "  trace_count\n",
+    "FROM session_rollups\n",
+    "ORDER BY start_ts DESC\n",
+    "LIMIT 30\n",
+    "\"\"\")\n",
+    "print(f\"Recent sessions ({len(df)} shown):\")\n",
+    "print(df.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "cell-33-span-tree",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:27.482970Z",
+     "iopub.status.busy": "2026-04-11T06:43:27.482808Z",
+     "iopub.status.idle": "2026-04-11T06:43:29.823881Z",
+     "shell.execute_reply": "2026-04-11T06:43:29.823061Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Span tree for session: e2e-a9b40dfdbe84\n",
+      "Total events: 33, Unique spans: 15\n",
+      "======================================================================\n",
+      "[1c5d2a3d] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (4078ms)\n",
+      "  [4da56afc] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (4077ms)\n",
+      "    [ca1069a7] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (2148ms)\n",
+      "    [0c421077] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [cb1f5828] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (1914ms)\n",
+      "[6d944fa2] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (35705ms)\n",
+      "  [c11e0281] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (35704ms)\n",
+      "    [6a6e6b52] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (29060ms)\n",
+      "    [ba01fa7e] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [8a1d7785] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (6631ms)\n",
+      "[edaac2cc] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (5410ms)\n",
+      "  [cf99a390] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (5410ms)\n",
+      "    [8f97b315] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (2113ms)\n",
+      "    [397df66f] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [9bf79f5b] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (3284ms)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 33: Span tree for a session\n",
+    "# Pick the most recent session (or set SESSION_ID_FILTER above)\n",
+    "target_session = df[\"session_id\"].iloc[0] if not df.empty else None\n",
+    "\n",
+    "if target_session:\n",
+    "    # Query all events for the session\n",
+    "    events = run(f\"\"\"\n",
+    "    SELECT\n",
+    "      span_id,\n",
+    "      parent_span_id,\n",
+    "      event_type,\n",
+    "      event_family,\n",
+    "      agent,\n",
+    "      status,\n",
+    "      error_message,\n",
+    "      CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms,\n",
+    "      CAST(JSON_VALUE(latency_ms, '$.time_to_first_token_ms') AS FLOAT64) AS ttft_ms,\n",
+    "      timestamp\n",
+    "    FROM filtered_events\n",
+    "    WHERE session_id = '{target_session}'\n",
+    "    ORDER BY timestamp\n",
+    "    \"\"\")\n",
+    "\n",
+    "    # Aggregate events into spans (deduplicate by span_id)\n",
+    "    span_map = {}\n",
+    "    for _, row in events.iterrows():\n",
+    "        sid = row.get(\"span_id\")\n",
+    "        if not sid:\n",
+    "            continue\n",
+    "        if sid not in span_map:\n",
+    "            span_map[sid] = {\n",
+    "                \"span_id\": sid,\n",
+    "                \"parent_span_id\": row.get(\"parent_span_id\"),\n",
+    "                \"agent\": row.get(\"agent\"),\n",
+    "                \"events\": [],\n",
+    "                \"total_ms\": None,\n",
+    "                \"ttft_ms\": None,\n",
+    "                \"has_error\": False,\n",
+    "                \"error_message\": None,\n",
+    "            }\n",
+    "        span_map[sid][\"events\"].append(row.get(\"event_type\", \"\"))\n",
+    "        # Capture latency from whichever event has it\n",
+    "        if row.get(\"total_ms\") and row[\"total_ms\"] > 0:\n",
+    "            span_map[sid][\"total_ms\"] = row[\"total_ms\"]\n",
+    "        if row.get(\"ttft_ms\") and row[\"ttft_ms\"] > 0:\n",
+    "            span_map[sid][\"ttft_ms\"] = row[\"ttft_ms\"]\n",
+    "        if row.get(\"error_message\"):\n",
+    "            span_map[sid][\"has_error\"] = True\n",
+    "            span_map[sid][\"error_message\"] = row[\"error_message\"]\n",
+    "        if row.get(\"status\") == \"ERROR\":\n",
+    "            span_map[sid][\"has_error\"] = True\n",
+    "\n",
+    "    # Build tree from parent_span_id\n",
+    "    children = {}\n",
+    "    roots = []\n",
+    "    for sid, span in span_map.items():\n",
+    "        pid = span.get(\"parent_span_id\")\n",
+    "        if pid and pid in span_map:\n",
+    "            children.setdefault(pid, []).append(span)\n",
+    "        else:\n",
+    "            roots.append(span)\n",
+    "\n",
+    "    def print_tree(node, indent=0):\n",
+    "        sid = node[\"span_id\"][:8]\n",
+    "        evts = \", \".join(node[\"events\"])\n",
+    "        ag = node.get(\"agent\") or \"\"\n",
+    "        lat = node.get(\"total_ms\")\n",
+    "        err = node.get(\"error_message\")\n",
+    "        prefix = \"  \" * indent\n",
+    "        err_mark = \" *** ERROR\" if node[\"has_error\"] else \"\"\n",
+    "        lat_str = f\" ({lat:.0f}ms)\" if lat and lat > 0 else \"\"\n",
+    "        print(f\"{prefix}[{sid}] events=[{evts}] agent={ag}{lat_str}{err_mark}\")\n",
+    "        if err:\n",
+    "            print(f\"{prefix}  error: {str(err)[:100]}\")\n",
+    "        for child in children.get(node[\"span_id\"], []):\n",
+    "            print_tree(child, indent + 1)\n",
+    "\n",
+    "    print(f\"Span tree for session: {target_session}\")\n",
+    "    print(f\"Total events: {len(events)}, Unique spans: {len(span_map)}\")\n",
+    "    print(\"=\" * 70)\n",
+    "    for root in roots:\n",
+    "        print_tree(root)\n",
+    "else:\n",
+    "    print(\"No sessions available for drill-down.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "cell-34-span-detail",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:29.826544Z",
+     "iopub.status.busy": "2026-04-11T06:43:29.826303Z",
+     "iopub.status.idle": "2026-04-11T06:43:31.872350Z",
+     "shell.execute_reply": "2026-04-11T06:43:31.871827Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- USER_MESSAGE_RECEIVED (span: 1c5d2a3d) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 1 part(s)\n",
+      "  content: {\"text_summary\":\"What's the weather like in Paris on 2025-04-20?\"}...\n",
+      "\n",
+      "--- INVOCATION_STARTING (span: 1c5d2a3d) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: null...\n",
+      "\n",
+      "--- AGENT_STARTING (span: 4da56afc) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: \"You are a helpful travel planning assistant. You help users plan trips by\\nsearching for flights, hotels, checking weather forecasts, and calculating\\nbudgets.\\n\\nGuidelines:\\n- Always search for fli...\n",
+      "\n",
+      "--- LLM_REQUEST (span: ca1069a7) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 1 part(s)\n",
+      "  content: {\"prompt\":[{\"content\":\"What's the weather like in Paris on 2025-04-20?\",\"role\":\"user\"}],\"system_prompt\":\"You are a helpful travel planning assistant. You help users plan trips by\\nsearching for flight...\n",
+      "\n",
+      "--- LLM_RESPONSE (span: ca1069a7) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 2148ms  ttft: 2148ms\n",
+      "  content: {\"response\":\"call: get_weather_forecast\",\"usage\":{\"completion\":22,\"prompt\":515,\"total\":577}}...\n",
+      "\n",
+      "--- TOOL_STARTING (span: 0c421077) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: {\"args\":{\"city\":\"Paris\",\"date\":\"2025-04-20\"},\"tool\":\"get_weather_forecast\",\"tool_origin\":\"LOCAL\"}...\n",
+      "\n",
+      "--- TOOL_COMPLETED (span: 0c421077) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 0ms\n",
+      "  content: {\"result\":{\"city\":\"Paris\",\"condition\":\"Rain\",\"date\":\"2025-04-20\",\"humidity_pct\":74,\"precipitation_chance_pct\":47,\"temperature_high_c\":22,\"temperature_low_c\":10,\"uv_index\":2,\"wind_speed_kmh\":30},\"tool\"...\n",
+      "\n",
+      "--- LLM_REQUEST (span: cb1f5828) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 3 part(s)\n",
+      "  content: {\"prompt\":[{\"content\":\"What's the weather like in Paris on 2025-04-20?\",\"role\":\"user\"},{\"content\":\"\",\"role\":\"model\"},{\"content\":\"\",\"role\":\"user\"}],\"system_prompt\":\"You are a helpful travel planning as...\n",
+      "\n",
+      "--- LLM_RESPONSE (span: cb1f5828) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 1914ms  ttft: 1914ms\n",
+      "  content: {\"response\":\"text: 'The weather in Paris on April 20, 2025, is expected to be rainy with a high of 22°C and a low of 10°C. There is a 47% chance of precipitation and a humidity level of 74%. Wind spee...\n",
+      "\n",
+      "--- AGENT_COMPLETED (span: 4da56afc) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 4077ms\n",
+      "  content: null...\n",
+      "\n",
+      "--- INVOCATION_COMPLETED (span: 1c5d2a3d) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 4078ms\n",
+      "  content: null...\n",
+      "\n",
+      "--- USER_MESSAGE_RECEIVED (span: 6d944fa2) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 1 part(s)\n",
+      "  content: {\"text_summary\":\"Find me flights from Chicago to Paris on 2025-04-20.\"}...\n",
+      "\n",
+      "--- INVOCATION_STARTING (span: 6d944fa2) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: null...\n",
+      "\n",
+      "--- AGENT_STARTING (span: c11e0281) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: \"You are a helpful travel planning assistant. You help users plan trips by\\nsearching for flights, hotels, checking weather forecasts, and calculating\\nbudgets.\\n\\nGuidelines:\\n- Always search for fli...\n",
+      "\n",
+      "--- LLM_REQUEST (span: 6a6e6b52) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 5 part(s)\n",
+      "  content: {\"prompt\":[{\"content\":\"What's the weather like in Paris on 2025-04-20?\",\"role\":\"user\"},{\"content\":\"\",\"role\":\"model\"},{\"content\":\"\",\"role\":\"user\"},{\"content\":\"The weather in Paris on April 20, 2025, is...\n",
+      "\n",
+      "--- LLM_RESPONSE (span: 6a6e6b52) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 29060ms  ttft: 29060ms\n",
+      "  content: {\"response\":\"call: search_flights\",\"usage\":{\"completion\":22,\"prompt\":678,\"total\":817}}...\n",
+      "\n",
+      "--- TOOL_STARTING (span: ba01fa7e) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  content: {\"args\":{\"date\":\"2025-04-20\",\"destination\":\"Paris\",\"origin\":\"Chicago\"},\"tool\":\"search_flights\",\"tool_origin\":\"LOCAL\"}...\n",
+      "\n",
+      "--- TOOL_COMPLETED (span: ba01fa7e) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 0ms\n",
+      "  content: {\"result\":{\"flights\":[{\"airline\":\"Southwest Airlines\",\"arrival_time\":\"01:00\",\"class\":\"Business\",\"date\":\"2025-04-20\",\"departure_time\":\"15:45\",\"destination\":\"Paris\",\"duration_hours\":10,\"flight_id\":\"FL-3...\n",
+      "\n",
+      "--- LLM_REQUEST (span: 8a1d7785) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  multimodal: 7 part(s)\n",
+      "  content: {\"prompt\":[{\"content\":\"What's the weather like in Paris on 2025-04-20?\",\"role\":\"user\"},{\"content\":\"\",\"role\":\"model\"},{\"content\":\"\",\"role\":\"user\"},{\"content\":\"The weather in Paris on April 20, 2025, is...\n",
+      "\n",
+      "--- LLM_RESPONSE (span: 8a1d7785) ---\n",
+      "  agent: travel_planner  status: OK\n",
+      "  latency: 6631ms  ttft: 6631ms\n",
+      "  content: {\"response\":\"text: 'I found several flight options from Chicago to Paris on April 20, 2025:\\n\\n*   **Delta Air Lines**\\n    *   **Price:** $373.09\\n    *   **Departure:** 09:30 AM\\n    *   **Arrival:*...\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 34: Span detail — pick a span to inspect\n",
+    "if target_session:\n",
+    "    detail = run(f\"\"\"\n",
+    "    SELECT\n",
+    "      span_id, parent_span_id, event_type, agent, status,\n",
+    "      error_message, is_truncated,\n",
+    "      JSON_VALUE(latency_ms, '$.total_ms') AS total_ms,\n",
+    "      JSON_VALUE(latency_ms, '$.time_to_first_token_ms') AS ttft_ms,\n",
+    "      SUBSTR(TO_JSON_STRING(content), 0, 500) AS content_preview,\n",
+    "      SUBSTR(TO_JSON_STRING(attributes), 0, 500) AS attributes_preview,\n",
+    "      ARRAY_LENGTH(content_parts) AS content_parts_count,\n",
+    "      timestamp\n",
+    "    FROM filtered_events\n",
+    "    WHERE session_id = '{target_session}'\n",
+    "    ORDER BY timestamp\n",
+    "    LIMIT 20\n",
+    "    \"\"\")\n",
+    "    for _, row in detail.iterrows():\n",
+    "        print(f\"--- {row['event_type']} (span: {str(row.get('span_id',''))[:8]}) ---\")\n",
+    "        print(f\"  agent: {row.get('agent')}  status: {row.get('status')}\")\n",
+    "        if row.get(\"total_ms\"):\n",
+    "            print(f\"  latency: {row['total_ms']}ms\", end=\"\")\n",
+    "            if row.get(\"ttft_ms\"):\n",
+    "                print(f\"  ttft: {row['ttft_ms']}ms\", end=\"\")\n",
+    "            print()\n",
+    "        if row.get(\"error_message\"):\n",
+    "            print(f\"  error: {str(row['error_message'])[:200]}\")\n",
+    "        if row.get(\"content_parts_count\") and int(row[\"content_parts_count\"]) > 0:\n",
+    "            print(f\"  multimodal: {row['content_parts_count']} part(s)\")\n",
+    "        if row.get(\"content_preview\"):\n",
+    "            print(f\"  content: {str(row['content_preview'])[:200]}...\")\n",
+    "        print()\n",
+    "else:\n",
+    "    print(\"No session selected.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "cell-35-error-chain",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:31.873853Z",
+     "iopub.status.busy": "2026-04-11T06:43:31.873760Z",
+     "iopub.status.idle": "2026-04-11T06:43:33.810611Z",
+     "shell.execute_reply": "2026-04-11T06:43:33.809674Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No errors in this session.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cell 35: Error chain — trace error propagation\n",
+    "if target_session:\n",
+    "    errors = run(f\"\"\"\n",
+    "    SELECT span_id, parent_span_id, event_type, agent, error_message,\n",
+    "           CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms,\n",
+    "           timestamp\n",
+    "    FROM filtered_events\n",
+    "    WHERE session_id = '{target_session}'\n",
+    "      AND (ENDS_WITH(event_type, '_ERROR')\n",
+    "           OR error_message IS NOT NULL\n",
+    "           OR status = 'ERROR')\n",
+    "    ORDER BY timestamp\n",
+    "    \"\"\")\n",
+    "    if not errors.empty:\n",
+    "        # Build span lookup for the full session\n",
+    "        all_spans = run(f\"\"\"\n",
+    "        SELECT span_id, parent_span_id, event_type, agent\n",
+    "        FROM filtered_events\n",
+    "        WHERE session_id = '{target_session}'\n",
+    "        \"\"\")\n",
+    "        span_map = {r[\"span_id\"]: r for _, r in all_spans.iterrows() if r.get(\"span_id\")}\n",
+    "\n",
+    "        print(f\"Error chain for session: {target_session}\")\n",
+    "        print(f\"Found {len(errors)} error event(s):\")\n",
+    "        print(\"=\" * 70)\n",
+    "        for _, err in errors.iterrows():\n",
+    "            print(f\"\\nError: {err['event_type']} (agent={err.get('agent')})\")\n",
+    "            print(f\"  message: {str(err.get('error_message',''))[:200]}\")\n",
+    "            # Walk up to root\n",
+    "            chain = []\n",
+    "            current = err.get(\"span_id\")\n",
+    "            visited = set()\n",
+    "            while current and current in span_map and current not in visited:\n",
+    "                visited.add(current)\n",
+    "                s = span_map[current]\n",
+    "                chain.append(f\"{s.get('event_type','')} [agent={s.get('agent','')}]\")\n",
+    "                current = s.get(\"parent_span_id\")\n",
+    "            if chain:\n",
+    "                print(\"  propagation path (leaf → root):\")\n",
+    "                for i, step in enumerate(chain):\n",
+    "                    print(f\"    {'  ' * i}→ {step}\")\n",
+    "    else:\n",
+    "        print(\"No errors in this session.\")\n",
+    "else:\n",
+    "    print(\"No session selected.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "closing-sep",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "cell-closing",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T06:43:33.813173Z",
+     "iopub.status.busy": "2026-04-11T06:43:33.812996Z",
+     "iopub.status.idle": "2026-04-11T06:43:34.320329Z",
+     "shell.execute_reply": "2026-04-11T06:43:34.319454Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dashboard V2 complete.\n",
+      "  Layers: 7 base tables (Layer 1) + 23 charts + 4 drill-down views (Layer 2)\n",
+      "  Data source: `test-project-0728-467323.agent_analytics.agent_events`\n",
+      "  Time range: last 720 hours\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Session ChoKGHRlc3QtcHJv... closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Dashboard V2 complete.\")\n",
+    "print(f\"  Layers: 7 base tables (Layer 1) + 23 charts + 4 drill-down views (Layer 2)\")\n",
+    "print(f\"  Data source: {TABLE_REF}\")\n",
+    "print(f\"  Time range: last {TIME_RANGE_HOURS} hours\")\n",
+    "\n",
+    "# Clean up BigQuery session\n",
+    "try:\n",
+    "    client.query(f\"CALL BQ.ABORT_SESSION('{SESSION_ID}')\", job_config=_job_config()).result()\n",
+    "    print(f\"  Session {SESSION_ID[:16]}... closed.\")\n",
+    "except Exception:\n",
+    "    print(f\"  Session will auto-expire.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/dashboard_v2_bigframes.ipynb
+++ b/examples/dashboard_v2_bigframes.ipynb
@@ -1,0 +1,1355 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:03.922828Z",
+     "iopub.status.busy": "2026-04-11T07:02:03.922672Z",
+     "iopub.status.idle": "2026-04-11T07:02:03.925492Z",
+     "shell.execute_reply": "2026-04-11T07:02:03.925048Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#      https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dashboard V2 — BigFrames Companion\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2_bigframes.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/colab-logo.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2_bigframes.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"> View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/main/examples/dashboard_v2_bigframes.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksez_HgKlFSz3Iq-WkBjgcm0hR0CDKoENQ=e14-rj-sc0xffffff-h130\" alt=\"Vertex AI logo\" width=\"32px\"> Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/bigquery\">\n",
+    "      <img src=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQq0MF-jjYwlnEaAQchRjsi41Xm9IXkmIl7GA&s\" alt=\"BQ Studio logo\" width=\"32px\"> Open in BQ Studio\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This is a **DataFrame-native companion** to `dashboard_v2.ipynb`. It provides\n",
+    "the same analytics using [BigFrames](https://cloud.google.com/bigquery/docs/bigframes-intro)\n",
+    "(`bigframes.pandas`) instead of raw SQL temp tables.\n",
+    "\n",
+    "**Key design rule**: This notebook does NOT reimplement Dashboard V2 semantics.\n",
+    "It loads base DataFrames via `bpd.read_gbq(<SQL>)` using the *same SQL*\n",
+    "from Dashboard V2 Layer 1 — preserving the source-of-truth hierarchy:\n",
+    "1. ADK plugin schema\n",
+    "2. SDK semantic mirrors (`views.py`, `event_semantics.py`)\n",
+    "3. SDK aggregation patterns (`evaluators.py`)\n",
+    "\n",
+    "For the canonical pure-SQL reference, see `dashboard_v2.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layer A: Setup & Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:03.927430Z",
+     "iopub.status.busy": "2026-04-11T07:02:03.927325Z",
+     "iopub.status.idle": "2026-04-11T07:02:04.650595Z",
+     "shell.execute_reply": "2026-04-11T07:02:04.650056Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dependencies installed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess, sys\n",
+    "\n",
+    "rc = subprocess.call(\n",
+    "    [sys.executable, \"-m\", \"pip\", \"install\", \"-q\",\n",
+    "     \"--break-system-packages\",\n",
+    "     \"google-cloud-bigquery\", \"bigframes\", \"matplotlib\", \"pandas\", \"db-dtypes\"],\n",
+    "    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,\n",
+    ")\n",
+    "print(\"Dependencies installed.\" if rc == 0 else \"pip install failed — check manually.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:04.670341Z",
+     "iopub.status.busy": "2026-04-11T07:02:04.670116Z",
+     "iopub.status.idle": "2026-04-11T07:02:09.663877Z",
+     "shell.execute_reply": "2026-04-11T07:02:09.663292Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project  : test-project-0728-467323\n",
+      "Location : (auto)\n",
+      "Dataset  : agent_analytics\n",
+      "Table    : agent_events\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "import bigframes.pandas as bpd\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=UserWarning, module=\"bigframes\")\n",
+    "matplotlib.rcParams[\"figure.dpi\"] = 100\n",
+    "\n",
+    "# ---------- Configuration ----------\n",
+    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"test-project-0728-467323\")\n",
+    "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
+    "TABLE_ID   = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
+    "LOCATION   = os.environ.get(\"BQ_LOCATION\") or None\n",
+    "TABLE_REF  = f\"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`\"\n",
+    "\n",
+    "TIME_RANGE_HOURS = 720  # last 30 days\n",
+    "\n",
+    "bpd.options.bigquery.project = PROJECT_ID\n",
+    "if LOCATION:\n",
+    "    bpd.options.bigquery.location = LOCATION\n",
+    "\n",
+    "def read_sql(sql):\n",
+    "    \"\"\"Load SQL results as a pandas DataFrame via BigFrames.\"\"\"\n",
+    "    return bpd.read_gbq(sql).to_pandas()\n",
+    "\n",
+    "print(f\"Project  : {PROJECT_ID}\")\n",
+    "print(f\"Location : {LOCATION or '(auto)'}\")\n",
+    "print(f\"Dataset  : {DATASET_ID}\")\n",
+    "print(f\"Table    : {TABLE_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layer B: Semantic Base DataFrames\n",
+    "\n",
+    "Each DataFrame mirrors a Layer 1 temp table from `dashboard_v2.ipynb`,\n",
+    "using the **exact same SQL** for semantic extraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:09.665618Z",
+     "iopub.status.busy": "2026-04-11T07:02:09.665383Z",
+     "iopub.status.idle": "2026-04-11T07:02:12.062537Z",
+     "shell.execute_reply": "2026-04-11T07:02:12.062035Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    Query processed 122.2 kB in a moment of slot time.\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "filtered_events: 148 rows\n",
+      "Event families : {'tool': 50, 'llm': 48, 'agent': 20, 'invocation': 20, 'user': 10}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# filtered_events — mirrors dashboard_v2.ipynb Layer 1 cell 2\n",
+    "# Source-of-truth: event_semantics.py:128,136-159 + plugin schema\n",
+    "\n",
+    "_WHERE = f\"timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {TIME_RANGE_HOURS} HOUR)\"\n",
+    "\n",
+    "filtered_events_df = read_sql(f\"\"\"\n",
+    "SELECT\n",
+    "  timestamp,\n",
+    "  event_type,\n",
+    "  agent,\n",
+    "  session_id,\n",
+    "  invocation_id,\n",
+    "  user_id,\n",
+    "  trace_id,\n",
+    "  span_id,\n",
+    "  parent_span_id,\n",
+    "  status,\n",
+    "  error_message,\n",
+    "  is_truncated,\n",
+    "  CASE\n",
+    "    WHEN event_type = 'USER_MESSAGE_RECEIVED' THEN 'user'\n",
+    "    WHEN event_type IN ('INVOCATION_STARTING','INVOCATION_COMPLETED') THEN 'invocation'\n",
+    "    WHEN event_type IN ('AGENT_STARTING','AGENT_COMPLETED') THEN 'agent'\n",
+    "    WHEN event_type IN ('LLM_REQUEST','LLM_RESPONSE','LLM_ERROR') THEN 'llm'\n",
+    "    WHEN event_type IN ('TOOL_STARTING','TOOL_COMPLETED','TOOL_ERROR') THEN 'tool'\n",
+    "    WHEN event_type = 'STATE_DELTA' THEN 'state'\n",
+    "    WHEN event_type LIKE 'HITL_%' THEN 'hitl'\n",
+    "    ELSE 'other'\n",
+    "  END AS event_family,\n",
+    "  (ENDS_WITH(event_type, '_ERROR')\n",
+    "   OR error_message IS NOT NULL\n",
+    "   OR status = 'ERROR') AS is_error,\n",
+    "  JSON_QUERY(attributes, '$.labels') AS labels,\n",
+    "  JSON_QUERY(attributes, '$.session_metadata') AS session_metadata,\n",
+    "  content,\n",
+    "  attributes,\n",
+    "  latency_ms,\n",
+    "  content_parts\n",
+    "FROM {TABLE_REF}\n",
+    "WHERE {_WHERE}\n",
+    "\"\"\")\n",
+    "\n",
+    "print(f\"filtered_events: {len(filtered_events_df):,} rows\")\n",
+    "print(f\"Event families : {dict(filtered_events_df['event_family'].value_counts())}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:12.064513Z",
+     "iopub.status.busy": "2026-04-11T07:02:12.064419Z",
+     "iopub.status.idle": "2026-04-11T07:02:12.980879Z",
+     "shell.execute_reply": "2026-04-11T07:02:12.980171Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    Query processed 40.7 kB in a moment of slot time.\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "llm_events: 48 rows (24 responses)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# llm_events — mirrors dashboard_v2.ipynb Layer 1 cell 3\n",
+    "# Source-of-truth: views.py:78-98, evaluators.py:682-712\n",
+    "\n",
+    "llm_events_df = read_sql(f\"\"\"\n",
+    "SELECT\n",
+    "  timestamp, agent, session_id, invocation_id, user_id,\n",
+    "  trace_id, span_id, parent_span_id,\n",
+    "  event_type, status, error_message,\n",
+    "  (ENDS_WITH(event_type, '_ERROR') OR error_message IS NOT NULL OR status = 'ERROR') AS is_error,\n",
+    "  JSON_VALUE(attributes, '$.model') AS model,\n",
+    "  CAST(JSON_VALUE(content, '$.usage.prompt') AS INT64) AS usage_prompt_tokens,\n",
+    "  CAST(JSON_VALUE(content, '$.usage.completion') AS INT64) AS usage_completion_tokens,\n",
+    "  CAST(JSON_VALUE(content, '$.usage.total') AS INT64) AS usage_total_tokens,\n",
+    "  JSON_VALUE(attributes, '$.model_version') AS model_version,\n",
+    "  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms,\n",
+    "  CAST(JSON_VALUE(latency_ms, '$.time_to_first_token_ms') AS FLOAT64) AS ttft_ms,\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.prompt_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.prompt') AS INT64),\n",
+    "    CAST(JSON_VALUE(attributes, '$.input_tokens') AS INT64)\n",
+    "  ) AS prompt_tokens,\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.candidates_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.completion') AS INT64),\n",
+    "    CAST(JSON_VALUE(attributes, '$.output_tokens') AS INT64)\n",
+    "  ) AS completion_tokens,\n",
+    "  COALESCE(\n",
+    "    CAST(JSON_VALUE(attributes, '$.usage_metadata.total_token_count') AS INT64),\n",
+    "    CAST(JSON_VALUE(content, '$.usage.total') AS INT64),\n",
+    "    COALESCE(\n",
+    "      CAST(JSON_VALUE(attributes, '$.input_tokens') AS INT64), 0\n",
+    "    ) + COALESCE(\n",
+    "      CAST(JSON_VALUE(attributes, '$.output_tokens') AS INT64), 0\n",
+    "    )\n",
+    "  ) AS total_tokens\n",
+    "FROM {TABLE_REF}\n",
+    "WHERE {_WHERE}\n",
+    "  AND event_type IN ('LLM_REQUEST','LLM_RESPONSE','LLM_ERROR')\n",
+    "\"\"\")\n",
+    "\n",
+    "print(f\"llm_events: {len(llm_events_df):,} rows ({(llm_events_df['event_type'] == 'LLM_RESPONSE').sum():,} responses)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:12.982745Z",
+     "iopub.status.busy": "2026-04-11T07:02:12.982610Z",
+     "iopub.status.idle": "2026-04-11T07:02:13.497663Z",
+     "shell.execute_reply": "2026-04-11T07:02:13.496954Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    Query processed 22.7 kB in a moment of slot time.\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session_rollups: 6 sessions\n",
+      "  with errors : 0\n",
+      "  total events: 148\n"
+     ]
+    }
+   ],
+   "source": [
+    "# session_rollups — mirrors dashboard_v2.ipynb Layer 1 cell 5\n",
+    "# Source-of-truth: evaluators.py session aggregation\n",
+    "\n",
+    "session_rollups_df = read_sql(f\"\"\"\n",
+    "SELECT\n",
+    "  session_id,\n",
+    "  ANY_VALUE(agent) AS agent,\n",
+    "  ANY_VALUE(user_id) AS user_id,\n",
+    "  MIN(trace_id) AS first_trace_id,\n",
+    "  MIN(timestamp) AS start_ts,\n",
+    "  MAX(timestamp) AS end_ts,\n",
+    "  TIMESTAMP_DIFF(MAX(timestamp), MIN(timestamp), MILLISECOND) AS duration_ms,\n",
+    "  COUNT(*) AS total_events,\n",
+    "  COUNTIF(event_type = 'LLM_REQUEST') AS llm_calls,\n",
+    "  COUNTIF(event_type = 'TOOL_STARTING') AS tool_calls,\n",
+    "  COUNTIF(event_type = 'TOOL_ERROR') AS tool_errors,\n",
+    "  COUNTIF(event_type = 'LLM_ERROR') AS llm_errors,\n",
+    "  COUNTIF(event_type LIKE 'HITL_%') AS hitl_events,\n",
+    "  COUNTIF(event_type = 'USER_MESSAGE_RECEIVED') AS turn_count,\n",
+    "  COUNTIF(event_type = 'STATE_DELTA') AS state_deltas,\n",
+    "  COUNTIF(\n",
+    "    ENDS_WITH(event_type, '_ERROR')\n",
+    "    OR error_message IS NOT NULL\n",
+    "    OR status = 'ERROR'\n",
+    "  ) > 0 AS has_error,\n",
+    "  COUNT(DISTINCT invocation_id) AS invocation_count,\n",
+    "  COUNT(DISTINCT trace_id) AS trace_count\n",
+    "FROM {TABLE_REF}\n",
+    "WHERE {_WHERE}\n",
+    "GROUP BY session_id\n",
+    "\"\"\")\n",
+    "\n",
+    "print(f\"session_rollups: {len(session_rollups_df):,} sessions\")\n",
+    "print(f\"  with errors : {session_rollups_df['has_error'].sum():,}\")\n",
+    "print(f\"  total events: {session_rollups_df['total_events'].sum():,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:13.499872Z",
+     "iopub.status.busy": "2026-04-11T07:02:13.499721Z",
+     "iopub.status.idle": "2026-04-11T07:02:13.997418Z",
+     "shell.execute_reply": "2026-04-11T07:02:13.996994Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    Query processed 26.0 kB in a moment of slot time.\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "multimodal_parts: 162 parts\n",
+      "  mime families: {'text': 110, 'application': 52}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# multimodal_parts — mirrors dashboard_v2.ipynb Layer 1 cell 7\n",
+    "# Source-of-truth: plugin schema content_parts UNNEST\n",
+    "\n",
+    "multimodal_parts_df = read_sql(f\"\"\"\n",
+    "SELECT\n",
+    "  e.timestamp,\n",
+    "  e.agent,\n",
+    "  e.session_id,\n",
+    "  e.event_type,\n",
+    "  CASE\n",
+    "    WHEN e.event_type IN ('LLM_REQUEST','LLM_RESPONSE','LLM_ERROR') THEN 'llm'\n",
+    "    WHEN e.event_type IN ('TOOL_STARTING','TOOL_COMPLETED','TOOL_ERROR') THEN 'tool'\n",
+    "    ELSE 'other'\n",
+    "  END AS event_family,\n",
+    "  e.is_truncated,\n",
+    "  cp.mime_type,\n",
+    "  REGEXP_EXTRACT(cp.mime_type, r'^([^/]+)') AS mime_family,\n",
+    "  cp.storage_mode,\n",
+    "  cp.uri,\n",
+    "  cp.text IS NOT NULL AS has_inline_text,\n",
+    "  cp.part_index\n",
+    "FROM {TABLE_REF} e, UNNEST(e.content_parts) AS cp\n",
+    "WHERE {_WHERE}\n",
+    "  AND e.content_parts IS NOT NULL\n",
+    "\"\"\")\n",
+    "\n",
+    "print(f\"multimodal_parts: {len(multimodal_parts_df):,} parts\")\n",
+    "if not multimodal_parts_df.empty:\n",
+    "    print(f\"  mime families: {dict(multimodal_parts_df['mime_family'].value_counts())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layer C: Chart Panels\n",
+    "\n",
+    "Charts built from the base DataFrames using pandas + matplotlib.\n",
+    "Panel structure mirrors `dashboard_v2.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:13.999247Z",
+     "iopub.status.busy": "2026-04-11T07:02:13.999135Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.004684Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.004159Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ---------- Chart helper ----------\n",
+    "\n",
+    "def time_plot(df, x_col, y_cols, title, ylabel, kind=\"line\", stacked=False, labels=None):\n",
+    "    \"\"\"Render a time-series chart with single-point bar fallback.\"\"\"\n",
+    "    if df.empty:\n",
+    "        print(f\"No data for: {title}\")\n",
+    "        return\n",
+    "    fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "    if len(df) == 1:\n",
+    "        colors = plt.cm.tab10.colors\n",
+    "        x_label = str(df[x_col].iloc[0])[:16]\n",
+    "        if isinstance(y_cols, list):\n",
+    "            bar_labels = labels or y_cols\n",
+    "            for i, col in enumerate(y_cols):\n",
+    "                ax.bar(i, df[col].iloc[0], label=bar_labels[i], color=colors[i % len(colors)])\n",
+    "            ax.set_xticks(range(len(y_cols)))\n",
+    "            ax.set_xticklabels(bar_labels, rotation=45, ha=\"right\")\n",
+    "        else:\n",
+    "            ax.bar([x_label], df[y_cols].iloc[0])\n",
+    "        ax.set_title(f\"{title} (single time bucket: {x_label})\", fontsize=12, fontweight=\"bold\")\n",
+    "    else:\n",
+    "        if isinstance(y_cols, list):\n",
+    "            for i, col in enumerate(y_cols):\n",
+    "                lbl = labels[i] if labels else col\n",
+    "                if kind == \"area\":\n",
+    "                    ax.fill_between(df[x_col], df[col], alpha=0.4, label=lbl)\n",
+    "                    ax.plot(df[x_col], df[col], linewidth=1)\n",
+    "                else:\n",
+    "                    ax.plot(df[x_col], df[col], label=lbl, linewidth=1.5)\n",
+    "        else:\n",
+    "            if kind == \"area\":\n",
+    "                ax.fill_between(df[x_col], df[y_cols], alpha=0.4)\n",
+    "                ax.plot(df[x_col], df[y_cols], linewidth=1)\n",
+    "            else:\n",
+    "                ax.plot(df[x_col], df[y_cols], linewidth=1.5)\n",
+    "        ax.set_title(title, fontsize=12, fontweight=\"bold\")\n",
+    "        ax.tick_params(axis=\"x\", rotation=30)\n",
+    "    ax.set_ylabel(ylabel)\n",
+    "    if isinstance(y_cols, list):\n",
+    "        ax.legend()\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 1: Token KPI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.006178Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.006100Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.011693Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.010975Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\n",
+      "TOKEN KPI\n",
+      "==================================================\n",
+      "  Prompt tokens     :       27,812\n",
+      "  Completion tokens :        4,048\n",
+      "  Total tokens      :       34,398\n",
+      "  LLM responses     :           24\n",
+      "  Avg tokens/resp   :        1,433\n"
+     ]
+    }
+   ],
+   "source": [
+    "responses = llm_events_df[llm_events_df[\"event_type\"] == \"LLM_RESPONSE\"]\n",
+    "total_prompt = responses[\"prompt_tokens\"].sum()\n",
+    "total_completion = responses[\"completion_tokens\"].sum()\n",
+    "total_all = responses[\"total_tokens\"].sum()\n",
+    "\n",
+    "print(\"=\" * 50)\n",
+    "print(\"TOKEN KPI\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"  Prompt tokens     : {int(total_prompt):>12,}\")\n",
+    "print(f\"  Completion tokens : {int(total_completion):>12,}\")\n",
+    "print(f\"  Total tokens      : {int(total_all):>12,}\")\n",
+    "print(f\"  LLM responses     : {len(responses):>12,}\")\n",
+    "if len(responses) > 0:\n",
+    "    print(f\"  Avg tokens/resp   : {int(total_all / len(responses)):>12,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 2: Token Usage Over Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.013184Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.013074Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.108011Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.107501Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYHlJREFUeJzt3Qd4FOX2x/ETei9SRaqidERBEQtKEVREUFBAL6KCiBdUQKqFotJUFBQEG0UvKmJF4FKkqUhRpAgCKoKgVOkgnf0/v/c6+58km5BAMiHJ9/M8+2R3dnZ2dlpmzpz3vFGhUChkAAAAAAAAQIAyBPllAAAAAAAAgBCUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAKAc0xUVJR7lC5dOqVnBbB58+aFt8n77rvvnF0ihw4dsiJFirj5HDBgQKI/f8MNN4R/58aNGy0I/fr1C3/nuHHjLEgp8XsTQ9uaN3/aBlOClos3D1peABJ+PM6fP7/bd1544QUWG4B4EZQCgDOkoJF3wXK6R0pdVCXnRXTMAIX/Ak6PtOyLL76wJk2a2Pnnn29ZsmSx8847z2rXrm2vvvqqHTlyxM5laXW71bLfsWOHZcuWzR566CFL75YvX+72Vz1S03pML4YNGxZeP0l1TNJ2f+mll1qhQoXccalkyZL2wAMP2O+//x7xM19++aXVr1/f8ubNazly5LDLL7/cRo8ebadOnYo23vz58+2xxx6zGjVqWNGiRd20dexr0aKFrVy5MuK0Q6GQvfPOO+64mC9fPsuePbuVKlXK7rrrLlu1alWCf9f+/futZ8+edtFFF1nWrFld4Plf//qXrV+/Pt7Pffjhh9GOZb169Urwdyb2ex9//HGrVatWeNnkypXLqlSpYr1797Y9e/Yk+Du3bdtmHTp0sBIlSrjp6O/DDz9s27dvjzNgG9cjMdvV0qVL3f+zAgUKuONnxYoVbdCgQXbs2LFY4x49etQGDhzoxtG4+kzTpk3thx9+iDZezpw57cEHH3TPFZQ6ePBggucHQDoUAgCckVKlSoV0GE3IY+7cuQmervcZTf9c07dv3/D8tWnTJtp7GzZsiPab06Jjx46FWrVqFe+6vvTSS0N//vlnKK1st3v37g19/fXX7vHzzz+HzkXHjx8PFSlSxM1zy5Ytz2gaK1euDP/OI0eOhILen8aOHZuk09b0vGnre86F35sYOr6cyfEzKfmPaddff32y7YdJoVy5cnHuxwUKFAj9+uuv0cYfM2ZMKCoqKuL4bdu2jTZuw4YN45x2tmzZQt9++2208U+cOBG666674vzMu+++m6DftG/fvlDVqlUjTiN//vxuG45k165d4eOB9+jZs2eCl2Vivzdjxoxx/tbKlSuHjh49etrv3LRpU6h48eIRp1GyZMnQH3/8EXHfiOvx3HPPJei3zpgxI5QlS5aI02jQoIFbl/7jbL169SKOmzVr1tCXX34Zbdrr1q0Lv//qq68maH4ApE9kSgHAGfroo4/s66+/Dj90l9TzyiuvRHvvsssuYzmnAU888YS9//777rnu/D/77LMu2+Ctt95yWQmyYsUKa9asWaxsgyDpDveJEyeSZLtVFsW1117rHhdffLGdi/773/+Gswm07M+EMhu836nMiLQuvf3e9KBq1aouA2vWrFnub548edzwXbt22TPPPBMeb+vWrfbII4+4bKZMmTLZSy+9ZB988IFdcMEF7v23337bpk6dGm3aF154ocuQmTlzpjveKVNKlBkaMwvpxRdfdJlKUq5cOZd9pXnSsG7duoU/ezrK9vEysZRx9dlnn4WzIJWB1LZt24ifU+aSjgfK5DkTif3em2++2R07la02Y8YM9/0eZYXNnTv3tN+pTLQ//vjDPb/jjjvs888/d39l06ZN1rlz5/C4Tz75ZLTjtB76DmVoeZT5dDqHDx+2+++/P5wR9dRTT9nHH39slStXdq+1rrXuPK+99prNnj3bPdc4Glef8TKolMGlv55LLrnEKlWq5J4H3TwZQCqT0lExAEgr/He+Y97Z153XJ554IlS+fHl3ZzlXrlyhK6+8MjR69OjQqVOnTpsppTuQ3t3M8847L7RixQo3/MCBAy4LolKlSm66uXPndnf0p02bFu8d/yVLloRuuOGGUPbs2d0d5SeffDJ08uTJZMuU+uijj0LXXHNNKE+ePKHMmTO779TrHj16hH//wYMHQx06dAhVr149VLhwYTeexr/qqqtCb731Vqx5+fvvv0OPPfZYqGDBgqGcOXOGGjdu7OYhrgwEfY+yA66++mq3nLS8dDd82LBhCfrtW7ZsiXZHedy4cdHe/+WXX0KZMmUKv//xxx+74VWqVHGvdTd9586d0T5z4403hsdfvXp1ePhXX33lfo9+m5ZD6dKlQ126dAnt3r072uf9d8y1zrt27RoqWrSoy4DQsjjb7VY0LNI6j/ndjzzyiNs2lUnQsWNHl33z+++/u9+h9RPXdna260Xuv/9+Nx/63crs8vvrr79CDz30kMs20LLUvnfxxRe7jKp58+aFx9N+4f0eb9mdyX6zcePGUJMmTdxvLlSoUOjRRx916zZSxk18mVLaxzWPWp+a72LFirkMls2bN59VNpyXNZWQ3ztnzpzQ5Zdf7tbJZZddFt4+XnvttVCZMmVcdoTW2/Lly2PNw2+//RZq166dW+7ab7QslD3z008/JWid+revWbNmhfr16+cySTQv1113XWjp0qVx/ua4phNz+164cGGoefPmofPPPz98XLr55ptDy5Yti7g8PO+88044y0j7prJcZMeOHW4/LVu2rPvN+fLlC91yyy3ueyJlsEV6eCKtn/jMnDkz1jDtQ940KlSoEB4+ZMiQ8HDtG573338/PPzWW28ND589e7bLkvH77LPPwuNqf/AcPnzYHQc0XMtT+9+ZUHaRlp+3X+v46x0v9H/U++7vv/8+2ue0rXjfrX0vsZlSZ/q9MSlj1ht30qRJ8Y67devWUIYMGdy4efPmdctQ9Fevvf8f27Zti3Ma+h8baVuN7xg+ceLE8HBlw3m0vfozvTzahrzh/m3an0mn+fDr3Llz+D1vPwGAmAhKAUASieviXoEE/8lszEfM5kYxg1I6+dXFunfC6p0M6+LbC3hEeowcOTI8Tf/FlS7AdBERc/w333wzWYJSuvD3TrgjPbyLHZ2Yx3ex1r9//2jfpwv/mOOUKFEifEEU8+L03nvvjXPaLVq0OO1vV2DMG1+BgpgXadKsWbPwOK1bt3bDBg8eHB72xhtvRGti4gWxdMHv0XqIa3mpiY4/MOW/4L7wwgujjRtkUOqiiy6KNa/6/QpcnG47O9v1Ipdcckl4PmKqW7dunNNXUMlzuiBNQvabPXv2RAwI+S9QExKUUpBPAZ9I86xtTwGf5A5KXXDBBS4A5P+sfn+3bt1iTVOBGf/+oICRd2Ef86Gg4OLFi0+7Tv3bV6SmVApYq3lQpN8c13T827cCoXE1u/LWRaSg1NSpU8P7rYJk3rpQADau5lcKeH3++efJGpSKRPPqTaNGjRrh4QoUe8PHjx8fHq7f4A3X+ouPP9Cq4Lk/gOUNV9Bd+7BuMuTIkSNUp06d0DfffJOgedc25E1Hx5FIQWg9Xn755fDwQ4cOhY+DCgT596+EBqXO5Hv9dKPok08+Ce872o/9Te8i0Q0Mb7paRn567b336aefxjkN/3Huww8/TNAxXDcSIv1/1b6sbdZ7T/9z9P/Kvz37m/Xps957ulHkpwCu956CngAQCc33ACCAJl9r164NN5n55JNPXPMH9UwjajYxceLEiJ/95ZdfXNOAAwcOuNT8adOmWfXq1cMp/D/++KN7fsstt7jmFios6zXH6tKli23evDnWNNV0QwVt1Tzg0UcfDQ9//fXXk+HX/68Ar9eUTc0/lP6v36y0fxVL9Yqiq9CumpioiYeaDag5gsbzmoypWKrXzEDva/5FTTTU/ERNLFTgd/fu3RGbrGnZeM1J1ARP83XVVVe5YVr+ca0Dz08//RR+rqYLavYSU7Vq1WKNf/fdd4d/o+bDo/n1mtipgK78+eef1qlTJ7e8cufO7Yp3qzmImljIunXr3PYUyW+//ebW5/Tp09261OeDogK9b7zxhtuuM2T436nFu+++65qHaB36i+76t7OkWC9ahtpPpGzZstHe037jNZ1RU8TJkye7pn5qkqJmfirGm1AJ2W+ef/75cFFpNefUbx87dmy4WU5C/P3339amTRvXDEbbmHoS1Pbeo0eP8LL+97//He80tFz924m2H6+ZjwpfJ4S2RRXB1nGlbt26bpjWp5pmtWvXzqZMmWLly5cPd3Kg7VQUV9f87927171WUybN/5AhQyxjxoyu4LHm53/x94T59ddfbfjw4W6fUbFtrxC1CkmfCf02FZA+efKke61CzZ9++qlbbirOrCLTkSxcuNDuvPNOt83pODtnzhwrU6aMe0/rxFvP9957r9sPR40a5Y7bx48fd8tdPZLpWB2z2ay/GVZSUvMqj/6PePy9LaqAt6dw4cLh51p/8RXpjmva/uOkmuxp/1UHBNqutS/WqVMnQc3Z4prHmPO5YcOG8POnn37aHQe1Pps3b37a70iq7xUdU3Sc13FXze7UrFFNHrWcvGaRSf2dHp1faFuUYsWK2e23336aXxn/9+q4o847/OP5x1Vxc+3LCZlH/zHZv20AgF/sM2oAQJJRcMF/Uf3ee++F6zXoAk91PUQX4+rJyE8Xbw0bNrSdO3e6+kW6CLz66qvD09W0RBdQXbt2dXVhVENEJ8Sq/aAAjgI8/voW3vg6UdZJ6K233uoCCbpg0IVfcsicOXP4uQJM6h1KJ7X6varJ5NG8K3Cg2hzLli1zF0TeRaO3PHTyrbopujj1dOzY0QXgRBfJ3oWy33/+859o4xcvXtw9V22QRYsWhceJuQ78dBHsUfArEv/wffv2ub/qQUl1SdSDlS7G9LsUkPQCVAritGrVyj2fNGlSuCaHLqq8IJcu4rUdaT1pWxk5cmQ4+ONR8EsX7ilB9VC8npZefvllW716tXuugIqWqQIQQ4cOdUEi/3aWFOtFQUgvwOEFev0XV7pQ1PsFCxZ0F0jaBjU8sT30JWS/8W+XWkcaT7RO1atWQiiAo31ebrzxRrftSOPGjd3+7AWA/vrrL/ebIlHgxt/DmQJkqh2VGDrmTJgwwe2X+p3eRa+mpQCkluuaNWuse/fubri3HFRTzftubb8KEIiOXVdeeaUL7OjiVL11eQH209H+7QUCFchWrRpRkF4BH/8xJiH8+5nmSwEpT1w1yRTg1/rUstByVy05L2CubVDzIgo2efuCjvVah5q+6jopUKXp6yLeX8cr0ro52x4T33zzTRszZox7ruCI//+AgmMefwAuZjBO48Xcp0S/9bnnnnPPFbzwH8e9YKRHx7bWrVu7ILWOXVpf+n+lY7zWwXfffRdr+loecc1jzNfeeN9//707/qkGnva9+CTl98ZH4/v/h8XlbL9T/+897du3j3XD5IYbbogYBE7M9/o/n5h59G8/OmYBQCQEpQAgGeni0rvbrEwgLyAlukDz/Pzzz7E+q4sYPURFa6+//vpoJ3fedBV8UkZDJLpojElBG++uqAIbOmnUhVbMi4lIvIwfiXmS63/tH++ee+5xgQpdCCjLQHRRds0117jsAm/elUF2uiLV3jzqbrinZs2a4efKttHviXmH3798/Vkup1tWfl7RYPGCBjH5h+viyKNMKAWldEGmwIXuZHsFY5WF4hX+9c+nMmz0iEnBri1btoQDOB4FLVKKf1v232H3slq0PWi4glL+7Swp1otfzG1SgRVdFCu4oqwNBTQUwFDxXS0vXaj711N8ErLfxLVdqrv4hPIvE2V16RHpdypAm9hAU2JoX/K2ef86VSDJ27/9QTFvOfjnf/ny5XbdddfFuV4TGpTyL0sFgrx9XNko2hdKlSqVqN/mn8dGjRol6DP+davtySvg7AXkvG1PmWzx/eYgKDjjBeoVJFMwzL+d+zME/YWpvUzUSON5FJhVAFzjKgtMN0v8y98fbFOwQsExTUfLRIF4HQO1Xeh/m44HkZaVlmVc8xhzPr3xdPxQAEjZisoWOl3WY1J9r0fBV/1/13apY7turmgf1bFeAVjdjInLmX6nFwTysk11bFNQKqES873+Y2ti5jExGZEA0i+a7wFAQPyBmkivY/Knxw8ePDjcu1hiRLqzGimbJKH8TcJi3vX0v/aPpxP1pUuXuosGXVzq4kjNOZQ9oEywb7/91o03YsSI8GfUi48yRtScRZkGnkg92p1uOSbU6e58K6DhUSZIpN7tlCUSaXxlPXkXa7owUzMy70ReQbukmNeYzT6C5L/g9Wdw+QN5ybVeFDDxtoFIzY0U2FMTu9tuu80uuugid+Gqi2Jld8SXgXW2+01SbZdxSUimRpDrNLEXn2cz/5GWrX+YPzslqbIz/MdjNT0+k/lP7nXmZSeqpzatD2VpKhges9fM0qVLh5/7/68ooObJly9frG1+/Pjxbp/RsUvv6xgdM+Dq9UIqyoj1ghQKYOl1pMzTSOKax5jz6TWfVHBSlAGpbUGP/v37h8dT81EN076flN/rUfBPQWIFu3UTSdlhkbKlk/I7vQCpl5WrAFhCezaM73v1v827IeaN5x9X7/n//8U3j/5jclyZnQBAUAoAkpGac+nk3bsg8Zo1yeLFi8PPveYofsqE8e52q06D7uh7FzU6ufMuGHSyrzvO/3ReEX7owixSps3ZZk94FExSkzqPV1NG/E3oNC/KKtDdezXJUkaF13RNJ+xekyfVefGolpKCUWpa4x/uUXDB42+GoZpLkQIT/uWrJnQxl5Ue69evj/e3qxaM10xBJ+FqihIzk8LffMtrtiTaBryMDDX7UZfrXiaPPzvMP599+/aNOJ/aBvzrIaggSHJIivWi4JB30R2pCareV/aAakHpfW0fXjNYXVQnZaAgru1STdbOZJmoNlNc24ACuvHxB5IiBXOTi3/+ld0Z1/wnpvnkkiVLws+1Dr26caon52XF+INo3kWyjosLFiyIdx69Zneno8xOb1/VulVwxgt+qVmot/9pG9AFe8zfrECOauYl5/rp2bOnC5iJ9olvvvkm4v8Wf4add1Mg5nYaMwtPTeLUjFi/WZmual4YKQNQw7xloeCFsglF69xbb8roURBHgY5I24d3M8Nbp6rT5v0f0Pte016JKystPkn5vWqGH4n/eHy6LGQdj7ztQc0alQEo+qvXXlA00vL2N91TE+jEiGs70PbtBZ20PHSuoeB/hQoV3DC9F9fxLeb68B+T/TdqAMCP5nsAkIx0otmyZUtXBNXLilGwQRfG+uvxagrFpKLCOqlT8WdlG6n5m7JsdKGtz+iEVIGhBg0auEwkBatUbFeZPGoOp5oiqieRVNTUTHe7dbGhE20VpG7SpIm7S62aIR5/kVk1p9AFjIIyuouuO+f+AJbXFEBNQLxmNX369HEX3ZpmpOKoCvh4J+PKsFIAT9P2X/T5abl7hdF1B1tF4nXRpuZ2KpKtYs4q1utfJzHpDrSKkKuouqhG0KZNm9yFgur8KPPGO5FXczZ/UMprwqd1oovTr776yg1T9o4/q0zLrVevXm6ZKDtOFzaavi7sFJhU4EYXQWqKlhYkxXrxAgbadrSMlDXgD1AoSKBggprPKIChLD2vGK8uNLWsE1PwPD5a5972qm1F61DrTr8roRSMVTBby0DNcnQxqGEKBmg7U5BFGXmnKxrsz3JR8y3VplIQR50tJLTJ4pnQctaFrI5BytJR0W8dtxSI0PwrwKQsyfiKaMek5r/KBNQ+rkwgj7YNr56UAkNepqK+U+tcx49IAQHNj7efaXlqXH1GwSHtW9qeYmYwal/U9LTP64Jc26aKpau+ltaR5kUBLgVRtV+rLpr2bQU2FFjQvq+Ldy/jROvH2w4VhFdTRq0XrR/RcVvLTzSeP1MlrrpuajLmBcEHDRrk5lUP0br3mtNqX9OxUoEiBch1E0H7Rrdu3cLT89dA0/JXHShRxqemrYCfgl4xAxxaRzp2a5vTsU4BYR37tOy87FAtKwXk46MbACoOr+/Wfqr/d5o/LXfdfBD9Hq8JqP5nxMy+0jx4/2vq1avnaoKdruh4Yr9X/990o0HbkI5d2k7UfM///1AdJMRHATr9H9V+oeOXvlPzoJtK3m9SFlTMbFjvWCDa57z6czHp/68KzHuB7nHjxrnnyurSetf/bwXodZzS79KyjLQd6Lm2M1HdNG1Dapqoz4r+D3t19DxeUE20XwFARBH75AMAJJq/S3J/1+PqSrl8+fJxdgHesmXL0KlTp8Lje8M1PTl48GCoWrVq4eEPPPBAuPv5KlWqxNu9uDcfkbo2jzTfCTFx4sQ4u1LX48orrwwdPnw4PP6zzz4b57gZMmQIdxGuLrxjvq9utatXrx5xuTZp0iTW+OrG/rzzzov4e+699954l5W6Dz+dY8eOhe666654p1O5cuXQ5s2bY332yJEjrpt1/7iTJ0+ONd6bb77plktc0/evv7i6u0+K7fZ03YnH9d1xdWUf13aWFOvliy++CI//0UcfRXsvvm21YcOG8c53Yvcb7ZP+4d6jatWqEafj77J+7Nix4eFTp051XcnHNd/esSE+O3fujDgNb10l5vfGtQ1oniOtp6VLl8ba1mM+Tse/fV188cWxPp8rV67QmjVrwuPPmDEj1jiZMmUKlS1bNuJ2Gt9+5q2LSMtj69atoRIlSoSH9+/f3w3//fffQ8WLF4/3N/v3h8cffzzefTuu/Sgukba7+LaZMWPGhKKioiKO27Zt22jj+uclIetz/fr1oaJFi0Ycr0iRIgn6PbJv375o+47/oe1r5cqV8X7ev3/17NkzQd+Z2O/1f0ekx7XXXuv+b5zOpk2b4tx+SpYsGfrjjz9ifebuu+8OjzNq1Kg4px3X/uvtN1myZIn4vQ0aNAidOHEiPO7x48dD9erViziujjVffvllrO+uVKmSe79GjRqnXQYA0i+a7wFAMtNddKX9q/tyNbvSnWZlZlxxxRWuy3D1ohdf0yuNq2KyXjMVZT/pTqbuhuvOuzJ0lJ2gO88qpq67tcq4UfMyZTIltbvuusvdoVW2geZJWVtqQqi7wQMHDnR3ZXVX3t/sTU11vGYAaoagZaLsLt3F9u6eap5V+0fzr89r+ehOt784vJ9+n7LDlLml361MLGUgeU1hYt6JVz0UZZ6oSZEyEnRHXHf1dQddGQYqun46yspQfRDd0dZdZt251jCtC/0O1RJRJkjMIuSi9e4VehfN90033RRrvHbt2rnfoV4UNX0tX/1V9pW6PPc310gLkmK9aDkq20CUkeKnbVKZG1onWgd6aD9Ur3HqhS0paTtQdosyZbRNah1r/rWfezT8dLTPqDcxZbRovrWNKQtSvdkpYyUh863x1ZxUPVqeLislqelYoNo9yqxQz29ap1o22pc1zCvyn1DKhlTTNGUrav0pK0dZg/5mwjqeaP/z1rP2F//xJdJ+ppp1/v1MzdKUxeP1ehmJtjMdj70MR2Xx6ZisbVZZIdquNF86hmkcPVcWljJcVePJo88pi0jH0JRoequmeFo+2s80n9pGtK1oW1X219nQOtdxUNk+WmdatvqdWubK+D1d1pe/fpnWkZapahVpO9I6UqF1Zat5WWVJLTHfq2OP1q/XMYD+v2m/1/FM26229YT0DqltQ9PW/0plc+kz+qvXWpYxM7yUSek1g9f3KhvtTGi/UdM9/T/T/2ftO2qmp+OmMrT9tdS0HpUxpmxFbdcaV//LdbzTNLQt+Sl71StZoDqRABCXKEWm4nwXAIBzlP59xbyYU29HXt2LqlWrRis8jrRNhYzVJEsX15s3b45WVDmlt0s131VTL1EgVfXVACAt69Gjh73wwguuObKaoCZVM2kAaQ+ZUgCAVEl1PlTbRHeRFYRQXQt/b2qJ6VkNqZ9qOCmbQTW3vBpuKUEZe8qcUYaAit8rC8wrPi1slwDSOtUre/PNN8PBKQJSAOJDphQAIFVScwA1/YpEPQApSOVvRggEQU2TVNw6EjUHUmFkAAAA/A+ZUgCAVEk1MFTDwqvrpLoaqqGlplGq40FACilBdXPUO5fqs6gGi5quqE6RehkkIAUAABAdmVIAAAAAAAAIHJlSAAAAAAAACBxBKQAAAAAAAAQuU/BfmTadOnXKtmzZYrlz547VFTQAAAAAAEB6EQqF7MCBA1asWDHLkCHufCiCUklEAakSJUok1eQAAAAAAABStc2bN1vx4sXjfJ+gVBJRhpS3wNUDFAAkJtNy586drpeu+O4iAAAABI3zFABnYv/+/S5xx4uVxIWgVBLxmuwpIEVQCkBiT/aOHDnijh0EpQAAwLmE8xQAZ+N05Y24JQ8AAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHDUlAIAAAAAAGfk5MmTdvz4cZZeOpM5c2bLmDHjWU+HoBQAAAAAAEiUUChk27Zts71797Lk0ql8+fJZ0aJFT1vMPD4EpQAAAAAAQKJ4AanChQtbjhw5ziowgdQXkPz7779tx44d7vX5559/xtMiKAUAAAAAABLVZM8LSBUoUIAllw5lz57d/VVgStvBmTblo9A5AAAAAABIMK+GlDKkkH7l+Gf9n01NMYJSAAAAAAAg0Wiyl75FJUGTTYJSAAAAAAAACBw1pRBL6V5TWSpAgDJYyCrkD9maPVF2yigQCQRh4+BGLGgAAIAURlAKAAAAAACkyiSHxN5ouu+++2z8+PHueebMma1kyZJ277332hNPPGGZMp1bIZJ58+ZZnTp1bM+ePZYvXz5Li86tJQ4AAAAAAJCMbrrpJhs7dqwdPXrUpk2bZh07dnQBqt69e0cb79ixY5YlSxbWRTKiphQAAAAAAEg3smbNakWLFrVSpUrZww8/bPXr17fJkye7LKqmTZvagAEDrFixYlauXDk3/o8//mh169a17NmzW4ECBax9+/Z28ODB8PS8zw0cONCKFCnispqeeeYZO3HihHXv3t3OO+88K168uAuEeTZu3OgKhX/wwQd29dVXW7Zs2axy5co2f/788PvKkpL8+fO7cfU9aQ1BKQAAAAAAkG4p2KSsKJk9e7atW7fOZs2aZVOmTLFDhw5Zw4YNXWDou+++s0mTJtmXX35pnTp1ijaNOXPm2JYtW+yrr76yl156yfr27Wu33nqr+9zixYutQ4cO9tBDD9kff/wR7XPdu3e3xx9/3JYtW2a1atWyxo0b265du6xEiRL28ccfu3E0P1u3brXhw4dbWkNQCgAAAAAApDuhUMgFmGbMmOEyoSRnzpz21ltvWaVKldzjvffesyNHjtg777zjMpk03ogRI+zdd9+17du3h6elbKhXXnnFZVc98MAD7u/ff//talVdfPHFrmmgmgJ+88030eahU6dO1qxZM6tQoYKNGjXK8ubNa2+//bZlzJjRTVMKFy7sMrv0XlpDUAoAAAAAAKQbyoDKlSuXazJ38803W4sWLaxfv37uvSpVqkSrI7VmzRq79NJLXbDKc80119ipU6dcBpNHAawMGf4/xKJmfJqWR0EmNf3bsWNHtHmpVatW+LkKrdeoUcN9Z3pBoXMAAAAAAJBuqFaTspIUfFLtKH+ve/7gU2KoULqfakBFGqZgFv4fmVIAAAAAACDdUOCpbNmyVrJkyWgBqUjUrG7FihWutpRnwYIFLivKK4R+NhYtWhR+rsLoS5cudd8pXsbWyZMnLa0iKAUAAAAAABDBPffc45r5tWnTxlatWmVz5861Rx55xFq3bu2a6J2tkSNH2qeffmpr1661jh072p49e1xNKlHvgMquUnPDnTt3RuvxL60gKAUAAAAAABBBjhw5XCH03bt32xVXXGHNmze3evXquWLnSWHw4MHuobpVKoI+efJkK1iwoHvvggsusP79+1uvXr1cACxmj39pQVRI5eZx1vbv3+8q4e/bt8/y5MmTqpdo6V5TU3oWgHQlg4WsQv6QrdkTZacsKqVnB0gXNg5ulNKzAACpgurfqDCzev/yF3FG+qbe6DZs2GBlypRxWURIvI0bN7rlt2zZMqtWrVqa2w4SGiPhqAIAAAAAAIDAEZQCAAAAAABA4OIvMw8AAAAAAIAkVbp0aaOaEplSAAAAAAAASAE03wMAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAADAOWDjxo0WFRVly5cvP6vpzJs3z01n7969di7LlJJfPmjQIPvkk09s7dq1lj17drv66qttyJAhVq5cufA4N9xwg82fPz/a5x566CEbPXp0+PWmTZvs4Ycftrlz51quXLmsTZs2btqZMmWKtkK6du1qq1evthIlSthTTz1l9913X7Tpjhw50l544QXbtm2bXXrppfbqq6/alVdemazLAAAAAACANKNf3oC/b98ZfUzX/QMGDLCpU6fan3/+aYULF7Zq1apZ586drV69epaa3HDDDW7ehw0bFh6m+MrWrVstb96A10dqypRSsKljx462aNEimzVrlh0/ftwaNGhghw4dijbegw8+6Bam93j++efD7508edIaNWpkx44ds2+//dbGjx9v48aNsz59+oTH2bBhgxunTp06Ltqojaxdu3Y2Y8aM8DgTJ050Qau+ffvaDz/84IJSDRs2tB07dgS0NAAAAAAAQBDZSNWrV7c5c+a4xJQff/zRpk+f7mIGilGkBVmyZLGiRYu6bKlzWYoGpbTSla1UqVIlFwRSMElZT0uXLo02Xo4cOdzC9B558uQJvzdz5kz76aef7D//+Y+LDN5888327LPPuqwnBapEWVVlypSxoUOHWoUKFaxTp07WvHlze/nll8PTeemll1zw6/7777eKFSu6z+h7x4wZE+ASAQAAAAAAyenf//63C9YsWbLEmjVrZpdccomLSyhRRUkzothEkyZNXGssxSDuuusu2759e3ga/fr1czEIxQxKlizpxtN0lTijRBrFLpR9pWwsP33vqFGjXOwie/bsduGFF9pHH30U7/yuWrXKja/vKFKkiLVu3dr++usv955iKkr4GT58uJu2Hgq6RWq+9/HHH7vfmTVrVitdurSLkfhp2MCBA+2BBx6w3Llzu9/1xhtvWJptvhfTvn3/S7s777zzog2fMGGCCzpppTZu3NiefvppFzCShQsXWpUqVdyK8SjDSc351FTvsssuc+PUr18/2jQ1jjKmRMErBcJ69+4dfj9DhgzuM/psJEePHnUPz/79+93fU6dOuUdqlsFCKT0LQLqifS7KQhT5AwKU2v9XA0CQx8tQKMRxExG3C+/hF3ReTszvP53du3e7BJnnnnvOxRVifl7N3RRY8gJSCu6cOHHCJbe0aNHClQ3yvnf9+vX23//+1z30/M4777TffvvNLr74Yvc5teZq27ataw5Ys2bN8HcopqGSQ8OGDbN3333XWrZsaStXrnRJNN78eMtWQaW6deu66SiZ5vDhw9arVy8XJJs9e7abxs8//+yCTc8884z7bKFChVyLMf90FPPQZ9Q6TL9D86asMMVf/KWNFKjSdBQfUbBMsZXatWtHK7PkX/be8SHmuVVCz7XOmaCUZlhBomuuucYqV64cHn733XdbqVKlrFixYm4l9ezZ09atW+dqUXntQP0BKfFe6734xlEgSSt0z549bqOLNI7qXUWiDah///6xhu/cudOOHDliqVmF/ASlgKBTVovn+t8/8FMEhYFA0DwfABJ+nabkAV146sY9ICq9o21DwRo9/DIHvIhifv/pKJ6g7VmBo7g+++WXX7omfQr2qCa1vP322y4zSplUNWrUCAdiXn/9dZdVpGwr1XbS9D///HO3v1x00UWubraCR2ou6FF2lhcI6tu3rytn9Morr7i61t48ectWw/W9XsBJ9J3KsFKrMX1v5syZXdZVwYIF3fv6fYpx+KejYJOCW14yjj6vDCw1X/zXv/4VnvZNN91k7du3d88ff/xxF/TS/Ou3RFr2Wga7du1y8+B34MCB1BWUUoROC+Sbb76JNtxbGKKMqPPPP99FGRWFjLRQgqIVqdQ+jwJc2lgVkfQ3L0yN1uw5t9ucAmkxU0qh4LV7FJRi/wOCoHR6AMDp6YJTTYB0nUNQCh4lYijooM7F/B2MpYTEfr+3HWfMmDHOz3rBKJUB8lStWtXy5cvn3rvqqqvcdNTcLX/+/OFx1LpL01Q9J/8wNbXzf5eKkPtf16pVy1asWBFteXrPFSdR1pX/ezy///67Kz/kNdvzT1O/zz8dBctuu+22aONcd911LhCmz3rjq7SSf5xI8+/RMC2HAgUKWLZs2aK9F/P1OR2UUhrclClT7KuvvrLixYvHO66X8vbrr7+6oJQWkNqB+nntPPWe99ff9tMbR8EjRRO18PWINI43jZjUBlOPmLRCUvvBmotiIHihf/Y99j8gGKn9fzUABEkXrGnhOgdJR9uCFwhJ6ULaif1+ZRbpMwrSxPVZb3ik9/2/W9lB/nHiGqbMpZjDYr6OOdx7fvDgQVfGSBlXMSlpJ9JnTzfN+MZRQO108+9/L67jQ0KPFyl6VNEPU0Dq008/dVXv/VHIuKj3PG/hexFFpdX50/CV+qaAkyKG3jhKN/PTOBruLXSl0vnH0R0BvfbGAQAAAAAAqZtqKKnGtDpHO3ToUKz3VcNJtZ02b97sHh41ldN7XpzhbHjF1P2v9Z2RXH755a5etrKyypYtG+2RM2fOcEzDa64XF01/wYIF0YbptYJ0XpZUSsiQ0k32VMD8vffec20wVftJD9V5EjXRU096Ksil6vGTJ0+2e++91xXZUuqcNGjQwG0Uqj6vdLcZM2bYU0895abtZTJ16NDBFRvr0aOHqxH12muv2YcffmhdunQJz4ua4r355ps2fvx4W7NmjSvmpQ1UvfEBAAAAAIC0QQEpBXGuvPJK1yPdL7/84uIAqt+kxBR1eqbyQffcc4/98MMPrnWWYhHXX3+9qyd1tiZNmuR67fv5559dTSlNXwk7kSi2oeLsrVq1su+++87FSRT3UKzCC0QpYLV48WIXN1FTu0hFxlUfSok3irHoexX7GDFihHXr1s1SUooGpdQNoormqRiYMp+8x8SJE8PRPhUYU+CpfPnybiGqINgXX3wRnoYiemr6p7/aeFSgSxuLvwiYMrCmTp3qsqPUPlIFvt566y0XHfWo+vyLL75offr0cUXElJGlivwxi58DAAAAAIDUS0W+FWyqU6eOizOos7Ubb7zRBW0Up1CTNBUrVx0nJcUoSKXPeLGKs6VO0z744AOXbPPOO+/Y+++/H2cGljp9U0aTAlCKjShYpk7iVN/KayKnwJJiIpqG6r9t2rQpYsaVknP0vfq9in0obuLveS8lRIUS238iIlKhc3UdqSBbai90XrrX1JSeBSDdFTpXr5fqZICaUkAwNg5uxKIGgARQxoVKpaiDCGpKwV/ofMOGDS4BJKEFrfE/CniphFHTpk3T9HaQ0BgJleoAAAAAAAAQOIJSAAAAAAAACFym4L8SAAAAAAAg/aGCUnRkSgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAADgjHpnRPp1KgnWPzWlAAAAAABAgmXJksUyZMhgW7ZssUKFCrnXUVFRLMF0VBfr2LFjtnPnTrcdaP2fKYJSAAAAAAAgwRSIKFOmjG3dutUFppA+5ciRw0qWLOm2hzNFUAoAAAAAACSKsmMUkDhx4oSdPHmSpZfOZMyY0TJlynTWGXIEpQAAAAAAQKIpIJE5c2b3AM4Ehc4BAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAACQvoJSgwYNsiuuuMJy585thQsXtqZNm9q6deuijXPkyBHr2LGjFShQwHLlymXNmjWz7du3Rxtn06ZN1qhRI8uRI4ebTvfu3e3EiRPRxpk3b55dfvnlljVrVitbtqyNGzcu1vyMHDnSSpcubdmyZbOaNWvakiVLkumXAwAAAAAApG8pGpSaP3++CzgtWrTIZs2aZcePH7cGDRrYoUOHwuN06dLFvvjiC5s0aZIbf8uWLXbHHXeE3z958qQLSB07dsy+/fZbGz9+vAs49enTJzzOhg0b3Dh16tSx5cuXW+fOna1du3Y2Y8aM8DgTJ060rl27Wt++fe2HH36wSy+91Bo2bGg7duwIcIkAAAAAAACkD1GhUChk54idO3e6TCcFn2rXrm379u2zQoUK2XvvvWfNmzd346xdu9YqVKhgCxcutKuuusr++9//2q233uqCVUWKFHHjjB492nr27OmmlyVLFvd86tSptmrVqvB3tWzZ0vbu3WvTp093r5UZpaytESNGuNenTp2yEiVK2COPPGK9evU67bzv37/f8ubN6+Y5T548lpqV7jU1pWcBSFcyWMgq5A/Zmj1RdsqiUnp2gHRh4+BGKT0LAJAq6LpIN+p1nZYhA9VfACRMQmMk59RRRTMr5513nvu7dOlSlz1Vv3798Djly5e3kiVLuqCU6G+VKlXCASlRhpMWwOrVq8Pj+KfhjeNNQ1lW+i7/ODrg6rU3DgAAAAAAAJJOJjuHIvBqVnfNNddY5cqV3bBt27a5TKd8+fJFG1cBKL3njeMPSHnve+/FN44CV4cPH7Y9e/a4ZoCRxlFmViRHjx51D4+m5f0OPVJ71gaAYPe5KAudW3cJgDQutf+vBoAgj5dqXMNxE0BiJPSYcc4EpVRbSs3rvvnmG0sNVKS9f//+sYaryaCKs6dmakYEIDgKRhXPZa7h3imCwkAgqBkJAAm/sFSLFgWmaL4HIKEOHDiQeoJSnTp1silTpthXX31lxYsXDw8vWrSoa1qn2k/+bCn1vqf3vHFi9pLn9c7nHydmj316rXaN2bNnt4wZM7pHpHG8acTUu3dvVxjdnymlGlSqgZXaa0qprg2AYDOlFApeu0dBKfY/IAiqjQIASFhQKioqyl3nEJQCkFDZsmU794NSirarkPinn35q8+bNszJlykR7v3r16pY5c2abPXu2NWvWzA1bt26dbdq0yWrVquVe6++AAQPCxfdEPfkpMFSxYsXwONOmTYs2bY3jTUNNBPVd+p6mTZuGD756rYBZJFmzZnWPmHSgTu0Hay6KgeCF/tn32P+AYKT2/9UAECQFpdLCdQ6A4CT0eJEppZvsqWe9zz//3HLnzh2uAaUK7cpg0t+2bdu6jCQVP1egSUEsBZPU8540aNDABZ9at25tzz//vJvGU0895abtBY06dOjgetXr0aOHPfDAAzZnzhz78MMPXY98Hn1HmzZtrEaNGnbllVfasGHD7NChQ3b//fen0NIBAAAAAABIu1I0KDVq1Cj394Ybbog2fOzYsXbfffe55y+//LKLsClTSoXF1Wvea6+9Fh5Xze7U9O/hhx92waqcOXO64NIzzzwTHkcZWApAdenSxYYPH+6aCL711ltuWp4WLVq4elB9+vRxga1q1arZ9OnTYxU/BwAAAAAAwNmLCqkNHc6aakops0tFAFN7TanSvf4/gwxAMDWl1MGA6rnRfA8IxsbBjVjUAJAAKmvilUqh+R6ApI6R0CgYAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAJz7Qanx48fb1KlTw6979Ohh+fLls6uvvtp+//33pJ4/AAAAAAAApEGJDkoNHDjQsmfP7p4vXLjQRo4cac8//7wVLFjQunTpkhzzCAAAAAAAgDQmU2I/sHnzZitbtqx7/tlnn1mzZs2sffv2ds0119gNN9yQHPMIAAAAAACA9J4plStXLtu1a5d7PnPmTLvxxhvd82zZstnhw4eTfg4BAAAAAACQ5iQ6U0pBqHbt2tlll11mP//8s91yyy1u+OrVq6106dLJMY8AAAAAAABI75lSqiFVq1Yt27lzp3388cdWoEABN3zp0qXWqlWr5JhHAAAAAAAApPdMKfW0N2LEiFjD+/fvn1TzBAAAAAAAgDQu0UEp2bt3ry1ZssR27Nhhp06dCg+Pioqy1q1bJ+X8AQAAAAAAIA1KdFDqiy++sHvuuccOHjxoefLkcYEoD0EpAAAAAAAAJEtNqccff9weeOABF5RSxtSePXvCj927dyd2cgAAAAAAAEiHEh2U+vPPP+3RRx+1HDlyJM8cAQAAAAAAIM1LdFCqYcOG9v333yfP3AAAAAAAACBdSHRNqUaNGln37t3tp59+sipVqljmzJmjvX/bbbcl5fwBAAAAAAAgDUp0ptSDDz5omzdvtmeeecbuvPNOa9q0afhx++23J2paX331lTVu3NiKFSvmiqR/9tln0d6/77773HD/46abboo2jupYqfC6iq7ny5fP2rZt6+pd+a1cudKuu+46y5Ytm5UoUcKef/75WPMyadIkK1++vBtHwbZp06Yl6rcAAAAAAAAgGYNSp06divNx8uTJRE3r0KFDdumll9rIkSPjHEdBqK1bt4Yf77//frT3FZBavXq1zZo1y6ZMmeICXe3btw+/v3//fmvQoIGVKlXKli5dai+88IL169fP3njjjfA43377rbVq1coFtJYtWxYOsq1atSpRvwcAAAAAAADJ1HzP78iRIy6z6EzdfPPN7hGfrFmzWtGiRSO+t2bNGps+fbp99913VqNGDTfs1VdftVtuucVefPFFl4E1YcIEO3bsmI0ZM8ayZMlilSpVsuXLl9tLL70UDl4NHz7cBb/ULFGeffZZF+QaMWKEjR49+ox/HwAAAAAAAJIoKKVsqIEDB7pgzfbt2+3nn3+2Cy+80J5++mkrXbq0yzZKSvPmzbPChQtb/vz5rW7duvbcc89ZgQIF3HsLFy50Tfa8gJTUr1/fMmTIYIsXL3bNCTVO7dq1XUDKX6x9yJAhtmfPHjddjdO1a9do36txYjYn9Dt69Kh7+DOyxMsaS80yWCilZwFIV7TPRVko8amrAM5Yav9fDQBBHi9DoRDHTQDJcq6V6KDUgAEDbPz48a4uk+pLeSpXrmzDhg1L0qCUspfuuOMOK1OmjK1fv96eeOIJl1mlIFLGjBlt27ZtLmDllylTJjvvvPPce6K/+rxfkSJFwu8pKKW/3jD/ON40Ihk0aJD1798/1vCdO3e6DLLUrEJ+glJAkBSMKp7LLEoHb4LCQCB27NjBkgaABF5Y7tu3zwWmdPMfABLiwIEDyROUeuedd1w9pnr16lmHDh3Cw1Ubau3atZaUWrZsGX6u4uNVq1a1iy66yGVP6ftTUu/evaNlVylTSkXUCxUq5Iqup2Zr9ujSGECQmVIKBa/do6AU+x8QhJg3tQAAcQel1OGUrnMISgFIqISWekp0UOrPP/+0smXLRjxYHT9+3JKTmgkWLFjQfv31VxeUUq2pmHc6T5w44Xrk8+pQ6a+aGfp5r083Tly1rLxaV3rEpAN1aj9Yc1EMBC/0z77H/gcEI7X/rwaAICkolRaucwAEJ6HHi0QfVSpWrGhff/11rOEfffSRXXbZZZac/vjjD9u1a5edf/757nWtWrVs7969rlc9z5w5c1yArGbNmuFx1COfP2CmIublypVzTfe8cWbPnh3tuzSOhgMAAAAAACDpJTpTqk+fPtamTRuXMaXgzyeffGLr1q1zzfqmTJmSqGkdPHjQZT15NmzY4HrGU00oPVSzqVmzZi5jSTWlevTo4bK0VIRcKlSo4OpOqbaVCq8r8NSpUyfX7E8978ndd9/tpqNaVz179rRVq1a53vZefvnl8Pc+9thjdv3119vQoUOtUaNG9sEHH9j333/vmikCAAAAAAAg6SU6U6pJkyb2xRdf2Jdffmk5c+Z0Qao1a9a4YTfeeGOipqXAj7KrvAwr1WjSc01ThcxXrlxpt912m11yySUuqFS9enWXpeVvNjdhwgQrX768a853yy232LXXXhstmJQ3b16bOXOmC3jp848//ribfvv27cPjXH311fbee++5z6k2lrK+1POeircDAAAAAAAg6UWF1I1CIpvQFS9ePOJ7ixYtsquuusrSIxU6VwBMPVOk9kLnpXtNTelZANJdoXP1eqlOBqgpBQRj4+BGLGoASAC1jlEdX3UQQU0pAEkdI0l0plSDBg1cIfGYFixY4JrSAQAAAAAAAKeT6KCUMqEUmDpw4EB4mAqJq+lc3759Ezs5AAAAAAAApEOJDkq99dZbVrJkSWvcuLEdPXrU5s6d64qDP/PMM9alS5fkmUsAAAAAAACk76CU2hGrd7rMmTNb3bp1XSHyQYMGuR7sAAAAAAAAgITIlJCR1AteTP369bNWrVrZv/71L6tdu3Z4nKpVqyboiwEAAAAAAJB+JSgoVa1aNYuKijJ/R33e69dff93eeOMN91zDTp48mZzzCwAAAAAAgPQSlNqwYUPyzwkAAAAAAADSjQQFpUqVKpX8cwIAAAAAAIB0I0FBqZjWr19vw4YNszVr1rjXFStWdIXOL7rooqSePwAAAAAAAKRBie59b8aMGS4ItWTJElfUXI/FixdbpUqVbNasWckzlwAAAAAAAEjfmVK9evWyLl262ODBg2MN79mzp914441JOX8AAAAAAABIgxKdKaUme23bto01/IEHHrCffvopqeYLAAAAAAAAaViig1KFChWy5cuXxxquYYULF06q+QIAAAAAAEAaluDme88884x169bNHnzwQWvfvr399ttvdvXVV7v3FixYYEOGDLGuXbsm57wCAAAAAAAgvQWl+vfvbx06dLCnn37acufObUOHDrXevXu794oVK2b9+vWzRx99NDnnFQAAAAAAAOktKBUKhdzfqKgoV+hcjwMHDrhhClIBAAAAAAAAydL7ngJSfgSjAAAAAAAAkOxBqUsuuSRWYCqm3bt3n9GMAAAAAAAAIP1IVFBKdaXy5s2bfHMDAAAAAACAdCFRQamWLVta4cKFk29uAAAAAAAAkC5kSOiIp2u2BwAAAAAAACR5UMrrfQ8AAAAAAAAIrPneqVOnzvrLAAAAAAAAgERlSgEAAAAAAABJhaAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQPoKSn311VfWuHFjK1asmEVFRdlnn30W7f1QKGR9+vSx888/37Jnz27169e3X375Jdo4u3fvtnvuucfy5Mlj+fLls7Zt29rBgwejjbNy5Uq77rrrLFu2bFaiRAl7/vnnY83LpEmTrHz58m6cKlWq2LRp05LpVwMAAAAAACBFg1KHDh2ySy+91EaOHBnxfQWPXnnlFRs9erQtXrzYcubMaQ0bNrQjR46Ex1FAavXq1TZr1iybMmWKC3S1b98+/P7+/futQYMGVqpUKVu6dKm98MIL1q9fP3vjjTfC43z77bfWqlUrF9BatmyZNW3a1D1WrVqVzEsAAAAAAAAgfYoKKR3pHKBMqU8//dQFg0SzpQyqxx9/3Lp16+aG7du3z4oUKWLjxo2zli1b2po1a6xixYr23XffWY0aNdw406dPt1tuucX++OMP9/lRo0bZk08+adu2bbMsWbK4cXr16uWystauXetet2jRwgXIFNTyXHXVVVatWjUXEEsIBb/y5s3r5lFZW6lZ6V5TU3oWgHQlg4WsQv6QrdkTZacsKqVnB0gXNg5ulNKzAACpwqlTp2zHjh1WuHBhy5CB6i8ALEljJJnsHLVhwwYXSFKTPY9+UM2aNW3hwoUuKKW/arLnBaRE4+tgqcyq22+/3Y1Tu3btcEBKlG01ZMgQ27Nnj+XPn9+N07Vr12jfr3FiNif0O3r0qHv4F7h30NYjtV8gAwh2n4uyEEX+gACl9v/VABDk8VIJAxw3ASRGQo8Z52xQSgEpUWaUn1577+mvIvZ+mTJlsvPOOy/aOGXKlIk1De89BaX0N77viWTQoEHWv3//WMN37twZrXlhaqSMDQDB0T3H4rnM5UidIigMBEJ3/QEACbuwVKaDAlNkSgFIqAMHDqTuoNS5rnfv3tGyq5QppSLqhQoVSvXN99SECECwmVIKBa/do6AU+x8QhJg3tQAAcQelVGpF1zkEpQAklDqRS9VBqaJFi7q/27dvd73vefRatZ68cWLe6Txx4oTrkc/7vP7qM37e69ON470fSdasWd0jJh2oU/vBmotiIHihf/Y99j8gGKn9fzUABElBqbRwnQMgOAk9XpyzRxU1uVNQaPbs2dGykVQrqlatWu61/u7du9f1queZM2eOi+ar9pQ3jnrkO378eHgc9dRXrlw513TPG8f/Pd443vcAAAAAAAAgaaVoUOrgwYO2fPly9/CKm+v5pk2bXDS+c+fO9txzz9nkyZPtxx9/tHvvvdf1qOf10FehQgW76aab7MEHH7QlS5bYggULrFOnTq4IusaTu+++2xU5b9u2ra1evdomTpxow4cPj9b07rHHHnO99g0dOtT1yNevXz/7/vvv3bQAAAAAAACQ9FK0+Z4CP3Xq1Am/9gJFbdq0sXHjxlmPHj3s0KFD1r59e5cRde2117rgkb9t4oQJE1zwqF69ei49rFmzZvbKK69E67Fv5syZ1rFjR6tevboVLFjQ+vTp46bpufrqq+29996zp556yp544gm7+OKLXc97lStXDmxZAAAAAAAApCdRIXWjgLOmpoUKgKlnitRe6Lx0r6kpPQtAuit0rl4v1ckANaWAYGwc3IhFDQAJoNIoquOrDiKoKQUgqWMk52xNKQAAAAAAAKRdBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAjcOR2U6tevn0VFRUV7lC9fPvz+kSNHrGPHjlagQAHLlSuXNWvWzLZv3x5tGps2bbJGjRpZjhw5rHDhwta9e3c7ceJEtHHmzZtnl19+uWXNmtXKli1r48aNC+w3AgAAAAAApEfndFBKKlWqZFu3bg0/vvnmm/B7Xbp0sS+++MImTZpk8+fPty1bttgdd9wRfv/kyZMuIHXs2DH79ttvbfz48S7g1KdPn/A4GzZscOPUqVPHli9fbp07d7Z27drZjBkzAv+tAAAAAAAA6UUmO8dlypTJihYtGmv4vn377O2337b33nvP6tat64aNHTvWKlSoYIsWLbKrrrrKZs6caT/99JN9+eWXVqRIEatWrZo9++yz1rNnT5eFlSVLFhs9erSVKVPGhg4d6qahzyvw9fLLL1vDhg0D/70AAAAAAADpwTmfKfXLL79YsWLF7MILL7R77rnHNceTpUuX2vHjx61+/frhcdW0r2TJkrZw4UL3Wn+rVKniAlIeBZr2799vq1evDo/jn4Y3jjcNAAAAAAAApLNMqZo1a7rmduXKlXNN9/r372/XXXedrVq1yrZt2+YynfLlyxftMwpA6T3RX39Aynvfey++cRS4Onz4sGXPnj3ivB09etQ9PBpfTp065R6pWQYLpfQsAOmK9rkoC537dwmANCS1/68GgCCPl6FQiOMmgGQ51zqng1I333xz+HnVqlVdkKpUqVL24YcfxhksCsqgQYNckCymnTt3ugLsqVmF/ASlgCApGFU8l1mUDt4EhYFA7NixgyUNAAm8sFTpFAWmMmTgFhqAhDlw4EDqD0rFpKyoSy65xH799Ve78cYbXQHzvXv3RsuWUu97Xg0q/V2yZEm0aXi98/nHidljn17nyZMn3sBX7969rWvXrtEypUqUKGGFChVyn03N1uzRpTGAIDOlFApeu0dBKfY/IAjqkRcAkLCglHpB13UOQSkACZUtW7a0F5Q6ePCgrV+/3lq3bm3Vq1e3zJkz2+zZs61Zs2bu/XXr1rmaU7Vq1XKv9XfAgAHubqh38jlr1iwXNKpYsWJ4nGnTpkX7Ho3jTSMuWbNmdY+YdKBO7QdrLoqB4IX+2ffY/4BgpPb/1QAQJAWl0sJ1DoDgJPR4cU4fVbp162bz58+3jRs32rfffmu33367ZcyY0Vq1amV58+a1tm3bumyluXPnusLn999/vwsmqec9adCggQs+KYi1YsUKmzFjhj311FPWsWPHcECpQ4cO9ttvv1mPHj1s7dq19tprr7nmgV26dEnhXw8AAAAAAJB2ndOZUn/88YcLQO3atculi1577bW2aNEi91xefvllF31TppSKjqvXPAWVPApgTZkyxR5++GEXrMqZM6e1adPGnnnmmfA4ZcqUsalTp7og1PDhw6148eL21ltvuWkBAAAAAAAgeUSFVLEOZ001pZS9pSKAqb2mVOleU1N6FoB0V1NKHQyonhvN94BgbBzciEUNAAmsKeWVQ6H5HoCkjpGc0833AAAAAAAAkDYRlAIAAAAAAEDgzumaUgAAAEA0/fKyQIBAZTDLU9Vs/0rXVzCAAPTbl24WM5lSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQSkAAAAAAAAEjqAUAAAAAAAAAkdQCgAAAAAAAIEjKAUAAAAAAIDAEZQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAACR1AKAAAAAAAAgSMoBQAAAAAAgMARlAIAAAAAAEDgCEoBAAAAAAAgcASlAAAAAAAAEDiCUgAAAAAAAAgcQakYRo4caaVLl7Zs2bJZzZo1bcmSJcGvFQAAAAAAgDSOoJTPxIkTrWvXrta3b1/74Ycf7NJLL7WGDRvajh07Um4NAQAAAAAApEEEpXxeeukle/DBB+3++++3ihUr2ujRoy1Hjhw2ZsyYlFtDAAAAAAAAaVCmlJ6Bc8WxY8ds6dKl1rt37/CwDBkyWP369W3hwoWxxj969Kh7ePbt2+f+7t27106dOmWp2tFDKT0HQDoTshNHQmZHo8xMDwDJTf+vkUq5YyWAoJyyKNt/5KRlORplGThPAYKxN/Wfp+zfv9/9DYVC8Y5HUOoff/31l508edKKFCkSbQHp9dq1a2MtuEGDBln//v1jDS9VqtTZrDcA6dSGlJ4BIJ3JPyyl5wAAUpMFKT0DQPoyOL+lFQcOHLC8efPG+T5BqTOkjCrVn/IoO2r37t1WoEABi4riDh6AxN1FKFGihG3evNny5MnDogMAAOcMzlMAnAllSCkgVaxYsXjHIyj1j4IFC1rGjBlt+/bt0RaQXhctWjTWgsuaNat7+OXLl++MVhYAiAJSBKUAAMC5iPMUAIkVX4aUh0Ln/8iSJYtVr17dZs+eHS37Sa9r1aqV6IUPAAAAAACAuJEp5aPmeG3atLEaNWrYlVdeacOGDbNDhw653vgAAAAAAACQdAhK+bRo0cJ27txpffr0sW3btlm1atVs+vTpsYqfA0BSUlPgvn37xmoSDAAAkNI4TwGQnKJCp+ufDwAAAAAAAEhi1JQCAAAAAABA4AhKAQAAAAAAIHAEpQAAAAAAABA4glIAAAAAAAAIHEEpAAAAAAAABI6gFAAkEzo3BQAAAIC4EZQCgGQSFRXl/m7atIllDAAAzgmnTp1K6VkAgDCCUgCQxD766CObOnWqe96tWzfr2bOnHT58mOUMAABSPCCVIcP/LgF/+uknW7FiBWsEQIoiKAUASejo0aM2e/Zsa9y4sTVv3txGjx5tvXr1suzZs7OcAQBAivICUj169LBbb73VatasaU2aNLGZM2eyZgCkiKgQRU8AIMmVK1fO1q9fb8OHD7eOHTvayZMnLWPGjCxpAACQohlSn332mbthNnToUMucObM99dRTlitXLuvUqZPdcccdrB0AgSIoBQBJ7NChQ9amTRv3fPLkyfbJJ5+4u5E6IVSdKa/WFAAAQJCmT59uc+fOtfPPP986d+7shv3xxx/uvEXnKY8++qjdfvvtrBQAgSEoBQBJePfRT9lRuuv49ttvhwNTnp9//tkuueQSlj0AAAjEzp07rWrVqrZ9+3Z3fvLKK6+E31Ng6r777nPP77//frvnnntYKwACQVAKAJIoIPXOO+/Y5s2bXSZU06ZNXRM+0Ynf2LFj7b333rMbb7zRnewVLFjQ1ZsCAABIDqrSEjM7e+3atXb33XdbpkyZ7IUXXrDrr78+/N6ff/5pt9xyi9WuXdteffVVVgqAQBCUAoAkONlTbYYRI0bYtddea0uXLrXixYvbnXfead27dw8XFFV9qSpVqrhi6D/++KOr4wAAAJCcN80OHDhgOXLksOPHj1u2bNncOUiLFi3soosucj0E69zFn01VoECBiBngAJAcCEoBwFnatGmTu+uogqHqxebEiRPWrVs3++677+yuu+5y9RkUvJozZ47t2LHDBatU9Fzj6U4lAABAcgSknn/+eVdDateuXVa5cmVXR0pN+FasWGGtWrWysmXLusDUNddcE20adNACICgEpQDgLOhkT73Y5MyZ0z744AN3d1H279/vglHr1q2zb775JlbPe5zsAQCA5PTkk0/a66+/bn369LENGzbYmjVrbNGiRTZz5ky78sorbeXKla52VO7cuV1JAQWrACBoBKUA4CzoxE5ZUkqJX7BggbsL6d2h/PXXX10xc92h9NdsAAAASE6///67NW7c2J577jm77bbbwsOeeOIJl7mtG2Zqvrd8+XJXW+rdd9+lyR6AFEFjYQBIIAWbYmrQoIF9+umnrnnegAEDbPfu3eGTumPHjtmFF17o6jgAAAAkB9WEGjNmTLRhBw8edD395s2bNzysZMmSLntKdS/nzZvnamNWq1bNJkyY4M5dIp3nAEByo5gJACSyPsP8+fNt7969rneafPny2XXXXWcff/yx63Hv77//djUaLrjgAhsyZIhLib/88stZxgAAIMkpU1u9/N5+++3RhpcpU8Zq1KhhM2bMsCuuuMLdINMNtPLly7ualuvXr4/VMx/FzQGkBDKlACAhB8t/AlIqBqoTvwcffND1pPef//zHBajq1atnn3/+uUuHV3O+999/39WXUrFz1ZNSDSkAAICkpJ58W7ZsaVmzZnUZ26ofJQpCqW6Uygx8+OGH4fOQI0eOWPbs2a1IkSKsCADnBIJSABAPpbZ7f3/66SeXJTV58mRXLLRhw4bWr18/F4Das2eP1a1b1xU9z58/vzv5e+2111zvehQ1BwAAQQSoVENq8ODB7vWLL77oalsOGzbMmjRp4gJWN910k+uMpWPHjqwQAOcEglIAEE+TPS+1/fDhw66HPXWZrIeyoN5++21XU0onfep5TxlTasqnO5LvvfeePfbYY3bgwIFYPe8BAACcje+//951qOJlcc+aNcu6dOliI0eOdHWjnn32WZflrXpR7du3d7WllixZYhUrVrRly5aFb5oBQEqj9z0AOA1lQyn93etNb8qUKa6WlOff//63ffnll+6k76GHHnJ1pFRAVJlTem/EiBEsYwAAkCR0PqLMJ5UOUC1LFTlfsWKFKyugTlbefPNNe/TRR935y9NPPx3+nN7LkiWLe666UgpMAUBKIygFADGoqZ6XIaU7jI888ohLeVegafHixXb//fe7u5GFChUKf0bFzXXHceLEieHPfv31124cFRUFAABIKmPHjrXevXu7LO1JkyZZ48aNw+cvXmCqc+fOLmOqV69ecZ7nAEBKIzwOADF4J2rqsWbp0qUuFV5BJ53cPfHEEy5rSk3y1DyvYMGCblzVlfKa+3kne2rKBwAAkFS8OpUlS5Z0mdnK3J49e7ZdfPHF4ZtgyoZShyw6F1HPfOoRuHXr1rHOcwDgXEBQCgAiWLRokavRsHnzZqtVq1Z4+MCBA93f//73v+6kUM3zChcu7IapdoMCU3SpDAAAkpJ3fuHVqVR9S3W6Mm7cOHfzTNlRullWrly5cGBKJQXUy56a+gHAuYpC5wAQwVVXXWVt2rRxPekpBX7Hjh3RAlM333yzK3T++eefRz+oZuCwCgAAko7/htf06dNdqQB1qKKaUO3atXM3yBYuXOiCU+vWrXPjNW/e3L755htr1qyZG081pADgXERNKQDpXszsJv/rV1991f7zn/9Y1apVXTDKX0fqjTfesLZt29K7HgAASHbK4Fb9qPPPP9927tzpsqHeffddu+yyy2z06NGu4HnmzJndeczvv//uHnoNAOcyglIA0jV/AOr111933SXrbqKa7HXo0MENHz58uLsrWalSpViBKX99BwAAgOSgG2HqSU/1LqtVq2YfffSR3XXXXa6cQMOGDd04GrZ69WrbvXu3DR06NJwhRS97AM5lBKUA4J+7j+rJRs3yjhw54k7sWrRo4e485smTx1566SX77LPPXP2ot956yxUWBQAASGqqFVWhQoVY5ynZsmWz/v37uxtlqhc1ePBgdwNt//797lwlJgJSAFIDip8ASPdUh0FN9D755BMbP368O9lbsGCBTZs2zbp27eqWj/7Wr1/f9bYX6cQPAADgbCnDSZnZX3/9dbThK1ascMXMdX6invUGDRrkAlLq8feFF15w5QZiIkMKQGpAUApAumyy56fMKJ24eT3W6M6iCp2rbsOECRNs1qxZbnifPn1s1KhR4V72AAAAkpJ60FOzPBUo9wem7r//ftdUr06dOi57++GHH3bDDxw4YMuWLbPt27ezIgCkSgSlAKQ7Xg2pbt26uQypokWL2pYtW2zp0qVuuFcfSncqVUx037594c9GRUW5u5L0sgcAAJKabpLphpiCT7fffrt99dVXbrjqSJUsWdKdmxQoUMAN+/nnn61Vq1YuINWvXz9WBoBUiaAUgHRDBck9U6dOtffff9+KFStmpUuXdid1AwYMcCd/CjxJzpw5LXv27C4I5ee9DwAAkNR0c0yBqbp167rA1Pz5810295NPPukCU506dXI31FT7UjfOvv32WxfM8p/nAEBqQaFzAOnOF198YVOmTLGyZcta9+7d3bC5c+faiBEjbO3ata5Wg2pHqZvlHTt22Pfff0/vegAAINl7Ao6pefPmNmfOHPv000/t+uuvt61bt7pzk5UrV9pFF11kNWvWdOcoFDUHkFoRlAKQ5n3zzTe2ePFi9zxXrlwuIKU6DV26dLG+ffuGx1u0aJHrYU+961188cWupz31wpc5c2Z399Fr1gcAAJDUAakPPvjANm7c6G6MVa9e3S677DI3XPWldPNM5yi1a9eONQ3OUQCkZgSlAKRpCjA98cQTVqJECfv1119dUz2lwO/du9d+//1314Tv8ssvj/YZvadAVI4cOVxTPe4+AgCApKbyAF5JgN69e7se9GrUqGGrVq2yCy+80DXd03C58847XYkBNetTb8AAkFZQUwpAmg5IdezY0TXLU7aUUt9193H37t3WpEkTK1KkiD3zzDMuBd47OdQdy3z58rl6Ul5Rc7pUBgAASc0LSCkIpbpR6u133rx5rje9G264wWVrDxs2LJxFVbVqVdfzHgCkJWRKAUiTdFKnAqHqjaZPnz7hu5GDBw+21157zdasWWPTp0+3UaNGWe7cuV1wqkqVKik92wAAIB0ZNGiQK1SucxQFnpSlLZs3b7b+/fu7v7qppuFqpqfx6AEYQFpCphSANOmCCy6wa6+91n744YdoPerpRE6PI0eOuBoNKmp+6NAhl1G1fv36lJ5tAACQjqg3PfUIrIxu/3mIyg7ce++9Lnvqp59+csNU21LnMMrqBoC0gqAUgDRJhcrffvttO3r0qA0YMMB++eUX13uNsqaU+l6gQAE3nrpTvvvuu10x0TJlyqT0bAMAgDQqUjDpnnvuscmTJ7t6liNHjrQ///wz/J5KDuh8JmZmFJlSANISmu8BSNMUjHrsscds+/bt9uOPP9rYsWPdCaBS4CVmj3rxdcsMAABwJvznF+oBWFna6mEvf/78rnblxIkTrVWrVtayZUtr3ry5FStWzJ599lkXpFLWN+cmANIqglIA0kVgqkOHDrZjxw5X/LxmzZpuuOpMide0DwAAIDn16NHD3nnnHTtw4ICrZdmuXTt3syx79uz24YcfuqCU3HfffXb8+HEbN26cu4Gmm2kxb6QBQFpAOgCANE+p76+//roVL17cFT5fsGBBOBhFQAoAACQX7waY/qq3X3XE8vnnn9uKFSusdOnSrtTA6NGj7fDhw3bXXXe5pnyiTKmhQ4e6QJSyrAhIAUirCEoBSBfKli1rr7zyijup69y5szsxBAAASC4KJnk3v06cOGG5cuWyatWq2RVXXOHOS8aMGWMVKlRwTfd080yBqVtvvdUmTJhgAwcOtBdeeMG2bdtG0z0AaVqmlJ4BAAgyY0oneGrCV7lyZRY8AABINl4dKNWGmjZtmitmrgwob3iOHDlsxIgR1qlTJ5s0aZJr0qfmfaotlSVLFrvzzjstW7Zs1r9/fwJTANIsakoBSLcoag4AAJLz/EI1odThypNPPmmzZs2yVatWWevWrV3PwJkzZ3bj/P33366uVKFChWzUqFHhpnpq5qcbahUrVmQlAUizCEoBAAAAQBKbMmWKKxdQrlw5a9asmWuep6ypuXPn2g033OCeq+c9OXr0qAtSKZiloub6S91LAOkBNaUAAAAAIAl9//331rVrVxsyZIhrgifqYa9Xr15Wp04dV/C8b9++rtaUZM2a1QWivKLmBKQApBcEpQAAAAAgCanZXceOHS1v3rz25ptvhofnyZPHevfubfXq1bMPPvjA1bmMdnH2T7M/AEgvaL4HAAAAAElUo9J7ffDgQXvnnXds5MiRVqtWrWgBqP3799v7779v7dq1C9eQAoD0iKAUAAAAAJxlQEoZUT/++KP99ddf1rx5c2vatKkdP37cBaNef/11q1mzZrSsKY9qSBGYApBekR8KAAAAAGdyMfVPQKp79+6uh73t27e7DKk777zTunTpYvv27bMHHnjA2rdvbz/88IMLVsVEQApAeva/7h4AAAAAAIk2f/58mzBhgk2dOtWuuOIKN+zDDz+0hx9+2HLmzGkDBw601q1b24EDB2zdunWxmvsBQHpGUAoAAAAAEmjFihW2ceNGK1iwoF1zzTV25MgRy5EjhxUvXtw1xVPA6a677nLDVTOqRYsWdumll1rnzp1dT3zqWY/AFAD8DyF6AAAAAEgAZUTdd999NmbMGJcZ5TW/+/33323Xrl3u+bFjx9zw2267zYoVK2a//vqre509e3YXkAqFQmRKAcA/yJQCAAAAgNNQT3odOnRwAambbrrJ8uXL54bXqVPHGjVqZP/617/sk08+sQsvvNANV3AqS5YsLjvKT4EpAMD/0PseAAAAAMRj9erVrhmemuCpSZ5HWU8KMqmu1JAhQ2zt2rU2YMAAN+zdd9+1bdu22ZIlSyhmDgBxIFMKAAAAAOLx559/2t9//221a9cOB6LE+3v99ddb/vz5bfTo0dapUycrWbKkXXDBBbZo0SIXkFKtKXrZA4DYCEoBAAAAQDyWLl3qes+75JJL3Gt/YMorWp45c2br2LGjvfjii3b8+HHLkyePG+fEiROWKROXXQAQCYXOAQAAACAeZcuWtUOHDtnMmTNj1YVSQErGjRtnw4cPt6xZs1revHnDvewRkAKAuBGUAgAAAIB4VK9e3RUtf+ONN2zTpk3h4cqYkv3799v69eutSpUq0ZrpeQErAEBkHCUBAAAAIB7qUU/1oqZMmWK9e/e2ZcuWueHKhtqyZYu1bNnSFTV/+OGHWY4AkAj0vgcAAAAAp6Fi5WPHjrV///vfVqRIEatcubJrnrdv3z73d8GCBa6uFEXNASDhCEoBAAAAQAItX77cxowZY+vWrbMSJUrYZZddZh06dHDN9ihqDgCJQ1AKAAAAAM4SGVIAkHgEpQAAAAAgEVTg3N8DHwDgzFDoHAAAAAASgYAUACQNglIAAAAAAAAIHEEpAAAAAAAABI6gFAAAAAAAAAJHUAoAAAAAAACBIygFAAAAAACAwBGUAgAAAAAAQOAISgEAAAAAACBwBKUAAAAAAAAQOIJSAAAAAAAACBxBKQAAAAAAAASOoBQAAAAAAAAsaP8HAz55tJezcdIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "resp = llm_events_df[llm_events_df[\"event_type\"] == \"LLM_RESPONSE\"].copy()\n",
+    "if not resp.empty:\n",
+    "    resp[\"hour\"] = resp[\"timestamp\"].dt.floor(\"h\")\n",
+    "    hourly = resp.groupby(\"hour\").agg(\n",
+    "        prompt=pd.NamedAgg(column=\"prompt_tokens\", aggfunc=\"sum\"),\n",
+    "        completion=pd.NamedAgg(column=\"completion_tokens\", aggfunc=\"sum\"),\n",
+    "        total=pd.NamedAgg(column=\"total_tokens\", aggfunc=\"sum\"),\n",
+    "    ).reset_index()\n",
+    "    time_plot(hourly, \"hour\", [\"prompt\", \"completion\"], \"Token Usage Over Time\", \"Tokens\",\n",
+    "              kind=\"area\", labels=[\"Prompt\", \"Completion\"])\n",
+    "else:\n",
+    "    print(\"No LLM response data for token chart.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 3: Sessions Over Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.109340Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.109252Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.160890Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.160191Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAT6JJREFUeJzt3QecHGX9P/DnUkhoCQESICSQ0GtACCqi0gmggAUFBEQEVJoUUUxoCaIRpCmgICBgpxcFgoAkgPQmIEVpSk+AkISSBJL9v77Pj7n/3uXucne57N7tvd+v177ubnZ299nZmbmdz3yfZ+pKpVIpAQAAAEAF9ajkiwEAAABAEEoBAAAAUHFCKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAXQjY8eOTXV1dfl28cUXV7s5NOOFF16o/5y22GKLTrucSqVSWn/99XM7DzjggDY//hvf+Eb9+5w4cWKqhFjvi9eM7aGSqvF+u+L+oWjDsGHDqtYG6Gpif7zmmmvmbefggw+udnMAWk0oBdABXnrppXxQHgdRiyyySOrfv39abbXV0k477ZROPPFEy7gD3HHHHWn33XdPQ4cOTX369ElLLbVU+vjHP55+/OMfp+nTp3fqZRzBUnGgPb9bVwoLL7300vT444/n3w8//PDU3UWYGMFO3K655ppqN4dGYtsqPp+33357gZfPpEmT0mGHHZZGjhyZll9++bzvX2GFFdJuu+2WHn300SYf8+CDD6ZddtklLbPMMqlv375pnXXWSePHj0+zZ89uMN/DDz+cfvjDH6ZPfepTacUVV8zPPXDgwPw/JfaFzfnLX/6Stt9++/z8sZ8cMmRIfsztt9/e6vc1a9as9JOf/CS3LdoYz/WFL3whPfTQQy0+7p577kk9e/as35fF/rot2vK6P/3pT/N+dfDgwfl9LrroojmQOeSQQ/L/49aK/x1HH310WnXVVfPzLLfccmmvvfZKzz77bLOBbXO3CJ1b65lnnkl77rlnfr143Xj9aEdT/8vmzp2bfvWrX6WPfexjabHFFsvfL7bZZpt06623Npgv2hDrY7jgggvSiy++2Or2AFRVCYAF8uqrr5ZWWGGFUuxSm7r17Nmz0yzh//73v6U77rgj315//fVSV3HUUUc1u3zjttJKK5X+9a9/lTqrzTffvMX2l98uuuii0syZM+s/p0cffbTUWW288ca5zZ/85Cfb9fh///vf9e/z7bffLlVCLN9iWZ9wwgkd+ty33XZb/XPvs88+neL9tkUsj/L1sFqKNqy88soLbTt8/vnnF/j5Ro0a1ex23Ldv39Jdd93VYP6bbrqptMgiizQ5/3bbbVf68MMP6+f99re/3exz9+jRo3TllVfO057vfe97zT7mRz/6Uave0wcffFDaeuutm3yOPn36lG655ZYmHzdr1qzSuuuu22D+3XbbrdXLsq2vu+qqqzb7XuP/8RtvvDHf15w2bVppxIgRTT7HgAEDGux7y7eN5m77779/q97rI488Uurfv3+Tz7HhhhuWpk+f3mD+2Jc0NW9dXV3pkksuaTBvPDaWV9wf6wNAV6BSCmABnXXWWenVV1/Nv2+99dbpqquuSn/729/Sr3/967T//vunAQMGdJplvNJKK6VPf/rT+TZo0KDUFZxzzjnp1FNPzb/HWfjvfe976eabb05/+MMfctex8L///S9XA7zzzjtVa2eczZ45c2az60hUNxS3DTfcsP6+MWPGNLhvxx13zGfOi8+peI+dzWOPPZarPsKXv/zldj3H6quvXv8+4+x/retu77c7WGWVVXJ1T+zzozolKqVC7Aui0qnw/vvvp3333be+IurYY49NV155ZVpvvfXy3/H4c889t8FzR/XVMccck2688cb0xz/+MVcCFfuaI488cp6qxdNOOy3/HpVVp59+errpppvyaxx//PG5crc1fvnLX9ZX4ETb4vHR1qKSKaqB4mdjUe31r3/9K1c4tUdbXze2oVNOOSVXJMb/g5NOOin17t073xf/j6+44or5vmZUPxUVbZ/97Gfzc33729/Of0+dOjXtt99+9fN+85vfbLCfLm7lXUyjqqs1Yj2YNm1a/v1b3/pWuvbaa/Prh0ceeaRBdfV1112XLrnkkvx7VIX9+c9/TmeccUbq1atX7q4X3fRef/31+vmXXHLJXEUV4n/khx9+2Ko2AVRVtVMxgK5u++23rz9z2VRVy7vvvjvPtMmTJ5eOOOKI0mqrrZbPnC+11FKlHXfcsXT33XfPM++5556bK1IWX3zxPO/gwYPzGeWTTz65fp45c+aUTjrppHymOs7Qx5nSoUOH5ue84IILWlUJ8eCDD5Z23XXX0nLLLVfq3bt3/vnlL3+59MADD7RYafK73/0uv260bfXVVy9deumlDeaPM9Zx1j+qmeJ5l1hiiTzf7rvvXpo4cWKLy/b9998vDRw4sP71xo4d2+D+t956K5/RLu4/7bTT8vSddtqpftpDDz3U4DEHHHBA/X3XX399/fR//vOfuU3LL798bmcs5/3226/04osvNnh8+TK88MILcwVCvLeoXohKmbZWbDRVkRJVHMX9MW9Trx2fayyPaO+SSy6Z2z516tTSm2++Wdprr71K/fr1y8smln0sx8auueaavB7Fuhef3RprrJGf77333mvVexg3blx9W2LZlYvniOq2Yv1ebLHFSsOGDSt98YtfLF111VVNVgCUL7vySpmoLorPM9b/5t5PrGNf//rX83uOCoS99967NGXKlCYrblqqlHruuedytUN8ntHuWPe++tWvlp544okFqoYrqqZa835jWX7mM58pLbrooqU111yzdPnll+d54uc666yT2xXVHbfeeusC7Vea0nj/cPbZZ+eKlNifbLTRRqW//e1vrao8amk/E8sylkOxjJdddtnSlltu2aASpqnPLe4vqoyWXnrp+nVuxowZ+fWKfV9sC9GuG264ockKtqZuRdub+3yaE59BVPg03q6K54jPsBD7xWJ6VFgV4rMppq+33nr106OarvH/jqiwKW93ebVrrBsxLZZBbDPttfbaa9c/f/l6U14VdsUVVzR4TFSpxmcT7/fYY49tV6VUe163sV122aV+3p/97GctzhuVXbF9FBVHr7zySp4+d+7c0lprrVX/PI3//zX+n1nMN3z48Px/eH778Hvvvbd+erzneL0Qrx/tKKq0Zs+enafvsMMO9fP/6U9/arKS7tRTT23QrjPPPLP+vttvv73F5QDQGQilABbQV77ylfovgDvvvHM+mIgvvC11oRsyZEiTB0cRhlx77bX18/72t79t9kBqxRVXrJ/vxBNPbHa+zTbbbL4Hi/Ga8dqtaVP5Qf0qq6wyz/wRzjz11FP182+11VbNtu2YY45pcdnGgWgxbxz0RODSUpeVOJgPf/7zn+unjRkzpn7e6B5ThFyDBg2qP6CMA9iiy0PjW4Q+EVY0tQwbv/9KhlJNdV+JgPTjH//4fJfzcccd1+xnEsuwpfW3EN2NioPgxgfm3/zmN5t9/j333LN+vvmFNBEyLbPMMi2+nzh4Gzly5DzzbLDBBm0KpeIAszhIbXyLIDUOJlv7mbY3lIrXb/x+40C1/EC/uEX4EqFse/YrzSlfv5rq1hTPU36Q29ZQasKECTm4aKqN5Z9F488tgoF4vzEtQsciKIgukOuvv36zy/2cc85ZqKFUUyKgKZ4jArfCoYceWj89At1CbDvl+97yz7SxCKnK2x2BXHj22Wfrp33sYx/LwXv8f4htM/YH1113XavaHvvX8s+6vDtheQh92GGH1U+PIGbTTTetD4LKt6/WhlLted3GIXh8XuUnMFoKk5oKlMrtu+++9fedccYZzT5H+X7ulFNOadU+PE6cFNPjdcpFO4r7Hn744RxYxT6wmBbbeCG67RXTI4wrF9tocd/48eNbXA4AnYHuewALqCiVL0rtP/OZz+QS+uheEN0p3n333QbzH3TQQfUDsX79619PEyZMyIOYLrHEEumDDz7I3QSKx0RZf4hS/ejaEd0boiQ/urANHz68/jmL+WLw79///vfplltuSb/97W/Td77znfruJM2J14puCvHa4cADD0w33HBDbmeI6XF/4/cRnnvuuXzfX//619x1sehaEt1YwowZM9Jtt92Wf49BWmP5RFeUeC/R5WvxxRdvsW1PPPFEg66HSy+99DzzlHeFK+bfeeed82cQohtI+cDEU6ZMyb/HYMSxXN977720zz775K4h8XcMnB5daX7wgx/k+V577bX6ZdHU+4/Baq+//vq8vKPbTCUH1Y7uK9Ftp3ivsS7FMojlH+tU4bzzzqv//f77708/+tGP8u+xblx44YX5cZ/73OfytOiSEt1D5ufJJ5/MP1deeeW83MoV62PcF91oYnnG68T63pburDHobwzuHJ9h0ebG7+eiiy5KDzzwQP49njve+2WXXVbfPaY1IgeJdaAY/Dq2r2jzySefnLuMRrfQ6HLzf3lJaraL5i9+8Yv6v3fYYYf6Lj7RBas14vWji19sJ8Ug0fGa0TUpBseO7Sz2K8W2FV262rNfaY3oihXdiOI1R40alafF87R3QPvYzqJd0Y0txH4y1t14r9EVrbl9wX/+85+8LOP9xnuJfdPGG2+c74vlGt1IQ3R7LbbD6PYWjjjiiDzYc+x7Gnebvfzyy+s/n/ntI9uifH8T7S7fXgsxuHUhtp3y/Vr5fC09dyy/WB6N95MxQPr555+fXn755dyF8L777svrTvxfmJ/y145BxmPdL5R3937++ecbdK++++6782cSy7s92vO6IdbxGNw7Bv/ecsst8749Pvvf/OY39etIa16z/POY32sWonvfn/70p/x7dFmM7as12vK68RrlA5+Xz99SG8u7apavGwCdVcNvkQC0WYQycWWjCIsKMW7IP/7xj3yLA8MIAuKA+a233soHVSG+PMcV+4oxNLbddtt09dVXpzfffDN/2Y7QphgjI668FF804ypP/fr1S1/72tcatKGYLw7s4io+I0aMyF/U99577/m2Pw6+33jjjfx7fJGPsT2KA6p77703jxsU98e4HY3HzNhggw3qA6hll122fkyQuLJQccAVBw1xYB33x3uIg+6YXozd0ZLyL+QRTjSlfHoRRMSVmL70pS/lsTiefvrpfOAaYzOVjzMSYVLx/ougKj6DYmyPGKMqwo04iIixWWIZxHsot9lmm7XqYG9hiFDt+9//fv49DsTjgDzEgWExFsrZZ5+dw4VoeyybGMeofD2NoGWNNdbIv0eAWTxHvKe4ElRLinWmqZCpWB8jJI31ce21187jZLX2wK1cHPhFmBCfZ7T9qaeeavB+yq9yFyFK8d5jO4mrkLXGP//5z/qrCMZrFet5XPksrvAYB91xcBdXAWvuYDfWr9h2yw8aiwCpLeKzjG0kgpIYPybEtvy73/0uh48R6tx5550NtrO27ldaI0Kx4447Lv8e7yPGs4lgKZZBBD1xFcy2iO1s8uTJ+fcI1GN/EutEsa01JcLACMRi+4xtOgKy+EyK8LsI5WL/GMFWPF987rGuxH4s9sOxDUfI2Hgcr9iXlo8HVFydb0GufhmfQQSIIYKm8iC1PBCM9pYr/7u54DD2w4ceemj+Pd5neXDc+EqCcaIk9gOx34qgNPa/sXxinxHbZrH+lNtkk03a3MYYyy/GxIv9eYTO5WFSUzrqdVsS7y/WjflZ0NeMMLwIWGNbiTCtXKxbTYXYbXndxq9dfn9LbSzfJxf7aYDOTCgFsIDii3gcxMcBQ5x9//vf/54PcosvxnFp6Z/97Gd5MNw4iCy+qEYFTpztbqkKJUKDqCaIg8GiIisu8b355pvnioU4sApxIB6X446z45tuumkOgmIA3qheigOyInhoyr///e/63z/xiU80uC8OyIvBrMvnK0Q7CuVfyouDpDiQ3GOPPXKYEAehcanvOGhYd91184FotK2lAZ/jALNQBEeNlU8vf664rHcxQGyEUfGacXAeIhwr3mv5+4oqrrg1Fp9ZhCGNQ4bPf/7zqVrisymUV1oU60QoD9HiM4nlU/5+Y52MW2PxXlurqQOvWB+j4iy2g6hSiW0k1sEIiSJIa21lSnz+5dUtjdexeD9RrdbU+hvbQWuVL5MYaLil7XJ+FRgLIkK8CKQaf6YxwHVRDdf4Mw1t3a+0RvmyjOUcbYgqnBDLvK2hVPkyjn1ZEUi1JIK0Iug788wzG+xv4mA7KklChE/lFavtfc8LIqqY4mRBtCUqmCJAi0rBQnklWOOBwovBzxvPVx7mRCVjhPQRAEVQW74eNl6WEcjFehQnFqJd8X8h9pMxqHc8rqn1I6pt2trGGMg9gsPRo0fnExTz01GvW/jkJz+ZK91iucQJlKhsjMA0LjASVUUt7Z8X5POIba18UPoYbLy12vK6jV875i8Gkm+pjS1VdAJ0RrrvAXSQOIiLq8RFJcErr7ySz9YXYlpbFGc+t9tuu1xtFZUPcXAfFRPRRSdCnjhAKw7I40t4hClRGRXVEXEWNcKwuAJgzNf4THprRbjVkvIzsuVduMq/FMcZ5ehuFV3qompmzpw5+cA/qgjizH1LIsQqxFn54iC0XAQfTc2/1VZb5eqOIpSKA7s4YC+vkmqLps6YN+5+UUnlAVyPHj2aDPLae6ASV2xq6gpb5YpwpKnPJD7bOHD+yle+ksOMWI8iHIjqjlinW3tFqMZVWM2tY61dXxdUW7q/dbbPdEHb39SyLZ8W23VHV2eUV9789Kc/bXCVsc7ymYUIv2NfFkFBBItRFdY4FC2vyip/H7EtlFfYNa7eiueKarEIXiJ8in3ZF7/4xQbzRNfmckUYFp9PeXhYXnnalPLXjjaVb6fFvjMUXcfj/1xx5b14rbjFiZRCnFCJaeXVjB3xuoVY1nGiILpujhs3rkF1Z3nX1vm9ZuP1qqXXDHGCJbqVFicHyk8EzE9bXjf2f+Xbfvn8LbWxfJ/cuLoXoDMSSgEsoOi6F2eLG4cVMUZN4wO2qNApDuQioIkv3x9ddKL+Fgc2xSWh4+84uIlwKYKtGFeluOx3VE9Fd5xivqhCia4/0VUt2lOM/RJfXu+6665m219eRRXjj5Qr/7ulaquWRJBQXPY6KjriC3PRBScOuFo6aIzuccWX6lgu0R2tXIRtMX5Iobx7YRzUF+PyRNeroltNUUXV1PuKz6zx5xG3aGMxrk4lQ5CFofz9RmDY3PudXyVLdMkL//3vf5sMmWLZR9epqLqK9XbXXXfN06ObXFNVd+0V21EhuskWostde5ZJhLjNLZP5dTktD5Ja04Woo7R1v9Ia5dt+dJWMbrCFqMJsHKIVB8nxvuOgvaVlHGPelVd6NCeqQotxiqKiJqqFiv1F7BeK0DIqk2Ida/yeY78b6/jC/HxiTKUIYuK1osvmxIkTm6zSK6+yLN8fxzpbbD9xQqE8iI3KzqgojX19VMNE99oYH6qxqFIqr5aJAD/EMijGGQtFQNXU+h1hSVTnFdt1tKm57am5Srz56ajXLbrNtbQ/nt+JmFjWxfob+7CoJivaGFXHLb3Xoot7W6ukGq8H8d6KYDlev/jcYh2Iyt54P/E/sKn1pqXPo+jW2/hEDUBnpfsewAKKwCgOFqIqJA5oozonzmiWd4uKcTNCfPmOLhUx9khUMkX1UHR1iq458cU4usdcddVV+QtnfFn/7ne/m1599dU8LkwcUETAE90VCkU1Sxzwx3PEl9M4kIsv9sXgz+XzNSUqV6JbVJyhjscccsgh+eAv2lg8RxwARhvaIw6SYxybOHCKZRPjyhQDs8YX8mhbc4McR1eF448/Pi+HEGfD4+Az2hzdUaJ6IsbTCbG8IvwqF+HT6aefnn8vDpSjoq18INh4XzEuVTxfhHrxGcW0OMiM8aSiUi2qsWplwNjoYvTzn/88/x4H/LH8YgyyOIiLdTKCwqi0KA/7mhIHSzFvfH4xblV59524Lyr7ooogBn+Pz6x8+c2vCqstIogsxlOKdSW6jMb6NL8xscpF2+MgNQKzGAw/BuSO7Tm6msY6EAFNBARNVYWVKw8UojIvqhdju4xApnxg4o7W1v1Ka0Sl21prrZU/xwiDizAo/i7CjfLtKLovR8VmdFtrKnSMbTaWQbH9x9+xr4ltPJZV7IOKMdLKRfVpHGT/5S9/yV2J43OJwdFjXxhdgyMgiBA+ni/2E7GviiAmPst4z7Eeb7HFFvN8PjEYeFTYxPpSVLp84xvfqO/yGxdoKB7XnKj8i7GaQoS4UTEU63r52ElFCBHhUuz/orootpsYpD260sU6W4hx3QrRFTzeX+yHIpw44YQT8muUP3f8X4lpsQyjSrboUhZBSZyUiNcpQqlYx8s/r+ZEGw477LD8e1ToRpAZJ0TiuUL8fym6xcXn13icwdhWigHAY12JbSnGW+vI140KrOjOGcsn1tF4/0X3vcJGG23U4utFNXGMcRefYfwfiuc66qij8v/yIoCN9aJxd90IjmIdD7GuNVftG/uNooIpvhdEWBlinxjLJbbJeJ0IuuN9xcmmIqCKbbcYly+WS9GlPLq7x7oQAXCM4VUEsuUnWULRzTaUh1oAnVa1L/8H0NXFJe5butz48ssvX3r11Vdbden2xpco32+//ZqdJy6tHpcCD1tvvXWz8y233HL50uktXar9mmuuaXBZ8pYuJ19+ye/yy7g3dwnsnj17Ntu2UaNGtWoZH3744S0ur6FDh5Yee+yxJh+79tprN5j3F7/4xTzzXH/99aU+ffo0+/zFpelbWoZtEcunpedoblk299rNXcq+/HWKdSocd9xxLS7PeL75ieVdzH/qqac2uG/VVVdt9rnXWWed+ku+N9fuppZ7c+9n9uzZpZEjR87zOiNGjGjyeZpbf+MS8UsttVSLy2V+Pvjgg7y9N35c8Vm15f02tw7E45r6nNqyX2lO+fq1+uqrz/P4Xr16NWj3E088UerRo8c886211lpNrqc33HBDs9tZ+WfReHm88847pQ033LB++je/+c08ferUqaX111+/xfdc3t6zzjqrxW27uc+nOeXrY2vWmZtuuqm0yCKLNDnfdtttV79dNG5Laz7PN998s7Tmmms2Od8SSyxRuu+++0qtEetwc/9P4rO75ZZbWnx8+fa12267teo12/q65a/R1C3Wv7feemu+rzlt2rQG+4nyW+wLHn300XkeM2bMmPp5jj766Gafu7ntNzz88MOl/v37N/m6sZ5Pnz69wfzNrQt1dXWlSy65ZJ7X/tznPpfvj31R+ToF0FnpvgewgOIM9imnnJLP1EdVUFRpxFnY+P3AAw/M1UbFJcqL8T/iTGZUBRRneaOiIX6Ps8pRBVBUIsTYR9GlLMblia4GMcZKVBvE2emomCq60cTl4OOMbbxmnDmNKoKoUInHx5n1lgYTD9ElJKooouIqnj8eH9VDMS5WdBmIyov2ioqx6PoWZ7rjrH7c4v3E+49qgNaIs9lxpjmqJOJ9xVnkWGZxFjvGL4oBfKPSpSnlZ5HjfRVd+spFxUR8TlFtEO2M54+z4DHIdlRCtLadXUVUIcTZ/ujyGRUq8X5juUZVR1SfRUXa/MTyLipMoiKlXAx8HOtUVFzFOGjx/FGhE2f940IA87tKV1vEc0c31vjsYvyVuEXVQwzwXIg2zE9UVsRYZ9HG2K5iG44xa+J9xrTiypItifUrtt9YjsXA5JXSlv1Ka8RnGPu1+NxiWUR1R6wz5dVD0eUqxreLCpyYJ5ZVdNlsrnokqrmi2ql8O4v1L56zpS5hsU+N1y7GiIvqp6gwis8n9luxD4hKoKh6is86BvmOfVlU7MRg2IWoSokKulhW5V35KiX+R8T+NKqmomor9oWxDGMfGZVgC7JdRLVcPHdUSMV2F8s29uGxv4vucEW1bmvW4agWigsVxLoTbYznjv8B8fxx8YyFoS2vG59pVMUW3R1jucW6EFWwsSyjWqupq4I2FvuK+D8a20xUNcU6HP//opo0llnjCq/oclpUKMX6U17Z1hbxfyWeP14nXi9eN17/Bz/4Qa7UbLzviPU9uonG42K7jnbH8ojq39i2y0WlXnSPLf73deS+FmBhqYtkaqE9OwBQs6IbTRHyRRe+ao1fEl9lGo/vFUFVhCAhDmxjTDOAWhbdWaP7ZoR6MRh7W6+SCVANKqUAgHb56le/Wl+hFtVs1RLVhGeddVaudIoxlGL8p/Iqhvld5RGgq4twvhgvMMZ3E0gBXYVKKQCgS4vuX9HtpSkRSEU3rq54pUQAgFrn6nsAQJcWY0jFFSfjalZxFcEYkyXGGIqrqcWYKwIpAIDOSaUUAAAAABVnTCkAAAAAKk4oBQAAAEDFdekxpebOnZteeeWVPHaE8SIAAAAAOsdVQWfMmJEGDx6cevToUZuhVARSLncKAAAA0Pm8+OKLaciQIbUZSkWFVPEm+/XrV+3mADUkKjGnTJmSBg4c2GKyDwDQVfm+Ayws06dPz0VERW5Tk6FU0WUvAimhFNDRX9JmzpyZ9y1CKQCgFvm+Ayxs8xtqyel/AAAAACpOKAUAAABAxQmlAAAAAKi4Lj2mFAAAANA5zJkzJ33wwQfVbgYV0Lt379SzZ88Ffh6hFAAAANBupVIpvfbaa+ntt9+2FLuRpZZaKi2//PLzHcy8JUIpAAAAoN2KQGrQoEFpscUWW6CQgq4RQr733ntp8uTJ+e8VVlih64ZSL7/8cjr66KPTjTfemN/Uaqutli666KI0cuTIajcNAAAAmE+XvSKQWmaZZSyrbmLRRRfNPyOYis++vV35qhpKTZ06NW222WZpyy23zKHUwIED03/+8580YMCAajYLAAAAaIViDKmokKJ7WeyjzzzWgS4ZSp188slp6NChuTKqMHz48Go2CQAAAGgjXfa6n7oO6KZZ1VDquuuuS6NGjUpf+cpX0qRJk9KKK66YDjrooHTAAQc0Of+sWbPyrTB9+vT8c+7cufkG0FFinxJ9pe1bAIBa5fsOHbkeFTe6j9JHn3lTmUxrj6OqGko999xz6Ve/+lU68sgj05gxY9L999+fvvvd76ZFFlkk7bPPPvPMP378+DRu3Lh5pk+ZMiXNnDkz1YL9Lrm/2k0AUko9UkpDliill96pSyJv6Bwu3GeTajcBoKbEQeO0adPyQWWPHvHtB9ouum7FuvThhx/mG82LrOPyyy9Pu+yyS00spg8//DB/9m+++Wbq3bt3g/tmzJjR+UOpaHwMaP6Tn/wk//2xj30sPf744+ncc89tMpQaPXp0DrDKK6Wi+1+MRdWvX79UC56c6ioF0Bn0SKUU53memprS3GS7hM4gBtEEoGOPx6L7TRxPCaVorygQiQCiV69e+VYYPvqGii7U58fv2Op557e+H3/88Wns2LFN3vfCCy+kVVZZJT300ENpww03bHM7Y+yl8uXUlcX7iGUZA9z37du3wX2N/272OVIVxWUD11lnnQbT1l577XTllVc2OX+fPn3yrbFYCLWyE3XwC51H6aNt0nYJnUOt/K8H6EwilKql4ykqL9adWI+KW7W05bVfffXV+t8vvfTSHEI9/fTT9dOWWGKJZp+vmN7e91vt5dSRivfS1D6ktfuUqu554sp75R98+Pe//51WXnnlqrUJAAAAqF3LL798/a1///45WCn+jsrs008/PQ0ZMiQXxUQ11IQJE+a5OFv09IrHbbHFFvnvGI5o2223Tcsuu2x+zs033zxXU9GJQ6kjjjgi3XPPPbn73jPPPJP++Mc/pl//+tfp4IMPrmazAAAAgG7o5z//eTrttNPSqaeemh599NF8cbadd945/ec//8n333ffffnnLbfckiuurrrqqvx3dGGMYYjuvPPOnHOsvvrqaccdd2z12ErdVVW7722yySbp6quvzmNFnXjiiTlxPPPMM9Oee+5ZzWYBAAAA3VCEUUcffXTafffd898nn3xyuu2223JWcc455+Qx2EKMoxSVVYWtttqqwfNEwc1SSy2VJk2alD7/+c9X+F10HVUfXSs+HB8QAAAAUE1xMbVXXnklDzVULv7+5z//2eJjX3/99XTsscemiRMnpsmTJ6c5c+ak9957L/3vf/9byK3u2qoeSgEAAAB0ZdF1780338zd/2Kc7BiPatNNN02zZ8+udtM6NZdYAAAAALq9fv36pcGDB6d//OMfDZZF/L3OOuvk3xdZZJH8MyqhGs/z3e9+N48jte666+ZQ6o033uj2y3R+VEoBAAAApJS+//3vpxNOOCGtuuqq+cp7F110UXrkkUfSH/7wh7x84up8iy66aL4iX1yhr2/fvvlqezGw+e9+97s0cuTI3A0wnifmo2UqpQAAAABSytVORx55ZPre976X1l9//Rw+XXfddTl0Cr169Uq/+MUv0nnnnZerqnbZZZc8/cILL0xTp05NG220Udp7773z80SARcvqSqVSKXVRkT5GIjlt2rRcZlcLhv3w+mo3AciJfSmtPaCUnpxal+amOssEOoEXfvq5ajcBoKbMnTs3D8gcB849eqhXoH1mzpyZnn/++TR8+PBcNUT3MbOFz761eY09DwAAAAAVJ5QCAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAJiPiRMnprq6uvT222+3ON+wYcPSmWeeaXm2Qq/WzAQAAADQamP7V3ZhjZ3W6lnPPffc9P3vfz9NnTo19er1f7HIO++8kwYMGJA222yzHD4V4vctt9wyPfPMM+lTn/pUevXVV1P//v/33i6++OJ0+OGHzzekao1vfOMb6ZJLLpln+qhRo9KECRNSrRJKAQAAAN1GhEwRQj3wwAPpk5/8ZJ52xx13pOWXXz7de++9aebMmalv3755+m233ZZWWmmltOqqq+a/Y56FZfvtt08XXXRRg2l9+vRpdv4PPvgg9e7du8G02bNnp0UWWaTNr93exy0o3fcAAACAbmPNNddMK6ywwjwVUbvssksaPnx4uueeexpMjxCrcfe9+H3fffdN06ZNy9PiNnbs2PrHvffee+mb3/xmWnLJJXOo9etf/3q+7erTp08OvcpvUb1ViNf41a9+lXbeeee0+OKLpx//+Mf5NTfccMN0wQUX5LYXYdr//ve//H6WWGKJ1K9fv/TVr341vf766/XP1dzjrrjiirT++uunRRddNC2zzDJpm222Se+++25aWIRSAAAAQLcSQVNUQRXi9y222CJtvvnm9dPff//9XDlVhFLloitfjBsVgU906YvbUUcdVX//aaedlkaOHJkefvjhdNBBB6UDDzwwPf300wvc7rFjx6YvfvGL6bHHHsuhV4iuhVdeeWW66qqr0iOPPJLmzp2bA6m33norTZo0Kd18883pueeeS7vttluD52r8uHgPe+yxR37eJ598MgdvX/rSl1KpVEoLi+57AAAAQLcSQVOMB/Xhhx/m8CnCowikoktcjDkV7r777jRr1qwmQ6no6hZjS0X1UlNd+nbcccccRoWjjz46nXHGGTnsiiqt5vz1r3/NlU3lxowZk2+Fr33ta7lCq3HXu9/+9rdp4MCB+e8IoSK0ev7559PQoUPztLh/3XXXTffff3/aZJNNmnzcQw89lJdHBFErr7xynhZVUwuTUAoAAADoVqIqKrqlRUgTA56vscYaOZyJYCpCnxhXKiqFVlllldz9rq1GjBhR/3sRXE2ePLnFx2y55Za5e165pZdeusHfUX3VWARIRbAUosopwqgikArrrLNOWmqppfJ9RSjV+HEbbLBB2nrrrXMQFQOsb7fddmnXXXdt0IWwowmlAAAAgG5ltdVWS0OGDMnVSxFKRRgVBg8enMOcu+66K9+31VZbtev5Gw9AHsFUdKtryeKLL57bNb95WjOtNRo/rmfPnrnKKt773/72t3TWWWelY445JndhjHGnFgZjSgEAAADdTlQmRTVU3KJyqvDZz3423Xjjjem+++5rsuteeRe+OXPmpM5m7bXXTi+++GK+FZ544ok8QHtUTLUkwrPNNtssjRs3LndpjPd49dVXL7S2qpQCAAAAup0InA4++OA8jlRRKRXi90MOOSSPudRSKDVs2LD0zjvvpFtvvTV3fVtsscXyrb1mzZqVXnvttQbTevXqlZZddtk2PU9cMS+64O255555MPYYJyrGt4r31VT3v0JURMV7iW57gwYNyn9PmTIlh1wLi0opAAAAoNuJwCkGOY8uc8stt1z99AhvZsyYkQclX2GFFZp9fFyB7zvf+U6+ql2MzXTKKacsUHsmTJiQX6/89ulPf7rNzxPVTtdee20eCyqqviKkirGxLr300hYfF1cSvP322/Mg7THG1rHHHpuvIrjDDjsswLuaT1tLC/PafgvZ9OnT82j306ZNywuvFgz74fXVbgKQE/tSWntAKT05tS7NTXWWCXQCL/z0c9VuAkBNifFtYuDlqIjo0UO9Au0TA4LHVd5izKG+fftajN3IzBY++9bmNfY8AAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAACABb6aI93L3A74zHulKho7dmwaN25cg2lrrrlmeuqpp6rWJgAAAKB1FllkkdSjR4/0yiuvpIEDB+a/6+rqLL4aViqV0uzZs9OUKVPyZx+feZcMpcK6666bbrnllvq/e/WqepMAAACAVohQYvjw4enVV1/NwRTdx2KLLZZWWmmlvA60V9UToAihll9++Wo3AwAAAGiHqJSJcOLDDz9Mc+bMsQy7gZ49e+Y8Z0Gr4qoeSv3nP/9JgwcPTn379k2bbrppGj9+fF6ZAQAAgK4hwonevXvnG3SJUOoTn/hEuvjii/M4UlHqF+NLfeYzn0mPP/54WnLJJeeZf9asWflWmD59ev3gWrUyqFqPVKp2E4CPtsW6VHI1COhEauV/PUBn2q/G2DD2r0BHa+1+paqh1A477FD/+4gRI3JItfLKK6fLLrss7bfffvPMH1VUjQdGDzG41syZM1MtWHuAUAo6g+gVPWSJlKIYda6wGDqFyZMnV7sJADV30Dht2rQcTC3ImDAAjc2YMSN1ie575ZZaaqm0xhprpGeeeabJ+0ePHp2OPPLIBpVSQ4cOzSP89+vXL9WCJ6e6SgF0lkqpiIifmhqhlO0SOoNBgwZVuwkANRdKRZerOJ4SSgEdKYZo6nKh1DvvvJOeffbZtPfeezd5f58+ffKtsdiB1spO1MEvdB6lj7ZJ2yV0DrXyvx6gM4lQqpaOp4DOobX7lKrueY466qg0adKk9MILL6S77rorffGLX8wjuO+xxx7VbBYAAAAAC1lVK6VeeumlHEC9+eabuWT005/+dLrnnnvy7wAAAADUrqqGUn/+85+r+fIAAAAAVImOwwAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAVJxQCgAAAICKE0oBAAAAUHFCKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAAAAqDihFAAAAAAVJ5QCAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAdN9Q6qc//Wmqq6tLhx9+eLWbAgAAAEB3CKXuv//+dN5556URI0ZUuykAAAAAdIdQ6p133kl77rlnOv/889OAAQOq3RwAAAAAKqBXqrKDDz44fe5zn0vbbLNNOumkk1qcd9asWflWmD59ev45d+7cfKsFPVKp2k0APtoW61Kp+sk9UK9W/tcDdKb9aqlUsn8Fqva9raqh1J///Of00EMP5e57rTF+/Pg0bty4eaZPmTIlzZw5M9WCtQcIpaAziDBqyBIp1cUOVVgMncLkyZOr3QSAmjtonDZtWg6mevRwKg7oODNmzOjcodSLL76YDjvssHTzzTenvn37tuoxo0ePTkceeWSDSqmhQ4emgQMHpn79+qVa8OTUOAQGOkOlVETET02NUMp2CZ3BoEGDqt0EgJoLpeJiU3E8JZQCOlJrc56qhVIPPvhgPuO50UYb1U+bM2dOuv3229PZZ5+du+n17NmzwWP69OmTb43FDrRWdqIOfqHzKH20TdouoXOolf/1AJ1JhFK1dDwFdA6t3adULZTaeuut02OPPdZg2r777pvWWmutdPTRR88TSAEAAABQO6oWSi255JJpvfXWazBt8cUXT8sss8w80wEAAACoLWo0AQAAAKi4ql59r7GJEydWuwkAAAAAVIBKKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAAAAqDihFAAAAABdI5RaZZVV0ptvvjnP9LfffjvfBwAAAAAdHkq98MILac6cOfNMnzVrVnr55Zfb85QAAAAAdCO92jLzddddV//7TTfdlPr371//d4RUt956axo2bFjHthAAAACA7h1KfeELX8g/6+rq0j777NPgvt69e+dA6rTTTuvYFgIAAADQvUOpuXPn5p/Dhw9P999/f1p22WUXVrsAAAAAqGFtCqUKzz//fMe3BAAAAIBuo12hVIjxo+I2efLk+gqqwm9+85uOaBsAAAAANapdodS4cePSiSeemEaOHJlWWGGFPMYUAAAAACzUUOrcc89NF198cdp7773b83AAAAAAurke7XnQ7Nmz06c+9amObw0AAAAA3UK7Qqn9998//fGPf+z41gAAAADQLbSr+97MmTPTr3/963TLLbekESNGpN69eze4//TTT++o9gEAAABQg9oVSj366KNpww03zL8//vjjDe4z6DkAAAAACyWUuu2229rzMAAAAABo/5hSAAAAAFDxSqktt9yyxW56f//73xekTQAAAADUuHaFUsV4UoUPPvggPfLII3l8qX322aej2gYAAABAjWpXKHXGGWc0OX3s2LHpnXfeWdA2AQAAAFDjOnRMqb322iv95je/6cinBAAAAKAGdWgodffdd6e+fft25FMCAAAAUIPa1X3vS1/6UoO/S6VSevXVV9MDDzyQjjvuuFY/z69+9at8e+GFF/Lf6667bjr++OPTDjvs0J5mAQAAAFDLoVT//v0b/N2jR4+05pprphNPPDFtt912rX6eIUOGpJ/+9Kdp9dVXz8HWJZdcknbZZZf08MMP54AKAAAAgNrUrlDqoosu6pAX32mnnRr8/eMf/zhXTt1zzz1CKQAAAIAa1q5QqvDggw+mJ598Mv8elU0f+9jH2v1cc+bMSZdffnl6991306abbrogzQIAAACgFkOpyZMnp9133z1NnDgxLbXUUnna22+/nbbccsv05z//OQ0cOLDVz/XYY4/lEGrmzJlpiSWWSFdffXVaZ511mpx31qxZ+VaYPn16/jl37tx8qwU9UqnaTQA+2hbrUqljrwYBLJBa+V8P0Jn2qzGMiv0r0NFau19pVyh16KGHphkzZqR//etfae21187TnnjiibTPPvuk7373u+lPf/pTq58rxqJ65JFH0rRp09IVV1yRn2PSpElNBlPjx49P48aNm2f6lClTcqhVC9YeIJSCziDCqCFLpFQXO1RhMXQKcVIMgI49aIzjsAimYpxggI4SmVFr1JViD9SOgc5vueWWtMkmmzSYft999+WBzqNqqr222WabtOqqq6bzzjuvVZVSQ4cOTVOnTk39+vVLtWC1MTdUuwnAR5VSaw0opaem1qW5OZoCqu2Zn+xY7SYA1FwoFSf4o6eLUAroSJHXDBgwIAffLeU1vdq78+rdu/c802PagpZ+xuPLg6dyffr0ybfGYgdaKztRB7/QeZQ+2iZtl9A51Mr/eoDOpK6urqaOp4DOobX7lHbtebbaaqt02GGHpVdeeaV+2ssvv5yOOOKItPXWW7f6eUaPHp1uv/329MILL+SxpeLvGKdqzz33bE+zAAAAAOgi2lUpdfbZZ6edd945DRs2LHefCy+++GJab7310u9///s2jQ3x9a9/Pb366qu5S+CIESPSTTfdlLbddtv2NAsAAACAWg6lIoh66KGH8rhSTz31VJ4WA57HeFBtceGFF7bn5QEAAADo4trUfe/vf/97vipeDFgVfY+joimuxBe3GPR83XXXTXfcccfCay0AAAAA3S+UOvPMM9MBBxzQ5Mjp0f3u29/+djr99NM7sn0AAAAAdPdQ6p///Gfafvvtm71/u+22Sw8++GBHtAsAAACAGtamUOr1119PvXv3bvb+Xr16pSlTpnREuwAAAACoYW0KpVZcccX0+OOPN3v/o48+mlZYYYWOaBcAAAAANaxNodSOO+6YjjvuuDRz5sx57nv//ffTCSeckD7/+c93ZPsAAAAAqEG92jLzsccem6666qq0xhprpEMOOSStueaaefpTTz2VzjnnnDRnzpx0zDHHLKy2AgAAANAdQ6nlllsu3XXXXenAAw9Mo0ePTqVSKU+vq6tLo0aNysFUzAMAAAAAHRZKhZVXXjndcMMNaerUqemZZ57JwdTqq6+eBgwY0NanAgAAAKCbanMoVYgQapNNNunY1gAAAADQLbRpoHMAAAAA6AhCKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAAAAqDihFAAAAAAVJ5QCAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAdK9Qavz48WmTTTZJSy65ZBo0aFD6whe+kJ5++ulqNgkAAACAWg+lJk2alA4++OB0zz33pJtvvjl98MEHabvttkvvvvtuNZsFAAAAwELWK1XRhAkTGvx98cUX54qpBx98MH32s5+tWrsAAAAAqOFQqrFp06bln0svvXST98+aNSvfCtOnT88/586dm2+1oEcqVbsJwEfbYl0qGXgPOpFa+V8P0Jn2q6VSyf4VqNr3tl6dqcGHH3542myzzdJ6663X7BhU48aNm2f6lClT0syZM1MtWHuAUAo6S9/mIUukVBf7J2ExdAqTJ0+udhMAakocg0VhQARTPXq4BhbQcWbMmNG1QqkYW+rxxx9Pd955Z7PzjB49Oh155JENKqWGDh2aBg4cmPr165dqwZNT4xAY6AyVUhERPzU1QinbJXQG0cUfgI4Nperq6vLxlFAK6Eh9+/btOqHUIYcckv7617+m22+/PQ0ZMqTZ+fr06ZNvjcUOtFZ2og5+ofMofbRN2i6hc6iV//UAnUmEUrV0PAV0Dq3dp1Q1lIoy0UMPPTRdffXVaeLEiWn48OHVbA4AAAAAFdKr2l32/vjHP6Zrr702Lbnkkum1117L0/v3758WXXTRajYNAAAAgIWoqjWav/rVr/LAeltssUVaYYUV6m+XXnppNZsFAAAAwEJW9e57AAAAAHQ/RrMDAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAVJxQCgAAAICKE0oBAAAAUHFCKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAAAAqDihFAAAAAAVJ5QCAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAA3SuUuv3229NOO+2UBg8enOrq6tI111xTzeYAAAAA0B1CqXfffTdtsMEG6ZxzzqlmMwAAAACosF6pinbYYYd8AwAAAKB7qWoo1VazZs3Kt8L06dPzz7lz5+ZbLeiRStVuAvDRtliXSgbeg06kVv7XA3Sm/WqpVLJ/Bar2va1LhVLjx49P48aNm2f6lClT0syZM1MtWHuAUAo6S9/mIUukVBc7VGExdAqTJ0+udhMAau6gcdq0aTmY6tHDNbCAjjNjxozaC6VGjx6djjzyyAaVUkOHDk0DBw5M/fr1S7XgyalxCAx0hkqpiIifmhqhlO0SOoNBgwZVuwkANRdKxQWn4nhKKAV0pL59+9ZeKNWnT598ayx2oLWyE3XwC51H6aNt0nYJnUOt/K8H6EwilKql4ymgc2jtPsWeBwAAAICKq2ql1DvvvJOeeeaZ+r+ff/759Mgjj6Sll146rbTSStVsGgAAAAC1Gko98MADacstt6z/uxgvap999kkXX3xxFVsGAAAAQM2GUltssUW+0gMAAAAA3YsxpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAEDFCaUAAAAAqDihFAAAAAAVJ5QCAAAAoOKEUgAAAABUnFAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAVJxQCgAAAICKE0oBAAAAUHFCKQAAAAAqTigFAAAAQMUJpQAAAACoOKEUAAAAABUnlAIAAACg4oRSAAAAAFScUAoAAACAihNKAQAAAFBxQikAAAAAKk4oBQAAAED3DKXOOeecNGzYsNS3b9/0iU98It13333VbhIAAAAAtRxKXXrppenII49MJ5xwQnrooYfSBhtskEaNGpUmT55c7aYBAAAAUKuh1Omnn54OOOCAtO+++6Z11lknnXvuuWmxxRZLv/nNb6rdNAAAAABqMZSaPXt2evDBB9M222zz/xvUo0f+++67765m0wAAAABYiHqlKnrjjTfSnDlz0nLLLddgevz91FNPzTP/rFmz8q0wbdq0/PPtt99Oc+fOTTVh1rvVbgGQldKHM0spzapLKcUNqLb4fw9Ax4ljqOnTp6dFFlkkFwcAdJTYt4RSqdR5Q6m2Gj9+fBo3btw801deeeWqtAeobc9XuwFAAwPOtEAAALqSGTNmpP79+3fOUGrZZZdNPXv2TK+//nqD6fH38ssvP8/8o0ePzoOilyf7b731VlpmmWVSXZ1KBqBjk/2hQ4emF198MfXr18+iBQBqju87wMISFVIRSA0ePLjF+aoaSkWZ6MYbb5xuvfXW9IUvfKE+aIq/DznkkHnm79OnT76VW2qppSrWXqD7iUBKKAUA1DLfd4CFoaUKqU7TfS8qn/bZZ580cuTI9PGPfzydeeaZ6d13381X4wMAAACgNlU9lNptt93SlClT0vHHH59ee+21tOGGG6YJEybMM/g5AAAAALWj6qFUiK56TXXXA6iW6Cp8wgknzNNlGACgVvi+A1RbXWl+1+cDAAAAgA7Wo6OfEAAAAADmRygFAAAAQMUJpQAAAACoOKEU0G1cddVV6bnnnqt2MwAAABBKAd1BXM9h8uTJadddd01HHXVU+u9//1vtJgEAAHR7KqWAbmHQoEHpwQcfTH//+98FUwBAzSourj579uxqNwVgvoRSQM2rq6tLc+bMSR/72MfSxIkT04033iiYAgBqMpCK7z0TJkxI+++/f3r55Zer3SSAFgmlgG6hZ8+eOZjacMMN05133pluuOEGwRQAUFMikIoxNHffffdcJT5lypRqNwmgRXWlor4ToIbPGDb28MMPp09/+tNpxx13TKeeempaeeWVq9I+AICO8uijj6Ztt902/ehHP0rf+ta36qdHOLX00kvnk3QAnYlKKaDmA6l77703XXTRRWn8+PHptddeS++//37uynfHHXeomAIAurTyGoNXXnklDRs2LAdSb731Vrr44ovTqFGj0ogRI9IxxxyjcgrodFRKATUdSF199dV5TIX1118/j6vQu3fvdOyxx+YKqaWWWio99NBDaauttkqf+MQn0gUXXJCGDh1a7aYDALRJhE9xpeHPfe5z+TvPkUcemcfRXHHFFdOqq66ahgwZkn74wx+m2267LW222WaWLtBp9Kp2AwAWhgikohLqwAMPzN3z9t133zR16tS0zDLLpJ/85Cdp1qxZ6ctf/nLaaKON0t/+9rf0xS9+MfXooXgUAOhaJ+BeeOGFPE5mBFHrrrtuDqjOP//8tMUWW6RvfOMbab311svzX3bZZWnGjBnVbjZAAyqlgJr8ghY/zzjjjPT666+nk08+OT377LN5jIXtttsun0mMwOpnP/tZ2nnnnfMYCxFS9enTp9rNBwBotXvuuSfdfPPN6c0330xnnnlm/fTG32vGjBmT/vSnP+WLvUT1FEBnoVIK6NLmzp2bK5w+/PDD1KtXrxxIPfbYY7l0ffvtt89/v/vuu+mb3/xm7qZ37rnnprfffjuPtzBu3Lj8mK997WtpkUUWqfZbAQBotfg+8/Of/zz95S9/SVtvvXWeFifl4rtREUhdd9116Yorrkg33XRTmjBhgkAK6HT0VQG6tAikogoqgqVw+eWX53L1uPrMOuusk9Zee+309NNP58E+i6vQvPTSS/nLW4yp8KlPfSo/R1NX6AMA6KwDm8fYmAcccEDaYYcdcuj097//PX+fKa6wF131Zs+eneePsaTiIi8AnY1KKaDLixL1G2+8MQ9Wfv/99+cr7cVVZoqufG+88UYua48xpeIL2pVXXpkroy688EJd9gCALqH4XlNUicfvUQXer1+/9MEHH6TDDjssnX322WnzzTfP8y+55JJpl112yYOfL7rootVuPkCTjCkF1IQYH+roo49OG2ywQbrvvvvyVfbKxRe0p556Kg90HuNMxfgLMcg5AEBXCaSiIipOvk2bNi1fMXj06NFp+PDh6YEHHshjaP773/9OZ511VvrsZz9b7SYDtIrue0BNiC9kY8eOzVVRO+20U/4ZYqypMGnSpHTKKaekww8/PN17770CKQCgy4hAKsaHigu0RLe9GJ4guuTF3zFW1MiRI+uvvrfXXnulf/zjH9VuMkCrqJQCuuTZwrhF6Xr57yEGOY8r7EXF1B//+Md8Zb1w11135fGjAAC6kuiuF4Oa77jjjunzn/98OvbYY/P0OXPm5Iu6vPbaa7mCavDgwXlcqd///vd5nlVWWaXaTQeYL6EU0CUU4yfEmAlF17xbbrkljyUVpeq77rprDqI23HDDHEyNGjUqX4HvpJNOStdee236zW9+k0vb4wsbAEBX6bJX/B4XcBkzZkzae++983iacYW9CKZWW221PHbUmWeemeedOXNm6tu3b5VbD9A6uu8BXSaQ+te//pXGjx+fp1199dX13fTii9npp5+eB/i89dZbcxg1ceLE9OSTT+YS9osvvjhfLlkgBQB0FRFIxfhRe+yxR/49bkW3vAik4vtPXGkvxo8qhi0IAimgKxFKAV0ikPrnP/+Zw6a4at5bb72VfvSjH+UBPS+55JL0t7/9LYdSQ4YMyZVRjz/+eFpjjTXSf/7zn3x/VEhtvPHG1X4rAADzFVVR4dVXX80XcllvvfXy38ccc0w+yRZjZBbBVHjnnXfSEkssUf84gK6kV7UbADC/QOqJJ55Im266aTr++OPTD3/4w/TSSy/l8RNWXHHF+nm33nrr/GXsu9/9bu7OF1/g4svaJz/5SQsYAOgyoiLqnnvuSX/4wx/y95ijjjoqT992223Tt7/97XTGGWfk70YxZMHTTz+dT87FRVyKrn4AXYlKKaBTB1JR9bT55punYcOG5avrFfctv/zyOZgq/g7bbLNN6tevX/rrX/9a1bYDALRVUen03HPPpSuuuCL96U9/yuFTURE1aNCgdNBBB6Wzzjorfz+67LLL0vPPP5+79MV4UwBdkVAK6NRd9j7xiU/kqqdp06blMaPCSiutlLvjjRs3Lt199931V96LL3PLLrtsWnXVVav8DgAA2iYqnWLMzDgJFyfk9txzzzwEwS9/+cv6eeJ7TlzcJabfcccd6ZprrkkjRoywqIEuS/c9oNOJkCm+bH3qU5/K4yfEZY0vvPDC/HtcZebss89O559/fnrllVfSzjvvnMva4+xhnDWML2innnpqtd8CAECbrrL3v//9L3/nOfzww/PFXNZdd938vSeuqhfVUvvtt1+ev7gScQxyHjeArkwoBXRK7733XjrwwAPTCSeckP/ebbfd8s8IpkIEU9dff3065JBD8qCfr7/+eh5jatKkSWmttdaqatsBAOZXEV6IQOqWW27J40Jtsskm9d95VllllXTooYfmeWPA8/i577775kAKoFYIpYBOKS5vHLfiDGL//v3T7rvvPk8wFbcpU6bkM4W9evXKY0oBAHT2i7jcdNNN6YgjjsjTJ06cmH7yk5+kwYMHp6lTp9Z/n1lzzTXTwQcfnL/nHH300TmQ2muvvar8LgA6jjGlgE6vuJpMfEGLYOrHP/5xuvTSS+vHmBo4cGBaeumlBVIAQKcPpB555JG00UYb5W54hZNOOilXQ8XQBDHA+YwZM+rvi2DqgAMOyFVScTVigFqiUgroUopgKr7Ufetb30qLLbZYGj9+fLWbBQDQqou4bLbZZunII49MP/jBDxrM873vfS9Nnz49jysVFeJf//rX0+KLL57vi6vrRXCl6x5Qa4RSQJcMpr7yla/kL2bOGAIAnVkMQxCB1GOPPZa/t3z/+9/PVxAuXHbZZTmEGjVqVJ4e8xdjScUV+JZYYok8n0AKqEV1pdjrAXThq9UAAHRmcUGWuKrwCiuskO6888766TGO1Mknn5xuu+223KWvEOFU3C644ILcbc/3HaBWGVMK6LJ8QQMAuoLZs2enkSNH5gHLf/nLX+Zpp556ajrjjDNypVQRSEU3vxBXHx47dmyurPJ9B6hlKqUAAAAWsueffz5frOXpp5/O3fXuueeedMUVV6QtttiiwXx//etf0+c//3mfB9AtqJQCAABYyEMODB8+PI0ZMyZfTe/ee+9Nu+22W30gVV4hFdNffPFFnwfQLQilAAAAFqLoghfB1CqrrJKvrrfLLrukhx9+OJ199tn/d1DWo0c67rjj0imnnJJuv/32NHToUJ8H0C3ovgcAAFDBi7Q899xzeZDzf/3rX+lb3/pWevnll3PXvhgEfeONN/ZZAN2GUAoAAKBCVwouD6biyntXX311evvtt9Pdd98tkAK6HaEUAADAAirGhYqueO+//37q3bt36tWrV5PzFsHUM888k84666x04IEHprXWWstnAHQ7QikAAIB2iqvoDRs2LC2//PL1V8+76KKL0htvvJEOPvjg9JnPfCatsMIKzQZTH374YbPhFUCtM9A5AABAO0yaNClts8026eKLL07vvvtuuu+++9JXv/rVHEL169cvHXbYYen0009Pzz777DyPLbr1CaSA7kwkDwAA0A6bb755OvTQQ9N5552XFl100TR16tQ8gPnhhx+e7z/nnHPyFfaia99BBx2UVl11VcsZoIxQCgAAoI0++OCDPG7U+PHjc7XTmWeemf+O6qhCdN8LMW5Uz5490/7775/WWGMNyxrgI0IpAACAVoiKpxjIPEQAFV588cX0ox/9KC255JJpzJgx6aGHHkqTJ09OgwYNqg+m4jEnnHBCWmSRRfLP4rEA3Z0xpQAAAFpz8NSjR3r++efTrrvumv++9tpr07bbbpun/eAHP0jHHXdcuummm9Ill1ySg6lCXF0vuvXtu+++AimAMiqlAAAAWmHOnDnp3//+d7r33nvTyJEjc1XUH/7whzR8+PB8f1RBxdX0orteXF0vQqiBAwfm+6LrHgANqZQCAABowfe+9710880353GhRo0alcOmCKTWX3/9tMcee+R5Zs6cmX9GV7599tknD34eA52/8cYbli1AM4RSAAAAzXj//fdz1VNR8RSGDRuWjjrqqFwVFd33Qt++ffO8RTAVXfwuv/zyVFdXZ9kCNKOuFHtYAAAA5hnUfNasWalPnz552oQJE3LIFNVScf/111+fvv/976ehQ4fmSqrCo48+mkaMGJHefPPNtMwyy1iqAM1QKQUAAND4QKlHj3xlvY022ii99NJLedqVV16Zdthhh3TjjTfm+6NK6tRTT833b7311nlw8xjs/Gtf+1rutieQAmiZSikAAIAmRCi1xRZbpE9/+tPpwgsvzFVTP/zhD/N4Uddcc03acccd81hSkyZNSocddliaMWNGDquuuuqqtMkmm1imAPMhlAIAAEgpjx1VPgZUXG3vtNNOS7///e/TySefnKuk3nrrrVwNdf7559cHUzHftGnT0v3335/WXXfdNGTIEMsToBWEUgAAQLdXjCE1derUNGDAgPrlEWHTZz/72TR48ODcbS/EWFHHH398Dqauu+66tP3223f75QfQHsaUAgAAur0IpJ599tm0xhprpC984Qt5fKj33nsv9e/fP4dPEydOTD/72c/ycoqxok466aT0ne98J1dK3XLLLd1++QG0R692PQoAAKAGq6U+/PDDXP30/vvv58ApBjD/+Mc/ng466KB02WWXpc985jPpk5/8ZK6mGjt2bL4y34orrljtpgN0SbrvAQAAqbt324swqlevXukXv/hFeuGFF9Jiiy2Wu+k9+OCD6cQTT8zVUXvvvXe+sl503SvGn2o8DhUAraf7HgAA0O1EmBSii16IQCpssMEG6cknn0ybbbZZOv3009PXv/71tMcee6Q777wzDR8+PJ1xxhnp8ccfrw+iBFIA7SeUAgAAup0Ik1577bW0zjrrpGOOOSb973//y9M333zzHEhFGBVX2jvkkEPSX/7ylxxE9ezZMw98PmbMmHzFvSLYAqB9dN8DAAC6pbfffjt314uKqI033jjttNNO6fDDD8/3feMb38g/f/7zn+fBzl9//fX0xBNPpNNOOy2NHz8+rb/++lVuPUDXJ5QCAAC6tQibTjjhhPTII4+kIUOGpHPPPTc9+uij6frrr0977bVX2mabbernNYYUQMcRSgEAAN1edNW7++6703HHHZe76H31q19NN998c66gOu+887r98gFYGIRSAAAAZY444oj01FNPpcceeyy98sor6de//nXaf//9LSOADiaUAgAAaNQ1b+LEiWnChAnpl7/8ZbrvvvvSWmutZRkBdDChFAAAQDNjRk2fPj3169fP8gFYCIRSAAAAAFRcj8q/JAAAAADdnVAKAAAAgIoTSgEAAABQcUIpAAAAACpOKAUAAABAxQmlAAAAAKg4oRQAAAAAFSeUAgAAAKDihFIAAAAAVJxQCgAAAICKE0oBAAAAUHFCKQAAAABSpf0/tEQMiWEAITkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if not session_rollups_df.empty:\n",
+    "    sr = session_rollups_df.copy()\n",
+    "    sr[\"hour\"] = sr[\"start_ts\"].dt.floor(\"h\")\n",
+    "    sessions_hourly = sr.groupby(\"hour\").agg(\n",
+    "        sessions=pd.NamedAgg(column=\"session_id\", aggfunc=\"count\"),\n",
+    "        error_sessions=pd.NamedAgg(column=\"has_error\", aggfunc=\"sum\"),\n",
+    "    ).reset_index()\n",
+    "    time_plot(sessions_hourly, \"hour\", [\"sessions\", \"error_sessions\"],\n",
+    "              \"Sessions Over Time\", \"Count\", labels=[\"Total\", \"With Errors\"])\n",
+    "else:\n",
+    "    print(\"No session data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 4: LLM + Tool Calls Over Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.162309Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.162214Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.216635Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.216150Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXaFJREFUeJzt3QmcTfX/x/HPjG1sYx1b1hBSEiFpoYSKX+JXWi2ptFhKi1S2VNqEJNoslaJ+ZWnToiy/UChJRREiu4yxDTL3/3h/+537vzPurMa9d2Zez8fjPObOuefee+7Z7jmf8/l+vlE+n89nAAAAAAAAQAhFh/LDAAAAAAAAACEoBQAAAAAAgJAjKAUAAAAAAICQIygFAAAAAACAkCMoBQAAAAAAgJAjKAUAAAAAAICQIygFAAAAAACAkCMoBQAAAAAAgJAjKAUAAAAAAICQIygFADghkydPtqioKDcMHTo0rEuze/fu/nmZN2+ef7w3rnr16mGdv9xAy9BbnpHsrrvucvNYp04d8/l8Eb9Nb9iwwf+ZLVu2tLy6DwejfdmbP+3j4aL14s2H1heAjLn11lvdfnPmmWdm+ngMIPcjKAUgV9CFVEYvWgIvqgMDF2ldCGkoWbKkHTp0KNk0hw8ftri4uGTTzZkzx8JxkZTeoAvPSLJmzRoXOKhbt64VK1bMYmNj3QnrnXfeaUuXLrWc4vfff7c+ffq471G0aFE36HHv3r3dczllv0lvCGcwILP++OMPe/XVV93jvn37RnwALVTrWsPo0aPDPSsI8lvjrZ8VK1ac8PL57bff3Hvp96Fq1apWqFAhK1WqlF1yySU2a9asoK/Ztm2b3X777ValShUrWLCg+3vHHXfY9u3bk023detWe+qpp6xt27ZWo0YNK1y4sBUvXtyaN29ukyZNSnWeVq1aZTfeeKOdcsopbn7KlStnF1xwgX8/zajp06dbixYt3G+GBj1+55130nxNfHy8VapUyX8sq1ChQqY+MzOfO2PGDPvXv/7lzjP0W6BlWblyZbv66qvtm2++yfDnJSUl2fjx4+3ss8+2IkWKWIkSJax169Y2d+7cNM9Tgg2ZuRmTkJBgAwYMsJo1a7r1VL58ebfe1q1bF3T6L774ws2X5k/z2ahRI5swYYKb/0B33323fztIb30ByIN8AJALDBkyRLfe3NCtW7c0p61WrZp/2q+++irV6fScN503TJkyJdk0b7/99nHTfPLJJ75Queiii477/NSGSZMmnZR50Pt6n6H1kBFjx4715c+fP9V5Peuss7I0L1r3wdatN07rPju9++67vpiYmFS/h57TNDlhv0lv8ParpUuX+hYuXOiGSHXvvfe6eS5YsKBv7969mX799u3b/d9x48aNvlBYv369f1lrv85uae0D4fi+mRF4LE7v+B6q463W18nYD7PjOD1ixIg09+VRo0Ylm/6PP/7wVa5cOei0VatW9W3evDnN37zAoV+/fsfNz3vvvef2xWDTX3LJJdlyvBo+fHiqr7vllluSTVu+fPkMf2ZmP7dnz56pTqvfvPnz52f6tyxwiIqKSnYeEuw8JeVQq1atDH2mjpUNGjQI+h6lSpXyrVy5Mtn0EydOdPMTbHoth5SaN2/unmvcuHGG5gdA3kGmFABkQsq7uq+88kq2ZqxkNptp7NixtnDhQv/QsGFD/3MPPfRQsucuv/xyiwT/+c9/XGbR33//7f5v06aNTZs2zd0BnjhxopvPnJDZ8v3339sNN9xgiYmJ7n/dHf/ggw/ccOWVV7pxek53mbMj++FEHDhwIOj4m2++Odk20qNHD/9zl112WbLnHn74YTf+nHPOsfPPP98NkUjb1ZtvvukeX3rppS4DL7OUxeF9R2Wa5HZ57fvmBcpc6devnzsevf/++9asWTP/c9qXA48Jmm7z5s3ucadOnVw2lf56WYdelosnJibGevbsae+99559+OGHyX5bnn/++WQZonp800032ZEjR1xW1QMPPODmSa977rnnXLZURugYOnz4cPdYmVn6rdCgx95v6MqVK497nTKJXnvtNTfPWZHZz61du7YNHDjQZVbpN03nCMoO845Nyn5Kz+zZs23KlCnusTK89Ps4atQoy58/v2v6pgxjL4NNmVSBx2lvuOqqq/zv17Fjxwx918DvcuGFF9rMmTOtV69e7v89e/a4dR6YMaffcc2P5kvrUvPpfVct848++ijZ+3vb1PLly13GFAD4hTsqBgA5IVOqePHi/sdr1qxxz69du9Z/lzDw+axkSnnzf6J3yQPv5Kd8r8OHD/uefPJJl4VUpEgRX+HChd1dUd1V13MpLV++3Pfvf//b3VUuUKCA+9u5c2ffsmXLspwpdfToUXfn3Zte75+UlHTcdD///LP/8YwZM3wdOnTwVa9e3VesWDE3L3qP7t27H5etkJlMqWPHjvkee+wxX/369V1GU6FChXxVqlTxXX755b5XX33Vlx7Nk/e+rVq1SvY99FjjvOc1rYwcOdI/7rnnnkv2flOnTvU/d//99/vH79ixw3fPPfe4u93KNihZsqSbx8WLF6eZTaLsBK1rvSajGWwZ2Y8C95/UPvudd97x1a1b121j559/vrvDruU9bNgwX6VKldz4du3a+TZs2HDc+//www++a6+91lehQgW3rjW97rpv2rQpQ99BmQjevIwZM+a45ydMmODu1BctWtQtG72/sjWeeuqpdLfpwP1L89m7d29fXFyc236CfR/vO59yyinuO7ds2dL3/fffB824SStTat++fW4+vG1VxxtN8/HHH59Qloe3P2Tk+2q/v+GGG9w+qGOBptN2ruWg76X50v4TbJkfOXLEbfuNGjVyxx4NTZs29b3xxhu+jEi5fc2dO9fXpEkTt8/quJAy8ye1zKO0Mq52797te/DBB3316tVz60rL+Oyzz3ZZncGWh7felEXkHdOio6P9WSxaNsokOe+889x7afnoeDt69Gi3XXjSynDx5j2z2ajKZtT3CbRr165k2anffPONG79161Y33xpXokQJ36FDh9x4/dX/Gp8vXz7ftm3b/MfmlPtiYmKi2ya8954+fbr/uTvvvNM/PqPrO5g77rjD/z76zQqWFab9MZC+g46beu6JJ57IUqZUVj43JW2f3rRXXHFFup952WWX+adXZpqnV69e/vHPPvtsqq/X+ihbtqx/m1y3bl26x3CdA+i3xcvG2rJli3871rE88DggOl564zRfwTLp2rdvn+xzV6xY4X/u0UcfTXc5AMg7CEoByBVOdlCqWbNmvjPPPDNZwGDAgAHu/zp16iS7WInEoJROUi+88MJUL370XGBgatasWS4gEGxajdfznsxcMC1YsMA/rU6Wf//993S/U+CJeMpBFxdqepSVoJROilN73xYtWqQ5TwcPHkzWHOXDDz88bpoPPvjA/7ym1QWSTvS9C0BdrAa66qqrkgU8RE2pUmtWk3I9BG6vNWrUSNasIpRBqZSfrUEBpltvvTXd5awgiwINwb6v3iMj20vgxWfKJoavv/56qutcgSNPRoI0p556arrfp2/fvsdNowt9BVIyGpSKj4/3H3uCDePGjQtJUKpmzZrHvb5Pnz7+C9nA4fPPP08WkFLQL7V5eOCBB9Jdp4Hbl4JGwY5NgQGDzAal1HwtMFgeOASui5RBqb/++ssFCvW/tvmXX37ZP23Xrl1T/c5dunTxT5faNIHznpUm0sEogOq9z6pVq9w4Ba+9cQqkBwoMrOvmQFoUJAx2PFSg0jsGqqlb7dq13T6uv08//XSyAF1aAveBwCZwgUHolM2+vd9oBYIC96/MBKWy8rmB276CeDrWZySY5AWBYmNj/dMHNqdVwNMbf+WVV6b6HoHHOd3AyMgxXDehAo/hgXr06OF/zgsAB96UCWxOqPn1xuvYkPKmlHd8b9u2bZrLAUDeQvM9AMigW265xf19/fXX7eDBg/6mdoEp7ZFKxY0XLFjgHquA7VtvvWVvv/22v6mOnlPzAFGzDn2no0ePuv9V7Pbjjz92BchF4/V8ak3C0vLDDz/4HyvNX4Vy06PmfS+99JJr8qGmGCokf++997rn1IQhs4VyPV7BXxWwV3MvFWzVulWx34oVK6b52rVr17rmKJ7AZpPBxmlavUbve/HFF7txixcvti1btrjHWpZegXwVe2/QoIF7rGXuNavp2rWrm0bNP1RoV+tBze+CrYf169e7Znbvvvuua4KR0SYy2UGfraLoarqh7+IVUVYzFjVrUSFgFc+Vr7/+2n766Sf3WPtUt27dXOcBag7y+OOP22effeaa+3jv4W2Dafnll1/8j2vVqhV0nev9VYxXzWumTp3qtqeMbIuBdu7c6d5D2462oZTfR4X81bxWoqOjbfDgwW4bbtq0aaZ6blNTqx9//NE9VjMpLVdtp16x5nvuucc2bdqU6uu9Jpoevc5r4qOmtBm1b98+d8x44okn/OP0/fR+Wqc6Tni0v3rGjBnjL8587rnnumn1ueoVUZ5++ulMFYDW+lXRaC0HfffApke7du2yrNB2pWZqomPiyy+/7PY1zZuOl8Go04v27dv717eOsephTPT9tI5E31PLTete31/UtEuDpGw2G9jsOjubXOv9tM2KCl/Xq1fPPQ7cFr39MrBZZ+B+nRo9p+bMomOTd7zZv3+/f9vUMXDQoEGuCLv2cf3Vvu01D0tPavOZ2jxqfkaOHOma2WWkyVx2fa7XbFtN0FXk/PTTT7dFixa5povaXtVUMi1qJqdi45n9zEAvvvii/7Ga+mVEZreDjCwXFZjX9/HouFutWjX3+Oeff87QfAHIG/KHewYAIKdQbSCdRCsQctttt7m/BQoUcBfSKWsnpEe9Is2fP/+48bo4CbxA0XtnR695CkIFnrDqYsq7gOjQoYN7rAsn9bqjQIB3cde4cWP/Ca5qDOniUfUg9Pznn3+e4VoVnr179/ofq1ZGRpeVAhSqWaELx5Q9IC5btsyyQutO1EOSehpSIEi9B6n+SXoCLxpEPTCmlHKc991Vh0oBMCVJqCaL6nJo+/G+l56Xv/76ywUDRRf+3gXvGWec4Wol6eJ+9+7d7uK5c+fOyT5L61XjS5cubaGmi3gFChWI0YXH/fff78brQtULaOj7jxs3zj1WsK5+/fpuu/MumvX9VNNEtH2qtyZdBH366adu2ytbtmyqnx8YmFCPY8HWuS4WFbBS4E41p66//vpMf89HH33Uf0H93//+1wWoAr+PAmBe1+eq7zJs2DD3WL12KSCbcjsORj1Yefuu5rl///6uRyzNs+qzaN/Uxb6WjxeoTUlBlsA6UXp9VuqBPfbYY3bttde6x1qPCjiI1qMCrXpP7+Jfy8Dj1fcSzb+37rSdK1DnTRNY8ygt+i4K+OTLl88Fbb799lsXDFSg45NPPsnQ/hsocD/Te2q/8QI26mEuNQoSe8ce9UanXh6DfWcFBdT7miiYv2TJEv80Xbp0cctN+0NgTaKU60dB3hPp/VKBBO+4omCJ6j5p/5TAoLa2sUCB/6d2E0LHIP0OeDUCR4wY4a/jpqBEIAUkdBxXPSJtr1pnOlZoGSmIr+Br4G+EnHbaaS7Qkdp8BpvHY8eOuZtImqcnn3zSHZPSCgRn1+emRQEZLXvvmJCalO+V2c9UMM7bxk499VRr167dcdMEWxaZ3Q4ysly86QKPw97jrAaQAeROBKUAIIN0ga+Lf10kKrvCK24deGcwUv3666/+x4EXf8raSDlNatN60ysolXK6zBTf9XhZQmnRxYW6m/buwgeT8sIno7wLxD///NN1Z64LBp3Eq9t0XTDpoiQ1KYtnK5jiFXgNHBfsu2sbUmaGghJe0XcvY0Xz4AVIdGHvXcAoSyi1bKfAzCCPAh/hCEh5gUzvgjdwHhQA8gQGlbz1F7g9KbigISUtj9WrV2c4qJLyAlABX2WoKCtL25UoYHDRRRe5Ys6B85gevcZTpkyZ475PYLHnwP1IF2V169ZNc5v26MLNyzRQ8Mmb54xsA9kt8Fih7+AFpbxlFmydplyv11xzzQnPvz5PwaPA+VJQKuUyzyjtZ1739dr/vYBUeryA1HXXXefP5gv2nQODVaFeZ97nKMir45yXuebdiPCC8h4FiQIFZoMGTudRcEnv7WWLKejYu3fvZAHQlFl/XrFrrTPdCBFl0ikopWNhyps1kyZNcgE5fb6y9VLOZ7B5VJHt7777zh0HAzP4UpNdnxv4vZWZpum1/JVxp4wxBeR0jH/22WdTnZeU76X38Iq0p7c+xAv2i767dyxOT2a3g9SmD5w22HymF5QDkDfRfA8AstCEL7X/s9prnpcdlbLHPK/Hs5Mls73cnWiveGeddZb/sS6S0mvGpAsX7+JdTd/UI5GaGnoXM+JdUGaW1p2XWaHsI93hXbdunWu6o4BDWsEuZdkE3hEO1rteYFNFLzNH1JxEwUwvw0ZZDF6mhrKDUmsulJpgd8xTNr8IpcDAY+AFUWq94GX2IiW9rITA4Ehg0xGvKai2KWWdqdcqZcapeaSCzFrnmQlqBN79VxZEWt/nZPcmmZWmtCdzvWb3Ok1LsGUbOE6BbU92Zmd4gTH1bBfYPDKS1pmOndqudazVMlHAQgGYQGrK5/F6dPMoGO5J2bx148aNLlDuBaQefPBB11wukIK12sc8XtOtlI9TZp4Gk9p8BptH74aH9nVtq/rugfOv12tcyl4FT/RzPXpvBc51g0NBOq8nvZRZy6kdVwL3qYx+pug3y/ttVHNBNd3NqMxuBxlZLmrWnDJb1Tsmp5XtCiDvISgFAJmgpmRecEHNSHSRmxWqteN1wR7YDbvXdMMb9H92CMz6UXMXT2AtF2+a1KZN+X9amUSpUUaS910VTNKFTFpZBN7dfVEGkZrMZFd9JF04q2mDmgKp+YYyP7yLFJ1Yqw5IanTCH7juVY8r8EJcj70aXV4zoMAuyb2mNFoGagLmXaCqiahH25l3ca3mhWqK8r8OSvyD7kqrGVmogyAnQ+D2pGarKb+rBi2ntJpUSWCmS2AzMtF7aBtU4FGZFMqA8C6klT3l1fXKDlpnnqVLlya7KFO2V0bows27qFOTTM1vymWioIuyOtLjbRNZDeJmx3pV0C/YevVqTmWEMjUDv0PgMUyZTikDaIEXycHWr/YzL8im+cvoulG2i16nLJErr7wyWeZT4Hf+6quvgn5nBcCDBfmya/3o+NWqVSuXsamgqY5zwWqynXfeef7PVxBL9ZBEf70bAgrAab/xqF6ajsPed1CTPQ0p6X0DX+fV7Ur52AvEq2ZgyuXkNVsMzI4MPDarNp8nq78N2fW5OkZ7zRhTOx6nl9mraZXhldHPDKSm/jqOiZraZiZbVjdmvP1GAUfvt1fLwmsOGPi5GVkuKTNaVQfRW++qtQUAHprvAch1dNESLNihekkp79p5BW0D6cJGNaNSO2FUlpNO0tSMJKOp8eGmgM7KlSvdY9Xv0MWtvkvgclIzFFGwRXe4VStETVR0p/eKK65w2TxekxVdLKvZRmbp4kgXc14zHjWlUi0PZYqpBpNOhtWUTSfEuiAKvJuu+ks6ydVFfWrBrMz497//7bKWdJKtJly6mAisT5WyCUNKKqysGkc60dZFtZqlqEmglquaj3gX2sqS0rSBFAzzlrFqc3lNPjRPHl1QqI6Xlrsu/pRdpffXPGs5afkoS0MXAYF3rXMqbU/aBnQRrQtofX+NU9BFGXXKelD2WXoFcgMv6BR4Crx4U1Mqr8mRLoS1PQZmuaS3zjNDgQodc7zaYcOHD7dGjRq55lMZqSclOr5ov1TtKAVNtW/qO2j/U4bXqlWr3DYwceJEFzBPi459qp+kLBJlhmnfUkZddgW+U6MArJc1qFp2auqm/U3rQQEg1d5Sc9mM1kzStq+gpY5p2se8pnvaf7z6OYEF7tVkSgE9BSi1nFLy9jPVddO2psePPPKI2z6UBaRt6I033jjudV4dJdVM0zFJn63fBWV06jt7RfWViamMVy1nbdsq8K3P0ucMGTLETRP4u6RtRdkoqn/WpEkT970UbPCyafWalMeTlJSBqfnxgt0KtusYofGBN0YUhFC9Om2rqlGnY7G2N2XYKNDpZTCpJpqXfamAlDI6d+zY4V+/Oi4HvrdXj0mUlegdC1UbUMc9BQq13YqC9fp9SY/eRwX0FbRTTTPNj461Xp06Bc68unv67l7nAx5t+9oHRcdQBfOVLZmdn6t9UkE+3TxRc0Qdz9SUUzXHPDoGpEedbXjNl7Vv6PO0zPS7ItqeA29giI4zgQXd0ypwrm1B+5H3Ou93Suvdu8Gi7eC+++5z26rWueicR82zve1ay1DbmOZLTZJVJ1KvCfwegXTs9o6xgcdpAPj/vkABIAdLq9vzlF2vB3aHnFYX4IHdhzdr1izNzw/sKvyTTz7J8vwHdl+eFYHzEfheiYmJvgsuuCDV73zhhRf6Dh8+7J9+5syZQbtd16Dxs2bN8k+ble7Kx44d68ufP3+q8+N1sf3333/7GjRocNzzLVq0CNplu7p598Zr/Xm8cVr3nrS6qVeX4fHx8el+j7ffftsXExOT6vvouWnTpgV97R133JFs2k6dOh03jbrXrly5coa269S6u8/qfpTaewTrTjy1z05t2wj8nMDt9KOPPvJ3GR5sCFx/qVG34xUqVHDTt2/fPtlzPXv2TPW9Cxcu7Fu3bl2a8x24f3nLPa3v07dv3+M+R929By5D730Cu6wP3Kb37NmTrFv6YEPgtp6azp07H/c6b11l9vsG2wYk2HrScSWtfS0jx73A7evUU0/1RUdHH/cejz32mH/6I0eO+KpWrXrcNPXq1Qu6naa1nwWui2DL45Zbbkl23Nq7d68b37Vr1zS/c+ByXrlypS8qKirVfTuzx9iM/B4GbjN//PFHqt9fy3Hz5s3+aQPnJaPr85prrkl12hdffDHd75OR7zV8+PA0Xxu4f+n4nhkZ/dzAzwg2FC9e3PfNN99k6DMDf8sCB20nU6ZMOW76zz77LMPnK6ntv9p2g/3eaihZsqTbTgNNnDgx6HarQcfalJ555hn/86tWrcrQcgCQN+SMW/wAgBOiu+3KyFFPROplTs3PdIdad8vV7EI9nwXWSNKdc2XgKHNHd7yVUaK7vsoGUqq+VxMpq5R9pSZzKsSqLtNVd0R3f3W3VVlqymDz7kLrTq3mR3f1NQ/qUls9Np0oNWVR71dqZqXP1ndUsXLd+ddd/8AmQKlREwllq+i9lB2g5apBjzVO31GfEUzKO90p/xc1dVRGlLIxtGy0znSXX491N3727NmZrkEVydSbmrLVdBde2TTKFlFWkLIOVET53XffTfc9tB69Zalt3itSLFq3yrLRNqf1q+1L27eyXpQx5TX/yi7K0lFWizIItO6UtaXmXIGZMYE1d4JRxof2RWV5qCabti+9Rpk32j9VQ+bcc89Nd15eeOEFl6EYrKfIk0nHFWWjqsc3FSXX9qtloWwgZcgoy0KZOBmlZajtXlkuOq4p40tNMAPr72m7mTlzpms6ps/XtqTeDzUPwXj7mbK4vP1MxwRtd4HZi8EoO0W1g0QZYerIQNmTqiOkjD/VdNK2pvnQ52hazUdgUzodhzWtmp6mLA4eCjqGqImpmhLrGKjlp7/6X022U3bikFnKzFMGjr6ndwxT00JlA2WkELlH+9K0adPcelUBbQ16rIxbZbedLBn9XB2rtA1pf/R+N7WvqjdO1fJStnJghwFpUVafaoBpG9QyU50pbTs6punYn5LXS256WVJp0WfoOKjfG+2f2mb1PZSVqO1D6y+QsveULaz50jrVsUn7pfYJ7zc8kJcdp4wrLRMA8EQpMuX/DwAAIIdTT1dqwqWaW7pYy8yFb3bSKVbK+l5qsqnghGq/KOCk/3NKM2AAyAo1hVXdKlEwL7WeOAHkTZwFAQCAXEWZH17PmKNHjw5bN+SqnzZw4EBX90iBMmXgKfPGK0Z89dVXE5ACkOvpOCzKttJxDwACkSkFAABwkpr9qNlYMGqqpaYyKvwMAACQV5EpBQAAcBKoRzzVTVJNHtVnUZ0i1VxRr1Wq1UNACgAA5HVkSgEAAAAAACDkyJQCAAAAAABAyBGUAgAAAAAAQMjlt1wuKSnJtmzZYsWLFz+uW2YAAAAAAABkL/V+vG/fPqtUqVKavQ3n+qCUAlLqGhoAAAAAAAChs2nTJqtcuXLeDUopQ8pbELGxseGeHQC5JANz586dFhcXl2bUHwAAICfg3AZAdktISHAJQl5MJs8GpbwmewpIEZQCkF0nbomJie6YQlAKAADkdJzbADhZ0iujxC1+AAAAAAAAhBxBKQAAAAAAAIQcQSkAAAAAAACEXK6vKQUAAAAAALLu2LFjdvToURYh/AoUKGD58uWzE0VQCgAAAAAAHMfn89m2bdssPj6epYPjlCxZ0ipUqJBuMfO0EJQCAAAAAADH8QJS5cqVsyJFipxQ8AG5K1h58OBB27Fjh/u/YsWKOTMoNWLECHv//fdt9erVVrhwYTvvvPPsqaeesjp16vinadmypc2fPz/Z63r16mUTJkwIwxwDAAAAAJA3mux5AakyZcqEe3YQYRTDEQWmtI1ktSlfWAudK9h011132ZIlS+zzzz93bVTbtGljBw4cSDbdrbfealu3bvUPTz/9dNjmGQAAAACA3M6rIaUMKSAYb9s4kXpjYc2UmjNnTrL/J0+e7CJsy5cvtwsvvDDZF1U7RQAAAAAAEDo02cPJ3DYiqqbU3r173d/SpUsnGz916lR78803XWCqQ4cONmjQoFSjtYcPH3aDJyEhwf1NSkpyAwCcKB1L1I6aYwoAAMgNOLdBWtuFNwApedtGsHhLRq+VIiYopRm+++67rUWLFnbGGWf4x19//fVWrVo1q1Spkq1cudIGDBhga9ascbWoUqtTNWzYsOPG79y50xITE0/qdwCQN+h4pSC6DsDR0WFtBQ0AOd9bXcI9B0Cel2TRtrdIdfMd3GDRxo18/ONo4XKW1OhO+3uX2d8Fctc5b8GK9ezdiWPtystaW8QpU9Nyir///ttdG+3evdsKFCiQ7Ll9+/blrKCUakutWrXK/vvf/yYbf9ttt/kfn3nmma6q+yWXXGLr1q2zmjWPX1kDBw60/v37J8uUqlKlisXFxVlsbOxJ/hYA8gIdeJWqquMKQSkAOEEJK1mEQAQEpaLMZ3EJPxKUgl9iUhXbl3TU8vsSLX9S8mZaNZ7fErIltb5vpUy/psfdQyw+YZ/NmPhcqtPk8x2x/EmHLLts2LTFTj23vf//UiVj7cy6tWz4A3faBc0aZfyN8oc/TDN06FCbNWuWff/992lOlz9/fnc9pEL4MTExyZ5L+X+q72ERoHfv3vbhhx/aggULrHLlymlO26xZM/d37dq1QYNShQoVckNKWlBcPALILgpKcVwBgOxAVgYQCRSUUpYUmVLwaFvQdqFwVFRYt82T89rs/l7ee30xbbzVr1PTdv0Vb48//5p16Ha3/bpwhpWPy2APhlHhXNreLERlqGaUnk/tuiij8Zew5uCp6YsCUjNmzLAvv/zSatSoke5rVqxY4f4qYwoAAAAAAOBEMpyiTmlk78z+zC646mYrXLO5Nbn8Rvt13UZbuuInO+eyG6xY7RZ22Y29befuPem+X5lSJa1CubJ2Rt1a9lCfmy1h33775vtV/udXrV7r3kvvWf6s1nZTn0ds11///74HDhywrl27WrFixVzcY+TIkdayZUtX7sijQNDMmTOTfW7JkiVd53GeTZs22TXXXOPGq273lVdeaRs2bPA/P2/ePGvatKkVLVrUTaNSShs3bnTvoZJIP/zwgz/oFPi+2S063E32VMD8rbfesuLFi9u2bdvccOjQPyl0aqI3fPhw1xufFt7s2bPdylHPfA0aNAjnrAMAAAAAgFxiyMgJ9ki/W+y7OVMtf758dn3vh+yBx8bYmEfvt4UzXrO16zfZ4GfGZ/j9Dh1KtNf/86F7XLDAP43U4vfus4uv6WVn169jyz550+ZMfcG27/rLruk1wP+6+++/3+bPn++az3322WcuePTdd99l6rscPXrU2rZt6+IsCxcutK+//toFudq1a2dHjhxxtaA6duxoF110kavdvXjxYlc6SQGoLl262L333mv169e3rVu3ukHjTpawNt8bP/6fFaqoX6BJkyZZ9+7drWDBgvbFF1/Y6NGjXbRQtaE6d+5sjzzySJjmGAAAAAAA5Db33d7V2rY8zz3ud8v1dt2dA23u9AnWoklDN67ndR1t8jsfpPs+513Zw6Kjo+zgoUTXOqxxg3p2yflN3XMvTJpuZ59Rx54Y2Mc//cSRQ6xKk8tcZlalCnH22muvueQd1dKWKVOmpFvmKKXp06e7Orivvvqqvwme4izKiFKQ65xzznEdN7Vv395fFqlevXr+1yuApXpRFSpUsJMtrEGp9LqVVBBKEUIAAAAAAICTpUG92v7H5cuWdn/PDBwXV9p27P4r3feZPn6E1a1Vw1atWesyrSaPGubvme6Hn3+1rxYtc033Ulq3cbMdSjzsMpm8Wtqipnd16tTJ1HdR0zvV4VamVKDExETXIq1NmzYuEUjZVJdeeqm1bt3aNfULR5mkiCh0DgAAAAAAEC4FAnq987KLko2zKJd9lJ4qlSpY7VOruuHvv4/ZVT3vtVVfvmuFChW0/QcPWodLL7SnHup73Osqlo9zTQQzQvOXMslHTfY8+/fvt8aNG9vUqVOPe616EPcyp/r27Wtz5sxxmVVqkfb555/bueeea6EU1ppSAAAAAAAAudG/27e2/Pnz2YtT3nH/Nzqjrv205nerXqWS1apRNdlQtEhhq1m9ssuq+uabb/zvsWfPHvv111+PCyyp1pPnt99+s4MHD/r/b9SokRtXrlw5q1WrVrKhRIkS/unOPvtsGzhwoC1atMjOOOMMV+9bVErp2LFjFgoEpQAAAAAAQK6yN2G/rVi1Jtmw6c9tIZ0HZTT1vfk6e3LcZDt46JDd1b2L/RW/16678yHXs9+6DZvs03mLrMc9Q1wQqFjRItazZ09X7PzLL7+0VatWuWZ20dHJQzcXX3yxvfDCC/b999/bsmXL7Pbbb/c3EZQbbrjBypYt63rcU6Hz9evXu1pSyozavHmz+1/BKBU4V497KqiuIJZXV6p69epumhUrVtiuXbvs8OHDJ20Z0Xwvh6n+4EfhngUgz4s2n9Ur5bNf9kRZkv2T2gsgPDY8eQWLHgAAHGfe4mV2dtvrko1TsfJXnx0c0qXV7Zr29vDT41yR8wfu7G5fz5xkA54YY22uv9MOHz5q1SpXsHYtz/MHnp555hnX/K5Dhw6uJpR6wlNR8kAjR460Hj162AUXXGCVKlWyMWPG2PLly/3PFylSxBYsWGADBgywTp062b59++yUU05xxdNjY2Pt0KFDtnr1aldEfffu3a6W1F133WW9evVyr1cHc++//761atXK4uPj/Z3RnQxRvvSqjedwCQkJLj1NK1ELP6cjKAWEH0EpIHIQlMoFhv5/MwIA4ZFk0bYjtoGVS1hp0ZZ+zRzkDYnFqtj6FiOtxilxFpOfG7EhU+ns40a1bNnSGjZsaKNHj7ZIosLpyqiqUaOGxcTEZCkWQ/M9AAAAAAAAhBxBKQAAAAAAAIQcNaUAAAAAAAAi1Lx58yy3IlMKAAAAAAAAIUdQCgAAAAAAACFHUAoAAAAAAAAhR1AKAAAAAAAAIUdQCgAAAAAAACFHUAoAAAAAAAAhR1AKAAAAAAAgA7rfPcQ63tw/4pfVvHnzLCoqyuLj4y2S5Q/3DAAAAAAAgBzk5Zah+6zb5mVq8qhTGqX5/JD+t9nQe2+3k+mVqe/bC5Om27qNmy1//nxWo8opdk2HS21gn5v9ga34hH02c+Jz2fJ5LVu2tIYNG9ro0aP948477zzbunWrlShRwiIZQSkAAAAAAJArbP3+M//j6bM/s8HPTrA1C973jytWtMhJ/fyJ02ba3UOeteeHP2AXndvIDh85ait/+c1WrV6b7Z915MgRK1iwYNDnNL5ChQoW6Wi+BwAAAAAAcoUK5cr6hxLFi1lU1P+PK1e2tD338ptWuXE7K1SjmTW89Fqb89XXyV7/4y+/2cVX32aFaza3MvVb2W0PDLf9Bw5m+PNnf7bAZUX1vK6j1apR1erXqWnXdWxnjz/Y2z0/dOQEm/LuBzbr03kuq0vDvEXL3HMDHh9jp512mhUpUsROPfVUGzRokB09etT/3kOHDnUZUa+++qrVqFHDYmJirHv37jZ//nwbM2aMa66nYcOGDcc135s8ebKVLFnSPv30U6tXr54VK1bM2rVr57KpPH///bf17dvXTVemTBkbMGCAdevWzTp27GgnC0EpAAAAAACQ64159S0b+dKb9uzge2zl59Otbcvm9q8e99hvv//hnj9w8JC1veEuK1Uy1pZ+9Ia9+9JT9sXCb633w09l+DMqxJWxJd/9aBs3bwn6/H23d3VBq3atznNZXRrOO+cs91zxokVd8Ojnn392QaZXXnnFRo0alez1a9eutffee8/ef/99W7FihZuuefPmduutt7oAk4YqVaoE/eyDBw/as88+a2+88YYtWLDA/vjjD7vvvvv8zz/11FM2depUmzRpkn399deWkJBgM2fOtJOJoBQAAAAAAMj1nn3pDRtwZze79sq2VqdWdXvq4X7WsH4dG/3qVPf8WzM+scTDR+z1McPtjLq17OLzm9oLjw2wN977yLbv3J2hz1DNqpKxxa16s/ZW54KrXP2od2Z/ZklJSf7mg4VjYqyQmteV+yeDq2DBAu65R+6+xdWCql69unXo0MEFjN55553jmuy9/vrrdvbZZ1uDBg1czSg11VN2lZrraciXL1/QeVPW1YQJE+ycc86xRo0aWe/evW3u3Ln+58eOHWsDBw60q666yurWrWsvvPCCy5o6mQhKAQAAAACAXC1h337bsm2ntWjSMNn4FuecZb/8tt491t+z6p1mRYsU/v/nm5zlAkpr1m3I0OdULB9niz+YYj/Ofcf69bzO/j72t3W7Z4i1u6G3PzCVmumzPrUWLVq4wJKa1z3yyCMumylQtWrVLC4uzrJCgauaNWv+/7xWrGg7duxwj/fu3Wvbt2+3pk2b+p9XcKtx48Z2MhGUAgAAAAAAyEbKtLqz+zX25tjH7fO3X7TPFyyx+YuXpzr94mU/2A19HrHLL7/cPvzwQ/v+++/t4YcfdplRgYoWLZrleSpQ4J+MLI9qTvl8PgsnglIAAAAAACBXiy1ezCpViLOvl65INv7rZT/Y6aed6h7Xq13DfvjlV1dbyv/80h8sOjra6tSsnuXPPr32P+/vvW/Bgvnt2LFjyaZZtGylVatc0QWi1Lyudu3atnHjxgy9v5rvpXy/zFIzwPLly9vSpUv94/Se3333nZ1M+U/quwMAAAAAAESA+2/vakNGvmQ1q1V2taQmvTPbVvy0xqaOfdw9f0Ony2zIyAnWrd9gG3pvL9u5e4/1GfS03dT5CisfVyZDn3HHg09YpfJxdvH5TaxyxXK2dfsue2zMqxZXppQ1b9zATVO9ciX7dN5iW7N2g5UpXcL1Elj71Kr2x5/bbNq0adakSRP76KOPbMaMGRn6TNWg+uabb1yve2r2V7p06Swtnz59+tiIESOsVq1arqaUakzt2bPHZVSdLASlAAAAAABArte353W2d99+u/fRUbZj918ug2n2pFEuICRFChe2T6eOs36Dn7EmV9xkRWJirPMVF9tzQ+7N8Ge0vqCZTZw2y8a/8a7t3rPXypYuac0bNbC50ydYmdL/FA2/9YZONm/xcjvn8htt/4GD9tW7L9u/2lxk99x6vSs+fvjwYbviiits0KBBNnTo0HQ/UwXRu3XrZqeffrodOnTI1q//p0ZWZg0YMMC2bdtmXbt2dfWkbrvtNmvbtm2qhdOzQ5Qv3A0ITzJ1Yag0NBXtio2NtZyu+oMfhXsWgDwv2nxWr5TPftkTZUl28u4aAEjfhievYDHldENLhHsOgDwvyaJtR2wDK5ew0qIt7ULMyDsSi1Wx9S1GWo1T4iwmP+e8IVPpbIsUKsxer149u+aaa2z48OHHPZ+YmOgCYDVq1LCYmJgsxWLIlAIAAAAAAMjjNm7caJ999plddNFFLlvrhRdecEGn66+//qR9JoXOAQAAAAAA8rjo6GibPHmyq2nVokUL+/HHH+2LL75w2VInC5lSAAAAAAAAeVyVKlXs66+/DulnkikFAAAAAACAkCMoBQAAAAAAgJAjKAUAAAAAAJLzqSdGnyX5WDBIvXe+E0VNKQAAAAAAkEzBg9st+tBftmVPrMWViLGC0WZRUSykky4xMeIXss/nsyNHjtjOnTtdcfSCBQtm+b0ISgEAAAAAgGSifX9bjW8H2da6N9uWuIZm0YQPQuLA+hyzJRYpUsSqVq3qAlNZxVYFAAAAAACOUzBxl1Vd8Yz9XTDWjhUoTqpUKPReliO2xHz58ln+/Pkt6gTT5whKAQAAAACAoKLMZwWO7HUDQiAmJk8tZgqdAwAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAgbwWlRowYYU2aNLHixYtbuXLlrGPHjrZmzZpk0yQmJtpdd91lZcqUsWLFilnnzp1t+/btYZtnAAAAAAAA5PCg1Pz5813AacmSJfb555/b0aNHrU2bNnbgwAH/NPfcc4998MEH9u6777rpt2zZYp06dQrnbAMAAAAAAOAEhbX3vTlz5iT7f/LkyS5javny5XbhhRfa3r177bXXXrO33nrLLr74YjfNpEmTrF69ei6Qde6554ZpzgEAAAAAAJBrakopCCWlS5d2fxWcUvZU69at/dPUrVvXqlataosXLw7bfAIAAAAAACAHZ0oFSkpKsrvvvttatGhhZ5xxhhu3bds2K1iwoJUsWTLZtOXLl3fPBXP48GE3eBISEvzvryGnizZfuGcByPO0H0aZL7Ki+kAelRt+28HRFAi3pP+d3egvgDBLSspT52gRE5RSbalVq1bZf//73xMunj5s2LDjxu/cudMVTc/p6pUiKAWEm07XKhczi3InceyTQDjt2LGDFZDTxTYI9xwAeZ6CUXuLVHeBqWjLHRfEQI61I3ec2+zbty/nBKV69+5tH374oS1YsMAqV67sH1+hQgU7cuSIxcfHJ8uWUu97ei6YgQMHWv/+/ZNlSlWpUsXi4uIsNjbWcrpf9ugyGEA46V6iQlGr9ygoxT4JhJNqUSKHS1gZ7jkA8jwFpZQFHpfwI0EpINzK5Y5zm5iYmMgPSvl8PuvTp4/NmDHD5s2bZzVq1Ej2fOPGja1AgQI2d+5c69y5sxu3Zs0a++OPP6x58+ZB37NQoUJuSCk6OtoNOR0XwEBk8P1vf2SfBMIrN/y2g6wMIBL8U5pA4Sn2SSCsoqPz1Dla/nA32VPPerNmzbLixYv760SVKFHCChcu7P727NnTZT6p+LkynRTEUkCKnvcAAAAAAAByrrAGpcaPH+/+tmzZMtn4SZMmWffu3d3jUaNGuQibMqVUwLxt27b24osvhmV+AQAAAAAAkD3C3nwvI+0Qx40b5wYAAAAAAADkDrmjsSIAAAAAAAByFIJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAAAIOYJSAAAAAAAACDmCUgAAAAAAAAg5glIAAAAAAADIW0GpBQsWWIcOHaxSpUoWFRVlM2fOTPZ89+7d3fjAoV27dmGbXwAAAAAAAOSCoNSBAwfsrLPOsnHjxqU6jYJQW7du9Q9vv/12SOcRAAAAAAAA2S+/hdFll13mhrQUKlTIKlSoELJ5AgAAAAAAwMkX8TWl5s2bZ+XKlbM6derYHXfcYbt37w73LAEAAAAAACAnZ0qlR033OnXqZDVq1LB169bZQw895DKrFi9ebPny5Qv6msOHD7vBk5CQ4P4mJSW5IaeLNl+4ZwHI87QfRpkv8qP6QB6QG37bwdEUCLek/53d6C+AMEtKylPnaFkKSp166qm2dOlSK1OmTLLx8fHx1qhRI/v9998tO1x77bX+x2eeeaY1aNDAatas6bKnLrnkkqCvGTFihA0bNuy48Tt37rTExETL6eqVIigFhJtO1yoXM4tyJ3Hsk0A47dixgxWQ08U2CPccAHmeglF7i1R3galoyx0XxECOtSN3nNvs27fv5AWlNmzYYMeOHTtuvDKU/vzzTztZFAwrW7asrV27NtWg1MCBA61///7JMqWqVKlicXFxFhsbazndL3t0GQwgnHQvUaGo1XsUlGKfBMJJTfyRwyWsDPccAHmeglLKAo9L+JGgFBBu5XLHuU1MTEz2B6Vmz57tf/zpp59aiRIl/P8rSDV37lyrXr26nSybN292NaUqVqyYZmF0DSlFR0e7IafjAhiIDL7/7Y/sk0B45YbfdpCVAUSCf0oTKDzFPgmEVXR0njpHy1RQqmPHju5vVFSUdevWLdlzBQoUcAGpkSNHZvj99u/f77KePOvXr7cVK1ZY6dKl3aBmeJ07d3a976mm1AMPPGC1atWytm3bZma2AQAAAAAAEGHyZ6VQlQqPq6aUmtKdiGXLllmrVq38/3vN7hTwGj9+vK1cudKmTJnialVVqlTJ2rRpY8OHDw+aCQUAAAAAAICcI0s1pZTRlB1atmxpPl/qRYLVRBAAAAAAAAC5T5aCUqL6URrU603Krv4mTpyYHfMGAAAAAACAXCpLQSnVenr00UftnHPOcUXHVWMKAAAAAAAAOKlBqQkTJtjkyZPtpptuysrLAQAAAAAAkMdlqa/BI0eO2HnnnZf9cwMAAAAAAIA8IUtBqVtuucXeeuut7J8bAAAAAAAA5AlZar6XmJhoL7/8sn3xxRfWoEEDK1CgQLLnn3vuueyaPwAAAAAAAORCWQpKrVy50ho2bOger1q1KtlzFD0HAAAAAADASQlKffXVV1l5GQAAAAAAAJD1mlIAAAAAAABAyDOlWrVqlWYzvS+//PJE5gkAAAAAAAC5XJaCUl49Kc/Ro0dtxYoVrr5Ut27dsmveAAAAAAAAkEtlKSg1atSooOOHDh1q+/fvP9F5AgAAAAAAQC6XrTWlbrzxRps4cWJ2viUAAAAAAAByoWwNSi1evNhiYmKy8y0BAAAAAACQC2Wp+V6nTp2S/e/z+Wzr1q22bNkyGzRoUHbNGwAAAAAAAHKpLAWlSpQokez/6Ohoq1Onjj366KPWpk2b7Jo3AAAAAAAA5FJZCkpNmjQp++cEAAAAAAAAeUaWglKe5cuX2y+//OIe169f384+++zsmi8AAAAAAADkYlkKSu3YscOuvfZamzdvnpUsWdKNi4+Pt1atWtm0adMsLi4uu+cTAAAAAAAAeb33vT59+ti+ffvsp59+sr/++ssNq1atsoSEBOvbt2/2zyUAAAAAAABylSxlSs2ZM8e++OILq1evnn/c6aefbuPGjaPQOQAAAAAAAE5OplRSUpIVKFDguPEap+cAAAAAAACAbA9KXXzxxdavXz/bsmWLf9yff/5p99xzj11yySVZeUsAAAAAAADkIVkKSr3wwguuflT16tWtZs2abqhRo4YbN3bs2OyfSwAAAAAAAOQqWaopVaVKFfvuu+9cXanVq1e7caov1bp16+yePwAAAAAAAOT1TKkvv/zSFTRXRlRUVJRdeumlric+DU2aNLH69evbwoULT97cAgAAAAAAIO8FpUaPHm233nqrxcbGHvdciRIlrFevXvbcc89l5/wBAAAAAAAgrwelfvjhB2vXrl2qz7dp08aWL1+eHfMFAAAAAACAXCxTQant27dbgQIFUn0+f/78tnPnzuyYLwAAAAAAAORimQpKnXLKKbZq1apUn1+5cqVVrFgxO+YLAAAAAAAAuVimglKXX365DRo0yBITE4977tChQzZkyBBr3759ds4fAAAAAAAAcqH8mZn4kUcesffff99OO+006927t9WpU8eNX716tY0bN86OHTtmDz/88MmaVwAAAAAAAOTFoFT58uVt0aJFdscdd9jAgQPN5/O58VFRUda2bVsXmNI0AAAAAAAAQLYFpaRatWr28ccf2549e2zt2rUuMFW7dm0rVapUZt8KAAAAAAAAeVSmg1IeBaGaNGmSvXMDAAAAAACAPCFThc4BAAAAAACA7EBQCgAAAAAAACFHUAoAAAAAAAAhR1AKAAAAAAAAIUdQCgAAAAAAAHkrKLVgwQLr0KGDVapUyaKiomzmzJnJnvf5fDZ48GCrWLGiFS5c2Fq3bm2//fZb2OYXAAAAAAAAuSAodeDAATvrrLNs3LhxQZ9/+umn7fnnn7cJEybYN998Y0WLFrW2bdtaYmJiyOcVAAAAAAAA2Se/hdFll13mhmCUJTV69Gh75JFH7Morr3TjXn/9dStfvrzLqLr22mtDPLcAAAAAAADIFUGptKxfv962bdvmmux5SpQoYc2aNbPFixenGpQ6fPiwGzwJCQnub1JSkhtyumjzhXsWgDxP+2GU+SjKB0SA3PDbDkqcAuGW9L+zG/0FEGZJSXnqHC1ig1IKSIkyowLpf++5YEaMGGHDhg07bvzOnTtzRbO/eqUISgHhptO1ysXMotxJHPskEE47duxgBeR0sQ3CPQdAnqdg1N4i1V1gKtpyxwUxkGPtyB3nNvv27cvZQamsGjhwoPXv3z9ZplSVKlUsLi7OYmNjLaf7ZY8ugwGEk+4lKhS1eo+CUuyTQDiVK1eOFZDTJawM9xwAeZ6CUsoCj0v4kaAUEG7lcse5TUxMTM4OSlWoUMH93b59u+t9z6P/GzZsmOrrChUq5IaUoqOj3ZDTcQEMRAbf//ZH9kkgvHLDbzvIygAiwT+lCRSeYp8Ewio6Ok+do0Xst61Ro4YLTM2dOzdZ1pN64WvevHlY5w0AAAAAAAAnJqyZUvv377e1a9cmK26+YsUKK126tFWtWtXuvvtue+yxx6x27douSDVo0CCrVKmSdezYMZyzDQAAAAAAgJwclFq2bJm1atXK/79XC6pbt242efJke+CBB+zAgQN22223WXx8vJ1//vk2Z86cDLdNBAAAAAAAQGQKa1CqZcuW5vOl3nNVVFSUPfroo24AAAAAAABA7hGxNaUAAAAAAACQexGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyBGUAgAAAAAAQMgRlAIAAAAAAEDIEZQCAAAAAABAyEV0UGro0KEWFRWVbKhbt264ZwsAAAAAAAAnKL9FuPr169sXX3zh/z9//oifZQAAAAAAAKQj4iM8CkJVqFAh3LMBAAAAAACAvBSU+u2336xSpUoWExNjzZs3txEjRljVqlVTnf7w4cNu8CQkJLi/SUlJbsjpos0X7lkA8jzth1Hmi+z2z0AekRt+28HRFAi3pP+d3egvgDDLJec2GT1Hi+igVLNmzWzy5MlWp04d27p1qw0bNswuuOACW7VqlRUvXjzoaxS00nQp7dy50xITEy2nq1eKoBQQbjpdq1zMLMqdxLFPAuG0Y8cOVkBOF9sg3HMA5HkKRu0tUt0FpqItd1wQAznWjtxxbrNv374MTRfl8/lyzBVVfHy8VatWzZ577jnr2bNnhjOlqlSpYnv27LHY2FjL6Wo99HG4ZwHI83QvsW4pn63eozuKCk0BCJe1T1zOws/pHi0T7jkA8jwFpXbGnmlxCT8SlALCbfBuyw0UiylVqpTt3bs3zVhMRGdKpVSyZEk77bTTbO3atalOU6hQITekFB0d7YacjgtgIDL4/rc/sk8C4ZUbfttBVgYQCf4pTaDwFPskEFbR0XnqHC1Hfdv9+/fbunXrrGLFiuGeFQAAAAAAAJyAiA5K3XfffTZ//nzbsGGDLVq0yK666irLly+fXXfddeGeNQAAAAAAAJyAiG6+t3nzZheA2r17t8XFxdn5559vS5YscY8BAAAAAACQc0V0UGratGnhngUAAAAAAADkteZ7AAAAAAAAyJ0ISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5AhKAQAAAAAAIOQISgEAAAAAACDkCEoBAAAAAAAg5HJEUGrcuHFWvXp1i4mJsWbNmtm3334b7lkCAAAAAABAbg5KTZ8+3fr3729Dhgyx7777zs466yxr27at7dixI9yzBgAAAAAAgNwalHruuefs1ltvtR49etjpp59uEyZMsCJFitjEiRPDPWsAAAAAAADIjUGpI0eO2PLly61169b+cdHR0e7/xYsXh3XeAAAAAAAAkHX5LYLt2rXLjh07ZuXLl082Xv+vXr066GsOHz7sBs/evXvd3/j4eEtKSrIc7/CBcM8BAPPZ34k+s8NRZqYBQLjo9x05nDuWAginJIuyhMRjVvBwlEVzbgOEV3zuOLdJSEhwf30+X84NSmXFiBEjbNiwYceNr1atWljmB0DutD7cMwDAKTWaBQEA2eNrFiQQCZ4sZbnJvn37rESJEjkzKFW2bFnLly+fbd++Pdl4/V+hQoWgrxk4cKArjO5RdtRff/1lZcqUsago7sQByJ6of5UqVWzTpk0WGxvLIgUAADka5zYAspsypBSQqlSpUprTRXRQqmDBgta4cWObO3eudezY0R9k0v+9e/cO+ppChQq5IVDJkiVDMr8A8hYFpAhKAQCA3IJzGwDZKa0MqRwRlBJlPXXr1s3OOecca9q0qY0ePdoOHDjgeuMDAAAAAABAzhTxQakuXbrYzp07bfDgwbZt2zZr2LChzZkz57ji5wAAAAAAAMg5Ij4oJWqql1pzPQAINTURHjJkyHFNhQEAAHIizm0AhEuUL73++QAAAAAAAIBsFp3dbwgAAAAAAACkh6AUAAAAAAAAQo6gFAAAAAAAAEKOoBQAAAAAAABCjqAUAKRw9OhRlgkAAMjx6NMKQKQjKAUgz1u0aJH9/fffbjk89dRT9tFHH3ESBwAAcnxAKioqyj2Oj48P9+wAQFD5g48GgLxh3bp1dscdd1idOnWsQoUK9uKLL9qPP/7oP4kDAADIaZKSkiw6+p/8g/fff99ee+01Gz9+vFWtWjXcswYAyZApBSBP08nZwIED7auvvnInbIsXL7Z69erRhA8AAOT4gNT8+fPtP//5jy1ZssQGDx5smzZtCvfsAUAyBKUA5NkTNilQoIDFxcVZ4cKFXYBq9OjRdvDgQTf+2LFj4Z5NAACATPECUv3797d+/fpZbGysnX322fbJJ5/YgAEDbMOGDSxRABEjykf1OwB5+A7i77//7gJSOhTOmzfPRo0aZTVq1LApU6a48Z4jR45YwYIFwzjXAAAAGTN37ly7/vrrbfbs2dasWTM3bsyYMTZt2jQ79dRTXQ3NypUrszgBhB2ZUgDybEBqyJAhdt1117nAVKVKlaxTp06uvtT69evt5ptvtsOHD7vp+vTp407uAAAAcoLExET3t2zZsv5xyprq0KGDqzGl0gUbN24M4xwCwD8ISgHIU7yAlE7GXn75ZZfGXrNmTTcuJibGbrjhBuvdu7etWbPGzjnnHGvTpo07ebv00kvDPOcAAADHC2z44j0uWrSoFStWzB948soW3HPPPS5DavXq1fbEE0/Y7t27WaQAwoqgFIA857vvvrPp06fb22+/7bKjSpQoYX/++afNmDHD/e3WrZuNHDnSWrVqZbVr13YndPnz56fGFAAAiCgKNnk9Bh89etR/rtKyZUsrX768qyv122+/+W/K7dixwxo1amRt27Z1nbz8+uuvYZ1/AKCmFIA8Rz3RKPC0aNEi++OPP+zdd9+1jz/+2LZu3WpnnXWWK3augqCBdJKXL1++sM0zAABAap5++mn78ssvXVHz9u3bW9euXW3//v3+elK33HKLy5BSlrimee+996xixYp222232bBhw1iwAMKGTCkAuZqXrh6oadOmrtaCmuS1bt3a9bb3+OOP2+LFi106u+4opkRACgAAROL5zZNPPumCUvXq1bO///7b7rrrLlfIXM33VqxYYfXr17epU6e60gXKqnrjjTfc66pVq+YvYQAA4ZI/bJ8MACEsar5gwQI7dOiQO1m74oor7KeffnI90NSqVcsuvPBCfw986pEmWCALAAAg0s5vVq5caUWKFLF33nnHLr74Yvvrr7/stddeczUzdV7z4IMPuud27drlXleuXDn3ukGDBtmmTZvs/PPPD/O3AZDXEZQCkGt5J2w6IVMNqbi4OFc7QUEoZUbpTqIoWKUaC927d7cjR47Y1VdfHeY5BwAASO7uu+92JQa88xs111PGtwJNs2bNcuNKly5tvXr1chlRCkxp2gceeMDfC586chk8eLC7WafSBboZBwDhRPM9ALnaiy++aJMnT7b//Oc/9u2339rw4cPtww8/tD179vhrRb3++uuui+S9e/fakiVLXFM9r1AoAABAuK1atcp+/vlnV8zcU7VqVRd40vmLmul5VDNKgalnnnnG3ZhTxy4e1ZVSJy+qr5myfiYAhAOFzgHkanfccYfrfWbo0KEuW+r22293XSBr/OHDh92dRPWu98UXX7hinwpIqYmfetsDAACING+++abdeOON7rHOYcaMGWPjx4+3V155xT9eFKxSNpQywDmvARCpCEoByJU1FkRN8VRfoUePHq5XvVatWrm7hgpMKfA0YsQIO/PMM61jx47+19DLHgAAiNTzmz///NPVwzz33HPtq6++8gemxo4d63rWU4Z4YGDKww03AJGK5nsAcg3vhG39+vUuvb1gwYLu7qC6Om7evLk7UVNASg4cOODqKajgeSB62QMAAJFiy5Yt/vObTz75xCpUqOCyuzds2OB6EfZ60evTp49rsqe/Ck6lRKYUgEhFUApArqJuji+44AJ3wqY7i23atLEGDRpY3bp1XZfIot5mrrvuOktISHC1GAAAACKNCpkr23vx4sV2zz33uN6Dd+/ebS1atLC33nrLVq9enSww1bt3b/v3v//t6mgCQE5B8z0AuYqa3ykodfDgQXv22WddrzSffvqpPf/8866oZ5UqVaxQoUIWExNjCxcutAIFCtBkDwAARJxvvvnG7r33Xtu6davroGXRokXuJptHwaprrrnG6tWrZ5999pkbt23bNldLUzUzASAnICgFINfUkAoMTKl+lO4mqsaC6krt2LHDli5daps3b3aBqbZt21LUHAAARJzA+pbqnGXw4MF23nnn2WOPPWYXXnhhsmkVmLr++uutRIkSyXrg8/l8BKYA5AgEpQDkeJMnT3YFyxs3bpzshO6iiy5ydwwnTJjgTuJUYyoQRc0BAECkUnM81ZTq2bOnjRw50ooUKeLGtWvXLtl0ygQfPXq0vffee0Fv1gFAJCMoBSDH8e7+KVNKvcmUK1fOatSoYVOmTHH1ozx6vmbNmla5cmXr37+//etf/6KQOQAAiEiB2U2qjXnDDTfYm2++6epGLVmyxNXBLF68uPXt29fVzJS3337bunTp4g9GccMNQE5DUApAjj1h27lzp8XFxdnevXutSZMmLnX91VdfdYEpTaMTMwWiPv/8c1fYXEErAACASKZA1Pfff+/OcR588EH/uc+3337rAlPK/FZQ6quvvrJly5Yl66EPAHIajl4AcgxlPnkBqalTp7rinz/99JMLRumk7K+//rJbbrnF1VRQBpXqMah+1A8//GCTJk0K9+wDAACkad26de4Gm0oPHDhwwI3TTTadAzVt2tR14lK6dGl755133LmOehRWQEqBKwDIiciUApDjiporAPX444+7VPZOnTpZnz59XG80CQkJ1qxZM3cHsXbt2i6TSsXOV65c6V5LSjsAAIh0H374oashtXr1ateMr379+u4cRucyujmn852jR4+64JT+V3Aqf/784Z5tAMgSMqUA5AheQOqee+6xm2++2WJjY+300093TfLGjBnjMqY0Tj3stWzZ0goXLuzqSSn9Xa9VUMvryQYAACDcdG4STPv27V0zPQWjlAGu4JTOYbzpdb5TpkwZf31NAlIAcjIypQDkGLpbqG6PP/74Y9fTnk7GnnvuOZfmrt71VMz8tNNOS5ZVJdxBBAAAkSTwXOWNN95wN9WKFStm55xzjssC9zKmxo0b5zKjJk6caHXq1ElWWxMAcgPyPAHkqBO4AgUKuBpS3gmZAlFHjhyxRx55xI3r16+fa8onXn0F7iACAIBI4gWklBGlOpm6uabamApQbd261e666y6XMSXjx493j3Vzrlq1amGecwDIXjTfAxCRvICS/nrp6l6PevHx8e5/BaOkd+/eVqFCBVu0aJGNHTvWfv31V//03E0EAACRSJne7777rr333nv21ltvuR71tm3b5jpyGTFihJtGwaju3bu73oQrV64c7lkGgGxH8z0AEZ3SrsCTAlGqESXt2rWz33//3RYsWOACUbJhwwaXKVWrVi2bPXu2tWjRwu68806rV69eWL8HAACAJ7DDFRUqHzZsmJUqVcoFoT744AO76aab7OGHH7Zdu3a5QueqmamMqUB02gIgtyEoBSBiA1KqFzV37lx3cqai5s8884wdOnTIunTpYn/++ac99NBDVrx4cVfsXM36VHtBdx2feOIJV49Bdxk1HgAAIJzUI3BcXJx7PH/+fLvoootcD8F79uxx5yq66Xbbbbe5Dl3mzZvn/teNuddee8169OjBygOQa1FTCkBE8QJSCjhNmjTJHnjgATvjjDPssssuc832VOjzs88+c3cOX3zxRUtMTLSqVavaf/7zH/c69VKju5DqgY+AFAAACDcFoR599FFXtPyll15yNaR+/PFHK1++vOtF76OPPrJChQq5TCkpWrSoXX311daxY0c3AEBuRlAKQMT55ZdfbNasWfbmm2/aJZdc4u4Y6mRNgSmluYuyo1R3QUEs3XlU7ajDhw+76bijCAAAIoWXDaX6UHq8bNkyF5DyssOLFClia9assU8++cSd66hZn85tlPWt8xt6EQaQm1HoHEDEFTdXRpQeKyCl4FSHDh1cbQWlte/du9emT5/uplNNqXLlyrkTNp3YKSAFAAAQCdQ8T5TtVLNmTVcTU/Uu9+3b58YrIKXzHWWE33rrrW5o2rSpbd682V5++WV3fqPn6UUYQG5GTSkAYbVp0ybbv3+/VapUyUqUKOHGqV6U7iZeccUVrje9p59+2nr16uWeW7p0qfXv39+ef/55O/vss1l7AAAg4qhwuUoLtGrVyvWep971Dh48aDNnznTFygcPHmzNmzd3QScFn1RzSh23bN261Z3/qBQBGVIA8gIypQCEjWoqXH755da6dWtXyPydd95xJ2yqpdCwYUPX64xO5LyAlJrnqSZD2bJl7ayzzmLNAQCAiKP6lz179nTZUVWqVHHjrr/+elf3UtlQCkTpfGbJkiUuICV63KRJE/vXv/7lAlIKXJEhBSAvIFMKQFgoLf3uu++2Z5991mrVquWa56mW1MKFC61atWq2ePFiV+RcJ2UKWqmWlHrX27Fjh3333XeuNkNgT30AAADh9t5779nNN9/segNWs71gna7ofEZFz9VZiwJVukm3ceNGW7VqlT9IBQB5BUEpACGnXvV0EqYUdtWL8sbprqL+duvWzY3773//69LflUGlGgy626iTON05JKUdAABEkkOHDrlMKJ2zPPzww/7xqiX1ww8/uMDTv//9b6tcubJ98cUX9sorr7gbbdWrV7ePP/7YBbC85nwAkFcQlAIQUkePHnWp6epRTz3NVK1a1Y1XM745c+bYQw895IJOnTt3dkGokiVL2pEjR6xgwYL+9yAgBQAAIo3OT1SoXHWklAEuzzzzjDvnmT9/vsXExLgSBerERWUK1BPfgQMHXF1NZX5zfgMgLyIoBSDkdBKmlPbt27fb559/bvfee6+7g3jfffe5JnmzZ8+29evXu5MzFQHt16+fNWrUyL2WO4gAACASqTmezml00+2iiy5yGd8qXt6lSxe76qqrXAct6mmvdu3aNmPGjGSvpSQBgLyKoBSAsIiPj3e9y6h2lE7OvvzySzvllFP8z3/zzTf27bff2meffeaa+anoJwAAQCRbtmyZjRo1ytauXWuxsbEuU0oFz4sXL+6ev+2221yvw+qNDwBAUApAmDOmunbt6rKkFJRSwXMVNg8WgOIOIgAAyCkZU2qOF1h6QNTDcPv27e2CCy6wYcOGhW3+ACCSkCkFICIypnbu3OlqLKg4aCCa6wEAgEjyxBNPuLpRKjEQjHfu4v1VOYJt27ZZr1693F9lg6t+JgDAjL7UAYSVCpl/9NFHVr58eevUqZP9+OOPyZ6nBxoAABApFFB69913bcSIEbZ8+fKg03jnLvqrrPCnnnrKevToYXv37rUlS5a4gJQywwEABKUAnCRqbheM7hoGC0x98MEH7jWPP/446wQAAESkZs2a2eDBg+3w4cM2dOjQVANTHnXqkpCQYJdcconrga9AgQIuc4pamQDwD5rvAch2gfWf1LteoUKFXIFP9TqT8vlAKvxZuHBhTtQAAEDECTx/ef/99238+PEWExPjglONGzdO9XWHDh1y5zeSWu1MAMirCEoBOGkGDBhgr7zyihUpUsRKlChht99+u/Xp0yfdwuWcsAEAgEji1YcKPEdRM76XX345Q4EpAEBw1JQCkG0Cm+apK2SlqX/11VfupK1Lly4u3f3pp5/+5+ATHZ1qEz/uIAIAgEih8xWvTpQeHz161D2++uqr3Q03ZUJlpCkfAOB4dPsAIFsEZj7p5Ez1E9ST3umnn+7qJ9SsWdP9Vc0ondjdf//9bnp61wMAADnh/GbUqFE2d+5cV0/qtNNOs2eeecY6d+7sCpe/8MILLjBFxhQAZA5BKQDZwjth08mY6kgpAKUTOf2VcuXK2S233OICUk8++aTt27fPHn30UXrXAwAAEX9+89BDD7mSBMqMSkxMtLffftu+/vprmzZtml155ZWueLmeV5mCiRMnWt26dcM96wCQI9B8D8AJCezSWHcJVVuhVatWVqNGDXeypiCVJy4uznr27Gm9evVyXSIH64kPAAAgkvz66682ffp0mzJlig0fPtxlSP3000/uxlrXrl3dNMqYuummm6xp06YuiwoAkDEUOgeQJSmb3S1evNgFoWrVqmUdO3a0AwcO2Ouvv+7uGA4ZMsQGDRrknzY+Pt4VPtfrab4HAAAi2YoVK6xNmza2cOFCq1OnjqsppUzwP//80xo2bGiPPfaYu+EWKK0OXQAA/48jJYBMu+uuu1wBc69Que4WtmjRwh544AHbs2ePG1e0aFG7+eabXfaUmumplpSnZMmSBKQAAEDECZbFrbqYGj9jxgz3vwJSyhSPjY21ypUru1qaKRGQAoCMISgFINPmzJnjaiooO0qBqfr169t7771nxYoVs0WLFvlPzgoVKmQ9evRwgSllSk2ePDnZ+wRmWgEAAISTAk3euYlqRGmQ4sWLu/Oed955x1577TV/T8ExMTEu+OTVzwQAZB7N9wBkWGAq+nnnnWc7duxwgabmzZu7kzPVW7jxxhvt3nvvddlRBQsWdNOql5pPPvnE2rdv73qoAQAAiCTqgEXBJxk5cqQtW7bM1ZK67rrr7IorrrDy5cvbgw8+6Hrfu/DCC10Pw7pJt3PnTvv+++85vwGALCIoBSBTdNfQCyyde+65tmvXrmSBKfVCo0KfCkypGGjKu4eBrwcAAAi3N954w9avX2+DBw92gSf1ote3b19bt26drV692t1ke/7556127druBty4ceNckEoduKinPa85n86DAACZQ1AKwEkJTHXv3t013Rs7dixBKAAAEJFeeuklu+OOO+zjjz92taM6dOhg48ePdz0Ji2poahrvXEc1pFJmj3PDDQCyjppSADLMK2yugJRXZ2HJkiVWtmxZF4RSjSndKbz22mvdCd3PP//MXUMAABCxGVLqJfjDDz+0du3a2f79+2379u3JbqYpOKVznLVr17rMKY8XkFIBdDLAASDrCEoBSJNqJ6irY3fAiI5OMzClzCg9VmBKj+fPn+/vZQ8AACBSKOupW7du1rJlS7v88svdODXDK1eunG3cuNH9752/KGClzlsWLlx43PvQaQsAnBiCUgBSpQLl6mlGwzPPPBM0MHX06FH3WMEo1Ve49NJL7aeffkr2PpywAQCASKGaUT179nSDzllUP0rOOOMMa9q0qauLqd6EvfOXPXv2WJEiRaxKlSphnnMAyH2oKQUgTVu2bLGnn37aBZ2uuuoqGzBgwHG1FAIf68Ru1KhRNNsDAAARZ/To0da/f3/76KOP7LLLLnP1oh555BHr0qWLvfDCC24a9Ras856uXbu6YuaqK7Vt2zb77rvvaKoHANmMoBSAdOlE7PHHH7elS5cGDUyp/kK/fv3sxhtvdCdyQi80AAAg0qi0wNatW139S9m7d6/rUe/hhx9OFpgaOHCg/fjjjy5LqlatWvbqq6/Syx4AnAQEpQBkOjDVsWNH12Wy6MTu6quvth07drjC5hT7BAAAkU71orzmeQkJCa7n4JSBqYMHD7qbbzExMe5/etkDgOz3/11LAEAaKlSo4E7WFJiaOXOma55388032w033ODuIqomgwJSZEgBAIBIF1jvMjY21p85paZ8OscZM2aMqyPloZc9ADg5yJQCkOmMqSeeeMK+/fZbW716tVWqVMl++OEHl9LOHUQAAJBTKWNKTfl69erl6mOqNAEA4OQiKAUgS4Ep1ZXauXOnzZo1i4AUAADIFeLj413dKdXIVMYUAODkIigFIEvUZK9EiRKu1gIZUgAAILfh/AYATj6CUgBOiNcDHwAAAAAAmUFQCgAAAAAAACFHegMAAAAAAABCjqAUAAAAAAAAQo6gFAAAAAAAAEKOoBQAAAAAAABCjqAUAAAAAAAAQo6gFAAAAAAAAEKOoBQAAAAAAABCjqAUAAAAAAAAQo6gFAAAAAAAAEKOoBQAAAAAAABCjqAUAAAAAAAALNT+D1kQ4n+IwskrAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fe = filtered_events_df.copy()\n",
+    "fe[\"hour\"] = fe[\"timestamp\"].dt.floor(\"h\")\n",
+    "calls = fe[fe[\"event_type\"].isin([\"LLM_REQUEST\", \"TOOL_STARTING\"])].copy()\n",
+    "if not calls.empty:\n",
+    "    calls_hourly = calls.groupby([\"hour\", \"event_type\"]).size().unstack(fill_value=0).reset_index()\n",
+    "    cols = [c for c in [\"LLM_REQUEST\", \"TOOL_STARTING\"] if c in calls_hourly.columns]\n",
+    "    if cols:\n",
+    "        time_plot(calls_hourly, \"hour\", cols, \"LLM + Tool Calls Over Time\", \"Count\",\n",
+    "                  labels=[c.replace(\"_\", \" \").title() for c in cols])\n",
+    "else:\n",
+    "    print(\"No LLM/Tool call data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 5: Errors Over Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.218125Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.218037Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.221574Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.221144Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No errors in time range.\n"
+     ]
+    }
+   ],
+   "source": [
+    "errors = fe[fe[\"is_error\"]].copy()\n",
+    "if not errors.empty:\n",
+    "    errors_hourly = errors.groupby([\"hour\", \"event_family\"]).size().unstack(fill_value=0).reset_index()\n",
+    "    err_cols = [c for c in errors_hourly.columns if c != \"hour\"]\n",
+    "    time_plot(errors_hourly, \"hour\", err_cols, \"Errors Over Time by Family\", \"Count\",\n",
+    "              labels=err_cols)\n",
+    "else:\n",
+    "    print(\"No errors in time range.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 6: LLM Latency (total_ms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.222863Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.222795Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.275164Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.274656Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUQ1JREFUeJzt3Qu4THX////33ja2Q5tyVkgREkIRHZUoVEpHFXUrd6IDRVS3SN/cHRSVcncX6b5TclfKIYcUCR0oORSVlNyOKTbKcc//en1+95r/2ofZe882e+3DPB/XNdeePbNmZq01a9bMeq335/NJCIVCIQMAAAAAAAAClBjkiwEAAAAAAABCKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAACI6/vjjLSEhwV0Ks759+7p5bNCggYVCoage+8orr4SXcdiwYRaEn376Kfya5513ngWpIJY3GvPnzw/P30033VRg86H3xZsPvV8AcufWW291n5smTZpEvT8GEH8IpQDgCOiALrcHT/6Dex105eaATJeKFSvan3/+mW6a/fv3W5UqVdJNN2vWrBzn1z99LA+ytB50GT16tBV3P/74o91xxx3WsGFDK1eunLvoer9+/dx9RWV7zelSkGFAtDZs2GAvvfSSu37nnXcW+gAtCPH0mSxqtI/33p/ly5cf8fN9//337rkUotWuXdtKly5tRx99tF1wwQX27rvvZvmYLVu22G233Wa1atWyUqVKub99+vSxrVu3pptu8+bN9thjj1nHjh2tbt26VqZMGTvqqKOsTZs2NmHChIjztGrVKrvhhhvs2GOPdfNTtWpVO/vss8Of09yaPHmynXnmmVa+fHl30fU333wz28fs3LnTatasGd6XVa9eParXjOZ133nnHbv00kvd97u+C7QujzvuOLvqqqvss88+y/XrpaWl2QsvvGDNmze3smXLWoUKFax9+/Y2b968bH8fZHXRvORWamqq3XfffXbiiSe696latWrufVu3bl2W03/wwQduvjR/ms8WLVrYuHHj3Pz73X333eHtIKf3CwCUXgMA8uihhx7SKUB36dmzZ7bT1qlTJzztRx99FHE63edN510mTpyYbprXX3890zTvv/9+jvPrn379+vVRLGnunlfLWJxNmTIllJycnGndexfdp2mKwvaa08Xbnr/44ovQwoUL3aWwuueee9w8lypVKrRr166oH79169bwMv7888+hIOjz563rc889N+bPn91nsiCWNxr+fWBO+9X8pPclP/aX/s/hhAkTjvj5Ro4cme1n+emnn043/YYNG0LHHXdcltPWrl07tHHjxmy/a/yXu+66K9P8vPXWW+6zmNX0F1xwQUz2VyNGjIj4uFtuuSXdtNWqVcv1a0b7ur169Yo4bVJSUmjBggW5ek1t51k9R0JCQrrv/6x+H2S81KtXL1evqX1l06ZNs3yOo48+OrRixYp0048fP97NT1bTaz1k1KZNG3dfy5YtczU/AOIXlVIAUARkPLv8z3/+s8DmJV599dVXdv3119u+ffvc/zo7Pm3aNHe57LLL3G26T2eZY1H9cCT27t2b5e1/+ctfbOHCheHLzTffHL7v4osvTnffAw884G4/7bTT7KyzznKXwujQoUP273//212/8MILLSUlJernUBWHt4yqNCnu4m1544EqV+666y63P3r77betdevW4fv0WfbvEzTdxo0b3fUrrrjCVVPpr1d16FW5eJKTk61Xr1721ltv2fTp061Tp07h+5555pl0FaK6fuONN9qBAwdcVdWgQYPcPOlxTz31lKuWyg3tQ0eMGOGuqzJr/Pjx7qLrosqwFStWZHqcKolefvllN895Ee3r1q9f34YMGeIqq1TVpO9mVYd5+yZVP+Xkvffes4kTJ7rrqvB644037Omnn7akpCTX9E1Nk70KNlVS+ffT3uXyyy8PP1/Xrl1ztaz+ZTnnnHNs6tSp9te//tX9//vvv7v33F8xpwphzY/mS++l5tNbVq3zGTNmpHt+b5tatmyZq5gCgIgKOhUDgKIsvyuljjrqqPD1tWvXuvt/+OGH8NlK//2xrJRauXJlqHv37qFGjRq5M6Y641ulSpVQp06d0p35ze6Msr9C48CBA6FRo0aFWrRoESpbtqy7tGrVKvSvf/0r4jzq8d99913okksuCZUrV87Nx1//+tfQn3/+mekxkyZNCp133nmhihUrujP0euwNN9wQ2rlzZ+ill14KP+fQoUPTPW7q1Knh+/r165ftutN8eNO2a9culJaWFr5P13Wbd7+mFS2zd9tTTz2V7vlee+218H0DBw4M375t27ZQ//793dluLYuWSet9yZIl2VaTqDqhWbNm7jF6X2K1/fq320iv/eabb4YaNmwYKlOmTOiss85yZ9gPHz4cGj58eKhmzZru9osuuij0008/ZXr+r7/+OnTttdeGqlevHipZsqSbXmfdf/nll1wtg7ZHb17GjBmT6f5x48a5M/XahrRu9Pyq1njsscfC06haxXsO/7rzV8poPrWN6HOgirislsdb5mOPPdYts7bJr776KsuKm+wqpXbv3u3mo3Hjxu619DnXNDNnzsxxfeTmM5mb5V26dGno+uuvD5UvX95Vmmg6bedaD1ouzVetWrWyXOfRfN6zknH7mjdvXuj0008PlS5dOnT88cdnqvyJVHmUXcXVjh07QoMHD3b7OL1XWsfNmzcPPfvss1muD+99UxWRqol0W2JiYriKRetGlSRt27Z1z6X1oyqU0aNHu+3Ck12Fizfvkd6fSFTNqOXx+/XXX91+23uezz77zN2+efNmN9+6rUKFCuH9qf7qf91eokSJ0JYtW9zt33zzTabP4r59+9w24T335MmTw/fdfvvt4dtz+35npU+fPuHnUSVYVlVhGffZWgbtN3Xfo48+mqdKqby8bkbaPr1pO3funONrXnzxxeHpVZnm0fedd/uTTz4Z8fF6PypXrhzeJtetW5fjPnz//v3uu0W36ffEpk2bwtux9uX+/YBof+ndpvnKqpKuS5cu6V53+fLl4fsefvjhHNcDgPhFKAUAhTiUat26dahJkybpgov77rvP/d+gQYN0B02xDKWya7KhH70ffvhhrg+AdYCqECDSdIMGDcpyHlNSUkKVKlXKNP0DDzyQbvq//OUvEZ9by6gDfB1YZ9Wswf/YxYsXR1wff/zxR7rmKNOnT880zbRp08L3a1odIOmHvncAqINVv8svvzxd4CFqShWpWY0Cm3fffTfL7aRu3brpmlUEGUplfG1dFDDdeuutmZbhzDPPTPfcClkUNGS1vHqOH3/8Mcdl8B98Zmxi+Oqrr0bcNhQceXIT0pxwwgk5Ls+dd96ZaRod6CtIyW0opSDV+8xndRk7dmwgodSJJ56Y6fF33HFH+EDWf5k7d274OaL9vGfFv30pNNK2n/F5/IFBtKGUmq95wVLGi/+9yBhK/fbbby4o1P/a5l988cXwtD169Ii4zNdcc014ukjTHEkoFYkCVO95Vq1a5W5TeO3dpiDdzx+sv/POO9k+t0LCrPaHCiq9faCautWvX999xvX38ccfTxfQZcf/GfCfCPGH0Arh/bzvRgVB/s9XNKFUXl7Xv+0rxNO+PjdhkhcC6bvOm97fnFaBp3f7ZZddFvE5/Ps5ncDIzT582bJl6fbhfjfffHP4Pi8A9p+U8Tcn1Px6t2vf4Hfw4MHw/r1jx47ZrgcA8Y3mewBQyN1yyy3u76uvvmp//PGHGzlL/KX1saYRzEaNGuXK+T/88EPXLEHNENQRqjo0HTlyZLrmYB51KOs1J/jPf/7jbhszZky4s9YzzjjDdQyr+/Qa8vjjj2fZIaw6YFVn7moy4jWnkH/84x/h67pPTSukRIkSdu+999rMmTPdulJTLnX6qk5qr776ajfNDz/8EH4tLYfX3EAdw6rj3kj0ODVH8Zx66qmZpvHfpmn1mBo1atj555/vbluyZIlt2rTJXVdTGq9jeo1O1LRpU3f99ttvDzer6dGjh5tG613LcPDgQbe+s2qat379etfMbsqUKe49y20TmVjQa6tTdK1LLYvXibKasahZi95vdZ4rixYtstWrV7vr2pZ79uzpOu1Xc5D/+7//szlz5rjmPt5zaH3k5Ntvvw1fr1evXrr7vE6e9fzqjFfb4WuvvWb33HOP67Q5Gtu3b3fPoaaCGnwg4/KsXbvWnn32WXc9MTHRhg4d6pottWrVKqpBBdTUauXKle66mklpvWp79jpr7t+/v/3yyy8RH5+bz2Ru7N69215//XV79NFHw7dp+fR8ek/VKXZWn8m8ft6ze3/VabTWg5bd3/To119/tbzQdqVmaqLmiy+++KL7rGne1OF3VjTYRJcuXcLvtzqQ1whjouXTeyRaTq03vfdaflHTLl0kY7PZ+++/P/z++JvFHSk9n7ZZb//WqFEjd92/LXqfS3+zTv/nOhLdp+bMon2Tt7/Zs2dPeNvUPvBvf/ub64Rdn3H91Wfbax6Wk0jzGWkeNT/6zlIzu9w0mYvV63rNtvVdo07OTz75ZFu8eLFruqjtVU0ls6Nmcvqui/Y1/Z5//vnwdTX1y41ot4PcrBd1MK/l8Wi/W6dOHXf9m2++ydV8AYhPhFIAUMipjyKFQepTonfv3u5vyZIl3QF9flFIopBHQYH6S9JoOzoI1cGFLF26NHxA5+9rSPPp9VWjkES8/n5kwIABVrlyZfejVv0zefzT+OngTv1SPPjgg26EO9GB6K5du9z1f/3rX+FpdcDzxBNPuL6R1KeJAg7vB7E/wFMoIZ9//nm4n45rr7022/XhP2gQhWUZZbzNm0dvOVUkoRBNdIDtjajo3f/bb7+5QE104K8DXo3mdMopp7iATXbs2JHlKIs6MNTtV155pXu/NOpWUHQQrz7PdECtIM2jA1UFGurfRPPlUVgnen+8g2Ytn/o00YHcJZdcEh49avbs2TkGD/77NeKYnz4nooNFBVbaJrt3725PPvlkuuAmNx5++GF3QK33y7+9eMujAMwb+lz9uwwfPtyFGAojtFy5oaB00qRJ4XnW50V9ZClA8/pn0cF+dqNZ5eYzmRuPPPKIW04Fi9q+PGPHjnXvqdZHxnVwpJ/3SMujwEfbl/qx0Shoon3R+++/b9Hyf860j9PnRp81jS43cODAdPsUP23bChtEo9FplMeslkehgEZfU3Dp3+9402Tsx0t9Ennvj3eAr5D3f60ZXPgWLQUJ3vpWWKJ+nxSUij/U1jbm5/8/Ur902gfp/Vd/SaITFF4/bgol/LT/1T7vueeec9uhaF/h9bmn8PWTTz5Jd9m2bVu285nVPB4+fNidvNE8/f3vf48YLHpi9brZUSCjde/tEyLJ+FzRvqbCuE8//dRdP+GEE+yiiy7KNI0CJW97yur5crMd5Ga9ZDWf3j45rwEygPiQVNAzAADI3jHHHGPdunVzB6teoKJOtv1nKGNNB5M6kIkk48FHdr777rvwda9iKbtqF48OdPzVR5UqVUr3+urY1//cCgAiadu2rQu11qxZ40ICdSKrzmU91113XbbLkLHzbIUpXgev/tv8NH+i906VGQqhVFGhzmK9ihUdtCgk8Q7svYMGVQlFqnbKal3pQF3bSUFo2bJl+IDXPw/+AETBRMZtx//eKVzIKmDQ+tB7lttO1jMeAKoiRe+3qrIUrIoCg3PPPdd15hxNSKPHRNoWxd/Zs7+TaR2UadvzKkuyowM3r9JA4ZM3z7nZBmJNFV7+ZVAVjHjrLKv39Eg+75Ho9RQe+edLFWoZ13lu6XPmDV+vg3ivgignXhCvfYVXzZfVMvvDqqDfM+91FPL+97//DVeuKej1KOj2eCcZPP5qUP90/s6u9dxetZi+J/r16xe+3wue/FV/Xpiq90wnGUSVdNq3a1+4YMGCdI+ZMGGCC+X0+qrWyzifWc2jOtn+8ssv3X7QX8EXSaxe17/cCrk1vda/Ku5UMaYQVft4heCRZHwuPYfXSXtO74cXEnu07N6+OCfRbgeRpvdPm9V85hTKAYBQKQUARagJX6T/Y0k/MtWcxTvbqzPPH330kfvR7R2IxvqHZlZngTNWvWhePHl5fa9qQWfEVaXjhVKNGzcON5+LRFU2/jPCWY2u9/XXX4eve5U5ouYkChFFZ+RVxeBVaqg6KKez+rlZVxmbXwTJC9/Ef0AUaRS8aN+7nKoS/OGIv+mIdOjQwR0MqxJGo1aVLVvWNY9UuKuQKZpQw7895rQt6kA0P+WmUiPI9zXW72l2slq3/ttUNeOJZXWGF4xpZLtoq+yCes8UfGq7ViCldaLAQgGMn1eFKF6lqEdhuCdj89aff/7ZBeVeIDV48GDXXM5PYa0+Yx6vUjXj9YyVp1mJNJ9ZzaPXLFqfdW2rWnb//Ovxui3jqIJH+roePbeCc1WoKqTzRtITr/Ixu/2K/zOV29f0wmAv6FM1ppru5la020Fu1ouqAzN+b3v7ZP9+GgAyIpQCgCLgvPPOC4ccavqhg+38ouYZ6iNDmjVrZvfdd597fVUVqOlLVryDQq8Cwe+kk04KX1cI4DUj8F+8Pmii5X/ujMNRZ9X8xmvOpWaJ3sFVTlVS3g9+/zpXpZX/QFzXdZtHTYH8Q5J7TWm0ftQEzDtAVdNMj95fbz2eeOKJrilKxvWkwNDfbCqoECQ/+N87NUXNarvQetK6zI6/0sXfjEz0HOorTCGrKilUAeEdSKt6KqumkHml98zzxRdfpDsoU7VXbujAzTuoU5M5zW/GdaLQRVUdOcnuM5mfYv1513Dy/mXw90elfVLGAM1/kJzV+6vPmReyaf5y+96o2kWPU5WImsj6K5/8y6wAP6tlXrduXZYhX6zeHzUtbNeunavYVGiqJo9Z9cmmqlHv9RVieft6/fWq+RTA+fvYU39pCqS8ZVCTPa9fQT89r/9xXr9dGa97Qfz8+fMzrSdVK4m/OtJrNun1zefJa995sXpd7aO9ZoyR9sc5VRVrWq9Jam5e00/9S2o/JmpqG021rJqFe58bBY5eZZ3Whdcc0P+6uVkvGSta1Q+i976rry0AiITmewAQIzp40tnjjBTqZDx76HWs66cDLPUZFemHqzoZ1o9FNWfJbYl+dtQviv9gzmuKpeZmClR0kKK+NzSvqsRRZ+ORDqC0fAqsdMZaVSg6K67HqL8UBTJeFZGa2Knpi5pQqSmIDgjVF486nvYOCqKhUMfrzFpNJnSAoAMzBWvqw0UdU3tn6NXcUa+vjpe95j+56U/Ko75d1MeRfmjroFrNUlR9pfdGzUe8A21VSWXsB0b9fKiKQPM1d+7ccJMPf19LOqBQf1iqotLBn6qr9PyqtNJBgw4YVaWhgwD/WeuiSs2A1A+XDqJ1AK3l120KXdQHit4jbTc5dZDrP6BT8OQ/eFNTKq/JkQ6EdbDur3LJ2GzlSCio0Gfd6ztMn5cWLVq45lNe/2E50edaIak6LlZzOQWhWgaFVarwWrVqldsG1Lm/guLsZPeZzE+x/rxr21doqWau+ox5n119frz+c/wd3KvJlAI9BZTeIAh+3udMIba2NV1Xn3XaPhRUaxvKql8prx8l9TuloFGvrf2xBjPQMnv7IfVnp2ZrWs/attXBt15Lr/PQQw+5afzfB9pWVI2iwPz00093y6WwwesMXY/JqV8pVWBqfrywWxVB2kfodo8GIdD+Xv3VaVvVflD93ml7U4WNgk6vgkl9onnVlwqkVNHp9bmkZVX44H9uhXJec3JVJXr7QoX/2u8pKNR2K/pu6dy5c7bL4z2POtDXd476ptP8aF/rdbyv4MzraF7L7g0+4NG27w2QoX2ownxVS8bydfWZVMinEx5qjqj9mZpy6rvVo31ATm677bZw82V9NvR6Wmf6XhFtz/4TGKL9jL9D9+w6ONe2oM+R9zjve0rvu3eCRduBBgrRtqr3XPRbQ78JvO1a61DbmOZLTZJr1qzpHuNfDj/tu719rH8/DQCZFPTwfwBQlGU3/HrGIeD9wzJnNxS5fxjz1q1bZ/v6/iHL33///RznN6d59YZN79u3b6b7NKR31apVMw0tLd26dYv4XPv37892iPiMw7hnHL4+q2X11qnodXJa9x4NXe6/v1WrVqFovP7666Hk5OSIr6f73njjjSwf26dPn3TTXnHFFZmm0fDaxx13XK62p0jD3ed1+430HFkNJx7ptSMNZe9/Hf97PWPGjPCQ4VldMm4DWdGw49WrV3fTd+nSJd19vXr1ivjcZcqUCa1bty7b+Y60zUVanjvvvDPT62i4d/869J7HP2S999mX33//Pd2w9FldtP5zkt1nMtrlzWobkKzep2g/71nxb18nnHBCKDExMdNzPPLII+HpDxw4EKpdu3amaRo1apTldprd58z/XmS1Pm655Zbwbc2aNQvt2rXL3d6jR49sl9m/nlesWBFKSEiI+NmO9P4cyfeQf5vZsGFDxOXXety4cWN4Wv+85Pb9vPrqqyNO+/zzz+e4PLlZrhEjRmT7WP/nq1q1arl+zWhe1/8aWV2OOuqo0GeffZar14z0PabtZOLEiZmmnzNnTq5/J0T6/Grbbdq0aZavW7FiRbed+o0fPz7L7VYX7WszeuKJJ8L3r1q1KlfrAUB8ovkeACDLpio6264qAJ2lVdWOzn5HGkVMoyupU+OsRqXTGVlVhanjdHVSrLPWOluu6gCdMddZV52ZzytVFaiyQX2pqBJAr6cmjjqjn7FCTWfUdXbXk5ume36qqlK1iprFqDpA60MXXddtqiy75pprsnxsxjPdGf8XzbcqolSNoTPRWk9aX7qus/HqByvaPqgKM42opg6kdRZe1TSqFlFVkKoO1InylClTcnwOVT9561JVaF4nxaJtQFU2DRo0cNuGqhxU0aGqF1VMec2/YkVVOqpq0Tam905VW2rO5d8O/X3uZEUVH6qGU5WHms9q+9JjVHmjyjr1IXPGGWfkOC/ZfSbzU6w/71qH2u5V5aIqIlV8qQmmqpE82m6mTp3qmo7p9bUtafTDSIM1eJ8zVXF5nzPt57Td+asXs6LqFG90S1WEqbJU1ZPqR0gVfxn3Q5pW8+FvSqeqJU2rpqcZOwcPgvYhamKqpsQasEHrT3/1v0YlzTiIQ7RUmacKHC2ntw9TBauqgXLTEblHn6U33njDva/qQFsXXdfgBapuyy+5fV3tq7QN6fOo/Yr2Rfqsqp9C9eW1YsWKdAMGZEdVfeoDTNug1pn6mdK2o32af1RTj6opc1MllR29hvaD+r7R51PbrJZDVYnaPvT++al6T9XCmi+9p9o36XOpz4TXD6WfVx2niiutEwCIJEHJVMR7AQAoZrymKmoqpeYXCt5QtGmkKzXhUp9bOliL5sA3lvSTKmP/XmqyqXBCfb8ocNL/sWh+CwCFlZrCqt8qUZgXaSROABB+FQEAij2FBeqjR5UNXofo6meIQKp4UOWHNyLl6NGjC2wYclUYDhkyxPV7pKBM/e6o8sbrjPiqq64ikAJQ7Gk/LKq20n4PALJDpRQAoNhTx9n+IbVVzfLxxx9nGi0IONJmP2o2lhU11VJTGXX8DAAAgP+HSikAQNxQn0LqX2jSpEkEUog5jYinfpPUJ4/6Z1E/RepzRaNWqa8eAikAAID0qJQCAAAAAABA4KiUAgAAAAAAQOAIpQAAAAAAABC4pOBfsnhKS0uzTZs22VFHHZVpOGgAAAAAAIB4EQqFbPfu3VazZs1sRx8mlIoRBVIakhoAAAAAAABmv/zyix133HGEUvlNFVLeCk9JSWHbQ9xVCm7fvt2qVKmSbQoOAMh/7JMBoHBgf4x4lpqa6gp3vKwkEiqlYsRrsqdAilAK8fiFu2/fPrftE0oBQMFinwwAhQP7Y8By7N6IkgYAAAAAAAAEjlAKAAAAAAAAgSOUAgAAAAAAQODoUwoAAAAAAMDn8OHDdvDgQdZJBCVLlrQSJUrYkSKUAgAAAAAAMLNQKGRbtmyxnTt3sj5yULFiRatevXqOnZlnh1AKAAAAAADALBxIVa1a1cqWLXtEgUtxDu7++OMP27Ztm/u/Ro0aeX4uQikAAAAAABD31GTPC6QqVaoU9+sjO2XKlHF/FUxpfeW1KR8dnQMAAAAAgLjn9SGlCinkzFtPR9L3FqEUAAAAAADA/9BkL7j1RCgFAAAAAACAwBFKAQAAAAAAIHB0dA4AAAAAAJCN4wfPCGz9/PT3zlE/5qabbrKJEye66yVLlrTatWtbjx497P7777eNGzda3bp1Mz1myZIldsYZZ4T/nzJliv3tb3+zn376yerXr2+PPfaYderUyfIToRQAAIXVsAoFPQcokhLNUpqapa4ws7SCnhkUJcN2FfQcAACOwEUXXWQTJkyw/fv328yZM61v374uoLruuuvc/R988IE1btw4PL1/hMHFixe76UaOHGldunSxSZMmWdeuXe3LL7+0U045xfILzfcAAAAAAACKuNKlS1v16tWtTp061qdPH2vfvr2999576UIo3e9dFFh5xowZ40KtgQMHWqNGjWzEiBHWokULe+655/J1ngmlAAAAAAAAipkyZcrYgQMHwv9feumlVrVqVTvrrLPShVVeUz6FWH4dO3Z0t+cnQikAAAAAAIBiIhQKuaZ6s2fPtvPPP9/Kly9vo0aNcn1GzZgxw4VSaprnD6a2bNli1apVS/c8+l+35yf6lAIAAAAAACjipk+f7gKogwcPWlpamnXv3t2GDRtm5cqVswEDBoSnO/30023Tpk32xBNPuOqpgkQoBQAAAAAAUMS1a9fOXnjhBStVqpTVrFnTkpIiRz6tW7e2uXPnhv9XH1Nbt25NN43+1+35ieZ7AAAAAAAARVy5cuWsXr16Vrt27WwDKVm+fLnVqFEj/H+bNm1s3rx56aZRaKXb8xOVUgAAAAAAAMXUxIkTXfVU8+bN3f9vv/22jR8/3l566aXwNHfddZede+65ru+pzp072xtvvGFLly61F198MV/njVAKAAAAAACgGBsxYoT9/PPProKqYcOGNnnyZLvyyivD97dt29YmTZpkDz74oN1///1Wv359mzp1qp1yyin5Ol8JIXXLjiOWmppqFSpUsF27dllKSgprFHFFneht27bNDS+amEirYCBmhlVgZSL6fbIl2raUplY1dYUlWhprEFHsc3axtoAY4jdy0bNv3z5bv3691a1b15KTkwt6dor0+sptRsLRIwAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAJQX/kgAAAAAAAEXIsAoBvtauqB9y00032cSJE931kiVLWu3ata1Hjx52//33W1JSkr355pv26KOP2nfffWdVqlSxfv362cCBA8OPnz9/vrVr1y7T827evNmqV69u+YVQCgAAAAAAoIi76KKLbMKECbZ//36bOXOm9e3b1wVUp556ql1//fX27LPPWocOHezbb7+1W2+91cqUKePCKb+1a9daSkpK+P+qVavm6zwTSgEAAAAAABRxpUuXDlc19enTx9555x177733bOXKlda1a1e77bbb3H0nnHCCDRkyxB577DEXXCUkJKQLoSpWrBjYPNOnFAAAAAAAQDFTpkwZO3DggKucSk5OznTfxo0b7eeff053u6qqatSoYRdeeKEtWrQo3+eRUAoAAAAAAKCYCIVC9sEHH9js2bPt/PPPt44dO9rbb79t8+bNs7S0NNev1KhRo8J9RomCqHHjxtlbb73lLrVq1bLzzjvPvvzyy3ydV5rvAQAAAAAAFHHTp0+38uXL28GDB1341L17dxs2bJiVLVvW1q1bZ126dHH3qc+ou+66y92XmPj/apUaNGjgLp62bdu6xzz99NP2r3/9K9/mmUopAAAAAACAIq5du3a2fPly+/777+3PP/90o/GVK1fO9Rml/qP27Nnjmutt2bLFWrVqFe5fKhJN88MPP+TrPFMpBQAAAAAAUMSVK1fO6tWrF/H+EiVK2LHHHuuuv/7669amTRurUqVKxOkVcKlZX34ilAIAAAAAACimfv31V/vPf/7j+ojat2+fTZgwwaZMmWILFiwITzN69GirW7euNW7c2E3z0ksv2Ycffmhz5szJ13kjlAIAAAAAACjGJk6caPfee6/rBF0VUvPnzw834RON0nfPPffYf//7X9cHVdOmTV1n6WoSmJ8IpQAAAAAAALIzbFehXj+vvPJKxPsqV65sS5YsyfbxgwYNcpeg0dE5AAAAAAAAAkcoBQAAAAAAgMARSgEAAAAAACBwhFIAAAAAAAAIHKEUAAAAAAAA4iuUGjlypJ1++ul21FFHWdWqVa1r1662du3adNPs27fP+vbta5UqVbLy5ctbt27dbOvWremm2bBhg3Xu3NkNW6jnGThwoB06dCjdNBrusEWLFla6dGmrV69elj3Tjx071o4//nhLTk621q1b2+eff55PSw4AAAAAABDfCjSUWrBggQucPv30U5s7d64dPHjQOnToYHv37g1P079/f5s2bZpNmTLFTb9p0ya74oorwvcfPnzYBVIHDhywxYsX28SJE13gNHTo0PA069evd9O0a9fOli9fbnfffbfdcsstNnv27PA0kydPtgEDBthDDz1kX375pTVr1sw6duxo27ZtC3CNAAAAAAAAxIeEUCgUskJi+/btrtJJ4dM555xju3btsipVqtikSZPsyiuvdNOsWbPGGjVqZEuWLLEzzjjD3n//fevSpYsLq6pVq+amGTdunN13333u+UqVKuWuz5gxw1atWhV+rWuvvdZ27txps2bNcv+rMkpVW88995z7Py0tzWrVqmV33HGHDR48OMd5T01NtQoVKrh5TklJyac1BBRO+rwowNXnNzGRVsFAzAyrwMpE9PtkS7RtKU2tauoKS7Q01iCi2OfsYm0BMcRv5KJHLbVU1FK3bl3Xggp5X1+5zUiSrBDRzMoxxxzj/i5btsxVT7Vv3z48TcOGDa127drhUEp/mzRpEg6kRBVOffr0sdWrV1vz5s3dNP7n8KZRxZSoykqvNWTIkPD9OrDWY/TYrOzfv99d/Cvc2/HoAsQTbfPKt9n2gVgj5EXeQqmQJbi/QHQbD79hgVjiN3LRfc+8C7LnraescpDcHhsWmlBKM6yQ6Mwzz7RTTjnF3bZlyxZX6VSxYsV00yqA0n3eNP5Ayrvfuy+7aRQk/fnnn/b777+7ZoBZTaPKrEj9YQ0fPjzT7arOUloIxBN9fhUqa4dEpRQQQylNWZ2Ifp9sibar7PEumKJSClGh2wogpviNXPSoKEbvm/qozthPNTLTOtL62rFjh5UsWTLdfbt377YiFUqpbyk1r/vkk0+sKFBVlfqg8ijgUnM/NTek+R7ijXZECQkJbvsnlAJiKHUFqxPR75Mt0RIsZFVSVxJKITpVq7LGgBjiN3LRowIThSlJSUnu4tf01eBOFq7okfffgGrtdfbZZ9tFF11k06dPt/ykdaTjPw1Ml7H5Xm6bPxaKUKpfv35uZX388cd23HHHhW+vXr26a1qnvp/81VIafU/3edNkHCXPG53PP03GEfv0v8KjMmXKWIkSJdwlq2m858hIo/jpkpHeEA7KEY8USrH9A7FGUxrkjUIpVUlRKYWo0C8kEHP8Ri5adDyj98y7FJSEI3jt8ePHu76xX375Zdu8ebPVrFnT8ou3nrI6DsxtLlKgnQ2oqY8CqXfeecc+/PBD1zmWX8uWLV0J2Lx588K3rV271jZs2GBt2rRx/+vvypUr042Sp5H8FDidfPLJ4Wn8z+FN4z2HmgjqtfzTKNXW/940AAAAAAAAhdWePXts8uTJro/tzp072yuvvOJu7969u11zzTWZmipWrlzZXn31Vfe/KsSuv/56K1eunNWoUcOefvppO++888J9ceeXxIJusvfvf//bja531FFHub6fdFE/T6Ke2nv16uWayX300UeuM/Kbb77ZBUXq5Fw6dOjgwqcbb7zRvv76a5s9e7Y9+OCD7rm9SqbbbrvNfvzxRxs0aJDrI+r555+3N9980/r37x+eF73GP//5T5s4caJ9++237k3cu3evez0AAAAAAIDC7M0333SDwzVo0MBuuOEGVzWlYiCFTdOmTXOhlUfZyR9//GGXX355OBNZtGiRvffee66IZ+HChfbll1/m+zwXaPO9F154wf1V+uY3YcIEu+mmm9x1pXMq++rWrZsb7U6j5ilU8qjZnZr+KURSWKVUr2fPnvbwww+Hp1EF1owZM1wINWbMGNdE8KWXXnLP5VFqqE7Khw4d6oKxU0891WbNmpWp83MAAAAAAIDC5uWXX3ZhlKhPKQ1GtWDBApd9KCtRKzUV9IiKgy699FJXIKQqKRXo6LYLLrggnMvkZ9O/QhFK5WaIRXWONXbsWHeJpE6dOjZz5sxsn0fB11dffZXtNGpKqAsAAAAAAEBRsXbtWtfftoInrxNyFd8oqFIecvXVV9trr73mQim1Cnv33XftjTfecNOqZZma87Vq1Sr8fGq5poqr/FYoOjoHAAAAAABA3ih8OnToULrqJhUCqVuj5557zjXhO/fcc11/3Gqep0HfVE1V0Aq0TykAAAAAAADkncIodVg+atQoW758efiifrcVUr3++uvWtm1bq1WrlusIXRVTV111lRtYTk444QR3/Ysvvgg/p5r+fffdd5bfqJQCAAAAAAAooqZPn26///67GyhOze781D+3qqg0AJxG4Rs3bpwLmzSYnEf9Sqlv7oEDB9oxxxxjVatWtYceesj1752QkJCv806lFAAAAAAAQBH18ssvW/v27TMFUl4otXTpUluxYoVrwvfNN9/Ysccea2eeeWa66Z566ik3eFyXLl3cc+n+Ro0auX6+8xOVUgAAAAAAANlY2XNloV0/06ZNi3ifOi/3DzIXacA5VUupWZ9HnaEPHz7cevfubfmJUAoAAAAAACCOffXVV7ZmzRoXYqk/qYcfftjdftlll+Xr6xJKAQAAAAAAxLknn3zS1q5da6VKlbKWLVvawoULrXLlyvn6moRSAAAAAAAAcax58+a2bNmywF+Xjs4BAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAA4H/S0tJYFwGtJ/qUAgAAAAAAcU8dfCcmJtqmTZusSpUq7v+EhIS4Xy8ZhUIhO3DggG3fvt2tL62nvCKUAgAAAAAAcU8BS926dW3z5s0umEL2ypYta7Vr13brLa8IpQAAAAAAAMxc1Y+ClkOHDtnhw4dZJxGUKFHCkpKSjriSjFAKAAAAAADgfxS0lCxZ0l2Qv+joHAAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEB8hVIff/yxXXLJJVazZk1LSEiwqVOnprv/pptucrf7LxdddFG6aX777Te7/vrrLSUlxSpWrGi9evWyPXv2pJtmxYoVdvbZZ1tycrLVqlXLHn/88UzzMmXKFGvYsKGbpkmTJjZz5sx8WmoAAAAAAAAUaCi1d+9ea9asmY0dOzbiNAqhNm/eHL68/vrr6e5XILV69WqbO3euTZ8+3QVdvXv3Dt+fmppqHTp0sDp16tiyZcvsiSeesGHDhtmLL74Ynmbx4sV23XXXuUDrq6++sq5du7rLqlWr8mnJAQAAAAAA4ltSQb74xRdf7C7ZKV26tFWvXj3L+7799lubNWuWffHFF3baaae525599lnr1KmTPfnkk64C67XXXrMDBw7Y+PHjrVSpUta4cWNbvny5PfXUU+HwasyYMS78GjhwoPt/xIgRLuR67rnnbNy4cTFfbgAAAAAAgHhXoKFUbsyfP9+qVq1qRx99tJ1//vn2yCOPWKVKldx9S5YscU32vEBK2rdvb4mJifbZZ5/Z5Zdf7qY555xzXCDl6dixoz322GP2+++/u+fVNAMGDEj3upomY3NCv/3797uLvyJL0tLS3AWIJ9rmQ6EQ2z4Qc3T9iOilWaKFLMH9BaLbePgNC8QSv5ERz9Jy+Z1SqEMpVS9dccUVVrduXVu3bp3df//9rrJKIVKJEiVsy5YtLrDyS0pKsmOOOcbdJ/qrx/tVq1YtfJ9CKf31bvNP4z1HVkaOHGnDhw/PdPv27dtt3759R7TcQFHc4ezatcsFUwqFAcRISlNWJaLfJ1ui7Sp7vAumEo2QAVHYto3VBcQQv5ERz3bv3l30Q6lrr702fF2djzdt2tROPPFEVz11wQUXFOi8DRkyJF11lSql1Il6lSpVXKfrQLx94WogAm3/hFJADKWuYHUi+n2yJVqChaxK6kpCKUQnw8leAEeG38iIZ8nJyUU/lMrohBNOsMqVK9sPP/zgQin1NbUtwxmdQ4cOuRH5vH6o9Hfr1q3ppvH+z2maSH1ZeX1d6ZKRDsg5KEc8UijF9g/EGlUuyBuFUqqSolIKUaHaGYg5fiMjXiXm8julSLWz2bhxo+3YscNq1Kjh/m/Tpo3t3LnTjarn+fDDD10i3bp16/A0GpHv4MGD4WnUiXmDBg1c0z1vmnnz5qV7LU2j2wEAAAAAABB7BRpK7dmzx42Ep4usX7/eXd+wYYO7T6Phffrpp/bTTz+50Oiyyy6zevXquU7IpVGjRq7fqVtvvdU+//xzW7RokfXr1881+9PIe9K9e3fXyXmvXr1s9erVNnnyZDfanr/p3V133eVG8Rs1apStWbPGhg0bZkuXLnXPBQAAAAAAgGIWSin4ad68ubuIgiJdHzp0qOvIfMWKFXbppZfaSSed5EKlli1b2sKFC9M1m3vttdesYcOGrjlfp06d7KyzzrIXX3wxfH+FChVszpw5LvDS4++55x73/L179w5P07ZtW5s0aZJ7XLNmzew///mPG3nvlFNOCXiNAAAAAAAAxIeEkIbLwhFTR+cKwDQCGR2dI96oyaz6d9NomPSpBsTQsAqsTkS/T7ZE25bS1KqmrqBPKUS5z9nFGgNiiN/IiGepucxIilSfUgAAAAAAACgeCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAAEDgCKUAAAAAAABQNEKpiRMn2owZM8L/Dxo0yCpWrGht27a1n3/+OZbzBwAAAAAAgGIoT6HUo48+amXKlHHXlyxZYmPHjrXHH3/cKleubP3794/1PAIAAAAAAKCYScrLg3755RerV6+euz516lTr1q2b9e7d284880w777zzYj2PAAAAAAAAKGbyVClVvnx527Fjh7s+Z84cu/DCC9315ORk+/PPP2M7hwAAAAAAACh28lQppRDqlltusebNm9t3331nnTp1crevXr3a6tSpE+t5BAAAAAAAQDGTp0op9SHVpk0b2759u7311ltWqVIld/uyZcuse/fusZ5HAAAAAAAAFDN5qpTSSHtPPvmkrVixwrZt22bvvfeeu71ly5axnj8AAAAAAAAUQ3kKpWbNmmU9evRw/UqFQqF09yUkJNjhw4djNX8AAAAAAAAohvLUfO+OO+6wq666yjZt2mRpaWnpLgRSAAAAAAAAyJdQauvWrTZgwACrVq1aXh4OAAAAAACAOJenUOrKK6+0+fPnx35uAAAAAAAAEBfy1KfUc88955rvLVy40Jo0aWIlS5ZMd/+dd94Zq/kDAAAAAABAMZSnUOr111+3OXPmWHJysquYUufmHl0nlAIAAAAAAEDMQ6kHHnjAhg8fboMHD7bExDy1AAQAAAAAAEAcy1OidODAAbvmmmsIpAAAAAAAABBcKNWzZ0+bPHly3l4RAAAAAAAAcS9PzfcOHz5sjz/+uM2ePduaNm2aqaPzp556Ku5XLAAAAAAAAGIcSq1cudKaN2/urq9atSrdff5OzwEAAAAAAICYhVIfffRRXh4GAAAAAAAAOAydBwAAAAAAgMARSgEAAAAAACBwhFIAAAAAAAAIHKEUAAAAAAAAAkcoBQAAAAAAgMARSgEAAAAAACBwhFIAAAAAAAAIHKEUAAAAAAAAAkcoBQAAAAAAgMARSgEAAAAAACBwhFIAAAAAAACIr1Dq448/tksuucRq1qxpCQkJNnXq1HT3h0IhGzp0qNWoUcPKlClj7du3t++//z7dNL/99ptdf/31lpKSYhUrVrRevXrZnj170k2zYsUKO/vssy05Odlq1apljz/+eKZ5mTJlijVs2NBN06RJE5s5c2Y+LTUAAAAAAAAKNJTau3evNWvWzMaOHZvl/QqPnnnmGRs3bpx99tlnVq5cOevYsaPt27cvPI0CqdWrV9vcuXNt+vTpLujq3bt3+P7U1FTr0KGD1alTx5YtW2ZPPPGEDRs2zF588cXwNIsXL7brrrvOBVpfffWVde3a1V1WrVqVz2sAAAAAAAAgPiWEVI5UCKhS6p133nFhkGi2VEF1zz332L333utu27Vrl1WrVs1eeeUVu/baa+3bb7+1k08+2b744gs77bTT3DSzZs2yTp062caNG93jX3jhBXvggQdsy5YtVqpUKTfN4MGDXVXWmjVr3P/XXHONC8gUannOOOMMO/XUU10glhsKvypUqODmUVVbQDxJS0uzbdu2WdWqVS0xkVbBQMwMq8DKRPT7ZEu0bSlNrWrqCku0NNYgotjn7GJtATHEb2TEs9RcZiSF9uhx/fr1LkhSkz2PFqh169a2ZMkS97/+qsmeF0iJptdBsSqrvGnOOeeccCAlqrZau3at/f777+Fp/K/jTeO9DgAAAAAAAGIryQopBVKiyig//e/dp7+qzPBLSkqyY445Jt00devWzfQc3n1HH320+5vd62Rl//797uJPAb00XBcgnmibV3Uj2z4Qa4X23BEKeaVUyBLcXyC6jYffsEBM98f8RkYcS8vld0qhDaUKu5EjR9rw4cMz3b59+/Z0fV4B8bLDUVmmgima7wExlNKU1Yno98mWaLvKHu+CKZrvISrbtrHCgBjiNzLi2e7du4t2KFW9enX3d+vWrW70PY/+V19P3jTqx8bv0KFDbkQ+7/H6q8f4ef/nNI13f1aGDBliAwYMSFcppZH9qlSpQp9SiMsvXPULp+2fUAqIodQVrE5Ev0+2REuwkFVJXUkohehkaIEA4MjwGxnxLDk5uWiHUmpyp1Bo3rx54RBKwY/6iurTp4/7v02bNrZz5043ql7Lli3dbR9++KH78KvvKW8adXR+8OBBK1mypLtNI/U1aNDANd3zptHr3H333eHX1zS6PZLSpUu7S0Y6IOegHPFIoRTbPxBrNKVB3iiUUpUUlVKICoOVADHHb2TEq8RcfqcUaGcDe/bsseXLl7uL17m5rm/YsMF9eBUSPfLII/bee+/ZypUrrUePHm5EPW+EvkaNGtlFF11kt956q33++ee2aNEi69evnxuZT9NJ9+7dXSfnvXr1stWrV9vkyZNtzJgx6aqc7rrrLjdq36hRo9yIfMOGDbOlS5e65wIAAAAAAEDsFWillIKfdu3ahf/3gqKePXvaK6+8YoMGDbK9e/da7969XUXUWWed5cIjfxnYa6+95sKjCy64wCVx3bp1s2eeeSbdiH1z5syxvn37umqqypUr29ChQ91zetq2bWuTJk2yBx980O6//36rX7++TZ061U455ZTA1gUAAAAAAEA8SQipZ2IcMTUtVACmzp5TUlJYo4grajKr/t00GibNV4EYGlaB1Yno98mWaNtSmlrV1BU030OU+5xdrDEghviNjHiWmsuMhLGCAQAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4JKCf0kAAAAAKDqaTGxS0LOAIijREq1+Un37/tD3lmZpBT07KEJW9lxp8YJKKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAEDhCKQAAAAAAAASOUAoAAAAAAACBI5QCAAAAAABA4AilAAAAAAAAELhCHUoNGzbMEhIS0l0aNmwYvn/fvn3Wt29fq1SpkpUvX966detmW7duTfccGzZssM6dO1vZsmWtatWqNnDgQDt06FC6aebPn28tWrSw0qVLW7169eyVV14JbBkBAAAAAADiUaEOpaRx48a2efPm8OWTTz4J39e/f3+bNm2aTZkyxRYsWGCbNm2yK664Inz/4cOHXSB14MABW7x4sU2cONEFTkOHDg1Ps379ejdNu3btbPny5Xb33XfbLbfcYrNnzw58WQEAAAAAAOJFkhVySUlJVr169Uy379q1y15++WWbNGmSnX/++e62CRMmWKNGjezTTz+1M844w+bMmWPffPONffDBB1atWjU79dRTbcSIEXbfffe5KqxSpUrZuHHjrG7dujZq1Cj3HHq8gq+nn37aOnbsGPjyAgAAAAAAxINCH0p9//33VrNmTUtOTrY2bdrYyJEjrXbt2rZs2TI7ePCgtW/fPjytmvbpviVLlrhQSn+bNGniAimPgqY+ffrY6tWrrXnz5m4a/3N406hiKjv79+93F09qaqr7m5aW5i5APNE2HwqF2PaB+CtoRiGUZokWsgT3F4hu4+E3bCSJfJ6Qx+0mwRLYfhC1tGKwP87tMhTqUKp169auuV2DBg1c073hw4fb2WefbatWrbItW7a4SqeKFSume4wCKN0n+usPpLz7vfuym0Yh059//mllypTJct4Ujml+Mtq+fbvr6wqIJ9rhqHpRwVRiIgdBQMykNGVlIvp9siXarrLHu2Aq0Yr+j1oEaNs2VncE9ZPqs26Qp1CqZomaLphKY3+MqHbH24r8+tq9e3fRD6Uuvvji8PWmTZu6kKpOnTr25ptvRgyLgjJkyBAbMGBA+H+FWLVq1bIqVapYSkpKgc4bUBChlAYi0PZPKAXEUOoKViei3ye7M/Mhq5K6klAK0alalTUWwfeHvmfdIE+hVMhC9sOhHwilEOXuuGqRX2Nq7VbkQ6mMVBV10kkn2Q8//GAXXnih68B8586d6aqlNPqe1weV/n7++efpnsMbnc8/TcYR+/S/gqXsgi+N1KdLRjog56Ac8UihFNs/EGtUuSBvFEqpSopKKUSFauds9sbsj5E3CqW0/bANIbrdcWLcLEORWtI9e/bYunXrrEaNGtayZUsrWbKkzZs3L3z/2rVrbcOGDa7vKdHflStXpit9mzt3rgucTj755PA0/ufwpvGeAwAAAAAAALFXqEOpe++91xYsWGA//fSTLV682C6//HIrUaKEXXfddVahQgXr1auXa0L30UcfuY7Pb775ZhcmqZNz6dChgwufbrzxRvv6669t9uzZ9uCDD1rfvn3DVU633Xab/fjjjzZo0CBbs2aNPf/88655YP/+/Qt46QEAAAAAAIqvQt18b+PGjS6A2rFjh+ur5qyzzrJPP/3UXZenn37alYR169bNjYSnUfMUKnkUYE2fPt2Ntqewqly5ctazZ097+OGHw9PUrVvXZsyY4UKoMWPG2HHHHWcvvfSSey4AAAAAAADkj4SQhsvCEVNH56re0ghkdHSOeOzoXM1k1SFfcWj/DBQawyoU9BygCFJPUttSmlrV1BX0KYXoDNvFGougycQmrBvkqaNzjdyojvLpUwrRWNlzZdxkJBw9AgAAAAAAIHCEUgAAAAAAAAgcoRQAAAAAAAACRygFAAAAAACAwBFKAQAAAAAAIHCEUgAAAAAAAAgcoRQAAAAAAAACRygFAAAAAACAwCUF/5Io7I4fPKOgZwFFTKKFrNHRIfv29wRLs4SCnh0UMT/9vXNBzwIAAACAAkClFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSAAAAAAAACByhFAAAAAAAAAJHKAUAAAAAAIDAEUoBAAAAAAAgcIRSGYwdO9aOP/54S05OttatW9vnn38e/LsCAAAAAABQzBFK+UyePNkGDBhgDz30kH355ZfWrFkz69ixo23btq3g3iEAAAAAAIBiiFDK56mnnrJbb73Vbr75Zjv55JNt3LhxVrZsWRs/fnzBvUMAAAAAAADFEKHU/xw4cMCWLVtm7du3//9XTmKi+3/JkiUF9f4AAAAAAAAUS0kFPQOFxa+//mqHDx+2atWqpbtd/69ZsybT9Pv373cXz65du9zfnTt3WlpamhVp+/cW9BygyAnZoX0hs/0JZqYLkHvabyIC95kCopNmCZa677CV2p9gieyTEQ32xxGF/gyxLSFqIf1GLnHIQod1jW0I8fX7ODU11f0NhbLf9gml8mjkyJE2fPjwTLfXqVMnr08JFGnrC3oGUGQdPbqg5wAojhYV9AygKPr70QU9B0Cxs9JWFvQsoAg6uk/x2R/v3r3bKlSoEPF+Qqn/qVy5spUoUcK2bt2abgXp/+rVq2dacUOGDHGdontUHfXbb79ZpUqVLCGBM9uIL0rBa9WqZb/88oulpKQU9OwAQFxjnwwAhQP7Y8SzUCjkAqmaNWtmOx2h1P+UKlXKWrZsafPmzbOuXbuGgyb9369fv0wrrnTp0u7iV7Fixdi9g0ARpECKUAoACgf2yQBQOLA/RryqkE2FlIdQykeVTz179rTTTjvNWrVqZaNHj7a9e/e60fgAAAAAAAAQO4RSPtdcc41t377dhg4dalu2bLFTTz3VZs2alanzcwAAAAAAABwZQqkM1FQvq+Z6ACJTU9aHHnooU5NWAEDw2CcDQOHA/hjIWUIop/H5AAAAAAAAgBhLjPUTAgAAAAAAADkhlAIAAAAAAEDgCKUAAAAAAAAQOEIpAAAAAAAABI5QCgAAAAAAAIEjlAIAAAAAIBcYvB6ILUIpALnCFzAAFIxffvnFDh48yOoHgELwezghIcFd/+9//1vQswMUC4RSADJZv369TZw40f7+97/b0qVLbdeuXe4LOC0tjbUFAAH6+uuvrU6dOvbuu++y3gGgAOl3sBdITZo0yW6//Xb7/PPPeU+AI0QoBSCdVatW2emnn24TJkywp556ynr27Gk33HCDbdiwwRITEwmmACDAQOqss86ygQMH2pVXXpnpfipYASC4QEq/g2XRokU2a9Ys++STT2zUqFH25Zdf8jYAR4BQCkDYn3/+aXfeeadde+21NmfOHNu2bZsNGjTI3d6hQwf76aefCKYAIADffPONtW7d2u6991577LHHXAClM/Jvvvmmuy81NZUKVgAIiBdIDRgwwJ2wrVKlinXq1Mnef/99e/zxx6mYAo5AQojTbAD+5/fff7czzzzTHnjgAbv++uvDZ4aWLFliDz30kLt/+vTpVqNGDdYZAOSTQ4cO2T333GPPPvusaz591FFH2YUXXmi//vqrrV692k444QRr3Lixu79mzZq8DwAQAFVIXXHFFfbOO+9Y27Zt3W1TpkyxRx55xE466SQbMmSItWjRgvcCiBKVUgDCUlJSrHr16i6E8vJqnRlSUDV48GBLTk625557jiYjAJCPkpKS7O6777YuXbrYiSeeaGeccYaVL1/e/vGPf7gKVjXn27p1qztZcODAAd4LAMgHGftS1W9iXUqXLh2+7aqrrnJh1Ntvv03FFJBHhFJAnNu7d2/4S7dEiRIugFq8eLF9+OGH6cKn9u3bu76m1IaeDs8BIH/VrVvXnQQ4++yzXfD05JNPWqtWraxixYrWq1cvO++882zhwoVuHw4AyL8me+rfTyOg6n9Vsnqj7nmjol5zzTXWsGFD1y/ryy+/zKh8QJQIpYA4tmzZMncGXn1FeQGUmu7pLL36Mfn000/TDUN+wQUXuP6l1IwPABA7mzdvtrlz59qCBQtcn1FSu3Zte/rpp92gE7ouhw8fdn91AKQTCd5BEwAg9qZNm+ZOzCqMUj9/Xbt2tZtvvtm++uorK1mypJtmx44ddtppp9lNN91kkydPdr+vAeQev2SAOKWzPjrTrov6J/GGuFUTvY8++sj27dtn/fr1c1+uXjXVBx98YBUqVLAyZcoU9OwDQLGxcuVKd4LgwQcftN69e7sTAAqjFEApjNJ+2jv4URAlamZdr169dM1IAACx1blzZ1ehqv2zjB492s4//3w3Mqr6knrmmWfcAEE6wasTumpyrc7PAeReUhTTAigmVqxY4ZqE3H777eFRndSB7v79+90BjkYUWbp0qStH1lC3/fv3t6ZNm7ohbxVYlStXrqAXAQCKhU2bNtmll15q3bt3dwc9ahby6quvuo7OVZWqgxz19+evqNJBkU4YzJ8/351IAAAcOZ2A9Vefqum0Tgjceuut7sSs9tcaXEL732HDhtmMGTPsjz/+sDp16riRUUW/oxs0aMDbAUSB0feAOLN79253dl3Bk9q+6wtYI+3pDM+3337r+o3661//aldeeaX7MlYJ8meffWaVKlVyI43oDBAAIDbmzZtnw4cPt5kzZ7rOzEUHP5dffrk72Bk6dKjr0FzUtO+VV16xjz/+2N566y079dRTeRsAIMb0e7hRo0bh/9esWeOqWUeMGGF33HFH+HaNjqoQyjs58Le//c3Gjx/v9tX6rQ0gd6iUAuKMhhZ/9NFH3ZeqDoQ++eQTVymlkZ727Nnj/lcFlaqhLr74YmvTpo27AABiT82jVYW6fv16a9KkibvtmGOOcfvfli1buoMcVbaquYgGokhNTXX7bq+PKQBA7CqkpkyZYvfff787Sfvwww+7k7jqw08j7L300kvWoUOHcCWUqljV/cV3333nWha8++67rukegRQQHSqlgDihJiEKnNRHSfPmzd1Zn27durnASV+ilStXdtP98MMP1rdvXzvppJNcnybe8LcAgNjuj3UgpMEktA+uUaOGa8anvksUSGmEPZ1A6Nixo6uaUh9/AIDYeuONN2zOnDk2ePBgq1+/vuvOQk2jR44c6VoMnHzyyW4QIFWuDhw40DWt1j7ZH2Tt3LnTdXuhPlp1ARAdQikgTvqQ0heoSox1NkdfuvqyrVq1qmu2pw4adabH6+z8sssuc+HV9OnTC3rWAaDY7o/XrVvnqqNUmar9sQ6MypYta9ddd50bcU/Uma4Oil588cWCnnUAKFZUedqiRQv3t1q1am4EPVVCaR8s6ifKC610wvaf//ynHXvssW6wIE7YArFD+QMQBwdAqoZSH1Hqp8Q7I6+SZH0BX3311e6LVYGUmvEpjNJBkb6YAQD5tz9WMxE1DdFQ43369LFFixa5ph9eIKUm1RrxlP0xAMSeTgjod7D6ipo4caI1btzYdWGh29RaQCcQ3n77bdex+bZt29xvZFW3AogtKqWAYuyXX35xZ4DatWsXHhVEdMZ9wIABrtRY7eT9fZtoND6dCVLpMqOHAED+7o/HjRtngwYNcgNK+DvW3bp1qz3//PP2wgsv2OLFi+mjBADygU4EaLRpNanWSNP79u1zTacfeeQRa9asmauaUkhVq1YtV92qAX9KlCiRaaQ+AHnHJwkoxnRGp27durZ//373ZevRbWXKlHFt5T06a6/SZB0gaRQoAikAyP/9sQ5w1JTPvz9WgHXvvffaP/7xD5s9ezaBFADkE/Xhd+ONN7r9rWgkPY1uqq4s2rdvb3PnznX9RKmSSv2tKpDS/pxACogdKqWAYu7777+3O++8053RGT16tDvToy/Xm2++2VVFedRsREPYqvNzAikAKLj9sbdPrl69ugutAAD55+WXX7YJEybYtGnT7IILLnDdWOgErUbX08AUCxcudM2uk5IYuB7ID4RSQJwcCN11111u5BD1adKzZ0/XVl50tkdnfUTt5EuWLFnAcwsA8bk/pjkIABSMVq1auW4tzjnnHNeP1DHHHJNpGvX/RzAFxB7N94A4oNH2xowZ48InnfVRx40ef/kxgRQAFNz+2BsBFQAQDA3yI6piVUfno0aNcoGUd7sfgRSQPwilgDg6EFJ7eXWkqw4c1TREOAgCAPbHABCPvN/BGoRix44drg8p/+0A8h+hFBBH6tWrZ88884yriFInup9++mlBzxIAxCX2xwBQeBx77LE2ZMgQe/LJJ+2bb74p6NkB4gqhFBCHFVNPPPGEHXfccVazZs2Cnh0AiFvsjwGg8OjUqZN17tzZGjZsWNCzAsQVOjoH4pSGHy9VqlRBzwYAxD32xwBQOKgvKTXd8w8EBCB/EUoBAAAAAAAgcDTfAwAAAAAAQOAIpQAAAAAAABA4QikAAAAAAAAEjlAKAAAAAAAAgSOUAgAAAAAAQOAIpQAAAAAAABA4QikAAAAAAAAEjlAKAAAAAAAAgSOUAgAAAAAAQOAIpQAAAAAAAGBB+/8AlXyVZVmmMEgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "resp_lat = llm_events_df[\n",
+    "    (llm_events_df[\"event_type\"] == \"LLM_RESPONSE\") & (llm_events_df[\"total_ms\"].notna())\n",
+    "].copy()\n",
+    "if not resp_lat.empty:\n",
+    "    resp_lat[\"hour\"] = resp_lat[\"timestamp\"].dt.floor(\"h\")\n",
+    "    lat_hourly = resp_lat.groupby(\"hour\").agg(\n",
+    "        p50=pd.NamedAgg(column=\"total_ms\", aggfunc=\"median\"),\n",
+    "        p95=pd.NamedAgg(column=\"total_ms\", aggfunc=lambda x: x.quantile(0.95)),\n",
+    "        avg=pd.NamedAgg(column=\"total_ms\", aggfunc=\"mean\"),\n",
+    "    ).reset_index()\n",
+    "    time_plot(lat_hourly, \"hour\", [\"p50\", \"p95\", \"avg\"],\n",
+    "              \"LLM Latency Over Time\", \"ms\", labels=[\"P50\", \"P95\", \"Avg\"])\n",
+    "else:\n",
+    "    print(\"No LLM latency data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 7: TTFT (Time to First Token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.276528Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.276427Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.322627Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.322081Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASfZJREFUeJzt3QeYVOXZN/Bn6aACFmpsGAsoogZ7iy1gizFiYostRqOxoxK7qPkkdo2aGGNU3nzqq8RYYlcUK3YN2EtUNApYwUZR5rvu875nvtlll11gOcuyv991zbVTzsyceWbm7Jz/uZ/nqSqVSqUEAAAAAAVqVeSTAQAAAEAQSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgHMgzFjxqSqqqrstN9++2nDBhg+fHi5za655ppFts3iteWvM17zwqhUKqU111wzW8cDDzwwNXf/5//8n+y19OjRI3311Vdzdd+nn366/H499thjc/3c+X1XXHHFVJQtttii/LzvvPNOKlJTvN65EeuVr2NTaQ7bAFgYxTY4/+7EthloGYRSADV2ZOo7RSDVHMSOUewQxenzzz9f4DvHtZ123nnnVJQXXnih/Hob8h5VBov1nRbWHfB5dcMNN6QXX3wxO3/UUUc16L2sPFXudDfkFMFJQ9o73sN5eV8OPvjg1LFjxzR58uR06aWXzlVbnHLKKdnf9dZbL22yySappbvlllvK36OiAy/mLLbj+XvTGMH+jBkz0p///Of085//PPXt2zd17tw5+x6tvvrq6dRTT6014J01a1b605/+lNZZZ53UqVOn1KVLl7TNNtuk0aNHz7bs3/72t7TvvvumNdZYIy255JKpffv2aeWVV05HHnlk+vjjj2tdp3jOM888Mw0YMCAttthi2Tr169cv/frXv05ffvllg1/bm2++mfbaa68sqI7n/f73v59++9vfpqlTp87xfr/5zW+qbWPuvvvuBj/n3Dzv+++/nw444IDsdS699NKpTZs2WRvFNuiyyy5L3333XYOf89lnn00/+clPssfp0KFD9v6NGDEie3/n9nfO3Py+if8jsb6LL754dorzN954Y63LTpw4MdtOL7fccqldu3bZ30MOOSRNmjSp2nLxGLEtDvEZBFqIEgClFVZYoRSbxIacHnzwwdLnn39eeuSRR7LT66+/vlC24A9/+MPyOr/99tsL/DlqO/3kJz8pL/vuu++W22zSpEmNvi5XX311+XlPO+20epeP97Gh73l8PhbUejSFgQMHZuu34YYbNvi9rDxVvsaGnOLz15D2fv755+f5fdljjz2y63r27FmaOXNmg9ph/Pjx5ce6/PLL56kt88/0008/XVoUvtv77rtvtW3dwvB653Vb3lQW1DYg3uv8ceMzML8+/PDDOX6/1ltvvdL06dPr/HxUnqqqqkojR46stmz79u3rfOw+ffqUPvnkk2rLT5w4sbTGGmvUeZ/33nuvQa/rhRdeKHXp0qXWx1h77bVLU6dOrfV+8bmO11G5/F133dXg9pyb543nmlPbH3TQQQ16znvuuafUrl27Wh9j0KBBpW+//Xaufuc8+uijDXre+FzX9RhnnnlmtWUnTJhQWnbZZWtddvnlly+9//771Zb/85//XL49ttHAoq9NU4diAAuDv//972natGnlyz/72c+yI3vhD3/4Q3ZUOBfdnuLo8Kabbtok67qwOvHEE9N2221X7bo4cptbfvnls1NDxRHzOFK+oMR7+sgjj5QvP//88+mII47Izvfs2TONGjWqfFscfV5UjB8/PjuyHoYMGVK+/pJLLklTpkwpXz788MOzyqXa3ttVV121WtuFzTbbrHw+2i7aMNerV69qVTc12ze3yiqrpG+//Xae3pdddtklXX/99dn3Nqobdtxxx3rb4uqrr87+tmrVKv30pz9N86KlbQda2utd1EV1zLbbbpt222237Ht67733pvPPPz+7LbpPXXvttWn//ffPLt92221p5MiR2fnevXunCy64IH344YfpuOOOy763hx56aBo8eHBWJZQ/dnxefvGLX2QVQ0888URWBRUVPG+//Xa6+OKL0+mnn15el+gK/9JLL2XnBw0alF3u1q1b+uCDD9JDDz2UVR41RKxvvi076KCD0g477JC9pocffjjbpp1xxhnp3HPPrXaf6dOnZ12Zo2tzbFcqfw801Nw8b/xvi3bZcsst07LLLps93xVXXJHuuOOO7Parrroqa985/Q/85ptvsufMK6JOPvnk7P/aaaedllXCxnt5+eWXZ+9Lbb9zwquvvlruwh3v//rrr1/v64zXEu9jWGKJJbL3MUQF3BdffJFV8u20005ZFVh+fVSG5dvpqJ6Lz9E//vGPNGHChKxat3K7HhXWUUUVVXlREXjeeefNxbsANEtNnYoBLIwqjyjWVi1QWc0RR45rO4p85513lg4//PDSUkstVVpyySVLhx56aGnatGlZxdCPf/zj0mKLLVbq0aNH6aSTTip999131R5/1qxZpauuuqq08cYbl5ZYYolShw4dSgMGDChddNFFsy07p3Wrq2olN2rUqNIWW2yRHd2No61x9DrW84MPPpjrio2oDmjokdXKZSvbOtpml112KXXu3Lm04oorZrd//PHHpV//+tfZEdW2bduWFl988dIqq6xS2n333UtjxoyZ7TFqnhpaqVDZbrVVRj377LOlXXfdNXvPYj3i75AhQ0rPPPNMg6okDjjggPL122+/fbkC4V//+lf2WqLCJx63d+/e2bI1qwIq2y8+GxdeeGHp+9//fva+xWdj9OjRDXqdp59+evlx4rkb470NdX3GGtq+dWno/T777LPycr/85S8b9NjxeY/l11lnnVqrHnbaaadSt27dSm3atMm+x2uttVb2WYzPac3XXbluNT8Df/vb37IKkHiv4rN7ww03zPZ88Vled911s+qSlVZaqXTJJZfU+VmaU6XULbfcUtp6661LXbt2zZ5v1VVXLQ0fPrz09ddfN7gKp7ZTvh1syOu99NJLs9s7depU2m677bJKiW+++aZ0xBFHlJZeeunsO/zzn/98tkqZ8PDDD2fbx2WWWSb7PsR24Oijjy59+umnpYao3BZ89NFHpX322Sdri9im7LnnntWqNOdUeTSniqvrrrsu227mbRzL/uIXv8gqaGtrj8bYBtRVoVRz3efmOxaVO48//vhs1++8887lxznkkEPK18d7mV9//fXXl6+P70R+/XnnnVetiqemo446qrxsPF7uqaeeKl+/zTbbZP8D58WTTz5Zfpx+/fqVHyf+p+VVUPH/eMaMGdXuF/+H8+qiyu9XQyul5vV569qG5Z/fOYntSL7s4MGDy9ePHTu2fH3//v3n+BiHHXZYnf8r6/qfHZ+J/PoRI0aUr4/z+fXxuHk1XqtWrbLr4ndGbAdC/M2rylq3bp1VyVWKyrK4LbaFwKJPKAWwgEKpCAxq7jzsvffe5R3hytNf/vKXao8fO1J17YDstttujRJKDRs2rM5lYufo3//+d+GhVPwArblTtdVWW9W5nrEjUfMxFkQodeutt2Y7i7U9flwft+dq2yE94YQTytdFYJD/MI/gsq4uLjXfg8r2q2yn/BThZUN23GOnK5aPoHNO3dyaWygV8nZZbbXV6n3c2FnMHzcCgEoRhEYYVddn6r777pvtddcV0tT2XsVO2quvvlptJ7K2z0GEYHMTSp1yyil1rvNmm202W1esBRFK1bbdi9C0MujIT3vttVe1dYjtYL4DW/MU72lDPt+V24J43trWJQ4OzGsoFYFnXW2UvxcLYhuwIEKpuhx33HHlxzn22GOz6yJkiWAvv74ymI1ue7V12a7NZZddVl42Qv7aPrsRcm2++ebZNi1CzPicRLDZEOeff375cfbff/9qt1X+742uwrlx48Zl2/E4UBTv4byEUvPyvLlo2wigKg8Y1BcmhTjolS8f983Fdr3y/1Vd35svv/yy/J5G8P6f//ynQf+z11xzzfL1Dz30UPn6OF+57Qo33XRT+bott9yy2uPH5fy2m2++uc7vWQRbwKLNQOcAC0h0I4py/CuvvDLrHpQP/Bol9//93/9dbVamGGw2FyX2//Vf/5WdX2211bIuSf/85z/ThhtuWB5cNE71dUtbe+21y9dFaXxcF6co0X/yySfTOeeck90WXRWiPD66ZkRXgnzdY8DXuRHdCGobEHtuxKCn0WUhuh1El7HoCvDggw+WX1es41133ZV1SYiuZ3nXhmizWL5yXfLX+8tf/jLNj+hGGAPSzpw5M7sc3QruvPPOcvvE9XF7XbO+RdeGGHQ27+IWryHa/Ouvv866MUS3kRjkNmaQi9c9bNiwet+Df//739ngufFYa621VnZdtNV1111X7+t55ZVXsr8rrLBC9rxN4d13310gg8nHIMrh9ddfr3eg4LwdKu+XGzt2bProo4+y83vssUe67777sgHA43vywx/+MLVu3brB6xTvVXw+br/99rT11ltn10W3lNgu5IYOHZp9DkJ8B+P7Ht2aoqtlQ0VXq7xLTXzH//rXv2bdGKMLUYjvwoUXXljn/eM+sUxlN83oupx/jyq7MM/JW2+9lX2Gb7311vS9730vu27cuHHZ64/2i89oDKYdYjuYd3f6z3/+kw477LCsbaJLUHQnveeee8pdx1577bVq3/GGiIGxY1sZ26FlllmmvC6xXZ4XN910U9atKsRn4Nhjj822BbG9/tGPflTnjH+NsQ046aSTqnVxiu17/t5EWzWW2J7F5y+Xfx4+++yzaoN15130Qvfu3cvno1venESXrZqPHV5++eVq/w+jy1ts0z755JOsC+FGG20026DYtansJly5jnWtZ3zefvWrX2WvO9p/XrdDc/u8ud133z37fRDdFKPbXYguj5XtNLfPGZ+lpZZaqtblKv3f//t/y+9pdF+OLpkNUdfz1vY657VdKrfJlZ8NYNFkTCmABSTGUcjHaoidwXysjPjhG+N3xEHtGG8ifnjHjD2VPxRzMRZEjDcRYsc2xuTIl4nHqE0+3lX8za277rrVfmxXhhfxHMccc0x2Pn74x/PFTlLsEH766afVftwuaNFOeZuFCPBiRy/aKnYq44dqjDsUP7pjNqbK15fPJhdi7KrGGvsmdhLzmaIGDhyY/vjHP5Z3qCLci/GZ4vYILmrONhg7dzEmUthggw2y8UJixqr8cfPgI3ZoN9988+z8j3/842wGo/gxH+9BPHa+Q52LmZZ+//vfZ+djxzZ2bELl56gu+WuJmZ4WNflris9L7MxW7vTUVDn7V822aNu2bfl8zBIV4XB8L+KzmH9XGipCwzyAivcxn6Usf69ixsAIwUKMmRPBQ4zFFmNiRXAWwU1DxI57LoKcGPcrxIxX+Tg1sd2IMLM28dzxnalssxg/b26/RxtvvHE6++yzy5/xmEksD/fytot1jXWK4DA+59FG8brzYG7XXXcth+rxWiJYis95BPTxeHnIX58IN2JmuBChQ75tiYAxxkybW3FQIRfB0VlnnVW+vPfee9d6n8baBsR2r/JzWde4hv9TLDVv8oAmxhkKEfxvtdVW2fmaoXvMoFbb+brC+XzMo/zzHwdZ9tlnn/JtNWeI/d3vfpd9LmJ2zBjDKELL2ObF/4j4zkTwXCnaIz6vlc9fuV51rWcEhk899VS2PvV9Jhrzeeck3ueGzL43v8+Z/y8L+bhTlfKZHhv6vLU957yuY+U2ua6ZGoFFh1AKYAGpHDC0MtiJACXEDm5cH6FU5Q/yyh+9+QDPc6rymBeVzxE7SrnYaV5ppZWyx4+dm9hxbsjAp3UNdJ7vGDdU7IxVioqK2JmNndgIfWKq6/jBHlOMx7Kxk1sZvi0IdbVViLbJBw2vubMSnnvuuexvVH7Ezmj8re1xo/orTjXFexA7iDV3PqNap7bB5Gvu2M3J/Oy8zq/aBjpvjMHk5/U11bxfVLNECPDGG29kFYVxivfuBz/4QTbdewTEDQ1G6nuvopIqF4NBVy4TIXFDQ6nKz1OEJZWBSS4PG5pyuxcqQ9a8HSrXPwagzwehrxRVVTHodR7U16fy+1q5XpVtPjcq17EhA+kvyG1AY4vQLoK1vAo3vgN5xW6oOeB2BIj5dzYfaLu25XJRVZYPoN63b9+sWqyyUrNyEPMINqMyLA8uYvD0cP/992d/ozotr6Cr/J6NGTOm2vPnIWeu5npG9VeEXvE/5S9/+Uu93+nGet5KUREZ1XBRBRYVffEcUR0cYWr8/53TdnFenzM8+uijWdVgiP+nldup+sTjxe+Wms9b23PO6zo25f8noHhCKYAFpDIsqfyx27lz5/l+7IYcbZ1XdXVBqU/sxM/vjlPN8v4QO6dRQRA7dFFtFmX+ceQ8TnGEO7ooNZX62iq6+MQR7/gBf+qpp5arRub3va48ily5Y9eQH/IRCLz33nvZDllTyatyGlv+muJ9qQx3alMZjNRsi6hkeeyxx7JuorHDGd1HoitVzAAWp6jCOv744xu0TnPzXs3rd6+hYoa02DFs6CxmRWz35nbnc163fbW1beV1NStTGqs6Y0FtAxpTzMgWM85GF8sQ3Uyj+2Ve0ZV/juM9zLt7RYgSXYBDPlNt6NOnz2zVV9HlOe8yGTOyRYVYdFerVDkza/64Nc9Xdh+sS2VFcM3ufjXXM0LOvG2j2qk2caAlPtP1Bf5z87yVogozTnllWlQDx/+4qAyLLowxC+HcPmd8z2MbVdtyDa2SmpN4vLxrcTxvhIx1vc55bZfKbXLNSmFg0WNMKYCFTGV1URwx/d9JKaqdYtyW+lTuEMaOQV3PEcFOLn7I5o8dO2w1x9pZ0GrbcYwd+ZheO3aS4shx/FiNI+khdm7ynYo5vd75UVdb1bxcW1VY7IzlbRg7AXmXu5rLx7gytb3P8dryKoHG0q9fv/K4TrHzsijJu8RF29Y37lPeDpX3y0Xbx05zVFFEd6OY9j6qaxZffPHs9oaM99JQUR2Vi+9e5c5Y3q2vISo/TxHk1vV5qi+QWlDfo7lZ/xhbp671z3fgG6Ly+xldbXNRDVozQKvcQY4qktqCoMp1zLtE1qcxtwEL4r2Jcbdi3LE8kIquwfHaalauxLZ5k002KV9+/PHHa/2cRoVVLrYvUX2VB1LRRS5C3toOPlQ+9oQJE2o9H11pw3777TdbO8XjhsqwO9YrDz0j5MkfKwK2qA6aW435vNE1vT71BWGVz1n5fsT4cvm2vX///rN1T45uiDE+Woigsa6up3P7vLV9DuJ/df65jW6sEYCG+Jt3a41tdVSFVqrcJkeFNLBoUykFsJCJ7kERwIT4sRjdGKIKKcYeie5EscMQR2/zQVHrUvlDNLombL/99ll3uOhGE13iYhDjcOmll2YDnMZzXHTRReUS+9gRKnI8qTnttMcR5BhfJNYzflDng6LGD/9Y39iBqny9UT0V1VXR9SGOgM9PF784Uh1VNxHYPfPMM9lgzLETF90s4nJ+JDfGhKkp7hfvV+yMRdgQXRyj69EvfvGLbPkIPuJ9jW4y0dZxXT7OTlTq/Otf/2r0QV5j5y/CvGi3qDzLB0pv7mIHLv9cVO7gzmlg7zg6H/fJu1hV7mhF19n43MX3It7f6OoS4xrV1g1lfsRnIHbc4jljRy3GB4vnjnWKcYUaas8998zGxwlHH310Nh5cVKVEu0TYFe95VJ3kA3XXpfJ7FGNQxQ5jnBZ097EYRyqqz6JtI7iJECR2VKPN4z2KgD525KMbb0PFuHMxwHi0a94dLA9eQteuXcvf7dgJjvG3IvSKAdlrE9/bfNscXTpjxz8Gpo/7R1tFZV1lZU9jbwMq35uoVImxseKzGVVGeaVRHuzHetQ1wHUu2jOeLx+rMD4vRx11VBZq5CJAiu9AiPbJuxhG1+l4rgjzYlD9EKFtvK5cfH+im14eKMX4RPnYipXjMYUYjy9vi3jd8b7F+kR1WeXj1Se6acag/BF4xOD48RmIrpbRdTAPiqL7bXTZi/aubfD/+J+YH5yJ+zdkGzk3z5t/BuPzF+0f1URRBTZy5MjyNizatr7JBaILe/xPjC6t8f2Oz3iMe1jZZvGe1RS/B/KuczGuVx621xTvV3QvzIPuCOVCjM0W47VFMBrdhOMzEuubdxmO7UU+flt01Y7XevPNN2eVafHbIyYficerHGS9ZlCZB1YRIMdjAIu4pp7+D2BhVDkdeD4Vel3T1MdU3bnKabsr71fXFO51TTu+zz77zHF69srp4etyySWXzHa/ymnChw0bVufjV05FPieVr6tyyuja1DW9dF1tkGvdunWd6zl48ODycjGldm1Tq9f2/tWm8j2tOZ36LbfcUm2K7cpTXH/rrbeWl61tOvh47Pz+8fe+++7Lrr/jjjvqnA6+5nrU1X51fRbrMn78+PLy5513XqO8t6FyvSs/4w1p3zlp6P1GjRpVXu72229v0GMfc8wx2fKtWrUqTZ48uXz9I488Msfv34gRI2Z73ZXrVttnIES75NdH++bGjh1bateu3WzPM2DAgFofp67tySmnnDLH9W7I5+Of//xnrfedl9db12e2ru3kX/7yl+y9qGv9K9usLpXbk1VWWWW2x+jfv3/pm2++KS9/wgknzLZMr169Sl27dq11u1S57jVP+XuxoLYBYeDAgbMtU9nmc/Mdq/w8NvQzU9frr6qqKo0cObLasvU9ds33M7ajbdq0qXXZzTbbrDR9+vRSQzz//POlLl261Po4a6+9dmnq1KlzvH/l9+uuu+5q0HPO7fNWPkdtp/j/3BD33HNPrduOOA0aNKj07bffVls+Li+//PLlZV5++eU6H7uu72/N22qezjzzzGrLTpgwobTsssvWumysy/vvv19t+UmTJpW3A8cee2yD2gFo3nTfA1gIxRHTOHIeg4/G0eQY7DWOhMdYH1HhlE8TPidxpDZm2or71TaAa8yQFZUY8RxRwh9HcOOIbYwvEVUaNcd4aCpx9DWqtqK6ILoexSmqGY477rhqg2VHxUBUDsTR5XzK+cYSR3qja0JUc8TsZNGlMI7q77LLLlmFy0477TTH+2+xxRbZkeV8QOE44h8VEFG9FtVWUREXry/eg3gdMfPY0KFDZxsMvDFEd4580OnG7IbW1PLXEkfVt9122wbdJx+0OI74x2ensltVfHeiuiWO4Mf7HdUE6623XjYmUF0z2M2reJ6YZS3el/iux/cwqhajoiBXOb5PXc4444ysG1a8/qjQic/T9773vazKKaqP8qqHOYnqjqgUigrFyjGwihAzv8U4OvG9yts9/kYVSnSlrBwHpyGia9XPf/7zbPsWA4xHFVoMll05eHRUlUT34KhaiYrL+K5HpU5d1ZUxGHXMwldz2xwVrnOa0bKxtgExA2G8v001e2ZU2sV3INYv2jHaNv4vRQVb5Wx68yK2o/H+RyVwvB/RtrGtj89tVALVnL2tLrFuUe0V1YOxvY77xf+zmDExxoSrHGy+Mc3N88ZnLl5vVLTF/6v8uxqfv6guy2ewbEglb/wPiqqp+EzE/8fomhz/N2Pmx5rdmGP7kHcnjJkVK7sxz42ooopJGKKaMb43cYrzMVB+zLJYKarkol3iN0m8xvy1xuXoYhvnK8W2OO+emldnAYu2qkimmnolAIDixI5D7KCH6E7T3MfsiO5TseMT3ZFiZy52AhsqdoCju2cEH5XjDhUpforVNp5avEf5bGgRukU3F4BFWWyLI8SKbXN0kwcWfSqlAKCFieqRqJgKtY2p0tzEWD4RSEV1Qoz5NTeiuijEEfuokGkKMeh87IDFeEUxoHqMIRTVIfmYUjH2TUwRD7Aoi21wPqZZQyo7gUWDSikAgCYUA1LX1V02ugBFtVQMBA0AsKhRKQUA0ISiEirGU+rbt282dlUEUTHWTIzRE1UDAikAYFGlUgoAAACAwqmUAgAAAKBwQikAAAAACtem+KdcNM2aNSt98MEHaYkllqh1WmcAAACAlqBUKqUvvvgi9e7dO7VqVXc9lFCqkUQgtdxyyzXWwwEAAAA0a++9915adtll67xdKNVIokIqb/DOnTs31sMCLaTS8qOPPkrdunWb41EEAICi+Z0CzIupU6dmhTt5VlIXoVQjybvsRSAllALm9sfetGnTsm2HUAoAWJj4nQLMj/qGN3JIHgAAAIDCCaUAAAAAKJxQCgAAAIDCGVOqYN99912aOXNm0U/bbLRt2za1bt26qVcDAAAAWMCEUgUplUpp4sSJ6fPPPy/qKZutrl27pp49e9Y7IBoAAADQfAmlCpIHUt27d0+dOnUSuNQR3H399ddp8uTJ2eVevXoV9fYAAAAABRNKFdRlLw+kll566SKestnq2LFj9jeCqWgvXfkAAABg0WSg8wLkY0hFhRT1y9vJ2FsAAACw6BJKFcgYSdoJAAAA+B9CKQAAAAAKJ5QCAAAAoHAGOm9iKx5/R2HP9c7vd5jr++y3335p5MiR2fm2bdum5ZdfPu2zzz7pxBNPTO+//37q06fPbPcZO3Zs2nDDDcuXR40alU455ZT0zjvvpFVWWSWdffbZafvtt5/PVwMAAAA0Z0Ip6rXtttumq6++Ok2fPj3deeed6dBDD80Cqj322CO7/f77709rrLFGefnKGQYff/zxbLkRI0akHXfcMV133XVp5513Ts8991zq37+/1gcA5s7wLloMCtUqpc4DUpo6LqU0S9tDEYZPaTHtrPse9Wrfvn3q2bNnWmGFFdIhhxySttlmm3TbbbdVC6Hi9vwUgVXu4osvzkKt4447LvXr1y+deeaZ6Qc/+EG69NJLtTwAAAC0YEIp5lrHjh3TjBkzypd32mmn1L1797TppptWC6vyrnwRYlUaPHhwdj0AAADQcgmlaLBSqZR11bvnnnvSVlttlRZffPF0/vnnZ2NG3XHHHVkoFV3zKoOpiRMnph49elR7nLgc1wMAAAAtlzGlqNftt9+eBVAzZ85Ms2bNSnvuuWcaPnx4WmyxxdLQoUPLy6233nrpgw8+SOeee25WPQUAAABQF6EU9dpyyy3Tn/70p9SuXbvUu3fv1KZN3R+bDTbYIN13333lyzHG1KRJk6otE5fjegAAAKDl0n2PekVF1Morr5yWX375OQZS4YUXXki9evUqX95oo43S6NGjqy0ToVVcDwAAALRcKqWYZyNHjsyqp9ZZZ53s8j/+8Y901VVXpSuvvLK8zJFHHpl++MMfZmNP7bDDDum///u/0zPPPJOuuOIKLQ8AAAAtmFCK+XLmmWemd999N6ug6tu3b7rhhhvSrrvuWr594403Ttddd106+eST04knnphWWWWVdMstt6T+/ftreQAAAGjBqkoxpRrzberUqalLly5pypQpqXPnztVumzZtWnr77bdTnz59UocOHbR2PbQXLU1MIDB58uTUvXv31KqVXtUAczS8iwaCAs1KrdLkzgNS96njUqs0S9tDEYZPWaQzkkr2fgAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMK1Kf4pqWZ4l+IaZPiUub7Lfvvtl0aOHJmdb9u2bVp++eXTPvvsk0488cTUpk2bdOONN6azzjorvf7666lbt27psMMOS8cdd1z5/mPGjElbbrnlbI/74Ycfpp49e87nCwIAAACaK6EU9dp2223T1VdfnaZPn57uvPPOdOihh2YB1dprr5322muvdMkll6RBgwalV155JR144IGpY8eOWThV6bXXXkudO3cuX+7evbuWBwAAgBZMKEW92rdvX65qOuSQQ9LNN9+cbrvttjR+/Pi08847p4MPPji7baWVVkonnHBCOvvss7PgqqqqqloI1bVrV60NAAAAZIwpxVyLSqgZM2ZklVMdOnSY7bb3338/vfvuu9Wuj6qqXr16pR/96Efpscce0+oAAADQwgmlaLBSqZTuv//+dM8996StttoqDR48OP3jH/9Io0ePTrNmzcrGlTr//PPLY0aFCKIuv/zydNNNN2Wn5ZZbLm2xxRbpueee0/IAAADQgum+R71uv/32tPjii6eZM2dm4dOee+6Zhg8fnjp16pTeeuuttOOOO2a3xZhRRx55ZHZbq1b/k3euttpq2Sm38cYbZ/e58MIL09/+9jetDwAAAC2USinqFbPnvfDCC+mNN95I33zzTTYb32KLLZaNGRXjR3355ZdZd72JEyem9ddfvzy+VF1imTfffFPLAwAAQAumUop6RQC18sor13l769at0/e+973s/PXXX5822mij1K1btzqXj4AruvUBAAAALZdQinn28ccfp7///e/ZGFHTpk1LV199dRo1alR66KGHystcdNFFqU+fPmmNNdbIlrnyyivTAw88kO69914tDwAAAC2YUIr5El35jj322GwQ9KiQGjNmTLkLX4hZ+o455pj0n//8JxuDasCAAdlg6dElEAAAAGi5hFJNbfiUtDC75ppr6rxtmWWWSWPHjp3j/YcNG5adAAAAACoZ6BwAAACAwgmlAAAAACicUAoAAACAwgmlAAAAACicUAoAAACAlhVKjRgxIq233nppiSWWSN27d08777xzeu2116otM23atHTooYempZdeOi2++OJpyJAhadKkSdWWmTBhQtphhx1Sp06dssc57rjj0rffflttmTFjxqQf/OAHqX379mnllVeudVa5yy67LK244oqpQ4cOaYMNNkhPPfVUo77eWbNmNerjLaq0EwAAACz62jTlkz/00ENZ4BTBVIRIJ554Yho0aFB6+eWX02KLLZYtc/TRR6c77rgjjRo1KnXp0iUddthhaZdddkmPPfZYdvt3332XBVI9e/ZMjz/+ePrwww/TPvvsk9q2bZvOOuusbJm33347W+bggw9O1157bRo9enT61a9+lXr16pUGDx6cLXPDDTekoUOHpssvvzwLpC666KLstgjJIuiaH+3atUutWrVKH3zwQerWrVt2uaqqar7bb1FTKpXSjBkz0kcffZS1V7QTAAAAsGiqKkUSsJCIMCICoAirNt988zRlypQsxLnuuuvSrrvumi3z6quvpn79+qWxY8emDTfcMN11111pxx13zAKfHj16ZMtEsPTb3/42e7wINuJ8BFsvvvhi+bl233339Pnnn6e77747uxxBVIRjl156ablaZ7nllkuHH354Ov744+td96lTp2ahWaxz586dZ7s9wpYIzL7++utGa69FVVS8RWAolKKliO3N5MmTs+1fBLIAzMHwLpoHCjQrtUqTOw9I3aeOS62Snh9QiOFTmn1D15eRLBSVUjXFyoallloq+/vss8+mmTNnpm222aa8TN++fdPyyy9fDqXi75prrlkOpEJUOB1yyCHppZdeSuuss062TOVj5MscddRR5cAonuuEE04o3x47hnGfuG9tpk+fnp0qGzzfuayt+1mbNm3Ssssum1WERXUXtWvdunXWVlFJphsfLUV81uP4gM88QEMI76HoUKqUqrK/QFFfvFnNvqkbum/TZmFa4QiJNtlkk9S/f//suokTJ2bVMl27dq22bARQcVu+TGUgld+e3zanZSJI+uabb9Jnn32WBUW1LROVWXWNh3X66afPdn1UZ8U4WABzs/2LUD6CKZVSAPXoPEATQYEijJrSacUsmFIpBQWZPLnZN/UXX3zRvEKpGFsqutc9+uijqTmIqqoYgyoXAVd094vuhnMqTQOoLZSK6sDYfgilAOoxdZwmgoJDqapUSt2mjhdKQVG6z9+41guDmECu2YRSMXj57bffnh5++OGsi1suBi+PrnUx9lNltVTMvhe35cvUnCUvn52vcpmaM/bF5QiPOnbsmHUZi1Nty+SPUVPM4henmmKH0k4lMLcilLL9AGiI5t+lAZqbCKWiSkqlFBSkVfPvLtvQXKRJX2l0VYlA6uabb04PPPBA6tOnT7XbBw4cmM2iF7Pl5WI2vAkTJqSNNtoouxx/x48fnw0SnLvvvvuywGn11VcvL1P5GPky+WNEF8F4rsplonIhLufLAAAAANB42jR1l72YWe/WW29NSyyxRHkMqBihPSqY4u8BBxyQdZOLwc8jaIrZ8CIoikHOw6BBg7Lwae+9907nnHNO9hgnn3xy9th5JdPBBx+czao3bNiw9Mtf/jILwG688cZsRr5cPMe+++6b1l133bT++uuniy66KH311Vdp//33b6LWAQAAAFh0NWko9ac//Sn7u8UWW1S7/uqrr0777bdfdv7CCy/Myr6GDBmSzXYXs+b98Y9/LC8b3e6i61/Mthdh1WKLLZaFS2eccUZ5majAigDq6KOPThdffHHWRfDKK6/MHiu32267ZYOUn3rqqVmwtfbaa6e77757tsHPAQAAAJh/VaXoQ8d8i4HOo7IrZtAy0DkwN6K7cHRB7t69uzHpAOozvIs2ggLFSFKTOw9I3aeOM6YUFGX4lBaTkTT/0bMAAAAAaHaEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQMsKpR5++OH04x//OPXu3TtVVVWlW265pdrt++23X3Z95Wnbbbettsynn36a9tprr9S5c+fUtWvXdMABB6Qvv/yy2jLjxo1Lm222WerQoUNabrnl0jnnnDPbuowaNSr17ds3W2bNNddMd9555wJ61QAAAAA0aSj11VdfpbXWWitddtlldS4TIdSHH35YPl1//fXVbo9A6qWXXkr33Xdfuv3227Og66CDDirfPnXq1DRo0KC0wgorpGeffTade+65afjw4emKK64oL/P444+nPfbYIwu0nn/++bTzzjtnpxdffHEBvXIAAACAlq1NUz75dtttl53mpH379qlnz5613vbKK6+ku+++Oz399NNp3XXXza675JJL0vbbb5/OO++8rALr2muvTTNmzEhXXXVVateuXVpjjTXSCy+8kC644IJyeHXxxRdn4ddxxx2XXT7zzDOzkOvSSy9Nl19+eaO/bgAAAICWrklDqYYYM2ZM6t69e1pyySXTVlttlX73u9+lpZdeOrtt7NixWZe9PJAK22yzTWrVqlV68skn009/+tNsmc033zwLpHKDBw9OZ599dvrss8+yx41lhg4dWu15Y5ma3QkrTZ8+PTtVVmSFWbNmZSeAhoptRqlUsu0AaBBDokKRZqVWqZSqsr9AUV+8Wc2+qRuaiyzUoVRUL+2yyy6pT58+6a233konnnhiVlkVIVLr1q3TxIkTs8CqUps2bdJSSy2V3Rbib9y/Uo8ePcq3RSgVf/PrKpfJH6M2I0aMSKeffvps13/00Udp2rRp8/W6gZYlNthTpkzJgqkI1QGYg84DNA8UKMKoKZ1WzIKpVqn57yhDszB5cmruvvjii+YfSu2+++7l8zH4+IABA9L3v//9rHpq6623btJ1O+GEE6pVV0WlVAyi3q1bt2zQdYC5CaViIofYfgilAOoxdZwmgoJDqapUSt2mjhdKQVG6Vy++aY5iErlmH0rVtNJKK6Vlllkmvfnmm1koFWNNTa6RIH777bfZjHz5OFTxd9KkSdWWyS/Xt0xdY1nlY13FqabYobRTCcytCKVsPwAaQqUGFC1CqaiSUikFBWnV/HtPNDQXaVav9P3330+ffPJJ6tWrV3Z5o402Sp9//nk2q17ugQceyKoONthgg/IyMSPfzJkzy8vEIOarrbZa1nUvX2b06NHVniuWiesBAAAAaHxNGkp9+eWX2Ux4cQpvv/12dn7ChAnZbTEb3hNPPJHeeeedLDT6yU9+klZeeeVsEPLQr1+/bNypAw88MD311FPpscceS4cddljW7S9m3gt77rlnNsj5AQcckF566aV0ww03ZLPtVXa9O/LII7NZ/M4///z06quvpuHDh6dnnnkmeywAAAAAFrFQKoKfddZZJzuFCIri/KmnnpoNZD5u3Li00047pVVXXTULlQYOHJgeeeSRat3mrr322tS3b9+sO9/222+fNt1003TFFVeUb+/SpUu69957s8Ar7n/MMcdkj3/QQQeVl9l4443Tddddl91vrbXWSn//+9+zmff69+9fcIsAAAAAtAxVpZjuifkWA51HABYzaBnoHJgb0eU4xseL2USNSQdQj+FdNBEUKEaSmtx5QOo+dZwxpaAow6e0mIykWY0pBQAAAMCiQSgFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQOGEUgAAAAAUTigFAAAAQPMIpUaOHJnuuOOO8uVhw4alrl27po033ji9++67jbl+AAAAACyC5imUOuuss1LHjh2z82PHjk2XXXZZOuecc9IyyyyTjj766MZeRwAAAAAWMW3m5U7vvfdeWnnllbPzt9xySxoyZEg66KCD0iabbJK22GKLxl5HAAAAABYx81Qptfjii6dPPvkkO3/vvfemH/3oR9n5Dh06pG+++aZx1xAAAACARc48VUpFCPWrX/0qrbPOOun1119P22+/fXb9Sy+9lFZYYYXGXkcAAAAAFjHzVCkVY0httNFG6aOPPko33XRTWnrppbPrn3322bTnnns29joCAAAAsIiZp0qpmGnvvPPOS+PGjUuTJ09Ot912W3b9wIEDG3v9AAAAAFgEzVModffdd6d99tknG1eqVCpVu62qqip99913jbV+AAAAACyC5qn73uGHH55+9rOfpQ8++CDNmjWr2kkgBQAAAMACCaUmTZqUhg4dmnr06DEvdwcAAACghZunUGrXXXdNY8aMafy1AQAAAKBFmKcxpS699NKs+94jjzyS1lxzzdS2bdtqtx9xxBGNtX4AAAAALILmKZS6/vrr07333ps6dOiQVUzF4Oa5OC+UAgAAAKDRQ6mTTjopnX766en4449PrVrNUw9AAAAAAFqweUqUZsyYkXbbbTeBFAAAAADFhVL77rtvuuGGG+btGQEAAABo8eap+953332XzjnnnHTPPfekAQMGzDbQ+QUXXNDiGxYAAACARg6lxo8fn9ZZZ53s/IsvvljttspBzwEAAACg0UKpBx98cF7uBgAAAAAZU+cBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAAUDihFAAAAACFE0oBAAAA0LJCqYcffjj9+Mc/Tr17905VVVXplltuqXZ7qVRKp556aurVq1fq2LFj2mabbdIbb7xRbZlPP/007bXXXqlz586pa9eu6YADDkhffvlltWXGjRuXNttss9ShQ4e03HLLpXPOOWe2dRk1alTq27dvtsyaa66Z7rzzzgX0qgEAAABo0lDqq6++SmuttVa67LLLar09wqM//OEP6fLLL09PPvlkWmyxxdLgwYPTtGnTystEIPXSSy+l++67L91+++1Z0HXQQQeVb586dWoaNGhQWmGFFdKzzz6bzj333DR8+PB0xRVXlJd5/PHH0x577JEFWs8//3zaeeeds9OLL764gFsAAAAAoGWqKkU50kIgKqVuvvnmLAwKsVpRQXXMMcekY489NrtuypQpqUePHumaa65Ju+++e3rllVfS6quvnp5++um07rrrZsvcfffdafvtt0/vv/9+dv8//elP6aSTTkoTJ05M7dq1y5Y5/vjjs6qsV199Nbu82267ZQFZhFq5DTfcMK299tpZINYQEX516dIlW8eo2gJoqFmzZqXJkyen7t27p1at9KoGmKPhXTQQFGhWapUmdx6Quk8dl1qlWdoeijB8SrNv54ZmJAvt3s/bb7+dBUnRZS8XL2iDDTZIY8eOzS7H3+iylwdSIZaPnbqorMqX2XzzzcuBVIhqq9deey199tln5WUqnydfJn8eAAAAABpXm7SQikAqRGVUpbic3xZ/o7KgUps2bdJSSy1VbZk+ffrM9hj5bUsuuWT2d07PU5vp06dnp8oUMK94iBNAQ8U2I6pDbTsAGmKhPaYKi2ylVClVZX+Bor54s5p9Uzd032ahDaUWdiNGjEinn376bNd/9NFH1ca8AmjIBjvKWiOY0n0PoB6dB2giKFCEUVM6rZgFU7rvQUEmT272Tf3FF18071CqZ8+e2d9JkyZls+/l4nKM9ZQvE+OwVPr222+zGfny+8ffuE+l/HJ9y+S31+aEE05IQ4cOrVYpFTP7devWzZhSwFyHUjGuXmw/hFIA9Zg6ThNBwaFUVSqlblPHC6WgKN2r9whrjjp06NC8Q6nocheh0OjRo8shVAQ/MVbUIYcckl3eaKON0ueff57Nqjdw4MDsugceeCDbwYuxp/JlYqDzmTNnprZt22bXxUx9q622WtZ1L18mnueoo44qP38sE9fXpX379tmpptihtFMJzK0IpWw/ABqi+XdpgOYmQqmoklIpBQVp1fy7yzY0F2nSV/rll1+mF154ITvlg5vH+QkTJmQ7aBES/e53v0u33XZbGj9+fNpnn32yGfXyGfr69euXtt1223TggQemp556Kj322GPpsMMOy2bmi+XCnnvumQ1yfsABB6SXXnop3XDDDeniiy+uVuV05JFHZrP2nX/++dmMfMOHD0/PPPNM9lgAAAAANL4mrZSK4GfLLbcsX86Don333Tddc801adiwYemrr75KBx10UFYRtemmm2bhUWUZ2LXXXpuFR1tvvXWWxA0ZMiT94Q9/qDZj37333psOPfTQrJpqmWWWSaeeemr2mLmNN944XXfddenkk09OJ554YlpllVXSLbfckvr3719YWwAAAAC0JFWlGFmX+RZdCyMAi8GKO3furEWBBosuxzE+XswmqvsvQD2Gd9FEUKDotDe584DUfeo43fegKMOntJiMpPl3VAQAAACg2RFKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhRNKAQAAAFA4oRQAAAAAhVuoQ6nhw4enqqqqaqe+ffuWb582bVo69NBD09JLL50WX3zxNGTIkDRp0qRqjzFhwoS0ww47pE6dOqXu3bun4447Ln377bfVlhkzZkz6wQ9+kNq3b59WXnnldM011xT2GgEAAABaooU6lAprrLFG+vDDD8unRx99tHzb0Ucfnf75z3+mUaNGpYceeih98MEHaZdddinf/t1332WB1IwZM9Ljjz+eRo4cmQVOp556anmZt99+O1tmyy23TC+88EI66qij0q9+9at0zz33FP5aAQAAAFqKNmkh16ZNm9SzZ8/Zrp8yZUr661//mq677rq01VZbZdddffXVqV+/fumJJ55IG264Ybr33nvTyy+/nO6///7Uo0ePtPbaa6czzzwz/fa3v82qsNq1a5cuv/zy1KdPn3T++ednjxH3j+DrwgsvTIMHDy789QIAAAC0BAt9KPXGG2+k3r17pw4dOqSNNtoojRgxIi2//PLp2WefTTNnzkzbbLNNedno2he3jR07Ngul4u+aa66ZBVK5CJoOOeSQ9NJLL6V11lknW6byMfJlomJqTqZPn56dclOnTs3+zpo1KzsBNFRsM0qlkm0HwKJR6A+LlFmpVSqlquwvUNQXb1azb+qG5iILdSi1wQYbZN3tVltttazr3umnn54222yz9OKLL6aJEydmlU5du3atdp8IoOK2EH8rA6n89vy2OS0TIdM333yTOnbsWOu6RTgW61PTRx99lI11BTA3G+yo/oxgqlUrP/gA5qjzAA0EBYowakqnFbNgqlVq/jvK0CxMnpyauy+++KL5h1Lbbbdd+fyAAQOykGqFFVZIN954Y51hUVFOOOGENHTo0PLlCLGWW2651K1bt9S5c+cmXTeg+YVSMZFDbD+EUgD1mDpOE0HBoVRVKqVuU8cLpaAo3bs3+7aO3m7NPpSqKaqiVl111fTmm2+mH/3oR9kA5p9//nm1aqmYfS8fgyr+PvXUU9UeI5+dr3KZmjP2xeUIluYUfMVMfXGqKXYo7VQCcytCKdsPgIZQqQFFi1AqqqRUSkFBWjX/3hMNzUWa1Sv98ssv01tvvZV69eqVBg4cmNq2bZtGjx5dvv21115LEyZMyMaeCvF3/PjxaXJF6dt9992XBU6rr756eZnKx8iXyR8DAAAAgMa3UIdSxx57bHrooYfSO++8kx5//PH005/+NLVu3TrtscceqUuXLumAAw7IutA9+OCD2cDn+++/fxYmxSDnYdCgQVn4tPfee6d//etf6Z577kknn3xyOvTQQ8tVTgcffHD697//nYYNG5ZeffXV9Mc//jHrHnj00Uc38asHAAAAWHQt1N333n///SyA+uSTT7KxVjbddNP0xBNPZOfDhRdemJWEDRkyJJsJL2bNi1ApFwHW7bffns22F2HVYostlvbdd990xhlnlJfp06dPuuOOO7IQ6uKLL07LLrtsuvLKK7PHAgAAAGDBqCrFdE/MtxjoPKq3YgYtA50DczvQeXQz7t69uzHpAOozvIs2ggLFSFKTOw9I3aeOM6YUFGX4lBaTkSzU3fcAAAAAWDQJpQAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMIJpQAAAAAonFAKAAAAgMIJpQAAAAAoXJvin5KF3YrH39HUqwAtSqtUSv2WLKVXPqtKs1JVU68OtAjv/H6Hpl4FAIAWT6UUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTSgEAAABQOKEUAAAAAIUTStVw2WWXpRVXXDF16NAhbbDBBumpp54q/l0BAAAAWMQJpSrccMMNaejQoem0005Lzz33XFprrbXS4MGD0+TJk5vuHQIAAABYBAmlKlxwwQXpwAMPTPvvv39affXV0+WXX546deqUrrrqqqZ7hwAAAAAWQUKp/zVjxoz07LPPpm222eb/N06rVtnlsWPHNtX7AwAAALBIatPUK7Cw+Pjjj9N3332XevToUe36uPzqq6/Otvz06dOzU27KlCnZ388//zzNmjUrNWvTv2rqNYAWppS+nVZKaXpVSilOwIIW/69pprJtJVCUWakqTZ32XWo3vSq18jsFivF58/+dMnXq1OxvqVSa43JCqXk0YsSIdPrpp892/QorrDCvDwm0YG839QpAC7PkRU29BgDNyWNNvQLQsvx+ybSo+OKLL1KXLl3qvF0o9b+WWWaZ1Lp16zRp0qRqDRSXe/bsOVvDnXDCCdmg6Lmojvr000/T0ksvnaqqHMED5u4ownLLLZfee++91LlzZ00HACw0/E4B5kVUSEUg1bt37zkuJ5T6X+3atUsDBw5Mo0ePTjvvvHM5aIrLhx122GwN1759++xUqWvXrvP0ZgGECKSEUgDAwsjvFGBuzalCKieUqhCVT/vuu29ad9110/rrr58uuuii9NVXX2Wz8QEAAADQeIRSFXbbbbf00UcfpVNPPTVNnDgxrb322unuu++ebfBzAAAAAOaPUKqG6KpXW3c9gAUlugKfdtpps3UJBgBoan6nAAtSVam++fkAAAAAoJG1auwHBAAAAID6CKUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCqAApVJJOwMATe69995LM2fObOrVAMgIpQAa2dtvv51GjhyZfv/736dnnnkmTZkyJVVVVaVZs2ZpawCgyfzrX/9KK6ywQrr11lu9C8BCoark8D1Ao3nxxRfTFltskfr3759efvnl1K1bt7TSSiulyy67LC2//PJZMNWqleMBAEDxgdSmm26afvOb36Szzz57tttjtzAOogEUyZ4RQCP55ptv0hFHHJF23333dO+996bJkyenYcOGZdcPGjQovfPOO1kgpWIKAChSHCjbYIMN0rHHHpsFUhFAPfXUU+nGG2/Mbps6daqqbqBJtGmapwVY9EybNi1NnDgxHXDAAaldu3bZdXvvvXdaeeWV02mnnZaGDBmSbr/99tSrV6+mXlUAoIX49ttv05///Oc0Y8aMNHTo0Oy6OFj28ccfp5deeimr6F5jjTXSJZdcknr37t3Uqwu0MCqlABpJ586dU8+ePdPYsWPLA5tHZdQmm2ySjj/++NShQ4d06aWXGvQcAChMmzZt0lFHHZV23HHH9P3vfz9tuOGGafHFF8+CqqjqPu6449KkSZOyA2gRXAEUSSgFMB+++uqrcne81q1bZwHU448/nh544IFq4dM222yT1ltvvXT33XfrvgcAFKpPnz7ZgbHNNtssC57OO++8tP7666euXbtmFd4xHuYjjzyS/a4BKJJQCmAePfvss9nRxhgrKg+gTjrppOyIZIzZ8MQTT1SbcnnrrbfOxpf67LPPtDkAsMB8+OGH6b777ksPPfRQNmZUiAlXLrzwwnTBBRdk58N3332X/e3bt292cM1kLEDRhFIA8ziDTRxVjFOMxZDPVhNd9B588MFsfKnDDjss3XDDDeVqqvvvvz916dIldezYUZsDAAvE+PHjs4NmJ598cjrooIOyg2IRRkUAFWFU/HZp27ZttmwEUSGGHogxMNu3b+9dAQpVVarsXwJAvcaNG5dNqXzIIYeUZ7CJwUKnT5+e/Zjr1q1bFkTttttu6T//+U96//3304ABA9Jzzz2XBVZrr722VgYAGt0HH3yQDSUQMwFHKBW/Q/7rv/4rnXXWWdnlqOSOMTArK6ouuuii9Ne//jWNGTMm9e/f37sCFEooBTAXvvjii+xIYgRPL774YlYBtddee2Vd+F555ZVs3Khf//rXadddd83GbIgufk8++WRaeuml08Ybb5wNMAoAsCCMHj06nX766enOO+/MBjMPUan905/+NH399dfp1FNPzQY0D9G175prrkkPP/xwuummmxw0A5pEm6Z5WoDmaYkllsiONh5++OHZj75HH300q5SKWW2+/PLL7PJvfvObtNhii6XtttsubbTRRtkJAGBBi0rtqMx+++2305prrpldt9RSS2W/SQYOHJhOOeWUbLDzrbbaKquomjp1avZ7Jh9jCqBoKqUAGiDK3yNwivEY1llnnfTqq6+mIUOGZIHTrbfempZZZplsuTfffDMdeuihadVVV83Gb4gBQw0aCgAs6N8oUb0dE6zE75JevXqlnXbaKZtdLwKpmGEvDqoNHjw4q5qKcS8BFgYqpQAaMIZU/ICL8aJef/31tMoqq6QRI0ZkPwCj214cgYxqqRjsPLr2xWDncYQyZuEDACjiN8pbb72VVUdFtXYcEPvZz36WOnXqlPbdd990zjnnZMvH+JdxH4CFhdn3AOYgfrhFNVSMERVjMuRHH88444zUo0eP9POf/zz74ReBVARTUUkVPwDXXXdd7QoAFPYbZdSoUdmYl99++202Gctjjz2W7rrrrnTBBRdky8cwAzELsN8owMLEYXyAOrz33nvZNMo77LBDNste6N27d1YmP3To0KxEvrIaKgYQjeVi9prhw4drVwCgsN8o0V0vZt8bNmxYdgCtX79+5eUnTZqU/vjHP6ann346XXzxxd4VYKGhUgqgDlH11KdPn6zUPbrq5eK6jh07ZrPr5eIIZYwldfnll2cz3qy22mraFQAo9DdKzPIbXfkqf6NEgHXsscemP//5z+mee+7JhhoAWFgY6BxgDt544410xBFHZIOHXnTRRWm55ZZLK620Utp///3LRyZDlMjH1Mox+LlACgBYWH6j5L9TevbsmYVWAAsToRRAA370HXnkkVn3vBi/IQYMjZn18iOVrVu3zs5Hd762bdtqTwCgyX+jRFhlBmBgYaf7HkA9Yra9GH8hwqfOnTtns9yUN6Kt/v9mVCAFACwsv1FiEhaAhZ1KKYAGevPNN9Phhx+ezbJ3yimnpE022UTbAQBNzm8UoLlSKQXQQDEw6B/+8IesIioGDH3iiSe0HQDQ5PxGAZoroRTAXJbJn3vuuWnZZZdNvXv31nYAwELBbxSgOdJ9D2AexFTL7dq103YAwELFbxSgORFKAQAAAFA43fcAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIDCCaUAAAAAKJxQCgAAAIBUtP8Hi6DcbDQMK08AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "resp_ttft = llm_events_df[\n",
+    "    (llm_events_df[\"event_type\"] == \"LLM_RESPONSE\") & (llm_events_df[\"ttft_ms\"].notna())\n",
+    "].copy()\n",
+    "if not resp_ttft.empty:\n",
+    "    resp_ttft[\"hour\"] = resp_ttft[\"timestamp\"].dt.floor(\"h\")\n",
+    "    ttft_hourly = resp_ttft.groupby(\"hour\").agg(\n",
+    "        p50=pd.NamedAgg(column=\"ttft_ms\", aggfunc=\"median\"),\n",
+    "        p95=pd.NamedAgg(column=\"ttft_ms\", aggfunc=lambda x: x.quantile(0.95)),\n",
+    "    ).reset_index()\n",
+    "    time_plot(ttft_hourly, \"hour\", [\"p50\", \"p95\"],\n",
+    "              \"Time to First Token (TTFT)\", \"ms\", labels=[\"P50\", \"P95\"])\n",
+    "else:\n",
+    "    print(\"No TTFT data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 8: Multimodal by MIME Family"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.323941Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.323851Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.374850Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.374321Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAObpJREFUeJzt3QmcjXX///HPjGWsYzeWxppbSlKRtU2ypKJdqZBoQ6hbFEkprZK9lepOqrtSERLRYkK0KVopZc8yKENm/o/39/5d539m04xrzpyZc17Px+N6zJzrXOfMdda53tf3+/l+Y9LS0tIMAAAAAHyI9XNjAAAAACBYAAAAAMgTtFgAAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAHwjWAAAAADwjWABAAAAwDeCBQAAAADfCBYACqwZM2ZYTEyMW+65554c3+6ss84K3G7Dhg1WEHn7V6dOnaO6/ZIlSwL30atXL4tWPA/RRe91732v1z6vPk8A8gbBAkCO6eDe+weupUOHDpm2WbVqVbpttBw4cCBPn+UvvvjC7YuW4IML5CxseUuRIkWsatWqdsEFF4T0edR9e6+XXrtIOrjV0q9fv0zbvP766+m2qVatWuA6hd3g64JlfI2WLVuW6b71egVvM2zYsGw/oxmX8uXL5yrQZ7fs3r37KJ45AJGuaLh3AEDhtWjRIvvll1+sdu3agXVPP/10yP+uDk5Hjx6d7qA52MSJE23Pnj3u9+rVq4d8fwqr1NRU2759u82ZM8fmzp1r06dPt549e4YkWHivl84oN23a1CLJrFmz7PHHH7fSpUvn+efgmWeesdatWwcu//777zZv3jyLVnfddZddf/317vcTTzwx3LsDIAOCBQBfB6bPPvus3Xvvve7y/v37bebMmWF/RjngOLI777zTOnfu7M46P/jgg/bJJ59YWlqaDR482K688korXrx4nrwOej8EH2xHqr1799orr7xi1113nbussL1w4cI8ue9XX33VnnjiCStbtqy7/Nxzz9nhw4dzdFu9xnqtgxUtmrt/+wqBCuoZefuT3xo0aOAWAAUTXaEAHBXvwEJnuRUwRAdXOsjK7qDjSP3hc9pHWtf37t07cFlnwjPWYWRVYxHc/UTXf/DBB3bqqadayZIl7ZRTTgl0BZo6darVq1fPSpQoYW3atLEvv/wy0z78+OOPbh8SExPdQXilSpXsvPPOcy04Ge3YscOuvfZaK1eunOuGot+1Lis6G62D05NOOskqV65sxYoVs4oVK1q7du1s9uzZlld0YNa2bVs7//zz7aWXXgqs37Vrl33zzTcuENx0003WrFkzS0hIcI9R+9+qVSsXJINlfF4//PBDt52e11tuucWtD25d0vPmba8uN6LnuGvXrq5blh6znk8d0N54443266+/5uqxLV682E477TT3+tWtW9fGjx8fuE777v3tUaNGpbvdW2+9FbhuwIABOf573ntdLQvBf0efCb8H37q9XouXX345XZAP/rtHoudTr3Pw0rJly1ztg173jPehRd3o5LbbbnMtKmoZjIuLszJlyrjP06OPPmp///13tp/xr776ys444wwrVaqUHXfccfbf//7XbaOfJ5xwgrsvfQ70euakxiKjULzWAHIgDQByaNSoUWn62tDSq1evtGLFirnf586d665v0aKFu9yvX7/Adlr++usvd/0HH3wQWNezZ8909+2tr127dmDd9OnTA+v1t0XXB9938OJtc+aZZwbWrV+/3q3TT29dzZo100qUKJHutiVLlky7/fbbM91nnTp10g4dOhTYp+XLl6eVLVs2y78fExOTNmXKlMC2KSkpaSeffHKm7Zo0aZLl401KSsr2sWl5/vnnA9se6bnMSvBzoufVs2vXrnR/49NPP03bvHnzEfdj9OjRgdsHP681atRI97xqv450P9qPHTt2pFWpUiXbbRYuXHjExxX8PDRq1Cjwngxexo4d67bdu3dvWpkyZdy6Y489Nt39XHfddYHtly1bdsS/Gfy4+vbtG/j9m2++Sfv777/d+yvj5yAhISHL5yzjv+Hg9d59N2/e3F03b948d7lIkSJpffr0CWx3xx13ZPkZzcn7IivBnzu9b44kLi4u29eud+/eWT628uXLp1WqVCnTZ2fEiBGZ7kOftZ07d2b53Ou1z3jf3ucpr15rALlDiwWAo6Iz2Trj7Z2t/frrr2358uXustcHOhR0RjO4e4fOgH/00Udu8bqi/BO1DLRv397VFag1QP766y93llX7rpoDnUX1zsgvWLDA/a7jF/09tcrIpZde6u5j5MiRFhsb664fNGiQbdy4MdCa8/nnn7vfdRZe3Vhee+0127dvX5b7pQJfdU1S4e/777/vWlWef/55q1Klirt+zJgxlpdUh6I+68HdZPS4dRZZ3dvUDee9995z+6E6Aq8LyiOPPGIHDx7MdH+bNm2yY445xv7zn//Yu+++a926dXOvS3ALk1477/VSK09SUpKr8xB1w1IXIrXO6LU488wzA2fGc2Lt2rV22WWXuddE3bo8aslSK5HOpl9++eWBVifv/aqWAN1GdDZdLS45pbPzJ598cuBzoMet95eeS7+jdXmfo5UrV7rPl1e30bFjR/c8/xO9dzIWXed2n5YuXZrpPoJrmvT+UYvK/PnzXQvCG2+8YS1atHDXqUXqt99+y3Sf6oKn99Lbb79t3bt3d+v02dH7Wy1X+vypVUT0WTua7pWheK0B/DNqLAD4OvB588033YGAurBIkyZNrHnz5iF7VtU9Z82aNYHLtWrVChyE5JS66agLUHx8vP3555+B7ha6r6eeesodPOkg9d///nfgwMQrGv/2228DIUAHPHrcOkDWegUCHXDrpwKGulx4dKDuHWCrS9S5556bab90oKP7VfcdHUjqwP9/J2P/54cffrDk5GS3335oP4IP9j3qFqKuL6KD5QkTJrhgpC5Swf36FYzWrVvnXutgCld6LzRs2DDdeoWkjN2wPN77RtS1TLfVQbNeA3WzyQ29fi+88IILI3pNVqxY4epHUlJSXMHzNddcY3369HEBT/Qe0EGwttu6datb5x3o5vZzoG5fL774YuD9ob/vd+AA77OkYKGD7nfeeSfw97LqohcOCuYKmjpwV3gL7v6k9+7q1auzDEF6nfRe0HOk0CoKtHoO1c1LQf/jjz9O9/nLrVC81gCOjBYLAEetU6dO7mDw0KFD7uy29O3bt8A/ozp49Q7OVcPgUc2FN/ynahw83tCa33//fboz1cEHxerX7/G2+/nnnwPrgsNW8LbBNLKQzijrbL7+ZnCoyLgvealChQrurL4OEEVnnTWkqVoPdLCYVbFwVvuhA8WMoeKfnH766YGWkIcfftiFA4UbnRXXGXqvfienoTO4hSP4efZeC9UDeK1RqgnSY9OZc49aTXKrR48e7qBYz5XXupVXnwPvfvT50udMwVOvTU6Lt73WIW8JbqHKCdW6ZLwPr5hbB+lnn322C9BbtmzJVFOR3ftEwdp7zYM/f3rveLUjWX3+cisUrzWAIyNYADhqOkMdfOZbBbNXX311ttsHj9kffLCaXTFzqHhn5b3H4MmuJSCrA/yMMs5HcDTbBo++M3ToUFcMrgO54FGucnOgnR2vO5LmSFDLg7oiqcDVOyifNGlSYFsFHXWH0vbBrSxZ7Ye6x+WWDsjVqqAWHZ391oGzur+oC47mh1DYOFrZPc86ky3btm1zj8072FTRcMZWmJy+n9QtzlOzZk13UJ8XdFY9eGQtDQec05Gdsirezu2ISlkVb3vvx2nTprmwI+oWqW5gep9ogIIjvU9C8fnLTl6/1gCOjGABwBfVNXgHB5dccskRJ+AKPqDQGU6P+mfnRvDBSF4caOfUv/71r8Dv6iIUfIbW68MdvJ1Gl/J89tlnWW4bTH3zvXqMhx56yB1oq0uStz6veN2R1L9cZ4kz1jEE/z2FHQUKnf39p/3I7kD+SK+XDhpVQ6I6FQWpzZs3u9YF9ZH3Wk9ySpMzBt9/8PMc/FrowNdrbbr//vvdSFh+z2AH1xUpjOWmNuRIdAb/iiuuyHSgXBAEvx/Gjh3rwpTeV15Xo4IgFK81gOxRYwHAF02ON3nyZBcUgs/aZkXDf+ogUwd/qmvQmXMdOKlgObddd4JDiYatVGuJzqQGh5e8pm4hjRo1cvUXOgBWFxgdROoAVrUmoqFZFbDkwgsvDExmdvfdd7vaDh0wDx8+PNvnUnUUf/zxh3tOdEZVcxjs3LkzZI8pu/3wunNpv1UsHFw/kFvBr5fqT/Q+0MGeuocpcA0cONA9Zwo86gKjoUhV+yKqj8gpzR+hM/pXXXWVCylqCRENXapue8Fn8nWGXa+Zt43fPvfq0qWDa80yn9eDF6jWR10O9dzkpsVBZ+m9OoVget71nPgVPDGmHruee73fve5gBUEoXmsA2SNYAPBN8w3khA76dfZVo8goXOhgRHSwrqLknNKZdh0Y6aBTha1eFx2NXpRxFu685M29oBGl1F1H/d692hLvehVe6yDQa81RdxEV2qq7l9dtLLuDQ3X98QrGvfChg0m1Knz33Xche1xZ7Yc3wZvqPrQouKkGRa0CueXNK6LWCXWX0SLr168PFPhqyUpuziyrVUIF9RqVKphaQ7yRtYLP/Hth0KvHqF+/vvkxbNgwCwXVCXhztOSGDvKzmqVbz/s/zReTEwpQGglLr6Gedy16nfX51GhfBUUoXmsAWaMrFIB8pa41GhJU/cYVNNRVQZOq5YYOtjUkqboJqRUgP+mgRAfXOjurvvTq764z8jojrj7cmljOo9YLHaCrZUP9x7VoCMzsJvbSEKka/UdnglV7oANyteyo7iA/qeXpySefdAFIgUJnuNUy1Lhx46O6P7UkaRQgBciMZ8rVbeyOO+5wE7epRkPPp1p19DfVEqbrctNqoD70el/o7+h5fOyxx7IsWNbrVaNGjcBlusYc3WdBB+x6ffU+Ud2ChlPu0KGDFSS81kD+idFkFvn49wAAKBDUoqS5RtQ9T/Mt+B0eFgUXrzWQP+gKBQCIGjqXtn//fvvpp58CE6WpKx2hIvLwWgP5jxYLAEDU0EzqKh73qCZAXfFyO8kiCj5eayD/UWMBAIg6Gg5WRfEqOCZURDZeayD/0GIBAAAAwDdaLAAAAAD4RrAAAAAA4BujQpm5ibo2bdrkZgBWIR8AAAAAcyOsaVJYzf2j4bkJFv9AocKbKRcAAABAehs3brRjjjnGjoQWCzPXUuE9YZoZFwAAAIBZcnKyOwHvHS8TLP6B1/1JoYJgAQAAAKSXk3IBircBAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgW1H/dwHkTJ1hc3mqEBE2PNgl3LsAAECBQ4sFAAAAAN8IFgAAAAB8I1gAAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAHwjWAAAAADwjWABAAAAwDeCBQAAAADfCBYAAAAAfCNYAAAAAPCNYAEAAADAN4IFAAAAAN8IFgAAAAB8I1gAAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAAp3sPjwww/tggsusBo1alhMTIzNnj073fVpaWl29913W/Xq1a1kyZLWvn17++GHH9Jts3PnTuvRo4fFx8db+fLlrU+fPrZv3758fiQAAABAdAtrsNi/f7+ddNJJNnny5Cyvf/jhh23ChAk2bdo0W758uZUuXdo6duxoBw4cCGyjUPHNN9/YwoULbc6cOS6s9OvXLx8fBQAAAICi4XwKOnfu7JasqLVi/PjxNmLECOvatatb98ILL1hCQoJr2ejevbutXbvW5s+fbytXrrRmzZq5bSZOnGjnnXeePfroo64lBAAAAECEB4sjWb9+vW3ZssV1f/KUK1fOWrRoYUlJSS5Y6Ke6P3mhQrR9bGysa+G46KKLsrzvlJQUt3iSk5Pdz9TUVLcgNGItjacWEYHvCQBAtEjNxbFxgQ0WChWiFopguuxdp59Vq1ZNd33RokWtYsWKgW2yMnbsWBs9enSm9du3b0/XzQp5q1EFggUiw7Zt28K9CwAA5Iu9e/cW/mARSsOHD7chQ4aka7FITEy0KlWquCJwhMbaXTE8tYgIGU9oAAAQqUqUKFH4g0W1atXcz61bt7pRoTy63LRp08A2Gc8c/v33326kKO/2WYmLi3NLRupCpQWhkWoEC0QGvicAANEiNhfHxgX2KLpu3bouHCxatChdy4JqJ1q1auUu6+fu3btt1apVgW0WL17s+oKpFgMAAABA/ghri4Xmm/jxxx/TFWx/8cUXrkaiVq1aNmjQIBszZow1aNDABY2RI0e6kZ66devmtm/UqJF16tTJ+vbt64akPXTokPXv398VdjMiFAAAABAlweKzzz6zs88+O3DZq3vo2bOnzZgxw4YOHermutC8FGqZaNu2rRteNriv10svveTCxDnnnOOaai655BI39wUAAACA/BOTpgkjopy6WGko2z179lC8HUJ1hs0N5d0D+WbDg114tgEAUSE5F8fJBbbGAgAAAEDhQbAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAABAZAeLw4cP28iRI61u3bpWsmRJq1+/vt13332WlpYW2Ea/33333Va9enW3Tfv27e2HH34I634DAAAA0aZAB4uHHnrIpk6dapMmTbK1a9e6yw8//LBNnDgxsI0uT5gwwaZNm2bLly+30qVLW8eOHe3AgQNh3XcAAAAgmhS1AmzZsmXWtWtX69Kli7tcp04de/nll23FihWB1orx48fbiBEj3HbywgsvWEJCgs2ePdu6d+8e1v0HAAAAokWBbrFo3bq1LVq0yL7//nt3+csvv7SPP/7YOnfu7C6vX7/etmzZ4ro/ecqVK2ctWrSwpKSksO03AAAAEG0KdIvFsGHDLDk52Y477jgrUqSIq7m4//77rUePHu56hQpRC0UwXfauy0pKSopbPPobkpqa6haERqz9/9oYoDDjewIAEC1Sc3FsXKCDxauvvmovvfSSzZw500444QT74osvbNCgQVajRg3r2bPnUd/v2LFjbfTo0ZnWb9++ndqMEGpUgWCByLBt27Zw7wIAAPli7969kREs/v3vf7tWC69W4sQTT7RffvnFBQMFi2rVqrn1W7dudaNCeXS5adOm2d7v8OHDbciQIelaLBITE61KlSoWHx8f0scUzdbuign3LgB5omrVqjyTAICoUKJEicgIFn/++afFxqYvA1GXKK9JRsPQKlyoDsMLEgoJGh3qpptuyvZ+4+Li3JKR/lbGv4e8k2oEC0QGvicAANEiNhfHxgU6WFxwwQWupqJWrVquK9Tnn39u48aNs+uuu85dHxMT47pGjRkzxho0aOCChua9UFepbt26hXv3AQAAgKhRoIOF5qtQULj55ptdn2YFhhtuuMFNiOcZOnSo7d+/3/r162e7d++2tm3b2vz583PVbAMAAADAn5i04Gmso5S6T2mY2j179lBjEUJ1hs0N5d0D+WbDg/+bWwcAgEiXnIvjZAoKAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAQHiCRb169eyPP/7ItH737t3uOgAAAADR5aiCxYYNG+zw4cOZ1qekpNjvv/+eF/sFAAAAoBApmpuN33777cDvCxYssHLlygUuK2gsWrTI6tSpk7d7CAAAACCygkW3bt3cz5iYGOvZs2e664oVK+ZCxWOPPZa3ewgAAAAgsoJFamqq+1m3bl1buXKlVa5cOVT7BQAAACBSg4Vn/fr1eb8nAAAAAKIrWIjqKbRs27Yt0JLhee655/Ji3wAAAABEcrAYPXq03XvvvdasWTOrXr26q7kAAAAAEL2OKlhMmzbNZsyYYddcc42FmoavveOOO2zevHn2559/2rHHHmvTp093oUbS0tJs1KhR9vTTT7t5NNq0aWNTp061Bg0ahHzfAAAAAPiYx+LgwYPWunVrC7Vdu3a5oKARpxQsvv32WzfqVIUKFQLbPPzwwzZhwgQXdpYvX26lS5e2jh072oEDB0K+fwAAAAB8BIvrr7/eZs6caaH20EMPWWJiomuhOO2009xoVB06dLD69esHWivGjx9vI0aMsK5du1qTJk3shRdesE2bNtns2bNDvn8AAAAAfHSFUmvAU089Ze+//747mFeLQrBx48ZZXtCEfGp9uOyyy2zp0qVWs2ZNu/nmm61v376B0am2bNli7du3D9xGk/a1aNHCkpKSrHv37nmyHwAAAABCECy++uora9q0qft9zZo16a7Ly0Lun3/+2dVLDBkyxO688043d8bAgQOtePHiboI+hQpJSEhIdztd9q7LSkpKils8ycnJ7qdGt8o4whXyTqyl8XQiIvA9AQCIFqm5ODY+qmDxwQcfWH49EBVpP/DAA+7yySef7IKM6ikyzvydG2PHjnUjW2W0fft2ajNCqFEFggUig4bZBgAgGuzduzf081jkBw1le/zxx6db16hRI3v99dfd79WqVXM/t27d6rb16LLXopKV4cOHu1aQ4BYL1XJUqVLF4uPjQ/BIIGt3MSwxIkPVqlXDvQsAAOSLEiVKhDZYnH322Ufs8rR48WLLCxoR6rvvvku37vvvv7fatWu731XMrXChifq8IKGQoNGhbrrppmzvNy4uzi0ZxcbGugWhkWoEC0QGvicAANEiNhfHxkcVLDK2Bhw6dMi++OIL103JTxeljAYPHuyGtVVXqMsvv9xWrFjhisa1iMLNoEGDbMyYMW7eCgWNkSNHWo0aNaxbt255th8AAAAAQhAsHn/88SzX33PPPbZv3z7LK82bN7c333zTdV3STN8KDhpetkePHoFthg4davv377d+/fq5CfLatm1r8+fPz1WzDQAAAAB/YtI0GUQe+fHHH918Ezt37rTCRN2nNEztnj17qLEIoTrD5oby7oF8s+HBLjzbAICokJyL4+Q8LSjQ3BG0FAAAAADR56i6Ql188cXpLqvRY/PmzfbZZ5+5GgcAAAAA0eWogoWaQzJWizds2NDVQXTo0CGv9g0AAABAJAeL6dOn5/2eAAAAACi0fE2Qt2rVKlu7dq37/YQTTnAzYwMAAACIPkcVLLZt22bdu3e3JUuWWPny5d06DfWqifNmzZrlZrAGAAAAED2OalSoAQMG2N69e+2bb75xQ8tq0eR4Go5q4MCBeb+XAAAAACKvxUIT0L3//vvWqFGjwLrjjz/eJk+eTPE2AAAAEIWOqsUiNTXVihUrlmm91uk6AAAAANHlqIJFu3bt7NZbb7VNmzYF1v3+++82ePBgO+ecc/Jy/wAAAABEarCYNGmSq6eoU6eO1a9f3y1169Z16yZOnJj3ewkAAAAg8mosEhMTbfXq1a7OYt26dW6d6i3at2+f1/sHAAAAINJaLBYvXuyKtNUyERMTY+eee64bIUpL8+bN3VwWH330Uej2FgAAAEDhb7EYP3689e3b1+Lj4zNdV65cObvhhhts3Lhxdvrpp+flPgIAgLx2TzmeU0SGe/aEew9wNC0WX375pXXq1Cnb6zt06OBm4wYAAAAQXXIVLLZu3ZrlMLOeokWL2vbt2/NivwAAAABEarCoWbOmm2E7O1999ZVVr149L/YLAAAAQKQGi/POO89GjhxpBw4cyHTdX3/9ZaNGjbLzzz8/L/cPAAAAQKQVb48YMcLeeOMN+9e//mX9+/e3hg0buvUacnby5Ml2+PBhu+uuu0K1rwAAAAAiIVgkJCTYsmXL7KabbrLhw4dbWlqaW6+hZzt27OjChbYBAAAAEF1yPUFe7dq17d1337Vdu3bZjz/+6MJFgwYNrEKFCqHZQwAAAACROfO2KEhoUjwAAAAAyFXxNgAAAABkhWABAAAAwDeCBQAAAADfCBYAAAAAfCNYAAAAAPCNYAEAAADAN4IFAAAAAN8IFgAAAAB8I1gAAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAHwjWAAAAADwjWABAAAAILqCxYMPPmgxMTE2aNCgwLoDBw7YLbfcYpUqVbIyZcrYJZdcYlu3bg3rfgIAAADRptAEi5UrV9qTTz5pTZo0Sbd+8ODB9s4779hrr71mS5cutU2bNtnFF18ctv0EAAAAolGhCBb79u2zHj162NNPP20VKlQIrN+zZ489++yzNm7cOGvXrp2deuqpNn36dFu2bJl9+umnYd1nAAAAIJoUtUJAXZ26dOli7du3tzFjxgTWr1q1yg4dOuTWe4477jirVauWJSUlWcuWLbO8v5SUFLd4kpOT3c/U1FS3IDRiLY2nFhGB7wlEhkJxbhH4Zxy7FZj/eQU+WMyaNctWr17tukJltGXLFitevLiVL18+3fqEhAR3XXbGjh1ro0ePzrR++/btrmYDodGoAsECkWHbtm3h3gXAv/j0XYuBQovv5JDau3dvZASLjRs32q233moLFy60EiVK5Nn9Dh8+3IYMGZKuxSIxMdGqVKli8fHxefZ3kN7aXTE8JYgIVatWDfcuAP4lf8WziMjAd3JI5eYYvEAHC3V10pnBU045JbDu8OHD9uGHH9qkSZNswYIFdvDgQdu9e3e6VguNClWtWrVs7zcuLs4tGcXGxroFoZFqBAtEBr4nEBno+osIwbFbgfmfV6CDxTnnnGNff/11unW9e/d2dRR33HGHa2UoVqyYLVq0yA0zK9999539+uuv1qpVqzDtNQAAABB9CnSwKFu2rDVu3DjdutKlS7s5K7z1ffr0cd2aKlas6LoxDRgwwIWK7Aq3AQAAAERZsMiJxx9/3DXRqMVCIz117NjRpkyZEu7dAgAAAKJKoQsWS5YsyVRQMnnyZLcAAAAACA8qlQEAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAAQLAAAAAAEH60WAAAAADwjWABAAAAwDeCBQAAAADfCBYAAAAAfCNYAAAAAPCNYAEAAADAN4IFAAAAAN8IFgAAAAB8I1gAAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAHwjWAAAAADwjWABAAAAwDeCBQAAAADfCBYAAAAAfCNYAAAAAPCNYAEAAADAN4IFAAAAAN8IFgAAAAAiO1iMHTvWmjdvbmXLlrWqVatat27d7Lvvvku3zYEDB+yWW26xSpUqWZkyZeySSy6xrVu3hm2fAQAAgGhUoIPF0qVLXWj49NNPbeHChXbo0CHr0KGD7d+/P7DN4MGD7Z133rHXXnvNbb9p0ya7+OKLw7rfAAAAQLQpagXY/Pnz012eMWOGa7lYtWqVnXHGGbZnzx579tlnbebMmdauXTu3zfTp061Ro0YujLRs2TJMew4AAABElwLdYpGRgoRUrFjR/VTAUCtG+/btA9scd9xxVqtWLUtKSgrbfgIAAADRpkC3WARLTU21QYMGWZs2baxx48Zu3ZYtW6x48eJWvnz5dNsmJCS467KTkpLiFk9ycnLgb2hBaMRaGk8tIgLfE4gMhercIpA9jt0KzP+8QhMsVGuxZs0a+/jjj/OkKHz06NGZ1m/fvt0VgyM0GlUgWCAybNu2Ldy7APgX34RnEZGB7+SQ2rt3b2QFi/79+9ucOXPsww8/tGOOOSawvlq1anbw4EHbvXt3ulYLjQql67IzfPhwGzJkSLoWi8TERKtSpYrFx8eH8JFEt7W7YsK9C0CeUK0XUOglfxXuPQDyBt/JIVWiRInICBZpaWk2YMAAe/PNN23JkiVWt27ddNefeuqpVqxYMVu0aJEbZlY0HO2vv/5qrVq1yvZ+4+Li3JJRbGysWxAaqUawQGTgewKRga6/iBAcuxWY/3lFC3r3J4349NZbb7m5LLy6iXLlylnJkiXdzz59+rjWBxV0q7VBQUShghGhAAAAgPxToIPF1KlT3c+zzjor3XoNKdurVy/3++OPP+6SlFosVJDdsWNHmzJlSlj2FwAAAIhWBb4rVE76fU2ePNktAAAAAMKDggIAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAOAbwQIAAACAbwQLAAAAAL4RLAAAAAD4RrAAAAAA4BvBAgAAAIBvERMsJk+ebHXq1LESJUpYixYtbMWKFeHeJQAAACBqRESweOWVV2zIkCE2atQoW716tZ100knWsWNH27ZtW7h3DQAAAIgKEREsxo0bZ3379rXevXvb8ccfb9OmTbNSpUrZc889F+5dAwAAAKJCUSvkDh48aKtWrbLhw4cH1sXGxlr79u0tKSkpy9ukpKS4xbNnzx73c/fu3ZaampoPex2lUvaHew+APKHvCqDQS4kJ9x4AeYPv5JBKTk52P9PS0iI/WOzYscMOHz5sCQkJ6dbr8rp167K8zdixY2306NGZ1teuXTtk+wkgclQYH+49AAAEPFiBJyMf7N2718qVKxfZweJoqHVDNRketVLs3LnTKlWqZDExnMFB4T2jkJiYaBs3brT4+Phw7w4ARDW+kxEp1FKhUFGjRo1/3LbQB4vKlStbkSJFbOvWrenW63K1atWyvE1cXJxbgpUvXz6k+wnkF4UKggUAFAx8JyMS/FNLRcQUbxcvXtxOPfVUW7RoUboWCF1u1apVWPcNAAAAiBaFvsVC1K2pZ8+e1qxZMzvttNNs/Pjxtn//fjdKFAAAAIDQi4hgccUVV9j27dvt7rvvti1btljTpk1t/vz5mQq6gUim7n2ayyVjNz8AQP7jOxnRKCYtJ2NHAQAAAEAk11gAAAAACD+CBQAAAADfCBYAAAAAfCNYAAAAACBYAMgZxmkAAAChRIsFEOF2795tv//+u8XExIR7VwAAITpxpMmBvd+BcCFYABFszZo11q5dO3v99dfd5RtuuMHmzp0b7t0CAOQRBQmdOIqNjXWTA3MSCeFEsAAikHfmqnHjxnbiiSfa008/bRUrVrQPP/zQatWqFe7dAwDk0fe8FyRuv/12a9GihXXv3j1wMgnIbwQLIALpzJVnx44d9s0331ibNm1s7dq1Lmh4/5AAAIX7e37dunX23HPP2bJly2zw4MG2adMmu/fee23evHnuer7vkZ8IFkAEOnDggN14443uH8zIkSPdP5vk5GR755133PU0lQNA4abAMG3aNDvrrLPshRdesClTplifPn1cyDjppJNs1KhRmU40AaHGuw0o5LIq1Pvkk0/s7bffdte1bNnSbrvtNvdP6K233rKtW7e6YHH48OGw7C8AIHf+/vvvTOsUGOrUqWMNGjSwbdu2WdOmTd36Y4891i6//HI3cMdjjz3m1tFqgfxCsAAKOa/14fvvvw+s+/PPP90/ItVVSI0aNezKK6+0L774ItA8XqRIkTDtMQAgNyeNihYt6n6++OKL9t///td9l8s555xjF1xwgW3evNmWLl0a2L5169bWrVs3e+qpp1x3WIUQRotCfiBYAIVQ8LCCWtQMftxxx1nnzp3dPxcVaaulonjx4q5blPTr18+OOeYYe/XVVy0pKcmWLFniukvRcgEABYO6q/7nP/9x3/HBXVb1vZ6YmGj33XefjRgxwo32N2nSJCtWrJhddNFF1rZtW3v00UcD2+uk0sUXX+wChbrCCl1gkR8IFkAh4oUA/bNQi4T+UWi59tpr7f3337fKlSu7fyI6S6X6Cm1XokSJwBmv/v37u/tQM3nXrl2tQoUKtFwAQAGhEz86IRRcF6Hv+vvvv9+1TKhlevHixS5c3HXXXa57q7pCXXLJJfbjjz+6k0wedY0aOnSo9e7dO0yPBtEoJo22MaDQeeSRR2zBggVWt25dN8rTwIEDA9dpMjy1XGgOi44dO7rRoIYMGWKlSpVy12/fvt1WrlxpZ555ppUuXTqMjwIAopdaJbwuSvpd3VO9OSl0Akjr1CKxYsUK953+5ptv2hlnnBG4vb7fdRutV3en0aNHuy5SixYtsrJly4b1sSF60WIBFHDBRXcqvFYgeOaZZ6xLly5WvXp1N+qTCvRUVyFqtWjYsKFbr+5QkydPtmbNmrluTzrzVaVKFTvvvPMIFQAQRl6rhIKEV/Om31evXu26Ni1cuDBQI7dv3z7XkiHed72GlNUJpt9++81q1qxp7du3d9upmysQLgQLoABSq4L60qrVQf98fvnlF3cG69NPP7W4uDhbvny56/Kklghdnj17tu3Zs8fdVpf1j0n1FBpuUK0Tw4cPd/90vAJAAEB47dy509VKqOuqvPfee67G4oQTTnDF2PPnz3f/C+Lj412R9kMPPeS281qfy5Qp47qz/vTTT+7y+eef77pJqcsUEC4EC6AA0oR26iv7yiuv2HXXXee6PGlyO/3jUQFf+fLl7aabbnK/q/VBxX5qvRANMaizXrqNKGBcc801dumll4b5UQEAPDrRo9ZktTyoi5O6O6nFQSeH7r77bjdkuAbiULDQbNrqEqU5Kjyqq6tXr54bAcoLHNWqVQsM6gGEA6cvgQJIEx7pH4YK9jTRkYJGo0aNXJCYOXOm6+6ks1oaOlZN5qLWDP2TUsuFznJ5Z7UAAAWDV0MhCgzq1qSBNipVqpRuhD6dUNLJJQ0vqy6tGnDj559/dl1ap0+f7r7fFTrUDVYtF8H3y+hPCCdaLIACSGet9I+jfv367kyWJkEShQ39I1IrhYYf9EKFCvceeOAB13Suf1Y6s+WdxQIAhL9WLvjgX1JSUtz3+4ABA1x31w0bNrj13hDhKsZWV1aN/KTWjXvuuceNGnXhhRda48aN3ShQN998s9uWMIGCglGhgALsiSeesJdeeskNE6shZfWPSD815KDqK5o3b+5aJ1RDIVOmTLEmTZqEe7cBABlGfxKN2vTtt9/aaaed5lqg1e1JNRIaElYnhebMmRPoyqTb9OrVy9avX29jx47N8mSRWjm0HcECBQXBAijgLRcan1w1FWPGjHHjlX/99deuO9TEiRPd6E8bN250/W8nTJgQ7t0FAGThjz/+cJOUfvTRR5aQkOACgTfJnUbr02zaN9xwg6ur69Spk7teI0VpxCe1XKv14vbbb083AEdwYAEKCoIFUMCp6fvhhx+2q666yrVSyJYtW9w/FDWd16pVyxXsAQDCzwsFHp38ue222+zQoUM2btw4N7DGG2+84QbUUPfVDh06uAAxbNgw+/zzz11N3d69e23WrFmu1iIpKcm1VhAiUBgQLIBC4Prrr3d1E5rDQv9sWrVq5frd0vwNAAVrziEvAGjeIbVO7Nq1y7Uwq5ZCw8OqdeKOO+5wgUMnhlQrIRpG/KKLLnLr1GVKQ4S//PLLgcnuaKFAYUCwAAoB9cHV0IMa47xr16526623hnuXAAAZRnoSzSN01113uRChUZs0FLiGAS9durTrDqWBNwYOHGgtWrSwc88913VzUouGaFhxzaStGgwFC6CwIVgAhQhnrAAgvFQTMXToUDv22GMDozJ5AeORRx5x81KoC5MmtdNgGt6cQpp3Qt2dHn30UTekuIaPVbhQF6l169Zl2aU1Y7cqoKCj6gcoROhjCwDhpS5OtWvXdjNdB9N8FOrmNHnyZDeYhlqXvVDhtWQoTChUiGrkFD40L5FqLYJ5E9wRKlDYECwAAAD+oTtqmzZt3OhONWvWdN1RVQuhob89GrFP25188snusjdsrFd7odtrjgoNGT5y5EhXO6e5iHQ7DSsbjPo5FFYECwAAgCPYs2ePa5Hw5gxSFyUN+60J7jSJnSh0FCtWzC1eONCilmYFDAWLJ5980s09NG/ePDepqeYoKlmyZCCEAIUdNRYAAABHoDqIGTNmuCLrDz74wE499VQ3J8X999/v5hnSaH3apmrVqq41Q8XbXsDQ0LHTp093LRSlSpVyIaVcuXKB+6Z2DpGEFgsAAIAMvC5MaklQSNAITuq6NHjwYLf+9NNPd3UWGhpWtRXa5r777nPzDj399NP2ww8/uDmHNLmpWjdUoC1eqFCrhzsQY5I7RBBaLAAAAP6PVxeRVeH07Nmz3YhPmpeiR48e9t1337lRoDQnhVoydBsFj7lz57rt//rrLzfsrFos1MoBRDqCBQAAQIZuSQoLU6dOtcaNG7tQ0LBhQ9u5c6eb3G7x4sWuUFs0id2DDz7ogoaGoVWB9rZt29wM2kWLFnUtHVnNdwFEIoIFAABAEE1Sd+WVV7p5KDRztgLF888/77o+rVixwi677DI3upO6Pmn4WXV/0jwVmsRUo0VlxHwUiBbUWAAAAJi5WbEvuOAC+/zzz+3FF190IWLNmjXWrl07Gzt2rCvY1qzYKsTWfBUaKSohIcFdrxYJtWRkhfkoEC1osQAAAFEluzoK1Ul07NjRjd60bNkyO/744936X375xS699FIXIDRMrAqzVWtRpUoVe+uttywlJcV27Njh5rgAohktFgAAIGp4tQ4KFcnJyfbbb7+5Imtp3ry5G1JWVHQtf//9t5tpW4Hj3XffdberV6+eXX311fbll1+6rlBxcXGBUMF8FIhmBAsAABA1vALqUaNGWWJionXu3NkVWH/77bdWpkwZ69u3rwsKGvlJVIAtKt5W1ye1TBQvXtwVa6uAW12hsrp/IBoRLAAAQNRQ3YQKrVUPoYJsdW1SVyYFigULFrjWCI3u9Nhjj7libI3wpG5Tr7/+up133nlWuXLlwHwUar3w5qMAQI0FAACIUBlHY/r111+tTp06rpVh+PDhNnDgQLd+w4YNdsstt1jFihVtypQp7nYaAUp1Ft27d7e1a9e60aE00V3r1q3D+IiAgo0WCwAAEFG8VgSFioMHD7paCq3TULDqAqW6iOBCa4WNTp062VdffeXmnyhfvrwNGzbMdYPq0qWLCxsKH4QK4MgYFQoAAESkhx56yHV30uhNNWrUcL/v37/fTjzxROvWrZs98cQTgRYNzVWhlgwNKduyZUsXRnr16uVGhFq1alWgkNuruQCQGS0WAAAgoqjLkwqyFSTU8tC/f3/XGtG7d29XmK2J7Z555hkXIjzr1q1z4cMrvo6Pj7c777zTDS2rFgthPgrgyGixAAAAETfR3dy5c+3222+3qlWr2h9//OG6NGl42GnTprlZtTUnxc8//+x+b9GihesipWAxe/ZsK1u2rLufQ4cOudqL1atX28qVKxnxCfgHBAsAABBRNm/e7Lo81a9f3wUGDR171VVX2e+//+5aJt577z03dKxqJjTTtrpKVatWzcaMGZPpvtQlSq0XAP4ZHQUBAEBEqV69uvuprlBz5syxWbNmuQnuNNRsmzZt3GWNCKW5KNTVSdupYDurOgpCBZBz1FgAAICIo7kpXnzxRTvllFPsrLPOcutUU1GqVClXd7Fx40YbPXq0GwVKw8h6KM4Gjh4tFgAAIOKoSFutDZpRW+FB9RKaFO+TTz5xQ8c2aNDAbTdgwABX3H3RRRcFWjoAHB1qLAAAQMSODtWqVSsrUaKEq6m44YYbbPz48em22bdvnz311FM2ZMiQsO0nECkIFgAAIGIpUPz0009Wr169dJPiAch7BAsAABAVNPt2bGwsw8YCIUKwAAAAAOAbo0IBAAAA8I1gAQAAAMA3ggUAAAAA3wgWAAAAAHwjWAAAAADwjWABAAAAwDeCBQAAAADfCBYAgKh31lln2aBBgwLPQ506dWz8+PFR/7wAQG4QLAAgivTq1cvNOnzjjTdmuu6WW25x12mb4O27devm6/Zal3Hp1KlTtvt4zz33ZHmb999/30LljTfesPvuuy9k9w8A0YBgAQBRJjEx0WbNmmV//fVXYN2BAwds5syZVqtWrTy/vULE5s2b0y0vv/zyEf/GCSeckOk2Z5xxhoVKxYoVrWzZsiG7fwCIBgQLAIgyp5xyigsHOkvv0e8KBSeffHKe3z4uLs6qVauWbqlQocIR/0bRokUz3aZ48eL24osvWrNmzVwI0LqrrrrKtm3bFrjdkiVLXOvGggUL3L6ULFnS2rVr57aZN2+eNWrUyOLj493t/vzzz2y7QgW77rrr7Pzzz0+37tChQ1a1alV79tln//H5AoBoQbAAgCikg+Xp06cHLj/33HPWu3fvfLv90dIBvbosffnllzZ79mzbsGFDuq5Xwd2pJk2aZMuWLbONGzfa5Zdf7mom1Koyd+5ce++992zixIk5+pvXX3+9zZ8/37WaeObMmeOCyRVXXJGnjw8ACjOCBQBEoauvvto+/vhj++WXX9zyySefuHWhuL0OwsuUKZNueeCBB454/19//XW67U877bRAoOncubPVq1fPWrZsaRMmTHAtEfv27Ut3+zFjxlibNm1cq0WfPn1s6dKlNnXqVHf59NNPt0svvdQ++OCDHD3W1q1bW8OGDV1riUeh6rLLLnP7BgD4n6L/9xMAEEWqVKliXbp0sRkzZlhaWpr7vXLlyiG5/dlnn+0O6jPWNByJDuTffvvtdN2pZNWqVa41Qi0Wu3btstTUVLf+119/teOPPz6wfZMmTQK/JyQkWKlSpVwYCV63YsWKHD9etVo89dRTNnToUNu6dasLM4sXL87x7QEgGhAsACBK6ex///793e+TJ08O2e1Lly5txx57bK7uW/UUGW+zf/9+69ixo1teeuklF24UKHT54MGD6bYtVqxY4HfVXARf9tZ5oSQnrr32Whs2bJglJSW57lV169Z1LR8AgP+PYAEAUUqjNemAXAfZOjjP79vn1rp16+yPP/6wBx980BWPy2effWb5oVKlSm7YXXWBUrjIj3oSAChsCBYAEKWKFClia9euDfweqtunpKTYli1bMo36lJuuV6JRp9SSoaJrzaOxZs2afJ17Qt2hNDrU4cOHrWfPnvn2dwGgsKB4GwCimIZe1RLK22tEperVq6db2rZtm+u/pa5Pqul47bXXXD2FWi4effRRyy/t27d3+67WmRo1auTb3wWAwiImTVV3AADgiDTyVM2aNV13qIsvvphnCwAyoCsUAABHoCLvHTt22GOPPWbly5e3Cy+8kOcLALJAsAAA4Ag08pRGgTrmmGNcVyzVhwAAMqMrFAAAAADfKN4GAAAA4BvBAgAAAIBvBAsAAAAAvhEsAAAAAPhGsAAAAADgG8ECAAAAgG8ECwAAAAC+ESwAAAAA+EawAAAAAGB+/T98cTHrbcxb8gAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Truncation rate: 0.0% of events with content_parts\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not multimodal_parts_df.empty:\n",
+    "    mime_counts = multimodal_parts_df[\"mime_family\"].value_counts()\n",
+    "    fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "    mime_counts.plot.bar(ax=ax, color=plt.cm.tab10.colors[:len(mime_counts)])\n",
+    "    ax.set_title(\"Multimodal Parts by MIME Family\", fontsize=12, fontweight=\"bold\")\n",
+    "    ax.set_ylabel(\"Count\")\n",
+    "    ax.set_xlabel(\"MIME Family\")\n",
+    "    ax.tick_params(axis=\"x\", rotation=30)\n",
+    "    ax.grid(True, alpha=0.3, axis=\"y\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "    # Truncation rate\n",
+    "    fe_with_parts = filtered_events_df[\n",
+    "        filtered_events_df[\"content_parts\"].notna()\n",
+    "    ]\n",
+    "    if not fe_with_parts.empty:\n",
+    "        trunc_rate = fe_with_parts[\"is_truncated\"].mean()\n",
+    "        print(f\"Truncation rate: {trunc_rate:.1%} of events with content_parts\")\n",
+    "else:\n",
+    "    print(\"No multimodal parts in time range.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel 9: Recent Sessions Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.376193Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.376106Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.385280Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.384770Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>session_id</th>\n",
+       "      <th>agent</th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>start_ts</th>\n",
+       "      <th>total_events</th>\n",
+       "      <th>llm_calls</th>\n",
+       "      <th>tool_calls</th>\n",
+       "      <th>has_error</th>\n",
+       "      <th>duration_ms</th>\n",
+       "      <th>turn_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>e2e-a9b40dfdbe84</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:44:09.959171+00:00</td>\n",
+       "      <td>33</td>\n",
+       "      <td>6</td>\n",
+       "      <td>3</td>\n",
+       "      <td>False</td>\n",
+       "      <td>46182</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>e2e-054c12957ba3</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:43:59.632517+00:00</td>\n",
+       "      <td>19</td>\n",
+       "      <td>3</td>\n",
+       "      <td>4</td>\n",
+       "      <td>False</td>\n",
+       "      <td>9920</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>e2e-781fb52f3814</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:43:46.386415+00:00</td>\n",
+       "      <td>21</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5</td>\n",
+       "      <td>False</td>\n",
+       "      <td>12856</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>e2e-3171eb36991f</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:37:14.206646+00:00</td>\n",
+       "      <td>33</td>\n",
+       "      <td>6</td>\n",
+       "      <td>3</td>\n",
+       "      <td>False</td>\n",
+       "      <td>26136</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>e2e-f676e06a719e</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:36:54.241866+00:00</td>\n",
+       "      <td>19</td>\n",
+       "      <td>3</td>\n",
+       "      <td>4</td>\n",
+       "      <td>False</td>\n",
+       "      <td>19455</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>e2e-125750c7b94d</td>\n",
+       "      <td>travel_planner</td>\n",
+       "      <td>demo_user</td>\n",
+       "      <td>2026-04-03 07:36:20.755950+00:00</td>\n",
+       "      <td>23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "      <td>False</td>\n",
+       "      <td>33078</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         session_id           agent    user_id  \\\n",
+       "0  e2e-a9b40dfdbe84  travel_planner  demo_user   \n",
+       "1  e2e-054c12957ba3  travel_planner  demo_user   \n",
+       "2  e2e-781fb52f3814  travel_planner  demo_user   \n",
+       "3  e2e-3171eb36991f  travel_planner  demo_user   \n",
+       "4  e2e-f676e06a719e  travel_planner  demo_user   \n",
+       "5  e2e-125750c7b94d  travel_planner  demo_user   \n",
+       "\n",
+       "                           start_ts  total_events  llm_calls  tool_calls  \\\n",
+       "0  2026-04-03 07:44:09.959171+00:00            33          6           3   \n",
+       "1  2026-04-03 07:43:59.632517+00:00            19          3           4   \n",
+       "2  2026-04-03 07:43:46.386415+00:00            21          3           5   \n",
+       "3  2026-04-03 07:37:14.206646+00:00            33          6           3   \n",
+       "4  2026-04-03 07:36:54.241866+00:00            19          3           4   \n",
+       "5  2026-04-03 07:36:20.755950+00:00            23          3           6   \n",
+       "\n",
+       "   has_error  duration_ms  turn_count  \n",
+       "0      False        46182           3  \n",
+       "1      False         9920           1  \n",
+       "2      False        12856           1  \n",
+       "3      False        26136           3  \n",
+       "4      False        19455           1  \n",
+       "5      False        33078           1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if not session_rollups_df.empty:\n",
+    "    recent = session_rollups_df.sort_values(\"start_ts\", ascending=False).head(15)\n",
+    "    display_cols = [\n",
+    "        \"session_id\", \"agent\", \"user_id\", \"start_ts\",\n",
+    "        \"total_events\", \"llm_calls\", \"tool_calls\",\n",
+    "        \"has_error\", \"duration_ms\", \"turn_count\",\n",
+    "    ]\n",
+    "    cols = [c for c in display_cols if c in recent.columns]\n",
+    "    display(recent[cols].reset_index(drop=True))\n",
+    "else:\n",
+    "    print(\"No sessions.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layer D: Span-Tree Drill-Down\n",
+    "\n",
+    "Reconstructs the span hierarchy for the most recent session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.386552Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.386479Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.924838Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.924463Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    Query processed 0 Bytes in a moment of slot time.\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Span tree for session: e2e-a9b40dfdbe84\n",
+      "Total events: 33, Unique spans: 15\n",
+      "======================================================================\n",
+      "[1c5d2a3d] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (4078ms)\n",
+      "  [4da56afc] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (4077ms)\n",
+      "    [ca1069a7] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (2148ms)\n",
+      "    [0c421077] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [cb1f5828] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (1914ms)\n",
+      "[6d944fa2] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (35705ms)\n",
+      "  [c11e0281] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (35704ms)\n",
+      "    [6a6e6b52] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (29060ms)\n",
+      "    [ba01fa7e] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [8a1d7785] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (6631ms)\n",
+      "[edaac2cc] events=[USER_MESSAGE_RECEIVED, INVOCATION_STARTING, INVOCATION_COMPLETED] agent=travel_planner (5410ms)\n",
+      "  [cf99a390] events=[AGENT_STARTING, AGENT_COMPLETED] agent=travel_planner (5410ms)\n",
+      "    [8f97b315] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (2113ms)\n",
+      "    [397df66f] events=[TOOL_STARTING, TOOL_COMPLETED] agent=travel_planner\n",
+      "    [9bf79f5b] events=[LLM_REQUEST, LLM_RESPONSE] agent=travel_planner (3284ms)\n"
+     ]
+    }
+   ],
+   "source": [
+    "target_session = None\n",
+    "if not session_rollups_df.empty:\n",
+    "    target_session = session_rollups_df.sort_values(\"start_ts\", ascending=False)[\"session_id\"].iloc[0]\n",
+    "\n",
+    "if target_session:\n",
+    "    events = read_sql(f\"\"\"\n",
+    "    SELECT\n",
+    "      span_id,\n",
+    "      parent_span_id,\n",
+    "      event_type,\n",
+    "      CASE\n",
+    "        WHEN event_type IN ('LLM_REQUEST','LLM_RESPONSE','LLM_ERROR') THEN 'llm'\n",
+    "        WHEN event_type IN ('TOOL_STARTING','TOOL_COMPLETED','TOOL_ERROR') THEN 'tool'\n",
+    "        ELSE 'other'\n",
+    "      END AS event_family,\n",
+    "      agent,\n",
+    "      status,\n",
+    "      error_message,\n",
+    "      CAST(JSON_VALUE(latency_ms, '$.total_ms') AS FLOAT64) AS total_ms,\n",
+    "      CAST(JSON_VALUE(latency_ms, '$.time_to_first_token_ms') AS FLOAT64) AS ttft_ms,\n",
+    "      timestamp\n",
+    "    FROM {TABLE_REF}\n",
+    "    WHERE session_id = '{target_session}'\n",
+    "    ORDER BY timestamp\n",
+    "    \"\"\")\n",
+    "\n",
+    "    # Aggregate events into spans (deduplicate by span_id)\n",
+    "    span_map = {}\n",
+    "    for _, row in events.iterrows():\n",
+    "        sid = row.get(\"span_id\")\n",
+    "        if not sid or pd.isna(sid):\n",
+    "            continue\n",
+    "        if sid not in span_map:\n",
+    "            span_map[sid] = {\n",
+    "                \"span_id\": sid,\n",
+    "                \"parent_span_id\": row.get(\"parent_span_id\") if pd.notna(row.get(\"parent_span_id\")) else None,\n",
+    "                \"agent\": row.get(\"agent\"),\n",
+    "                \"events\": [],\n",
+    "                \"total_ms\": None,\n",
+    "                \"ttft_ms\": None,\n",
+    "                \"has_error\": False,\n",
+    "                \"error_message\": None,\n",
+    "            }\n",
+    "        span_map[sid][\"events\"].append(row.get(\"event_type\", \"\"))\n",
+    "        total_ms = row.get(\"total_ms\")\n",
+    "        if pd.notna(total_ms) and total_ms > 0:\n",
+    "            span_map[sid][\"total_ms\"] = float(total_ms)\n",
+    "        ttft_ms = row.get(\"ttft_ms\")\n",
+    "        if pd.notna(ttft_ms) and ttft_ms > 0:\n",
+    "            span_map[sid][\"ttft_ms\"] = float(ttft_ms)\n",
+    "        err_msg = row.get(\"error_message\")\n",
+    "        if pd.notna(err_msg) and err_msg:\n",
+    "            span_map[sid][\"has_error\"] = True\n",
+    "            span_map[sid][\"error_message\"] = str(err_msg)\n",
+    "        status = row.get(\"status\")\n",
+    "        if pd.notna(status) and status == \"ERROR\":\n",
+    "            span_map[sid][\"has_error\"] = True\n",
+    "\n",
+    "    # Build tree\n",
+    "    children = {}\n",
+    "    roots = []\n",
+    "    for sid, span in span_map.items():\n",
+    "        pid = span.get(\"parent_span_id\")\n",
+    "        if pid and pid in span_map:\n",
+    "            children.setdefault(pid, []).append(span)\n",
+    "        else:\n",
+    "            roots.append(span)\n",
+    "\n",
+    "    def print_tree(node, indent=0):\n",
+    "        sid = node[\"span_id\"][:8]\n",
+    "        evts = \", \".join(node[\"events\"])\n",
+    "        ag = node.get(\"agent\") or \"\"\n",
+    "        lat = node.get(\"total_ms\")\n",
+    "        err = node.get(\"error_message\")\n",
+    "        prefix = \"  \" * indent\n",
+    "        err_mark = \" *** ERROR\" if node[\"has_error\"] else \"\"\n",
+    "        lat_str = f\" ({lat:.0f}ms)\" if lat and lat > 0 else \"\"\n",
+    "        print(f\"{prefix}[{sid}] events=[{evts}] agent={ag}{lat_str}{err_mark}\")\n",
+    "        if err:\n",
+    "            print(f\"{prefix}  error: {str(err)[:100]}\")\n",
+    "        for child in children.get(node[\"span_id\"], []):\n",
+    "            print_tree(child, indent + 1)\n",
+    "\n",
+    "    print(f\"Span tree for session: {target_session}\")\n",
+    "    print(f\"Total events: {len(events)}, Unique spans: {len(span_map)}\")\n",
+    "    print(\"=\" * 70)\n",
+    "    for root in roots:\n",
+    "        print_tree(root)\n",
+    "else:\n",
+    "    print(\"No sessions available for drill-down.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parity Validation\n",
+    "\n",
+    "Compare key metrics against `dashboard_v2.ipynb` on the same dataset/time window."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-11T07:02:14.927069Z",
+     "iopub.status.busy": "2026-04-11T07:02:14.926929Z",
+     "iopub.status.idle": "2026-04-11T07:02:14.933904Z",
+     "shell.execute_reply": "2026-04-11T07:02:14.933309Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "PARITY VALIDATION — compare these with dashboard_v2.ipynb\n",
+      "============================================================\n",
+      "  Filtered events     :        148\n",
+      "  Distinct sessions   :          6\n",
+      "  LLM events          :         48\n",
+      "  Total tokens        :     34,398\n",
+      "  Error events        :          0\n",
+      "  Multimodal parts    :        162\n",
+      "  TTFT median (ms)    :     3837.0\n",
+      "  Drill-down events   :         33\n",
+      "  Drill-down spans    :         15\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 60)\n",
+    "print(\"PARITY VALIDATION — compare these with dashboard_v2.ipynb\")\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"  Filtered events     : {len(filtered_events_df):>10,}\")\n",
+    "print(f\"  Distinct sessions   : {filtered_events_df['session_id'].nunique():>10,}\")\n",
+    "print(f\"  LLM events          : {len(llm_events_df):>10,}\")\n",
+    "resp_df = llm_events_df[llm_events_df['event_type'] == 'LLM_RESPONSE']\n",
+    "print(f\"  Total tokens        : {int(resp_df['total_tokens'].sum()):>10,}\")\n",
+    "print(f\"  Error events        : {int(filtered_events_df['is_error'].sum()):>10,}\")\n",
+    "print(f\"  Multimodal parts    : {len(multimodal_parts_df):>10,}\")\n",
+    "if not resp_df.empty and resp_df['ttft_ms'].notna().any():\n",
+    "    print(f\"  TTFT median (ms)    : {resp_df['ttft_ms'].median():>10.1f}\")\n",
+    "if target_session and 'events' in dir():\n",
+    "    print(f\"  Drill-down events   : {len(events):>10,}\")\n",
+    "    print(f\"  Drill-down spans    : {len(span_map):>10,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "**End of Dashboard V2 BigFrames Companion Notebook**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/ontology_graph_v4_demo.ipynb
+++ b/examples/ontology_graph_v4_demo.ipynb
@@ -1,0 +1,1118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2025 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#      https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "# Ontology Graph V4: Configuration-Driven Context Graph Pipeline\n",
+    "\n",
+    "**Integrating BigQuery Agent Analytics SDK with YAML-Driven Property Graphs**\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/ontology_graph_v4_demo.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/colab-logo.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/main/examples/ontology_graph_v4_demo.ipynb\">\n",
+    "      <img src=\"https://www.gstatic.com/images/branding/product/1x/google_cloud_48dp.png\" alt=\"Vertex AI logo\" width=\"32\"> Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/bigquery/import?url=https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/blob/main/examples/ontology_graph_v4_demo.ipynb\">\n",
+    "      <img src=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTW1gvOovVlbZAIZylUtf5Iu8-693qS1w5NJw&s\" alt=\"BQ logo\" width=\"35\"> Open in BQ Studio\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "\n",
+    "The **Ontology Graph V4** pipeline introduces a fully configuration-driven approach to building\n",
+    "context graphs from unstructured ADK telemetry. Instead of hard-coding entity extraction logic,\n",
+    "the entire ontology is declared in a **YAML specification** file.\n",
+    "\n",
+    "The pipeline performs the following steps:\n",
+    "\n",
+    "1. **YAML Spec** defines the ontology: entities (with typed properties and keys), relationships\n",
+    "   (with source/target bindings), and table bindings.\n",
+    "2. **AI.GENERATE** (or Gemini API fallback) extracts a typed graph from unstructured ADK\n",
+    "   telemetry, guided by a compiled extraction prompt and output schema.\n",
+    "3. **Physical tables** are created and populated automatically based on the spec bindings.\n",
+    "4. **BigQuery Property Graph DDL** is generated dynamically from the spec and executed.\n",
+    "5. **GQL showcase queries** demonstrate graph traversal over the materialized property graph.\n",
+    "\n",
+    "This notebook walks through each phase individually, then shows the one-shot orchestrator and\n",
+    "CLI commands that run the full pipeline in a single call."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "## Demo Scenario: Yahoo ADCP Ad Decisioning\n",
+    "\n",
+    "This demo uses the **Yahoo Ad Context Protocol (ADCP)** ad decisioning use case. The ontology\n",
+    "models the following domain objects and relationships:\n",
+    "\n",
+    "```\n",
+    "DecisionPoint --CandidateEdge--> YahooAdUnit\n",
+    "RejectionReason --ForCandidate--> YahooAdUnit\n",
+    "```\n",
+    "\n",
+    "- **DecisionPoint**: A point in the ad-serving pipeline where candidate ads are evaluated.\n",
+    "- **YahooAdUnit**: An ad creative that is a candidate for serving.\n",
+    "- **CandidateEdge**: Links a decision point to the ad units it considered.\n",
+    "- **RejectionReason**: Captures why a specific ad unit was rejected at a decision point.\n",
+    "- **ForCandidate**: Links a rejection reason back to the ad unit it pertains to.\n",
+    "\n",
+    "The YAML spec (`ymgo_graph_spec.yaml`) encodes this ontology. AI.GENERATE extracts structured\n",
+    "graph data from raw ADK session logs and materializes it into BigQuery tables and a native\n",
+    "property graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q bigquery-agent-analytics google-cloud-bigquery pyyaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "source": [
+    "## Authenticate & Configure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Not running in Colab -- using default credentials.\n",
+      "Project  : test-project-0728-467323\n",
+      "Dataset  : agent_analytics\n",
+      "Table    : agent_events\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "try:\n",
+    "    from google.colab import auth\n",
+    "    auth.authenticate_user()\n",
+    "    print(\"Colab authentication successful.\")\n",
+    "except ImportError:\n",
+    "    print(\"Not running in Colab -- using default credentials.\")\n",
+    "\n",
+    "# ---------- Configuration ----------\n",
+    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"your-project-id\")\n",
+    "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
+    "TABLE_ID = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
+    "\n",
+    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"true\"\n",
+    "os.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\n",
+    "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = \"global\"\n",
+    "\n",
+    "print(f\"Project  : {PROJECT_ID}\")\n",
+    "print(f\"Dataset  : {DATASET_ID}\")\n",
+    "print(f\"Table    : {TABLE_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "## Phase 1: Load the YAML Ontology Spec\n",
+    "\n",
+    "The YAML spec is the single source of truth for the ontology. It declares:\n",
+    "\n",
+    "- **Entities** with typed properties, primary keys, and BigQuery table bindings.\n",
+    "- **Relationships** with source/target entity references and edge properties.\n",
+    "\n",
+    "The `load_graph_spec` function parses the YAML file and resolves environment placeholders\n",
+    "(e.g., `{env}`) so that table references point to the correct BigQuery dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Wrote ymgo_graph_spec.yaml (2984 bytes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Write the YMGO graph spec into the working directory so it is\n",
+    "# available regardless of how the notebook was launched (Colab,\n",
+    "# Vertex AI Workbench, local Jupyter, etc.).\n",
+    "\n",
+    "SPEC_PATH = \"ymgo_graph_spec.yaml\"\n",
+    "\n",
+    "_YMGO_SPEC = \"\"\"\\\n",
+    "# YMGO (Yahoo Media Graph Ontology) V3 \u2014 Context Graph Specification\n",
+    "#\n",
+    "# This YAML defines the ontology for a configuration-driven context graph.\n",
+    "# Use {{ env }} placeholders for environment-specific table bindings,\n",
+    "# resolved at load time via load_graph_spec(path, env=\"project.dataset\").\n",
+    "\n",
+    "graph:\n",
+    "  name: YMGO_Context_Graph_V3\n",
+    "\n",
+    "  # ==========================================\n",
+    "  # 1. ENTITIES (Nodes)\n",
+    "  # ==========================================\n",
+    "  entities:\n",
+    "    - name: mako_DecisionPoint\n",
+    "      description: \"The atomic unit of decisioning where an agent evaluates alternatives.\"\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.decision_points\"\n",
+    "      keys:\n",
+    "        primary: [decision_id]\n",
+    "      properties:\n",
+    "        - name: decision_id\n",
+    "          type: string\n",
+    "        - name: decision_type\n",
+    "          type: string\n",
+    "\n",
+    "    - name: sup_YahooAdUnit\n",
+    "      extends: mako_Candidate\n",
+    "      description: \"A specific ad slot on a Yahoo property being evaluated as a candidate.\"\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.yahoo_ad_units\"\n",
+    "      keys:\n",
+    "        primary: [adUnitId]\n",
+    "      properties:\n",
+    "        - name: adUnitId\n",
+    "          type: string\n",
+    "        - name: adUnitName\n",
+    "          type: string\n",
+    "        - name: adUnitSize\n",
+    "          type: string\n",
+    "          description: \"e.g., '300x250', '728x90'\"\n",
+    "        - name: adUnitPosition\n",
+    "          type: string\n",
+    "          description: \"ATF (above the fold) | BTF (below the fold)\"\n",
+    "\n",
+    "    - name: mako_RejectionReason\n",
+    "      description: \"Structured reason why a Candidate was not selected at a DecisionPoint.\"\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.rejection_reasons\"\n",
+    "      keys:\n",
+    "        primary: [rejection_id]\n",
+    "      properties:\n",
+    "        - name: rejection_id\n",
+    "          type: string\n",
+    "        - name: rejectionType\n",
+    "          type: string\n",
+    "          description: \"RULE_BASED | MODEL_BASED | TIMEOUT | ERROR\"\n",
+    "        - name: rejectionRule\n",
+    "          type: string\n",
+    "          description: \"The specific rule or model threshold that caused rejection.\"\n",
+    "\n",
+    "  # ==========================================\n",
+    "  # 2. RELATIONSHIPS (Edges)\n",
+    "  # ==========================================\n",
+    "  relationships:\n",
+    "    - name: CandidateEdge\n",
+    "      description: \"Connects a decision point to the evaluated Yahoo Ad Unit.\"\n",
+    "      from_entity: mako_DecisionPoint\n",
+    "      to_entity: sup_YahooAdUnit\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.candidate_edges\"\n",
+    "        from_columns: [decision_id]\n",
+    "        to_columns: [adUnitId]\n",
+    "      properties:\n",
+    "        - name: edge_type\n",
+    "          type: string\n",
+    "          description: \"SELECTED_CANDIDATE or DROPPED_CANDIDATE\"\n",
+    "        - name: mako_scoreValue\n",
+    "          type: double\n",
+    "          description: \"The confidence or predicted Q-value for this candidate.\"\n",
+    "\n",
+    "    - name: ForCandidate\n",
+    "      description: \"Maps the MAKO rejection rationale directly to the dropped candidate.\"\n",
+    "      from_entity: mako_RejectionReason\n",
+    "      to_entity: sup_YahooAdUnit\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.rejection_mappings\"\n",
+    "        from_columns: [rejection_id]\n",
+    "        to_columns: [adUnitId]\n",
+    "\"\"\"\n",
+    "\n",
+    "with open(SPEC_PATH, \"w\") as _f:\n",
+    "    _f.write(_YMGO_SPEC)\n",
+    "\n",
+    "print(f\"Wrote {SPEC_PATH} ({len(_YMGO_SPEC)} bytes)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Entities: ['mako_DecisionPoint', 'sup_YahooAdUnit', 'mako_RejectionReason']\n",
+      "Relationships: ['CandidateEdge', 'ForCandidate']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_models import load_graph_spec\n",
+    "\n",
+    "ENV = f\"{PROJECT_ID}.{DATASET_ID}\"\n",
+    "\n",
+    "spec = load_graph_spec(SPEC_PATH, env=ENV)\n",
+    "print(f\"Graph: {spec.name}\")\n",
+    "print(f\"Entities: {[e.name for e in spec.entities]}\")\n",
+    "print(f\"Relationships: {[r.name for r in spec.relationships]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "source": [
+    "## Inspect Entity Details\n",
+    "\n",
+    "Each entity in the spec has a name, primary key columns, typed properties, and a binding\n",
+    "that maps it to a physical BigQuery table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Entity: mako_DecisionPoint\n",
+      "  Keys: primary=['decision_id']\n",
+      "  Properties: ['decision_id', 'decision_type']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.decision_points\n",
+      "\n",
+      "Entity: sup_YahooAdUnit\n",
+      "  Keys: primary=['adUnitId']\n",
+      "  Properties: ['adUnitId', 'adUnitName', 'adUnitSize', 'adUnitPosition']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.yahoo_ad_units\n",
+      "\n",
+      "Entity: mako_RejectionReason\n",
+      "  Keys: primary=['rejection_id']\n",
+      "  Properties: ['rejection_id', 'rejectionType', 'rejectionRule']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.rejection_reasons\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for entity in spec.entities:\n",
+    "    print(f\"Entity: {entity.name}\")\n",
+    "    print(f\"  Keys: {entity.keys}\")\n",
+    "    print(f\"  Properties: {[p.name for p in entity.properties]}\")\n",
+    "    print(f\"  Binding source: {entity.binding.source}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "source": [
+    "## Phase 2: Compile the Extraction Schema\n",
+    "\n",
+    "Before calling AI.GENERATE, we need two artifacts compiled from the spec:\n",
+    "\n",
+    "1. **Extraction Prompt** -- a natural-language instruction that tells the LLM what entities\n",
+    "   and relationships to extract from the raw telemetry.\n",
+    "2. **Output Schema** -- a JSON schema that constrains the LLM output to match the declared\n",
+    "   ontology structure.\n",
+    "\n",
+    "Both are generated deterministically from the YAML spec."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Extraction Prompt ===\n",
+      "Extract nodes and edges from the agent telemetry below according to the provided ontology.\n",
+      "\n",
+      "Entity types:\n",
+      "  - mako_DecisionPoint \u2014 The atomic unit of decisioning where an agent evaluates alternatives. (properties: decision_id, decision_type)\n",
+      "  - sup_YahooAdUnit \u2014 A specific ad slot on a Yahoo property being evaluated as a candidate. (properties: adUnitId, adUnitName, adUnitSize, adUnitPosition)\n",
+      "  - mako_RejectionReason \u2014 Structured reason why a Candidate was not selected at a DecisionPoint. (properties: rejection_id, rejectionType, rejectionRule)\n",
+      "\n",
+      "=== Output Schema (truncated) ===\n",
+      "\"{\\\"type\\\":\\\"OBJECT\\\",\\\"properties\\\":{\\\"nodes\\\":{\\\"type\\\":\\\"ARRAY\\\",\\\"items\\\":{\\\"type\\\":\\\"OBJECT\\\",\\\"properties\\\":{\\\"entity_name\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"decision_id\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"decision_type\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitId\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitName\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitSize\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitPosition\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejection_id\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejectionType\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejectionRule\\\":{\\\"type\\\":\\\"STRING\\\"}}}},...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_schema_compiler import (\n",
+    "    compile_extraction_prompt,\n",
+    "    compile_output_schema,\n",
+    ")\n",
+    "\n",
+    "prompt = compile_extraction_prompt(spec)\n",
+    "print(\"=== Extraction Prompt ===\")\n",
+    "print(prompt[:500])\n",
+    "\n",
+    "schema = compile_output_schema(spec)\n",
+    "import json\n",
+    "print(\"\\n=== Output Schema (truncated) ===\")\n",
+    "print(json.dumps(schema, indent=2)[:600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "## Phase 3: Extract the Graph (AI.GENERATE)\n",
+    "\n",
+    "The `OntologyGraphManager` orchestrates graph extraction. It reads raw ADK telemetry from\n",
+    "BigQuery, sends it through AI.GENERATE (or falls back to the Gemini API), and returns a\n",
+    "typed graph with nodes and edges.\n",
+    "\n",
+    "Set `use_ai_generate=True` to use BigQuery ML's `AI.GENERATE` function, or `False` to use\n",
+    "the Gemini API directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Extracted 4 nodes, 2 edges\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_graph import OntologyGraphManager\n",
+    "\n",
+    "extractor = OntologyGraphManager(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=DATASET_ID,\n",
+    "    spec=spec,\n",
+    "    table_id=TABLE_ID,\n",
+    "    endpoint=\"gemini-2.5-flash\",\n",
+    ")\n",
+    "\n",
+    "SESSION_IDS = [\"adcp-033c95d7a97d\"]  # Replace with your session IDs\n",
+    "\n",
+    "graph = extractor.extract_graph(\n",
+    "    session_ids=SESSION_IDS,\n",
+    "    use_ai_generate=True,\n",
+    ")\n",
+    "print(f\"Extracted {len(graph.nodes)} nodes, {len(graph.edges)} edges\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=Yahoo Homepage\n",
+      "    adUnitId = Yahoo Homepage\n",
+      "    adUnitName = Yahoo Homepage\n",
+      "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=Yahoo Mail\n",
+      "    adUnitId = Yahoo Mail\n",
+      "    adUnitName = Yahoo Mail\n",
+      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_query_homepage_eval\n",
+      "    decision_id = dp_query_homepage_eval\n",
+      "    decision_type = query_ad_inventory\n",
+      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_query_mail_eval\n",
+      "    decision_id = dp_query_mail_eval\n",
+      "    decision_type = query_ad_inventory\n"
+     ]
+    }
+   ],
+   "source": [
+    "for node in graph.nodes[:5]:\n",
+    "    print(f\"  [{node.entity_name}] {node.node_id}\")\n",
+    "    for p in node.properties:\n",
+    "        print(f\"    {p.name} = {p.value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "source": [
+    "## Phase 4: Create Tables & Materialize\n",
+    "\n",
+    "The `OntologyMaterializer` uses the spec bindings to:\n",
+    "\n",
+    "1. **Create physical BigQuery tables** for each entity and relationship.\n",
+    "2. **Route extracted nodes and edges** into the correct tables based on entity/relationship\n",
+    "   name matching.\n",
+    "3. **Insert rows** using the BigQuery streaming API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Tables created:\n",
+      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics.decision_points\n",
+      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics.yahoo_ad_units\n",
+      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics.rejection_reasons\n",
+      "  CandidateEdge -> test-project-0728-467323.agent_analytics.candidate_edges\n",
+      "  ForCandidate -> test-project-0728-467323.agent_analytics.rejection_mappings\n",
+      "\n",
+      "Rows materialized: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer\n",
+    "\n",
+    "materializer = OntologyMaterializer(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=DATASET_ID,\n",
+    "    spec=spec,\n",
+    ")\n",
+    "\n",
+    "tables = materializer.create_tables()\n",
+    "print(\"Tables created:\")\n",
+    "for name, ref in tables.items():\n",
+    "    print(f\"  {name} -> {ref}\")\n",
+    "\n",
+    "rows = materializer.materialize(graph, SESSION_IDS)\n",
+    "print(f\"\\nRows materialized: {rows}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "source": [
+    "## Phase 5: Generate Property Graph DDL\n",
+    "\n",
+    "BigQuery supports native **Property Graphs** via DDL. The `OntologyPropertyGraphCompiler`\n",
+    "transpiles the YAML spec into a `CREATE PROPERTY GRAPH` statement that references the\n",
+    "physical tables created in Phase 4.\n",
+    "\n",
+    "This step bridges the relational materialization with graph-native query capabilities (GQL)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "  NODE TABLES (\n",
+      "    `test-project-0728-467323.agent_analytics.decision_points` AS mako_DecisionPoint\n",
+      "      KEY (decision_id, session_id)\n",
+      "      LABEL mako_DecisionPoint\n",
+      "      PROPERTIES (\n",
+      "        decision_id,\n",
+      "        decision_type,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.yahoo_ad_units` AS sup_YahooAdUnit\n",
+      "      KEY (adUnitId, session_id)\n",
+      "      LABEL sup_YahooAdUnit\n",
+      "      LABEL mako_Candidate\n",
+      "      PROPERTIES (\n",
+      "        adUnitId,\n",
+      "        adUnitName,\n",
+      "        adUnitSize,\n",
+      "        adUnitPosition,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.rejection_reasons` AS mako_RejectionReason\n",
+      "      KEY (rejection_id, session_id)\n",
+      "      LABEL mako_RejectionReason\n",
+      "      PROPERTIES (\n",
+      "        rejection_id,\n",
+      "        rejectionType,\n",
+      "        rejectionRule,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      )\n",
+      "  )\n",
+      "  EDGE TABLES (\n",
+      "    `test-project-0728-467323.agent_analytics.candidate_edges` AS CandidateEdge\n",
+      "      KEY (decision_id, adUnitId, session_id)\n",
+      "      SOURCE KEY (decision_id, session_id) REFERENCES mako_DecisionPoint (decision_id, session_id)\n",
+      "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
+      "      LABEL CandidateEdge\n",
+      "      PROPERTIES (\n",
+      "        edge_type,\n",
+      "        mako_scoreValue,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.rejection_mappings` AS ForCandidate\n",
+      "      KEY (rejection_id, adUnitId, session_id)\n",
+      "      SOURCE KEY (rejection_id, session_id) REFERENCES mako_RejectionReason (rejection_id, session_id)\n",
+      "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
+      "      LABEL ForCandidate\n",
+      "      PROPERTIES (\n",
+      "        extracted_at\n",
+      "      )\n",
+      "  )\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_property_graph import (\n",
+    "    OntologyPropertyGraphCompiler,\n",
+    "    compile_property_graph_ddl,\n",
+    ")\n",
+    "\n",
+    "# Preview the DDL\n",
+    "ddl = compile_property_graph_ddl(spec, PROJECT_ID, DATASET_ID)\n",
+    "print(ddl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiler = OntologyPropertyGraphCompiler(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=DATASET_ID,\n",
+    "    spec=spec,\n",
+    ")\n",
+    "created = compiler.create_property_graph()\n",
+    "print(f\"Property Graph created: {created}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3f4a5b6",
+   "metadata": {},
+   "source": [
+    "## Phase 6: GQL Showcase Query\n",
+    "\n",
+    "With the property graph in place, we can run **GQL (Graph Query Language)** queries to\n",
+    "traverse the graph. The SDK provides a `compile_showcase_gql` helper that generates a\n",
+    "representative traversal query from the spec."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "f4a5b6c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== GQL Showcase Query ===\n",
+      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "MATCH\n",
+      "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
+      "WHERE dp.session_id = @session_id\n",
+      "RETURN\n",
+      "  dp.decision_id AS src_decision_id,\n",
+      "  dp.decision_type AS src_decision_type,\n",
+      "  ece.edge_type,\n",
+      "  ece.mako_scoreValue,\n",
+      "  yau.adUnitId AS dst_adUnitId,\n",
+      "  yau.adUnitName AS dst_adUnitName,\n",
+      "  yau.adUnitSize AS dst_adUnitSize,\n",
+      "  yau.adUnitPosition AS dst_adUnitPosition\n",
+      "ORDER BY dp.decision_id\n",
+      "LIMIT @result_limit\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_orchestrator import compile_showcase_gql\n",
+    "\n",
+    "gql = compile_showcase_gql(spec, PROJECT_ID, DATASET_ID)\n",
+    "print(\"=== GQL Showcase Query ===\")\n",
+    "print(gql)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "a5b6c7d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Rows returned: 2\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "execution_count": 25,
+     "data": {
+      "text/plain": [
+       "          src_decision_id src_decision_type          edge_type  mako_scoreValue   dst_adUnitId dst_adUnitName dst_adUnitSize dst_adUnitPosition\n",
+       "0  dp_query_homepage_eval  query_ad_inventory  evaluated_candidate          21.06  Yahoo Homepage  Yahoo Homepage           None               None\n",
+       "1     dp_query_mail_eval  query_ad_inventory  evaluated_candidate          36.89     Yahoo Mail     Yahoo Mail           None               None"
+      ],
+      "text/html": [
+       "<div>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n",
+       "      <th></th><th>src_decision_id</th><th>src_decision_type</th><th>edge_type</th><th>mako_scoreValue</th><th>dst_adUnitId</th><th>dst_adUnitName</th><th>dst_adUnitSize</th><th>dst_adUnitPosition</th>\n",
+       "    </tr>\n  </thead>\n  <tbody>\n",
+       "    <tr><th>0</th><td>dp_query_homepage_eval</td><td>query_ad_inventory</td><td>evaluated_candidate</td><td>21.06</td><td>Yahoo Homepage</td><td>Yahoo Homepage</td><td>None</td><td>None</td></tr>\n",
+       "    <tr><th>1</th><td>dp_query_mail_eval</td><td>query_ad_inventory</td><td>evaluated_candidate</td><td>36.89</td><td>Yahoo Mail</td><td>Yahoo Mail</td><td>None</td><td>None</td></tr>\n",
+       "  </tbody>\n</table>\n</div>"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "from google.cloud import bigquery\n",
+    "\n",
+    "bq = bigquery.Client(project=PROJECT_ID)\n",
+    "job = bq.query(\n",
+    "    gql,\n",
+    "    job_config=bigquery.QueryJobConfig(\n",
+    "        query_parameters=[\n",
+    "            bigquery.ScalarQueryParameter(\"session_id\", \"STRING\", SESSION_IDS[0]),\n",
+    "            bigquery.ScalarQueryParameter(\"result_limit\", \"INT64\", 50),\n",
+    "        ]\n",
+    "    ),\n",
+    ")\n",
+    "results = job.to_dataframe()\n",
+    "print(f\"Rows returned: {len(results)}\")\n",
+    "results.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6c7d8e9",
+   "metadata": {},
+   "source": [
+    "## Phase 7: One-Shot Pipeline (`build_ontology_graph`)\n",
+    "\n",
+    "The `build_ontology_graph` orchestrator runs the entire pipeline in a single call:\n",
+    "spec loading, extraction, table creation, materialization, property graph DDL, and\n",
+    "showcase GQL generation. This is the recommended entry point for production use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "c7d8e9f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Graph ref: test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3\n",
+      "Nodes: 4\n",
+      "Edges: 2\n",
+      "Tables: ['mako_DecisionPoint', 'sup_YahooAdUnit', 'mako_RejectionReason', 'CandidateEdge', 'ForCandidate']\n",
+      "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n",
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_orchestrator import build_ontology_graph\n",
+    "\n",
+    "result = build_ontology_graph(\n",
+    "    session_ids=SESSION_IDS,\n",
+    "    spec_path=SPEC_PATH,\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=DATASET_ID,\n",
+    "    env=ENV,\n",
+    ")\n",
+    "\n",
+    "print(f\"Graph: {result['graph_name']}\")\n",
+    "print(f\"Graph ref: {result['graph_ref']}\")\n",
+    "print(f\"Nodes: {len(result['graph'].nodes)}\")\n",
+    "print(f\"Edges: {len(result['graph'].edges)}\")\n",
+    "print(f\"Tables: {list(result['tables_created'].keys())}\")\n",
+    "print(f\"Rows: {result['rows_materialized']}\")\n",
+    "print(f\"Property Graph created: {result['property_graph_created']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8e9f0a1",
+   "metadata": {},
+   "source": [
+    "## Phase 8: CLI Commands\n",
+    "\n",
+    "The same pipeline is available from the command line via `bq-agent-sdk`. This is\n",
+    "useful for CI/CD pipelines, cron jobs, or quick ad-hoc runs without a notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "e9f0a1b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Graph ref: test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3\n",
+      "Nodes: 4, Edges: 2\n",
+      "Tables: mako_DecisionPoint, sup_YahooAdUnit, mako_RejectionReason, CandidateEdge, ForCandidate\n",
+      "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n",
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Full pipeline\n",
+    "!bq-agent-sdk ontology-build \\\n",
+    "    --project-id={PROJECT_ID} \\\n",
+    "    --dataset-id={DATASET_ID} \\\n",
+    "    --spec-path={SPEC_PATH} \\\n",
+    "    --session-ids={','.join(SESSION_IDS)} \\\n",
+    "    --env={ENV}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "f0a1b2c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "MATCH\n",
+      "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
+      "WHERE dp.session_id = @session_id\n",
+      "RETURN\n",
+      "  dp.decision_id AS src_decision_id,\n",
+      "  dp.decision_type AS src_decision_type,\n",
+      "  ece.edge_type,\n",
+      "  ece.mako_scoreValue,\n",
+      "  yau.adUnitId AS dst_adUnitId,\n",
+      "  yau.adUnitName AS dst_adUnitName,\n",
+      "  yau.adUnitSize AS dst_adUnitSize,\n",
+      "  yau.adUnitPosition AS dst_adUnitPosition\n",
+      "ORDER BY dp.decision_id\n",
+      "LIMIT @result_limit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate GQL query\n",
+    "!bq-agent-sdk ontology-showcase-gql \\\n",
+    "    --project-id={PROJECT_ID} \\\n",
+    "    --dataset-id={DATASET_ID} \\\n",
+    "    --spec-path={SPEC_PATH} \\\n",
+    "    --env={ENV}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d5",
+   "metadata": {},
+   "source": [
+    "## Phase 9: Adapt for Your Own Ontology\n",
+    "\n",
+    "The V4 pipeline is fully generic. To model your own domain:\n",
+    "\n",
+    "1. **Copy** `ymgo_graph_spec.yaml` as a starting template.\n",
+    "2. **Replace entities** with your domain objects (e.g., `Customer`, `Order`, `Product`).\n",
+    "3. **Define relationships** between them (e.g., `Placed` from `Customer` to `Order`).\n",
+    "4. **Set `binding.source`** to point to your BigQuery tables.\n",
+    "5. **Run the same pipeline** -- no code changes required.\n",
+    "\n",
+    "Below is a minimal 2-entity, 1-relationship example you can customize."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "b2c3d4e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "graph:\n",
+      "  name: my_domain_graph\n",
+      "\n",
+      "  entities:\n",
+      "    - name: Customer\n",
+      "      description: \"A customer who places orders.\"\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.customers\"\n",
+      "      keys:\n",
+      "        primary: [customer_id]\n",
+      "      properties:\n",
+      "        - name: customer_id\n",
+      "          type: string\n",
+      "        - name: customer_name\n",
+      "          type: string\n",
+      "        - name: email\n",
+      "          type: string\n",
+      "\n",
+      "    - name: Order\n",
+      "      description: \"A purchase order.\"\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.orders\"\n",
+      "      keys:\n",
+      "        primary: [order_id]\n",
+      "      properties:\n",
+      "        - name: order_id\n",
+      "          type: string\n",
+      "        - name: order_date\n",
+      "          type: string\n",
+      "        - name: total_amount\n",
+      "          type: string\n",
+      "\n",
+      "  relationships:\n",
+      "    - name: Placed\n",
+      "      description: \"Customer placed an order.\"\n",
+      "      from_entity: Customer\n",
+      "      to_entity: Order\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.placed_edges\"\n",
+      "        from_columns: [customer_id]\n",
+      "        to_columns: [order_id]\n",
+      "      properties:\n",
+      "        - name: placed_at\n",
+      "          type: string\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "CUSTOM_SPEC_YAML = \"\"\"\n",
+    "graph:\n",
+    "  name: my_domain_graph\n",
+    "\n",
+    "  entities:\n",
+    "    - name: Customer\n",
+    "      description: \"A customer who places orders.\"\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.customers\"\n",
+    "      keys:\n",
+    "        primary: [customer_id]\n",
+    "      properties:\n",
+    "        - name: customer_id\n",
+    "          type: string\n",
+    "        - name: customer_name\n",
+    "          type: string\n",
+    "        - name: email\n",
+    "          type: string\n",
+    "\n",
+    "    - name: Order\n",
+    "      description: \"A purchase order.\"\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.orders\"\n",
+    "      keys:\n",
+    "        primary: [order_id]\n",
+    "      properties:\n",
+    "        - name: order_id\n",
+    "          type: string\n",
+    "        - name: order_date\n",
+    "          type: string\n",
+    "        - name: total_amount\n",
+    "          type: string\n",
+    "\n",
+    "  relationships:\n",
+    "    - name: Placed\n",
+    "      description: \"Customer placed an order.\"\n",
+    "      from_entity: Customer\n",
+    "      to_entity: Order\n",
+    "      binding:\n",
+    "        source: \"{{ env }}.placed_edges\"\n",
+    "        from_columns: [customer_id]\n",
+    "        to_columns: [order_id]\n",
+    "      properties:\n",
+    "        - name: placed_at\n",
+    "          type: string\n",
+    "\"\"\"\n",
+    "\n",
+    "print(CUSTOM_SPEC_YAML)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "c3d4e5f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Custom spec saved to: my_domain_graph_spec.yaml\n",
+      "Graph: my_domain_graph\n",
+      "Entities: ['Customer', 'Order']\n",
+      "Relationships: ['Placed']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save the custom spec and run the pipeline\n",
+    "custom_spec_path = \"my_domain_graph_spec.yaml\"\n",
+    "\n",
+    "with open(custom_spec_path, \"w\") as f:\n",
+    "    f.write(CUSTOM_SPEC_YAML)\n",
+    "\n",
+    "print(f\"Custom spec saved to: {custom_spec_path}\")\n",
+    "\n",
+    "# Load and verify\n",
+    "custom_spec = load_graph_spec(custom_spec_path, env=ENV)\n",
+    "print(f\"Graph: {custom_spec.name}\")\n",
+    "print(f\"Entities: {[e.name for e in custom_spec.entities]}\")\n",
+    "print(f\"Relationships: {[r.name for r in custom_spec.relationships]}\")\n",
+    "\n",
+    "# Run the full pipeline with your custom spec\n",
+    "# result = build_ontology_graph(\n",
+    "#     session_ids=[\"YOUR_SESSION_ID\"],\n",
+    "#     spec_path=custom_spec_path,\n",
+    "#     project_id=PROJECT_ID,\n",
+    "#     dataset_id=DATASET_ID,\n",
+    "#     env=ENV,\n",
+    "# )\n",
+    "# print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/bigquery_agent_analytics/_deploy_runtime.py
+++ b/src/bigquery_agent_analytics/_deploy_runtime.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared deployment runtime helpers.
+
+This module keeps deployment-specific bootstrap logic in one place so
+the BigQuery Remote Function path and the streaming evaluation worker
+use the same environment conventions when constructing an SDK client.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from bigquery_agent_analytics import Client
+
+
+def resolve_client_options(
+    user_defined_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  """Resolve ``Client`` constructor kwargs from request context + env vars."""
+  udc = user_defined_context or {}
+  project_id = udc.get("project_id", os.environ.get("BQ_AGENT_PROJECT"))
+  dataset_id = udc.get("dataset_id", os.environ.get("BQ_AGENT_DATASET"))
+  table_id = udc.get(
+      "table_id",
+      os.environ.get("BQ_AGENT_TABLE", "agent_events"),
+  )
+  location = udc.get(
+      "location",
+      os.environ.get("BQ_AGENT_LOCATION"),
+  )
+  endpoint = udc.get("endpoint") or os.environ.get("BQ_AGENT_ENDPOINT")
+  connection_id = udc.get("connection_id") or os.environ.get(
+      "BQ_AGENT_CONNECTION_ID"
+  )
+
+  if not project_id or not dataset_id:
+    raise ValueError("project_id and dataset_id required")
+
+  return {
+      "project_id": project_id,
+      "dataset_id": dataset_id,
+      "table_id": table_id,
+      "location": location,
+      "verify_schema": False,
+      "endpoint": endpoint,
+      "connection_id": connection_id,
+  }
+
+
+def build_client_from_context(
+    user_defined_context: dict[str, Any] | None = None,
+) -> Client:
+  """Build a ``Client`` from request context + deployment env vars."""
+  return Client(**resolve_client_options(user_defined_context))

--- a/src/bigquery_agent_analytics/_streaming_evaluation.py
+++ b/src/bigquery_agent_analytics/_streaming_evaluation.py
@@ -1,0 +1,287 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for the scheduled streaming evaluation deployment surface."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import hashlib
+import json
+from typing import Any
+
+from bigquery_agent_analytics import CodeEvaluator
+from bigquery_agent_analytics import EvaluationReport
+from bigquery_agent_analytics import serialize
+from bigquery_agent_analytics import udf_kernels
+
+STREAMING_EVALUATOR_PROFILE = "streaming_observability_v1"
+STREAMING_PROCESSOR_NAME = STREAMING_EVALUATOR_PROFILE
+STREAMING_RESULTS_TABLE = "streaming_evaluation_results"
+STREAMING_STATE_TABLE = "_streaming_eval_state"
+STREAMING_RUNS_TABLE = "_streaming_eval_runs"
+
+DEFAULT_POLL_INTERVAL_MINUTES = 5
+DEFAULT_OVERLAP_MINUTES = 15
+DEFAULT_INITIAL_LOOKBACK_MINUTES = 30
+
+TRIGGER_KIND_SESSION_TERMINAL = "session_terminal"
+TRIGGER_KIND_ERROR_EVENT = "error_event"
+_VALID_TRIGGER_KINDS = {
+    TRIGGER_KIND_SESSION_TERMINAL,
+    TRIGGER_KIND_ERROR_EVENT,
+}
+
+_LATENCY_THRESHOLD_MS = 5000.0
+_MAX_ERROR_RATE = 0.1
+_MAX_TURNS = 10
+
+
+@dataclass(frozen=True)
+class StreamingTrigger:
+  """Normalized trigger row from the scheduled overlap scan."""
+
+  session_id: str
+  trace_id: str | None
+  span_id: str | None
+  event_type: str
+  trigger_kind: str
+  trigger_timestamp: datetime
+  dedupe_key: str
+
+  @property
+  def is_final(self) -> bool:
+    return self.trigger_kind == TRIGGER_KIND_SESSION_TERMINAL
+
+
+def build_streaming_observability_evaluator() -> CodeEvaluator:
+  """Build the fixed launch evaluator profile for streaming observability."""
+
+  def _score_latency(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_latency(
+        session_summary.get("avg_latency_ms", 0),
+        _LATENCY_THRESHOLD_MS,
+    )
+
+  def _score_error_rate(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_error_rate(
+        session_summary.get("tool_calls", 0),
+        session_summary.get("tool_errors", 0),
+        _MAX_ERROR_RATE,
+    )
+
+  def _score_turn_count(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_turn_count(
+        session_summary.get("turn_count", 0),
+        _MAX_TURNS,
+    )
+
+  evaluator = CodeEvaluator(name=STREAMING_EVALUATOR_PROFILE)
+  evaluator.add_metric("latency", _score_latency, threshold=0.5)
+  evaluator.add_metric("error_rate", _score_error_rate, threshold=0.5)
+  evaluator.add_metric("turn_count", _score_turn_count, threshold=0.5)
+  return evaluator
+
+
+def classify_trigger_kind(
+    event_type: str | None,
+    status: str | None = None,
+    error_message: str | None = None,
+) -> str | None:
+  """Classify an event row into a launch trigger kind."""
+  if event_type == "AGENT_COMPLETED":
+    return TRIGGER_KIND_SESSION_TERMINAL
+  if event_type == "TOOL_ERROR":
+    return TRIGGER_KIND_ERROR_EVENT
+  if status == "ERROR" and error_message is not None:
+    return TRIGGER_KIND_ERROR_EVENT
+  return None
+
+
+def is_launch_trigger_row(
+    event_type: str | None,
+    status: str | None = None,
+    error_message: str | None = None,
+) -> bool:
+  """Return ``True`` when a row qualifies for launch trigger handling."""
+  return classify_trigger_kind(event_type, status, error_message) is not None
+
+
+def build_trigger_dedupe_key(
+    session_id: str,
+    trace_id: str | None,
+    span_id: str | None,
+    event_type: str,
+    trigger_timestamp: datetime | str,
+) -> str:
+  """Build a stable idempotency key for a trigger row."""
+  timestamp = _coerce_timestamp(trigger_timestamp)
+  timestamp_micros = int(timestamp.timestamp() * 1_000_000)
+  raw = "|".join(
+      [
+          session_id or "",
+          trace_id or "",
+          span_id or "",
+          event_type or "",
+          str(timestamp_micros),
+      ]
+  )
+  return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def parse_trigger_payload(payload: dict[str, Any]) -> StreamingTrigger:
+  """Parse a JSON payload into a validated ``StreamingTrigger``."""
+  missing = [
+      field
+      for field in (
+          "session_id",
+          "event_type",
+          "trigger_kind",
+          "trigger_timestamp",
+      )
+      if not payload.get(field)
+  ]
+  if missing:
+    raise ValueError(f"Missing required trigger fields: {', '.join(missing)}")
+
+  trigger_kind = payload["trigger_kind"]
+  if trigger_kind not in _VALID_TRIGGER_KINDS:
+    raise ValueError(f"Unsupported trigger_kind: {trigger_kind}")
+
+  trigger_timestamp = _coerce_timestamp(payload["trigger_timestamp"])
+  dedupe_key = payload.get("dedupe_key") or build_trigger_dedupe_key(
+      session_id=payload["session_id"],
+      trace_id=payload.get("trace_id"),
+      span_id=payload.get("span_id"),
+      event_type=payload["event_type"],
+      trigger_timestamp=trigger_timestamp,
+  )
+
+  return StreamingTrigger(
+      session_id=payload["session_id"],
+      trace_id=payload.get("trace_id"),
+      span_id=payload.get("span_id"),
+      event_type=payload["event_type"],
+      trigger_kind=trigger_kind,
+      trigger_timestamp=trigger_timestamp,
+      dedupe_key=dedupe_key,
+  )
+
+
+def parse_trigger_row(row: Mapping[str, Any]) -> StreamingTrigger:
+  """Parse a BigQuery row from the overlap scan into a ``StreamingTrigger``."""
+  payload = dict(row)
+  payload["trigger_timestamp"] = payload.get(
+      "trigger_timestamp"
+  ) or payload.get("timestamp")
+  payload["trigger_kind"] = payload.get(
+      "trigger_kind"
+  ) or classify_trigger_kind(
+      event_type=payload.get("event_type"),
+      status=payload.get("status"),
+      error_message=payload.get("error_message"),
+  )
+  return parse_trigger_payload(payload)
+
+
+def serialize_streaming_result_row(
+    trigger: StreamingTrigger,
+    report: EvaluationReport,
+    processed_at: datetime | None = None,
+) -> dict[str, Any]:
+  """Serialize one trigger execution to a fixed BigQuery row shape."""
+  processed = processed_at or datetime.now(timezone.utc)
+  session_score = report.session_scores[0] if report.session_scores else None
+  aggregate_scores = (
+      session_score.scores if session_score else report.aggregate_scores
+  )
+  details: dict[str, Any] = {}
+  if report.details:
+    details["report"] = report.details
+  if session_score and session_score.details:
+    details["session"] = session_score.details
+  if session_score and session_score.llm_feedback:
+    details["llm_feedback"] = session_score.llm_feedback
+
+  passed = False
+  if session_score is not None:
+    passed = session_score.passed
+  elif report.total_sessions > 0:
+    passed = report.failed_sessions == 0
+
+  return {
+      "dedupe_key": trigger.dedupe_key,
+      "session_id": trigger.session_id,
+      "trace_id": trigger.trace_id,
+      "span_id": trigger.span_id,
+      "trigger_kind": trigger.trigger_kind,
+      "trigger_event_type": trigger.event_type,
+      "trigger_timestamp": trigger.trigger_timestamp,
+      "is_final": trigger.is_final,
+      "evaluator_profile": STREAMING_EVALUATOR_PROFILE,
+      "passed": passed,
+      "aggregate_scores_json": json.dumps(aggregate_scores, sort_keys=True),
+      "details_json": json.dumps(details, sort_keys=True),
+      "report_json": json.dumps(serialize(report), sort_keys=True),
+      "processed_at": processed,
+  }
+
+
+def compute_scan_start(
+    run_started_at: datetime | str,
+    checkpoint_timestamp: datetime | str | None = None,
+    overlap: timedelta | None = None,
+    initial_lookback: timedelta | None = None,
+) -> datetime:
+  """Compute the lower bound for the next overlap scan."""
+  run_started = _coerce_timestamp(run_started_at)
+  overlap_window = overlap or timedelta(minutes=DEFAULT_OVERLAP_MINUTES)
+  bootstrap_window = initial_lookback or timedelta(
+      minutes=DEFAULT_INITIAL_LOOKBACK_MINUTES
+  )
+
+  if checkpoint_timestamp is None:
+    return run_started - bootstrap_window
+
+  checkpoint = _coerce_timestamp(checkpoint_timestamp)
+  if checkpoint > run_started:
+    checkpoint = run_started
+  return checkpoint - overlap_window
+
+
+def _coerce_timestamp(value: datetime | str) -> datetime:
+  """Parse timestamps into UTC datetimes."""
+  if isinstance(value, datetime):
+    if value.tzinfo is None:
+      return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+  normalized = value.strip()
+  if normalized.endswith(" UTC"):
+    normalized = normalized.removesuffix(" UTC") + "+00:00"
+  if normalized.endswith("Z"):
+    normalized = normalized[:-1] + "+00:00"
+
+  try:
+    parsed = datetime.fromisoformat(normalized)
+  except ValueError as exc:
+    raise ValueError(f"Invalid trigger_timestamp: {value}") from exc
+
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return parsed.astimezone(timezone.utc)

--- a/tests/test_streaming_evaluation.py
+++ b/tests/test_streaming_evaluation.py
@@ -1,0 +1,885 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the scheduled streaming evaluation deployment path."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from bigquery_agent_analytics._deploy_runtime import resolve_client_options
+from bigquery_agent_analytics._streaming_evaluation import build_streaming_observability_evaluator
+from bigquery_agent_analytics._streaming_evaluation import build_trigger_dedupe_key
+from bigquery_agent_analytics._streaming_evaluation import classify_trigger_kind
+from bigquery_agent_analytics._streaming_evaluation import compute_scan_start
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_payload
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_row
+from bigquery_agent_analytics._streaming_evaluation import serialize_streaming_result_row
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_EVALUATOR_PROFILE
+from bigquery_agent_analytics.evaluators import EvaluationReport
+from bigquery_agent_analytics.evaluators import SessionScore
+
+_ROOT = Path(__file__).resolve().parents[1]
+_NOW = datetime(2026, 3, 28, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def _import_module(name: str, relative_path: str):
+  spec = importlib.util.spec_from_file_location(
+      name,
+      _ROOT / relative_path,
+  )
+  mod = importlib.util.module_from_spec(spec)
+  sys.modules[name] = mod
+  spec.loader.exec_module(mod)
+  return mod
+
+
+def _normalize_sql(sql_text: str) -> str:
+  lines = [
+      line.strip()
+      for line in sql_text.splitlines()
+      if line.strip() and not line.strip().startswith("--")
+  ]
+  return " ".join(lines).rstrip(";")
+
+
+def _report() -> EvaluationReport:
+  return EvaluationReport(
+      dataset="test",
+      evaluator_name=STREAMING_EVALUATOR_PROFILE,
+      total_sessions=1,
+      passed_sessions=1,
+      failed_sessions=0,
+      aggregate_scores={
+          "latency": 0.9,
+          "error_rate": 1.0,
+          "turn_count": 0.8,
+      },
+      details={"source": "unit-test"},
+      created_at=_NOW,
+      session_scores=[
+          SessionScore(
+              session_id="sess-1",
+              scores={
+                  "latency": 0.9,
+                  "error_rate": 1.0,
+                  "turn_count": 0.8,
+              },
+              passed=True,
+              details={"checked": True},
+          )
+      ],
+  )
+
+
+def _empty_report() -> EvaluationReport:
+  return EvaluationReport(
+      dataset="test",
+      evaluator_name=STREAMING_EVALUATOR_PROFILE,
+      total_sessions=0,
+      passed_sessions=0,
+      failed_sessions=0,
+      aggregate_scores={},
+      details={"source": "unit-test"},
+      created_at=_NOW,
+      session_scores=[],
+  )
+
+
+class _FakeSelectJob:
+
+  def __init__(self, rows):
+    self._rows = rows
+
+  def result(self):
+    return self._rows
+
+
+class _FakeDmlJob:
+
+  def __init__(self, affected_rows: int | None = 1):
+    self.num_dml_affected_rows = affected_rows
+
+  def result(self):
+    return None
+
+
+class _FakeBigQueryClient:
+
+  def __init__(
+      self,
+      *,
+      checkpoint_rows=None,
+      trigger_rows=None,
+      merge_affected_rows=None,
+      error_on: str | None = None,
+  ):
+    self.checkpoint_rows = checkpoint_rows or []
+    self.trigger_rows = trigger_rows or []
+    self.merge_affected_rows = list(merge_affected_rows or [])
+    self.error_on = error_on
+    self.queries = []
+    self.job_configs = []
+
+  def query(self, query, job_config=None):
+    self.queries.append(query)
+    self.job_configs.append(job_config)
+    if self.error_on and self.error_on in query:
+      raise RuntimeError("transient failure")
+    compact = query.lstrip()
+    if compact.startswith("SELECT checkpoint_timestamp"):
+      return _FakeSelectJob(self.checkpoint_rows)
+    if compact.startswith("SELECT\n  session_id,"):
+      return _FakeSelectJob(self.trigger_rows)
+    if "streaming_evaluation_results" in query:
+      affected_rows = (
+          self.merge_affected_rows.pop(0) if self.merge_affected_rows else 1
+      )
+      return _FakeDmlJob(affected_rows)
+    if compact.startswith("MERGE") or compact.startswith("INSERT INTO"):
+      return _FakeDmlJob(1)
+    raise AssertionError(f"Unexpected query: {query}")
+
+
+@pytest.fixture(scope="module")
+def rf_dispatch():
+  return _import_module("rf_dispatch", "deploy/remote_function/dispatch.py")
+
+
+@pytest.fixture(scope="module")
+def streaming_worker():
+  return _import_module(
+      "streaming_worker",
+      "deploy/streaming_evaluation/worker.py",
+  )
+
+
+class TestSharedRuntime:
+
+  def test_resolve_client_options_from_env(self, monkeypatch):
+    monkeypatch.setenv("BQ_AGENT_PROJECT", "env-project")
+    monkeypatch.setenv("BQ_AGENT_DATASET", "env-dataset")
+    monkeypatch.setenv("BQ_AGENT_TABLE", "env-table")
+    monkeypatch.setenv("BQ_AGENT_LOCATION", "US")
+
+    options = resolve_client_options({})
+    assert options["project_id"] == "env-project"
+    assert options["dataset_id"] == "env-dataset"
+    assert options["table_id"] == "env-table"
+    assert options["location"] == "US"
+    assert options["verify_schema"] is False
+
+  def test_resolve_client_options_leaves_location_unset_by_default(
+      self,
+      monkeypatch,
+  ):
+    monkeypatch.setenv("BQ_AGENT_PROJECT", "env-project")
+    monkeypatch.setenv("BQ_AGENT_DATASET", "env-dataset")
+    monkeypatch.delenv("BQ_AGENT_LOCATION", raising=False)
+
+    options = resolve_client_options({})
+
+    assert options["location"] is None
+
+  def test_remote_and_streaming_import_same_resolver(
+      self,
+      rf_dispatch,
+      streaming_worker,
+  ):
+    assert rf_dispatch.resolve_client_options is resolve_client_options
+    assert streaming_worker.resolve_client_options is resolve_client_options
+
+
+class TestHelpers:
+
+  def test_streaming_profile_contains_fixed_metrics(self):
+    evaluator = build_streaming_observability_evaluator()
+    metric_names = [metric.name for metric in evaluator._metrics]
+
+    assert evaluator.name == STREAMING_EVALUATOR_PROFILE
+    assert metric_names == ["latency", "error_rate", "turn_count"]
+
+  def test_dedupe_key_is_stable(self):
+    first = build_trigger_dedupe_key(
+        session_id="sess-1",
+        trace_id="trace-1",
+        span_id="span-1",
+        event_type="AGENT_COMPLETED",
+        trigger_timestamp=_NOW,
+    )
+    second = build_trigger_dedupe_key(
+        session_id="sess-1",
+        trace_id="trace-1",
+        span_id="span-1",
+        event_type="AGENT_COMPLETED",
+        trigger_timestamp="2026-03-28T18:30:00Z",
+    )
+
+    assert first == second
+
+  def test_classify_trigger_kind_prefers_terminal_then_error(self):
+    assert classify_trigger_kind("AGENT_COMPLETED") == "session_terminal"
+    assert classify_trigger_kind("TOOL_ERROR") == "error_event"
+    assert (
+        classify_trigger_kind(
+            "AGENT_STEP",
+            status="ERROR",
+            error_message="boom",
+        )
+        == "error_event"
+    )
+    assert classify_trigger_kind("AGENT_STEP", status="ERROR") is None
+    assert classify_trigger_kind("AGENT_STEP", error_message="boom") is None
+    assert classify_trigger_kind("AGENT_STEP") is None
+
+  def test_parse_trigger_row_classifies_from_overlap_scan_fields(self):
+    trigger = parse_trigger_row(
+        {
+            "session_id": "sess-1",
+            "trace_id": "trace-1",
+            "span_id": "span-1",
+            "event_type": "TOOL_ERROR",
+            "status": "ERROR",
+            "error_message": "boom",
+            "trigger_timestamp": "2026-03-28T18:30:00Z",
+        }
+    )
+
+    assert trigger.trigger_kind == "error_event"
+    assert trigger.is_final is False
+
+  def test_compute_scan_start_uses_checkpoint_overlap(self):
+    scan_start = compute_scan_start(
+        run_started_at=_NOW,
+        checkpoint_timestamp=_NOW,
+        overlap=timedelta(minutes=15),
+        initial_lookback=timedelta(minutes=30),
+    )
+    assert scan_start == _NOW - timedelta(minutes=15)
+
+  def test_compute_scan_start_bootstraps_with_initial_lookback(self):
+    scan_start = compute_scan_start(
+        run_started_at=_NOW,
+        checkpoint_timestamp=None,
+        overlap=timedelta(minutes=15),
+        initial_lookback=timedelta(minutes=30),
+    )
+    assert scan_start == _NOW - timedelta(minutes=30)
+
+  def test_serialize_result_row_uses_session_scores(self):
+    trigger = parse_trigger_payload(
+        {
+            "session_id": "sess-1",
+            "trace_id": "trace-1",
+            "span_id": "span-1",
+            "event_type": "AGENT_COMPLETED",
+            "trigger_kind": "session_terminal",
+            "trigger_timestamp": "2026-03-28T18:30:00Z",
+        }
+    )
+
+    row = serialize_streaming_result_row(trigger, _report(), processed_at=_NOW)
+
+    assert row["session_id"] == "sess-1"
+    assert row["trigger_kind"] == "session_terminal"
+    assert row["is_final"] is True
+    assert row["evaluator_profile"] == STREAMING_EVALUATOR_PROFILE
+    assert row["passed"] is True
+    assert json.loads(row["aggregate_scores_json"]) == {
+        "error_rate": 1.0,
+        "latency": 0.9,
+        "turn_count": 0.8,
+    }
+    assert json.loads(row["details_json"]) == {
+        "report": {"source": "unit-test"},
+        "session": {"checked": True},
+    }
+
+
+class TestWorker:
+
+  def test_valid_run_processes_and_persists(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["status"] == "processed"
+    assert response["processed_rows"] == 1
+    assert response["duplicate_rows"] == 0
+    assert response["ignored_rows"] == 0
+    client.evaluate.assert_called_once()
+
+    trigger_scan_config = fake_bq.job_configs[1]
+    scan_params = {
+        param.name: param.value
+        for param in trigger_scan_config.query_parameters
+    }
+    assert scan_params["scan_start"] == _NOW - timedelta(minutes=30)
+    assert scan_params["scan_end"] == _NOW
+
+    result_params = None
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "streaming_evaluation_results" in query:
+        result_params = {
+            param.name: param.value for param in job_config.query_parameters
+        }
+        break
+
+    assert result_params is not None
+    assert result_params["session_id"] == "sess-1"
+    assert result_params["trigger_kind"] == "session_terminal"
+    assert result_params["is_final"] is True
+    assert result_params["evaluator_profile"] == STREAMING_EVALUATOR_PROFILE
+
+  def test_duplicate_trigger_returns_200(self, streaming_worker, monkeypatch):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "TOOL_ERROR",
+                "status": "ERROR",
+                "error_message": "boom",
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "error_event",
+            }
+        ],
+        merge_affected_rows=[0],
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["status"] == "processed"
+    assert response["processed_rows"] == 0
+    assert response["duplicate_rows"] == 1
+
+  def test_missing_session_id_is_ignored(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["ignored_rows"] == 1
+    client.evaluate.assert_not_called()
+
+  def test_malformed_row_is_counted_once(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["ignored_rows"] == 1
+    assert caplog.messages == [
+        "Ignoring malformed trigger row: Missing required trigger fields: event_type, trigger_kind"
+    ]
+    client.evaluate.assert_not_called()
+
+  def test_bigquery_or_evaluation_failure_retries(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.side_effect = RuntimeError("transient failure")
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["status"] == "retry"
+    assert response["reason"] == "internal error"
+
+  def test_zero_session_report_is_skipped_not_retried(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _empty_report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 0
+    assert response["ignored_rows"] == 1
+    assert caplog.messages[-1] == (
+        "No events found for session_id=sess-1; skipping trigger"
+    )
+
+  def test_checkpoint_does_not_advance_if_success_history_write_fails(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        error_on="_streaming_eval_runs",
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["status"] == "retry"
+    state_queries = [
+        query for query in fake_bq.queries if "_streaming_eval_state" in query
+    ]
+    assert len(state_queries) == 1
+
+  def test_checkpoint_failure_rewrites_success_run_history_to_failed(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        error_on="checkpoint_timestamp = S.checkpoint_timestamp",
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["reason"] == "internal error"
+    runs_writes = []
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "_streaming_eval_runs" in query:
+        runs_writes.append(
+            {param.name: param.value for param in job_config.query_parameters}
+        )
+
+    assert [write["status"] for write in runs_writes] == ["success", "failed"]
+    assert runs_writes[-1]["error_message"] == "transient failure"
+
+  def test_missing_dml_stats_are_treated_as_processed(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        merge_affected_rows=[None],
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 1
+    assert response["duplicate_rows"] == 0
+    assert any(
+        "BigQuery DML stats were unavailable" in message
+        for message in caplog.messages
+    )
+
+  def test_same_session_can_emit_error_and_terminal_rows(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-error",
+                "event_type": "TOOL_ERROR",
+                "status": "ERROR",
+                "error_message": "boom",
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "error_event",
+            },
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-final",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW + timedelta(minutes=1),
+                "trigger_kind": "session_terminal",
+            },
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 2
+    persisted = []
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "streaming_evaluation_results" in query:
+        persisted.append(
+            {param.name: param.value for param in job_config.query_parameters}
+        )
+    assert [row["trigger_kind"] for row in persisted] == [
+        "error_event",
+        "session_terminal",
+    ]
+
+  def test_invalid_overlap_env_uses_default(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    monkeypatch.setenv("BQ_AGENT_OVERLAP_MINUTES", "fifteen")
+
+    config = streaming_worker.load_runtime_config(client)
+
+    assert config.overlap == timedelta(minutes=15)
+    assert caplog.messages == [
+        "Invalid integer value for BQ_AGENT_OVERLAP_MINUTES='fifteen'; using default 15"
+    ]
+
+
+class TestDeployAssets:
+
+  def test_trigger_query_contains_exact_launch_filters(self):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+
+    assert "event_type = 'AGENT_COMPLETED'" in sql
+    assert "event_type = 'TOOL_ERROR'" in sql
+    assert "status = 'ERROR'" in sql
+    assert "error_message IS NOT NULL" in sql
+    assert "OR status = 'ERROR'" not in sql
+
+  def test_trigger_query_matches_worker_scan_query(self, streaming_worker):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+    normalized_file = (
+        _normalize_sql(sql)
+        .replace(
+            "`PROJECT.DATASET.SOURCE_TABLE`",
+            "`{project}.{dataset}.{table}`",
+        )
+        .replace(
+            "SCAN_START",
+            "@scan_start",
+        )
+        .replace(
+            "SCAN_END",
+            "@scan_end",
+        )
+    )
+
+    assert normalized_file == _normalize_sql(
+        streaming_worker._TRIGGER_SCAN_QUERY
+    )
+
+  def test_trigger_query_contains_expected_scan_fields(self):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+
+    for field in (
+        "session_id",
+        "trace_id",
+        "span_id",
+        "event_type",
+        "trigger_timestamp",
+        "trigger_kind",
+    ):
+      assert field in sql
+
+  def test_setup_assets_point_to_scheduler_and_state_tables(self):
+    setup_sh = (_ROOT / "deploy/streaming_evaluation/setup.sh").read_text()
+    readme = (_ROOT / "deploy/streaming_evaluation/README.md").read_text()
+    requirements = (
+        _ROOT / "deploy/streaming_evaluation/requirements.txt"
+    ).read_text()
+
+    assert ".streaming_evaluation_state.json" in setup_sh
+    assert "streaming_evaluation_results" in setup_sh
+    assert "_streaming_eval_state" in setup_sh
+    assert "_streaming_eval_runs" in setup_sh
+    assert 'PROJECT and DATASET are required for "up"' in setup_sh
+    assert 'cp "$SCRIPT_DIR/requirements.txt" "$staging/"' in setup_sh
+    assert "wait_for_service_account" in setup_sh
+    assert "scheduler jobs create http" in setup_sh
+    assert "cloudscheduler.googleapis.com" in setup_sh
+    assert "roles/iam.serviceAccountOpenIdTokenCreator" in setup_sh
+    assert "--timeout 300" in setup_sh
+    assert "trap 'rm -rf \"$staging\"' RETURN" in setup_sh
+    assert "Cloud Scheduler" in readme
+    assert "No special BigQuery reservation is required" in readme
+    assert "enable the required Cloud Run" in readme
+    assert "BigQuery tables were preserved intentionally" in setup_sh
+    assert "intentionally preserves the BigQuery tables" in readme
+    assert "pyyaml>=6.0" in requirements
+    assert "google-adk" not in requirements
+    assert setup_sh.index(
+        'ensure_scheduler_job "$scheduler_sa_email" "$url"'
+    ) < (setup_sh.index('write_state "$bq_location" "$scheduler_sa_email"'))
+
+  def test_streaming_worker_import_does_not_require_google_adk(self):
+    script = f"""
+import builtins
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path({str(_ROOT)!r})
+orig_import = builtins.__import__
+
+def blocked(name, globals=None, locals=None, fromlist=(), level=0):
+  if name == "google.adk" or name.startswith("google.adk."):
+    raise ImportError("blocked google.adk")
+  return orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = blocked
+sys.path.insert(0, str(root / "src"))
+spec = importlib.util.spec_from_file_location(
+    "streaming_worker_no_adk",
+    root / "deploy/streaming_evaluation/worker.py",
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["streaming_worker_no_adk"] = module
+spec.loader.exec_module(module)
+print("ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        cwd=_ROOT,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
## Summary

Catches up the GCP official SDK repo with the latest features from the development repo. Adds **25 new files** across 6 categories:

### Streaming Evaluation (PR #62)
- `src/bigquery_agent_analytics/_deploy_runtime.py` — Internal deployment runtime utilities
- `src/bigquery_agent_analytics/_streaming_evaluation.py` — Streaming evaluation helpers (trigger parsing, overlap scan, dedup)
- `deploy/streaming_evaluation/` — Full Cloud Scheduler → Cloud Run deployment surface (worker, setup script, trigger SQL, requirements)
- `tests/test_streaming_evaluation.py` — Comprehensive test coverage

### Dashboard V2 (PRs #75, #77, #78)
- `examples/dashboard_v2.ipynb` — 2-layer SQL observability dashboard (no SDK dependency, location-configurable)
- `examples/dashboard_v2_bigframes.ipynb` — BigFrames companion using `bpd.read_gbq()` for pandas-native analysis

### Ontology Graph V4 Demo (PR #59)
- `examples/ontology_graph_v4_demo.ipynb` — End-to-end ontology extraction and GQL showcase

### Design Documents
- Context Graph V2/V3 design docs
- Hatteras categorical evaluation design
- Ontology Graph V4 design
- Python UDF support design
- Remote function rationale and implementation plan
- CLI proposal, unified analytics PRD

### CI & Tooling
- `.github/workflows/ci.yml` — Automated test workflow
- `.gitignore` — Standard Python gitignore

### Additional Examples
- `examples/ci_eval_pipeline.sh` — CI evaluation pipeline script
- `examples/cli_agent_tool.py` — CLI agent tool example
