### PR TITLE
feat(cli): add gm compile command

### DIFF
--- a/docs/ontology/cli.md
+++ b/docs/ontology/cli.md
@@ -132,9 +132,11 @@ rule as `gm validate` (§4).
 ### Usage
 
 ```
-gm compile <binding> [-o <out>]
+gm compile <binding> [--ontology <path>] [-o <out>]
 ```
 
+- Input must be a binding YAML file. Passing an ontology file (or any
+  other non-binding YAML) exits 2 with `cli-wrong-kind`.
 - Runs validation implicitly on both files before emission. Any error
   fails the compile; no partial DDL is emitted.
 - Writes DDL to stdout unless `-o` is given.
@@ -143,7 +145,8 @@ gm compile <binding> [-o <out>]
 
 | Flag | Purpose |
 |---|---|
-| `-o <file>`, `--out <file>` | Write DDL to file instead of stdout. |
+| `-o <file>`, `--output <file>` | Write DDL to file instead of stdout. |
+| `--ontology <path>` | Path to the companion ontology. Overrides auto-discovery (same as `gm validate`). |
 | `--json` | Structured errors for the implicit validation step. |
 
 On any validation or compilation error, no DDL is emitted — even partially.

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -15,17 +15,18 @@
 """``gm`` command-line interface.
 
 ``gm validate`` accepts either an ontology YAML or a binding YAML and
-dispatches to the matching loader. For binding files, the companion
-ontology is auto-discovered as ``<name>.ontology.yaml`` next to the
-binding by default; pass ``--ontology PATH`` to point at a specific
-ontology file instead. The ``gm compile`` and ``gm import-owl`` commands
-referenced elsewhere will be wired up when their modules land.
+dispatches to the matching loader. ``gm compile`` takes a binding YAML
+and emits the corresponding ``CREATE PROPERTY GRAPH`` DDL on stdout
+(or to ``-o PATH``). Both commands resolve a binding's companion
+ontology by auto-discovering ``<name>.ontology.yaml`` next to the
+binding; ``--ontology PATH`` overrides that lookup.
 
 Exit codes:
 
   0 — success
   1 — validation / compilation error
-  2 — usage error (bad flag, missing file, missing companion ontology)
+  2 — usage error (bad flag, missing file, missing companion ontology,
+      compile invoked on a non-binding file)
   3 — internal error
 """
 
@@ -42,12 +43,15 @@ import yaml
 
 from .binding_loader import load_binding
 from .binding_loader import load_binding_from_string
+from .binding_models import Binding
+from .compiler import compile_graph
 from .loader import load_ontology
 from .loader import load_ontology_from_string
+from .ontology_models import Ontology
 
 app = typer.Typer(
     name="gm",
-    help="Graph-model CLI. Currently supports: validate.",
+    help="Graph-model CLI. Commands: validate, compile.",
     add_completion=False,
     no_args_is_help=True,
 )
@@ -269,20 +273,160 @@ def validate(
   # Success: nothing on stdout.
 
 
+# --------------------------------------------------------------------- #
+# gm compile                                                             #
+# --------------------------------------------------------------------- #
+
+
+@app.command("compile")
+def compile_command(
+    file: Path = typer.Argument(
+        ...,
+        help="Path to a binding YAML file.",
+    ),
+    ontology_path: Path = typer.Option(
+        None,
+        "--ontology",
+        help=(
+            "Path to the companion ontology YAML. Defaults to "
+            "<ontology>.ontology.yaml next to the binding."
+        ),
+    ),
+    output_path: Path = typer.Option(
+        None,
+        "-o",
+        "--output",
+        help=(
+            "Write DDL to this file instead of stdout. The file is "
+            "overwritten if it already exists."
+        ),
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON errors on stderr.",
+    ),
+) -> None:
+  """Compile a binding to BigQuery ``CREATE PROPERTY GRAPH`` DDL.
+
+  On success, writes the DDL to stdout (or to ``--output PATH`` if
+  provided) and exits 0 with nothing on stderr. On any failure,
+  structured errors land on stderr and the DDL is not written.
+
+  The input must be a binding YAML file. Ontology files cannot be
+  compiled on their own (they're backend-neutral; they need a
+  binding to pick up physical tables and columns).
+  """
+  if not file.exists() or not file.is_file():
+    _emit_errors(
+        [
+            {
+                "file": str(file),
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-file",
+                "severity": "error",
+                "message": f"File not found: {file}",
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+
+  text = file.read_text(encoding="utf-8")
+  try:
+    kind = _detect_kind(text)
+  except yaml.YAMLError as exc:
+    _emit_errors(
+        _collect_errors(str(file), exc, kind="binding"),
+        as_json=json_output,
+    )
+    raise typer.Exit(code=1)
+
+  if kind != "binding":
+    # Ontology-only compile isn't meaningful (there's no physical
+    # mapping to emit). Reject with a usage-level error instead of
+    # silently falling through to something that can't work. Message
+    # depends on whether we at least recognized the file as an
+    # ontology — if so the user has a clear fix (point at the
+    # binding), otherwise they need to learn the file-kind contract.
+    if kind == "ontology":
+      message = "gm compile requires a binding file; got an ontology."
+    else:
+      message = (
+          "gm compile requires a binding file (top-level "
+          "'binding:'); got neither an ontology nor a binding."
+      )
+    _emit_errors(
+        [
+            {
+                "file": str(file),
+                "line": 0,
+                "col": 0,
+                "rule": "cli-wrong-kind",
+                "severity": "error",
+                "message": message,
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+
+  ontology, binding = _load_ontology_and_binding(
+      file, ontology_path=ontology_path, json_output=json_output
+  )
+
+  try:
+    ddl = compile_graph(ontology, binding)
+  except ValueError as exc:
+    # compile_graph raises ValueError for compile-time rule violations
+    # (extends, derived cycles). Route with a ``compile-validation``
+    # rule so downstream tooling can distinguish these from
+    # binding/ontology loader errors, even though they're all in the
+    # same exit-1 bucket.
+    _emit_errors(
+        _collect_errors(str(file), exc, kind="compile"),
+        as_json=json_output,
+    )
+    raise typer.Exit(code=1)
+  except Exception as exc:  # pragma: no cover - defensive
+    typer.echo(f"internal error: {exc}", err=True)
+    raise typer.Exit(code=3)
+
+  # Write the DDL. The string already ends in ``\n`` so neither branch
+  # adds another one.
+  if output_path is not None:
+    output_path.write_text(ddl, encoding="utf-8")
+  else:
+    typer.echo(ddl, nl=False)
+
+
 def _validate_binding_file(
     file: Path,
     *,
     ontology_path: Path | None,
     json_output: bool,
 ) -> None:
-  """Dispatch to the binding loader.
+  """Validate a binding file. Thin wrapper: load pair and discard."""
+  _load_ontology_and_binding(
+      file, ontology_path=ontology_path, json_output=json_output
+  )
+  # Success: nothing on stdout.
 
-  The CLI resolves and loads the companion ontology itself rather than
-  letting ``load_binding`` auto-discover, because otherwise an error
-  surfaced inside the ontology file (e.g. a bad key reference) would
-  bubble out of ``load_binding`` as a generic ``ValueError`` and get
-  reported with ``file=<binding>`` and ``rule=binding-validation`` —
-  misleading, since the real fault is in the ontology.
+
+def _load_ontology_and_binding(
+    file: Path,
+    *,
+    ontology_path: Path | None,
+    json_output: bool,
+) -> tuple[Ontology, Binding]:
+  """Resolve, load, and return both sides of a binding + ontology pair.
+
+  Shared by ``gm validate`` and ``gm compile``. The CLI resolves the
+  companion ontology itself (rather than letting ``load_binding``
+  auto-discover) so that errors surfaced inside the ontology file are
+  reported against the ontology path with ``rule=ontology-validation``
+  — not masked as a binding error.
 
   Resolution order:
 
@@ -297,13 +441,17 @@ def _validate_binding_file(
       with ``file`` set to the ontology path (exit 1).
     - Binding parse/shape/validation error → tagged ``kind=binding``
       with ``file`` set to the binding path (exit 1).
+
+  Returns the pair on success. Any failure calls ``_emit_errors`` and
+  raises ``typer.Exit`` — callers never see a partial result.
   """
   text = file.read_text(encoding="utf-8")
 
-  # If the caller didn't supply --ontology, try to compute the companion
-  # path from the binding itself. A failed peek (malformed YAML, or no
-  # parseable ontology name) leaves ``ontology_path`` as None; the binding
-  # loader below will then surface the real shape/parse error.
+  # Peek at the binding to compute the companion path, unless the
+  # caller supplied --ontology. A failed peek (malformed YAML, or no
+  # parseable ontology name) leaves ``ontology_path`` as None; we
+  # then defer to ``load_binding`` below to surface the real binding
+  # error with proper kind-tagging.
   discovered_via_peek = False
   peeked_name: str | None = None
   if ontology_path is None:
@@ -312,73 +460,73 @@ def _validate_binding_file(
       ontology_path = file.parent / f"{peeked_name}.ontology.yaml"
       discovered_via_peek = True
 
-  ontology = None
-  if ontology_path is not None:
-    if (
-        not ontology_path.exists()
-        or not ontology_path.is_file()
-        or not os.access(ontology_path, os.R_OK)
-    ):
-      # Auto-discovery and explicit-flag paths get distinct messages —
-      # the former explains *why* we looked where we did, the latter
-      # simply reports what the user asked us to open.
-      if discovered_via_peek:
-        message = (
-            f"Binding references ontology {peeked_name!r}, "
-            f"but no companion ontology file found at {ontology_path}."
-        )
-      else:
-        message = f"Ontology file not found: {ontology_path}"
+  if ontology_path is None:
+    try:
+      load_binding(file)
+    except FileNotFoundError as exc:
       _emit_errors(
           [
               {
-                  "file": str(ontology_path)
-                  if not discovered_via_peek
-                  else str(file),
+                  "file": str(file),
                   "line": 0,
                   "col": 0,
                   "rule": "cli-missing-ontology",
                   "severity": "error",
-                  "message": message,
+                  "message": str(exc),
               }
           ],
           as_json=json_output,
       )
       raise typer.Exit(code=2)
-    try:
-      ontology = load_ontology(ontology_path)
     except (ValueError, ValidationError, yaml.YAMLError) as exc:
       _emit_errors(
-          _collect_errors(str(ontology_path), exc, kind="ontology"),
+          _collect_errors(str(file), exc, kind="binding"),
           as_json=json_output,
       )
       raise typer.Exit(code=1)
+    # If load_binding somehow succeeded without a peek path, the
+    # caller lost the ontology object. Defensive: should not happen.
+    raise typer.Exit(code=3)  # pragma: no cover
 
-  try:
-    if ontology is not None:
-      load_binding_from_string(text, ontology=ontology)
+  if not ontology_path.exists() or not ontology_path.is_file():
+    # Auto-discovery and explicit-flag paths get distinct messages —
+    # the former explains *why* we looked where we did, the latter
+    # simply reports what the user asked us to open.
+    if discovered_via_peek:
+      message = (
+          f"Binding references ontology {_peek_ontology_name(text)!r}, "
+          f"but no companion ontology file found at {ontology_path}."
+      )
+      reported_file = str(file)
     else:
-      # Peek failed — defer to load_binding so the underlying yaml /
-      # pydantic error surfaces directly against the binding file.
-      load_binding(file)
-  except FileNotFoundError as exc:
-    # Only reachable when ``ontology is None`` (peek failed), and
-    # ``load_binding``'s own discovery then raised. Treat the same as
-    # the peek-found-but-missing case.
+      message = f"Ontology file not found: {ontology_path}"
+      reported_file = str(ontology_path)
     _emit_errors(
         [
             {
-                "file": str(file),
+                "file": reported_file,
                 "line": 0,
                 "col": 0,
                 "rule": "cli-missing-ontology",
                 "severity": "error",
-                "message": str(exc),
+                "message": message,
             }
         ],
         as_json=json_output,
     )
     raise typer.Exit(code=2)
+
+  try:
+    ontology = load_ontology(ontology_path)
+  except (ValueError, ValidationError, yaml.YAMLError) as exc:
+    _emit_errors(
+        _collect_errors(str(ontology_path), exc, kind="ontology"),
+        as_json=json_output,
+    )
+    raise typer.Exit(code=1)
+
+  try:
+    binding = load_binding_from_string(text, ontology=ontology)
   except (ValueError, ValidationError, yaml.YAMLError) as exc:
     _emit_errors(
         _collect_errors(str(file), exc, kind="binding"),
@@ -388,7 +536,8 @@ def _validate_binding_file(
   except Exception as exc:  # pragma: no cover - defensive
     typer.echo(f"internal error: {exc}", err=True)
     raise typer.Exit(code=3)
-  # Success: nothing on stdout.
+
+  return ontology, binding
 
 
 def _peek_ontology_name(binding_text: str) -> str | None:

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -176,10 +176,11 @@ def _detect_kind(text: str) -> str:
 
 @app.command("validate")
 def validate(
-    # Existence/readability are validated inside the command (not via
-    # ``exists=True``) so that ``--json`` can produce a structured error
-    # instead of falling through to Typer's human usage text.
-    file: Path = typer.Argument(
+    # Type is ``str`` rather than ``Path`` because Typer maps
+    # ``pathlib.Path`` to ``click.Path(readable=True)``, which
+    # pre-validates readability and emits human usage text on failure —
+    # bypassing ``--json`` structured output.
+    file: str = typer.Argument(
         ...,
         help="Path to an ontology or binding YAML file.",
     ),
@@ -188,10 +189,7 @@ def validate(
         "--json",
         help="Emit structured JSON errors on stderr.",
     ),
-    # Type is ``str | None`` rather than ``Path | None`` because Typer
-    # maps ``pathlib.Path`` to ``TyperPath(readable=True)``, which
-    # pre-validates readability and emits human usage text on failure —
-    # bypassing ``--json`` structured output.
+    # Same ``str`` rationale as ``file`` above.
     ontology_path: str | None = typer.Option(
         None,
         "--ontology",
@@ -202,11 +200,12 @@ def validate(
     ),
 ) -> None:
   """Validate a single ontology or binding YAML file."""
-  if not file.exists() or not file.is_file():
+  file_path = Path(file)
+  if not file_path.exists() or not file_path.is_file():
     _emit_errors(
         [
             {
-                "file": str(file),
+                "file": file,
                 "line": 0,
                 "col": 0,
                 "rule": "cli-missing-file",
@@ -217,8 +216,23 @@ def validate(
         as_json=json_output,
     )
     raise typer.Exit(code=2)
+  if not os.access(file_path, os.R_OK):
+    _emit_errors(
+        [
+            {
+                "file": file,
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-file",
+                "severity": "error",
+                "message": f"File not readable: {file}",
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
 
-  text = file.read_text(encoding="utf-8")
+  text = file_path.read_text(encoding="utf-8")
   try:
     kind = _detect_kind(text)
   except yaml.YAMLError as exc:
@@ -236,7 +250,7 @@ def validate(
         Path(ontology_path) if ontology_path is not None else None
     )
     _validate_binding_file(
-        file, ontology_path=resolved_ontology, json_output=json_output
+        file_path, ontology_path=resolved_ontology, json_output=json_output
     )
     return
 
@@ -280,11 +294,13 @@ def validate(
 
 @app.command("compile")
 def compile_command(
-    file: Path = typer.Argument(
+    # All path params use ``str`` (not ``Path``) so Typer does not
+    # pre-validate readability and bypass ``--json`` structured output.
+    file: str = typer.Argument(
         ...,
         help="Path to a binding YAML file.",
     ),
-    ontology_path: Path = typer.Option(
+    ontology_path: str | None = typer.Option(
         None,
         "--ontology",
         help=(
@@ -292,7 +308,7 @@ def compile_command(
             "<ontology>.ontology.yaml next to the binding."
         ),
     ),
-    output_path: Path = typer.Option(
+    output_path: str | None = typer.Option(
         None,
         "-o",
         "--output",
@@ -317,11 +333,12 @@ def compile_command(
   compiled on their own (they're backend-neutral; they need a
   binding to pick up physical tables and columns).
   """
-  if not file.exists() or not file.is_file():
+  file_path = Path(file)
+  if not file_path.exists() or not file_path.is_file():
     _emit_errors(
         [
             {
-                "file": str(file),
+                "file": file,
                 "line": 0,
                 "col": 0,
                 "rule": "cli-missing-file",
@@ -332,24 +349,33 @@ def compile_command(
         as_json=json_output,
     )
     raise typer.Exit(code=2)
+  if not os.access(file_path, os.R_OK):
+    _emit_errors(
+        [
+            {
+                "file": file,
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-file",
+                "severity": "error",
+                "message": f"File not readable: {file}",
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
 
-  text = file.read_text(encoding="utf-8")
+  text = file_path.read_text(encoding="utf-8")
   try:
     kind = _detect_kind(text)
   except yaml.YAMLError as exc:
     _emit_errors(
-        _collect_errors(str(file), exc, kind="binding"),
+        _collect_errors(file, exc, kind="binding"),
         as_json=json_output,
     )
     raise typer.Exit(code=1)
 
   if kind != "binding":
-    # Ontology-only compile isn't meaningful (there's no physical
-    # mapping to emit). Reject with a usage-level error instead of
-    # silently falling through to something that can't work. Message
-    # depends on whether we at least recognized the file as an
-    # ontology — if so the user has a clear fix (point at the
-    # binding), otherwise they need to learn the file-kind contract.
     if kind == "ontology":
       message = "gm compile requires a binding file; got an ontology."
     else:
@@ -360,7 +386,7 @@ def compile_command(
     _emit_errors(
         [
             {
-                "file": str(file),
+                "file": file,
                 "line": 0,
                 "col": 0,
                 "rule": "cli-wrong-kind",
@@ -372,20 +398,18 @@ def compile_command(
     )
     raise typer.Exit(code=2)
 
+  resolved_ontology = (
+      Path(ontology_path) if ontology_path is not None else None
+  )
   ontology, binding = _load_ontology_and_binding(
-      file, ontology_path=ontology_path, json_output=json_output
+      file_path, ontology_path=resolved_ontology, json_output=json_output
   )
 
   try:
     ddl = compile_graph(ontology, binding)
   except ValueError as exc:
-    # compile_graph raises ValueError for compile-time rule violations
-    # (extends, derived cycles). Route with a ``compile-validation``
-    # rule so downstream tooling can distinguish these from
-    # binding/ontology loader errors, even though they're all in the
-    # same exit-1 bucket.
     _emit_errors(
-        _collect_errors(str(file), exc, kind="compile"),
+        _collect_errors(file, exc, kind="compile"),
         as_json=json_output,
     )
     raise typer.Exit(code=1)
@@ -393,10 +417,25 @@ def compile_command(
     typer.echo(f"internal error: {exc}", err=True)
     raise typer.Exit(code=3)
 
-  # Write the DDL. The string already ends in ``\n`` so neither branch
-  # adds another one.
   if output_path is not None:
-    output_path.write_text(ddl, encoding="utf-8")
+    resolved_output = Path(output_path)
+    try:
+      resolved_output.write_text(ddl, encoding="utf-8")
+    except (FileNotFoundError, PermissionError) as exc:
+      _emit_errors(
+          [
+              {
+                  "file": str(resolved_output),
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-output-error",
+                  "severity": "error",
+                  "message": f"Cannot write output file: {exc}",
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=1)
   else:
     typer.echo(ddl, nl=False)
 
@@ -488,7 +527,11 @@ def _load_ontology_and_binding(
     # caller lost the ontology object. Defensive: should not happen.
     raise typer.Exit(code=3)  # pragma: no cover
 
-  if not ontology_path.exists() or not ontology_path.is_file():
+  if (
+      not ontology_path.exists()
+      or not ontology_path.is_file()
+      or not os.access(ontology_path, os.R_OK)
+  ):
     # Auto-discovery and explicit-flag paths get distinct messages —
     # the former explains *why* we looked where we did, the latter
     # simply reports what the user asked us to open.

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -712,6 +712,71 @@ def test_compile_missing_companion_ontology_is_usage_error(tmp_path):
   assert result.output == expected
 
 
+def test_compile_unreadable_file_with_json_emits_structured_json(tmp_path):
+  spec = tmp_path / "locked.binding.yaml"
+  spec.write_text("binding: x\n", encoding="utf-8")
+  spec.chmod(0o000)
+
+  result = _RUNNER.invoke(app, ["compile", str(spec), "--json"])
+
+  assert result.exit_code == 2
+  assert "cli-missing-file" in result.output
+
+
+def test_compile_unreadable_ontology_with_json_emits_structured_json(tmp_path):
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  unreadable = tmp_path / "locked.ontology.yaml"
+  unreadable.write_text("ontology: tiny\n", encoding="utf-8")
+  unreadable.chmod(0o000)
+
+  result = _RUNNER.invoke(
+      app,
+      ["compile", str(binding), "--ontology", str(unreadable), "--json"],
+  )
+
+  assert result.exit_code == 2
+  assert "cli-missing-ontology" in result.output
+
+
+def test_compile_output_to_nonexistent_dir_emits_structured_error(tmp_path):
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  bad_output = tmp_path / "no" / "such" / "dir" / "out.sql"
+
+  result = _RUNNER.invoke(
+      app, ["compile", str(binding), "-o", str(bad_output)]
+  )
+
+  assert result.exit_code == 1
+  assert "cli-output-error" in result.output
+
+
+def test_compile_output_to_nonexistent_dir_json_emits_structured_json(
+    tmp_path,
+):
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  bad_output = tmp_path / "no" / "such" / "dir" / "out.sql"
+
+  result = _RUNNER.invoke(
+      app, ["compile", str(binding), "-o", str(bad_output), "--json"]
+  )
+
+  assert result.exit_code == 1
+  assert "cli-output-error" in result.output
+
+
+def test_validate_unreadable_file_with_json_emits_structured_json(tmp_path):
+  spec = tmp_path / "locked.ontology.yaml"
+  spec.write_text("ontology: tiny\n", encoding="utf-8")
+  spec.chmod(0o000)
+
+  result = _RUNNER.invoke(app, ["validate", str(spec), "--json"])
+
+  assert result.exit_code == 2
+  assert "cli-missing-file" in result.output
+
+
 def test_validate_missing_file_with_json_emits_structured_json(tmp_path):
   missing = tmp_path / "does-not-exist.ontology.yaml"
 

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -460,6 +460,258 @@ def test_validate_missing_file_emits_structured_error(tmp_path):
   assert result.output == expected
 
 
+# --------------------------------------------------------------------- #
+# gm compile                                                             #
+# --------------------------------------------------------------------- #
+#
+# ``gm compile`` reuses the binding-plus-ontology loading path that
+# ``gm validate`` set up, so most of the failure modes (missing
+# companion, broken companion ontology, binding shape/semantic errors)
+# are guaranteed-equivalent by construction and aren't re-tested here.
+# The compile-specific surface the tests below pin:
+#
+#   - Happy path writes the exact DDL the compiler emits to stdout.
+#   - ``-o PATH`` routes the DDL to a file and leaves stdout empty.
+#   - Compile-time rule violations (an entity with ``extends``) route
+#     through ``rule=compile-validation``, distinguishing them from
+#     loader-level binding/ontology errors.
+#   - An ontology file passed to ``gm compile`` is a usage error —
+#     you can't compile without a physical mapping.
+
+
+_COMPILE_ONTOLOGY = """
+  ontology: tiny
+  entities:
+    - name: Thing
+      keys: {primary: [id]}
+      properties:
+        - {name: id, type: string}
+        - {name: label, type: string}
+"""
+
+_COMPILE_BINDING = """
+  binding: tiny-bq-prod
+  ontology: tiny
+  target: {backend: bigquery, project: p, dataset: d}
+  entities:
+    - name: Thing
+      source: raw.things
+      properties:
+        - {name: id, column: thing_id}
+        - {name: label, column: display}
+"""
+
+# The exact DDL the compiler produces for the fixture pair above.
+# Kept in sync with the emitter's formatting rules; any change to the
+# compiler's output shape will fail this test and the golden in
+# ``test_compiler.py`` simultaneously — that's deliberate.
+_COMPILE_EXPECTED_DDL = textwrap.dedent(
+    """\
+    CREATE PROPERTY GRAPH tiny
+      NODE TABLES (
+        raw.things AS Thing
+          KEY (thing_id)
+          LABEL Thing PROPERTIES (thing_id AS id, display AS label)
+      );
+    """
+)
+
+
+def test_compile_binding_writes_ddl_to_stdout(tmp_path):
+  # Happy path: drop a binding and its companion ontology into the
+  # same directory, run ``gm compile``, expect the exact DDL on
+  # stdout with exit 0 and nothing on stderr.
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(app, ["compile", str(binding)])
+
+  assert result.exit_code == 0
+  assert result.output == _COMPILE_EXPECTED_DDL
+
+
+def test_compile_binding_with_output_flag_writes_file_and_no_stdout(tmp_path):
+  # ``-o PATH`` should land the DDL in the named file and leave
+  # stdout empty — important so the command is pipeable into build
+  # systems that redirect stdout but care about exit codes.
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  out_path = tmp_path / "out.sql"
+
+  result = _RUNNER.invoke(
+      app, ["compile", str(binding), "-o", str(out_path)]
+  )
+
+  assert result.exit_code == 0
+  assert result.output == ""
+  assert out_path.read_text(encoding="utf-8") == _COMPILE_EXPECTED_DDL
+
+
+def test_compile_binding_with_explicit_ontology_flag(tmp_path):
+  # Mirror of the validate test: stash the ontology where
+  # auto-discovery can't find it, pass it explicitly, and confirm
+  # the DDL comes through.
+  sibling = tmp_path / "sibling"
+  sibling.mkdir()
+  ontology = _write(sibling, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(
+      app, ["compile", str(binding), "--ontology", str(ontology)]
+  )
+
+  assert result.exit_code == 0
+  assert result.output == _COMPILE_EXPECTED_DDL
+
+
+def test_compile_routes_compile_time_errors_with_compile_validation_rule(
+    tmp_path,
+):
+  # A binding can be loader-valid but still fail at compile time —
+  # the canonical case is an ontology that uses ``extends``, which
+  # v0 compile rejects. These errors must be tagged
+  # ``rule=compile-validation`` (not ``binding-validation`` or
+  # ``ontology-validation``) so tooling can tell them apart.
+  _write(
+      tmp_path,
+      "tiny.ontology.yaml",
+      """
+      ontology: tiny
+      entities:
+        - name: Parent
+          keys: {primary: [id]}
+          properties: [{name: id, type: string}]
+        - name: Child
+          extends: Parent
+          properties: []
+      """,
+  )
+  binding = _write(
+      tmp_path,
+      "tiny.binding.yaml",
+      """
+      binding: b
+      ontology: tiny
+      target: {backend: bigquery, project: p, dataset: d}
+      entities:
+        - name: Parent
+          source: t
+          properties: [{name: id, column: id}]
+      """,
+  )
+
+  result = _RUNNER.invoke(app, ["compile", str(binding)])
+
+  expected = (
+      f"{binding}:0:0: compile-validation \u2014 Entity 'Child' uses "
+      "'extends'; v0 compilation does not support inheritance.\n"
+  )
+  assert result.exit_code == 1
+  assert result.output == expected
+
+
+def test_compile_on_ontology_file_is_usage_error(tmp_path):
+  # Passing an ontology file to ``gm compile`` is nonsensical — an
+  # ontology alone has no physical mapping. Fail fast (exit 2) with
+  # a clear message rather than accepting the file and then dying
+  # deep inside the loader.
+  ontology = _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+
+  result = _RUNNER.invoke(app, ["compile", str(ontology)])
+
+  expected = (
+      f"{ontology}:0:0: cli-wrong-kind \u2014 "
+      "gm compile requires a binding file; got an ontology.\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
+def test_compile_missing_binding_file_is_usage_error(tmp_path):
+  # Same surface as ``gm validate`` for a missing input, kept as a
+  # sanity test so the compile command doesn't accidentally skip
+  # the existence check.
+  missing = tmp_path / "nope.binding.yaml"
+
+  result = _RUNNER.invoke(app, ["compile", str(missing)])
+
+  expected = (
+      f"{missing}:0:0: cli-missing-file \u2014 File not found: {missing}\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
+def test_compile_json_error_output_uses_compile_validation_rule(tmp_path):
+  # ``--json`` for compile errors flows through the same emitter as
+  # validate, so the routing is inherited; this test pins that the
+  # rule prefix survives into the JSON payload unchanged.
+  _write(
+      tmp_path,
+      "tiny.ontology.yaml",
+      """
+      ontology: tiny
+      entities:
+        - name: Parent
+          keys: {primary: [id]}
+          properties: [{name: id, type: string}]
+        - name: Child
+          extends: Parent
+          properties: []
+      """,
+  )
+  binding = _write(
+      tmp_path,
+      "tiny.binding.yaml",
+      """
+      binding: b
+      ontology: tiny
+      target: {backend: bigquery, project: p, dataset: d}
+      entities:
+        - name: Parent
+          source: t
+          properties: [{name: id, column: id}]
+      """,
+  )
+
+  result = _RUNNER.invoke(app, ["compile", str(binding), "--json"])
+
+  expected = textwrap.dedent(
+      f"""\
+      [
+        {{
+          "file": "{binding}",
+          "line": 0,
+          "col": 0,
+          "rule": "compile-validation",
+          "severity": "error",
+          "message": "Entity 'Child' uses 'extends'; v0 compilation does not support inheritance."
+        }}
+      ]
+      """
+  )
+  assert result.exit_code == 1
+  assert result.output == expected
+
+
+def test_compile_missing_companion_ontology_is_usage_error(tmp_path):
+  # Regression guard shared with validate: the compile command must
+  # also surface cli-missing-ontology (not a generic binding error)
+  # when the companion is absent, with the same message format.
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(app, ["compile", str(binding)])
+
+  expected_path = tmp_path / "tiny.ontology.yaml"
+  expected = (
+      f"{binding}:0:0: cli-missing-ontology \u2014 Binding references "
+      f"ontology 'tiny', but no companion ontology file found at "
+      f"{expected_path}.\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
 def test_validate_missing_file_with_json_emits_structured_json(tmp_path):
   missing = tmp_path / "does-not-exist.ontology.yaml"
 


### PR DESCRIPTION
Stacks on #19 (which stacks on #18 → #17 → #16). Review this PR's diff against \`feat/compile\` to isolate the CLI changes.

## Summary
Wires \`compile_graph\` into the CLI. Closes the happy-path arc: YAML source → validated objects → emitted DDL, all reachable from one binary.

\`\`\`
gm compile <binding.yaml> [--ontology PATH] [-o OUT_PATH] [--json]
\`\`\`

On success the DDL goes to stdout (or to \`-o PATH\`) and stderr is empty. On failure, structured errors land on stderr in the same shape \`gm validate\` already uses.

## What's new

- **Shared loader extracted.** \`_load_ontology_and_binding(file, ontology_path, json_output) -> (Ontology, Binding)\` now owns the companion-ontology resolution, ontology-side error routing, and binding-side error routing. Both \`gm validate\` and \`gm compile\` call through it. Validate becomes a thin load-and-discard wrapper; compile takes the pair and calls \`compile_graph\`.
- **New rule prefix \`compile-validation\`.** \`compile_graph\`'s \`ValueError\`s (inheritance rejection, derived cycles) surface with this prefix, distinct from \`binding-validation\` / \`ontology-validation\` so tooling can tell compile-time rule violations from loader violations.
- **New usage error \`cli-wrong-kind\` (exit 2).** \`gm compile\` invoked on an ontology file or unknown-kind YAML gets rejected up front with a clear message — you can't compile an ontology alone because there's no physical mapping to emit.

## Error routing summary (compile)

| Scenario                                       | rule                    | exit |
|------------------------------------------------|-------------------------|------|
| Binding file missing                           | \`cli-missing-file\`      | 2    |
| Input is an ontology or unknown-kind YAML      | \`cli-wrong-kind\`        | 2    |
| Companion ontology missing (auto-discovery)    | \`cli-missing-ontology\`  | 2    |
| \`--ontology PATH\` points at missing file       | \`cli-missing-ontology\`  | 2    |
| Ontology file has validation errors            | \`ontology-validation\`   | 1    |
| Binding has shape / semantic errors            | \`binding-validation\`    | 1    |
| Compile-time rule violation (extends, cycles)  | \`compile-validation\`    | 1    |
| Malformed YAML                                 | \`yaml-parse\`            | 1    |

## Test plan
- [x] \`uv run --with pytest python -m pytest tests/bigquery_ontology -q\` — 88 passed
- [x] Happy path: DDL written to stdout matches the compiler's exact output
- [x] \`-o PATH\`: DDL written to file, stdout empty
- [x] \`--ontology PATH\`: override works when auto-discovery can't find the companion
- [x] Compile-time error (entity \`extends\`) routed with \`compile-validation\` rule, plain output
- [x] Compile-time error with \`--json\` keeps the \`compile-validation\` prefix in the JSON payload
- [x] Ontology file passed to \`gm compile\` rejected with \`cli-wrong-kind\`
- [x] Missing binding file surfaces \`cli-missing-file\`
- [x] Missing companion ontology surfaces \`cli-missing-ontology\` (regression guard for the shared loader)
- [x] All 11 pre-existing \`gm validate\` tests still pass after the refactor