### PR TITLE
Implement V5 Context Graph with TTL import and temporal lineage

### DIFF
--- a/docs/context_graph_v5_design.md
+++ b/docs/context_graph_v5_design.md
@@ -1,0 +1,1056 @@
+# Context Graph V5 — Implementation Design
+
+Status: approved
+Scope: BigQuery-only V5 demo on the current SDK runtime. Offline TTL
+import to runtime GraphSpec, mixed structured + AI extraction without
+duplication, and additive concrete-entity temporal lineage.
+
+Excludes: ontology/binding contract migration (`docs/ontology/*.md`),
+Spanner backend, BKA runtime, and MAKO synchronization. Those are
+follow-up epics listed in Part III.
+
+Target: April 15, 2026 working session (Haiyuan, Pufan, Mikul, Umang).
+
+Tracking: [haiyuan-eng-google/BigQuery-Agent-Analytics-SDK#83](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK/issues/83)
+
+---
+
+## Part I: Current State Analysis
+
+### What exists today (V4)
+
+The V4 pipeline is a BigQuery-only, session-scoped, YAML-driven flow:
+
+```
+YAML GraphSpec ──> AI.GENERATE extraction ──> Materialize ──> Property Graph
+```
+
+| Module | File | Responsibility |
+|--------|------|----------------|
+| Spec models | `ontology_models.py` | Pydantic `GraphSpec` with embedded `BindingSpec` per entity/relationship |
+| Schema compiler | `ontology_schema_compiler.py` | Compiles `GraphSpec` into AI.GENERATE prompt + `output_schema` JSON |
+| Graph extractor | `ontology_graph.py` | Queries `agent_events`, runs AI.GENERATE, hydrates `ExtractedGraph` |
+| Materializer | `ontology_materializer.py` | Creates BigQuery tables, routes nodes/edges, delete-then-insert |
+| DDL transpiler | `ontology_property_graph.py` | Generates `CREATE PROPERTY GRAPH` DDL from spec |
+| Orchestrator | `ontology_orchestrator.py` | Ties phases 1-5 into `build_ontology_graph()` |
+
+#### Key design constraints baked into V4
+
+1. **Combined spec shape.** `GraphSpec` carries both logical schema and
+   physical bindings in a single YAML. The draft `docs/ontology/*.md`
+   design separates these into `*.ontology.yaml` + `*.binding.yaml`, but
+   no code implements that separation yet.
+
+2. **Session-scoped identity.** Node IDs are `{session_id}:{entity}:{keys}`
+   (`ontology_graph.py:155`). Node table KEY is `(primary_keys..., session_id)`
+   (`ontology_property_graph.py:101`). Edge KEY includes `session_id`
+   (`ontology_property_graph.py:194-200`). GQL showcase filters by
+   `session_id` (`ontology_orchestrator.py:144`). Materializer deletes
+   by `session_id` (`ontology_materializer.py:283-286`).
+
+3. **AI-only extraction.** Two paths exist: `AI.GENERATE` (server-side,
+   session-level transcript aggregation via `STRING_AGG`,
+   `ontology_graph.py:76-98`) and a raw-payload fallback that returns
+   untyped `raw_payload` nodes (`ontology_graph.py:465-514`). No
+   structured fast-path.
+
+4. **Runtime type subset.** Schema compiler supports 8 types: `string`,
+   `int64`, `double`, `float64`, `bool`/`boolean`, `timestamp`, `date`,
+   `bytes` (`ontology_schema_compiler.py:54-64`). Materializer DDL maps
+   the same 8 (`ontology_materializer.py:70-81`). The ontology design
+   docs define 11 types (adding `numeric`, `time`, `datetime`, `json`).
+
+### What V5 adds (this design)
+
+Three new capabilities, all additive to the V4 pipeline:
+
+| Capability | V4 | V5 |
+|------------|----|----|
+| Ontology input | Hand-authored YAML | OWL/Turtle import to YAML |
+| Extraction | AI.GENERATE only | Structured + AI.GENERATE (dedupe-safe) |
+| Temporal scope | Single-session snapshots | Cross-session lineage via concrete self-edges |
+
+### What V5 does NOT change
+
+- `GraphSpec` combined shape (ontology + binding in one YAML)
+- Session-scoped node identity (`{session_id}:{entity}:{keys}`)
+- Node table KEY columns
+- `_build_node_id()` logic
+- Delete-then-insert idempotency pattern (lineage edges use the same
+  pattern with destination-session ownership)
+- BigQuery-only execution (no Spanner)
+
+### What V5 does change (beyond new files)
+
+- `BindingSpec` gains two optional fields (`from_session_column`,
+  `to_session_column`) — backward-compatible, defaults to `None`
+- `compile_edge_table_clause()` uses session column overrides when present
+- `_route_edge()` sets session ownership from `to_session_column` for
+  lineage edges
+- `OntologyGraphManager` gains an optional `extractors` parameter
+
+---
+
+## Part II: V5 Demo Implementation Plan
+
+### Step 0: Golden Fixtures
+
+**Goal:** Lock expected pipeline behavior in tests before changing code.
+
+#### Fixture set
+
+| Fixture | Contents | Purpose |
+|---------|----------|---------|
+| `tests/fixtures/yamo_sample.ttl` | ~5 OWL classes, ~10 properties, 2 SKOS concept schemes | TTL import test input |
+| `tests/fixtures/yamo_sample_import.yaml` | Expected unresolved import output | Import phase golden output |
+| `tests/fixtures/yamo_sample_resolved.yaml` | Expected resolved `GraphSpec` YAML | Resolve phase golden output |
+| `tests/fixtures/mixed_events.json` | Array of agent events: 3 BKA-typed structured + 3 raw unstructured + 1 partial (typed fields + free-text reasoning) | Structured extraction test |
+| `tests/fixtures/mixed_extraction_expected.json` | Expected `ExtractedGraph` JSON | Extraction golden output |
+| `tests/fixtures/lineage_sessions.json` | Two sessions where `sup_YahooAdUnit` entity evolves (name change, position change) | Temporal lineage test |
+| `tests/fixtures/lineage_expected.json` | Expected lineage edges + materialized rows | Lineage golden output |
+
+#### Test structure
+
+```python
+# tests/test_v5_golden.py
+
+class TestTTLImportGolden:
+    """Step 1 golden tests — import + resolve."""
+
+    def test_import_produces_expected_artifact(self):
+        result = ttl_import("tests/fixtures/yamo_sample.ttl", ...)
+        assert result == load_expected("tests/fixtures/yamo_sample_import.yaml")
+
+    def test_resolve_produces_valid_graph_spec(self):
+        resolved = ttl_resolve("tests/fixtures/yamo_sample_import.yaml", ...)
+        spec = load_graph_spec_from_string(resolved)  # must not raise
+        assert spec == load_expected("tests/fixtures/yamo_sample_resolved.yaml")
+
+class TestMixedExtractionGolden:
+    """Step 2 golden tests — structured + AI extraction."""
+
+    def test_structured_events_handled(self): ...
+    def test_unhandled_events_reach_ai(self): ...
+    def test_partial_span_included_in_transcript(self): ...
+
+class TestLineageGolden:
+    """Step 3 golden tests — temporal lineage edges."""
+
+    def test_lineage_edges_materialized(self): ...
+    def test_session_scoped_delete_preserves_lineage(self): ...
+```
+
+**Acceptance criteria:**
+- Pre-existing V4 baseline tests stay green (no regressions)
+- New V5 golden fixtures are committed and their test skeletons are
+  authored, but the V5 tests are expected to **fail** initially — they
+  define the target behavior for Steps 1-3 and start passing as each
+  step lands
+- All fixtures committed before any pipeline code changes
+
+---
+
+### Step 1: Offline TTL Import (Two-Phase)
+
+**Goal:** Import YAMO Turtle files into a runtime-ready `GraphSpec` YAML
+that `load_graph_spec()` accepts, without requiring the draft
+`*.ontology.yaml` + `*.binding.yaml` contract.
+
+#### Why two phases
+
+`load_graph_spec()` calls `_validate_graph_spec()` which checks that every
+key column exists in entity properties (`ontology_models.py:251-259`) and
+that relationship endpoints reference declared entities
+(`ontology_models.py:261-272`). If the importer emits `FILL_IN` for
+missing keys (per `owl-import.md` section 10), `load_graph_spec()` will raise
+`ValueError` at load time. "Runtime-ready GraphSpec" and "unresolved
+placeholders" must be distinct artifacts.
+
+#### Architecture
+
+```
+                                     *.import.yaml
+OWL/TTL file ──> ttl_import() ──────> (unresolved artifact)
+                                     + ImportReport (JSON)
+                                           │
+                                    user edits / defaults dict
+                                           │
+                                           ▼
+                                     ttl_resolve() ──> GraphSpec YAML
+                                                       (load_graph_spec() ready)
+```
+
+#### Phase 1: Import (`ttl_import`)
+
+**New file:** `src/bigquery_agent_analytics/ttl_importer.py`
+
+```python
+def ttl_import(
+    ttl_path: str,
+    include_namespaces: list[str],
+    dataset_template: str = "{{ env }}",
+) -> TTLImportResult:
+    """Parse OWL/Turtle and emit an unresolved import artifact.
+
+    Args:
+        ttl_path: Path to .ttl or .owl file.
+        include_namespaces: IRI prefixes to include (per owl-import.md section 4).
+        dataset_template: Template for binding.source (default: {{ env }}).
+
+    Returns:
+        TTLImportResult with .yaml_text and .report.
+    """
+```
+
+**`TTLImportResult` model:**
+
+```python
+@dataclass
+class TTLImportResult:
+    yaml_text: str        # unresolved *.import.yaml content
+    report: ImportReport  # structured drop/placeholder summary
+
+@dataclass
+class ImportReport:
+    classes_mapped: int
+    properties_mapped: int
+    relationships_mapped: int
+    classes_excluded: dict[str, int]     # namespace -> count
+    properties_excluded: dict[str, int]
+    placeholders: list[PlaceholderInfo]   # location + reason
+    type_warnings: list[TypeWarning]      # unsupported type mappings
+    drops: list[DropInfo]                 # OWL features we can't map
+```
+
+**Artifact boundary (execution risk mitigation):**
+
+The unresolved output uses suffix `*.import.yaml` and a different
+top-level structure. The file includes an `ontology_import:` metadata
+block above the `graph:` block. `load_graph_spec_from_string()` reads
+`data["graph"]` (`ontology_models.py:333`), so the YAML parses
+successfully — but `_validate_graph_spec()` then rejects `FILL_IN`
+values in key columns (`ontology_models.py:251-259`), producing a clear
+`ValueError` pointing at the unresolved placeholder. This is the single
+designed failure mode.
+
+```yaml
+# yamo_sample.import.yaml — NOT a valid GraphSpec
+ontology_import:
+  status: unresolved
+  source_file: yamo_v2.2.ttl
+  import_timestamp: "2026-04-15T10:00:00Z"
+  placeholders_remaining: 3
+
+graph:
+  name: YAMO_Context_Graph
+
+  entities:
+    - name: AdUnit
+      description: "A specific ad slot"
+      # no owl:hasKey in OWL source
+      # candidate data properties: ad_unit_id, external_ref
+      binding:
+        source: "{{ env }}.ad_units"
+      keys:
+        primary: [FILL_IN]
+      properties:
+        - name: ad_unit_id
+          type: string
+        # ...
+```
+
+The `ontology_import:` block is ignored by the YAML loader (it only reads
+`data["graph"]`), but makes the file visually and programmatically
+distinct from a resolved GraphSpec. Tooling can check for
+`data.get("ontology_import", {}).get("status") == "unresolved"` to
+produce a friendlier error before validation runs.
+
+**Type compatibility gate:**
+
+The current runtime type subset is:
+
+| Runtime type | Schema compiler (`_TYPE_MAP`) | Materializer (`_DDL_TYPE_MAP`) |
+|--------------|------------------------------|--------------------------------|
+| `string` | `STRING` | `STRING` |
+| `int64` | `INTEGER` | `INT64` |
+| `double` | `NUMBER` | `FLOAT64` |
+| `float64` | `NUMBER` | `FLOAT64` |
+| `bool` | `BOOLEAN` | `BOOL` |
+| `boolean` | `BOOLEAN` | `BOOL` |
+| `timestamp` | `STRING` | `TIMESTAMP` |
+| `date` | `STRING` | `DATE` |
+| `bytes` | `STRING` | `BYTES` |
+
+OWL import may produce `numeric`, `time`, `datetime`, or `json` (from
+`owl-import.md` section 6 type mapping). The importer applies these
+narrowing rules:
+
+| OWL / ontology type | Runtime mapping | Rationale |
+|---------------------|-----------------|-----------|
+| `numeric` | `double` | Acceptable precision loss for demo |
+| `time` | `string` | No BQ DDL support in materializer |
+| `datetime` | `timestamp` | Semantically close |
+| `json` | `string` | Serialized as text |
+
+Any XSD type not in the OWL mapping table (`owl-import.md` section 6) maps
+to `string` with a warning in the `ImportReport.type_warnings` list.
+
+#### Phase 2: Resolve (`ttl_resolve`)
+
+```python
+def ttl_resolve(
+    import_yaml_path: str,
+    defaults: dict[str, Any] | None = None,
+) -> str:
+    """Resolve placeholders in an import artifact.
+
+    Args:
+        import_yaml_path: Path to *.import.yaml.
+        defaults: Optional dict of {placeholder_location: value}
+            for programmatic resolution.
+
+    Returns:
+        Runtime-ready GraphSpec YAML string.
+
+    Raises:
+        ValueError: If unresolved FILL_IN placeholders remain.
+    """
+```
+
+The resolve phase:
+
+1. Reads the `*.import.yaml` artifact
+2. Applies user edits or defaults dict to replace `FILL_IN` values
+3. Strips the `ontology_import:` metadata block
+4. Validates via `load_graph_spec_from_string()` — must succeed
+5. Returns clean `GraphSpec` YAML
+
+**Demo workflow:** For the April 15 demo, commit the pre-resolved YAML
+(`examples/yamo_resolved_graph_spec.yaml`) so the demo does not require
+interactive placeholder repair. The import + resolve phases are shown as
+prior-step outputs.
+
+**Acceptance criteria:**
+- `ttl_import("yamo.ttl")` produces `*.import.yaml` + `ImportReport`
+- `load_graph_spec()` raises on the unresolved artifact (by design)
+- `ttl_resolve()` produces YAML that `load_graph_spec()` accepts
+- No type outside `{string, int64, double, float64, bool, boolean, timestamp, date, bytes}` reaches `_bq_schema_type()` or `_ddl_type()`
+- Type narrowing decisions logged in `ImportReport.type_warnings`
+- Golden fixture test passes
+
+---
+
+### Step 2: Structured Extractor Registry (Dedupe-Safe)
+
+**Goal:** Route known event types directly to `ExtractedNode`/`ExtractedEdge`
+without LLM extraction, falling back to AI.GENERATE for unstructured
+events. Prevent double-extraction of structured events.
+
+#### Why deduplication matters
+
+The current AI path uses session-level transcript aggregation:
+
+```sql
+-- ontology_graph.py:76-98
+WITH session_transcripts AS (
+  SELECT session_id,
+    STRING_AGG(COALESCE(...), '\n---\n' ORDER BY timestamp) AS transcript
+  FROM agent_events
+  WHERE session_id IN UNNEST(@session_ids)
+    AND event_type IN ('LLM_RESPONSE', 'TOOL_COMPLETED', ...)
+  GROUP BY session_id
+)
+SELECT session_id, AI.GENERATE(CONCAT(prompt, transcript), ...) ...
+```
+
+If structured-handled events remain in the `STRING_AGG` transcript, the
+LLM will re-extract the same facts, producing duplicate nodes/edges. The
+structured fast path must be **additive without duplication**.
+
+#### Data contracts
+
+**New file:** `src/bigquery_agent_analytics/structured_extraction.py`
+
+```python
+@dataclass
+class StructuredExtractionResult:
+    """Result from a structured extractor."""
+    nodes: list[ExtractedNode]
+    edges: list[ExtractedEdge]
+    fully_handled_span_ids: set[str]      # exclude from AI transcript
+    partially_handled_span_ids: set[str]  # include with extraction hint
+
+StructuredExtractor = Callable[
+    [dict, GraphSpec],  # (event_dict, spec)
+    StructuredExtractionResult,
+]
+```
+
+**Handling semantics:**
+
+| Category | Meaning | AI transcript behavior |
+|----------|---------|----------------------|
+| `fully_handled_span_ids` | All semantic content extracted structurally | Excluded from `STRING_AGG` |
+| `partially_handled_span_ids` | Typed fields extracted, but span also has free-text reasoning | Included in `STRING_AGG` with prompt hint listing already-extracted facts |
+| Neither | Unstructured event | Included normally |
+
+#### Modified extraction flow
+
+Changes to `OntologyGraphManager`:
+
+```python
+class OntologyGraphManager:
+    def __init__(
+        self,
+        ...
+        extractors: dict[str, StructuredExtractor] | None = None,
+    ) -> None:
+        ...
+        self.extractors = extractors or {}
+```
+
+**New `extract_graph` flow:**
+
+```
+1. Query raw events (all spans for sessions)
+         │
+         ▼
+2. For each event, check event_type against self.extractors
+    ├── Match found ──> Run extractor ──> Collect nodes, edges,
+    │                                      fully/partially_handled_span_ids
+    └── No match ──> Skip (will be handled by AI)
+         │
+         ▼
+3. Build AI.GENERATE transcript CTE with exclusion filter:
+   WHERE base.span_id NOT IN UNNEST(@fully_handled_span_ids)
+         │
+         ▼
+4. For partially_handled spans, prepend to AI prompt:
+   "The following facts were already extracted from typed events,
+    focus on unstructured content: [list of extracted entity names]"
+         │
+         ▼
+5. Run AI.GENERATE on filtered transcript
+         │
+         ▼
+6. Merge: structured nodes/edges + AI-extracted nodes/edges
+   (dedup by node_id — structured wins on conflict)
+```
+
+**Modified SQL template** (`_EXTRACT_ONTOLOGY_AI_QUERY`):
+
+```sql
+WITH session_transcripts AS (
+  SELECT
+    base.session_id,
+    STRING_AGG(
+      COALESCE(...),
+      '\n---\n'
+      ORDER BY base.timestamp ASC
+    ) AS transcript
+  FROM `{project}.{dataset}.{table}` AS base
+  WHERE base.session_id IN UNNEST(@session_ids)
+    AND base.event_type IN (...)
+    AND base.content IS NOT NULL
+    AND base.span_id NOT IN UNNEST(@excluded_span_ids)  -- NEW
+  GROUP BY base.session_id
+)
+...
+```
+
+When `self.extractors` is empty (backward-compatible default),
+`@excluded_span_ids` is an empty array and the query is identical to V4.
+
+#### Example structured extractor
+
+```python
+def extract_bka_decision_event(
+    event: dict,
+    spec: GraphSpec,
+) -> StructuredExtractionResult:
+    """Extract a BKA-typed decision event into DecisionPoint + CandidateEdge."""
+    content = event.get("content", {})
+    if not isinstance(content, dict) or "decision_id" not in content:
+        return StructuredExtractionResult([], [], set(), set())
+
+    session_id = event["session_id"]
+    span_id = event["span_id"]
+
+    # Build DecisionPoint node
+    dp_node = ExtractedNode(
+        node_id=f"{session_id}:mako_DecisionPoint:decision_id={content['decision_id']}",
+        entity_name="mako_DecisionPoint",
+        labels=["mako_DecisionPoint"],
+        properties=[
+            ExtractedProperty(name="decision_id", value=content["decision_id"]),
+            ExtractedProperty(name="decision_type", value=content.get("decision_type", "")),
+        ],
+    )
+
+    nodes = [dp_node]
+    edges = []
+
+    # Check if the event also has free-text reasoning
+    has_free_text = bool(content.get("reasoning_text"))
+
+    if has_free_text:
+        return StructuredExtractionResult(
+            nodes=nodes,
+            edges=edges,
+            fully_handled_span_ids=set(),
+            partially_handled_span_ids={span_id},
+        )
+    else:
+        return StructuredExtractionResult(
+            nodes=nodes,
+            edges=edges,
+            fully_handled_span_ids={span_id},
+            partially_handled_span_ids=set(),
+        )
+```
+
+**Acceptance criteria:**
+- Structured events produce nodes/edges without LLM round-trip
+- `fully_handled_span_ids` are excluded from AI transcript (`STRING_AGG`)
+- `partially_handled_span_ids` are included with extraction hint in prompt
+- Sessions with zero structured events produce identical results to V4
+- Golden fixture test passes for mixed-event fixture (including partial case)
+- No changes to `OntologyGraphManager` public API when `extractors` is `None`
+
+---
+
+### Step 3: Concrete-Entity Temporal Lineage
+
+**Goal:** Track how the same business entity evolves across sessions,
+without changing node key semantics or the delete-then-insert pattern.
+
+#### Why not a generic EVOLVED_FROM
+
+`RelationshipSpec` requires concrete `from_entity` and `to_entity` names
+(`ontology_models.py:121-124`). `_validate_graph_spec()` checks that both
+are declared entities (`ontology_models.py:261-272`). A generic
+`EVOLVED_FROM: Entity -> Entity` cannot pass validation because `Entity`
+is not a declared entity name.
+
+Additionally, a single generic edge table would need columns from every
+entity's primary key, making the schema unbounded.
+
+#### Design: per-entity self-edge relationships
+
+Add concrete lineage relationship types as self-edges on specific entity
+types. Each lineage relationship:
+
+- Points from one session's version to the same entity in another session
+- Is owned by the **destination session** for delete-safety
+- Lives in a separate edge table
+
+#### Required contract extension: BindingSpec session columns
+
+The current DDL compiler hardcodes endpoint session key construction
+(`ontology_property_graph.py:202-208`):
+
+```python
+# Current V4 — always uses the edge's own session_id for both endpoints
+src_key_str = ", ".join([*from_cols, "session_id"])
+dst_key_str = ", ".join([*to_cols, "session_id"])
+```
+
+For lineage edges, SOURCE needs `from_session_id` (the prior session)
+and DESTINATION needs `to_session_id` (the current session), both
+mapping to the node table's `session_id` key. The current code cannot
+express this — it always appends the edge's own `session_id` column
+for both sides.
+
+**Solution: extend `BindingSpec` with optional session column overrides.**
+
+Change in `ontology_models.py`:
+
+```python
+class BindingSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str = Field(...)
+    from_columns: Optional[list[str]] = Field(default=None, ...)
+    to_columns: Optional[list[str]] = Field(default=None, ...)
+    # NEW: optional session column overrides for cross-session edges
+    from_session_column: Optional[str] = Field(
+        default=None,
+        description=(
+            "Edge column to use as session key for SOURCE endpoint. "
+            "When set, this column maps to the source node's session_id "
+            "key instead of the edge's own session_id. "
+            "Used for cross-session lineage edges."
+        ),
+    )
+    to_session_column: Optional[str] = Field(
+        default=None,
+        description=(
+            "Edge column to use as session key for DESTINATION endpoint. "
+            "When set, this column maps to the destination node's "
+            "session_id key instead of the edge's own session_id. "
+            "Used for cross-session lineage edges."
+        ),
+    )
+```
+
+When both are `None` (the default), behavior is identical to V4: the
+edge's own `session_id` column is used for both endpoints. This is a
+backward-compatible extension — existing YAML specs are unaffected.
+
+**YAML spec additions** (added to `ymgo_graph_spec.yaml`):
+
+```yaml
+relationships:
+  # ... existing CandidateEdge, ForCandidate ...
+
+  - name: sup_YahooAdUnitEvolvedFrom
+    description: "Tracks evolution of a YahooAdUnit across sessions."
+    from_entity: sup_YahooAdUnit
+    to_entity: sup_YahooAdUnit
+    binding:
+      source: "{{ env }}.sup_yahoo_ad_unit_lineage"
+      from_columns: [adUnitId]
+      to_columns: [adUnitId]
+      from_session_column: from_session_id   # NEW
+      to_session_column: to_session_id       # NEW
+    properties:
+      - name: from_session_id
+        type: string
+        description: "Session where the prior version appeared."
+      - name: to_session_id
+        type: string
+        description: "Session where the evolved version appeared."
+      - name: event_time
+        type: timestamp
+        description: "When the evolution was detected."
+      - name: changed_properties
+        type: string
+        description: "Comma-separated list of properties that changed."
+```
+
+#### DDL compiler changes
+
+Modify `compile_edge_table_clause()` in `ontology_property_graph.py`
+to use the session column overrides when present:
+
+```python
+# ontology_property_graph.py — compile_edge_table_clause()
+
+# Session key columns for SOURCE and DESTINATION endpoints.
+# Default: edge's own session_id (V4 behavior).
+# Override: binding.from_session_column / to_session_column (V5 lineage).
+src_session_col = rel.binding.from_session_column or "session_id"
+dst_session_col = rel.binding.to_session_column or "session_id"
+
+# SOURCE KEY uses src_session_col mapped to node's session_id key
+src_key_str = ", ".join([*from_cols, src_session_col])
+src_ref_str = ", ".join([*src.keys.primary, "session_id"])
+
+# DESTINATION KEY uses dst_session_col mapped to node's session_id key
+dst_key_str = ", ".join([*to_cols, dst_session_col])
+dst_ref_str = ", ".join([*tgt.keys.primary, "session_id"])
+```
+
+When `from_session_column` and `to_session_column` are both `None`, this
+produces identical DDL to V4. When set, the generated DDL maps the
+override columns to the node's `session_id` key.
+
+#### Materializer changes
+
+Modify `_route_edge()` in `ontology_materializer.py` to set the edge's
+`session_id` column to the destination session value when
+`to_session_column` is set:
+
+```python
+# ontology_materializer.py — _route_edge()
+
+# Determine session_id for delete-scoped ownership.
+# For lineage edges with to_session_column, session_id = to_session value.
+# For normal edges, session_id = the session being processed (V4 behavior).
+if rel.binding.to_session_column and rel.binding.to_session_column in row:
+    row["session_id"] = row[rel.binding.to_session_column]
+else:
+    row["session_id"] = session_id
+```
+
+This ensures lineage edges are owned by the destination session for
+delete-then-insert idempotency.
+
+#### Physical table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS `project.dataset.sup_yahoo_ad_unit_lineage` (
+  adUnitId STRING,          -- shared key (same business entity)
+  from_session_id STRING,   -- source session (maps to SOURCE KEY)
+  to_session_id STRING,     -- destination session (maps to DESTINATION KEY)
+  event_time TIMESTAMP,
+  changed_properties STRING,
+  session_id STRING,        -- = to_session_id (for delete-scoped ownership)
+  extracted_at TIMESTAMP
+)
+```
+
+#### Lineage edge ownership and delete-safety
+
+The materializer deletes by `session_id` (`ontology_materializer.py:283-286`):
+
+```sql
+DELETE FROM `table` WHERE session_id IN UNNEST(@session_ids)
+```
+
+Lineage edges span two sessions. The `session_id` column on the lineage
+edge table is set to `to_session_id` (the destination) via the
+materializer change above. This means:
+
+- Re-running extraction for session B deletes and re-creates lineage
+  edges where B is the destination
+- Re-running extraction for session A does NOT delete lineage edges
+  where A is the source and B is the destination
+- This matches the semantics: "session B discovered that entity X
+  evolved from session A"
+
+#### Lineage detection logic
+
+**New function** in `ontology_graph.py`:
+
+```python
+def detect_lineage_edges(
+    current_graph: ExtractedGraph,
+    current_session_id: str,
+    prior_graphs: dict[str, ExtractedGraph],
+    lineage_entity_types: list[str],
+    spec: GraphSpec,
+) -> list[ExtractedEdge]:
+    """Detect evolution edges between current and prior session graphs.
+
+    For each entity type in lineage_entity_types, find nodes that share
+    the same primary key across sessions and have different property
+    values.
+
+    Args:
+        current_graph: Graph extracted from the current session.
+        current_session_id: The current session ID.
+        prior_graphs: Dict of {session_id: ExtractedGraph} for prior sessions.
+        lineage_entity_types: Entity names to check for evolution.
+        spec: GraphSpec for entity key lookups.
+
+    Returns:
+        List of ExtractedEdge instances for the lineage relationships.
+    """
+```
+
+The detection is purely additive:
+
+1. For each entity type in `lineage_entity_types`, collect current-session
+   nodes keyed by primary key values
+2. For each prior session, collect prior-session nodes for the same entity
+   type
+3. For each shared primary key: diff property values
+4. If any property changed, emit a lineage edge with `changed_properties`
+   listing the changed fields
+5. If no property changed, no lineage edge (identical across sessions)
+
+#### Property Graph DDL for lineage
+
+With the `BindingSpec` extension, the DDL compiler produces:
+
+```sql
+`project.dataset.sup_yahoo_ad_unit_lineage` AS sup_YahooAdUnitEvolvedFrom
+  KEY (adUnitId, from_session_id, to_session_id, session_id)
+  SOURCE KEY (adUnitId, from_session_id)
+    REFERENCES sup_YahooAdUnit (adUnitId, session_id)
+  DESTINATION KEY (adUnitId, to_session_id)
+    REFERENCES sup_YahooAdUnit (adUnitId, session_id)
+  LABEL sup_YahooAdUnitEvolvedFrom
+  PROPERTIES (
+    event_time,
+    changed_properties,
+    extracted_at
+  )
+```
+
+`SOURCE KEY (adUnitId, from_session_id)` maps to the source node's
+`(adUnitId, session_id)` key. `DESTINATION KEY (adUnitId, to_session_id)`
+maps to the destination node's `(adUnitId, session_id)` key. This allows
+GQL traversal across sessions.
+
+#### Validation additions
+
+`_validate_graph_spec()` needs two new checks for session column
+overrides:
+
+1. If `from_session_column` is set, it must name a declared property
+   on the relationship
+2. If `to_session_column` is set, same rule
+3. Both must be set together or both absent (like `from_columns`/`to_columns`)
+
+#### GQL showcase: cross-session lineage traversal
+
+New showcase template in `ontology_orchestrator.py`:
+
+```sql
+GRAPH `{graph_ref}`
+MATCH
+  (prior:sup_YahooAdUnit)-[ev:sup_YahooAdUnitEvolvedFrom]->(current:sup_YahooAdUnit)
+WHERE current.session_id = @session_id
+RETURN
+  prior.adUnitId,
+  prior.adUnitName AS prior_name,
+  prior.adUnitPosition AS prior_position,
+  ev.from_session_id,
+  ev.changed_properties,
+  ev.event_time,
+  current.adUnitName AS current_name,
+  current.adUnitPosition AS current_position
+ORDER BY ev.event_time DESC
+LIMIT @result_limit
+```
+
+**Acceptance criteria:**
+- Existing session-scoped pipeline works unchanged (all V4 tests pass) —
+  `from_session_column` / `to_session_column` default to `None`,
+  producing identical DDL and materialization behavior
+- Lineage edges materialized in separate table per entity type
+- `_build_node_id()` and node table KEY columns unmodified
+- DDL compiler uses `from_session_column` / `to_session_column` for
+  SOURCE KEY / DESTINATION KEY when present
+- Materializer sets `session_id = to_session_column` value for
+  delete-scoped ownership
+- Session-scoped delete of session B removes lineage edges owned by B
+  (destination) but not lineage edges where B is the source
+- GQL traversal across sessions works for entities with lineage
+- Golden fixture test passes for lineage fixture
+
+---
+
+### Step 4: V5 Demo Notebook
+
+**File:** `examples/ontology_graph_v5_demo.ipynb`
+
+#### Demo flow
+
+```
+Cell 1: Environment setup
+  - Project/dataset configuration
+  - Import SDK modules
+
+Cell 2: TTL Import (Step 1 — show, don't run live)
+  - Display the YAMO sample TTL fixture
+  - Show ttl_import() output: *.import.yaml + ImportReport
+  - Show ttl_resolve() output: resolved GraphSpec YAML
+  - Load the pre-committed resolved YAML for runtime use
+
+Cell 3: Mixed Extraction (Step 2)
+  - Register structured extractors for BKA-typed decision events
+  - Run extract_graph() with mixed structured + AI.GENERATE
+  - Display extraction stats: N structured, M AI-extracted, K partial
+  - Show that structured events are excluded from AI transcript
+
+Cell 4: Materialization
+  - Create tables and materialize extracted graph
+  - Display row counts per entity/relationship table
+
+Cell 5: Temporal Lineage (Step 3)
+  - Run extraction for a second session with evolved entities
+  - Detect and materialize lineage edges
+  - Display lineage edge details: which properties changed
+
+Cell 6: Property Graph + GQL
+  - Create Property Graph (including lineage edge tables)
+  - Run forward traversal GQL (V4 showcase)
+  - Run cross-session lineage GQL (V5 showcase)
+  - Display results side by side
+
+Cell 7: Summary
+  - Architecture diagram
+  - Performance comparison: structured vs AI extraction time
+  - What's next: link to follow-up epics
+```
+
+**Acceptance criteria:**
+- Notebook runs end-to-end against a live BQ dataset
+- All seven cells produce visible output
+- No interactive placeholder repair required (pre-committed resolved YAML)
+- Mixed extraction demonstrably faster for known event types
+- Cross-session lineage GQL returns meaningful results
+
+---
+
+## Execution Risks
+
+### Risk 1: Import/Resolve Artifact Boundary
+
+**Risk:** If the unresolved import artifact looks too similar to a runtime
+`GraphSpec`, someone will feed it into `load_graph_spec()` by mistake.
+
+**Mitigation:** Use `*.import.yaml` suffix and `ontology_import:` metadata
+block. The YAML parses (the loader reads `data["graph"]`), but
+`_validate_graph_spec()` rejects `FILL_IN` values in key columns with a
+clear `ValueError`. The `ontology_import:` block makes the file visually
+distinct, and tooling can check
+`data.get("ontology_import", {}).get("status") == "unresolved"` to
+produce a friendlier error before validation runs.
+
+### Risk 2: Partial Span Handling
+
+**Risk:** Binary `fully_handled` / `not handled` under-extracts when a
+structured extractor handles only part of a span's semantics (e.g.,
+typed BKA fields extracted, but free-text reasoning in the same span
+only the LLM would catch).
+
+**Mitigation:** The `StructuredExtractionResult` contract distinguishes
+`fully_handled_span_ids` (exclude from transcript) from
+`partially_handled_span_ids` (include with extraction hint). Step 0's
+mixed-event fixture includes at least one partial-handling test case to
+drive this design before registry code is written.
+
+### Risk 3: Lineage DDL Self-Reference
+
+**Risk:** BigQuery Property Graph `SOURCE KEY ... REFERENCES` syntax for
+self-referential edges (same node table for both SOURCE and DESTINATION)
+may have undocumented restrictions.
+
+**Mitigation:** Validate the self-referential DDL against BigQuery before
+committing to this design. If self-reference is not supported, fall back
+to a dedicated lineage node type (e.g., `sup_YahooAdUnit_Version` with
+`version_id` key) and point edges between versions.
+
+---
+
+## Part III: Long-Term Production Epics
+
+These are follow-up issues, each with their own design docs and acceptance
+criteria. None are blockers for the V5 demo. Dependency graph:
+
+```
+B1 (ontology + binding compiler, flat only)
+├── B2 (full OWL importer emitting *.ontology.yaml)
+├── B3 (Spanner backend)
+│   └── B5 (MAKO governance bridge)
+├── B4 (BKA ingestion contract)
+└── B6 (inheritance lowering in compiler)
+```
+
+### Epic B1: Ontology + Binding Compiler (Flat Only)
+
+Implement the draft design docs (`docs/ontology/*.md`) as code.
+
+**Scope:**
+- `*.ontology.yaml` parser with validation per `ontology.md` section 10 (all 13
+  rules: unique names, key integrity, type validation, `extra="forbid"`)
+- `*.binding.yaml` parser with validation per `binding.md` section 9 (all 13
+  rules: name resolution, property coverage, type compatibility)
+- Resolver: cross-check ontology + binding names, substitute derived
+  expressions, resolve endpoints per `compilation.md` section 3
+- Emitter: produce `CREATE PROPERTY GRAPH` DDL for BigQuery and Spanner
+  per `compilation.md` section 4
+- `gm validate` CLI command per `cli.md` section 4
+- `gm compile` CLI command per `cli.md` section 5
+- Migrate runtime from `GraphSpec` (combined) to ontology + binding
+  (separated)
+
+**Explicit acceptance criterion:** `extends` on entities or relationships
+is rejected at compile time with a clear error message. This is specified
+in `compilation.md:8`: "v0 compiles flat ontologies only." Inheritance
+lowering is Epic B6's scope.
+
+**Key design decisions to make:**
+- How to handle the transition period where both `GraphSpec` (V4/V5) and
+  `*.ontology.yaml` + `*.binding.yaml` (B1) coexist
+- Whether `gm validate` replaces or wraps `load_graph_spec()`
+
+### Epic B2: Full OWL/Turtle Importer (`gm import-owl`)
+
+Implement `owl-import.md` fully, emitting `*.ontology.yaml` (not
+`GraphSpec`).
+
+**Scope:**
+- Full `gm import-owl` CLI command per `cli.md` section 6
+- Namespace filtering per `owl-import.md` section 4
+- Complete OWL mapping table per `owl-import.md` section 5
+- Deterministic output per `owl-import.md` section 14
+- Drop surfacing: structured annotations + YAML comments per
+  `owl-import.md` section 13
+- Placeholder resolution workflow per `owl-import.md` section 11
+- YAMO v2.2 scale target: 36 classes, 112 properties, 31 SKOS schemes
+
+**Depends on:** Epic B1 (needs `*.ontology.yaml` contract).
+
+**Relationship to V5 Step 1:** The V5 demo importer is a bridge — it
+emits the current `GraphSpec` shape. Epic B2 replaces it with the
+production importer emitting the new contract.
+
+### Epic B3: Spanner Graph Backend
+
+**Scope:**
+- Spanner target in `*.binding.yaml` per `binding.md` section 3:
+  `backend: spanner`, `instance:`, `database:`
+- Spanner DDL emission in compiler per `compilation.md` section 4
+- Type compatibility validation: `time` and `datetime` rejected on
+  Spanner targets per `binding.md` section 8
+- Runtime layer for <100ms semantic search (Spanner Graph)
+
+**Depends on:** Epic B1 (needs binding contract with `target.backend`).
+
+### Epic B4: BKA Ingestion Contract
+
+**Scope:**
+- Typed Python logging SDK for YMGO orchestrator
+- Structured event schema for decision traces
+- High-throughput ingestion path: 5M-10M events/day target
+- Maps BKA events to ontology entities (per B1 contract)
+
+**Depends on:** Epic B1 (structured events map to ontology entities).
+
+**Relationship to V5 Step 2:** The V5 structured extractors are a
+lightweight bridge. Epic B4 replaces ad-hoc extractors with a formal
+typed SDK.
+
+### Epic B5: MAKO Governance Bridge
+
+**Scope:**
+- Spanner to BigQuery synchronization layer
+- Temporal `EVOLVED_FROM` replication from hot (Spanner) to warm
+  (BigQuery)
+- EU regulatory audit support (DSA/GDPR): immutable decision lineage
+- Hot/warm consistency guarantees
+
+**Depends on:** Epic B3 (needs Spanner backend) and Epic B1 (needs
+temporal lineage model finalized in the ontology contract).
+
+### Epic B6: Inheritance Lowering in Compiler
+
+**Scope:**
+- `extends` support in compilation — currently rejected per
+  `compilation.md:8`
+- Substitutability: `MATCH (:Parent)` matches all descendants
+- Per-label property projections
+- Lowering strategies: label-referenced edges, fan-out, union views
+- Cross-table identity for inherited entities
+- Overlapping sibling handling
+
+**Depends on:** Epic B1 (needs flat compiler as foundation).
+
+Explicitly carved out from B1 per `compilation.md:238-240`: "Inheritance
+lowering — substitutability, per-label property projections, cross-table
+identity, overlapping siblings — is the subject of a separate future
+design."
+
+---
+
+## Module Change Summary
+
+| File | Step 0 | Step 1 | Step 2 | Step 3 |
+|------|--------|--------|--------|--------|
+| `ttl_importer.py` | — | **NEW** | — | — |
+| `structured_extraction.py` | — | — | **NEW** | — |
+| `ontology_models.py` | — | — | — | Modified (`BindingSpec`: add `from_session_column`, `to_session_column`) |
+| `ontology_graph.py` | — | — | Modified (extractor registry, span exclusion) | Modified (lineage detection) |
+| `ontology_property_graph.py` | — | — | — | Modified (use session column overrides in `compile_edge_table_clause`) |
+| `ontology_materializer.py` | — | — | — | Modified (`_route_edge` session ownership from `to_session_column`) |
+| `ontology_orchestrator.py` | — | — | — | Modified (lineage GQL template) |
+| `ontology_schema_compiler.py` | — | — | — | — (no changes) |
+| `tests/test_v5_golden.py` | **NEW** | Extended | Extended | Extended |
+| `tests/fixtures/` | **NEW** (7 files) | — | — | — |
+| `examples/yamo_resolved_graph_spec.yaml` | — | **NEW** | — | — |
+| `examples/ontology_graph_v5_demo.ipynb` | — | — | — | **NEW** |

--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -449,17 +449,70 @@ except ImportError as e:
 # Ontology Orchestrator
 try:
   from .ontology_orchestrator import build_ontology_graph
+  from .ontology_orchestrator import compile_lineage_gql
   from .ontology_orchestrator import compile_showcase_gql
 
   __all__.extend(
       [
           "build_ontology_graph",
+          "compile_lineage_gql",
           "compile_showcase_gql",
       ]
   )
 except ImportError as e:
   logger.debug(
       "Could not import ontology orchestrator: %s.",
+      e,
+  )
+
+# V5: Structured Extraction
+try:
+  from .structured_extraction import extract_bka_decision_event
+  from .structured_extraction import run_structured_extractors
+  from .structured_extraction import StructuredExtractionResult
+  from .structured_extraction import StructuredExtractor
+
+  __all__.extend(
+      [
+          "StructuredExtractionResult",
+          "StructuredExtractor",
+          "extract_bka_decision_event",
+          "run_structured_extractors",
+      ]
+  )
+except ImportError as e:
+  logger.debug(
+      "Could not import structured extraction: %s.",
+      e,
+  )
+
+# V5: TTL Importer
+try:
+  from .ttl_importer import ttl_import
+  from .ttl_importer import ttl_resolve
+  from .ttl_importer import TTLImportResult
+
+  __all__.extend(
+      [
+          "TTLImportResult",
+          "ttl_import",
+          "ttl_resolve",
+      ]
+  )
+except ImportError as e:
+  logger.debug(
+      "Could not import ttl importer: %s.",
+      e,
+  )
+
+# V5: Lineage Detection
+try:
+  from .ontology_graph import detect_lineage_edges
+
+  __all__.append("detect_lineage_edges")
+except ImportError as e:
+  logger.debug(
+      "Could not import lineage detection: %s.",
       e,
   )
 

--- a/src/bigquery_agent_analytics/ontology_graph.py
+++ b/src/bigquery_agent_analytics/ontology_graph.py
@@ -40,6 +40,7 @@ Example usage::
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 from typing import Optional
@@ -54,6 +55,8 @@ from .ontology_models import ExtractedProperty
 from .ontology_models import GraphSpec
 from .ontology_schema_compiler import compile_extraction_prompt
 from .ontology_schema_compiler import compile_output_schema
+from .structured_extraction import run_structured_extractors
+from .structured_extraction import StructuredExtractor
 
 logger = logging.getLogger("bigquery_agent_analytics." + __name__)
 
@@ -87,13 +90,17 @@ WITH session_transcripts AS (
     ) AS transcript
   FROM `{project}.{dataset}.{table}` AS base
   WHERE base.session_id IN UNNEST(@session_ids)
-    AND base.event_type IN (
-      'LLM_RESPONSE',
-      'TOOL_COMPLETED',
-      'AGENT_COMPLETED',
-      'HITL_CONFIRMATION_REQUEST_COMPLETED'
+    AND (
+      base.event_type IN (
+        'LLM_RESPONSE',
+        'TOOL_COMPLETED',
+        'AGENT_COMPLETED',
+        'HITL_CONFIRMATION_REQUEST_COMPLETED'
+      )
+      OR base.span_id IN UNNEST(@partial_span_ids)
     )
     AND base.content IS NOT NULL
+    AND base.span_id NOT IN UNNEST(@excluded_span_ids)
   GROUP BY base.session_id
 )
 SELECT
@@ -133,6 +140,19 @@ WHERE base.session_id IN UNNEST(@session_ids)
     'AGENT_COMPLETED',
     'HITL_CONFIRMATION_REQUEST_COMPLETED'
   )
+  AND base.content IS NOT NULL
+ORDER BY base.timestamp ASC
+"""
+
+_FETCH_RAW_EVENTS_QUERY = """\
+SELECT
+  base.span_id,
+  base.session_id,
+  base.event_type,
+  base.timestamp,
+  TO_JSON_STRING(base.content) AS content_json
+FROM `{project}.{dataset}.{table}` AS base
+WHERE base.session_id IN UNNEST(@session_ids)
   AND base.content IS NOT NULL
 ORDER BY base.timestamp ASC
 """
@@ -346,6 +366,7 @@ class OntologyGraphManager:
       endpoint: str = "gemini-2.5-flash",
       location: Optional[str] = None,
       bq_client: Optional[bigquery.Client] = None,
+      extractors: Optional[dict[str, StructuredExtractor]] = None,
   ) -> None:
     self.project_id = project_id
     self.dataset_id = dataset_id
@@ -354,6 +375,7 @@ class OntologyGraphManager:
     self.endpoint = endpoint
     self.location = location
     self._bq_client = bq_client
+    self.extractors = extractors or {}
 
   @property
   def bq_client(self) -> bigquery.Client:
@@ -429,15 +451,124 @@ class OntologyGraphManager:
     Returns:
         An ``ExtractedGraph`` with nodes and edges.
     """
-    if use_ai_generate:
-      return self._extract_via_ai_generate(session_ids)
-    return self._extract_payloads(session_ids)
+    # Run structured extractors first if any are registered.
+    structured_nodes: list[ExtractedNode] = []
+    structured_edges: list[ExtractedEdge] = []
+    excluded_span_ids: list[str] = []
+    partial_span_ids: list[str] = []
+    partial_hint = ""
 
-  def _extract_via_ai_generate(self, session_ids: list[str]) -> ExtractedGraph:
-    """Server-side extraction using AI.GENERATE with output_schema."""
+    if self.extractors and use_ai_generate:
+      raw_events = self._fetch_raw_events(session_ids)
+      if raw_events:
+        structured_result = run_structured_extractors(
+            raw_events,
+            self.extractors,
+            self.spec,
+        )
+        structured_nodes = structured_result.nodes
+        structured_edges = structured_result.edges
+        excluded_span_ids = list(structured_result.fully_handled_span_ids)
+        partial_span_ids = list(structured_result.partially_handled_span_ids)
+
+        # Build prompt hint for partially-handled spans so the LLM
+        # focuses on unstructured content and avoids re-extracting
+        # facts already captured structurally.
+        if partial_span_ids:
+          entity_names = sorted({n.entity_name for n in structured_nodes})
+          partial_hint = (
+              "Note: the following entity types were already "
+              "extracted from structured events — focus on "
+              "unstructured content only: " + ", ".join(entity_names) + ".\n"
+          )
+
+    if use_ai_generate:
+      ai_graph = self._extract_via_ai_generate(
+          session_ids,
+          excluded_span_ids,
+          partial_span_ids,
+          partial_hint,
+      )
+    else:
+      ai_graph = self._extract_payloads(session_ids)
+
+    # Merge: structured nodes/edges + AI-extracted, dedup by node_id.
+    if structured_nodes or structured_edges:
+      seen_nodes: dict[str, ExtractedNode] = {}
+      for node in structured_nodes:
+        seen_nodes[node.node_id] = node
+      for node in ai_graph.nodes:
+        if node.node_id not in seen_nodes:
+          seen_nodes[node.node_id] = node
+      all_edges = structured_edges + ai_graph.edges
+      return ExtractedGraph(
+          name=self.spec.name,
+          nodes=list(seen_nodes.values()),
+          edges=all_edges,
+      )
+
+    return ai_graph
+
+  def _fetch_raw_events(self, session_ids: list[str]) -> list[dict]:
+    """Fetch raw events with full content for structured extraction.
+
+    Unlike ``_EXTRACT_PAYLOADS_QUERY`` (V4), this returns all event
+    types and preserves ``event_type`` and full ``content`` JSON so
+    that registered structured extractors can match on event type and
+    access typed fields.
+    """
+    query = _FETCH_RAW_EVENTS_QUERY.format(
+        project=self.project_id,
+        dataset=self.dataset_id,
+        table=self.table_id,
+    )
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ArrayQueryParameter(
+                "session_ids",
+                "STRING",
+                session_ids,
+            ),
+        ]
+    )
+    try:
+      job = self.bq_client.query(query, job_config=job_config)
+      events = []
+      for row in job.result():
+        event = dict(row)
+        # Parse content_json back into a dict for extractors.
+        raw_content = event.pop("content_json", None)
+        if raw_content:
+          try:
+            event["content"] = json.loads(raw_content)
+          except (json.JSONDecodeError, TypeError):
+            event["content"] = raw_content
+        events.append(event)
+      return events
+    except Exception as e:
+      logger.warning("Failed to fetch raw events: %s", e)
+      return []
+
+  def _extract_via_ai_generate(
+      self,
+      session_ids: list[str],
+      excluded_span_ids: Optional[list[str]] = None,
+      partial_span_ids: Optional[list[str]] = None,
+      partial_hint: str = "",
+  ) -> ExtractedGraph:
+    """Server-side extraction using AI.GENERATE with output_schema.
+
+    The transcript CTE includes events matching the V4 allowlist OR
+    events whose span_id is in ``partial_span_ids`` (custom event
+    types that were partially handled by structured extractors and
+    still need LLM processing for unstructured content).
+    """
     prompt = compile_extraction_prompt(self.spec)
     schema_hint = compile_output_schema(self.spec)
-    full_prompt = prompt + "\n\nReturn a single JSON object:\n" + schema_hint
+    full_prompt = prompt
+    if partial_hint:
+      full_prompt += "\n" + partial_hint
+    full_prompt += "\n\nReturn a single JSON object:\n" + schema_hint
 
     query = _EXTRACT_ONTOLOGY_AI_QUERY.format(
         prompt=_escape_sql_literal(full_prompt),
@@ -449,7 +580,21 @@ class OntologyGraphManager:
 
     job_config = bigquery.QueryJobConfig(
         query_parameters=[
-            bigquery.ArrayQueryParameter("session_ids", "STRING", session_ids),
+            bigquery.ArrayQueryParameter(
+                "session_ids",
+                "STRING",
+                session_ids,
+            ),
+            bigquery.ArrayQueryParameter(
+                "excluded_span_ids",
+                "STRING",
+                excluded_span_ids or [],
+            ),
+            bigquery.ArrayQueryParameter(
+                "partial_span_ids",
+                "STRING",
+                partial_span_ids or [],
+            ),
         ]
     )
 
@@ -512,3 +657,122 @@ class OntologyGraphManager:
         name=self.spec.name,
         nodes=nodes,
     )
+
+
+# ------------------------------------------------------------------ #
+# Lineage Detection                                                    #
+# ------------------------------------------------------------------ #
+
+
+def detect_lineage_edges(
+    current_graph: ExtractedGraph,
+    current_session_id: str,
+    prior_graphs: dict[str, ExtractedGraph],
+    lineage_entity_types: list[str],
+    spec: GraphSpec,
+) -> list[ExtractedEdge]:
+  """Detect evolution edges between current and prior session graphs.
+
+  For each entity type in ``lineage_entity_types``, find nodes that
+  share the same primary key across sessions and have different
+  property values.
+
+  Args:
+      current_graph: Graph extracted from the current session.
+      current_session_id: The current session ID.
+      prior_graphs: Dict of ``{session_id: ExtractedGraph}`` for
+          prior sessions.
+      lineage_entity_types: Entity names to check for evolution.
+      spec: GraphSpec for entity key lookups.
+
+  Returns:
+      List of ``ExtractedEdge`` instances for lineage relationships.
+  """
+  entity_map = {e.name: e for e in spec.entities}
+  lineage_edges: list[ExtractedEdge] = []
+
+  for entity_name in lineage_entity_types:
+    entity_spec = entity_map.get(entity_name)
+    if entity_spec is None:
+      continue
+
+    key_cols = entity_spec.keys.primary
+
+    # Index current-session nodes by primary key values.
+    current_by_key: dict[str, ExtractedNode] = {}
+    for node in current_graph.nodes:
+      if node.entity_name != entity_name:
+        continue
+      prop_map = {p.name: p.value for p in node.properties}
+      key_vals = tuple(str(prop_map.get(k, "")) for k in key_cols)
+      key_str = ",".join(f"{k}={v}" for k, v in zip(key_cols, key_vals))
+      if key_str:
+        current_by_key[key_str] = node
+
+    # Compare against each prior session.
+    for prior_session_id, prior_graph in prior_graphs.items():
+      prior_by_key: dict[str, ExtractedNode] = {}
+      for node in prior_graph.nodes:
+        if node.entity_name != entity_name:
+          continue
+        prop_map = {p.name: p.value for p in node.properties}
+        key_vals = tuple(str(prop_map.get(k, "")) for k in key_cols)
+        key_str = ",".join(f"{k}={v}" for k, v in zip(key_cols, key_vals))
+        if key_str:
+          prior_by_key[key_str] = node
+
+      # Find shared keys with changed properties.
+      for key_str, current_node in current_by_key.items():
+        prior_node = prior_by_key.get(key_str)
+        if prior_node is None:
+          continue
+
+        current_props = {p.name: p.value for p in current_node.properties}
+        prior_props = {p.name: p.value for p in prior_node.properties}
+
+        changed = []
+        all_prop_names = set(current_props) | set(prior_props)
+        for pname in sorted(all_prop_names):
+          if pname in key_cols:
+            continue
+          if current_props.get(pname) != prior_props.get(pname):
+            changed.append(pname)
+
+        if not changed:
+          continue
+
+        rel_name = f"{entity_name}EvolvedFrom"
+        edge_id = (
+            f"{current_session_id}:{rel_name}:" f"{prior_session_id}:{key_str}"
+        )
+
+        lineage_edges.append(
+            ExtractedEdge(
+                edge_id=edge_id,
+                relationship_name=rel_name,
+                from_node_id=prior_node.node_id,
+                to_node_id=current_node.node_id,
+                properties=[
+                    ExtractedProperty(
+                        name="from_session_id",
+                        value=prior_session_id,
+                    ),
+                    ExtractedProperty(
+                        name="to_session_id",
+                        value=current_session_id,
+                    ),
+                    ExtractedProperty(
+                        name="event_time",
+                        value=datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).isoformat(),
+                    ),
+                    ExtractedProperty(
+                        name="changed_properties",
+                        value=",".join(changed),
+                    ),
+                ],
+            )
+        )
+
+  return lineage_edges

--- a/src/bigquery_agent_analytics/ontology_materializer.py
+++ b/src/bigquery_agent_analytics/ontology_materializer.py
@@ -271,7 +271,14 @@ def _route_edge(
   for prop in edge.properties:
     row[prop.name] = prop.value
 
-  row["session_id"] = session_id
+  # Determine session_id for delete-scoped ownership.
+  # For lineage edges with to_session_column, session_id = to_session value
+  # so that the edge is owned by the destination session.
+  # For normal edges, session_id = the session being processed (V4 behavior).
+  if rel.binding.to_session_column and rel.binding.to_session_column in row:
+    row["session_id"] = row[rel.binding.to_session_column]
+  else:
+    row["session_id"] = session_id
   row["extracted_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
   return row
 

--- a/src/bigquery_agent_analytics/ontology_models.py
+++ b/src/bigquery_agent_analytics/ontology_models.py
@@ -89,6 +89,24 @@ class BindingSpec(BaseModel):
       default=None,
       description="Join columns to the target entity.",
   )
+  from_session_column: Optional[str] = Field(
+      default=None,
+      description=(
+          "Edge column to use as session key for SOURCE endpoint. "
+          "When set, this column maps to the source node's session_id "
+          "key instead of the edge's own session_id. "
+          "Used for cross-session lineage edges."
+      ),
+  )
+  to_session_column: Optional[str] = Field(
+      default=None,
+      description=(
+          "Edge column to use as session key for DESTINATION endpoint. "
+          "When set, this column maps to the destination node's "
+          "session_id key instead of the edge's own session_id. "
+          "Used for cross-session lineage edges."
+      ),
+  )
 
 
 class EntitySpec(BaseModel):
@@ -305,6 +323,30 @@ def _validate_graph_spec(spec: GraphSpec) -> None:
               f"not in target entity {rel.to_entity!r} "
               f"primary keys {sorted(target_keys)}."
           )
+
+    # Session column override validation: both required together.
+    has_from_session = rel.binding.from_session_column is not None
+    has_to_session = rel.binding.to_session_column is not None
+    if has_from_session != has_to_session:
+      raise ValueError(
+          f"Relationship {rel.name!r}: from_session_column and "
+          f"to_session_column must both be present or both be absent."
+      )
+
+    if has_from_session:
+      rel_prop_names = {p.name for p in rel.properties}
+      if rel.binding.from_session_column not in rel_prop_names:
+        raise ValueError(
+            f"Relationship {rel.name!r}: from_session_column "
+            f"{rel.binding.from_session_column!r} not found in "
+            f"relationship properties."
+        )
+      if rel.binding.to_session_column not in rel_prop_names:
+        raise ValueError(
+            f"Relationship {rel.name!r}: to_session_column "
+            f"{rel.binding.to_session_column!r} not found in "
+            f"relationship properties."
+        )
 
 
 def load_graph_spec_from_string(

--- a/src/bigquery_agent_analytics/ontology_orchestrator.py
+++ b/src/bigquery_agent_analytics/ontology_orchestrator.py
@@ -60,6 +60,17 @@ logger = logging.getLogger("bigquery_agent_analytics." + __name__)
 # GQL Showcase Query                                                   #
 # ------------------------------------------------------------------ #
 
+_LINEAGE_GQL_TEMPLATE = """\
+GRAPH `{graph_ref}`
+MATCH
+  ({prior_alias}:{entity_label})-[{edge_alias}:{edge_label}]->({current_alias}:{entity_label})
+{where_clause}\
+RETURN
+  {return_columns}
+ORDER BY {edge_alias}.event_time DESC
+LIMIT @result_limit
+"""
+
 _SHOWCASE_GQL_TEMPLATE = """\
 GRAPH `{graph_ref}`
 MATCH
@@ -167,6 +178,84 @@ def compile_showcase_gql(
       where_clause=where_clause,
       return_columns=",\n  ".join(return_cols),
       order_column=order_column,
+  )
+
+
+def compile_lineage_gql(
+    spec: GraphSpec,
+    project_id: str,
+    dataset_id: str,
+    relationship_name: str,
+    graph_name: Optional[str] = None,
+    session_filter: bool = True,
+) -> str:
+  """Generate a GQL lineage traversal query for cross-session edges.
+
+  Produces a ``MATCH`` query for a self-edge lineage relationship,
+  returning prior-session properties, edge metadata (changed_properties,
+  event_time), and current-session properties.
+
+  Args:
+      spec: The validated graph spec.
+      project_id: GCP project ID.
+      dataset_id: BigQuery dataset ID.
+      relationship_name: The lineage relationship to traverse.
+      graph_name: Override graph name (defaults to ``spec.name``).
+      session_filter: If True, adds a ``WHERE`` clause filtering
+          the current (destination) node by ``@session_id``.
+
+  Returns:
+      A GQL query string.
+
+  Raises:
+      ValueError: If the relationship is not found or is not a
+          self-edge (from_entity != to_entity).
+  """
+  rel_map = {r.name: r for r in spec.relationships}
+  if relationship_name not in rel_map:
+    raise ValueError(
+        f"Relationship {relationship_name!r} not found in spec. "
+        f"Available: {sorted(rel_map.keys())}."
+    )
+  rel = rel_map[relationship_name]
+  if rel.from_entity != rel.to_entity:
+    raise ValueError(
+        f"Relationship {relationship_name!r} is not a self-edge "
+        f"(from={rel.from_entity!r}, to={rel.to_entity!r}). "
+        f"Lineage GQL requires from_entity == to_entity."
+    )
+
+  entity_map = {e.name: e for e in spec.entities}
+  entity = entity_map[rel.from_entity]
+
+  name = graph_name or spec.name
+  graph_ref = f"{project_id}.{dataset_id}.{name}"
+
+  prior_alias = "prior"
+  current_alias = "current"
+  edge_alias = _short_alias(rel.name, prefix="e")
+
+  where_clause = ""
+  if session_filter:
+    where_clause = f"WHERE {current_alias}.session_id = @session_id\n"
+
+  return_cols = []
+  for prop in entity.properties:
+    return_cols.append(f"{prior_alias}.{prop.name} AS prior_{prop.name}")
+  for prop in rel.properties:
+    return_cols.append(f"{edge_alias}.{prop.name}")
+  for prop in entity.properties:
+    return_cols.append(f"{current_alias}.{prop.name} AS current_{prop.name}")
+
+  return _LINEAGE_GQL_TEMPLATE.format(
+      graph_ref=graph_ref,
+      prior_alias=prior_alias,
+      entity_label=entity.name,
+      edge_alias=edge_alias,
+      edge_label=rel.name,
+      current_alias=current_alias,
+      where_clause=where_clause,
+      return_columns=",\n  ".join(return_cols),
   )
 
 

--- a/src/bigquery_agent_analytics/ontology_property_graph.py
+++ b/src/bigquery_agent_analytics/ontology_property_graph.py
@@ -188,29 +188,45 @@ def compile_edge_table_clause(
         f"materialization but not for Property Graph compilation."
     )
 
-  # Edge KEY = from_columns + to_columns + session_id (deduplicated).
-  # session_id is part of node KEY, so the edge must carry it for
-  # both SOURCE and DESTINATION references.
+  # Session key columns for SOURCE and DESTINATION endpoints.
+  # Default: edge's own session_id (V4 behavior).
+  # Override: binding.from_session_column / to_session_column (V5 lineage).
+  src_session_col = rel.binding.from_session_column or "session_id"
+  dst_session_col = rel.binding.to_session_column or "session_id"
+
+  # Edge KEY = from_columns + to_columns + session columns (deduplicated).
   edge_key_cols = list(from_cols)
   for col in to_cols:
     if col not in edge_key_cols:
       edge_key_cols.append(col)
-  if "session_id" not in edge_key_cols:
-    edge_key_cols.append("session_id")
+  for col in [src_session_col, dst_session_col, "session_id"]:
+    if col not in edge_key_cols:
+      edge_key_cols.append(col)
   edge_key_str = ", ".join(edge_key_cols)
 
-  # SOURCE KEY references the from-entity's node key (PK + session_id).
-  src_key_str = ", ".join([*from_cols, "session_id"])
+  # SOURCE KEY uses src_session_col mapped to node's session_id key.
+  src_key_str = ", ".join([*from_cols, src_session_col])
   src_ref_str = ", ".join([*src.keys.primary, "session_id"])
 
-  # DESTINATION KEY references the to-entity's node key (PK + session_id).
-  dst_key_str = ", ".join([*to_cols, "session_id"])
+  # DESTINATION KEY uses dst_session_col mapped to node's session_id key.
+  dst_key_str = ", ".join([*to_cols, dst_session_col])
   dst_ref_str = ", ".join([*tgt.keys.primary, "session_id"])
 
   # Properties: relationship-specific properties + metadata.
-  # Exclude columns already in the edge KEY (session_id is now in KEY).
+  # Exclude columns already in the edge KEY — except session column
+  # overrides, which must stay in PROPERTIES so they are queryable in
+  # GQL (BigQuery Property Graph does not auto-expose KEY columns).
   key_set = set(edge_key_cols)
-  prop_names = [p.name for p in rel.properties if p.name not in key_set]
+  session_override_cols = set()
+  if rel.binding.from_session_column:
+    session_override_cols.add(rel.binding.from_session_column)
+  if rel.binding.to_session_column:
+    session_override_cols.add(rel.binding.to_session_column)
+  prop_names = [
+      p.name
+      for p in rel.properties
+      if p.name not in key_set or p.name in session_override_cols
+  ]
   prop_names.append("extracted_at")
   props_str = ",\n        ".join(prop_names)
 

--- a/src/bigquery_agent_analytics/structured_extraction.py
+++ b/src/bigquery_agent_analytics/structured_extraction.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured extraction registry for dedupe-safe context graph population.
+
+Step 2 of the V5 Context Graph design: typed extractors that convert raw
+agent telemetry events into ``ExtractedNode`` / ``ExtractedEdge`` instances
+with explicit span-handling metadata.  Each extractor declares which spans
+it fully or partially handles so downstream AI transcript construction can
+skip already-covered data.
+
+Typical usage::
+
+    from bigquery_agent_analytics.structured_extraction import (
+        run_structured_extractors,
+        extract_bka_decision_event,
+    )
+
+    extractors = {'bka_decision': extract_bka_decision_event}
+    result = run_structured_extractors(events, extractors, spec)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Callable
+
+from bigquery_agent_analytics.ontology_models import ExtractedEdge
+from bigquery_agent_analytics.ontology_models import ExtractedNode
+from bigquery_agent_analytics.ontology_models import ExtractedProperty
+from bigquery_agent_analytics.ontology_models import GraphSpec
+
+# ------------------------------------------------------------------ #
+# Data contracts                                                       #
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class StructuredExtractionResult:
+  """Result of a single structured extractor run.
+
+  Attributes:
+    nodes: Extracted node instances.
+    edges: Extracted edge instances.
+    fully_handled_span_ids: Span IDs whose content is completely captured
+        by the extracted nodes/edges and should be excluded from the AI
+        transcript.
+    partially_handled_span_ids: Span IDs whose content is only partially
+        captured (e.g. free-text fields remain) and should be included in
+        the AI transcript with an extraction hint.
+  """
+
+  nodes: list[ExtractedNode] = field(default_factory=list)
+  edges: list[ExtractedEdge] = field(default_factory=list)
+  fully_handled_span_ids: set[str] = field(default_factory=set)
+  partially_handled_span_ids: set[str] = field(default_factory=set)
+
+
+# Type alias for extractor callables.
+StructuredExtractor = Callable[[dict, GraphSpec], StructuredExtractionResult]
+
+
+# ------------------------------------------------------------------ #
+# Merge helper                                                         #
+# ------------------------------------------------------------------ #
+
+
+def merge_extraction_results(
+    results: list[StructuredExtractionResult],
+) -> StructuredExtractionResult:
+  """Merge multiple extraction results into a single result.
+
+  Nodes are deduplicated by ``node_id`` — when multiple results produce a
+  node with the same ID the *last* occurrence wins.  Edges are simply
+  concatenated (edge dedup is left to the downstream materialiser).
+  Span-ID sets are unioned.
+
+  Args:
+    results: Individual extraction results to merge.
+
+  Returns:
+    A single ``StructuredExtractionResult`` combining all inputs.
+  """
+  node_map: dict[str, ExtractedNode] = {}
+  all_edges: list[ExtractedEdge] = []
+  fully_handled: set[str] = set()
+  partially_handled: set[str] = set()
+
+  for result in results:
+    for node in result.nodes:
+      node_map[node.node_id] = node
+    all_edges.extend(result.edges)
+    fully_handled |= result.fully_handled_span_ids
+    partially_handled |= result.partially_handled_span_ids
+
+  return StructuredExtractionResult(
+      nodes=list(node_map.values()),
+      edges=all_edges,
+      fully_handled_span_ids=fully_handled,
+      partially_handled_span_ids=partially_handled,
+  )
+
+
+# ------------------------------------------------------------------ #
+# Example extractor: BKA decision events                               #
+# ------------------------------------------------------------------ #
+
+
+def extract_bka_decision_event(
+    event: dict,
+    spec: GraphSpec,
+) -> StructuredExtractionResult:
+  """Extract a ``mako_DecisionPoint`` node from a BKA decision event.
+
+  Looks for ``decision_id`` in the event's ``content`` dict.  If found,
+  produces a node whose ``node_id`` is deterministic:
+
+      ``{session_id}:mako_DecisionPoint:decision_id={value}``
+
+  If the event also contains ``reasoning_text`` (unstructured free-text),
+  the span is marked as *partially handled* so the AI transcript still
+  includes it with an extraction hint.  Otherwise the span is *fully
+  handled*.
+
+  Args:
+    event: Raw telemetry event dict.  Expected keys: ``span_id``,
+        ``session_id``, ``content`` (a nested dict with at least
+        ``decision_id``).
+    spec: The active ``GraphSpec`` (unused by this extractor but
+        required by the ``StructuredExtractor`` signature).
+
+  Returns:
+    A ``StructuredExtractionResult`` — empty if the event does not
+    contain a ``decision_id``.
+  """
+  content = event.get('content')
+  if not isinstance(content, dict):
+    return StructuredExtractionResult()
+
+  decision_id = content.get('decision_id')
+  if decision_id is None:
+    return StructuredExtractionResult()
+
+  session_id = event.get('session_id', '')
+  span_id = event.get('span_id', '')
+
+  node_id = f'{session_id}:mako_DecisionPoint:decision_id={decision_id}'
+
+  properties: list[ExtractedProperty] = [
+      ExtractedProperty(name='decision_id', value=decision_id),
+  ]
+
+  # Carry over any additional structured fields from content.
+  for key in ('outcome', 'confidence', 'alternatives_considered'):
+    if key in content:
+      properties.append(ExtractedProperty(name=key, value=content[key]))
+
+  node = ExtractedNode(
+      node_id=node_id,
+      entity_name='mako_DecisionPoint',
+      labels=['mako_DecisionPoint'],
+      properties=properties,
+  )
+
+  has_reasoning_text = bool(content.get('reasoning_text'))
+
+  if has_reasoning_text:
+    fully_handled: set[str] = set()
+    partially_handled: set[str] = {span_id} if span_id else set()
+  else:
+    fully_handled = {span_id} if span_id else set()
+    partially_handled = set()
+
+  return StructuredExtractionResult(
+      nodes=[node],
+      edges=[],
+      fully_handled_span_ids=fully_handled,
+      partially_handled_span_ids=partially_handled,
+  )
+
+
+# ------------------------------------------------------------------ #
+# Runner                                                               #
+# ------------------------------------------------------------------ #
+
+
+def run_structured_extractors(
+    events: list[dict],
+    extractors: dict[str, StructuredExtractor],
+    spec: GraphSpec,
+) -> StructuredExtractionResult:
+  """Run registered extractors against a list of telemetry events.
+
+  For each event whose ``event_type`` matches a key in *extractors*,
+  the corresponding extractor is invoked.  All individual results are
+  merged via :func:`merge_extraction_results`.
+
+  Args:
+    events: Raw telemetry event dicts.  Each must have an
+        ``event_type`` key to match against the extractor registry.
+    extractors: Mapping of ``event_type`` string to extractor callable.
+    spec: The active ``GraphSpec`` forwarded to each extractor.
+
+  Returns:
+    A single merged ``StructuredExtractionResult``.
+  """
+  results: list[StructuredExtractionResult] = []
+
+  for event in events:
+    event_type = event.get('event_type')
+    if event_type is None:
+      continue
+    extractor = extractors.get(event_type)
+    if extractor is None:
+      continue
+    results.append(extractor(event, spec))
+
+  if not results:
+    return StructuredExtractionResult()
+
+  return merge_extraction_results(results)

--- a/src/bigquery_agent_analytics/ttl_importer.py
+++ b/src/bigquery_agent_analytics/ttl_importer.py
@@ -1,0 +1,774 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-phase OWL/Turtle importer for V5 Context Graph.
+
+Phase 1 (``ttl_import``) parses an OWL/Turtle file via ``rdflib``,
+maps classes, datatype properties, and object properties to the
+``GraphSpec`` YAML format, and emits a ``*.import.yaml`` artifact
+with ``FILL_IN`` placeholders for anything that requires human
+review.
+
+Phase 2 (``ttl_resolve``) reads the import artifact, substitutes
+``FILL_IN`` placeholders with user-supplied defaults, strips the
+``ontology_import:`` metadata block, validates the result against
+``load_graph_spec_from_string``, and returns clean GraphSpec YAML.
+
+``rdflib`` is an optional dependency: a clear error is raised when
+``ttl_import`` is called without it installed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+from pathlib import Path
+import re
+from typing import Any, Optional
+
+import yaml
+
+from bigquery_agent_analytics.ontology_models import load_graph_spec_from_string
+
+logger = logging.getLogger('bigquery_agent_analytics.' + __name__)
+
+# ------------------------------------------------------------------ #
+# Optional rdflib import                                               #
+# ------------------------------------------------------------------ #
+
+_RDFLIB_AVAILABLE = False
+try:
+  import rdflib
+  from rdflib import OWL
+  from rdflib import RDF
+  from rdflib import RDFS
+  from rdflib import XSD
+  from rdflib.namespace import SKOS
+
+  _RDFLIB_AVAILABLE = True
+except ImportError:
+  rdflib = None  # type: ignore[assignment]
+
+_FILL_IN = 'FILL_IN'
+
+
+# ------------------------------------------------------------------ #
+# Report data classes                                                  #
+# ------------------------------------------------------------------ #
+
+
+@dataclasses.dataclass
+class PlaceholderInfo:
+  """Describes a FILL_IN placeholder inserted into the import YAML."""
+
+  location: str
+  reason: str
+
+
+@dataclasses.dataclass
+class TypeWarning:
+  """Records an XSD-to-runtime type mapping that lost precision."""
+
+  owl_type: str
+  mapped_type: str
+  property_name: str
+  entity_name: str
+
+
+@dataclasses.dataclass
+class DropInfo:
+  """Records an OWL construct that could not be mapped."""
+
+  construct: str
+  entity_name: str
+  detail: str
+
+
+@dataclasses.dataclass
+class ImportReport:
+  """Summary of what was imported and what was skipped/warned."""
+
+  classes_mapped: int = 0
+  properties_mapped: int = 0
+  relationships_mapped: int = 0
+  classes_excluded: dict[str, int] = dataclasses.field(default_factory=dict)
+  properties_excluded: dict[str, int] = dataclasses.field(default_factory=dict)
+  placeholders: list[PlaceholderInfo] = dataclasses.field(default_factory=list)
+  type_warnings: list[TypeWarning] = dataclasses.field(default_factory=list)
+  drops: list[DropInfo] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class TTLImportResult:
+  """Return value of ``ttl_import``."""
+
+  yaml_text: str
+  report: ImportReport
+
+
+# ------------------------------------------------------------------ #
+# XSD -> runtime type mapping                                          #
+# ------------------------------------------------------------------ #
+
+# Map of XSD local name -> (runtime_type, optional_warning_reason).
+_XSD_TYPE_MAP: dict[str, tuple[str, Optional[str]]] = {
+    # Strings
+    'string': ('string', None),
+    'normalizedString': ('string', None),
+    'token': ('string', None),
+    'anyURI': ('string', None),
+    # Integers
+    'integer': ('int64', None),
+    'int': ('int64', None),
+    'long': ('int64', None),
+    'short': ('int64', None),
+    'byte': ('int64', None),
+    'nonNegativeInteger': ('int64', None),
+    'nonPositiveInteger': ('int64', None),
+    'positiveInteger': ('int64', None),
+    'negativeInteger': ('int64', None),
+    'unsignedLong': ('int64', None),
+    'unsignedInt': ('int64', None),
+    'unsignedShort': ('int64', None),
+    'unsignedByte': ('int64', None),
+    # Floating point
+    'double': ('double', None),
+    'float': ('double', None),
+    # Decimal (narrowed)
+    'decimal': ('double', 'narrowed from numeric (xsd:decimal)'),
+    # Boolean
+    'boolean': ('boolean', None),
+    # Date/time
+    'date': ('date', None),
+    'dateTime': ('timestamp', 'narrowed from dateTime to timestamp'),
+    'dateTimeStamp': ('timestamp', None),
+    'time': ('string', 'unsupported xsd:time, narrowed to string'),
+    # Binary
+    'hexBinary': ('bytes', None),
+    'base64Binary': ('bytes', None),
+}
+
+
+def _map_xsd_type(
+    xsd_uri: str,
+    property_name: str,
+    entity_name: str,
+    report: ImportReport,
+) -> str:
+  """Map an XSD datatype URI to a runtime type string."""
+  # Extract local name from the URI.
+  local_name = str(xsd_uri).rsplit('#', maxsplit=1)[-1]
+  local_name = local_name.rsplit('/', maxsplit=1)[-1]
+
+  # Handle rdf:JSON specifically.
+  if str(xsd_uri).endswith('JSON') or local_name == 'JSON':
+    report.type_warnings.append(
+        TypeWarning(
+            owl_type=str(xsd_uri),
+            mapped_type='string',
+            property_name=property_name,
+            entity_name=entity_name,
+        )
+    )
+    return 'string'
+
+  entry = _XSD_TYPE_MAP.get(local_name)
+  if entry is not None:
+    runtime_type, warning_reason = entry
+    if warning_reason:
+      report.type_warnings.append(
+          TypeWarning(
+              owl_type=str(xsd_uri),
+              mapped_type=runtime_type,
+              property_name=property_name,
+              entity_name=entity_name,
+          )
+      )
+    return runtime_type
+
+  # Unknown type -> string with warning.
+  report.type_warnings.append(
+      TypeWarning(
+          owl_type=str(xsd_uri),
+          mapped_type='string',
+          property_name=property_name,
+          entity_name=entity_name,
+      )
+  )
+  return 'string'
+
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+def _require_rdflib() -> None:
+  """Raise a clear error if rdflib is not installed."""
+  if not _RDFLIB_AVAILABLE:
+    raise ImportError(
+        'rdflib is required for OWL/Turtle import but is not installed. '
+        'Install it with: pip install rdflib'
+    )
+
+
+def _local_name(uri: Any) -> str:
+  """Extract the local (fragment / last path segment) name from a URI."""
+  s = str(uri)
+  if '#' in s:
+    return s.rsplit('#', maxsplit=1)[-1]
+  return s.rsplit('/', maxsplit=1)[-1]
+
+
+def _matches_namespace(
+    uri: Any,
+    include_namespaces: list[str],
+) -> bool:
+  """Return True if the URI starts with any of the given prefixes."""
+  s = str(uri)
+  return any(s.startswith(ns) for ns in include_namespaces)
+
+
+def _pluralize(name: str) -> str:
+  """Naive English pluralization for table names."""
+  if name.endswith('s') or name.endswith('x') or name.endswith('z'):
+    return name + 'es'
+  if name.endswith('sh') or name.endswith('ch'):
+    return name + 'es'
+  if name.endswith('y') and len(name) > 1 and name[-2] not in 'aeiou':
+    return name[:-1] + 'ies'
+  return name + 's'
+
+
+def _to_table_name(name: str) -> str:
+  """Convert a CamelCase or mixed name to a lowercased plural table name."""
+  # Insert underscores before uppercase runs: CamelCase -> Camel_Case.
+  result = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', name)
+  result = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1_\2', result)
+  result = result.lower()
+  return _pluralize(result)
+
+
+# ------------------------------------------------------------------ #
+# Phase 1: ttl_import                                                  #
+# ------------------------------------------------------------------ #
+
+
+def ttl_import(
+    ttl_path: str,
+    include_namespaces: list[str],
+    dataset_template: str = '{{ env }}',
+) -> TTLImportResult:
+  """Import an OWL/Turtle file into a GraphSpec-compatible YAML artifact.
+
+  Args:
+      ttl_path: Path to the ``.ttl`` or ``.owl`` file.
+      include_namespaces: IRI prefix strings. Only classes and
+          properties whose IRI starts with one of these prefixes
+          are imported.
+      dataset_template: Template for the dataset portion of
+          BigQuery table bindings. Defaults to ``{{ env }}``.
+
+  Returns:
+      A ``TTLImportResult`` with the generated YAML text and a
+      detailed ``ImportReport``.
+
+  Raises:
+      ImportError: If ``rdflib`` is not installed.
+      FileNotFoundError: If ``ttl_path`` does not exist.
+  """
+  _require_rdflib()
+
+  path = Path(ttl_path)
+  if not path.exists():
+    raise FileNotFoundError(f'TTL file not found: {ttl_path}')
+
+  g = rdflib.Graph()
+  g.parse(str(path))
+
+  report = ImportReport()
+
+  # ---- Collect classes ---- #
+  class_uris: list[Any] = []
+  for subj in g.subjects(RDF.type, OWL.Class):
+    if not _matches_namespace(subj, include_namespaces):
+      ns = str(subj).rsplit('#', maxsplit=1)[0]
+      ns = ns.rsplit('/', maxsplit=1)[0]
+      report.classes_excluded[ns] = report.classes_excluded.get(ns, 0) + 1
+      continue
+    class_uris.append(subj)
+
+  # Sort for deterministic output.
+  class_uris.sort(key=lambda u: str(u))
+
+  # Build a map of class URI -> entity info.
+  class_name_map: dict[str, str] = {}  # URI string -> entity name
+  entity_primary_keys: dict[str, list[str]] = {}  # entity name -> keys
+
+  entities: list[dict[str, Any]] = []
+  for cls_uri in class_uris:
+    name = _local_name(cls_uri)
+    class_name_map[str(cls_uri)] = name
+
+    description = ''
+    for label_obj in g.objects(cls_uri, RDFS.label):
+      description = str(label_obj)
+      break
+
+    # Collect skos:altLabel (tracked but not used in GraphSpec).
+    alt_labels: list[str] = []
+    for alt in g.objects(cls_uri, SKOS.altLabel):
+      alt_labels.append(str(alt))
+    if alt_labels:
+      logger.debug(
+          'Class %s has altLabels: %s (not used in GraphSpec)',
+          name,
+          alt_labels,
+      )
+
+    # Inheritance: rdfs:subClassOf.
+    parents: list[str] = []
+    for parent_uri in g.objects(cls_uri, RDFS.subClassOf):
+      # Skip blank nodes (OWL restrictions).
+      if isinstance(parent_uri, rdflib.BNode):
+        report.drops.append(
+            DropInfo(
+                construct='owl:Restriction (via rdfs:subClassOf bnode)',
+                entity_name=name,
+                detail='Blank-node restriction on subClassOf dropped.',
+            )
+        )
+        continue
+      parent_name = _local_name(parent_uri)
+      if _matches_namespace(parent_uri, include_namespaces):
+        parents.append(parent_name)
+
+    extends: Optional[str] = None
+    if len(parents) == 1:
+      extends = parents[0]
+    elif len(parents) > 1:
+      extends = _FILL_IN
+      report.placeholders.append(
+          PlaceholderInfo(
+              location=f'entities[{name}].extends',
+              reason=(
+                  f'Multiple parents found: {parents}. '
+                  f'GraphSpec supports single inheritance only.'
+              ),
+          )
+      )
+
+    # owl:hasKey -> primary key.
+    primary_keys: list[str] = []
+    for key_list in g.objects(cls_uri, OWL.hasKey):
+      if isinstance(key_list, rdflib.BNode):
+        # It is an RDF list; walk it.
+        for item in g.items(key_list):
+          primary_keys.append(_local_name(item))
+
+    has_key_placeholder = False
+    if not primary_keys:
+      primary_keys = [_FILL_IN]
+      has_key_placeholder = True
+      report.placeholders.append(
+          PlaceholderInfo(
+              location=f'entities[{name}].keys.primary',
+              reason='No owl:hasKey found; primary key must be specified.',
+          )
+      )
+
+    entity_primary_keys[name] = primary_keys
+
+    # Collect datatype properties for this class.
+    properties: list[dict[str, Any]] = []
+    for prop_uri in g.subjects(RDF.type, OWL.DatatypeProperty):
+      if not _matches_namespace(prop_uri, include_namespaces):
+        continue
+      # Check if this property has rdfs:domain pointing to this class.
+      domains = list(g.objects(prop_uri, RDFS.domain))
+      if not domains or cls_uri not in domains:
+        continue
+
+      prop_name = _local_name(prop_uri)
+      # Determine type from rdfs:range.
+      prop_type = 'string'
+      ranges = list(g.objects(prop_uri, RDFS.range))
+      if ranges:
+        prop_type = _map_xsd_type(str(ranges[0]), prop_name, name, report)
+
+      prop_desc = ''
+      for label_obj in g.objects(prop_uri, RDFS.label):
+        prop_desc = str(label_obj)
+        break
+
+      prop_entry: dict[str, Any] = {
+          'name': prop_name,
+          'type': prop_type,
+      }
+      if prop_desc:
+        prop_entry['description'] = prop_desc
+
+      properties.append(prop_entry)
+      report.properties_mapped += 1
+
+    # If we have primary keys that are not FILL_IN, ensure each key
+    # column appears in the properties list.
+    if not has_key_placeholder:
+      existing_prop_names = {p['name'] for p in properties}
+      for key_col in primary_keys:
+        if key_col not in existing_prop_names:
+          properties.insert(
+              0,
+              {'name': key_col, 'type': 'string'},
+          )
+
+    table_name = _to_table_name(name)
+    entity: dict[str, Any] = {
+        'name': name,
+    }
+    if description:
+      entity['description'] = description
+    if extends is not None:
+      entity['extends'] = extends
+    entity['binding'] = {
+        'source': f'{dataset_template}.{table_name}',
+    }
+    entity['keys'] = {'primary': primary_keys}
+    if properties:
+      entity['properties'] = properties
+
+    entities.append(entity)
+    report.classes_mapped += 1
+
+  # ---- Collect object properties (relationships) ---- #
+  relationships: list[dict[str, Any]] = []
+  for prop_uri in g.subjects(RDF.type, OWL.ObjectProperty):
+    if not _matches_namespace(prop_uri, include_namespaces):
+      ns = str(prop_uri).rsplit('#', maxsplit=1)[0]
+      ns = ns.rsplit('/', maxsplit=1)[0]
+      report.properties_excluded[ns] = report.properties_excluded.get(ns, 0) + 1
+      continue
+
+    rel_name = _local_name(prop_uri)
+
+    # domain -> from_entity, range -> to_entity.
+    domains = list(g.objects(prop_uri, RDFS.domain))
+    ranges = list(g.objects(prop_uri, RDFS.range))
+
+    from_entity: Optional[str] = None
+    to_entity: Optional[str] = None
+
+    if domains and str(domains[0]) in class_name_map:
+      from_entity = class_name_map[str(domains[0])]
+    if ranges and str(ranges[0]) in class_name_map:
+      to_entity = class_name_map[str(ranges[0])]
+
+    if from_entity is None:
+      from_entity = _FILL_IN
+      report.placeholders.append(
+          PlaceholderInfo(
+              location=f'relationships[{rel_name}].from_entity',
+              reason='No rdfs:domain or domain not in included classes.',
+          )
+      )
+    if to_entity is None:
+      to_entity = _FILL_IN
+      report.placeholders.append(
+          PlaceholderInfo(
+              location=f'relationships[{rel_name}].to_entity',
+              reason='No rdfs:range or range not in included classes.',
+          )
+      )
+
+    rel_desc = ''
+    for label_obj in g.objects(prop_uri, RDFS.label):
+      rel_desc = str(label_obj)
+      break
+
+    table_name = _to_table_name(rel_name)
+
+    # Derive from_columns / to_columns from entity primary keys.
+    from_columns: Optional[list[str]] = None
+    to_columns: Optional[list[str]] = None
+    if from_entity != _FILL_IN and from_entity in entity_primary_keys:
+      from_columns = list(entity_primary_keys[from_entity])
+    if to_entity != _FILL_IN and to_entity in entity_primary_keys:
+      to_columns = list(entity_primary_keys[to_entity])
+
+    binding: dict[str, Any] = {
+        'source': f'{dataset_template}.{table_name}',
+    }
+    if from_columns is not None:
+      binding['from_columns'] = from_columns
+    if to_columns is not None:
+      binding['to_columns'] = to_columns
+
+    rel: dict[str, Any] = {
+        'name': rel_name,
+    }
+    if rel_desc:
+      rel['description'] = rel_desc
+    rel['from_entity'] = from_entity
+    rel['to_entity'] = to_entity
+    rel['binding'] = binding
+
+    relationships.append(rel)
+    report.relationships_mapped += 1
+
+  # ---- Track unmappable OWL constructs ---- #
+  # owl:equivalentClass
+  for subj, _, obj in g.triples((None, OWL.equivalentClass, None)):
+    subj_name = _local_name(subj)
+    if str(subj) in class_name_map:
+      report.drops.append(
+          DropInfo(
+              construct='owl:equivalentClass',
+              entity_name=subj_name,
+              detail=f'Equivalent to {_local_name(obj)}; dropped.',
+          )
+      )
+
+  # owl:disjointWith
+  for subj, _, obj in g.triples((None, OWL.disjointWith, None)):
+    subj_name = _local_name(subj)
+    if str(subj) in class_name_map:
+      report.drops.append(
+          DropInfo(
+              construct='owl:disjointWith',
+              entity_name=subj_name,
+              detail=f'Disjoint with {_local_name(obj)}; dropped.',
+          )
+      )
+
+  # owl:unionOf, owl:intersectionOf
+  for predicate_name, predicate in [
+      ('owl:unionOf', OWL.unionOf),
+      ('owl:intersectionOf', OWL.intersectionOf),
+  ]:
+    for subj, _, _ in g.triples((None, predicate, None)):
+      subj_name = _local_name(subj)
+      if str(subj) in class_name_map:
+        report.drops.append(
+            DropInfo(
+                construct=predicate_name,
+                entity_name=subj_name,
+                detail=f'{predicate_name} expression dropped.',
+            )
+        )
+
+  # ---- Build the YAML output ---- #
+  graph_name_parts = []
+  for ns in include_namespaces:
+    part = ns.rstrip('/').rstrip('#').rsplit('/', maxsplit=1)[-1]
+    graph_name_parts.append(part)
+  graph_name = '_'.join(graph_name_parts) + '_imported'
+
+  graph_data: dict[str, Any] = {
+      'name': graph_name,
+  }
+  if entities:
+    graph_data['entities'] = entities
+  if relationships:
+    graph_data['relationships'] = relationships
+
+  ontology_import_meta: dict[str, Any] = {
+      'status': 'unresolved',
+      'source_file': str(path.resolve()),
+      'import_timestamp': datetime.datetime.now(
+          tz=datetime.timezone.utc
+      ).isoformat(),
+      'placeholders_remaining': len(report.placeholders),
+  }
+
+  # Build the full document dict: ontology_import on top, then graph.
+  full_doc: dict[str, Any] = {
+      'ontology_import': ontology_import_meta,
+      'graph': graph_data,
+  }
+
+  yaml_text = yaml.dump(
+      full_doc,
+      default_flow_style=False,
+      sort_keys=False,
+      allow_unicode=True,
+      width=120,
+  )
+
+  return TTLImportResult(yaml_text=yaml_text, report=report)
+
+
+# ------------------------------------------------------------------ #
+# Phase 2: ttl_resolve                                                 #
+# ------------------------------------------------------------------ #
+
+
+def ttl_resolve(
+    import_yaml_path: str,
+    defaults: Optional[dict[str, str]] = None,
+) -> str:
+  """Resolve FILL_IN placeholders and produce clean GraphSpec YAML.
+
+  Args:
+      import_yaml_path: Path to the ``*.import.yaml`` artifact
+          produced by ``ttl_import``.
+      defaults: Optional mapping of dotted-path locations to
+          replacement values. Paths use the same format as
+          ``PlaceholderInfo.location``, e.g.
+          ``'entities[Foo].keys.primary'`` maps to a list value
+          like ``'["foo_id"]'``.  Scalar values are used as-is;
+          list values should be passed as Python lists.
+
+  Returns:
+      A clean GraphSpec YAML string (without the
+      ``ontology_import:`` metadata block) that passes
+      ``load_graph_spec_from_string`` validation.
+
+  Raises:
+      FileNotFoundError: If the import YAML does not exist.
+      ValueError: If any ``FILL_IN`` placeholders remain after
+          applying defaults, or if the resulting YAML fails
+          validation.
+  """
+  path = Path(import_yaml_path)
+  if not path.exists():
+    raise FileNotFoundError(f'Import YAML not found: {import_yaml_path}')
+
+  raw = path.read_text(encoding='utf-8')
+  data = yaml.safe_load(raw)
+
+  # Strip the ontology_import metadata.
+  data.pop('ontology_import', None)
+
+  if defaults:
+    _apply_defaults(data, defaults)
+
+  # Serialize back to YAML.
+  yaml_text = yaml.dump(
+      data,
+      default_flow_style=False,
+      sort_keys=False,
+      allow_unicode=True,
+      width=120,
+  )
+
+  # Check for remaining FILL_IN placeholders.
+  remaining = _find_fill_in_locations(data)
+  if remaining:
+    locations_str = ', '.join(remaining)
+    raise ValueError(
+        f'Unresolved FILL_IN placeholders remain at: {locations_str}. '
+        f'Provide values via the defaults parameter.'
+    )
+
+  # Validate against GraphSpec.
+  try:
+    load_graph_spec_from_string(yaml_text)
+  except Exception as exc:
+    raise ValueError(
+        f'Resolved YAML failed GraphSpec validation: {exc}'
+    ) from exc
+
+  return yaml_text
+
+
+def _apply_defaults(
+    data: dict[str, Any],
+    defaults: dict[str, Any],
+) -> None:
+  """Apply default values to FILL_IN placeholders in the parsed YAML.
+
+  Paths follow the ``PlaceholderInfo.location`` format:
+  - ``entities[Name].extends`` -> scalar replacement
+  - ``entities[Name].keys.primary`` -> list replacement
+  - ``relationships[Name].from_entity`` -> scalar replacement
+  """
+  graph = data.get('graph', {})
+  entities_list: list[dict] = graph.get('entities', [])
+  rels_list: list[dict] = graph.get('relationships', [])
+
+  entity_by_name = {e['name']: e for e in entities_list}
+  rel_by_name = {r['name']: r for r in rels_list}
+
+  for location, value in defaults.items():
+    _apply_single_default(location, value, entity_by_name, rel_by_name)
+
+
+def _apply_single_default(
+    location: str,
+    value: Any,
+    entity_by_name: dict[str, dict],
+    rel_by_name: dict[str, dict],
+) -> None:
+  """Apply a single default value at the given dotted path."""
+  # Parse patterns like:
+  #   entities[Foo].extends
+  #   entities[Foo].keys.primary
+  #   relationships[Bar].from_entity
+  entity_match = re.match(r'entities\[([^\]]+)\]\.(.+)', location)
+  rel_match = re.match(r'relationships\[([^\]]+)\]\.(.+)', location)
+
+  if entity_match:
+    name = entity_match.group(1)
+    field_path = entity_match.group(2)
+    target = entity_by_name.get(name)
+    if target is None:
+      logger.warning(
+          'Default location %r: entity %r not found.', location, name
+      )
+      return
+    _set_nested(target, field_path, value)
+  elif rel_match:
+    name = rel_match.group(1)
+    field_path = rel_match.group(2)
+    target = rel_by_name.get(name)
+    if target is None:
+      logger.warning(
+          'Default location %r: relationship %r not found.',
+          location,
+          name,
+      )
+      return
+    _set_nested(target, field_path, value)
+  else:
+    logger.warning('Default location %r: unrecognized path format.', location)
+
+
+def _set_nested(target: dict[str, Any], dotted_path: str, value: Any) -> None:
+  """Set a value at a dotted path within a nested dict."""
+  parts = dotted_path.split('.')
+  for part in parts[:-1]:
+    if part not in target or not isinstance(target[part], dict):
+      target[part] = {}
+    target = target[part]
+  target[parts[-1]] = value
+
+
+def _find_fill_in_locations(
+    data: Any,
+    prefix: str = '',
+) -> list[str]:
+  """Recursively find all FILL_IN string values in a data structure."""
+  results: list[str] = []
+  if isinstance(data, dict):
+    for key, val in data.items():
+      path = f'{prefix}.{key}' if prefix else key
+      results.extend(_find_fill_in_locations(val, path))
+  elif isinstance(data, list):
+    for i, val in enumerate(data):
+      path = f'{prefix}[{i}]'
+      results.extend(_find_fill_in_locations(val, path))
+  elif data == _FILL_IN:
+    results.append(prefix)
+  return results

--- a/tests/fixtures/lineage_sessions.json
+++ b/tests/fixtures/lineage_sessions.json
@@ -1,0 +1,34 @@
+{
+  "sess-A": {
+    "nodes": [
+      {
+        "node_id": "sess-A:sup_YahooAdUnit:adUnitId=unit-1",
+        "entity_name": "sup_YahooAdUnit",
+        "labels": ["sup_YahooAdUnit", "mako_Candidate"],
+        "properties": [
+          {"name": "adUnitId", "value": "unit-1"},
+          {"name": "adUnitName", "value": "Homepage Banner"},
+          {"name": "adUnitSize", "value": "300x250"},
+          {"name": "adUnitPosition", "value": "ATF"}
+        ]
+      }
+    ],
+    "edges": []
+  },
+  "sess-B": {
+    "nodes": [
+      {
+        "node_id": "sess-B:sup_YahooAdUnit:adUnitId=unit-1",
+        "entity_name": "sup_YahooAdUnit",
+        "labels": ["sup_YahooAdUnit", "mako_Candidate"],
+        "properties": [
+          {"name": "adUnitId", "value": "unit-1"},
+          {"name": "adUnitName", "value": "Homepage Hero"},
+          {"name": "adUnitSize", "value": "300x250"},
+          {"name": "adUnitPosition", "value": "BTF"}
+        ]
+      }
+    ],
+    "edges": []
+  }
+}

--- a/tests/fixtures/mixed_events.json
+++ b/tests/fixtures/mixed_events.json
@@ -1,0 +1,74 @@
+[
+  {
+    "session_id": "sess-1",
+    "span_id": "span-001",
+    "event_type": "BKA_DECISION",
+    "content": {
+      "decision_id": "dec-100",
+      "outcome": "APPROVED",
+      "confidence": 0.95
+    },
+    "timestamp": "2026-04-13T10:00:00Z"
+  },
+  {
+    "session_id": "sess-1",
+    "span_id": "span-002",
+    "event_type": "BKA_DECISION",
+    "content": {
+      "decision_id": "dec-101",
+      "outcome": "REJECTED",
+      "confidence": 0.40
+    },
+    "timestamp": "2026-04-13T10:01:00Z"
+  },
+  {
+    "session_id": "sess-1",
+    "span_id": "span-003",
+    "event_type": "LLM_RESPONSE",
+    "content": {
+      "text": "The ad unit meets baseline criteria."
+    },
+    "timestamp": "2026-04-13T10:02:00Z"
+  },
+  {
+    "session_id": "sess-1",
+    "span_id": "span-004",
+    "event_type": "LLM_RESPONSE",
+    "content": {
+      "text": "Candidate ranking complete for campaign alpha."
+    },
+    "timestamp": "2026-04-13T10:03:00Z"
+  },
+  {
+    "session_id": "sess-2",
+    "span_id": "span-005",
+    "event_type": "BKA_DECISION",
+    "content": {
+      "decision_id": "dec-200",
+      "outcome": "APPROVED",
+      "confidence": 0.88
+    },
+    "timestamp": "2026-04-13T11:00:00Z"
+  },
+  {
+    "session_id": "sess-2",
+    "span_id": "span-006",
+    "event_type": "LLM_RESPONSE",
+    "content": {
+      "text": "Budget verification passed."
+    },
+    "timestamp": "2026-04-13T11:01:00Z"
+  },
+  {
+    "session_id": "sess-1",
+    "span_id": "span-007",
+    "event_type": "BKA_DECISION",
+    "content": {
+      "decision_id": "dec-102",
+      "outcome": "APPROVED",
+      "confidence": 0.72,
+      "reasoning_text": "Selected due to high historical CTR and brand-safe content."
+    },
+    "timestamp": "2026-04-13T10:04:00Z"
+  }
+]

--- a/tests/fixtures/yamo_sample.ttl
+++ b/tests/fixtures/yamo_sample.ttl
@@ -1,0 +1,85 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix yamo: <https://example.com/yamo#> .
+
+# ============================================================
+# Classes
+# ============================================================
+
+yamo:Party a owl:Class ;
+  rdfs:label "Party" ;
+  owl:hasKey ( yamo:party_id ) .
+
+yamo:AdUnit a owl:Class ;
+  rdfs:label "Ad Unit" ;
+  rdfs:subClassOf yamo:Party ;
+  owl:hasKey ( yamo:ad_unit_id ) .
+
+yamo:Campaign a owl:Class ;
+  rdfs:label "Campaign" ;
+  owl:hasKey ( yamo:campaign_id ) .
+
+yamo:RejectionReason a owl:Class ;
+  rdfs:label "Rejection Reason" ;
+  owl:hasKey ( yamo:rejection_type ) .
+
+# DecisionPoint has NO owl:hasKey -> should produce FILL_IN.
+yamo:DecisionPoint a owl:Class ;
+  rdfs:label "Decision Point" .
+
+# ============================================================
+# Datatype Properties
+# ============================================================
+
+yamo:party_id a owl:DatatypeProperty ;
+  rdfs:domain yamo:Party ;
+  rdfs:range xsd:string .
+
+yamo:name a owl:DatatypeProperty ;
+  rdfs:domain yamo:Party ;
+  rdfs:range xsd:string .
+
+yamo:ad_unit_id a owl:DatatypeProperty ;
+  rdfs:domain yamo:AdUnit ;
+  rdfs:range xsd:string .
+
+yamo:campaign_id a owl:DatatypeProperty ;
+  rdfs:domain yamo:Campaign ;
+  rdfs:range xsd:string .
+
+yamo:decision_id a owl:DatatypeProperty ;
+  rdfs:domain yamo:DecisionPoint ;
+  rdfs:range xsd:string .
+
+yamo:decision_type a owl:DatatypeProperty ;
+  rdfs:domain yamo:DecisionPoint ;
+  rdfs:range xsd:string .
+
+yamo:rejection_type a owl:DatatypeProperty ;
+  rdfs:domain yamo:RejectionReason ;
+  rdfs:range xsd:string .
+
+# budget is xsd:decimal -> should narrow to double with a warning.
+yamo:budget a owl:DatatypeProperty ;
+  rdfs:domain yamo:Campaign ;
+  rdfs:range xsd:decimal .
+
+yamo:start_date a owl:DatatypeProperty ;
+  rdfs:domain yamo:Campaign ;
+  rdfs:range xsd:date .
+
+# ============================================================
+# Object Properties (relationships)
+# ============================================================
+
+yamo:evaluates a owl:ObjectProperty ;
+  rdfs:label "evaluates" ;
+  rdfs:domain yamo:DecisionPoint ;
+  rdfs:range yamo:AdUnit .
+
+yamo:rejectedBy a owl:ObjectProperty ;
+  rdfs:label "rejected by" ;
+  rdfs:domain yamo:AdUnit ;
+  rdfs:range yamo:RejectionReason .

--- a/tests/test_ontology_graph.py
+++ b/tests/test_ontology_graph.py
@@ -953,6 +953,6 @@ class TestExtractGraph:
     call_args = mock_client.query.call_args
     job_config = call_args[1].get("job_config") or call_args[0][1]
     params = job_config.query_parameters
-    assert len(params) == 1
-    assert params[0].name == "session_ids"
-    assert params[0].values == ["sess1", "sess2"]
+    assert len(params) >= 1
+    session_param = next(p for p in params if p.name == "session_ids")
+    assert session_param.values == ["sess1", "sess2"]

--- a/tests/test_v5_golden.py
+++ b/tests/test_v5_golden.py
@@ -1,0 +1,896 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden tests for V5 Context Graph: TTL import, structured extraction,
+lineage detection, DDL session columns, materializer ownership, and
+lineage GQL generation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from bigquery_agent_analytics.ontology_graph import detect_lineage_edges
+from bigquery_agent_analytics.ontology_materializer import _route_edge
+from bigquery_agent_analytics.ontology_materializer import compile_relationship_ddl
+from bigquery_agent_analytics.ontology_models import _validate_graph_spec
+from bigquery_agent_analytics.ontology_models import BindingSpec
+from bigquery_agent_analytics.ontology_models import EntitySpec
+from bigquery_agent_analytics.ontology_models import ExtractedEdge
+from bigquery_agent_analytics.ontology_models import ExtractedGraph
+from bigquery_agent_analytics.ontology_models import ExtractedNode
+from bigquery_agent_analytics.ontology_models import ExtractedProperty
+from bigquery_agent_analytics.ontology_models import GraphSpec
+from bigquery_agent_analytics.ontology_models import KeySpec
+from bigquery_agent_analytics.ontology_models import load_graph_spec
+from bigquery_agent_analytics.ontology_models import load_graph_spec_from_string
+from bigquery_agent_analytics.ontology_models import PropertySpec
+from bigquery_agent_analytics.ontology_models import RelationshipSpec
+from bigquery_agent_analytics.ontology_orchestrator import compile_lineage_gql
+from bigquery_agent_analytics.structured_extraction import extract_bka_decision_event
+from bigquery_agent_analytics.structured_extraction import merge_extraction_results
+from bigquery_agent_analytics.structured_extraction import run_structured_extractors
+from bigquery_agent_analytics.structured_extraction import StructuredExtractionResult
+
+# ------------------------------------------------------------------ #
+# Fixture Paths                                                        #
+# ------------------------------------------------------------------ #
+
+_FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+_TTL_PATH = os.path.join(_FIXTURES_DIR, "yamo_sample.ttl")
+_MIXED_EVENTS_PATH = os.path.join(_FIXTURES_DIR, "mixed_events.json")
+_LINEAGE_SESSIONS_PATH = os.path.join(_FIXTURES_DIR, "lineage_sessions.json")
+
+
+def _load_mixed_events() -> list[dict]:
+  """Load the mixed_events.json fixture."""
+  with open(_MIXED_EVENTS_PATH, encoding="utf-8") as f:
+    return json.load(f)
+
+
+def _load_lineage_sessions() -> dict[str, dict]:
+  """Load the lineage_sessions.json fixture."""
+  with open(_LINEAGE_SESSIONS_PATH, encoding="utf-8") as f:
+    return json.load(f)
+
+
+def _demo_spec() -> GraphSpec:
+  """Load the existing YMGO demo spec."""
+  demo_path = os.path.join(
+      os.path.dirname(__file__),
+      "..",
+      "examples",
+      "ymgo_graph_spec.yaml",
+  )
+  return load_graph_spec(demo_path, env="p.d")
+
+
+def _hydrate_lineage_graph(session_data: dict) -> ExtractedGraph:
+  """Build an ExtractedGraph from a lineage session dict."""
+  nodes = []
+  for raw in session_data.get("nodes", []):
+    props = [
+        ExtractedProperty(name=p["name"], value=p["value"])
+        for p in raw.get("properties", [])
+    ]
+    nodes.append(
+        ExtractedNode(
+            node_id=raw["node_id"],
+            entity_name=raw["entity_name"],
+            labels=raw.get("labels", [raw["entity_name"]]),
+            properties=props,
+        )
+    )
+  edges = []
+  for raw in session_data.get("edges", []):
+    props = [
+        ExtractedProperty(name=p["name"], value=p["value"])
+        for p in raw.get("properties", [])
+    ]
+    edges.append(
+        ExtractedEdge(
+            edge_id=raw["edge_id"],
+            relationship_name=raw["relationship_name"],
+            from_node_id=raw["from_node_id"],
+            to_node_id=raw["to_node_id"],
+            properties=props,
+        )
+    )
+  return ExtractedGraph(name="lineage_test", nodes=nodes, edges=edges)
+
+
+def _make_entity(name, props=None, keys=None, source="p.d.t", labels=None):
+  """Shortcut for building an EntitySpec in tests."""
+  props = props or [PropertySpec(name="eid", type="string")]
+  keys = keys or ["eid"]
+  labels = labels or [name]
+  return EntitySpec(
+      name=name,
+      binding=BindingSpec(source=source),
+      keys=KeySpec(primary=keys),
+      properties=props,
+      labels=labels,
+  )
+
+
+def _make_lineage_spec() -> GraphSpec:
+  """Build a GraphSpec with a lineage self-edge for testing."""
+  entity = _make_entity(
+      name="sup_YahooAdUnit",
+      props=[
+          PropertySpec(name="adUnitId", type="string"),
+          PropertySpec(name="adUnitName", type="string"),
+          PropertySpec(name="adUnitPosition", type="string"),
+          PropertySpec(name="adUnitSize", type="string"),
+      ],
+      keys=["adUnitId"],
+      source="p.d.yahoo_ad_units",
+  )
+  lineage_rel = RelationshipSpec(
+      name="sup_YahooAdUnitEvolvedFrom",
+      from_entity="sup_YahooAdUnit",
+      to_entity="sup_YahooAdUnit",
+      binding=BindingSpec(
+          source="p.d.ad_unit_lineage",
+          from_columns=["adUnitId"],
+          to_columns=["adUnitId"],
+          from_session_column="from_session_id",
+          to_session_column="to_session_id",
+      ),
+      properties=[
+          PropertySpec(name="from_session_id", type="string"),
+          PropertySpec(name="to_session_id", type="string"),
+          PropertySpec(name="event_time", type="timestamp"),
+          PropertySpec(name="changed_properties", type="string"),
+      ],
+  )
+  return GraphSpec(
+      name="lineage_test",
+      entities=[entity],
+      relationships=[lineage_rel],
+  )
+
+
+# ------------------------------------------------------------------ #
+# TestBindingSpecSessionColumns                                        #
+# ------------------------------------------------------------------ #
+
+
+class TestBindingSpecSessionColumns:
+  """BindingSpec from_session_column / to_session_column validation."""
+
+  def test_session_columns_default_none(self):
+    """Loading the existing YMGO spec yields None session columns."""
+    spec = _demo_spec()
+    for rel in spec.relationships:
+      assert rel.binding.from_session_column is None
+      assert rel.binding.to_session_column is None
+
+  def test_session_columns_valid(self):
+    """Constructing a spec with valid session columns succeeds."""
+    entity = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a",
+    )
+    rel = RelationshipSpec(
+        name="AEvolvedFrom",
+        from_entity="A",
+        to_entity="A",
+        binding=BindingSpec(
+            source="p.d.a_lineage",
+            from_columns=["a_id"],
+            to_columns=["a_id"],
+            from_session_column="from_session_id",
+            to_session_column="to_session_id",
+        ),
+        properties=[
+            PropertySpec(name="from_session_id", type="string"),
+            PropertySpec(name="to_session_id", type="string"),
+            PropertySpec(name="changed_properties", type="string"),
+        ],
+    )
+    spec = GraphSpec(name="g", entities=[entity], relationships=[rel])
+    spec.entities[0].labels = ["A"]
+    # Should not raise.
+    _validate_graph_spec(spec)
+    assert rel.binding.from_session_column == "from_session_id"
+    assert rel.binding.to_session_column == "to_session_id"
+
+  def test_session_columns_must_be_paired(self):
+    """from_session_column without to_session_column raises ValueError."""
+    entity = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a",
+    )
+    rel = RelationshipSpec(
+        name="AEvolvedFrom",
+        from_entity="A",
+        to_entity="A",
+        binding=BindingSpec(
+            source="p.d.a_lineage",
+            from_columns=["a_id"],
+            to_columns=["a_id"],
+            from_session_column="from_session_id",
+            # to_session_column intentionally omitted
+        ),
+        properties=[
+            PropertySpec(name="from_session_id", type="string"),
+        ],
+    )
+    spec = GraphSpec(name="g", entities=[entity], relationships=[rel])
+    spec.entities[0].labels = ["A"]
+    with pytest.raises(
+        ValueError,
+        match="from_session_column and to_session_column must both be present",
+    ):
+      _validate_graph_spec(spec)
+
+  def test_session_columns_must_reference_properties(self):
+    """Non-existent property name in from_session_column raises ValueError."""
+    entity = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a",
+    )
+    rel = RelationshipSpec(
+        name="AEvolvedFrom",
+        from_entity="A",
+        to_entity="A",
+        binding=BindingSpec(
+            source="p.d.a_lineage",
+            from_columns=["a_id"],
+            to_columns=["a_id"],
+            from_session_column="nonexistent_col",
+            to_session_column="also_nonexistent",
+        ),
+        properties=[
+            PropertySpec(name="something_else", type="string"),
+        ],
+    )
+    spec = GraphSpec(name="g", entities=[entity], relationships=[rel])
+    spec.entities[0].labels = ["A"]
+    with pytest.raises(
+        ValueError,
+        match="from_session_column.*not found in relationship properties",
+    ):
+      _validate_graph_spec(spec)
+
+
+# ------------------------------------------------------------------ #
+# TestTTLImport                                                        #
+# ------------------------------------------------------------------ #
+
+
+_rdflib_available = False
+try:
+  import rdflib as _rdflib_check  # noqa: F401
+
+  _rdflib_available = True
+except ImportError:
+  pass
+
+
+@pytest.mark.skipif(
+    not _rdflib_available,
+    reason="rdflib not installed",
+)
+class TestTTLImport:
+  """Step 1 -- TTL import + resolve."""
+
+  def test_import_produces_unresolved_artifact(self):
+    """Importing yamo_sample.ttl produces YAML with ontology_import metadata."""
+    from bigquery_agent_analytics.ttl_importer import ttl_import
+
+    result = ttl_import(
+        _TTL_PATH,
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    assert "ontology_import:" in result.yaml_text
+    assert result.report.classes_mapped == 5
+    assert result.report.relationships_mapped == 2
+
+  def test_import_placeholder_for_missing_key(self):
+    """DecisionPoint (no owl:hasKey) should have FILL_IN for keys."""
+    import yaml
+
+    from bigquery_agent_analytics.ttl_importer import ttl_import
+
+    result = ttl_import(
+        _TTL_PATH,
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(result.yaml_text)
+    entities = data["graph"]["entities"]
+    dp = next(e for e in entities if e["name"] == "DecisionPoint")
+    assert "FILL_IN" in dp["keys"]["primary"]
+    # Verify placeholder is tracked in the report.
+    placeholder_locations = [p.location for p in result.report.placeholders]
+    assert any(
+        "DecisionPoint" in loc and "keys.primary" in loc
+        for loc in placeholder_locations
+    )
+
+  def test_import_type_narrowing(self):
+    """budget (xsd:decimal) should map to double with a type warning."""
+    from bigquery_agent_analytics.ttl_importer import ttl_import
+
+    result = ttl_import(
+        _TTL_PATH,
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    budget_warnings = [
+        w for w in result.report.type_warnings if w.property_name == "budget"
+    ]
+    assert len(budget_warnings) == 1
+    assert budget_warnings[0].mapped_type == "double"
+    assert "decimal" in budget_warnings[0].owl_type
+
+  def test_resolve_produces_valid_graph_spec(self, tmp_path):
+    """Resolve with defaults fixing FILL_IN, then load_graph_spec_from_string succeeds."""
+    import yaml
+
+    from bigquery_agent_analytics.ttl_importer import ttl_import
+    from bigquery_agent_analytics.ttl_importer import ttl_resolve
+
+    result = ttl_import(
+        _TTL_PATH,
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    import_file = tmp_path / "yamo.import.yaml"
+    import_file.write_text(result.yaml_text, encoding="utf-8")
+
+    # Provide defaults for all FILL_IN placeholders.
+    # DecisionPoint has no owl:hasKey, so its PK and the evaluates
+    # relationship from_columns both inherited FILL_IN.
+    resolved_yaml = ttl_resolve(
+        str(import_file),
+        defaults={
+            "entities[DecisionPoint].keys.primary": ["decision_id"],
+            "relationships[evaluates].binding.from_columns": ["decision_id"],
+        },
+    )
+    # The resolved YAML should be loadable as a valid GraphSpec.
+    spec = load_graph_spec_from_string(resolved_yaml)
+    entity_names = {e.name for e in spec.entities}
+    assert "Party" in entity_names
+    assert "DecisionPoint" in entity_names
+    assert "Campaign" in entity_names
+
+  def test_resolve_rejects_unresolved(self, tmp_path):
+    """Resolve without fixing FILL_IN raises ValueError."""
+    from bigquery_agent_analytics.ttl_importer import ttl_import
+    from bigquery_agent_analytics.ttl_importer import ttl_resolve
+
+    result = ttl_import(
+        _TTL_PATH,
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    import_file = tmp_path / "yamo.import.yaml"
+    import_file.write_text(result.yaml_text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unresolved FILL_IN"):
+      ttl_resolve(str(import_file))
+
+
+# ------------------------------------------------------------------ #
+# TestStructuredExtraction                                             #
+# ------------------------------------------------------------------ #
+
+
+class TestStructuredExtraction:
+  """Step 2 -- structured extraction."""
+
+  def test_bka_extractor_fully_handled(self):
+    """BKA event without reasoning_text is fully handled."""
+    events = _load_mixed_events()
+    # First event: BKA_DECISION without reasoning_text.
+    event = events[0]
+    spec = _demo_spec()
+    result = extract_bka_decision_event(event, spec)
+    assert len(result.nodes) == 1
+    assert result.nodes[0].entity_name == "mako_DecisionPoint"
+    assert "span-001" in result.fully_handled_span_ids
+    assert len(result.partially_handled_span_ids) == 0
+
+  def test_bka_extractor_partially_handled(self):
+    """BKA event with reasoning_text is only partially handled."""
+    events = _load_mixed_events()
+    # Last event (index 6): BKA_DECISION with reasoning_text.
+    event = events[6]
+    spec = _demo_spec()
+    result = extract_bka_decision_event(event, spec)
+    assert len(result.nodes) == 1
+    assert "span-007" in result.partially_handled_span_ids
+    assert len(result.fully_handled_span_ids) == 0
+
+  def test_bka_extractor_ignores_non_matching(self):
+    """LLM_RESPONSE event returns empty result from BKA extractor."""
+    events = _load_mixed_events()
+    # Third event (index 2): LLM_RESPONSE.
+    event = events[2]
+    spec = _demo_spec()
+    result = extract_bka_decision_event(event, spec)
+    assert len(result.nodes) == 0
+    assert len(result.edges) == 0
+    assert len(result.fully_handled_span_ids) == 0
+
+  def test_run_extractors_merges_results(self):
+    """run_structured_extractors with mixed events produces merged result."""
+    events = _load_mixed_events()
+    spec = _demo_spec()
+    extractors = {"BKA_DECISION": extract_bka_decision_event}
+    result = run_structured_extractors(events, extractors, spec)
+    # 4 BKA_DECISION events -> 4 unique decision_ids (dec-100..102, dec-200).
+    assert len(result.nodes) == 4
+    node_ids = {n.node_id for n in result.nodes}
+    assert any("dec-100" in nid for nid in node_ids)
+    assert any("dec-200" in nid for nid in node_ids)
+
+  def test_merge_deduplicates_nodes(self):
+    """Same node_id from two extractors: last wins."""
+    node_v1 = ExtractedNode(
+        node_id="sess:mako_DecisionPoint:decision_id=dec-1",
+        entity_name="mako_DecisionPoint",
+        labels=["mako_DecisionPoint"],
+        properties=[
+            ExtractedProperty(name="decision_id", value="dec-1"),
+            ExtractedProperty(name="outcome", value="REJECTED"),
+        ],
+    )
+    node_v2 = ExtractedNode(
+        node_id="sess:mako_DecisionPoint:decision_id=dec-1",
+        entity_name="mako_DecisionPoint",
+        labels=["mako_DecisionPoint"],
+        properties=[
+            ExtractedProperty(name="decision_id", value="dec-1"),
+            ExtractedProperty(name="outcome", value="APPROVED"),
+        ],
+    )
+    r1 = StructuredExtractionResult(nodes=[node_v1])
+    r2 = StructuredExtractionResult(nodes=[node_v2])
+    merged = merge_extraction_results([r1, r2])
+    assert len(merged.nodes) == 1
+    # Last wins.
+    prop_map = {p.name: p.value for p in merged.nodes[0].properties}
+    assert prop_map["outcome"] == "APPROVED"
+
+
+# ------------------------------------------------------------------ #
+# TestLineageDetection                                                 #
+# ------------------------------------------------------------------ #
+
+
+class TestLineageDetection:
+  """Step 3 -- temporal lineage."""
+
+  def test_detect_lineage_edges_finds_changes(self):
+    """Compare sess-A and sess-B, find changed properties."""
+    sessions = _load_lineage_sessions()
+    spec = _demo_spec()
+
+    current_graph = _hydrate_lineage_graph(sessions["sess-B"])
+    prior_graphs = {
+        "sess-A": _hydrate_lineage_graph(sessions["sess-A"]),
+    }
+
+    edges = detect_lineage_edges(
+        current_graph=current_graph,
+        current_session_id="sess-B",
+        prior_graphs=prior_graphs,
+        lineage_entity_types=["sup_YahooAdUnit"],
+        spec=spec,
+    )
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.relationship_name == "sup_YahooAdUnitEvolvedFrom"
+    # Check that changed_properties includes adUnitName and adUnitPosition.
+    changed = next(
+        p.value for p in edge.properties if p.name == "changed_properties"
+    )
+    assert "adUnitName" in changed
+    assert "adUnitPosition" in changed
+    # adUnitSize should NOT be in changed (it stayed 300x250).
+    assert "adUnitSize" not in changed
+
+  def test_detect_lineage_edges_no_change(self):
+    """Identical nodes across sessions produce no lineage edges."""
+    sessions = _load_lineage_sessions()
+    spec = _demo_spec()
+
+    # Use the same session data for both prior and current.
+    current_graph = _hydrate_lineage_graph(sessions["sess-A"])
+    prior_graphs = {
+        "sess-A": _hydrate_lineage_graph(sessions["sess-A"]),
+    }
+
+    edges = detect_lineage_edges(
+        current_graph=current_graph,
+        current_session_id="sess-A",
+        prior_graphs=prior_graphs,
+        lineage_entity_types=["sup_YahooAdUnit"],
+        spec=spec,
+    )
+    assert len(edges) == 0
+
+  def test_detect_lineage_edges_new_entity(self):
+    """Entity only in current session (not in prior) produces no edge."""
+    sessions = _load_lineage_sessions()
+    spec = _demo_spec()
+
+    current_graph = _hydrate_lineage_graph(sessions["sess-B"])
+    # Prior has no matching entity.
+    empty_prior = ExtractedGraph(name="empty")
+    prior_graphs = {"sess-X": empty_prior}
+
+    edges = detect_lineage_edges(
+        current_graph=current_graph,
+        current_session_id="sess-B",
+        prior_graphs=prior_graphs,
+        lineage_entity_types=["sup_YahooAdUnit"],
+        spec=spec,
+    )
+    assert len(edges) == 0
+
+
+# ------------------------------------------------------------------ #
+# TestDDLSessionColumns                                                #
+# ------------------------------------------------------------------ #
+
+
+class TestDDLSessionColumns:
+  """Step 3 -- DDL compiler with session column overrides."""
+
+  def test_edge_ddl_without_session_columns(self):
+    """Existing behavior unchanged: edge uses session_id for both endpoints."""
+    from bigquery_agent_analytics.ontology_property_graph import compile_edge_table_clause
+
+    spec = _demo_spec()
+    rel = spec.relationships[0]  # CandidateEdge
+    clause = compile_edge_table_clause(rel, spec, "proj", "ds")
+    assert "SOURCE KEY (decision_id, session_id)" in clause
+    assert "REFERENCES mako_DecisionPoint (decision_id, session_id)" in clause
+
+  def test_edge_ddl_with_session_columns(self):
+    """Lineage edge uses from_session_id/to_session_id for endpoints."""
+    from bigquery_agent_analytics.ontology_property_graph import compile_edge_table_clause
+
+    entity = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a_table",
+    )
+    rel = RelationshipSpec(
+        name="AEvolvedFrom",
+        from_entity="A",
+        to_entity="A",
+        binding=BindingSpec(
+            source="p.d.a_lineage",
+            from_columns=["a_id"],
+            to_columns=["a_id"],
+            from_session_column="from_session_id",
+            to_session_column="to_session_id",
+        ),
+        properties=[
+            PropertySpec(name="from_session_id", type="string"),
+            PropertySpec(name="to_session_id", type="string"),
+            PropertySpec(name="changed_properties", type="string"),
+        ],
+    )
+    spec = GraphSpec(name="g", entities=[entity], relationships=[rel])
+
+    clause = compile_edge_table_clause(rel, spec, "proj", "ds")
+    # SOURCE KEY should use from_session_id, not session_id.
+    assert "SOURCE KEY (a_id, from_session_id)" in clause
+    assert "REFERENCES A (a_id, session_id)" in clause
+    # DESTINATION KEY should use to_session_id.
+    assert "DESTINATION KEY (a_id, to_session_id)" in clause
+
+
+# ------------------------------------------------------------------ #
+# TestMaterializerSessionOwnership                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestMaterializerSessionOwnership:
+  """Step 3 -- materializer session ownership."""
+
+  def test_route_edge_normal(self):
+    """Normal edge: session_id set from the session_id parameter."""
+    spec = _demo_spec()
+    rel = spec.relationships[0]  # CandidateEdge
+    edge = ExtractedEdge(
+        edge_id="sess-1:CandidateEdge:0",
+        relationship_name="CandidateEdge",
+        from_node_id="sess-1:mako_DecisionPoint:decision_id=d1",
+        to_node_id="sess-1:sup_YahooAdUnit:adUnitId=u1",
+        properties=[
+            ExtractedProperty(name="edge_type", value="SELECTED_CANDIDATE"),
+            ExtractedProperty(name="mako_scoreValue", value=0.95),
+        ],
+    )
+    row = _route_edge(edge, rel, spec, "sess-1")
+    assert row["session_id"] == "sess-1"
+
+  def test_route_edge_lineage(self):
+    """Lineage edge: session_id set from to_session_column value."""
+    entity = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a_table",
+    )
+    rel = RelationshipSpec(
+        name="AEvolvedFrom",
+        from_entity="A",
+        to_entity="A",
+        binding=BindingSpec(
+            source="p.d.a_lineage",
+            from_columns=["a_id"],
+            to_columns=["a_id"],
+            from_session_column="from_session_id",
+            to_session_column="to_session_id",
+        ),
+        properties=[
+            PropertySpec(name="from_session_id", type="string"),
+            PropertySpec(name="to_session_id", type="string"),
+            PropertySpec(name="changed_properties", type="string"),
+        ],
+    )
+    spec = GraphSpec(name="g", entities=[entity], relationships=[rel])
+
+    edge = ExtractedEdge(
+        edge_id="sess-B:AEvolvedFrom:sess-A:a_id=x1",
+        relationship_name="AEvolvedFrom",
+        from_node_id="sess-A:A:a_id=x1",
+        to_node_id="sess-B:A:a_id=x1",
+        properties=[
+            ExtractedProperty(name="from_session_id", value="sess-A"),
+            ExtractedProperty(name="to_session_id", value="sess-B"),
+            ExtractedProperty(name="changed_properties", value="score"),
+        ],
+    )
+    row = _route_edge(edge, rel, spec, "sess-B")
+    # session_id should be set from to_session_column value.
+    assert row["session_id"] == "sess-B"
+
+
+# ------------------------------------------------------------------ #
+# TestLineageGQL                                                       #
+# ------------------------------------------------------------------ #
+
+
+class TestLineageGQL:
+  """Step 3 -- lineage GQL generation."""
+
+  def test_compile_lineage_gql(self):
+    """Generates correct GQL with prior/current aliases."""
+    entity = _make_entity(
+        "sup_YahooAdUnit",
+        props=[
+            PropertySpec(name="adUnitId", type="string"),
+            PropertySpec(name="adUnitName", type="string"),
+        ],
+        keys=["adUnitId"],
+        source="p.d.yahoo_ad_units",
+    )
+    rel = RelationshipSpec(
+        name="sup_YahooAdUnitEvolvedFrom",
+        from_entity="sup_YahooAdUnit",
+        to_entity="sup_YahooAdUnit",
+        binding=BindingSpec(
+            source="p.d.ad_unit_lineage",
+            from_columns=["adUnitId"],
+            to_columns=["adUnitId"],
+            from_session_column="from_session_id",
+            to_session_column="to_session_id",
+        ),
+        properties=[
+            PropertySpec(name="from_session_id", type="string"),
+            PropertySpec(name="to_session_id", type="string"),
+            PropertySpec(name="event_time", type="timestamp"),
+            PropertySpec(name="changed_properties", type="string"),
+        ],
+    )
+    spec = GraphSpec(
+        name="lineage_graph",
+        entities=[entity],
+        relationships=[rel],
+    )
+
+    gql = compile_lineage_gql(
+        spec=spec,
+        project_id="proj",
+        dataset_id="ds",
+        relationship_name="sup_YahooAdUnitEvolvedFrom",
+    )
+    assert "prior" in gql
+    assert "current" in gql
+    assert "sup_YahooAdUnit" in gql
+    assert "sup_YahooAdUnitEvolvedFrom" in gql
+    assert "prior_adUnitId" in gql or "prior.adUnitId" in gql
+    assert "current_adUnitName" in gql or "current.adUnitName" in gql
+    assert "event_time" in gql
+    assert "ORDER BY" in gql
+
+  def test_compile_lineage_gql_rejects_non_self_edge(self):
+    """Non-self-edge raises ValueError."""
+    a = _make_entity(
+        "A",
+        props=[PropertySpec(name="a_id", type="string")],
+        keys=["a_id"],
+        source="p.d.a",
+    )
+    b = _make_entity(
+        "B",
+        props=[PropertySpec(name="b_id", type="string")],
+        keys=["b_id"],
+        source="p.d.b",
+    )
+    rel = RelationshipSpec(
+        name="AToB",
+        from_entity="A",
+        to_entity="B",
+        binding=BindingSpec(
+            source="p.d.a_to_b",
+            from_columns=["a_id"],
+            to_columns=["b_id"],
+        ),
+    )
+    spec = GraphSpec(name="g", entities=[a, b], relationships=[rel])
+
+    with pytest.raises(ValueError, match="not a self-edge"):
+      compile_lineage_gql(
+          spec=spec,
+          project_id="proj",
+          dataset_id="ds",
+          relationship_name="AToB",
+      )
+
+
+# ------------------------------------------------------------------ #
+# Fix validation: query shape, partial hint, DDL PROPERTIES           #
+# ------------------------------------------------------------------ #
+
+
+class TestFetchRawEventsQuery:
+  """Verify _FETCH_RAW_EVENTS_QUERY returns event_type and content."""
+
+  def test_fetch_query_includes_event_type_and_content(self):
+    """The structured-extraction query must return event_type and
+    content_json (full content) so extractors can match and parse."""
+    from bigquery_agent_analytics.ontology_graph import _FETCH_RAW_EVENTS_QUERY
+
+    assert "event_type" in _FETCH_RAW_EVENTS_QUERY
+    assert "content" in _FETCH_RAW_EVENTS_QUERY
+    # Must NOT have the V4 event-type allowlist — all types returned.
+    assert "LLM_RESPONSE" not in _FETCH_RAW_EVENTS_QUERY
+
+  def test_fetch_query_no_event_type_filter(self):
+    """The raw events query must not filter on event_type, so that
+    BKA_DECISION and other custom types reach the extractors."""
+    from bigquery_agent_analytics.ontology_graph import _FETCH_RAW_EVENTS_QUERY
+
+    assert "event_type IN" not in _FETCH_RAW_EVENTS_QUERY
+
+  def test_ai_transcript_includes_partial_span_ids(self):
+    """The AI transcript CTE must include an OR clause for
+    @partial_span_ids so that partially-handled custom event types
+    (like BKA_DECISION) are eligible for transcript inclusion."""
+    from bigquery_agent_analytics.ontology_graph import _EXTRACT_ONTOLOGY_AI_QUERY
+
+    assert "partial_span_ids" in _EXTRACT_ONTOLOGY_AI_QUERY
+    # The OR clause widens eligibility beyond the V4 allowlist.
+    assert "OR base.span_id IN UNNEST(@partial_span_ids)" in (
+        _EXTRACT_ONTOLOGY_AI_QUERY
+    )
+
+
+class TestPartialHintBuilt:
+  """Verify partial_hint is built from partially_handled_span_ids."""
+
+  def test_partial_hint_passed_to_ai(self):
+    """When extractors produce partially_handled spans, the AI prompt
+    should include a hint about already-extracted entities."""
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+
+    from bigquery_agent_analytics.ontology_graph import OntologyGraphManager
+
+    spec = _make_lineage_spec()
+
+    def fake_extractor(event, spec):
+      from bigquery_agent_analytics.structured_extraction import StructuredExtractionResult
+
+      return StructuredExtractionResult(
+          nodes=[
+              ExtractedNode(
+                  node_id="s1:sup_YahooAdUnit:adUnitId=u1",
+                  entity_name="sup_YahooAdUnit",
+                  labels=["sup_YahooAdUnit"],
+                  properties=[],
+              )
+          ],
+          edges=[],
+          fully_handled_span_ids=set(),
+          partially_handled_span_ids={"span-partial"},
+      )
+
+    mock_client = MagicMock()
+    mock_job = MagicMock()
+    mock_job.result.return_value = []
+    mock_client.query.return_value = mock_job
+
+    mgr = OntologyGraphManager(
+        project_id="p",
+        dataset_id="d",
+        spec=spec,
+        bq_client=mock_client,
+        extractors={"BKA_DECISION": fake_extractor},
+    )
+
+    # Patch _fetch_raw_events to return a matching event.
+    with patch.object(
+        mgr,
+        "_fetch_raw_events",
+        return_value=[
+            {
+                "span_id": "span-partial",
+                "session_id": "s1",
+                "event_type": "BKA_DECISION",
+                "content": {"decision_id": "d1", "reasoning_text": "why"},
+            }
+        ],
+    ):
+      mgr.extract_graph(session_ids=["s1"])
+
+    # The AI query should have been called with the partial hint.
+    call_args = mock_client.query.call_args
+    sql = call_args[0][0]
+    assert "already extracted from structured events" in sql
+
+    # The partial span ID must be passed as a query parameter so the
+    # transcript CTE includes it (OR base.span_id IN UNNEST(@partial_span_ids)).
+    job_config = call_args[1].get("job_config") or call_args[0][1]
+    params = {p.name: p for p in job_config.query_parameters}
+    assert "partial_span_ids" in params
+    assert "span-partial" in params["partial_span_ids"].values
+
+
+class TestDDLSessionColumnsInProperties:
+  """Verify session column overrides remain in PROPERTIES."""
+
+  def test_lineage_session_cols_in_properties(self):
+    """from_session_id and to_session_id must appear in PROPERTIES
+    even though they are in the edge KEY, so GQL can query them."""
+    from bigquery_agent_analytics.ontology_property_graph import compile_edge_table_clause
+
+    spec = _make_lineage_spec()
+    rel = next(
+        r for r in spec.relationships if r.name == "sup_YahooAdUnitEvolvedFrom"
+    )
+    clause = compile_edge_table_clause(rel, spec, "p", "d")
+
+    # Session columns must be in PROPERTIES section.
+    props_section = clause.split("PROPERTIES")[1]
+    assert "from_session_id" in props_section
+    assert "to_session_id" in props_section


### PR DESCRIPTION
## Summary

Implements the V5 Context Graph design ([GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#12](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/12)) — three new capabilities on the existing SDK runtime, BigQuery-only, all additive:

- **Step 1 — Two-phase TTL/OWL import**: `ttl_import()` parses Turtle via rdflib into an unresolved `*.import.yaml` artifact with `FILL_IN` placeholders and type narrowing (11→8 type subset). `ttl_resolve()` produces `load_graph_spec()`-ready YAML.
- **Step 2 — Structured extractor registry**: `StructuredExtractionResult` with `fully_handled_span_ids` / `partially_handled_span_ids` for dedupe-safe mixed extraction. AI.GENERATE transcript CTE excludes structurally-handled spans.
- **Step 3 — Concrete-entity temporal lineage**: `BindingSpec` extended with `from_session_column` / `to_session_column` (backward-compatible). DDL compiler, materializer, and GQL generator updated. `detect_lineage_edges()` compares nodes across sessions.

### Files changed

| File | Change |
|------|--------|
| `ttl_importer.py` | **NEW** — two-phase OWL/Turtle importer |
| `structured_extraction.py` | **NEW** — extractor registry + BKA example |
| `ontology_models.py` | `BindingSpec` + session column validation |
| `ontology_graph.py` | Extractor registry, span exclusion, lineage detection |
| `ontology_property_graph.py` | Session column overrides in DDL |
| `ontology_materializer.py` | Lineage session ownership |
| `ontology_orchestrator.py` | `compile_lineage_gql()` + GQL template |
| `context_graph_v5_design.md` | Full implementation design doc |
| `test_v5_golden.py` | 23 new tests across 7 test classes |
| `tests/fixtures/` | 3 golden fixtures (TTL, events, lineage) |

## Test plan

- [x] All 1410 tests pass (200 existing ontology + 23 new V5, 0 regressions)
- [x] `BindingSpec` session columns default to `None` — V4 DDL identical
- [x] TTL import produces unresolved artifact + import report
- [x] TTL resolve produces `load_graph_spec()`-ready YAML
- [x] Structured extractor handles full/partial/non-matching events
- [x] Lineage detection finds changed properties across sessions
- [x] DDL compiler uses session column overrides for SOURCE/DESTINATION KEY
- [x] Materializer sets `session_id` from `to_session_column` for lineage edges
- [x] `compile_lineage_gql()` generates correct cross-session GQL