### PR TITLE
feat(compile): add gm compile pipeline for BigQuery property graphs

### DIFF
--- a/docs/ontology/compilation.md
+++ b/docs/ontology/compilation.md
@@ -48,22 +48,29 @@ edge_tables: [<EdgeTable>, ...]
 ```
 
 ```yaml
-# NodeTable
-label: <string>                   # entity name
-key_columns: [<string>, ...]
-source: <string>                  # fully qualified
+# ResolvedLabelAndProperties
+label: <string>
 properties: [<ResolvedProperty>, ...]
 ```
 
 ```yaml
-# EdgeTable
-label: <string>                   # relationship name
+# ResolvedNodeTable
+alias: <string>                   # identifier used after AS and in REFERENCES
+source: <string>                  # fully qualified
+key_columns: [<string>, ...]
+label_and_properties: [<ResolvedLabelAndProperties>, ...]   # one per v0, more reserved for multi-label
+```
+
+```yaml
+# ResolvedEdgeTable
+alias: <string>
 source: <string>
+key_columns: [<string>, ...]      # row-level identity, always non-empty; see §3
 from_key_columns: [<string>, ...]
 to_key_columns: [<string>, ...]
 from_node_table: <string>         # which node table this edge's source points to
 to_node_table: <string>
-properties: [<ResolvedProperty>, ...]
+label_and_properties: [<ResolvedLabelAndProperties>, ...]
 ```
 
 ```yaml
@@ -86,6 +93,36 @@ are resolved recursively; cycles are a compile-time error.
 For each relationship, look up the single node table for each endpoint
 entity. Because v0 does not lower inheritance, each endpoint entity is
 bound to exactly one node table, so endpoint resolution is direct.
+
+### Derive table aliases
+
+Every node and edge table gets an alias after `AS` in the emitted
+DDL, and edge tables use node-table aliases in their `REFERENCES`
+clauses. We use the ontology label verbatim as the alias (`Account`,
+`HOLDS`, etc.) so the DDL reads by logical type rather than leaking
+physical table basenames. The ontology loader already guarantees
+entity and relationship names are unique within the ontology and
+disjoint across kinds, so this aliasing is collision-free by
+construction — no runtime uniqueness check is required.
+
+### Resolve edge keys
+
+Every edge in the resolved graph carries a non-empty `key_columns`.
+BigQuery's property-graph model wants row-level identity on edges
+even when the ontology doesn't spell one out, so the resolver picks
+a value in all three cases:
+
+- **`keys.primary` declared.** `key_columns` is the bound physical
+  columns for those properties. Example: `TRANSFER` with primary
+  `[transaction_id]` → `KEY (txn_id)`.
+- **`keys.additional` declared.** `key_columns` is the endpoint
+  columns followed by the bound additional-key columns — together
+  they form a globally-unique row identifier. Example: `HOLDS` with
+  additional `[as_of]` → `KEY (account_id, security_id, snapshot_date)`.
+- **No keys declared.** `key_columns` is just the endpoint columns,
+  expressing "one edge per endpoint pair" as a safe default. Authors
+  who need multi-edges should declare `keys.additional` with a
+  discriminator property.
 
 ## 4. Emission
 
@@ -140,10 +177,10 @@ Emitted DDL:
 ```sql
 CREATE PROPERTY GRAPH finance
   NODE TABLES (
-    raw.accounts AS accounts
+    raw.accounts AS Account
       KEY (acct_id)
       LABEL Account PROPERTIES (acct_id AS account_id, created_ts AS opened_at),
-    raw.persons AS persons
+    raw.persons AS Person
       KEY (person_id)
       LABEL Person PROPERTIES (
         person_id,
@@ -151,18 +188,39 @@ CREATE PROPERTY GRAPH finance
         given_name AS first_name,
         family_name AS last_name,
         (given_name || ' ' || family_name) AS full_name
-      )
+      ),
+    ref.securities AS Security
+      KEY (cusip)
+      LABEL Security PROPERTIES (cusip AS security_id)
   )
   EDGE TABLES (
-    raw.holdings AS holdings
-      SOURCE KEY (account_id) REFERENCES accounts (acct_id)
-      DESTINATION KEY (security_id) REFERENCES securities (cusip)
+    raw.holdings AS HOLDS
+      KEY (account_id, security_id)
+      SOURCE KEY (account_id) REFERENCES Account (acct_id)
+      DESTINATION KEY (security_id) REFERENCES Security (cusip)
       LABEL HOLDS PROPERTIES (snapshot_date AS as_of, qty AS quantity)
   );
 ```
 
 Derived expressions become SQL expressions in the `PROPERTIES` list;
 column renames become `AS` clauses.
+
+Formatting rules applied to the output, all in service of determinism:
+
+- `LABEL <name> PROPERTIES (...)` stays bundled as a single clause
+  per the GCP grammar's `LabelAndProperties` production. Even though
+  each element carries only one label today, keeping label and
+  property list paired reserves the shape for future multi-label
+  support without another emitter rewrite.
+- The bundled clause stays on a single line when the rendered line
+  (including its indent) fits within 80 columns; otherwise the
+  property list breaks across lines, one property per line, with
+  the closing paren on its own line. The `LABEL <name> PROPERTIES (`
+  opener remains intact on the first line so the label-property
+  association survives the wrap visually.
+- Node tables and edge tables are sorted alphabetically by label;
+  property lists within each table follow the ontology's declaration
+  order.
 
 ### Spanner
 
@@ -175,11 +233,14 @@ The resolved model maps to the `CREATE PROPERTY GRAPH` grammar as follows:
 
 | Resolved model | GCP grammar |
 |---|---|
-| `NodeTable.source` | `<source> [AS <alias>]` |
-| `NodeTable.key_columns` | `KEY (<cols>)` |
-| `NodeTable.label` + `properties` | `LABEL <name> PROPERTIES (<spec_list>)` |
-| `EdgeTable.from_key_columns` + `from_node_table` | `SOURCE KEY (<cols>) REFERENCES <node>` |
-| `EdgeTable.to_key_columns` + `to_node_table` | `DESTINATION KEY (<cols>) REFERENCES <node>` |
+| `ResolvedNodeTable.source` + `alias` | `<source> AS <alias>` |
+| `ResolvedNodeTable.key_columns` | `KEY (<cols>)` |
+| `ResolvedNodeTable.label_and_properties[i]` | `LABEL <name> PROPERTIES (<spec_list>)` (one per entry; `LabelAndPropertiesList` overall) |
+| `ResolvedEdgeTable.source` + `alias` | `<source> AS <alias>` |
+| `ResolvedEdgeTable.key_columns` | `KEY (<cols>)` |
+| `ResolvedEdgeTable.from_key_columns` + `from_node_table` | `SOURCE KEY (<cols>) REFERENCES <node>` |
+| `ResolvedEdgeTable.to_key_columns` + `to_node_table` | `DESTINATION KEY (<cols>) REFERENCES <node>` |
+| `ResolvedEdgeTable.label_and_properties[i]` | `LABEL <name> PROPERTIES (<spec_list>)` (one per entry) |
 
 The resolved model collapses the grammar's variant forms to a single
 canonical shape. We always emit the explicit

--- a/src/bigquery_ontology/__init__.py
+++ b/src/bigquery_ontology/__init__.py
@@ -27,6 +27,7 @@ from .binding_models import Binding
 from .binding_models import EntityBinding
 from .binding_models import PropertyBinding
 from .binding_models import RelationshipBinding
+from .compiler import compile_graph
 from .loader import load_ontology
 from .loader import load_ontology_from_string
 from .ontology_models import Cardinality
@@ -51,6 +52,7 @@ __all__ = [
     "PropertyType",
     "Relationship",
     "RelationshipBinding",
+    "compile_graph",
     "load_binding",
     "load_binding_from_string",
     "load_ontology",

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -130,12 +130,7 @@ def _discover_ontology(binding_text: str, binding_path: Path) -> Ontology:
   any structural errors here are swallowed so that the richer pydantic
   error from ``Binding(**data)`` surfaces instead.
   """
-  try:
-    data = yaml.safe_load(binding_text)
-  except yaml.YAMLError:
-    # Let load_binding_from_string surface the YAML error with full
-    # context.
-    raise
+  data = yaml.safe_load(binding_text)
   ontology_name: str | None = None
   if isinstance(data, dict) and isinstance(data.get("ontology"), str):
     ontology_name = data["ontology"]
@@ -193,17 +188,22 @@ def _validate_binding(binding: Binding, ontology: Ontology) -> None:
 
 
 def _check_unique_binding_names(binding: Binding) -> None:
-  """Entity and relationship binding names must each be unique.
+  """Entity and relationship binding names must be unique across kinds.
 
-  An entity and a relationship sharing a binding-level name cannot
-  collide — the ontology already rejects that case across its own
-  namespace, and we validate against the ontology below — so we only
-  check within each kind.
+  The ontology loader already prevents entity/relationship name
+  collisions, so a cross-kind duplicate in a valid binding is
+  impossible in practice. We check defensively — the cost is
+  negligible and the error message is clearer than a downstream
+  name-resolution failure.
   """
   _assert_unique((eb.name for eb in binding.entities), "entity binding")
   _assert_unique(
       (rb.name for rb in binding.relationships), "relationship binding"
   )
+  all_names = [eb.name for eb in binding.entities] + [
+      rb.name for rb in binding.relationships
+  ]
+  _assert_unique(iter(all_names), "binding")
 
 
 def _assert_unique(names: Iterable[str], kind: str) -> None:

--- a/src/bigquery_ontology/binding_models.py
+++ b/src/bigquery_ontology/binding_models.py
@@ -107,11 +107,7 @@ class EntityBinding(BaseModel):
 
   name: str
   source: str
-  # Whether a ``properties: []`` list is *correct* depends on how many
-  # non-derived properties the entity declares — a question this shape
-  # model cannot answer. Accept any list length here and let the loader
-  # enforce all-or-nothing coverage once it has the ontology in hand.
-  properties: list[PropertyBinding] = Field(default_factory=list)
+  properties: list[PropertyBinding]
 
 
 class RelationshipBinding(BaseModel):

--- a/src/bigquery_ontology/compiler.py
+++ b/src/bigquery_ontology/compiler.py
@@ -1,0 +1,619 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compile an ontology + binding into BigQuery ``CREATE PROPERTY GRAPH`` DDL.
+
+The compiler is a single pass split into two stages:
+
+  1. **Resolve.** Cross-reference the ontology and the binding to
+     produce an in-memory ``ResolvedGraph``. This is where derived
+     expressions get rewritten to reference physical columns, edge
+     endpoints pick up their node-table aliases and key columns, and
+     the list is sorted alphabetically for deterministic output.
+  2. **Emit.** Walk the ``ResolvedGraph`` and produce the DDL text.
+     The emitter is intentionally mechanical — all interesting
+     decisions happen in stage 1 so that stage 2 is just rendering.
+
+The compiler trusts that the loaders already ran: it does *not*
+re-validate shape, name uniqueness, or property coverage. It only
+enforces the rules that are specifically compilation-level and that
+the loaders don't know about:
+
+  - No ``extends`` anywhere in the ontology (v0 rejects hierarchies;
+    inheritance lowering is a separate, future design).
+  - No cycles among derived properties.
+  - Node-table aliases are unique.
+
+Determinism contract: same ``Ontology`` + ``Binding`` → byte-identical
+output. Node and edge tables are emitted in alphabetical order by
+label; properties within each table are emitted in ontology
+declaration order.
+
+Known limitation (documented, not fixed in v0): derived-expression
+substitution uses word-boundary regex rather than a SQL lexer. This
+is sufficient for expressions of the form
+``first_name || ' ' || last_name`` but will misfire if a property
+name happens to appear as a substring inside a single-quoted string
+literal (e.g. ``'name'``). Upgrading to a real SQL lexer is a
+follow-up when a real user expression exercises the gap.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .binding_models import Binding
+from .binding_models import EntityBinding
+from .binding_models import PropertyBinding
+from .binding_models import RelationshipBinding
+from .ontology_models import Entity
+from .ontology_models import Ontology
+from .ontology_models import Property
+from .ontology_models import Relationship
+from .resolved_models import ResolvedEdgeTable
+from .resolved_models import ResolvedGraph
+from .resolved_models import ResolvedLabelAndProperties
+from .resolved_models import ResolvedNodeTable
+from .resolved_models import ResolvedProperty
+
+
+# --------------------------------------------------------------------- #
+# Public entry point                                                    #
+# --------------------------------------------------------------------- #
+
+
+def compile_graph(ontology: Ontology, binding: Binding) -> str:
+  """Compile an ontology + binding pair into BigQuery DDL.
+
+  Returns a single ``CREATE PROPERTY GRAPH`` statement terminated by a
+  semicolon and a trailing newline. The output is deterministic:
+  re-running with the same inputs produces byte-identical text, and
+  unrelated ontology changes (e.g. adding a new entity) only show up
+  as an additive diff in the emitted DDL.
+
+  Raises:
+      ValueError: Any compile-time rule is violated (``extends`` used,
+          alias collision, derived-expression cycle).
+  """
+  graph = _resolve(ontology, binding)
+  return _emit_bigquery(graph)
+
+
+# --------------------------------------------------------------------- #
+# Resolution                                                             #
+# --------------------------------------------------------------------- #
+
+
+def _resolve(ontology: Ontology, binding: Binding) -> ResolvedGraph:
+  """Produce a ``ResolvedGraph`` from validated ontology+binding inputs."""
+  _reject_extends(ontology)
+
+  # Index ontology and binding by name so the per-entity / per-edge
+  # resolution steps are straight lookups rather than linear scans.
+  entity_map: dict[str, Entity] = {e.name: e for e in ontology.entities}
+  rel_map: dict[str, Relationship] = {r.name: r for r in ontology.relationships}
+  entity_binding_map: dict[str, EntityBinding] = {
+      eb.name: eb for eb in binding.entities
+  }
+
+  # Build node tables first. Edge tables reference node tables by
+  # alias/key-columns, so node tables have to exist before we can
+  # resolve edges.
+  node_tables = tuple(
+      sorted(
+          (
+              _resolve_node_table(entity_map[eb.name], eb)
+              for eb in binding.entities
+          ),
+          key=lambda nt: nt.alias,
+      )
+  )
+
+  # Map alias -> ResolvedNodeTable for edge-resolution lookups. Aliases equal
+  # entity names (see ``_resolve_node_table``), so a relationship's
+  # ``from_`` / ``to`` values look up directly.
+  node_by_alias: dict[str, ResolvedNodeTable] = {nt.alias: nt for nt in node_tables}
+
+  edge_tables = tuple(
+      sorted(
+          (
+              _resolve_edge_table(rel_map[rb.name], rb, node_by_alias)
+              for rb in binding.relationships
+          ),
+          key=lambda et: et.alias,
+      )
+  )
+
+  return ResolvedGraph(
+      name=ontology.ontology,
+      node_tables=node_tables,
+      edge_tables=edge_tables,
+  )
+
+
+def _reject_extends(ontology: Ontology) -> None:
+  """Compile-time rule: v0 does not support inheritance.
+
+  The ontology loader *accepts* ``extends``, because the ontology
+  itself is backend-neutral and inheritance is a legal ontology-level
+  concept. Compilation is the layer that has to choose a lowering
+  strategy for inheritance (fan-out, union-view, label-referenced
+  edges), and v0 explicitly punts on that. Rejecting here — rather
+  than earlier — keeps the ontology and binding models reusable by
+  future compilers that *do* lower inheritance.
+  """
+  for entity in ontology.entities:
+    if entity.extends is not None:
+      raise ValueError(
+          f"Entity {entity.name!r} uses 'extends'; v0 compilation "
+          "does not support inheritance."
+      )
+  for rel in ontology.relationships:
+    if rel.extends is not None:
+      raise ValueError(
+          f"Relationship {rel.name!r} uses 'extends'; v0 compilation "
+          "does not support inheritance."
+      )
+
+
+def _resolve_node_table(entity: Entity, eb: EntityBinding) -> ResolvedNodeTable:
+  """Build one ``ResolvedNodeTable`` from an entity + its binding.
+
+  The binding loader already guaranteed full property coverage, so we
+  can walk the entity's declared properties in order and look each
+  one up in the binding. Derived properties are substituted here;
+  stored properties are copied through with their bound column.
+  """
+  column_by_property = {pb.name: pb.column for pb in eb.properties}
+
+  # The primary-key property names are translated to physical columns
+  # via the same binding map. The loader guarantees every key property
+  # is bound, so this is an infallible lookup.
+  #
+  # ``entity.keys`` is guaranteed non-None by the ontology loader for
+  # flat ontologies (v0 rejects ``extends``, so no inherited keys to
+  # walk). Belt-and-braces anyway — a defensive check here would
+  # shadow real bugs, so we let it blow up loudly if something slips.
+  assert entity.keys is not None and entity.keys.primary is not None
+  key_columns = tuple(column_by_property[p] for p in entity.keys.primary)
+
+  properties = _resolve_properties(
+      declared=entity.properties,
+      column_by_property=column_by_property,
+      owner=f"entity {entity.name!r}",
+  )
+
+  return ResolvedNodeTable(
+      # Alias matches the entity name so the emitted DDL reads by
+      # logical type (``raw.accounts AS Account``) instead of leaking
+      # the physical table basename. Entity names are unique within
+      # the ontology and disjoint from relationship names (enforced
+      # by the ontology loader), so aliases are collision-free by
+      # construction — no runtime uniqueness check needed.
+      alias=entity.name,
+      source=eb.source,
+      key_columns=key_columns,
+      # v0 emits one label per node — the entity name — bundled
+      # with the entity's full (non-derived + derived) property set.
+      # The tuple shape reserves the door for future multi-label
+      # work; see ``ResolvedLabelAndProperties`` docstring.
+      label_and_properties=(
+          ResolvedLabelAndProperties(
+              label=entity.name, properties=properties
+          ),
+      ),
+  )
+
+
+def _resolve_edge_table(
+    rel: Relationship,
+    rb: RelationshipBinding,
+    node_by_alias: dict[str, ResolvedNodeTable],
+) -> ResolvedEdgeTable:
+  """Build one ``ResolvedEdgeTable`` from a relationship + its binding.
+
+  The relationship's ``from_`` / ``to`` name the endpoint *entities*;
+  we turn those into the endpoint *node tables'* aliases and key
+  columns so the emitter can render ``REFERENCES alias (cols)``
+  without further lookup.
+  """
+  from_node = node_by_alias[rel.from_]
+  to_node = node_by_alias[rel.to]
+
+  column_by_property = {pb.name: pb.column for pb in rb.properties}
+  properties = _resolve_properties(
+      declared=rel.properties,
+      column_by_property=column_by_property,
+      owner=f"relationship {rel.name!r}",
+  )
+
+  return ResolvedEdgeTable(
+      # Same rationale as ResolvedNodeTable.alias: use the relationship name
+      # so the DDL reads by logical name rather than physical table
+      # basename.
+      alias=rel.name,
+      source=rb.source,
+      from_columns=tuple(rb.from_columns),
+      from_node_alias=from_node.alias,
+      from_node_key_columns=from_node.key_columns,
+      to_columns=tuple(rb.to_columns),
+      to_node_alias=to_node.alias,
+      to_node_key_columns=to_node.key_columns,
+      key_columns=_resolve_edge_key_columns(rel, rb, column_by_property),
+      # v0 emits one label per edge — the relationship name — bundled
+      # with the relationship's full property set.
+      label_and_properties=(
+          ResolvedLabelAndProperties(
+              label=rel.name, properties=properties
+          ),
+      ),
+  )
+
+
+def _resolve_edge_key_columns(
+    rel: Relationship,
+    rb: RelationshipBinding,
+    column_by_property: dict[str, str],
+) -> tuple[str, ...]:
+  """Compute the edge's ``KEY (...)`` columns.
+
+  Every edge gets a KEY clause in the emitted DDL — BigQuery's graph
+  model needs a row-level identity on edges even when the ontology
+  does not spell one out. We pick the identity from the ontology's
+  declared keys when available, otherwise fall back to the endpoint
+  columns.
+
+  Three cases, mutually exclusive:
+
+    - **``primary`` declared.** The relationship identifies a row
+      standalone (e.g. ``TRANSFER`` with primary
+      ``[transaction_id]``). KEY = bound primary columns.
+    - **``additional`` declared.** The relationship identifies a row
+      by uniqueness *within* an endpoint pair (e.g. ``HOLDS`` with
+      additional ``[as_of]`` — for a given (account, security), no
+      two rows share ``as_of``). BigQuery's KEY wants a globally-
+      unique tuple, so we prefix the endpoint columns:
+      KEY = from_columns + to_columns + bound additional columns.
+    - **No keys declared.** The ontology's Keys docstring reads this
+      as "multi-edges permitted," but DDL still needs *some* identity.
+      The least-surprising default is "one edge per endpoint pair" —
+      KEY = from_columns + to_columns. Authors who actually want
+      multi-edges should declare ``keys.additional`` with a
+      discriminator property (the ``HOLDS`` case above).
+
+  The mutual exclusion between ``primary`` and ``additional`` is
+  enforced by the ontology loader, so at most one of the first two
+  branches can fire.
+  """
+  from_to_columns = tuple(rb.from_columns) + tuple(rb.to_columns)
+  if rel.keys is None:
+    return from_to_columns
+  if rel.keys.primary:
+    return tuple(column_by_property[p] for p in rel.keys.primary)
+  if rel.keys.additional:
+    return from_to_columns + tuple(
+        column_by_property[p] for p in rel.keys.additional
+    )
+  return from_to_columns
+
+
+def _resolve_properties(
+    *,
+    declared: list[Property],
+    column_by_property: dict[str, str],
+    owner: str,
+) -> tuple[ResolvedProperty, ...]:
+  """Walk declared properties in order, resolving each.
+
+  Derived properties are substituted on demand; each call caches its
+  result in ``resolved_sql`` so a derived property referenced by
+  multiple other properties (or just this emission) only has its
+  substitution computed once. The same cache is also how we detect
+  cycles — an in-progress property is tracked in ``resolving`` and a
+  re-entry is raised as a cycle rather than blowing the stack.
+  """
+  # A property-name → Property map so the derived-substitution pass
+  # can recurse by name without another linear scan.
+  property_map = {p.name: p for p in declared}
+  resolved_sql: dict[str, str] = {}
+  resolving: set[str] = set()
+
+  out: list[ResolvedProperty] = []
+  for prop in declared:
+    sql = _resolve_sql(
+        prop,
+        property_map=property_map,
+        column_by_property=column_by_property,
+        resolved_sql=resolved_sql,
+        resolving=resolving,
+        owner=owner,
+    )
+    out.append(
+        ResolvedProperty(
+            name=prop.name,
+            type=prop.type.value,
+            sql=sql,
+            derived=prop.expr is not None,
+        )
+    )
+  return tuple(out)
+
+
+def _resolve_sql(
+    prop: Property,
+    *,
+    property_map: dict[str, Property],
+    column_by_property: dict[str, str],
+    resolved_sql: dict[str, str],
+    resolving: set[str],
+    owner: str,
+) -> str:
+  """Resolve one property to its SQL string.
+
+  Stored properties return their bound column verbatim. Derived
+  properties recursively resolve each property-name reference in
+  their ``expr:``, splice the results back in, and cache the final
+  string. Cycle detection is scoped to this entity/relationship —
+  properties on other elements cannot be referenced, so a per-call
+  ``resolving`` set is sufficient.
+  """
+  if prop.name in resolved_sql:
+    return resolved_sql[prop.name]
+  if prop.name in resolving:
+    raise ValueError(
+        f"Derived property cycle on {owner} at {prop.name!r}."
+    )
+
+  if prop.expr is None:
+    # Stored property — the bound column is the SQL. (The loader has
+    # already checked that every non-derived property has a binding,
+    # so this lookup cannot miss.)
+    result = column_by_property[prop.name]
+    resolved_sql[prop.name] = result
+    return result
+
+  resolving.add(prop.name)
+  try:
+    # Walk the expression once per declared property name. Longer
+    # names first so a property called ``full_name`` isn't shadowed
+    # by a substitution of ``name`` that would otherwise clip its
+    # leading ``full_``. Word-boundary anchors prevent substring
+    # matches inside bigger identifiers.
+    substituted = prop.expr
+    for name in sorted(property_map.keys(), key=len, reverse=True):
+      if name == prop.name:
+        # Self-reference in an expr would already have been a cycle
+        # via the ``resolving`` set, but skip it explicitly so the
+        # check below doesn't even look.
+        continue
+      pattern = rf"\b{re.escape(name)}\b"
+      if not re.search(pattern, substituted):
+        continue
+      nested = _resolve_sql(
+          property_map[name],
+          property_map=property_map,
+          column_by_property=column_by_property,
+          resolved_sql=resolved_sql,
+          resolving=resolving,
+          owner=owner,
+      )
+      # If the nested result is itself a derived expression, wrap it
+      # in parentheses before splicing so operator precedence in the
+      # outer expression stays correct regardless of what the user
+      # wrote. Column names don't need this.
+      if property_map[name].expr is not None:
+        nested = f"({nested})"
+      substituted = re.sub(pattern, nested, substituted)
+    result = substituted
+  finally:
+    resolving.discard(prop.name)
+
+  resolved_sql[prop.name] = result
+  return result
+
+
+# --------------------------------------------------------------------- #
+# Emission (BigQuery)                                                    #
+# --------------------------------------------------------------------- #
+#
+# Formatting choices, all driven by the spec's worked example:
+#
+#   - Two-space indent per level.
+#   - ``LABEL <name> PROPERTIES (...)`` is emitted as one bundled
+#     clause per the GCP grammar's ``LabelAndProperties`` production
+#     — not split across lines, even though today each element only
+#     carries one label. Keeping them bundled reserves the shape for
+#     future multi-label support, where each label has its own
+#     property list and the visual grouping stops being optional.
+#   - Single-line ``LABEL <name> PROPERTIES (...)`` when the
+#     rendered line fits inside ``_INLINE_PROPERTIES_MAX_WIDTH``;
+#     otherwise the property list breaks across lines (one property
+#     per line) with the closing paren on its own line. The
+#     ``LABEL <name> PROPERTIES (`` opening stays on the first line
+#     so the label-property association remains visually intact.
+#   - Comma-and-newline separator between node-table entries and
+#     between edge-table entries; final entry has no trailing comma.
+#   - Statement terminator ``;`` on its own trailing line.
+#
+# These choices give a diff-friendly, grep-friendly shape without
+# requiring a full pretty-printer.
+
+# The width threshold at which property lists flip from inline to
+# multi-line. 80 columns is enough room for the spec's two-property
+# entries to fit inline while still breaking Person's five-property
+# entry onto multiple lines. Conservative values below the 120-ish
+# common modern width keep output readable in split views and code
+# review tools.
+_INLINE_PROPERTIES_MAX_WIDTH = 80
+
+
+def _emit_bigquery(graph: ResolvedGraph) -> str:
+  """Render a ``ResolvedGraph`` as BigQuery DDL text."""
+  lines: list[str] = []
+  lines.append(f"CREATE PROPERTY GRAPH {graph.name}")
+
+  if graph.node_tables:
+    lines.append("  NODE TABLES (")
+    lines.extend(_emit_node_table_entries(graph.node_tables))
+    # Close the NODE TABLES list. EDGE TABLES, when present,
+    # continues on the next line at the same indent; otherwise the
+    # statement terminator gets tacked onto this line at the end of
+    # emission.
+    lines.append("  )")
+
+  if graph.edge_tables:
+    lines.append("  EDGE TABLES (")
+    lines.extend(_emit_edge_table_entries(graph.edge_tables))
+    lines.append("  )")
+
+  # The statement terminator goes at the end of the last already-
+  # emitted line rather than on a line of its own so the output reads
+  # as one coherent SQL statement.
+  lines[-1] = lines[-1] + ";"
+  return "\n".join(lines) + "\n"
+
+
+def _emit_node_table_entries(node_tables: tuple[ResolvedNodeTable, ...]) -> list[str]:
+  """Render the NODE TABLES list body (entries, no surrounding parens)."""
+  entries: list[list[str]] = [_emit_node_table(nt) for nt in node_tables]
+  return _join_entries(entries)
+
+
+def _emit_node_table(nt: ResolvedNodeTable) -> list[str]:
+  """One ``NODE TABLE`` entry as a list of lines (no trailing comma)."""
+  # Example layout:
+  #     raw.accounts AS Account
+  #       KEY (acct_id)
+  #       LABEL Account PROPERTIES (acct_id AS account_id, created_ts AS opened_at)
+  lines = [f"    {nt.source} AS {nt.alias}"]
+  lines.append(f"      KEY ({', '.join(nt.key_columns)})")
+  # One ``LABEL X PROPERTIES(...)`` clause per bundle. v0 always has
+  # exactly one bundle, but iterating the tuple is already the
+  # multi-label shape and costs nothing today.
+  for lp in nt.label_and_properties:
+    lines.extend(_emit_label_clause(lp.label, lp.properties, indent="      "))
+  return lines
+
+
+def _emit_edge_table_entries(edge_tables: tuple[ResolvedEdgeTable, ...]) -> list[str]:
+  """Render the EDGE TABLES list body (entries, no surrounding parens)."""
+  entries: list[list[str]] = [_emit_edge_table(et) for et in edge_tables]
+  return _join_entries(entries)
+
+
+def _emit_edge_table(et: ResolvedEdgeTable) -> list[str]:
+  """One ``EDGE TABLE`` entry as a list of lines (no trailing comma)."""
+  # Example layout:
+  #     raw.holdings AS HOLDS
+  #       KEY (account_id, security_id, snapshot_date)
+  #       SOURCE KEY (account_id) REFERENCES Account (acct_id)
+  #       DESTINATION KEY (security_id) REFERENCES Security (cusip)
+  #       LABEL HOLDS PROPERTIES (snapshot_date AS as_of, qty AS quantity)
+  #
+  # The ``KEY`` clause is always emitted. The resolver computes a
+  # sensible default (endpoint columns) when the ontology did not
+  # spell out any keys, so by the time we get here ``key_columns``
+  # is guaranteed non-empty.
+  lines = [f"    {et.source} AS {et.alias}"]
+  lines.append(f"      KEY ({', '.join(et.key_columns)})")
+  lines.append(
+      f"      SOURCE KEY ({', '.join(et.from_columns)})"
+      f" REFERENCES {et.from_node_alias}"
+      f" ({', '.join(et.from_node_key_columns)})"
+  )
+  lines.append(
+      f"      DESTINATION KEY ({', '.join(et.to_columns)})"
+      f" REFERENCES {et.to_node_alias}"
+      f" ({', '.join(et.to_node_key_columns)})"
+  )
+  # Same multi-label iteration as node tables; v0 length is always 1.
+  for lp in et.label_and_properties:
+    lines.extend(_emit_label_clause(lp.label, lp.properties, indent="      "))
+  return lines
+
+
+def _emit_label_clause(
+    label: str,
+    properties: tuple[ResolvedProperty, ...],
+    *,
+    indent: str,
+) -> list[str]:
+  """Render a bundled ``LABEL <name> PROPERTIES (...)`` clause.
+
+  The GCP grammar treats label and its property list as one unit
+  (``LabelAndProperties``), so we emit them together. Produces a
+  single line when the rendered line fits comfortably; otherwise
+  wraps the property list across lines while keeping the
+  ``LABEL <name> PROPERTIES (`` opener intact on the first line —
+  preserving the visual association between the label and the
+  properties it governs.
+
+  Multi-line shape:
+
+      LABEL X PROPERTIES (
+        prop_1,
+        prop_2
+      )
+  """
+  property_strs = [_emit_property(p) for p in properties]
+  inline = f"{indent}LABEL {label} PROPERTIES ({', '.join(property_strs)})"
+  if len(inline) <= _INLINE_PROPERTIES_MAX_WIDTH:
+    return [inline]
+
+  property_indent = indent + "  "
+  lines = [f"{indent}LABEL {label} PROPERTIES ("]
+  for i, s in enumerate(property_strs):
+    suffix = "," if i < len(property_strs) - 1 else ""
+    lines.append(f"{property_indent}{s}{suffix}")
+  lines.append(f"{indent})")
+  return lines
+
+
+def _emit_property(prop: ResolvedProperty) -> str:
+  """Render one property as it appears inside a PROPERTIES(...) list.
+
+  Three shapes:
+
+    - Stored property whose column happens to match the logical
+      name: emit just the column.
+    - Stored property with a rename: emit ``column AS name``.
+    - Derived property: emit ``(expr) AS name`` — the parens make the
+      expression a single SQL term regardless of what operators it
+      contains, so nesting inside a larger expression is safe.
+  """
+  if prop.derived:
+    return f"({prop.sql}) AS {prop.name}"
+  if prop.sql == prop.name:
+    return prop.name
+  return f"{prop.sql} AS {prop.name}"
+
+
+def _join_entries(entries: list[list[str]]) -> list[str]:
+  """Flatten a list of multi-line entries, adding trailing commas.
+
+  Each entry is itself a list of lines (so an entry can span multiple
+  rows without the caller having to thread commas through). We append
+  a single ``,`` to the last line of every entry except the final
+  one, mirroring how the spec's example formats node / edge lists.
+  """
+  out: list[str] = []
+  for i, entry in enumerate(entries):
+    for j, line in enumerate(entry):
+      is_last_line = j == len(entry) - 1
+      is_last_entry = i == len(entries) - 1
+      if is_last_line and not is_last_entry:
+        out.append(line + ",")
+      else:
+        out.append(line)
+  return out

--- a/src/bigquery_ontology/compiler.py
+++ b/src/bigquery_ontology/compiler.py
@@ -350,6 +350,30 @@ def _resolve_properties(
   return tuple(out)
 
 
+_IDENTIFIER_RE = re.compile(r"\b([a-zA-Z_]\w*)\b")
+
+
+def _reject_unresolved_names(
+    expr: str,
+    self_name: str,
+    property_map: dict[str, Property],
+    owner: str,
+) -> None:
+  """Raise if ``expr`` contains identifiers not in the property map."""
+  unknown = {
+      tok
+      for tok in _IDENTIFIER_RE.findall(expr)
+      if tok != self_name and tok not in property_map
+  }
+  if unknown:
+    names = ", ".join(sorted(unknown))
+    raise ValueError(
+        f"Derived property {self_name!r} on {owner} references "
+        f"unknown name(s): {names}. Every name in a derived "
+        f"expression must be a property on the same element."
+    )
+
+
 def _resolve_sql(
     prop: Property,
     *,
@@ -385,37 +409,41 @@ def _resolve_sql(
 
   resolving.add(prop.name)
   try:
-    # Walk the expression once per declared property name. Longer
-    # names first so a property called ``full_name`` isn't shadowed
-    # by a substitution of ``name`` that would otherwise clip its
-    # leading ``full_``. Word-boundary anchors prevent substring
-    # matches inside bigger identifiers.
-    substituted = prop.expr
-    for name in sorted(property_map.keys(), key=len, reverse=True):
-      if name == prop.name:
-        # Self-reference in an expr would already have been a cycle
-        # via the ``resolving`` set, but skip it explicitly so the
-        # check below doesn't even look.
-        continue
-      pattern = rf"\b{re.escape(name)}\b"
-      if not re.search(pattern, substituted):
-        continue
-      nested = _resolve_sql(
-          property_map[name],
-          property_map=property_map,
-          column_by_property=column_by_property,
-          resolved_sql=resolved_sql,
-          resolving=resolving,
-          owner=owner,
+    _reject_unresolved_names(prop.expr, prop.name, property_map, owner)
+
+    # Build a single alternation pattern for all property names that
+    # appear in the expression, then substitute in one pass so that
+    # a column name introduced by one replacement can never be
+    # re-matched as a different property name.
+    names_in_expr = [
+        name
+        for name in sorted(property_map.keys(), key=len, reverse=True)
+        if name != prop.name
+        and re.search(rf"\b{re.escape(name)}\b", prop.expr)
+    ]
+
+    if names_in_expr:
+      combined = re.compile(
+          "|".join(rf"\b{re.escape(n)}\b" for n in names_in_expr)
       )
-      # If the nested result is itself a derived expression, wrap it
-      # in parentheses before splicing so operator precedence in the
-      # outer expression stays correct regardless of what the user
-      # wrote. Column names don't need this.
-      if property_map[name].expr is not None:
-        nested = f"({nested})"
-      substituted = re.sub(pattern, nested, substituted)
-    result = substituted
+
+      def _replacer(match: re.Match[str]) -> str:
+        name = match.group(0)
+        nested = _resolve_sql(
+            property_map[name],
+            property_map=property_map,
+            column_by_property=column_by_property,
+            resolved_sql=resolved_sql,
+            resolving=resolving,
+            owner=owner,
+        )
+        if property_map[name].expr is not None:
+          nested = f"({nested})"
+        return nested
+
+      result = combined.sub(_replacer, prop.expr)
+    else:
+      result = prop.expr
   finally:
     resolving.discard(prop.name)
 

--- a/src/bigquery_ontology/resolved_models.py
+++ b/src/bigquery_ontology/resolved_models.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory intermediate models produced by the compiler's resolution stage.
+
+A ``ResolvedGraph`` sits between the validated-but-abstract
+``Ontology`` + ``Binding`` pair and the string-typed DDL emitted for a
+specific backend. It collapses two concerns:
+
+  - **Cross-object lookup.** An entity binding knows its source table
+    and columns; a relationship binding knows its endpoint *entity
+    names*. To emit DDL we need the endpoint's *node table alias and
+    key columns* — a resolved graph pre-computes that wiring so the
+    emitter can walk one tree and produce text.
+
+  - **Derived-expression substitution.** Ontology-level derived
+    properties carry an ``expr:`` in terms of logical property names.
+    DDL has to reference physical column names. Resolution substitutes
+    each property-name token with the corresponding column (recursing
+    through chains of derived properties), so the emitter sees an
+    already-SQL-ready expression string.
+
+Everything here is a frozen dataclass. The intermediate is produced,
+consumed, and thrown away in a single compile call — no persistence,
+no mutation, no validation rules. The loaders did validation; the
+compiler did resolution; the emitter just types out text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResolvedProperty:
+  """One property in the form the emitter actually writes to DDL.
+
+  ``name`` is the logical (ontology-declared) property name that
+  becomes the SQL alias after ``AS``. ``sql`` is what sits on the
+  left of the ``AS``:
+
+    - For a bound (non-derived) property, ``sql`` is the physical
+      column name as declared in the binding.
+    - For a derived property, ``sql`` is the ``expr:`` with every
+      property-name token recursively substituted to physical column
+      names — the emitter wraps it in parentheses so SQL precedence is
+      safe regardless of what operators the user wrote.
+
+  ``derived`` preserves which of the two paths produced this property
+  so the emitter can decide whether to add parentheses and to skip the
+  ``AS`` rename when the logical and physical names happen to match.
+
+  ``type`` is the logical type (from the ontology). It is not emitted
+  in ``CREATE PROPERTY GRAPH`` — property types are inferred from the
+  underlying table columns — but the compiler keeps it around for
+  target-compat checks (relevant on Spanner, no-op on BigQuery).
+  """
+
+  name: str
+  type: str
+  sql: str
+  derived: bool
+
+
+@dataclass(frozen=True)
+class ResolvedLabelAndProperties:
+  """One label on a node or edge, paired with its property list.
+
+  Mirrors the GCP ``CREATE PROPERTY GRAPH`` grammar's
+  ``LabelAndProperties`` production. A node or edge table may carry
+  multiple labels in general (``LabelAndPropertiesList``), each with
+  its own subset of physical columns surfaced as properties — the
+  pairing is what makes multi-label schemas unambiguous.
+
+  v0 populates exactly one of these per table (each entity or
+  relationship contributes one label whose property list is the full
+  set bound to that element), but the nested type reflects the
+  grammar's coupling regardless. Future multi-label work becomes a
+  data-model population change rather than an emitter rewrite — the
+  emitter already iterates the tuple and renders each bundle.
+  """
+
+  label: str
+  properties: tuple[ResolvedProperty, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedNodeTable:
+  """One ``NODE TABLE`` entry.
+
+  ``alias`` is the identifier used after ``AS`` in the emitted DDL
+  and again in any edge table's ``REFERENCES`` clause. We use the
+  ontology entity name verbatim (``Account``, ``Person``) rather than
+  deriving something from the physical source name, so the emitted
+  DDL reads by logical type instead of leaking table basenames. The
+  ontology loader already guarantees entity names are unique within
+  the ontology *and* disjoint from relationship names, so aliases
+  are unique by construction — no runtime check needed.
+
+  ``key_columns`` are the *physical* columns backing the entity's
+  primary-key properties, in declaration order. They land both in
+  this node's own ``KEY (...)`` clause and in any edge table's
+  ``REFERENCES alias (...)`` for this node.
+
+  ``label_and_properties`` is a tuple of ``ResolvedLabelAndProperties``
+  bundles. Exactly one in v0 (whose ``label`` equals the entity name,
+  whose ``properties`` is the full declared-order property list for
+  the entity). The tuple shape is what the grammar calls for in
+  general, so carrying it here — even at length one — keeps the model
+  honest and leaves the door open for inheritance-lowering work that
+  emits several labels per table.
+  """
+
+  alias: str
+  source: str
+  key_columns: tuple[str, ...]
+  label_and_properties: tuple[ResolvedLabelAndProperties, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedEdgeTable:
+  """One ``EDGE TABLE`` entry.
+
+  ``from_columns`` / ``to_columns`` are columns on the *edge* table's
+  own source (e.g. ``raw.holdings``). ``from_node_alias`` /
+  ``to_node_alias`` name the NODE TABLE aliases that those keys
+  reference, and ``from_node_key_columns`` / ``to_node_key_columns``
+  are the physical key columns on those node tables. Denormalizing
+  this onto the edge saves the emitter from a per-edge lookup into
+  the node-table map — emission becomes a straight-line render.
+
+  ``key_columns`` holds the edge's own primary-key columns. It is
+  always non-empty — every edge in the emitted DDL gets a ``KEY``
+  clause, because BigQuery needs a row-level identity on edges even
+  when the ontology didn't spell one out. The resolver picks the
+  columns by these rules:
+
+    - ``keys.primary`` declared → exactly the bound physical columns
+      for those properties (standalone row identity, e.g. ``TRANSFER``
+      keyed by ``transaction_id``).
+    - ``keys.additional`` declared → endpoint columns followed by
+      the bound additional-key columns; together they form the
+      row's unique tuple (e.g. ``HOLDS`` keyed by ``(account_id,
+      security_id, as_of)``).
+    - No keys declared → just the endpoint columns, expressing "one
+      edge per endpoint pair" as a safe default. Authors who need
+      actual multi-edges should declare ``keys.additional`` with a
+      discriminator property.
+
+  ``label_and_properties`` — same shape and rationale as
+  ``ResolvedNodeTable.label_and_properties``: always length-1 in v0,
+  tuple because the GCP grammar allows a list and modeling it here
+  means future multi-label work is a resolver change, not a schema
+  one.
+  """
+
+  alias: str
+  source: str
+  from_columns: tuple[str, ...]
+  from_node_alias: str
+  from_node_key_columns: tuple[str, ...]
+  to_columns: tuple[str, ...]
+  to_node_alias: str
+  to_node_key_columns: tuple[str, ...]
+  key_columns: tuple[str, ...]
+  label_and_properties: tuple[ResolvedLabelAndProperties, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedGraph:
+  """One ``CREATE PROPERTY GRAPH`` statement, ready to render.
+
+  ``name`` is copied from the ontology's ``ontology:`` field — the
+  binding does not re-declare a graph name, so there's no way for the
+  two to disagree.
+
+  ``node_tables`` and ``edge_tables`` are already alphabetized by
+  alias at resolution time so the emitter can rely on the iteration
+  order without a re-sort. This matters for the determinism guarantee
+  (the same inputs must produce byte-identical DDL) and also makes
+  diffs of emitted output readable when an ontology grows.
+  """
+
+  name: str
+  node_tables: tuple[ResolvedNodeTable, ...]
+  edge_tables: tuple[ResolvedEdgeTable, ...]

--- a/tests/bigquery_ontology/test_binding_loader.py
+++ b/tests/bigquery_ontology/test_binding_loader.py
@@ -49,6 +49,7 @@ import textwrap
 
 import pytest
 
+from bigquery_ontology import Binding
 from bigquery_ontology import load_binding
 from bigquery_ontology import load_binding_from_string
 from bigquery_ontology import load_ontology_from_string
@@ -292,6 +293,31 @@ def test_duplicate_relationship_binding_name_is_error():
   _assert_value_error(
       binding_yaml, "Duplicate relationship binding name: 'HOLDS'"
   )
+
+
+def test_cross_kind_duplicate_binding_name_is_error():
+  """Defensive: same name used for an entity binding and a relationship."""
+  from bigquery_ontology.binding_loader import _check_unique_binding_names
+  from bigquery_ontology.binding_models import Backend
+  from bigquery_ontology.binding_models import BigQueryTarget
+  from bigquery_ontology.binding_models import EntityBinding
+  from bigquery_ontology.binding_models import RelationshipBinding
+
+  binding = Binding(
+      binding="b",
+      ontology="x",
+      target=BigQueryTarget(
+          backend=Backend.BIGQUERY, project="p", dataset="d"
+      ),
+      entities=[EntityBinding(name="Foo", source="t", properties=[])],
+      relationships=[
+          RelationshipBinding(
+              name="Foo", source="e", from_columns=["a"], to_columns=["b"]
+          )
+      ],
+  )
+  with pytest.raises(ValueError, match="Duplicate binding name: 'Foo'"):
+    _check_unique_binding_names(binding)
 
 
 def test_entity_binding_references_unknown_entity():

--- a/tests/bigquery_ontology/test_binding_models.py
+++ b/tests/bigquery_ontology/test_binding_models.py
@@ -240,7 +240,8 @@ def test_entity_with_empty_properties_round_trips():
       "entities": [
         {
           "name": "E",
-          "source": "t"
+          "source": "t",
+          "properties": []
         }
       ]
     }"""
@@ -258,6 +259,18 @@ def _assert_validation_error(yaml_text: str, must_contain: str) -> None:
   with pytest.raises(ValidationError) as exc_info:
     _load(yaml_text)
   assert must_contain in str(exc_info.value)
+
+
+def test_entity_missing_properties_is_error():
+  yaml_input = """
+    binding: b
+    ontology: x
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+  """
+  _assert_validation_error(yaml_input, "properties")
 
 
 def test_missing_top_level_binding_is_error():

--- a/tests/bigquery_ontology/test_compiler.py
+++ b/tests/bigquery_ontology/test_compiler.py
@@ -1,0 +1,601 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the compiler in ``src/bigquery_ontology/compiler.py``.
+
+Style mirrors the other test files in this package: literal YAML
+inputs, full-text expected outputs. The large ``test_compiles_finance_…``
+test is a *golden* — it asserts byte-identical DDL, which is both a
+functional check (the emitter produces valid-looking BigQuery DDL)
+and a regression guard for the determinism contract. Small targeted
+tests exercise each compile-time rule on its own.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bigquery_ontology import compile_graph
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+
+
+# --------------------------------------------------------------------- #
+# Shared finance fixture                                                 #
+# --------------------------------------------------------------------- #
+#
+# This pair is the compilation spec's worked example, completed with
+# the ``Security`` node table (the spec fragment elides it, but a
+# binding that edges from ``HOLDS`` to ``Security`` must also bind
+# ``Security`` — that's a loader-level rule). Multiple tests reuse
+# these strings so changes to the emitted-DDL format land in one place.
+
+
+_FINANCE_ONTOLOGY = """
+  ontology: finance
+  entities:
+    - name: Person
+      keys: {primary: [person_id]}
+      properties:
+        - {name: person_id, type: string}
+        - {name: name, type: string}
+        - {name: first_name, type: string}
+        - {name: last_name, type: string}
+        - name: full_name
+          type: string
+          expr: "first_name || ' ' || last_name"
+    - name: Account
+      keys: {primary: [account_id]}
+      properties:
+        - {name: account_id, type: string}
+        - {name: opened_at, type: timestamp}
+    - name: Security
+      keys: {primary: [security_id]}
+      properties:
+        - {name: security_id, type: string}
+  relationships:
+    - name: HOLDS
+      from: Account
+      to: Security
+      properties:
+        - {name: as_of, type: timestamp}
+        - {name: quantity, type: double}
+"""
+
+_FINANCE_BINDING = """
+  binding: finance-bq-prod
+  ontology: finance
+  target:
+    backend: bigquery
+    project: my-proj
+    dataset: finance
+  entities:
+    - name: Person
+      source: raw.persons
+      properties:
+        - {name: person_id, column: person_id}
+        - {name: name, column: display_name}
+        - {name: first_name, column: given_name}
+        - {name: last_name, column: family_name}
+    - name: Account
+      source: raw.accounts
+      properties:
+        - {name: account_id, column: acct_id}
+        - {name: opened_at, column: created_ts}
+    - name: Security
+      source: ref.securities
+      properties:
+        - {name: security_id, column: cusip}
+  relationships:
+    - name: HOLDS
+      source: raw.holdings
+      from_columns: [account_id]
+      to_columns: [security_id]
+      properties:
+        - {name: as_of, column: snapshot_date}
+        - {name: quantity, column: qty}
+"""
+
+
+def _load(ontology_yaml: str, binding_yaml: str):
+  ontology = load_ontology_from_string(textwrap.dedent(ontology_yaml).lstrip())
+  binding = load_binding_from_string(
+      textwrap.dedent(binding_yaml).lstrip(), ontology=ontology
+  )
+  return ontology, binding
+
+
+# --------------------------------------------------------------------- #
+# Golden: the spec's worked example                                      #
+# --------------------------------------------------------------------- #
+
+
+def test_compiles_finance_worked_example_to_exact_ddl():
+  # This is the test that proves the pipeline end-to-end:
+  # ontology YAML + binding YAML → one ``CREATE PROPERTY GRAPH``
+  # statement matching the compilation spec's worked example. It
+  # exercises every interesting path at once — alphabetical node and
+  # edge ordering (Account, Person, Security), short vs. wrapped
+  # property lists, rename vs. passthrough column mapping, derived
+  # expression substitution (``full_name``), and edge-endpoint
+  # wiring via the ``REFERENCES <alias> (<key_cols>)`` clauses.
+  ontology, binding = _load(_FINANCE_ONTOLOGY, _FINANCE_BINDING)
+
+  ddl = compile_graph(ontology, binding)
+
+  expected = textwrap.dedent(
+      """\
+      CREATE PROPERTY GRAPH finance
+        NODE TABLES (
+          raw.accounts AS Account
+            KEY (acct_id)
+            LABEL Account PROPERTIES (acct_id AS account_id, created_ts AS opened_at),
+          raw.persons AS Person
+            KEY (person_id)
+            LABEL Person PROPERTIES (
+              person_id,
+              display_name AS name,
+              given_name AS first_name,
+              family_name AS last_name,
+              (given_name || ' ' || family_name) AS full_name
+            ),
+          ref.securities AS Security
+            KEY (cusip)
+            LABEL Security PROPERTIES (cusip AS security_id)
+        )
+        EDGE TABLES (
+          raw.holdings AS HOLDS
+            KEY (account_id, security_id)
+            SOURCE KEY (account_id) REFERENCES Account (acct_id)
+            DESTINATION KEY (security_id) REFERENCES Security (cusip)
+            LABEL HOLDS PROPERTIES (snapshot_date AS as_of, qty AS quantity)
+        );
+      """
+  )
+  assert ddl == expected
+
+
+def test_compile_is_deterministic():
+  # Determinism contract: same inputs, byte-identical output across
+  # runs. Not exciting on its own, but it guards against accidental
+  # use of dict iteration order or set traversal in the resolver or
+  # emitter — both of which would pass a single run but diverge
+  # between Python versions or across processes.
+  ontology, binding = _load(_FINANCE_ONTOLOGY, _FINANCE_BINDING)
+  assert compile_graph(ontology, binding) == compile_graph(ontology, binding)
+
+
+# --------------------------------------------------------------------- #
+# Smaller shape tests                                                    #
+# --------------------------------------------------------------------- #
+
+
+def test_single_entity_without_relationships_produces_node_tables_only():
+  # Confirms the emitter skips the EDGE TABLES block cleanly when the
+  # binding has no relationships — no stray commas, no empty
+  # parentheses, ``;`` lands on the NODE TABLES closing paren.
+  ontology_yaml = """
+    ontology: tiny
+    entities:
+      - name: Thing
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: tiny
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Thing
+        source: raw.things
+        properties:
+          - {name: id, column: id}
+  """
+  ontology, binding = _load(ontology_yaml, binding_yaml)
+  expected = textwrap.dedent(
+      """\
+      CREATE PROPERTY GRAPH tiny
+        NODE TABLES (
+          raw.things AS Thing
+            KEY (id)
+            LABEL Thing PROPERTIES (id)
+        );
+      """
+  )
+  assert compile_graph(ontology, binding) == expected
+
+
+def test_property_with_same_logical_and_physical_name_omits_as():
+  # A stored property whose bound column equals its logical name
+  # should emit as the bare column identifier, not ``col AS col``.
+  # Covered incidentally by the golden (``person_id``), pinned
+  # explicitly here so a format refactor can't silently regress it.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: E
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+        properties:
+          - {name: id, column: id}
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+  assert "LABEL E PROPERTIES (id)" in ddl
+  assert "id AS id" not in ddl
+
+
+def test_derived_expression_recursively_substitutes_derived_dependencies():
+  # A derived property that references another derived property must
+  # substitute the inner expression and wrap it in parentheses so
+  # precedence survives. Here ``label`` depends on ``combined`` which
+  # in turn depends on ``a`` and ``b`` (stored). We assert the final
+  # emitted SQL splices column names, not property names, into both
+  # levels.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: E
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+          - {name: a, type: string}
+          - {name: b, type: string}
+          - {name: combined, type: string, expr: "a || b"}
+          - {name: label, type: string, expr: "'#' || combined"}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+        properties:
+          - {name: id, column: row_id}
+          - {name: a, column: col_a}
+          - {name: b, column: col_b}
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+  assert "(col_a || col_b) AS combined" in ddl
+  assert "('#' || (col_a || col_b)) AS label" in ddl
+
+
+# --------------------------------------------------------------------- #
+# Edge key emission                                                      #
+# --------------------------------------------------------------------- #
+#
+# Every edge gets a ``KEY (...)`` clause in the emitted DDL, because
+# BigQuery's graph model wants row-level identity on edges even when
+# the ontology does not spell one out. The three tests below pin the
+# three cases:
+#
+#   - ``keys.primary`` declared (e.g. ``TRANSFER`` with
+#     ``transaction_id``) → KEY is the bound primary columns alone.
+#   - ``keys.additional`` declared (e.g. ``HOLDS`` with ``as_of``) →
+#     KEY is the endpoint columns plus the additional columns,
+#     making the row globally unique as BigQuery expects.
+#   - No keys declared → KEY falls back to the endpoint columns
+#     alone, expressing "one edge per endpoint pair" as the safest
+#     default. Authors who want actual multi-edges add
+#     ``keys.additional``.
+
+
+def test_edge_with_primary_key_emits_standalone_key_clause():
+  # TRANSFER-style: ``transaction_id`` alone identifies any row in
+  # ``raw.transactions``. The KEY clause maps the primary-key
+  # property to its bound column and nothing else.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: Account
+        keys: {primary: [account_id]}
+        properties: [{name: account_id, type: string}]
+    relationships:
+      - name: TRANSFER
+        from: Account
+        to: Account
+        keys: {primary: [transaction_id]}
+        properties:
+          - {name: transaction_id, type: string}
+          - {name: amount, type: double}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: raw.accounts
+        properties:
+          - {name: account_id, column: acct_id}
+    relationships:
+      - name: TRANSFER
+        source: raw.transactions
+        from_columns: [src_account]
+        to_columns: [dst_account]
+        properties:
+          - {name: transaction_id, column: txn_id}
+          - {name: amount, column: amount_usd}
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+
+  expected = textwrap.dedent(
+      """\
+      CREATE PROPERTY GRAPH o
+        NODE TABLES (
+          raw.accounts AS Account
+            KEY (acct_id)
+            LABEL Account PROPERTIES (acct_id AS account_id)
+        )
+        EDGE TABLES (
+          raw.transactions AS TRANSFER
+            KEY (txn_id)
+            SOURCE KEY (src_account) REFERENCES Account (acct_id)
+            DESTINATION KEY (dst_account) REFERENCES Account (acct_id)
+            LABEL TRANSFER PROPERTIES (txn_id AS transaction_id, amount_usd AS amount)
+        );
+      """
+  )
+  assert ddl == expected
+
+
+def test_edge_with_additional_key_emits_endpoints_plus_additional():
+  # HOLDS-style: for a given ``(account, security)`` pair, ``as_of``
+  # is unique. BigQuery's KEY needs a globally-unique tuple, so we
+  # prefix the endpoint columns — ``(account_id, security_id,
+  # snapshot_date)`` — forming a composite row identifier that
+  # matches the ontology's stated uniqueness.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: Account
+        keys: {primary: [account_id]}
+        properties: [{name: account_id, type: string}]
+      - name: Security
+        keys: {primary: [security_id]}
+        properties: [{name: security_id, type: string}]
+    relationships:
+      - name: HOLDS
+        from: Account
+        to: Security
+        keys: {additional: [as_of]}
+        properties:
+          - {name: as_of, type: timestamp}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Account
+        source: raw.accounts
+        properties: [{name: account_id, column: acct_id}]
+      - name: Security
+        source: ref.securities
+        properties: [{name: security_id, column: cusip}]
+    relationships:
+      - name: HOLDS
+        source: raw.holdings
+        from_columns: [account_id]
+        to_columns: [security_id]
+        properties:
+          - {name: as_of, column: snapshot_date}
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+
+  # Assert the precise KEY tuple (order: from_columns, to_columns,
+  # then additional).
+  assert "KEY (account_id, security_id, snapshot_date)" in ddl
+  # And that the KEY clause sits before SOURCE KEY per the BigQuery
+  # grammar — we can check ordering by line number.
+  lines = ddl.splitlines()
+  edge_key_line = next(
+      i
+      for i, line in enumerate(lines)
+      if line.strip().startswith("KEY (account_id, security_id,")
+  )
+  source_key_line = next(
+      i for i, line in enumerate(lines) if "SOURCE KEY" in line
+  )
+  assert edge_key_line < source_key_line
+
+
+def test_edge_without_declared_keys_falls_back_to_endpoint_columns():
+  # When a relationship declares no ``keys`` block, the compiler
+  # still emits a ``KEY`` clause — just using the endpoint columns
+  # as an implicit "one edge per endpoint pair" identity. Without
+  # this fallback the emitted DDL would lack any row identity on
+  # the edge, which BigQuery's graph model needs.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: A
+        keys: {primary: [id]}
+        properties: [{name: id, type: string}]
+    relationships:
+      - name: R
+        from: A
+        to: A
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: A
+        source: t
+        properties: [{name: id, column: id}]
+    relationships:
+      - name: R
+        source: edges
+        from_columns: [a]
+        to_columns: [b]
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+
+  # KEY is the endpoint columns, in from-then-to order, matching
+  # the binding's ``from_columns: [a]`` and ``to_columns: [b]``.
+  assert "KEY (a, b)" in ddl
+
+
+# --------------------------------------------------------------------- #
+# Compile-time rule violations                                           #
+# --------------------------------------------------------------------- #
+
+
+def test_entity_extends_is_rejected():
+  # v0 explicitly punts on inheritance lowering. The ontology loader
+  # accepts ``extends`` (it's a legal logical concept), but the
+  # compiler refuses to emit DDL for it. This test pins the exact
+  # error so downstream tooling can match on it.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: Parent
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+      - name: Child
+        extends: Parent
+        properties: []
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: Parent
+        source: t1
+        properties: [{name: id, column: id}]
+  """
+  ontology, binding = _load(ontology_yaml, binding_yaml)
+  with pytest.raises(ValueError) as exc_info:
+    compile_graph(ontology, binding)
+  assert str(exc_info.value) == (
+      "Entity 'Child' uses 'extends'; v0 compilation does not support "
+      "inheritance."
+  )
+
+
+def test_relationship_extends_is_rejected():
+  # The mirror of the entity-extends rule. Worth a separate test
+  # because the compiler walks entities and relationships in two
+  # independent loops — regressing one wouldn't break the other.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: A
+        keys: {primary: [id]}
+        properties: [{name: id, type: string}]
+    relationships:
+      - name: R1
+        from: A
+        to: A
+      - name: R2
+        extends: R1
+        from: A
+        to: A
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: A
+        source: t
+        properties: [{name: id, column: id}]
+  """
+  ontology, binding = _load(ontology_yaml, binding_yaml)
+  with pytest.raises(ValueError) as exc_info:
+    compile_graph(ontology, binding)
+  assert str(exc_info.value) == (
+      "Relationship 'R2' uses 'extends'; v0 compilation does not support "
+      "inheritance."
+  )
+
+
+def test_derived_property_cycle_is_rejected():
+  # Two derived properties that reference each other blow the
+  # substitution stack if left to recurse. The resolver detects the
+  # cycle on entering a property that's already being resolved, and
+  # names the property where the cycle closed.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: E
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+          - {name: a, type: string, expr: "b"}
+          - {name: b, type: string, expr: "a"}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+        properties:
+          - {name: id, column: id}
+  """
+  ontology, binding = _load(ontology_yaml, binding_yaml)
+  with pytest.raises(ValueError, match="cycle"):
+    compile_graph(ontology, binding)
+
+
+def test_entities_sharing_a_source_basename_compile_cleanly():
+  # Regression guard for the aliasing approach. Two entities binding
+  # to tables whose basenames happen to collide (``customers.users``
+  # vs ``hr.users``) used to require a compile-time alias-uniqueness
+  # check. Now that aliases come from the ontology labels —
+  # ``CustomerUser``, ``InternalUser`` — there's nothing to collide
+  # with, and the previously-tricky case compiles without incident.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: CustomerUser
+        keys: {primary: [id]}
+        properties: [{name: id, type: string}]
+      - name: InternalUser
+        keys: {primary: [id]}
+        properties: [{name: id, type: string}]
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: CustomerUser
+        source: customers.users
+        properties: [{name: id, column: id}]
+      - name: InternalUser
+        source: hr.users
+        properties: [{name: id, column: id}]
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+  assert "customers.users AS CustomerUser" in ddl
+  assert "hr.users AS InternalUser" in ddl

--- a/tests/bigquery_ontology/test_compiler.py
+++ b/tests/bigquery_ontology/test_compiler.py
@@ -567,6 +567,69 @@ def test_derived_property_cycle_is_rejected():
     compile_graph(ontology, binding)
 
 
+def test_substitution_does_not_rematch_inserted_column_names():
+  # Regression: properties ``a`` (bound to column ``x``) and ``x``
+  # (bound to column ``y``), with derived ``d: expr: "a"``. A
+  # sequential substitution loop would replace ``a`` → ``x``, then
+  # the ``x`` pass would fire on the inserted column name, producing
+  # ``(y) AS d`` instead of the correct ``(x) AS d``. Single-pass
+  # substitution prevents this.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: E
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+          - {name: a, type: string}
+          - {name: x, type: string}
+          - {name: d, type: string, expr: "a"}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+        properties:
+          - {name: id, column: row_id}
+          - {name: a, column: x}
+          - {name: x, column: y}
+  """
+  ddl = compile_graph(*_load(ontology_yaml, binding_yaml))
+  assert "(x) AS d" in ddl
+  assert "(y) AS d" not in ddl
+
+
+def test_unresolved_name_in_derived_expression_is_rejected():
+  # A derived expression referencing a name that doesn't exist as a
+  # property on the same element must fail at compile time rather
+  # than leaking an unsubstituted token into emitted DDL.
+  ontology_yaml = """
+    ontology: o
+    entities:
+      - name: E
+        keys: {primary: [id]}
+        properties:
+          - {name: id, type: string}
+          - {name: d, type: string, expr: "missing_prop || id"}
+  """
+  binding_yaml = """
+    binding: b
+    ontology: o
+    target: {backend: bigquery, project: p, dataset: d}
+    entities:
+      - name: E
+        source: t
+        properties:
+          - {name: id, column: row_id}
+  """
+  ontology, binding = _load(ontology_yaml, binding_yaml)
+  with pytest.raises(ValueError, match="missing_prop"):
+    compile_graph(ontology, binding)
+
+
 def test_entities_sharing_a_source_basename_compile_cleanly():
   # Regression guard for the aliasing approach. Two entities binding
   # to tables whose basenames happen to collide (``customers.users``


### PR DESCRIPTION
Stacks on #18 (which stacks on #17, which stacks on #16). Review this PR's diff against \`feat/binding-cli\` to isolate the compile changes.

## Summary
Adds \`compile_graph(ontology, binding) -> str\`, which turns a validated \`Ontology\` + \`Binding\` pair into one deterministic \`CREATE PROPERTY GRAPH\` statement for BigQuery. Closes the happy-path arc: YAML → validated objects → DDL.

## Pipeline
\`\`\`
  ontology.yaml ─┐
                 ├── Resolver ── ResolvedGraph ── Emitter ── DDL
  binding.yaml ──┘
\`\`\`

**Resolver** (\`compiler.py\`) cross-references the two inputs, builds the intermediate, and catches compile-time-only rules.

**Emitter** (\`compiler.py\`) walks the \`ResolvedGraph\` and produces text. Mechanical — all interesting decisions happen during resolution so emission is byte-deterministic.

**Intermediate** (\`resolved_models.py\`): frozen dataclasses — \`ResolvedProperty\`, \`ResolvedLabelAndProperties\`, \`ResolvedNodeTable\`, \`ResolvedEdgeTable\`, \`ResolvedGraph\`. Shape mirrors the GCP grammar:
- \`LabelAndProperties\` is a first-class bundle (label + its properties), not two peer fields
- \`label_and_properties: tuple[...]\` on node/edge tables, always length-1 in v0 but reserves the shape for future multi-label work

## Compile-time rules beyond the loaders
- **No \`extends\`**. v0 rejects hierarchical ontologies; inheritance lowering is a separate future design.
- **Derived-expression substitution**. Word-boundary regex, recursive, cycle-detected. Documented limitation: doesn't inspect SQL string literals (pragmatic for v0).
- **Edge keys always emitted**. Three resolution cases — \`keys.primary\` → bound columns; \`keys.additional\` → endpoint columns + additional; none → endpoint columns as safe default.

## Emitted DDL shape
- One \`CREATE PROPERTY GRAPH <name>\`.
- Node and edge tables alphabetized by alias (= label = entity/relationship name).
- Aliases are the ontology labels verbatim (\`raw.accounts AS Account\`), so DDL reads by logical type. Collision-free by construction since the ontology loader already enforces unique names.
- \`LABEL X PROPERTIES (...)\` bundled per the GCP grammar's \`LabelAndProperties\` production. Inline when short, wrapped across lines when long (80-col threshold).

## Spec alignment
\`docs/ontology/compilation.md\` updated so the spec describes what we ship:
- §2a Type overview: \`Resolved*\` prefix on all types, \`label_and_properties\` field, edge \`key_columns\` first-class.
- §3 Resolution: new subsections for alias derivation and edge-key resolution (three cases).
- §4 Worked example: expanded to the complete three-node, one-edge form the emitter actually produces.
- §4 Grammar-mapping table: reflects the new model shape, including the \`LabelAndPropertiesList\` footnote.

## Test plan
- [x] \`uv run --with pytest python -m pytest tests/bigquery_ontology -q\` — 80 passed
- [x] Byte-exact golden of the spec's finance worked example
- [x] Determinism: compile twice, assert byte-identical
- [x] NODE TABLES without EDGE TABLES (clean terminator placement)
- [x] Passthrough: \`id\` column bound to \`id\` property emits bare, not \`id AS id\`
- [x] Nested derived substitution: \`(col_a || col_b)\` spliced, outer derived wraps inner in parens
- [x] Edge KEY: primary → standalone; additional → endpoints + additional; no keys → endpoint-only fallback
- [x] Compile-time errors: entity \`extends\`, relationship \`extends\`, derived cycle
- [x] Regression: two entities with the same source basename compile cleanly (label-based aliasing)

## Intentionally out of scope
- \`gm compile\` CLI wiring — next PR, so this one stays focused on the compilation core.
- Spanner emission, inheritance lowering, measures — per spec §9.