### PR TITLE
Add Python 3.14 support and fix related test issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BigQuery Agent Analytics SDK
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13-blue)](pyproject.toml)
+[![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14-blue)](pyproject.toml)
 [![CI](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/actions/workflows/ci.yml/badge.svg)](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/actions/workflows/ci.yml)
 
 An open-source Python SDK for analyzing, evaluating, and curating agent traces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [

--- a/tests/test_categorical_evaluator.py
+++ b/tests/test_categorical_evaluator.py
@@ -583,7 +583,7 @@ class TestCategoricalTranscriptQuery:
 
 def _run(coro):
   """Helper to run async tests."""
-  return asyncio.get_event_loop().run_until_complete(coro)
+  return asyncio.run(coro)
 
 
 def _mock_genai_modules(mock_client):

--- a/tests/test_pr16_fixes.py
+++ b/tests/test_pr16_fixes.py
@@ -33,6 +33,7 @@ Covers:
 """
 
 import asyncio
+import inspect
 from datetime import datetime
 from datetime import timezone
 from unittest.mock import MagicMock
@@ -651,15 +652,15 @@ class TestAsyncAPIs:
 
   def test_insights_async_exists(self):
     assert hasattr(Client, "insights_async")
-    assert asyncio.iscoroutinefunction(Client.insights_async)
+    assert inspect.iscoroutinefunction(Client.insights_async)
 
   def test_drift_detection_async_exists(self):
     assert hasattr(Client, "drift_detection_async")
-    assert asyncio.iscoroutinefunction(Client.drift_detection_async)
+    assert inspect.iscoroutinefunction(Client.drift_detection_async)
 
   def test_deep_analysis_async_exists(self):
     assert hasattr(Client, "deep_analysis_async")
-    assert asyncio.iscoroutinefunction(Client.deep_analysis_async)
+    assert inspect.iscoroutinefunction(Client.deep_analysis_async)
 
 
 # ================================================================== #

--- a/tests/test_pr16_fixes.py
+++ b/tests/test_pr16_fixes.py
@@ -33,9 +33,9 @@ Covers:
 """
 
 import asyncio
-import inspect
 from datetime import datetime
 from datetime import timezone
+import inspect
 from unittest.mock import MagicMock
 from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- Adds Python 3.14 to the CI test matrix (`.github/workflows/ci.yml`)
- Adds `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`
- Updates the README badge to include 3.14

No source code changes needed — the codebase uses no deprecated stdlib modules removed in 3.14 and no deprecated `typing` patterns.

**Not changed** (platform runtime constraints, not SDK version support):
- `udf_sql_templates.py` — BigQuery UDF runtime is pinned to `python-3.11`
- `deploy/remote_function/deploy.sh` — Cloud Functions runtime is `python312`
- Design docs — historical references to deployment platform runtimes

## Test plan
- [ ] CI passes on Python 3.14 in the test matrix
- [ ] `pip install -e ".[dev]"` succeeds on Python 3.14
- [ ] All existing tests pass on 3.14