### PR TITLE
feat(ontology): add binding loader with cross-ontology validation

### DIFF
--- a/src/bigquery_ontology/__init__.py
+++ b/src/bigquery_ontology/__init__.py
@@ -19,6 +19,8 @@ backend-neutral ontology described in YAML, with entities, relationships,
 properties, keys, and single-parent inheritance.
 """
 
+from .binding_loader import load_binding
+from .binding_loader import load_binding_from_string
 from .binding_models import Backend
 from .binding_models import BigQueryTarget
 from .binding_models import Binding
@@ -49,6 +51,8 @@ __all__ = [
     "PropertyType",
     "Relationship",
     "RelationshipBinding",
+    "load_binding",
+    "load_binding_from_string",
     "load_ontology",
     "load_ontology_from_string",
 ]

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -1,0 +1,379 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loader and validator for binding YAML.
+
+Shape validation (required fields, unknown keys, enum membership, list
+min-length) lives in ``binding_models`` and runs at pydantic parse
+time. Semantic validation — everything that requires consulting the
+referenced ontology — lives here. The two halves together cover the
+binding spec end-to-end.
+
+The governing mental model is **partial at the ontology level, total
+within each element**:
+
+  - You may leave whole entities or whole relationships out of the
+    binding. Anything absent is simply not realized on this target.
+  - But once you include an entity or relationship, you must bind
+    every one of its non-derived properties (including inherited
+    ones) — no cherry-picking. Derived (``expr:``) properties are the
+    mirror image and must *never* appear.
+
+Rules enforced by ``_validate_binding``:
+
+  - The binding's declared ontology name matches the injected
+    ``Ontology`` object's name.
+  - Entity and relationship binding names are unique within the
+    binding and each resolves to a declared element in the ontology.
+  - Total coverage within each included entity/relationship, per the
+    model above.
+  - Each included relationship's ``from_columns`` / ``to_columns``
+    arity matches the endpoint entity's primary-key arity.
+  - Each included relationship's endpoints each have at least one
+    bound descendant in the binding — an edge that points at an
+    entity tree with no bound node would dangle.
+
+Spanner-specific type checks from the spec are intentionally skipped —
+this loader is BigQuery-only, which supports every logical type.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+from .binding_models import Binding
+from .binding_models import EntityBinding
+from .binding_models import PropertyBinding
+from .binding_models import RelationshipBinding
+from .loader import _effective_keys
+from .loader import _effective_properties
+from .loader import _is_entity_subtype
+from .loader import load_ontology
+from .ontology_models import Entity
+from .ontology_models import Ontology
+from .ontology_models import Property
+from .ontology_models import Relationship
+
+# --------------------------------------------------------------------- #
+# Public entry points                                                    #
+# --------------------------------------------------------------------- #
+
+
+def load_binding(
+    path: str | Path, *, ontology: Optional[Ontology] = None
+) -> Binding:
+  """Load and validate a binding from a YAML file.
+
+  If ``ontology`` is not supplied, the loader reads the binding's
+  top-level ``ontology:`` key and looks for ``<name>.ontology.yaml`` in
+  the same directory as the binding file. Supply ``ontology``
+  explicitly to override that lookup, or to share a single parsed
+  ontology across many bindings.
+
+  Raises:
+      FileNotFoundError: The binding file, or its auto-discovered
+          companion ontology file, does not exist.
+      ValueError: Any semantic validation failure.
+      pydantic.ValidationError: Shape failures (unknown keys, bad
+          enums, missing required fields).
+      yaml.YAMLError: Malformed YAML in either file.
+  """
+  binding_path = Path(path)
+  text = binding_path.read_text(encoding="utf-8")
+
+  if ontology is None:
+    ontology = _discover_ontology(text, binding_path)
+
+  return load_binding_from_string(text, ontology=ontology)
+
+
+def load_binding_from_string(
+    yaml_string: str, *, ontology: Ontology
+) -> Binding:
+  """Parse and validate a binding from a YAML string.
+
+  Unlike :func:`load_binding`, the ontology must be supplied
+  explicitly here — there is no file context from which to discover
+  one.
+  """
+  data = yaml.safe_load(yaml_string)
+  if not isinstance(data, dict):
+    raise ValueError("Binding document must be a YAML mapping.")
+  binding = Binding(**data)
+  _validate_binding(binding, ontology)
+  return binding
+
+
+# --------------------------------------------------------------------- #
+# Companion-ontology discovery                                           #
+# --------------------------------------------------------------------- #
+
+
+def _discover_ontology(binding_text: str, binding_path: Path) -> Ontology:
+  """Locate and load ``<ontology>.ontology.yaml`` next to the binding.
+
+  Peeks at the binding YAML purely to pull out the ``ontology:`` name;
+  any structural errors here are swallowed so that the richer pydantic
+  error from ``Binding(**data)`` surfaces instead.
+  """
+  try:
+    data = yaml.safe_load(binding_text)
+  except yaml.YAMLError:
+    # Let load_binding_from_string surface the YAML error with full
+    # context.
+    raise
+  ontology_name: str | None = None
+  if isinstance(data, dict) and isinstance(data.get("ontology"), str):
+    ontology_name = data["ontology"]
+  if not ontology_name:
+    raise ValueError(
+        f"Binding {binding_path} does not declare an 'ontology:' name; "
+        "cannot auto-discover companion ontology file."
+    )
+  companion = binding_path.parent / f"{ontology_name}.ontology.yaml"
+  if not companion.exists():
+    raise FileNotFoundError(
+        f"Binding references ontology {ontology_name!r}, but no companion "
+        f"ontology file found at {companion}."
+    )
+  return load_ontology(companion)
+
+
+# --------------------------------------------------------------------- #
+# Validation                                                             #
+# --------------------------------------------------------------------- #
+
+
+def _validate_binding(binding: Binding, ontology: Ontology) -> None:
+  """Run every cross-ontology check on a parsed binding."""
+  if binding.ontology != ontology.ontology:
+    raise ValueError(
+        f"Binding declares ontology {binding.ontology!r} but was paired "
+        f"with ontology {ontology.ontology!r}."
+    )
+
+  entity_map = {e.name: e for e in ontology.entities}
+  rel_map = {r.name: r for r in ontology.relationships}
+
+  _check_unique_binding_names(binding)
+  _check_binding_names_resolve(binding, entity_map, rel_map)
+
+  for eb in binding.entities:
+    _check_entity_property_coverage(eb, entity_map[eb.name], entity_map)
+
+  for rb in binding.relationships:
+    rel = rel_map[rb.name]
+    _check_relationship_property_coverage(rb, rel, rel_map)
+    _check_relationship_endpoint_arity(rb, rel, entity_map)
+
+  bound_entity_names = {eb.name for eb in binding.entities}
+  for rb in binding.relationships:
+    _check_relationship_endpoint_closure(
+        rb, rel_map[rb.name], entity_map, bound_entity_names
+    )
+
+
+# --------------------------------------------------------------------- #
+# Individual checks                                                      #
+# --------------------------------------------------------------------- #
+
+
+def _check_unique_binding_names(binding: Binding) -> None:
+  """Entity and relationship binding names must each be unique.
+
+  An entity and a relationship sharing a binding-level name cannot
+  collide — the ontology already rejects that case across its own
+  namespace, and we validate against the ontology below — so we only
+  check within each kind.
+  """
+  _assert_unique((eb.name for eb in binding.entities), "entity binding")
+  _assert_unique(
+      (rb.name for rb in binding.relationships), "relationship binding"
+  )
+
+
+def _assert_unique(names: Iterable[str], kind: str) -> None:
+  seen: set[str] = set()
+  for n in names:
+    if n in seen:
+      raise ValueError(f"Duplicate {kind} name: {n!r}")
+    seen.add(n)
+
+
+def _check_binding_names_resolve(
+    binding: Binding,
+    entity_map: dict[str, Entity],
+    rel_map: dict[str, Relationship],
+) -> None:
+  """Every bound name must reference a declared ontology element."""
+  for eb in binding.entities:
+    if eb.name not in entity_map:
+      raise ValueError(
+          f"Entity binding {eb.name!r} does not name a declared entity "
+          f"in ontology {binding.ontology!r}."
+      )
+  for rb in binding.relationships:
+    if rb.name not in rel_map:
+      raise ValueError(
+          f"Relationship binding {rb.name!r} does not name a declared "
+          f"relationship in ontology {binding.ontology!r}."
+      )
+
+
+def _check_entity_property_coverage(
+    eb: EntityBinding,
+    entity: Entity,
+    entity_map: dict[str, Entity],
+) -> None:
+  """Every non-derived property (inherited included) is bound exactly once."""
+  effective = _effective_properties(entity, entity_map)
+  _check_property_coverage(
+      bindings=eb.properties,
+      effective=effective,
+      owner=f"Entity binding {eb.name!r}",
+  )
+
+
+def _check_relationship_property_coverage(
+    rb: RelationshipBinding,
+    rel: Relationship,
+    rel_map: dict[str, Relationship],
+) -> None:
+  """Same as entity coverage, applied to a relationship's own properties."""
+  effective = _effective_properties(rel, rel_map)
+  _check_property_coverage(
+      bindings=rb.properties,
+      effective=effective,
+      owner=f"Relationship binding {rb.name!r}",
+  )
+
+
+def _check_property_coverage(
+    *,
+    bindings: list[PropertyBinding],
+    effective: dict[str, Property],
+    owner: str,
+) -> None:
+  """Enforce total coverage for one included entity or relationship.
+
+  ``effective`` is the element's full property set with inheritance
+  flattened. Given that, four failure modes are caught at once:
+
+    1. A PropertyBinding names a property not declared on the element.
+    2. A PropertyBinding names a derived (``expr:``) property — those
+       are excluded from bindings by design (the compiler substitutes
+       the expression).
+    3. Two PropertyBindings target the same property name.
+    4. A non-derived property has no PropertyBinding — partial coverage
+       within an included element is not allowed.
+  """
+  required = {
+      name for name, prop in effective.items() if prop.expr is None
+  }
+  seen: set[str] = set()
+  for pb in bindings:
+    if pb.name not in effective:
+      raise ValueError(
+          f"{owner}: property {pb.name!r} is not declared on this element."
+      )
+    if effective[pb.name].expr is not None:
+      raise ValueError(
+          f"{owner}: property {pb.name!r} is derived (has 'expr:') and "
+          "must not appear in a binding."
+      )
+    if pb.name in seen:
+      raise ValueError(
+          f"{owner}: property {pb.name!r} is bound more than once."
+      )
+    seen.add(pb.name)
+
+  missing = sorted(required - seen)
+  if missing:
+    raise ValueError(
+        f"{owner}: missing bindings for non-derived properties "
+        f"{missing!r}."
+    )
+
+
+def _check_relationship_endpoint_arity(
+    rb: RelationshipBinding,
+    rel: Relationship,
+    entity_map: dict[str, Entity],
+) -> None:
+  """``from_columns`` / ``to_columns`` arity must match the endpoint keys."""
+  from_pk = _primary_key_len(rel.from_, entity_map)
+  to_pk = _primary_key_len(rel.to, entity_map)
+  if len(rb.from_columns) != from_pk:
+    raise ValueError(
+        f"Relationship binding {rb.name!r}: from_columns has "
+        f"{len(rb.from_columns)} column(s) but endpoint entity "
+        f"{rel.from_!r} has {from_pk}-column primary key."
+    )
+  if len(rb.to_columns) != to_pk:
+    raise ValueError(
+        f"Relationship binding {rb.name!r}: to_columns has "
+        f"{len(rb.to_columns)} column(s) but endpoint entity "
+        f"{rel.to!r} has {to_pk}-column primary key."
+    )
+
+
+def _primary_key_len(entity_name: str, entity_map: dict[str, Entity]) -> int:
+  """Primary-key arity of an entity, honoring inherited keys."""
+  entity = entity_map[entity_name]
+  keys = _effective_keys(entity, entity_map)
+  if keys is None or not keys.primary:
+    # The ontology loader guarantees every entity has an effective
+    # primary key; treat absence as an internal invariant violation.
+    raise ValueError(
+        f"Entity {entity_name!r} has no effective primary key; "
+        "ontology is invalid."
+    )
+  return len(keys.primary)
+
+
+def _check_relationship_endpoint_closure(
+    rb: RelationshipBinding,
+    rel: Relationship,
+    entity_map: dict[str, Entity],
+    bound_entity_names: set[str],
+) -> None:
+  """Both endpoints must have ≥1 bound descendant (including themselves).
+
+  A bound edge that points at an entity tree with no bound node has
+  nothing to connect — equivalent to leaving the relationship itself
+  unbound but paying the compile-time cost anyway. Treat as an error.
+  """
+  for side_label, endpoint in (("from", rel.from_), ("to", rel.to)):
+    if not _has_bound_descendant(endpoint, entity_map, bound_entity_names):
+      raise ValueError(
+          f"Relationship binding {rb.name!r}: endpoint ({side_label}) "
+          f"entity {endpoint!r} has no bound descendant in this binding."
+      )
+
+
+def _has_bound_descendant(
+    endpoint: str,
+    entity_map: dict[str, Entity],
+    bound_entity_names: set[str],
+) -> bool:
+  """True iff some bound entity equals ``endpoint`` or extends it."""
+  for bound in bound_entity_names:
+    if _is_entity_subtype(bound, endpoint, entity_map):
+      return True
+  return False
+
+

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -130,12 +130,7 @@ def _discover_ontology(binding_text: str, binding_path: Path) -> Ontology:
   any structural errors here are swallowed so that the richer pydantic
   error from ``Binding(**data)`` surfaces instead.
   """
-  try:
-    data = yaml.safe_load(binding_text)
-  except yaml.YAMLError:
-    # Let load_binding_from_string surface the YAML error with full
-    # context.
-    raise
+  data = yaml.safe_load(binding_text)
   ontology_name: str | None = None
   if isinstance(data, dict) and isinstance(data.get("ontology"), str):
     ontology_name = data["ontology"]
@@ -193,17 +188,22 @@ def _validate_binding(binding: Binding, ontology: Ontology) -> None:
 
 
 def _check_unique_binding_names(binding: Binding) -> None:
-  """Entity and relationship binding names must each be unique.
+  """Entity and relationship binding names must be unique across kinds.
 
-  An entity and a relationship sharing a binding-level name cannot
-  collide — the ontology already rejects that case across its own
-  namespace, and we validate against the ontology below — so we only
-  check within each kind.
+  The ontology loader already prevents entity/relationship name
+  collisions, so a cross-kind duplicate in a valid binding is
+  impossible in practice. We check defensively — the cost is
+  negligible and the error message is clearer than a downstream
+  name-resolution failure.
   """
   _assert_unique((eb.name for eb in binding.entities), "entity binding")
   _assert_unique(
       (rb.name for rb in binding.relationships), "relationship binding"
   )
+  all_names = [eb.name for eb in binding.entities] + [
+      rb.name for rb in binding.relationships
+  ]
+  _assert_unique(iter(all_names), "binding")
 
 
 def _assert_unique(names: Iterable[str], kind: str) -> None:

--- a/src/bigquery_ontology/binding_models.py
+++ b/src/bigquery_ontology/binding_models.py
@@ -80,8 +80,8 @@ class PropertyBinding(BaseModel):
 
   model_config = ConfigDict(extra="forbid")
 
-  name: str
-  column: str
+  name: str = Field(min_length=1)
+  column: str = Field(min_length=1)
 
 
 class EntityBinding(BaseModel):
@@ -91,6 +91,14 @@ class EntityBinding(BaseModel):
   (``type = 'customer'``, etc.) build a view in the warehouse and bind
   to that view rather than extending this model with expressions.
 
+  Coverage is all-or-nothing per entity: deciding to include the entity
+  in a binding commits you to binding *every* one of its non-derived
+  properties (including inherited ones), no cherry-picking. If you want
+  to omit the entity from this target, leave it out of the parent
+  ``Binding`` entirely. Derived (``expr:``) properties are the mirror
+  image — they must *never* appear in a binding, since the compiler
+  substitutes their expression at DDL emission.
+
   The primary key is implicit: the ontology names the key properties,
   and the matching ``PropertyBinding`` entries here supply the columns.
   """
@@ -99,16 +107,21 @@ class EntityBinding(BaseModel):
 
   name: str
   source: str
-  # An empty list is accepted so this shape model stays ontology-free;
-  # whether an empty list is *correct* depends on how many non-derived
-  # properties the bound entity declares, which only the loader can
-  # answer. A strict non-empty check here would false-positive on
-  # entities that legitimately have no non-derived properties.
+  # Whether a ``properties: []`` list is *correct* depends on how many
+  # non-derived properties the entity declares — a question this shape
+  # model cannot answer. Accept any list length here and let the loader
+  # enforce all-or-nothing coverage once it has the ontology in hand.
   properties: list[PropertyBinding] = Field(default_factory=list)
 
 
 class RelationshipBinding(BaseModel):
   """Realizes one ontology relationship against a physical edge table.
+
+  Coverage rules match ``EntityBinding``: once a relationship appears
+  in a binding, every one of its non-derived properties must be bound
+  (no cherry-picking), and derived (``expr:``) properties must not
+  appear. To omit a relationship from a target, leave it out of the
+  parent ``Binding`` entirely.
 
   ``from_columns`` and ``to_columns`` are the columns in ``source`` that
   carry the source and target endpoint keys — a list because primary
@@ -135,18 +148,20 @@ class Binding(BaseModel):
   the logical ontology this binding realizes — not a path; the loader
   resolves it to an ontology file.
 
-  A binding may realize a *subset* of the referenced ontology: entities
-  and relationships that are absent here are simply not realized on
-  this target. Both ``entities`` and ``relationships`` default to empty
-  so that parse-only shape checks succeed on minimal stub files; a
-  binding that realizes nothing is semantically pointless but not
-  shape-invalid.
+  A binding may realize a *subset* of the referenced ontology at the
+  entity/relationship level — any element left out of ``entities`` or
+  ``relationships`` is simply absent from this target. Within each
+  element you choose to include, however, coverage is total: see
+  ``EntityBinding`` and ``RelationshipBinding``. Both list fields
+  default to empty so that parse-only shape checks succeed on minimal
+  stub files; a binding that realizes nothing is semantically
+  pointless but not shape-invalid.
   """
 
   model_config = ConfigDict(extra="forbid")
 
-  binding: str
-  ontology: str
+  binding: str = Field(min_length=1)
+  ontology: str = Field(min_length=1)
   target: BigQueryTarget
   entities: list[EntityBinding] = Field(default_factory=list)
   relationships: list[RelationshipBinding] = Field(default_factory=list)

--- a/src/bigquery_ontology/binding_models.py
+++ b/src/bigquery_ontology/binding_models.py
@@ -107,11 +107,7 @@ class EntityBinding(BaseModel):
 
   name: str
   source: str
-  # Whether a ``properties: []`` list is *correct* depends on how many
-  # non-derived properties the entity declares — a question this shape
-  # model cannot answer. Accept any list length here and let the loader
-  # enforce all-or-nothing coverage once it has the ontology in hand.
-  properties: list[PropertyBinding] = Field(default_factory=list)
+  properties: list[PropertyBinding]
 
 
 class RelationshipBinding(BaseModel):

--- a/tests/bigquery_ontology/test_binding_loader.py
+++ b/tests/bigquery_ontology/test_binding_loader.py
@@ -1,0 +1,604 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semantic tests for the binding loader.
+
+Each test pairs a literal ontology YAML with a literal binding YAML,
+and asserts either successful validation or the exact ``ValueError``
+message. Shape-level validation is covered by
+``test_binding_models.py``; this file exercises only cross-ontology
+semantics.
+
+The mental model the tests collectively prove: **partial at the
+ontology level, total within each element**. A binding may leave whole
+entities or relationships out, but whatever it *does* include must
+bind every non-derived property (and no derived ones).
+
+Most tests share the ``ONTOLOGY`` fixture below, which was shaped to
+cover the dimensions the loader cares about:
+
+  - ``Party`` — a parent entity with its own primary key and two
+    plain properties, so children can exercise inherited coverage.
+  - ``Person extends Party`` — adds stored properties (``dob``,
+    ``first_name``, ``last_name``) plus a *derived* property
+    (``full_name`` with ``expr:``). Used to test that derived
+    properties must never appear in a binding.
+  - ``Account``, ``Security`` — separate single-key entities, used
+    as endpoints of ``HOLDS``.
+  - ``HOLDS`` — a simple edge with one property for relationship
+    coverage checks.
+
+Tests that need a different shape (e.g. abstract-parent endpoints)
+declare a local ontology inline rather than extending this one.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bigquery_ontology import load_binding
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+
+
+ONTOLOGY = """
+  ontology: finance
+  entities:
+    - name: Party
+      keys:
+        primary: [party_id]
+      properties:
+        - name: party_id
+          type: string
+        - name: name
+          type: string
+    - name: Person
+      extends: Party
+      properties:
+        - name: dob
+          type: date
+        - name: first_name
+          type: string
+        - name: last_name
+          type: string
+        - name: full_name
+          type: string
+          expr: "first_name || ' ' || last_name"
+    - name: Account
+      keys:
+        primary: [account_id]
+      properties:
+        - name: account_id
+          type: string
+    - name: Security
+      keys:
+        primary: [security_id]
+      properties:
+        - name: security_id
+          type: string
+  relationships:
+    - name: HOLDS
+      from: Account
+      to: Security
+      properties:
+        - name: quantity
+          type: double
+"""
+
+
+def _ontology():
+  return load_ontology_from_string(textwrap.dedent(ONTOLOGY).lstrip())
+
+
+def _load(binding_yaml: str):
+  return load_binding_from_string(
+      textwrap.dedent(binding_yaml).lstrip(), ontology=_ontology()
+  )
+
+def _assert_value_error(binding_yaml: str, expected_message: str) -> None:
+  with pytest.raises(ValueError) as exc_info:
+    _load(binding_yaml)
+  assert str(exc_info.value) == expected_message
+
+
+# --------------------------------------------------------------------- #
+# Valid bindings                                                         #
+# --------------------------------------------------------------------- #
+
+
+def test_full_binding_validates():
+  binding_yaml = """
+    binding: finance-bq-prod
+    ontology: finance
+    target:
+      backend: bigquery
+      project: p
+      dataset: d
+    entities:
+      - name: Person
+        source: raw.persons
+        properties:
+          - name: party_id
+            column: person_id
+          - name: name
+            column: display_name
+          - name: dob
+            column: date_of_birth
+          - name: first_name
+            column: given_name
+          - name: last_name
+            column: family_name
+      - name: Account
+        source: raw.accounts
+        properties:
+          - name: account_id
+            column: acct_id
+      - name: Security
+        source: ref.securities
+        properties:
+          - name: security_id
+            column: cusip
+    relationships:
+      - name: HOLDS
+        source: raw.holdings
+        from_columns: [acct_id]
+        to_columns: [cusip]
+        properties:
+          - name: quantity
+            column: qty
+  """
+  b = _load(binding_yaml)
+  assert b.binding == "finance-bq-prod"
+  assert {e.name for e in b.entities} == {"Person", "Account", "Security"}
+  assert [r.name for r in b.relationships] == ["HOLDS"]
+
+
+def test_partial_binding_without_relationship_validates():
+  # Demonstrates the "partial at the ontology level" half of the
+  # rule. We include ``Account`` and leave everything else out —
+  # including ``Security`` and ``HOLDS``. A reader might worry that
+  # omitting ``Security`` is a problem because the fixture's ``HOLDS``
+  # points at it, but ``HOLDS`` itself is also omitted, so no edge
+  # in this binding has any expectation of ``Security`` being bound.
+  binding_yaml = """
+    binding: partial
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: raw.accounts
+        properties:
+          - name: account_id
+            column: acct_id
+  """
+  _load(binding_yaml)
+
+
+def test_unbound_parent_with_bound_child_satisfies_endpoint_closure():
+  # Endpoint closure is descendant-aware: binding a concrete child
+  # (``Person``) is enough to satisfy an edge whose declared endpoint
+  # is the abstract parent (``Party``). We use a fresh ontology here
+  # because the shared fixture's ``HOLDS`` endpoints are already
+  # concrete — there would be nothing to test.
+  ontology_yaml = """
+    ontology: tiny
+    entities:
+      - name: Party
+        keys: {primary: [party_id]}
+        properties: [{name: party_id, type: string}]
+      - name: Person
+        extends: Party
+        properties: []
+    relationships:
+      - name: KNOWS
+        from: Party
+        to: Party
+  """
+  binding_yaml = """
+    binding: b
+    ontology: tiny
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Person
+        source: t
+        properties:
+          - name: party_id
+            column: id
+    relationships:
+      - name: KNOWS
+        source: edges
+        from_columns: [a]
+        to_columns: [b]
+  """
+  ontology = load_ontology_from_string(textwrap.dedent(ontology_yaml).lstrip())
+  load_binding_from_string(
+      textwrap.dedent(binding_yaml).lstrip(), ontology=ontology
+  )
+
+
+# --------------------------------------------------------------------- #
+# Cross-ontology errors                                                  #
+# --------------------------------------------------------------------- #
+
+
+def test_binding_ontology_name_mismatch_is_error():
+  binding_yaml = """
+    binding: b
+    ontology: not-finance
+    target: {backend: bigquery, project: p, dataset: d}
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Binding declares ontology 'not-finance' but was paired with "
+      "ontology 'finance'.",
+  )
+
+
+def test_duplicate_entity_binding_name_is_error():
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t1
+        properties: [{name: account_id, column: c}]
+      - name: Account
+        source: t2
+        properties: [{name: account_id, column: c}]
+  """
+  _assert_value_error(
+      binding_yaml, "Duplicate entity binding name: 'Account'"
+  )
+
+
+def test_duplicate_relationship_binding_name_is_error():
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties: [{name: account_id, column: c}]
+      - name: Security
+        source: t
+        properties: [{name: security_id, column: c}]
+    relationships:
+      - name: HOLDS
+        source: e1
+        from_columns: [a]
+        to_columns: [s]
+        properties: [{name: quantity, column: q}]
+      - name: HOLDS
+        source: e2
+        from_columns: [a]
+        to_columns: [s]
+        properties: [{name: quantity, column: q}]
+  """
+  _assert_value_error(
+      binding_yaml, "Duplicate relationship binding name: 'HOLDS'"
+  )
+
+
+def test_entity_binding_references_unknown_entity():
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Ghost
+        source: t
+        properties: []
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Entity binding 'Ghost' does not name a declared entity in "
+      "ontology 'finance'.",
+  )
+
+
+def test_relationship_binding_references_unknown_relationship():
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    relationships:
+      - name: MISSING
+        source: t
+        from_columns: [a]
+        to_columns: [b]
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Relationship binding 'MISSING' does not name a declared relationship "
+      "in ontology 'finance'.",
+  )
+
+
+def test_missing_non_derived_property_is_error():
+  # The "total within each element" half of the rule. ``Person``'s
+  # effective (flattened) properties are: ``party_id``, ``name`` (both
+  # inherited from ``Party``), plus ``dob``, ``first_name``,
+  # ``last_name``, and the derived ``full_name``. The binding below
+  # covers every stored one *except* ``name`` — partial coverage
+  # inside an included entity is not allowed, so the loader rejects.
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Person
+        source: t
+        properties:
+          - name: party_id
+            column: pid
+          - name: dob
+            column: d
+          - name: first_name
+            column: f
+          - name: last_name
+            column: l
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Entity binding 'Person': missing bindings for non-derived "
+      "properties ['name'].",
+  )
+
+
+def test_binding_derived_property_is_error():
+  # ``Person.full_name`` is declared with ``expr:`` in the ontology,
+  # so the compiler will substitute the expression at DDL-emission
+  # time. A binding that lists it would shadow that substitution —
+  # the loader rejects it rather than silently accepting a column
+  # that the emitted query will never consult.
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Person
+        source: t
+        properties:
+          - name: party_id
+            column: pid
+          - name: name
+            column: n
+          - name: dob
+            column: d
+          - name: first_name
+            column: f
+          - name: last_name
+            column: l
+          - name: full_name
+            column: fn
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Entity binding 'Person': property 'full_name' is derived (has "
+      "'expr:') and must not appear in a binding.",
+  )
+
+
+def test_unknown_property_name_in_binding_is_error():
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties:
+          - name: account_id
+            column: c
+          - name: bogus
+            column: c2
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Entity binding 'Account': property 'bogus' is not declared on "
+      "this element.",
+  )
+
+
+def test_property_bound_twice_is_error():
+  # A PropertyBinding list with two entries for the same ontology
+  # property is ambiguous — which column wins? The loader refuses to
+  # guess and flags the duplicate up front.
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties:
+          - name: account_id
+            column: c1
+          - name: account_id
+            column: c2
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Entity binding 'Account': property 'account_id' is bound more than once.",
+  )
+
+
+def test_relationship_from_columns_arity_mismatch_is_error():
+  # ``Account``'s primary key is a single column, but the binding
+  # supplies two ``from_columns``. The loader surfaces both the
+  # binding's arity and the endpoint's expected arity so the author
+  # can tell which side is wrong.
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties: [{name: account_id, column: c}]
+      - name: Security
+        source: t
+        properties: [{name: security_id, column: c}]
+    relationships:
+      - name: HOLDS
+        source: e
+        from_columns: [a, b]
+        to_columns: [s]
+        properties: [{name: quantity, column: q}]
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Relationship binding 'HOLDS': from_columns has 2 column(s) but "
+      "endpoint entity 'Account' has 1-column primary key.",
+  )
+
+
+def test_relationship_to_columns_arity_mismatch_is_error():
+  # Mirror of the ``from_columns`` test, to make sure the check also
+  # fires against the ``to`` endpoint (both sides are validated
+  # independently, not short-circuited after one side passes).
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties: [{name: account_id, column: c}]
+      - name: Security
+        source: t
+        properties: [{name: security_id, column: c}]
+    relationships:
+      - name: HOLDS
+        source: e
+        from_columns: [a]
+        to_columns: [s, s2]
+        properties: [{name: quantity, column: q}]
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Relationship binding 'HOLDS': to_columns has 2 column(s) but "
+      "endpoint entity 'Security' has 1-column primary key.",
+  )
+
+
+def test_bound_relationship_with_unbound_endpoint_is_error():
+  # ``HOLDS`` goes from ``Account`` to ``Security``. The binding
+  # realizes ``Account`` and ``HOLDS`` but forgets ``Security``,
+  # leaving the edge pointing at an entity tree with no bound node.
+  # The loader flags the ``to`` endpoint specifically.
+  binding_yaml = """
+    binding: b
+    ontology: finance
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: t
+        properties: [{name: account_id, column: c}]
+    relationships:
+      - name: HOLDS
+        source: e
+        from_columns: [a]
+        to_columns: [s]
+        properties: [{name: quantity, column: q}]
+  """
+  _assert_value_error(
+      binding_yaml,
+      "Relationship binding 'HOLDS': endpoint (to) entity 'Security' has "
+      "no bound descendant in this binding.",
+  )
+
+
+# --------------------------------------------------------------------- #
+# File-based entry point: companion ontology auto-discovery              #
+# --------------------------------------------------------------------- #
+
+
+def test_load_binding_autodiscovers_companion_ontology(tmp_path):
+  # Drop a binding and its companion ``<name>.ontology.yaml`` into
+  # the same directory, then call ``load_binding`` without passing
+  # an ontology explicitly — the loader should find the companion,
+  # parse it, and validate the binding against it.
+  (tmp_path / "finance.ontology.yaml").write_text(
+      textwrap.dedent(ONTOLOGY).lstrip(), encoding="utf-8"
+  )
+  binding_file = tmp_path / "finance-bq-prod.binding.yaml"
+  binding_file.write_text(
+      textwrap.dedent(
+          """
+          binding: finance-bq-prod
+          ontology: finance
+          target: {backend: bigquery, project: p, dataset: d}
+          entities:
+            - name: Account
+              source: raw.accounts
+              properties:
+                - name: account_id
+                  column: acct_id
+          """
+      ).lstrip(),
+      encoding="utf-8",
+  )
+  b = load_binding(binding_file)
+  assert b.binding == "finance-bq-prod"
+
+
+def test_load_binding_raises_when_companion_ontology_missing(tmp_path):
+  # Binding points at ``nowhere``, but we never create a
+  # ``nowhere.ontology.yaml`` next to it — the loader should raise a
+  # FileNotFoundError that names the missing ontology, not a generic
+  # OSError.
+  binding_file = tmp_path / "b.binding.yaml"
+  binding_file.write_text(
+      textwrap.dedent(
+          """
+          binding: b
+          ontology: nowhere
+          target: {backend: bigquery, project: p, dataset: d}
+          """
+      ).lstrip(),
+      encoding="utf-8",
+  )
+  with pytest.raises(FileNotFoundError, match="nowhere"):
+    load_binding(binding_file)
+
+
+def test_load_binding_accepts_explicit_ontology(tmp_path):
+  # The inverse of the auto-discovery path: no companion file exists
+  # in ``tmp_path``, but the caller passes a pre-loaded ``Ontology``
+  # directly, so the loader should skip discovery entirely. This is
+  # the path a CLI would take when the ontology was loaded from an
+  # explicit flag rather than a sibling file.
+  binding_file = tmp_path / "b.binding.yaml"
+  binding_file.write_text(
+      textwrap.dedent(
+          """
+          binding: b
+          ontology: finance
+          target: {backend: bigquery, project: p, dataset: d}
+          entities:
+            - name: Account
+              source: t
+              properties:
+                - name: account_id
+                  column: c
+          """
+      ).lstrip(),
+      encoding="utf-8",
+  )
+  load_binding(binding_file, ontology=_ontology())

--- a/tests/bigquery_ontology/test_binding_loader.py
+++ b/tests/bigquery_ontology/test_binding_loader.py
@@ -49,6 +49,7 @@ import textwrap
 
 import pytest
 
+from bigquery_ontology import Binding
 from bigquery_ontology import load_binding
 from bigquery_ontology import load_binding_from_string
 from bigquery_ontology import load_ontology_from_string
@@ -292,6 +293,31 @@ def test_duplicate_relationship_binding_name_is_error():
   _assert_value_error(
       binding_yaml, "Duplicate relationship binding name: 'HOLDS'"
   )
+
+
+def test_cross_kind_duplicate_binding_name_is_error():
+  """Defensive: same name used for an entity binding and a relationship."""
+  from bigquery_ontology.binding_loader import _check_unique_binding_names
+  from bigquery_ontology.binding_models import Backend
+  from bigquery_ontology.binding_models import BigQueryTarget
+  from bigquery_ontology.binding_models import EntityBinding
+  from bigquery_ontology.binding_models import RelationshipBinding
+
+  binding = Binding(
+      binding="b",
+      ontology="x",
+      target=BigQueryTarget(
+          backend=Backend.BIGQUERY, project="p", dataset="d"
+      ),
+      entities=[EntityBinding(name="Foo", source="t", properties=[])],
+      relationships=[
+          RelationshipBinding(
+              name="Foo", source="e", from_columns=["a"], to_columns=["b"]
+          )
+      ],
+  )
+  with pytest.raises(ValueError, match="Duplicate binding name: 'Foo'"):
+    _check_unique_binding_names(binding)
 
 
 def test_entity_binding_references_unknown_entity():

--- a/tests/bigquery_ontology/test_binding_models.py
+++ b/tests/bigquery_ontology/test_binding_models.py
@@ -240,7 +240,8 @@ def test_entity_with_empty_properties_round_trips():
       "entities": [
         {
           "name": "E",
-          "source": "t"
+          "source": "t",
+          "properties": []
         }
       ]
     }"""
@@ -258,6 +259,18 @@ def _assert_validation_error(yaml_text: str, must_contain: str) -> None:
   with pytest.raises(ValidationError) as exc_info:
     _load(yaml_text)
   assert must_contain in str(exc_info.value)
+
+
+def test_entity_missing_properties_is_error():
+  yaml_input = """
+    binding: b
+    ontology: x
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+  """
+  _assert_validation_error(yaml_input, "properties")
 
 
 def test_missing_top_level_binding_is_error():


### PR DESCRIPTION
Stacks on #16. Review this PR's diff against \`feat/binding-models\` to isolate the loader changes.

## Summary
Adds \`load_binding\` and \`load_binding_from_string\`, paralleling the ontology loader. Pairs a binding YAML with an injected \`Ontology\` (or auto-discovers a companion \`<name>.ontology.yaml\` next to the binding file) and enforces the cross-ontology rules the model layer cannot see.

The governing mental model documented across the module/class/test docstrings is **partial at the ontology level, total within each element**:

- You may leave whole entities or relationships out of the binding; absent elements are simply not realized on this target.
- Whatever you *do* include must bind every one of its non-derived properties (inherited ones included) and must not bind any derived (\`expr:\`) property.

## Rules enforced
- Binding's declared \`ontology:\` name matches the paired \`Ontology\` object.
- Entity and relationship binding names are unique within the binding and each resolves to a declared ontology element.
- Total coverage within each included element (catches: missing non-derived property, derived property bound, duplicate binding, unknown property name).
- Relationship \`from_columns\` / \`to_columns\` arity matches the endpoint entity's primary-key arity.
- Each included relationship has ≥1 bound descendant at each endpoint (prevents dangling edges into unbound entity trees).

## Also
- Tightens \`binding_models.py\` with \`min_length=1\` on \`binding\`, \`ontology\`, \`PropertyBinding.name\`, and \`PropertyBinding.column\` (rule 1, and the "non-empty column" half of rule 7 — pure shape).
- Reuses \`_effective_properties\`, \`_effective_keys\`, \`_is_entity_subtype\` from the ontology loader via package-private imports.

## Intentionally out of scope
- Spanner-specific type-compat rules (this loader is BigQuery-only).
- CLI wiring — the deferred \`gm validate <binding>\` branch will be a follow-up PR so the CLI diff stays reviewable on its own.

## Test plan
- [x] \`uv run --with pytest python -m pytest tests/bigquery_ontology -q\` — 62 passed
- [x] Full happy path (\`finance\` example with inheritance, derived property, single-column edge)
- [x] Partial binding: omit unrelated entities and relationships
- [x] Abstract-parent endpoint satisfied by a bound concrete child
- [x] Ontology-name mismatch between binding and paired \`Ontology\`
- [x] Duplicate entity / relationship binding names
- [x] Binding names that don't resolve in the ontology
- [x] Coverage failures: missing non-derived property, derived property bound, unknown property, double-binding
- [x] Arity mismatch on both \`from_columns\` and \`to_columns\`
- [x] Relationship included without a bound endpoint descendant
- [x] File-based: companion-ontology auto-discovery, missing-companion \`FileNotFoundError\`, explicit \`ontology=\` override