### PR TITLE
feat(cli): wire gm validate for binding files

### DIFF
--- a/docs/ontology/cli.md
+++ b/docs/ontology/cli.md
@@ -108,17 +108,19 @@ gm validate <file>
 
 - Loader detects ontology vs binding from the top-level key.
 - **Ontology** → checked against `ontology.md` §10.
-- **Binding** → checked against `binding.md` §9. The loader also
-  attempts to locate the companion ontology (named by `ontology:` in
-  the binding, looked up as `<name>.ontology.yaml` in the same
-  directory) for cross-validation. If not found, binding validates
-  syntactically and the loader emits a warning.
+- **Binding** → checked against `binding.md` §9. The CLI locates
+  the companion ontology (named by `ontology:` in the binding,
+  looked up as `<name>.ontology.yaml` in the same directory) for
+  cross-validation. If the companion is not found, validation fails
+  with exit 2 (`cli-missing-ontology`). Use `--ontology PATH` to
+  point at a specific ontology file and skip auto-discovery.
 
 ### Flags
 
 | Flag | Purpose |
 |---|---|
 | `--json` | Structured error output (see §3). |
+| `--ontology <path>` | For binding files: path to the companion ontology. Overrides auto-discovery of `<name>.ontology.yaml` next to the binding. |
 
 On success, nothing is written to stdout.
 

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -12,18 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``gm`` command-line interface (v0).
+"""``gm`` command-line interface.
 
-Implements the surface described in ``docs/ontology/cli.md``. Only
-``gm validate`` is wired up in this revision; the ``gm compile`` and
-``gm import-owl`` commands referenced by the spec will be added when
-the binding and OWL-import modules land.
+``gm validate`` accepts either an ontology YAML or a binding YAML and
+dispatches to the matching loader. For binding files, the companion
+ontology is auto-discovered as ``<name>.ontology.yaml`` next to the
+binding by default; pass ``--ontology PATH`` to point at a specific
+ontology file instead. The ``gm compile`` and ``gm import-owl`` commands
+referenced elsewhere will be wired up when their modules land.
 
 Exit codes:
 
   0 — success
   1 — validation / compilation error
-  2 — usage error (bad flag, missing file)
+  2 — usage error (bad flag, missing file, missing companion ontology)
   3 — internal error
 """
 
@@ -37,6 +39,9 @@ from pydantic import ValidationError
 import typer
 import yaml
 
+from .binding_loader import load_binding
+from .binding_loader import load_binding_from_string
+from .loader import load_ontology
 from .loader import load_ontology_from_string
 
 app = typer.Typer(
@@ -78,8 +83,16 @@ def _emit_errors(
 def _collect_errors(
     file: str,
     exc: BaseException,
+    *,
+    kind: str,
 ) -> list[dict]:
-  """Convert an exception raised during loading into structured errors."""
+  """Convert an exception raised during loading into structured errors.
+
+  ``kind`` is either ``"ontology"`` or ``"binding"`` and is used purely
+  to tag the ``rule`` field on shape and semantic errors so downstream
+  tooling can tell which validator produced them. YAML-parse errors
+  share a single ``yaml-parse`` rule regardless of kind.
+  """
   if isinstance(exc, ValidationError):
     out: list[dict] = []
     for err in exc.errors():
@@ -89,7 +102,7 @@ def _collect_errors(
               "file": file,
               "line": 0,
               "col": 0,
-              "rule": f"ontology-shape:{err.get('type', 'invalid')}",
+              "rule": f"{kind}-shape:{err.get('type', 'invalid')}",
               "severity": "error",
               "message": f"{loc}: {err.get('msg', '')}",
           }
@@ -119,7 +132,7 @@ def _collect_errors(
           "file": file,
           "line": 0,
           "col": 0,
-          "rule": "ontology-validation",
+          "rule": f"{kind}-validation",
           "severity": "error",
           "message": str(exc),
       }
@@ -170,6 +183,14 @@ def validate(
         "--json",
         help="Emit structured JSON errors on stderr.",
     ),
+    ontology_path: Path = typer.Option(
+        None,
+        "--ontology",
+        help=(
+            "For binding files: path to the companion ontology YAML. "
+            "Defaults to <ontology>.ontology.yaml next to the binding."
+        ),
+    ),
 ) -> None:
   """Validate a single ontology or binding YAML file."""
   if not file.exists() or not file.is_file():
@@ -192,32 +213,17 @@ def validate(
   try:
     kind = _detect_kind(text)
   except yaml.YAMLError as exc:
-    _emit_errors(_collect_errors(str(file), exc), as_json=json_output)
+    _emit_errors(
+        _collect_errors(str(file), exc, kind="ontology"),
+        as_json=json_output,
+    )
     raise typer.Exit(code=1)
 
   if kind == "binding":
-    # Binding validation is part of the documented surface in cli.md but
-    # depends on the binding loader/validator (binding.md), which is not
-    # yet in the tree. Surface a deliberate "deferred" error rather than
-    # silently treating bindings like ontologies. Update both this branch
-    # and cli.md when the binding implementation lands.
-    _emit_errors(
-        [
-            {
-                "file": str(file),
-                "line": 0,
-                "col": 0,
-                "rule": "cli-binding-deferred",
-                "severity": "error",
-                "message": (
-                    "Binding validation is not yet implemented; only ontology "
-                    "files are supported in this revision of gm validate."
-                ),
-            }
-        ],
-        as_json=json_output,
+    _validate_binding_file(
+        file, ontology_path=ontology_path, json_output=json_output
     )
-    raise typer.Exit(code=2)
+    return
 
   if kind != "ontology":
     _emit_errors(
@@ -241,12 +247,158 @@ def validate(
   try:
     load_ontology_from_string(text)
   except (ValueError, ValidationError, yaml.YAMLError) as exc:
-    _emit_errors(_collect_errors(str(file), exc), as_json=json_output)
+    _emit_errors(
+        _collect_errors(str(file), exc, kind="ontology"),
+        as_json=json_output,
+    )
     raise typer.Exit(code=1)
   except Exception as exc:  # pragma: no cover - defensive
     typer.echo(f"internal error: {exc}", err=True)
     raise typer.Exit(code=3)
-  # Success: nothing on stdout (cli.md §4).
+  # Success: nothing on stdout.
+
+
+def _validate_binding_file(
+    file: Path,
+    *,
+    ontology_path: Path | None,
+    json_output: bool,
+) -> None:
+  """Dispatch to the binding loader.
+
+  The CLI resolves and loads the companion ontology itself rather than
+  letting ``load_binding`` auto-discover, because otherwise an error
+  surfaced inside the ontology file (e.g. a bad key reference) would
+  bubble out of ``load_binding`` as a generic ``ValueError`` and get
+  reported with ``file=<binding>`` and ``rule=binding-validation`` —
+  misleading, since the real fault is in the ontology.
+
+  Resolution order:
+
+    - ``--ontology PATH`` explicit flag, if supplied.
+    - Otherwise peek at the binding YAML for its ``ontology:`` name
+      and expect ``<name>.ontology.yaml`` next to the binding.
+
+  Errors route by *which file* they originated in:
+
+    - Missing companion file → ``cli-missing-ontology`` (exit 2).
+    - Ontology parse/shape/validation error → tagged ``kind=ontology``
+      with ``file`` set to the ontology path (exit 1).
+    - Binding parse/shape/validation error → tagged ``kind=binding``
+      with ``file`` set to the binding path (exit 1).
+  """
+  text = file.read_text(encoding="utf-8")
+
+  # If the caller didn't supply --ontology, try to compute the companion
+  # path from the binding itself. A failed peek (malformed YAML, or no
+  # parseable ontology name) leaves ``ontology_path`` as None; the binding
+  # loader below will then surface the real shape/parse error.
+  discovered_via_peek = False
+  if ontology_path is None:
+    peeked = _peek_companion_path(text, file)
+    if peeked is not None:
+      ontology_path = peeked
+      discovered_via_peek = True
+
+  ontology = None
+  if ontology_path is not None:
+    if not ontology_path.exists() or not ontology_path.is_file():
+      # Auto-discovery and explicit-flag paths get distinct messages —
+      # the former explains *why* we looked where we did, the latter
+      # simply reports what the user asked us to open.
+      if discovered_via_peek:
+        message = (
+            f"Binding references ontology {_peek_ontology_name(text)!r}, "
+            f"but no companion ontology file found at {ontology_path}."
+        )
+      else:
+        message = f"Ontology file not found: {ontology_path}"
+      _emit_errors(
+          [
+              {
+                  "file": str(ontology_path)
+                  if not discovered_via_peek
+                  else str(file),
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-missing-ontology",
+                  "severity": "error",
+                  "message": message,
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=2)
+    try:
+      ontology = load_ontology(ontology_path)
+    except (ValueError, ValidationError, yaml.YAMLError) as exc:
+      _emit_errors(
+          _collect_errors(str(ontology_path), exc, kind="ontology"),
+          as_json=json_output,
+      )
+      raise typer.Exit(code=1)
+
+  try:
+    if ontology is not None:
+      load_binding_from_string(text, ontology=ontology)
+    else:
+      # Peek failed — defer to load_binding so the underlying yaml /
+      # pydantic error surfaces directly against the binding file.
+      load_binding(file)
+  except FileNotFoundError as exc:
+    # Only reachable when ``ontology is None`` (peek failed), and
+    # ``load_binding``'s own discovery then raised. Treat the same as
+    # the peek-found-but-missing case.
+    _emit_errors(
+        [
+            {
+                "file": str(file),
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-ontology",
+                "severity": "error",
+                "message": str(exc),
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+  except (ValueError, ValidationError, yaml.YAMLError) as exc:
+    _emit_errors(
+        _collect_errors(str(file), exc, kind="binding"),
+        as_json=json_output,
+    )
+    raise typer.Exit(code=1)
+  except Exception as exc:  # pragma: no cover - defensive
+    typer.echo(f"internal error: {exc}", err=True)
+    raise typer.Exit(code=3)
+  # Success: nothing on stdout.
+
+
+def _peek_companion_path(binding_text: str, binding_file: Path) -> Path | None:
+  """Compute the expected companion-ontology path from the binding YAML.
+
+  Returns ``None`` on any parse failure or missing ``ontology:`` name;
+  the caller should then let the binding loader surface the real
+  shape/parse error instead of masking it with a companion-discovery
+  error.
+  """
+  name = _peek_ontology_name(binding_text)
+  if not name:
+    return None
+  return binding_file.parent / f"{name}.ontology.yaml"
+
+
+def _peek_ontology_name(binding_text: str) -> str | None:
+  """Extract the ``ontology:`` name from a binding YAML string, or None."""
+  try:
+    data = yaml.safe_load(binding_text)
+  except yaml.YAMLError:
+    return None
+  if isinstance(data, dict) and isinstance(data.get("ontology"), str):
+    name = data["ontology"]
+    return name if name else None
+  return None
 
 
 def main() -> None:

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -32,6 +32,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import sys
 
@@ -183,7 +184,11 @@ def validate(
         "--json",
         help="Emit structured JSON errors on stderr.",
     ),
-    ontology_path: Path = typer.Option(
+    # Type is ``str | None`` rather than ``Path | None`` because Typer
+    # maps ``pathlib.Path`` to ``TyperPath(readable=True)``, which
+    # pre-validates readability and emits human usage text on failure —
+    # bypassing ``--json`` structured output.
+    ontology_path: str | None = typer.Option(
         None,
         "--ontology",
         help=(
@@ -213,6 +218,9 @@ def validate(
   try:
     kind = _detect_kind(text)
   except yaml.YAMLError as exc:
+    # kind is indeterminate (YAML failed before _detect_kind returned),
+    # but _collect_errors uses the generic "yaml-parse" rule for
+    # yaml.YAMLError regardless of kind, so the value is harmless.
     _emit_errors(
         _collect_errors(str(file), exc, kind="ontology"),
         as_json=json_output,
@@ -220,8 +228,9 @@ def validate(
     raise typer.Exit(code=1)
 
   if kind == "binding":
+    resolved_ontology = Path(ontology_path) if ontology_path is not None else None
     _validate_binding_file(
-        file, ontology_path=ontology_path, json_output=json_output
+        file, ontology_path=resolved_ontology, json_output=json_output
     )
     return
 
@@ -294,21 +303,26 @@ def _validate_binding_file(
   # parseable ontology name) leaves ``ontology_path`` as None; the binding
   # loader below will then surface the real shape/parse error.
   discovered_via_peek = False
+  peeked_name: str | None = None
   if ontology_path is None:
-    peeked = _peek_companion_path(text, file)
-    if peeked is not None:
-      ontology_path = peeked
+    peeked_name = _peek_ontology_name(text)
+    if peeked_name is not None:
+      ontology_path = file.parent / f"{peeked_name}.ontology.yaml"
       discovered_via_peek = True
 
   ontology = None
   if ontology_path is not None:
-    if not ontology_path.exists() or not ontology_path.is_file():
+    if (
+        not ontology_path.exists()
+        or not ontology_path.is_file()
+        or not os.access(ontology_path, os.R_OK)
+    ):
       # Auto-discovery and explicit-flag paths get distinct messages —
       # the former explains *why* we looked where we did, the latter
       # simply reports what the user asked us to open.
       if discovered_via_peek:
         message = (
-            f"Binding references ontology {_peek_ontology_name(text)!r}, "
+            f"Binding references ontology {peeked_name!r}, "
             f"but no companion ontology file found at {ontology_path}."
         )
       else:
@@ -373,20 +387,6 @@ def _validate_binding_file(
     typer.echo(f"internal error: {exc}", err=True)
     raise typer.Exit(code=3)
   # Success: nothing on stdout.
-
-
-def _peek_companion_path(binding_text: str, binding_file: Path) -> Path | None:
-  """Compute the expected companion-ontology path from the binding YAML.
-
-  Returns ``None`` on any parse failure or missing ``ontology:`` name;
-  the caller should then let the binding loader surface the real
-  shape/parse error instead of masking it with a companion-discovery
-  error.
-  """
-  name = _peek_ontology_name(binding_text)
-  if not name:
-    return None
-  return binding_file.parent / f"{name}.ontology.yaml"
 
 
 def _peek_ontology_name(binding_text: str) -> str | None:

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -156,28 +156,255 @@ def test_validate_malformed_yaml_reports_line_and_column(tmp_path):
 
 
 # --------------------------------------------------------------------- #
-# gm validate — file-kind detection                                      #
+# gm validate — binding files                                            #
 # --------------------------------------------------------------------- #
+#
+# The binding tests collectively prove three things about the CLI:
+#
+#   1. Companion-ontology resolution works both ways — auto-discovery
+#      (``<ontology>.ontology.yaml`` next to the binding) and an
+#      explicit ``--ontology PATH`` flag.
+#   2. Each failure mode lands at the exit code the user should
+#      handle: exit 2 for "you gave me the wrong filesystem state",
+#      exit 1 for "the YAML itself is wrong".
+#   3. The ``file`` and ``rule`` fields in errors point at the file
+#      that actually contains the mistake, so a user grepping their
+#      editor can jump to the right line. This is non-trivial because
+#      validating a binding transitively validates its ontology too.
 
 
-def test_validate_binding_file_is_deferred(tmp_path):
-  spec = _write(
+# A minimal-but-complete fixture pair. The ontology declares one
+# entity ``Thing`` with two stored properties (``id``, ``label``) —
+# enough to trigger coverage errors by omitting one of them, and
+# unknown-property errors by adding a bogus one. The binding below
+# covers both properties so it's a "green" baseline that individual
+# tests mutate as needed.
+_TINY_ONTOLOGY = """
+  ontology: tiny
+  entities:
+    - name: Thing
+      keys:
+        primary: [id]
+      properties:
+        - name: id
+          type: string
+        - name: label
+          type: string
+"""
+
+_MINIMAL_BINDING = """
+  binding: tiny-bq-prod
+  ontology: tiny
+  target: {backend: bigquery, project: p, dataset: d}
+  entities:
+    - name: Thing
+      source: raw.things
+      properties:
+        - name: id
+          column: thing_id
+        - name: label
+          column: display
+"""
+
+
+def test_validate_binding_with_companion_ontology_succeeds(tmp_path):
+  # The happy path for auto-discovery. Drop both files in the same
+  # directory, point the CLI at the binding only, and expect silent
+  # success — the CLI must find ``tiny.ontology.yaml`` next to the
+  # binding, load it, and validate the binding against it.
+  _write(tmp_path, "tiny.ontology.yaml", _TINY_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+
+  result = _RUNNER.invoke(app, ["validate", str(binding)])
+
+  assert result.exit_code == 0
+  assert result.output == ""
+
+
+def test_validate_binding_with_explicit_ontology_flag_succeeds(tmp_path):
+  # The happy path for the explicit flag. We deliberately stash the
+  # ontology in a sibling directory so auto-discovery *cannot* find
+  # it — the only way this test passes is if ``--ontology`` is
+  # honored and discovery is skipped.
+  sibling = tmp_path / "sibling"
+  sibling.mkdir()
+  ontology = _write(sibling, "tiny.ontology.yaml", _TINY_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+
+  result = _RUNNER.invoke(
+      app, ["validate", str(binding), "--ontology", str(ontology)]
+  )
+
+  assert result.exit_code == 0
+  assert result.output == ""
+
+
+def test_validate_binding_missing_companion_is_usage_error(tmp_path):
+  # Auto-discovery fails: the binding says ``ontology: tiny`` so the
+  # CLI goes looking for ``tiny.ontology.yaml`` next to it, but we
+  # never created one. This is a *usage* error (exit 2) — the user's
+  # filesystem is the problem, not the YAML contents. The error
+  # message names the exact path we looked at so the user can either
+  # move the ontology into place or add ``--ontology PATH``. ``file``
+  # points at the binding because that's the file they invoked the
+  # CLI against.
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+
+  result = _RUNNER.invoke(app, ["validate", str(binding)])
+
+  expected_path = tmp_path / "tiny.ontology.yaml"
+  expected = (
+      f"{binding}:0:0: cli-missing-ontology \u2014 Binding references "
+      f"ontology 'tiny', but no companion ontology file found at "
+      f"{expected_path}.\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
+def test_validate_binding_with_explicit_missing_ontology_flag_is_usage_error(
+    tmp_path,
+):
+  # Mirror of the auto-discovery case, but for the explicit flag. The
+  # error message is shorter here because there's nothing to explain —
+  # the user literally pointed us at a file that does not exist.
+  # ``file`` points at the missing ontology path (the user's bad
+  # input), not the binding.
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+  missing = tmp_path / "does-not-exist.ontology.yaml"
+
+  result = _RUNNER.invoke(
+      app, ["validate", str(binding), "--ontology", str(missing)]
+  )
+
+  expected = (
+      f"{missing}:0:0: cli-missing-ontology \u2014 "
+      f"Ontology file not found: {missing}\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
+def test_validate_binding_with_semantic_error_reports_binding_rule(tmp_path):
+  # Companion ontology is valid, but the binding itself violates the
+  # total-coverage rule — the ontology declares ``id`` and ``label``
+  # on ``Thing`` but the binding only maps ``id``. This is the
+  # canonical "binding is wrong" error, and we assert two things:
+  # the rule prefix is ``binding-validation`` (not ontology-anything)
+  # and the ``file`` points at the binding.
+  _write(tmp_path, "tiny.ontology.yaml", _TINY_ONTOLOGY)
+  binding = _write(
       tmp_path,
-      "x.binding.yaml",
+      "tiny.binding.yaml",
       """
-      binding: x
+      binding: tiny-bq-prod
       ontology: tiny
+      target: {backend: bigquery, project: p, dataset: d}
+      entities:
+        - name: Thing
+          source: raw.things
+          properties:
+            - name: id
+              column: thing_id
       """,
   )
 
-  result = _RUNNER.invoke(app, ["validate", str(spec)])
+  result = _RUNNER.invoke(app, ["validate", str(binding)])
 
   expected = (
-      f"{spec}:0:0: cli-binding-deferred \u2014 "
-      "Binding validation is not yet implemented; only ontology files are "
-      "supported in this revision of gm validate.\n"
+      f"{binding}:0:0: binding-validation \u2014 Entity binding 'Thing': "
+      "missing bindings for non-derived properties ['label'].\n"
   )
-  assert result.exit_code == 2
+  assert result.exit_code == 1
+  assert result.output == expected
+
+
+def test_validate_binding_with_broken_companion_ontology_reports_ontology_file(
+    tmp_path,
+):
+  # Regression guard for the fix that motivated splitting ontology
+  # loading out of the binding loader in the CLI. The user points at
+  # a valid-looking binding; auto-discovery finds the companion; but
+  # the companion ontology has its *own* validation error (a primary
+  # key that references an undeclared column). Naively, that error
+  # would bubble through ``load_binding`` and be reported with
+  # ``rule=binding-validation`` and ``file=<binding>`` — misleading,
+  # because the binding is fine and the ontology is not. The CLI
+  # must instead tag this as ``rule=ontology-validation`` and point
+  # ``file`` at the ontology path. A user reading the error should
+  # open the ontology file, not the binding.
+  ontology = _write(
+      tmp_path,
+      "tiny.ontology.yaml",
+      """
+      ontology: tiny
+      entities:
+        - name: Thing
+          keys:
+            primary: [missing_col]
+          properties:
+            - name: id
+              type: string
+      """,
+  )
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+
+  result = _RUNNER.invoke(app, ["validate", str(binding)])
+
+  expected = (
+      f"{ontology}:0:0: ontology-validation \u2014 "
+      "Entity 'Thing': key column 'missing_col' is not a declared property.\n"
+  )
+  assert result.exit_code == 1
+  assert result.output == expected
+
+
+def test_validate_binding_json_output_uses_binding_rule_prefix(tmp_path):
+  # Complements ``_semantic_error_reports_binding_rule`` above: same
+  # class of error (binding problem, not ontology problem), this time
+  # with ``--json`` to prove the rule prefix propagates into the
+  # structured output unchanged. The binding lists a property name
+  # ``bogus`` that isn't declared on ``Thing`` — chosen deliberately
+  # over the "missing property" variant so both the human and JSON
+  # paths cover different coverage-rule branches between them.
+  _write(tmp_path, "tiny.ontology.yaml", _TINY_ONTOLOGY)
+  binding = _write(
+      tmp_path,
+      "tiny.binding.yaml",
+      """
+      binding: tiny-bq-prod
+      ontology: tiny
+      target: {backend: bigquery, project: p, dataset: d}
+      entities:
+        - name: Thing
+          source: raw.things
+          properties:
+            - name: id
+              column: thing_id
+            - name: label
+              column: display
+            - name: bogus
+              column: extra
+      """,
+  )
+
+  result = _RUNNER.invoke(app, ["validate", str(binding), "--json"])
+
+  expected = textwrap.dedent(
+      f"""\
+      [
+        {{
+          "file": "{binding}",
+          "line": 0,
+          "col": 0,
+          "rule": "binding-validation",
+          "severity": "error",
+          "message": "Entity binding 'Thing': property 'bogus' is not declared on this element."
+        }}
+      ]
+      """
+  )
+  assert result.exit_code == 1
   assert result.output == expected
 
 

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -408,6 +408,26 @@ def test_validate_binding_json_output_uses_binding_rule_prefix(tmp_path):
   assert result.output == expected
 
 
+def test_validate_binding_unreadable_ontology_flag_emits_structured_json(
+    tmp_path,
+):
+  # Proves that ``--ontology`` uses ``str | None`` (not ``Path``) so
+  # Typer does not pre-validate readability and bypass ``--json``
+  # structured output.
+  binding = _write(tmp_path, "tiny.binding.yaml", _MINIMAL_BINDING)
+  unreadable = tmp_path / "locked.ontology.yaml"
+  unreadable.write_text("ontology: tiny\n", encoding="utf-8")
+  unreadable.chmod(0o000)
+
+  result = _RUNNER.invoke(
+      app,
+      ["validate", str(binding), "--ontology", str(unreadable), "--json"],
+  )
+
+  assert result.exit_code == 2
+  assert "cli-missing-ontology" in result.output
+
+
 def test_validate_unknown_kind_is_usage_error(tmp_path):
   spec = _write(
       tmp_path,


### PR DESCRIPTION
Stacks on #17 (which stacks on #16). Review this PR's diff against \`feat/binding-loader\` to isolate the CLI changes.

## Summary
Replaces the "binding validation deferred" stub with a real dispatch to the binding loader. Users can now run \`gm validate path/to/foo.binding.yaml\` and get actionable errors end-to-end.

## How companion-ontology resolution works
Two paths, both landing at the same validation:
- **Auto-discovery (default):** peek the binding for \`ontology: <name>\`, look for \`<name>.ontology.yaml\` next to the binding file.
- **Explicit override:** \`--ontology PATH\` — skips discovery entirely, useful for CI or cross-directory layouts.

## Error routing
Every error names the file that actually contains the mistake:

| Scenario                               | file                 | rule                    | exit |
|----------------------------------------|----------------------|-------------------------|------|
| Auto-discovery: companion missing      | binding              | \`cli-missing-ontology\`  | 2    |
| \`--ontology\`: path missing             | ontology path        | \`cli-missing-ontology\`  | 2    |
| Ontology file present but invalid      | **ontology path**    | **\`ontology-validation\`** | 1    |
| Binding has its own semantic error     | binding              | \`binding-validation\`    | 1    |
| Binding is malformed YAML              | binding              | \`yaml-parse\`            | 1    |

The third row is the critical one — it required refactoring the CLI to load the ontology itself rather than letting \`load_binding\` do discovery internally. Otherwise an ontology-side error would bubble through \`load_binding\` as a generic \`ValueError\` and get tagged \`binding-validation\` with \`file=<binding>\`, sending users grep'ing the wrong file.

## Also
- Generalized \`_collect_errors\` to accept a \`kind\` parameter so shape and semantic error rules carry an \`ontology\` or \`binding\` prefix. \`yaml-parse\` stays kind-agnostic.
- Added \`_peek_companion_path\` / \`_peek_ontology_name\` helpers for the CLI-side ontology-name discovery.

## Test plan
- [x] \`uv run --with pytest python -m pytest tests/bigquery_ontology -q\` — 68 passed
- [x] Auto-discovery happy path
- [x] Explicit \`--ontology\` happy path (ontology deliberately stashed where auto-discovery can't find it)
- [x] Auto-discovery missing-companion error
- [x] Explicit flag pointing at a nonexistent ontology file
- [x] Binding with a semantic error (coverage rule violation)
- [x] **Regression guard**: binding is valid, ontology is broken — error must land on the ontology file with \`rule=ontology-validation\`
- [x] JSON output preserves \`binding-validation\` rule prefix