### PR TITLE
feat: batch_load materializer + deterministic V5 demo notebook

### DIFF
--- a/examples/ontology_graph_v5_demo.ipynb
+++ b/examples/ontology_graph_v5_demo.ipynb
@@ -787,6 +787,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "note_ai_variance",
+   "metadata": {},
+   "source": [
+    "### Operational Note: AI Extraction Variance\n",
+    "\n",
+    "The unstructured portion of this demo still relies on `AI.GENERATE`. That means extraction quality\n",
+    "can vary across models, prompts, and source traces.\n",
+    "\n",
+    "The demo is stable because:\n",
+    "- deterministic structured extractors handle known event types first\n",
+    "- the notebook uses controlled fixtures and isolated scratch targets\n",
+    "- schema filtering drops extra AI-emitted fields before materialization\n",
+    "\n",
+    "For real telemetry, treat AI-extracted graph content as model-dependent output rather than a\n",
+    "strictly deterministic parse.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "cell18",
@@ -1062,6 +1081,23 @@
     "\n",
     "We create a synthetic \"Session B\" with a modified `sup_YahooAdUnit` to demonstrate\n",
     "cross-session lineage detection without requiring a second real extraction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "note_synthetic_lineage",
+   "metadata": {},
+   "source": [
+    "### Demo Note: Synthetic Lineage Input\n",
+    "\n",
+    "The lineage walkthrough below uses a synthetic follow-up session that reuses a known `adUnitId` with modified properties.\n",
+    "\n",
+    "This is intentional for demo determinism: it proves the end-to-end V5 lineage path\n",
+    "(`detect_lineage_edges` → materialization → `compile_lineage_gql` → BigQuery query execution)\n",
+    "without depending on real telemetry sessions having overlapping entity keys.\n",
+    "\n",
+    "In production data, lineage edges will only appear when multiple sessions extract the same entity\n",
+    "primary key and at least one tracked property changes.\n"
    ]
   },
   {
@@ -1484,7 +1520,9 @@
     "**Limitations:**\n",
     "- The lineage demo uses a synthetic Session B; real lineage requires multiple real sessions.\n",
     "- GQL query results depend on the actual data extracted from your ADK telemetry.\n",
-    "- The scratch dataset auto-expires tables after 1 hour, but explicit cleanup is still recommended."
+    "- The scratch dataset auto-expires tables after 1 hour, but explicit cleanup is still recommended.",
+    "\n",
+    "This notebook demonstrates the V5 feature path end to end; it is a deterministic demo, not a proof that current real-world telemetry always yields lineage overlap or perfectly stable AI extraction.\n"
    ]
   }
  ],

--- a/examples/ontology_graph_v5_demo.ipynb
+++ b/examples/ontology_graph_v5_demo.ipynb
@@ -3,13 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7164e6b7",
+   "id": "cell01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:45.218768Z",
-     "iopub.status.busy": "2026-04-13T23:32:45.218521Z",
-     "iopub.status.idle": "2026-04-13T23:32:45.224647Z",
-     "shell.execute_reply": "2026-04-13T23:32:45.223757Z"
+     "iopub.execute_input": "2026-04-14T05:51:00.557503Z",
+     "iopub.status.busy": "2026-04-14T05:51:00.557271Z",
+     "iopub.status.idle": "2026-04-14T05:51:00.561760Z",
+     "shell.execute_reply": "2026-04-14T05:51:00.560983Z"
     }
    },
    "outputs": [],
@@ -31,12 +31,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2a3cd83",
+   "id": "cell02",
    "metadata": {},
    "source": [
     "# Context Graph V5: TTL Import, Mixed Extraction, Temporal Lineage\n",
     "\n",
-    "**Extending the BigQuery Agent Analytics SDK with OWL Import, Structured Extractors, and Cross-Session Lineage**\n",
+    "**End-to-end demo of the V5 pipeline: OWL/TTL import, structured + AI extraction,\n",
+    "batch materialization with status reporting, and cross-session lineage queries.**\n",
     "\n",
     "<table align=\"left\">\n",
     "  <td>\n",
@@ -59,37 +60,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0782b337",
+   "id": "cell03",
    "metadata": {},
    "source": [
     "## Overview\n",
     "\n",
     "The **Context Graph V5** pipeline extends V4 with three new capabilities:\n",
     "\n",
-    "1. **OWL/Turtle Import** -- A two-phase importer (`ttl_import` + `ttl_resolve`) that parses\n",
-    "   OWL/Turtle ontology files via `rdflib`, maps OWL classes and properties to the GraphSpec\n",
-    "   YAML format, and produces a clean spec with `FILL_IN` placeholders resolved by the user.\n",
-    "   This bridges existing ontology standards (OWL 2, RDFS) into the configuration-driven pipeline.\n",
+    "1. **TTL/OWL Import** -- bootstrap an ontology spec from an existing OWL/Turtle file,\n",
+    "   then resolve placeholder keys interactively.\n",
+    "2. **Mixed Extraction** -- combine deterministic structured extractors (e.g., BKA decision\n",
+    "   events) with AI-based extraction for the remaining telemetry.\n",
+    "3. **Temporal Lineage** -- detect property changes on shared-key entities across sessions\n",
+    "   and materialize cross-session lineage edges queryable via GQL.\n",
     "\n",
-    "2. **Structured Extraction** -- A typed extractor registry that converts known event types\n",
-    "   (e.g., `BKA_DECISION`) into `ExtractedNode`/`ExtractedEdge` instances deterministically,\n",
-    "   without AI. Extractors declare which spans they fully or partially handle, so downstream\n",
-    "   `AI.GENERATE` can skip already-covered data. This hybrid approach combines the precision of\n",
-    "   structured parsing with the flexibility of AI extraction.\n",
+    "Additional V5 improvements:\n",
     "\n",
-    "3. **Temporal Lineage** -- Cross-session entity evolution detection via `detect_lineage_edges`.\n",
-    "   When the same entity (matched by primary key) appears in multiple sessions with different\n",
-    "   property values, a lineage edge is created to track how it changed over time. A dedicated\n",
-    "   `compile_lineage_gql` helper generates GQL queries for traversing these evolution paths.\n",
-    "\n",
-    "Together, these features let you import an external ontology, extract graphs with mixed\n",
-    "structured+AI pipelines, and track how entities evolve across sessions -- all within the\n",
-    "same configuration-driven framework established in V4."
+    "- **`batch_load` write mode** -- uses `load_table_from_json` with staging tables for\n",
+    "  more reliable materialization with full status reporting.\n",
+    "- **`materialize_with_status()`** -- returns `MaterializationResult` with per-table\n",
+    "  `TableStatus` (cleanup status, insert status, idempotency flag).\n",
+    "- **Scratch datasets** with auto-expiring tables for safe, isolated demos."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "06f04244",
+   "id": "cell04",
    "metadata": {},
    "source": [
     "## Install Dependencies"
@@ -98,13 +94,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "59931a15",
+   "id": "cell05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:45.227281Z",
-     "iopub.status.busy": "2026-04-13T23:32:45.227116Z",
-     "iopub.status.idle": "2026-04-13T23:32:45.951060Z",
-     "shell.execute_reply": "2026-04-13T23:32:45.950221Z"
+     "iopub.execute_input": "2026-04-14T05:51:00.564140Z",
+     "iopub.status.busy": "2026-04-14T05:51:00.564010Z",
+     "iopub.status.idle": "2026-04-14T05:51:01.258177Z",
+     "shell.execute_reply": "2026-04-14T05:51:01.257497Z"
     }
    },
    "outputs": [
@@ -124,13 +120,7 @@
       "\u001b[0m\u001b[31mERROR: Could not find a version that satisfies the requirement bigquery-agent-analytics (from versions: none)\u001b[0m\u001b[31m\r\n",
       "\u001b[0m\r\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.0.1\u001b[0m\r\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/usr/local/opt/python@3.9/bin/python3.9 -m pip install --upgrade pip\u001b[0m\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/usr/local/opt/python@3.9/bin/python3.9 -m pip install --upgrade pip\u001b[0m\r\n",
       "\u001b[31mERROR: No matching distribution found for bigquery-agent-analytics\u001b[0m\u001b[31m\r\n",
       "\u001b[0m"
      ]
@@ -142,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38267c01",
+   "id": "cell06",
    "metadata": {},
    "source": [
     "## Authenticate & Configure"
@@ -151,13 +141,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6088bdf4",
+   "id": "cell07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:45.954156Z",
-     "iopub.status.busy": "2026-04-13T23:32:45.953986Z",
-     "iopub.status.idle": "2026-04-13T23:32:45.960729Z",
-     "shell.execute_reply": "2026-04-13T23:32:45.960172Z"
+     "iopub.execute_input": "2026-04-14T05:51:01.260594Z",
+     "iopub.status.busy": "2026-04-14T05:51:01.260428Z",
+     "iopub.status.idle": "2026-04-14T05:51:01.265400Z",
+     "shell.execute_reply": "2026-04-14T05:51:01.264969Z"
     }
    },
    "outputs": [
@@ -168,8 +158,7 @@
       "Not running in Colab -- using default credentials.\n",
       "Project  : test-project-0728-467323\n",
       "Dataset  : agent_analytics\n",
-      "Table    : agent_events\n",
-      "Env      : test-project-0728-467323.agent_analytics\n"
+      "Table    : agent_events\n"
      ]
     }
    ],
@@ -187,7 +176,6 @@
     "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"your-project-id\")\n",
     "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
     "TABLE_ID = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
-    "ENV = f\"{PROJECT_ID}.{DATASET_ID}\"\n",
     "\n",
     "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"true\"\n",
     "os.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\n",
@@ -195,40 +183,70 @@
     "\n",
     "print(f\"Project  : {PROJECT_ID}\")\n",
     "print(f\"Dataset  : {DATASET_ID}\")\n",
-    "print(f\"Table    : {TABLE_ID}\")\n",
-    "print(f\"Env      : {ENV}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b10cd998",
-   "metadata": {},
-   "source": [
-    "## Step 1: OWL/Turtle Import\n",
-    "\n",
-    "The V5 pipeline starts with an optional **two-phase OWL/Turtle import** that bridges existing\n",
-    "ontology standards into the GraphSpec YAML format.\n",
-    "\n",
-    "- **Phase 1 (`ttl_import`)**: Parses the `.ttl` file via `rdflib`, maps `owl:Class` to entities,\n",
-    "  `owl:DatatypeProperty` to typed properties, and `owl:ObjectProperty` to relationships. Where\n",
-    "  the OWL source lacks information (e.g., no `owl:hasKey`), the importer inserts `FILL_IN`\n",
-    "  placeholders and records each one in an `ImportReport`.\n",
-    "\n",
-    "- **Phase 2 (`ttl_resolve`)**: Reads the import artifact, substitutes `FILL_IN` placeholders\n",
-    "  with user-supplied defaults, strips the `ontology_import:` metadata block, validates the\n",
-    "  result against `load_graph_spec_from_string`, and returns clean GraphSpec YAML."
+    "print(f\"Table    : {TABLE_ID}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d2328157",
+   "id": "cell08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:45.962742Z",
-     "iopub.status.busy": "2026-04-13T23:32:45.962616Z",
-     "iopub.status.idle": "2026-04-13T23:32:45.967950Z",
-     "shell.execute_reply": "2026-04-13T23:32:45.967346Z"
+     "iopub.execute_input": "2026-04-14T05:51:01.266952Z",
+     "iopub.status.busy": "2026-04-14T05:51:01.266846Z",
+     "iopub.status.idle": "2026-04-14T05:51:04.035016Z",
+     "shell.execute_reply": "2026-04-14T05:51:04.033869Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scratch dataset: agent_analytics_v5_7e508241\n",
+      "Tables auto-expire in 1 hour\n"
+     ]
+    }
+   ],
+   "source": [
+    "import uuid\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "RUN_ID = uuid.uuid4().hex[:8]\n",
+    "SCRATCH_DATASET = f\"{DATASET_ID}_v5_{RUN_ID}\"\n",
+    "SCRATCH_ENV = f\"{PROJECT_ID}.{SCRATCH_DATASET}\"\n",
+    "\n",
+    "bq = bigquery.Client(project=PROJECT_ID)\n",
+    "ds = bigquery.Dataset(f\"{PROJECT_ID}.{SCRATCH_DATASET}\")\n",
+    "ds.default_table_expiration_ms = 3600000  # 1h TTL\n",
+    "bq.create_dataset(ds, exists_ok=True)\n",
+    "print(f\"Scratch dataset: {SCRATCH_DATASET}\")\n",
+    "print(f\"Tables auto-expire in 1 hour\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell09",
+   "metadata": {},
+   "source": [
+    "## Step 1: TTL Import\n",
+    "\n",
+    "Import an OWL/Turtle ontology file into a GraphSpec-compatible YAML artifact.\n",
+    "The `ttl_import` function reads the `.ttl` file, filters by namespace, and generates\n",
+    "a YAML spec with entities, relationships, properties, and primary keys derived from\n",
+    "`owl:hasKey` declarations. Classes without `owl:hasKey` get a `FILL_IN` placeholder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-14T05:51:04.038277Z",
+     "iopub.status.busy": "2026-04-14T05:51:04.037894Z",
+     "iopub.status.idle": "2026-04-14T05:51:04.045612Z",
+     "shell.execute_reply": "2026-04-14T05:51:04.044781Z"
     }
    },
    "outputs": [
@@ -241,13 +259,9 @@
     }
    ],
    "source": [
-    "# Write the YAMO sample OWL/Turtle ontology into the working directory\n",
-    "# so it is available regardless of how the notebook was launched.\n",
-    "\n",
     "TTL_PATH = \"yamo_sample.ttl\"\n",
     "\n",
-    "_YAMO_TTL = \"\"\"\\\n",
-    "@prefix owl:  <http://www.w3.org/2002/07/owl#> .\n",
+    "_TTL_CONTENT = \"\"\"@prefix owl:  <http://www.w3.org/2002/07/owl#> .\n",
     "@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
     "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
     "@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .\n",
@@ -334,22 +348,22 @@
     "  rdfs:range yamo:RejectionReason .\n",
     "\"\"\"\n",
     "\n",
-    "with open(TTL_PATH, \"w\") as _f:\n",
-    "    _f.write(_YAMO_TTL)\n",
+    "with open(TTL_PATH, \"w\") as f:\n",
+    "    f.write(_TTL_CONTENT)\n",
     "\n",
-    "print(f\"Wrote {TTL_PATH} ({len(_YAMO_TTL)} bytes)\")"
+    "print(f\"Wrote {TTL_PATH} ({len(_TTL_CONTENT)} bytes)\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "2a06d9a1",
+   "execution_count": 6,
+   "id": "cell11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:45.969629Z",
-     "iopub.status.busy": "2026-04-13T23:32:45.969524Z",
-     "iopub.status.idle": "2026-04-13T23:32:49.126720Z",
-     "shell.execute_reply": "2026-04-13T23:32:49.126166Z"
+     "iopub.execute_input": "2026-04-14T05:51:04.047610Z",
+     "iopub.status.busy": "2026-04-14T05:51:04.047446Z",
+     "iopub.status.idle": "2026-04-14T05:51:05.795709Z",
+     "shell.execute_reply": "2026-04-14T05:51:05.795251Z"
     }
    },
    "outputs": [
@@ -361,11 +375,9 @@
       "Classes mapped: 5\n",
       "Properties mapped: 9\n",
       "Relationships mapped: 2\n",
-      "\n",
-      "Placeholders (1):\n",
+      "Placeholders: 1\n",
       "  - entities[DecisionPoint].keys.primary: No owl:hasKey found; primary key must be specified.\n",
-      "\n",
-      "Type warnings (1):\n",
+      "Type warnings: 1\n",
       "  - budget: http://www.w3.org/2001/XMLSchema#decimal -> double\n"
      ]
     },
@@ -379,31 +391,34 @@
     }
    ],
    "source": [
-    "from bigquery_agent_analytics.ttl_importer import ttl_import, ttl_resolve\n",
+    "from bigquery_agent_analytics.ttl_importer import ttl_import\n",
     "\n",
-    "result = ttl_import(\"yamo_sample.ttl\", include_namespaces=[\"https://example.com/yamo#\"])\n",
+    "result = ttl_import(\n",
+    "    ttl_path=TTL_PATH,\n",
+    "    include_namespaces=[\"https://example.com/yamo#\"],\n",
+    ")\n",
     "print(\"=== Import Report ===\")\n",
     "print(f\"Classes mapped: {result.report.classes_mapped}\")\n",
     "print(f\"Properties mapped: {result.report.properties_mapped}\")\n",
     "print(f\"Relationships mapped: {result.report.relationships_mapped}\")\n",
-    "print(f\"\\nPlaceholders ({len(result.report.placeholders)}):\")\n",
+    "print(f\"Placeholders: {len(result.report.placeholders)}\")\n",
     "for p in result.report.placeholders:\n",
     "    print(f\"  - {p.location}: {p.reason}\")\n",
-    "print(f\"\\nType warnings ({len(result.report.type_warnings)}):\")\n",
+    "print(f\"Type warnings: {len(result.report.type_warnings)}\")\n",
     "for w in result.report.type_warnings:\n",
-    "    print(f\"  - {w.property_name}: {w.owl_type} -> {w.mapped_type}\")"
+    "    print(f\"  - {w.property_name}: {w.owl_type} -> {w.mapped_type}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "6a1e93cc",
+   "execution_count": 7,
+   "id": "cell12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:49.128094Z",
-     "iopub.status.busy": "2026-04-13T23:32:49.127890Z",
-     "iopub.status.idle": "2026-04-13T23:32:49.130294Z",
-     "shell.execute_reply": "2026-04-13T23:32:49.129850Z"
+     "iopub.execute_input": "2026-04-14T05:51:05.797597Z",
+     "iopub.status.busy": "2026-04-14T05:51:05.797360Z",
+     "iopub.status.idle": "2026-04-14T05:51:05.799573Z",
+     "shell.execute_reply": "2026-04-14T05:51:05.799015Z"
     }
    },
    "outputs": [
@@ -411,11 +426,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Unresolved Import YAML (first 40 lines) ===\n",
       "ontology_import:\n",
       "  status: unresolved\n",
       "  source_file: /Users/haiyuancao/BigQuery-Agent-Analytics-SDK/examples/yamo_sample.ttl\n",
-      "  import_timestamp: '2026-04-13T23:32:49.122884+00:00'\n",
+      "  import_timestamp: '2026-04-14T05:51:05.791802+00:00'\n",
       "  placeholders_remaining: 1\n",
       "graph:\n",
       "  name: yamo_imported\n",
@@ -451,39 +465,86 @@
       "      source: '{{ env }}.decision_points'\n",
       "    keys:\n",
       "      primary:\n",
-      "      - FILL_IN\n"
+      "      - FILL_IN\n",
+      "    properties:\n",
+      "    - name: decision_id\n",
+      "      type: string\n",
+      "    - name: decision_type\n",
+      "      type: string\n",
+      "  - name: Party\n",
+      "    description: Party\n",
+      "    binding:\n",
+      "      source: '{{ env }}.parties'\n",
+      "    keys:\n",
+      "      primary:\n",
+      "      - party_id\n",
+      "    properties:\n",
+      "    - name: party_id\n",
+      "      type: string\n",
+      "    - name: name\n",
+      "      type: string\n",
+      "  - name: RejectionReason\n",
+      "    description: Rejection Reason\n",
+      "    binding:\n",
+      "      source: '{{ env }}.rejection_reasons'\n",
+      "    keys:\n",
+      "      primary:\n",
+      "      - rejection_type\n",
+      "    properties:\n",
+      "    - name: rejection_type\n",
+      "      type: string\n",
+      "  relationships:\n",
+      "  - name: evaluates\n",
+      "    description: evaluates\n",
+      "    from_entity: DecisionPoint\n",
+      "    to_entity: AdUnit\n",
+      "    binding:\n",
+      "      source: '{{ env }}.evaluateses'\n",
+      "      from_columns:\n",
+      "      - FILL_IN\n",
+      "      to_columns:\n",
+      "      - ad_unit_id\n",
+      "  - name: rejectedBy\n",
+      "    description: rejected by\n",
+      "    from_entity: AdUnit\n",
+      "    to_entity: RejectionReason\n",
+      "    binding:\n",
+      "      source: '{{ env }}.rejected_bies'\n",
+      "      from_columns:\n",
+      "      - ad_unit_id\n",
+      "      to_columns:\n",
+      "      - rejection_type\n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "# Show the unresolved YAML artifact (first 40 lines)\n",
-    "print(\"=== Unresolved Import YAML (first 40 lines) ===\")\n",
-    "for i, line in enumerate(result.yaml_text.splitlines()[:40]):\n",
-    "    print(line)"
+    "# The full generated YAML -- note FILL_IN placeholders for classes without owl:hasKey\n",
+    "print(result.yaml_text)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3536794a",
+   "id": "cell13",
    "metadata": {},
    "source": [
     "### Resolve Placeholders\n",
     "\n",
-    "Phase 2 (`ttl_resolve`) takes the import artifact and replaces `FILL_IN` placeholders with\n",
-    "user-supplied values. In this example, the `DecisionPoint` class had no `owl:hasKey`, so we\n",
-    "supply its primary key and the `evaluates` relationship's `from_columns` binding."
+    "The `ttl_resolve` function takes the generated YAML text and a dict mapping\n",
+    "`FILL_IN` placeholders to actual primary key column names. This produces a\n",
+    "fully valid GraphSpec YAML."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "7d158110",
+   "execution_count": 8,
+   "id": "cell14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:49.131364Z",
-     "iopub.status.busy": "2026-04-13T23:32:49.131285Z",
-     "iopub.status.idle": "2026-04-13T23:32:49.144519Z",
-     "shell.execute_reply": "2026-04-13T23:32:49.144067Z"
+     "iopub.execute_input": "2026-04-14T05:51:05.800894Z",
+     "iopub.status.busy": "2026-04-14T05:51:05.800802Z",
+     "iopub.status.idle": "2026-04-14T05:51:05.815366Z",
+     "shell.execute_reply": "2026-04-14T05:51:05.814957Z"
     }
    },
    "outputs": [
@@ -499,55 +560,55 @@
    ],
    "source": [
     "import tempfile, os\n",
+    "from bigquery_agent_analytics.ttl_importer import ttl_resolve\n",
     "from bigquery_agent_analytics.ontology_models import load_graph_spec_from_string\n",
     "\n",
+    "# Write unresolved artifact to a temp file for ttl_resolve.\n",
     "with tempfile.NamedTemporaryFile(mode=\"w\", suffix=\".import.yaml\", delete=False) as f:\n",
     "    f.write(result.yaml_text)\n",
     "    import_path = f.name\n",
     "\n",
-    "resolved_yaml = ttl_resolve(import_path, defaults={\n",
-    "    \"entities[DecisionPoint].keys.primary\": [\"decision_id\"],\n",
-    "    \"relationships[evaluates].binding.from_columns\": [\"decision_id\"],\n",
-    "})\n",
+    "resolved = ttl_resolve(\n",
+    "    import_path,\n",
+    "    defaults={\n",
+    "        \"entities[DecisionPoint].keys.primary\": [\"decision_id\"],\n",
+    "        \"relationships[evaluates].binding.from_columns\": [\"decision_id\"],\n",
+    "    },\n",
+    ")\n",
     "os.unlink(import_path)\n",
     "\n",
-    "spec_from_owl = load_graph_spec_from_string(resolved_yaml)\n",
+    "spec_from_owl = load_graph_spec_from_string(resolved)\n",
     "print(f\"Resolved spec: {spec_from_owl.name}\")\n",
     "print(f\"Entities: {[e.name for e in spec_from_owl.entities]}\")\n",
-    "print(f\"Relationships: {[r.name for r in spec_from_owl.relationships]}\")"
+    "print(f\"Relationships: {[r.name for r in spec_from_owl.relationships]}\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6de5c197",
+   "id": "cell15",
    "metadata": {},
    "source": [
-    "## Step 2: Mixed Structured + AI Extraction\n",
+    "## Step 2: Mixed Extraction (Structured + AI)\n",
     "\n",
-    "V5 introduces a **structured extractor registry** that runs alongside AI extraction. Each\n",
-    "extractor is a function that takes a raw telemetry event and the `GraphSpec`, and returns\n",
-    "a `StructuredExtractionResult` with:\n",
+    "V5 supports **mixed extraction**: deterministic structured extractors handle well-known\n",
+    "event types (e.g., BKA decision events), while AI.GENERATE covers the remaining\n",
+    "unstructured telemetry.\n",
     "\n",
-    "- **nodes/edges**: Deterministically extracted graph elements (no AI needed).\n",
-    "- **fully_handled_span_ids**: Spans whose content is completely captured -- excluded from\n",
-    "  the AI transcript to avoid duplicate extraction.\n",
-    "- **partially_handled_span_ids**: Spans with remaining free-text that AI should still process.\n",
-    "\n",
-    "The `OntologyGraphManager` accepts an `extractors` dict mapping `event_type` strings to\n",
-    "extractor callables. During extraction, matched events are processed structurally first,\n",
-    "and only unhandled spans are sent to `AI.GENERATE`."
+    "- Structured extractors declare which spans they fully or partially handle.\n",
+    "- The AI transcript excludes fully-handled spans, reducing cost and hallucination risk.\n",
+    "- Both paths produce `ExtractedNode` / `ExtractedEdge` instances that merge seamlessly."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c28b3f9e",
+   "execution_count": 9,
+   "id": "cell16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:49.145793Z",
-     "iopub.status.busy": "2026-04-13T23:32:49.145718Z",
-     "iopub.status.idle": "2026-04-13T23:32:49.153404Z",
-     "shell.execute_reply": "2026-04-13T23:32:49.152998Z"
+     "iopub.execute_input": "2026-04-14T05:51:05.816781Z",
+     "iopub.status.busy": "2026-04-14T05:51:05.816676Z",
+     "iopub.status.idle": "2026-04-14T05:51:05.824227Z",
+     "shell.execute_reply": "2026-04-14T05:51:05.823751Z"
     }
    },
    "outputs": [
@@ -555,7 +616,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wrote ymgo_graph_spec.yaml (3620 bytes)\n",
+      "Wrote ymgo_graph_spec_v5.yaml\n",
       "Graph: YMGO_Context_Graph_V3\n",
       "Entities: ['mako_DecisionPoint', 'sup_YahooAdUnit', 'mako_RejectionReason']\n",
       "Relationships: ['CandidateEdge', 'ForCandidate', 'sup_YahooAdUnitEvolvedFrom']\n"
@@ -563,23 +624,14 @@
     }
    ],
    "source": [
-    "# Write the YMGO graph spec with the V5 lineage relationship appended.\n",
+    "from bigquery_agent_analytics.ontology_models import load_graph_spec\n",
     "\n",
-    "SPEC_PATH = \"ymgo_graph_spec.yaml\"\n",
+    "SPEC_PATH = \"ymgo_graph_spec_v5.yaml\"\n",
     "\n",
-    "_YMGO_SPEC = \"\"\"\\\n",
-    "# YMGO (Yahoo Media Graph Ontology) V3 — Context Graph Specification\n",
-    "#\n",
-    "# This YAML defines the ontology for a configuration-driven context graph.\n",
-    "# Use {{ env }} placeholders for environment-specific table bindings,\n",
-    "# resolved at load time via load_graph_spec(path, env=\"project.dataset\").\n",
-    "\n",
+    "_YMGO_SPEC_V5 = \"\"\"\\\n",
     "graph:\n",
     "  name: YMGO_Context_Graph_V3\n",
     "\n",
-    "  # ==========================================\n",
-    "  # 1. ENTITIES (Nodes)\n",
-    "  # ==========================================\n",
     "  entities:\n",
     "    - name: mako_DecisionPoint\n",
     "      description: \"The atomic unit of decisioning where an agent evaluates alternatives.\"\n",
@@ -607,10 +659,8 @@
     "          type: string\n",
     "        - name: adUnitSize\n",
     "          type: string\n",
-    "          description: \"e.g., '300x250', '728x90'\"\n",
     "        - name: adUnitPosition\n",
     "          type: string\n",
-    "          description: \"ATF (above the fold) | BTF (below the fold)\"\n",
     "\n",
     "    - name: mako_RejectionReason\n",
     "      description: \"Structured reason why a Candidate was not selected at a DecisionPoint.\"\n",
@@ -623,14 +673,9 @@
     "          type: string\n",
     "        - name: rejectionType\n",
     "          type: string\n",
-    "          description: \"RULE_BASED | MODEL_BASED | TIMEOUT | ERROR\"\n",
     "        - name: rejectionRule\n",
     "          type: string\n",
-    "          description: \"The specific rule or model threshold that caused rejection.\"\n",
     "\n",
-    "  # ==========================================\n",
-    "  # 2. RELATIONSHIPS (Edges)\n",
-    "  # ==========================================\n",
     "  relationships:\n",
     "    - name: CandidateEdge\n",
     "      description: \"Connects a decision point to the evaluated Yahoo Ad Unit.\"\n",
@@ -643,10 +688,8 @@
     "      properties:\n",
     "        - name: edge_type\n",
     "          type: string\n",
-    "          description: \"SELECTED_CANDIDATE or DROPPED_CANDIDATE\"\n",
     "        - name: mako_scoreValue\n",
     "          type: double\n",
-    "          description: \"The confidence or predicted Q-value for this candidate.\"\n",
     "\n",
     "    - name: ForCandidate\n",
     "      description: \"Maps the MAKO rejection rationale directly to the dropped candidate.\"\n",
@@ -678,29 +721,26 @@
     "          type: string\n",
     "\"\"\"\n",
     "\n",
-    "with open(SPEC_PATH, \"w\") as _f:\n",
-    "    _f.write(_YMGO_SPEC)\n",
+    "with open(SPEC_PATH, \"w\") as f:\n",
+    "    f.write(_YMGO_SPEC_V5)\n",
+    "print(f\"Wrote {SPEC_PATH}\")\n",
     "\n",
-    "print(f\"Wrote {SPEC_PATH} ({len(_YMGO_SPEC)} bytes)\")\n",
-    "\n",
-    "from bigquery_agent_analytics.ontology_models import load_graph_spec\n",
-    "\n",
-    "spec = load_graph_spec(SPEC_PATH, env=ENV)\n",
+    "spec = load_graph_spec(SPEC_PATH, env=SCRATCH_ENV)\n",
     "print(f\"Graph: {spec.name}\")\n",
     "print(f\"Entities: {[e.name for e in spec.entities]}\")\n",
-    "print(f\"Relationships: {[r.name for r in spec.relationships]}\")"
+    "print(f\"Relationships: {[r.name for r in spec.relationships]}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "440b4560",
+   "execution_count": 10,
+   "id": "cell17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:49.154403Z",
-     "iopub.status.busy": "2026-04-13T23:32:49.154344Z",
-     "iopub.status.idle": "2026-04-13T23:32:49.156786Z",
-     "shell.execute_reply": "2026-04-13T23:32:49.156378Z"
+     "iopub.execute_input": "2026-04-14T05:51:05.825656Z",
+     "iopub.status.busy": "2026-04-14T05:51:05.825570Z",
+     "iopub.status.idle": "2026-04-14T05:51:05.828369Z",
+     "shell.execute_reply": "2026-04-14T05:51:05.827982Z"
     }
    },
    "outputs": [
@@ -709,49 +749,53 @@
      "output_type": "stream",
      "text": [
       "Nodes extracted: 1\n",
+      "  demo-session:mako_DecisionPoint:decision_id=dp_demo_eval\n",
+      "    decision_id = dp_demo_eval\n",
+      "    outcome = selected\n",
+      "    confidence = 0.92\n",
       "Fully handled spans: {'span-001'}\n",
-      "  [mako_DecisionPoint] demo-session-1:mako_DecisionPoint:decision_id=dp_homepage_eval\n",
-      "    decision_id = dp_homepage_eval\n",
-      "    outcome = selected\n"
+      "Partially handled spans: set()\n"
      ]
     }
    ],
    "source": [
     "from bigquery_agent_analytics.structured_extraction import (\n",
     "    extract_bka_decision_event,\n",
-    "    StructuredExtractionResult,\n",
+    "    StructuredExtractor,\n",
     ")\n",
     "\n",
-    "# Demo: run the extractor on a sample event\n",
-    "sample_event = {\n",
+    "# Demo: run the BKA extractor on a synthetic event\n",
+    "demo_event = {\n",
     "    \"span_id\": \"span-001\",\n",
-    "    \"session_id\": \"demo-session-1\",\n",
-    "    \"event_type\": \"BKA_DECISION\",\n",
+    "    \"session_id\": \"demo-session\",\n",
+    "    \"event_type\": \"bka_decision\",\n",
     "    \"content\": {\n",
-    "        \"decision_id\": \"dp_homepage_eval\",\n",
-    "        \"decision_type\": \"query_ad_inventory\",\n",
+    "        \"decision_id\": \"dp_demo_eval\",\n",
     "        \"outcome\": \"selected\",\n",
+    "        \"confidence\": 0.92,\n",
     "    },\n",
     "}\n",
-    "demo_result = extract_bka_decision_event(sample_event, spec)\n",
+    "\n",
+    "demo_result = extract_bka_decision_event(demo_event, spec)\n",
     "print(f\"Nodes extracted: {len(demo_result.nodes)}\")\n",
-    "print(f\"Fully handled spans: {demo_result.fully_handled_span_ids}\")\n",
     "for node in demo_result.nodes:\n",
-    "    print(f\"  [{node.entity_name}] {node.node_id}\")\n",
+    "    print(f\"  {node.node_id}\")\n",
     "    for p in node.properties:\n",
-    "        print(f\"    {p.name} = {p.value}\")"
+    "        print(f\"    {p.name} = {p.value}\")\n",
+    "print(f\"Fully handled spans: {demo_result.fully_handled_span_ids}\")\n",
+    "print(f\"Partially handled spans: {demo_result.partially_handled_span_ids}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "6e9b5025",
+   "execution_count": 11,
+   "id": "cell18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:49.157862Z",
-     "iopub.status.busy": "2026-04-13T23:32:49.157789Z",
-     "iopub.status.idle": "2026-04-13T23:32:51.772627Z",
-     "shell.execute_reply": "2026-04-13T23:32:51.770982Z"
+     "iopub.execute_input": "2026-04-14T05:51:05.829554Z",
+     "iopub.status.busy": "2026-04-14T05:51:05.829479Z",
+     "iopub.status.idle": "2026-04-14T05:51:08.680095Z",
+     "shell.execute_reply": "2026-04-14T05:51:08.678386Z"
     }
    },
    "outputs": [
@@ -761,15 +805,27 @@
      "text": [
       "Extracted 3 nodes, 2 edges\n",
       "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=yahoo_homepage_display_premium\n",
+      "    adUnitId = yahoo_homepage_display_premium\n",
+      "    adUnitName = Yahoo Homepage\n",
+      "    adUnitSize = display\n",
+      "    adUnitPosition = Premium Placement\n",
       "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=yahoo_mail_display_standard\n",
-      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_allocate_media_budget_1\n"
+      "    adUnitId = yahoo_mail_display_standard\n",
+      "    adUnitName = Yahoo Mail\n",
+      "    adUnitSize = display\n",
+      "    adUnitPosition = Standard\n",
+      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_allocate_media_budget_1\n",
+      "    decision_id = dp_allocate_media_budget_1\n",
+      "    decision_type = media_budget_allocation\n"
      ]
     }
    ],
    "source": [
     "from bigquery_agent_analytics.ontology_graph import OntologyGraphManager\n",
     "\n",
-    "SESSION_IDS = [\"adcp-033c95d7a97d\"]\n",
+    "SESSION_IDS = [\"adcp-033c95d7a97d\"]  # Replace with your session IDs\n",
+    "\n",
+    "extractors = {\"bka_decision\": extract_bka_decision_event}\n",
     "\n",
     "extractor = OntologyGraphManager(\n",
     "    project_id=PROJECT_ID,\n",
@@ -777,37 +833,45 @@
     "    spec=spec,\n",
     "    table_id=TABLE_ID,\n",
     "    endpoint=\"gemini-2.5-flash\",\n",
-    "    extractors={\"BKA_DECISION\": extract_bka_decision_event},\n",
+    "    extractors=extractors,\n",
     ")\n",
     "\n",
-    "graph = extractor.extract_graph(session_ids=SESSION_IDS, use_ai_generate=True)\n",
+    "graph = extractor.extract_graph(\n",
+    "    session_ids=SESSION_IDS,\n",
+    "    use_ai_generate=True,\n",
+    ")\n",
     "print(f\"Extracted {len(graph.nodes)} nodes, {len(graph.edges)} edges\")\n",
     "for node in graph.nodes[:5]:\n",
-    "    print(f\"  [{node.entity_name}] {node.node_id}\")"
+    "    print(f\"  [{node.entity_name}] {node.node_id}\")\n",
+    "    for p in node.properties:\n",
+    "        print(f\"    {p.name} = {p.value}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0f04f606",
+   "id": "cell19",
    "metadata": {},
    "source": [
-    "## Step 3: Materialize & Create Property Graph\n",
+    "## Step 3: Materialize with `batch_load`\n",
     "\n",
-    "With the extracted graph in hand, we create physical BigQuery tables, materialize the nodes\n",
-    "and edges, generate the Property Graph DDL (now including the lineage edge table), and create\n",
-    "the native BigQuery Property Graph."
+    "The V5 materializer supports a `batch_load` write mode that uses `load_table_from_json`\n",
+    "with a staging table instead of the streaming `insert_rows_json` API. This provides:\n",
+    "\n",
+    "- More reliable inserts for large batches.\n",
+    "- Full status reporting via `materialize_with_status()`.\n",
+    "- Per-table `TableStatus` with cleanup status, insert status, and idempotency flags."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f1e07f2e",
+   "execution_count": 12,
+   "id": "cell20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:32:51.778376Z",
-     "iopub.status.busy": "2026-04-13T23:32:51.778022Z",
-     "iopub.status.idle": "2026-04-13T23:33:01.545037Z",
-     "shell.execute_reply": "2026-04-13T23:33:01.543043Z"
+     "iopub.execute_input": "2026-04-14T05:51:08.684595Z",
+     "iopub.status.busy": "2026-04-14T05:51:08.684297Z",
+     "iopub.status.idle": "2026-04-14T05:52:06.759019Z",
+     "shell.execute_reply": "2026-04-14T05:52:06.758102Z"
     }
    },
    "outputs": [
@@ -816,45 +880,12 @@
      "output_type": "stream",
      "text": [
       "Tables created:\n",
-      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics.decision_points\n",
-      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics.yahoo_ad_units\n",
-      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics.rejection_reasons\n",
-      "  CandidateEdge -> test-project-0728-467323.agent_analytics.candidate_edges\n",
-      "  ForCandidate -> test-project-0728-467323.agent_analytics.rejection_mappings\n",
-      "  sup_YahooAdUnitEvolvedFrom -> test-project-0728-467323.agent_analytics.sup_yahoo_ad_unit_lineage\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Delete for sessions failed on test-project-0728-467323.agent_analytics.yahoo_ad_units: 400 GET https://bigquery.googleapis.com/bigquery/v2/projects/test-project-0728-467323/queries/497993c1-6e45-4bbe-b39e-3a0cee124cf3?maxResults=0&location=US&prettyPrint=false: UPDATE or DELETE statement over table test-project-0728-467323.agent_analytics.yahoo_ad_units would affect rows in the streaming buffer, which is not supported\n",
-      "\n",
-      "Location: US\n",
-      "Job ID: 497993c1-6e45-4bbe-b39e-3a0cee124cf3\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Delete for sessions failed on test-project-0728-467323.agent_analytics.decision_points: 400 GET https://bigquery.googleapis.com/bigquery/v2/projects/test-project-0728-467323/queries/d914bee5-2ba6-47c1-83e1-821981b6e67a?maxResults=0&location=US&prettyPrint=false: UPDATE or DELETE statement over table test-project-0728-467323.agent_analytics.decision_points would affect rows in the streaming buffer, which is not supported\n",
-      "\n",
-      "Location: US\n",
-      "Job ID: d914bee5-2ba6-47c1-83e1-821981b6e67a\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Delete for sessions failed on test-project-0728-467323.agent_analytics.candidate_edges: 400 GET https://bigquery.googleapis.com/bigquery/v2/projects/test-project-0728-467323/queries/18e844dd-261c-4ff7-85ca-ae217c6744b1?maxResults=0&location=US&prettyPrint=false: UPDATE or DELETE statement over table test-project-0728-467323.agent_analytics.candidate_edges would affect rows in the streaming buffer, which is not supported\n",
-      "\n",
-      "Location: US\n",
-      "Job ID: 18e844dd-261c-4ff7-85ca-ae217c6744b1\n",
-      "\n"
+      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics_v5_7e508241.decision_points\n",
+      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units\n",
+      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics_v5_7e508241.rejection_reasons\n",
+      "  CandidateEdge -> test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges\n",
+      "  ForCandidate -> test-project-0728-467323.agent_analytics_v5_7e508241.rejection_mappings\n",
+      "  sup_YahooAdUnitEvolvedFrom -> test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage\n"
      ]
     },
     {
@@ -862,37 +893,46 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Rows materialized: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 1, 'CandidateEdge': 2}\n"
+      "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 1, 'CandidateEdge': 2}\n",
+      "  test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units: cleanup=deleted insert=inserted idempotent=True\n",
+      "  test-project-0728-467323.agent_analytics_v5_7e508241.decision_points: cleanup=deleted insert=inserted idempotent=True\n",
+      "  test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges: cleanup=deleted insert=inserted idempotent=True\n"
      ]
     }
    ],
    "source": [
     "from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer\n",
-    "from bigquery_agent_analytics.ontology_property_graph import (\n",
-    "    OntologyPropertyGraphCompiler,\n",
-    "    compile_property_graph_ddl,\n",
+    "\n",
+    "materializer = OntologyMaterializer(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=SCRATCH_DATASET,\n",
+    "    spec=spec,\n",
+    "    write_mode=\"batch_load\",\n",
     ")\n",
     "\n",
-    "materializer = OntologyMaterializer(project_id=PROJECT_ID, dataset_id=DATASET_ID, spec=spec)\n",
+    "# Create tables first\n",
     "tables = materializer.create_tables()\n",
     "print(\"Tables created:\")\n",
     "for name, ref in tables.items():\n",
     "    print(f\"  {name} -> {ref}\")\n",
     "\n",
-    "rows = materializer.materialize(graph, SESSION_IDS)\n",
-    "print(f\"\\nRows materialized: {rows}\")"
+    "# Materialize with full status reporting\n",
+    "result = materializer.materialize_with_status(graph, SESSION_IDS)\n",
+    "print(f\"\\nRows: {result.row_counts}\")\n",
+    "for ref, ts in result.table_statuses.items():\n",
+    "    print(f\"  {ref}: cleanup={ts.cleanup_status} insert={ts.insert_status} idempotent={ts.idempotent}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "7931482f",
+   "execution_count": 13,
+   "id": "cell21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:01.549041Z",
-     "iopub.status.busy": "2026-04-13T23:33:01.548697Z",
-     "iopub.status.idle": "2026-04-13T23:33:01.554086Z",
-     "shell.execute_reply": "2026-04-13T23:33:01.552986Z"
+     "iopub.execute_input": "2026-04-14T05:52:06.761046Z",
+     "iopub.status.busy": "2026-04-14T05:52:06.760893Z",
+     "iopub.status.idle": "2026-04-14T05:52:06.763938Z",
+     "shell.execute_reply": "2026-04-14T05:52:06.763167Z"
     }
    },
    "outputs": [
@@ -900,9 +940,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
       "  NODE TABLES (\n",
-      "    `test-project-0728-467323.agent_analytics.decision_points` AS mako_DecisionPoint\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.decision_points` AS mako_DecisionPoint\n",
       "      KEY (decision_id, session_id)\n",
       "      LABEL mako_DecisionPoint\n",
       "      PROPERTIES (\n",
@@ -911,7 +951,7 @@
       "        session_id,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics.yahoo_ad_units` AS sup_YahooAdUnit\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units` AS sup_YahooAdUnit\n",
       "      KEY (adUnitId, session_id)\n",
       "      LABEL sup_YahooAdUnit\n",
       "      LABEL mako_Candidate\n",
@@ -923,7 +963,7 @@
       "        session_id,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics.rejection_reasons` AS mako_RejectionReason\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.rejection_reasons` AS mako_RejectionReason\n",
       "      KEY (rejection_id, session_id)\n",
       "      LABEL mako_RejectionReason\n",
       "      PROPERTIES (\n",
@@ -935,7 +975,7 @@
       "      )\n",
       "  )\n",
       "  EDGE TABLES (\n",
-      "    `test-project-0728-467323.agent_analytics.candidate_edges` AS CandidateEdge\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges` AS CandidateEdge\n",
       "      KEY (decision_id, adUnitId, session_id)\n",
       "      SOURCE KEY (decision_id, session_id) REFERENCES mako_DecisionPoint (decision_id, session_id)\n",
       "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -945,7 +985,7 @@
       "        mako_scoreValue,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics.rejection_mappings` AS ForCandidate\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.rejection_mappings` AS ForCandidate\n",
       "      KEY (rejection_id, adUnitId, session_id)\n",
       "      SOURCE KEY (rejection_id, session_id) REFERENCES mako_RejectionReason (rejection_id, session_id)\n",
       "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -953,7 +993,7 @@
       "      PROPERTIES (\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics.sup_yahoo_ad_unit_lineage` AS sup_YahooAdUnitEvolvedFrom\n",
+      "    `test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage` AS sup_YahooAdUnitEvolvedFrom\n",
       "      KEY (adUnitId, from_session_id, to_session_id, session_id)\n",
       "      SOURCE KEY (adUnitId, from_session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
       "      DESTINATION KEY (adUnitId, to_session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -970,20 +1010,22 @@
     }
    ],
    "source": [
-    "ddl = compile_property_graph_ddl(spec, PROJECT_ID, DATASET_ID)\n",
+    "from bigquery_agent_analytics.ontology_property_graph import compile_property_graph_ddl\n",
+    "\n",
+    "ddl = compile_property_graph_ddl(spec, PROJECT_ID, SCRATCH_DATASET)\n",
     "print(ddl)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "f72fc03a",
+   "execution_count": 14,
+   "id": "cell22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:01.557311Z",
-     "iopub.status.busy": "2026-04-13T23:33:01.557053Z",
-     "iopub.status.idle": "2026-04-13T23:33:06.161407Z",
-     "shell.execute_reply": "2026-04-13T23:33:06.160556Z"
+     "iopub.execute_input": "2026-04-14T05:52:06.765498Z",
+     "iopub.status.busy": "2026-04-14T05:52:06.765386Z",
+     "iopub.status.idle": "2026-04-14T05:52:08.887700Z",
+     "shell.execute_reply": "2026-04-14T05:52:08.886766Z"
     }
    },
    "outputs": [
@@ -996,79 +1038,42 @@
     }
    ],
    "source": [
-    "compiler = OntologyPropertyGraphCompiler(project_id=PROJECT_ID, dataset_id=DATASET_ID, spec=spec)\n",
+    "from bigquery_agent_analytics.ontology_property_graph import OntologyPropertyGraphCompiler\n",
+    "\n",
+    "compiler = OntologyPropertyGraphCompiler(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    dataset_id=SCRATCH_DATASET,\n",
+    "    spec=spec,\n",
+    ")\n",
     "created = compiler.create_property_graph()\n",
     "print(f\"Property Graph created: {created}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "05d00e4b",
+   "id": "cell23",
    "metadata": {},
    "source": [
-    "## Step 4: Temporal Lineage -- Cross-Session Entity Evolution\n",
+    "## Step 4: Temporal Lineage\n",
     "\n",
-    "V5 introduces **temporal lineage**: the ability to detect how entities evolve across sessions.\n",
-    "When the same entity (matched by primary key) appears in two sessions with different property\n",
-    "values, `detect_lineage_edges` creates a lineage edge recording:\n",
+    "Detect property changes on shared-key entities across sessions. When the same\n",
+    "`adUnitId` appears in two sessions with different property values, lineage edges\n",
+    "are created to track the evolution.\n",
     "\n",
-    "- The prior and current session IDs\n",
-    "- A timestamp of when the evolution was detected\n",
-    "- A comma-separated list of properties that changed\n",
-    "\n",
-    "This enables use cases like tracking how ad unit configurations drift over time, or auditing\n",
-    "which decision parameters changed between sessions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "4fcaf323",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:06.163667Z",
-     "iopub.status.busy": "2026-04-13T23:33:06.163519Z",
-     "iopub.status.idle": "2026-04-13T23:33:25.194811Z",
-     "shell.execute_reply": "2026-04-13T23:33:25.193940Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Session B: 3 nodes, 2 edges\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Session B rows: {'mako_DecisionPoint': 1, 'sup_YahooAdUnit': 2, 'CandidateEdge': 2}\n"
-     ]
-    }
-   ],
-   "source": [
-    "SESSION_IDS_B = [\"adcp-040c04837251\"]  # Second session\n",
-    "\n",
-    "graph_b = extractor.extract_graph(session_ids=SESSION_IDS_B, use_ai_generate=True)\n",
-    "print(f\"Session B: {len(graph_b.nodes)} nodes, {len(graph_b.edges)} edges\")\n",
-    "\n",
-    "# Materialize session B\n",
-    "rows_b = materializer.materialize(graph_b, SESSION_IDS_B)\n",
-    "print(f\"Session B rows: {rows_b}\")"
+    "We create a synthetic \"Session B\" with a modified `sup_YahooAdUnit` to demonstrate\n",
+    "cross-session lineage detection without requiring a second real extraction."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "59ee3099",
+   "id": "cell24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:25.196605Z",
-     "iopub.status.busy": "2026-04-13T23:33:25.196489Z",
-     "iopub.status.idle": "2026-04-13T23:33:25.200772Z",
-     "shell.execute_reply": "2026-04-13T23:33:25.200136Z"
+     "iopub.execute_input": "2026-04-14T05:52:08.890273Z",
+     "iopub.status.busy": "2026-04-14T05:52:08.890090Z",
+     "iopub.status.idle": "2026-04-14T05:52:21.064561Z",
+     "shell.execute_reply": "2026-04-14T05:52:21.063461Z"
     }
    },
    "outputs": [
@@ -1076,7 +1081,65 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Lineage edges detected: 0\n"
+      "Synthetic Session B: {'sup_YahooAdUnit': 1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bigquery_agent_analytics.ontology_models import (\n",
+    "    ExtractedGraph,\n",
+    "    ExtractedNode,\n",
+    "    ExtractedProperty,\n",
+    ")\n",
+    "\n",
+    "session_a_ad_units = [n for n in graph.nodes if n.entity_name == \"sup_YahooAdUnit\"]\n",
+    "if session_a_ad_units:\n",
+    "    original = session_a_ad_units[0]\n",
+    "    original_props = {p.name: p.value for p in original.properties}\n",
+    "    shared_id = original_props.get(\"adUnitId\", \"unknown\")\n",
+    "\n",
+    "    synthetic_node = ExtractedNode(\n",
+    "        node_id=f\"sess-synthetic-B:sup_YahooAdUnit:adUnitId={shared_id}\",\n",
+    "        entity_name=\"sup_YahooAdUnit\",\n",
+    "        labels=[\"sup_YahooAdUnit\", \"mako_Candidate\"],\n",
+    "        properties=[\n",
+    "            ExtractedProperty(name=\"adUnitId\", value=shared_id),\n",
+    "            ExtractedProperty(name=\"adUnitName\", value=original_props.get(\"adUnitName\", \"\") + \" (Redesigned)\"),\n",
+    "            ExtractedProperty(name=\"adUnitSize\", value=original_props.get(\"adUnitSize\", \"300x250\")),\n",
+    "            ExtractedProperty(name=\"adUnitPosition\", value=\"BTF\"),\n",
+    "        ],\n",
+    "    )\n",
+    "    synthetic_graph = ExtractedGraph(name=spec.name, nodes=[synthetic_node], edges=[])\n",
+    "    result_b = materializer.materialize_with_status(synthetic_graph, [\"sess-synthetic-B\"])\n",
+    "    print(f\"Synthetic Session B: {result_b.row_counts}\")\n",
+    "else:\n",
+    "    print(\"No ad units found in Session A -- skipping synthetic lineage demo\")\n",
+    "    synthetic_graph = ExtractedGraph(name=spec.name, nodes=[], edges=[])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "cell25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-14T05:52:21.067078Z",
+     "iopub.status.busy": "2026-04-14T05:52:21.066887Z",
+     "iopub.status.idle": "2026-04-14T05:52:21.071544Z",
+     "shell.execute_reply": "2026-04-14T05:52:21.071010Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lineage edges detected: 1\n",
+      "  sess-synthetic-B:sup_YahooAdUnitEvolvedFrom:adcp-033c95d7a97d:adUnitId=yahoo_homepage_display_premium\n",
+      "    from_session_id = adcp-033c95d7a97d\n",
+      "    to_session_id = sess-synthetic-B\n",
+      "    event_time = 2026-04-14T05:52:21.069343+00:00\n",
+      "    changed_properties = adUnitName,adUnitPosition\n"
      ]
     }
    ],
@@ -1084,42 +1147,29 @@
     "from bigquery_agent_analytics.ontology_graph import detect_lineage_edges\n",
     "\n",
     "lineage_edges = detect_lineage_edges(\n",
-    "    current_graph=graph_b,\n",
-    "    current_session_id=SESSION_IDS_B[0],\n",
+    "    current_graph=synthetic_graph,\n",
+    "    current_session_id=\"sess-synthetic-B\",\n",
     "    prior_graphs={SESSION_IDS[0]: graph},\n",
     "    lineage_entity_types=[\"sup_YahooAdUnit\"],\n",
     "    spec=spec,\n",
     ")\n",
-    "\n",
     "print(f\"Lineage edges detected: {len(lineage_edges)}\")\n",
     "for edge in lineage_edges:\n",
-    "    print(f\"\\n  {edge.relationship_name}: {edge.from_node_id} -> {edge.to_node_id}\")\n",
+    "    print(f\"  {edge.edge_id}\")\n",
     "    for p in edge.properties:\n",
     "        print(f\"    {p.name} = {p.value}\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "1a6cea6e",
-   "metadata": {},
-   "source": [
-    "## Step 5: GQL Queries\n",
-    "\n",
-    "V5 adds `compile_lineage_gql` alongside the existing V4 `compile_showcase_gql`. The lineage\n",
-    "GQL traverses self-edge relationships (where `from_entity == to_entity`) and returns prior\n",
-    "and current session property values with the evolution metadata."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "431b8218",
+   "execution_count": 17,
+   "id": "cell26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:25.202425Z",
-     "iopub.status.busy": "2026-04-13T23:33:25.202327Z",
-     "iopub.status.idle": "2026-04-13T23:33:25.205177Z",
-     "shell.execute_reply": "2026-04-13T23:33:25.204587Z"
+     "iopub.execute_input": "2026-04-14T05:52:21.073951Z",
+     "iopub.status.busy": "2026-04-14T05:52:21.073781Z",
+     "iopub.status.idle": "2026-04-14T05:52:40.292497Z",
+     "shell.execute_reply": "2026-04-14T05:52:40.291544Z"
     }
    },
    "outputs": [
@@ -1127,8 +1177,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== V4: Forward Traversal GQL ===\n",
-      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "Lineage rows: {'sup_YahooAdUnitEvolvedFrom': 1}\n",
+      "  test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage: cleanup=deleted insert=inserted idempotent=True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Materialize lineage edges into the lineage table\n",
+    "lineage_graph = ExtractedGraph(\n",
+    "    name=spec.name,\n",
+    "    nodes=[],\n",
+    "    edges=lineage_edges,\n",
+    ")\n",
+    "result_lineage = materializer.materialize_with_status(lineage_graph, [\"sess-synthetic-B\"])\n",
+    "print(f\"Lineage rows: {result_lineage.row_counts}\")\n",
+    "for ref, ts in result_lineage.table_statuses.items():\n",
+    "    print(f\"  {ref}: cleanup={ts.cleanup_status} insert={ts.insert_status} idempotent={ts.idempotent}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell27",
+   "metadata": {},
+   "source": [
+    "## Step 5: GQL Queries\n",
+    "\n",
+    "Query the materialized property graph using BigQuery GQL. We compile two queries:\n",
+    "\n",
+    "1. **Showcase GQL** -- standard forward traversal from `DecisionPoint` to `YahooAdUnit`.\n",
+    "2. **Lineage GQL** -- cross-session lineage traversal via `sup_YahooAdUnitEvolvedFrom`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cell28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-14T05:52:40.295242Z",
+     "iopub.status.busy": "2026-04-14T05:52:40.295073Z",
+     "iopub.status.idle": "2026-04-14T05:52:40.299011Z",
+     "shell.execute_reply": "2026-04-14T05:52:40.298229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Showcase GQL ===\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
       "MATCH\n",
       "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
       "WHERE dp.session_id = @session_id\n",
@@ -1145,8 +1243,8 @@
       "LIMIT @result_limit\n",
       "\n",
       "\n",
-      "=== V5: Cross-Session Lineage GQL ===\n",
-      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "=== Lineage GQL ===\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
       "MATCH\n",
       "  (prior:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(current:sup_YahooAdUnit)\n",
       "WHERE current.session_id = @session_id\n",
@@ -1170,32 +1268,37 @@
     }
    ],
    "source": [
-    "from bigquery_agent_analytics.ontology_orchestrator import compile_showcase_gql, compile_lineage_gql\n",
+    "from bigquery_agent_analytics.ontology_orchestrator import (\n",
+    "    compile_showcase_gql,\n",
+    "    compile_lineage_gql,\n",
+    ")\n",
     "\n",
-    "print(\"=== V4: Forward Traversal GQL ===\")\n",
-    "gql = compile_showcase_gql(spec, PROJECT_ID, DATASET_ID)\n",
-    "print(gql)\n",
+    "# Standard forward traversal GQL\n",
+    "showcase_gql = compile_showcase_gql(spec=spec, project_id=PROJECT_ID, dataset_id=SCRATCH_DATASET)\n",
+    "print(\"=== Showcase GQL ===\")\n",
+    "print(showcase_gql)\n",
     "\n",
-    "print(\"\\n=== V5: Cross-Session Lineage GQL ===\")\n",
+    "# Lineage traversal GQL\n",
     "lineage_gql = compile_lineage_gql(\n",
     "    spec=spec,\n",
     "    project_id=PROJECT_ID,\n",
-    "    dataset_id=DATASET_ID,\n",
+    "    dataset_id=SCRATCH_DATASET,\n",
     "    relationship_name=\"sup_YahooAdUnitEvolvedFrom\",\n",
     ")\n",
+    "print(\"\\n=== Lineage GQL ===\")\n",
     "print(lineage_gql)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "8acade17",
+   "execution_count": 19,
+   "id": "cell29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T23:33:25.206716Z",
-     "iopub.status.busy": "2026-04-13T23:33:25.206612Z",
-     "iopub.status.idle": "2026-04-13T23:33:29.936367Z",
-     "shell.execute_reply": "2026-04-13T23:33:29.935713Z"
+     "iopub.execute_input": "2026-04-14T05:52:40.300953Z",
+     "iopub.status.busy": "2026-04-14T05:52:40.300822Z",
+     "iopub.status.idle": "2026-04-14T05:52:43.598632Z",
+     "shell.execute_reply": "2026-04-14T05:52:43.598080Z"
     }
    },
    "outputs": [
@@ -1203,254 +1306,168 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Forward traversal: 16 rows\n"
+      "Forward traversal: 2 rows\n",
+      "              src_decision_id        src_decision_type         edge_type  \\\n",
+      "0  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
+      "1  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
+      "\n",
+      "   mako_scoreValue                    dst_adUnitId  dst_adUnitName  \\\n",
+      "0             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
+      "1             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
+      "\n",
+      "  dst_adUnitSize dst_adUnitPosition  \n",
+      "0        display           Standard  \n",
+      "1        display  Premium Placement  \n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>src_decision_id</th>\n",
-       "      <th>src_decision_type</th>\n",
-       "      <th>edge_type</th>\n",
-       "      <th>mako_scoreValue</th>\n",
-       "      <th>dst_adUnitId</th>\n",
-       "      <th>dst_adUnitName</th>\n",
-       "      <th>dst_adUnitSize</th>\n",
-       "      <th>dst_adUnitPosition</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>0.82</td>\n",
-       "      <td>yahoo_mail_display_standard</td>\n",
-       "      <td>Yahoo Mail</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Standard</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>1.23</td>\n",
-       "      <td>yahoo_homepage_display_premium</td>\n",
-       "      <td>Yahoo Homepage</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Premium Placement</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>0.82</td>\n",
-       "      <td>yahoo_mail_display_standard</td>\n",
-       "      <td>Yahoo Mail</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Standard</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>1.23</td>\n",
-       "      <td>yahoo_homepage_display_premium</td>\n",
-       "      <td>Yahoo Homepage</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Premium Placement</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>1.23</td>\n",
-       "      <td>yahoo_homepage_display_premium</td>\n",
-       "      <td>Yahoo Homepage</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Premium Placement</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>0.82</td>\n",
-       "      <td>yahoo_mail_display_standard</td>\n",
-       "      <td>Yahoo Mail</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Standard</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>0.82</td>\n",
-       "      <td>yahoo_mail_display_standard</td>\n",
-       "      <td>Yahoo Mail</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Standard</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>1.23</td>\n",
-       "      <td>yahoo_homepage_display_premium</td>\n",
-       "      <td>Yahoo Homepage</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Premium Placement</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>1.23</td>\n",
-       "      <td>yahoo_homepage_display_premium</td>\n",
-       "      <td>Yahoo Homepage</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Premium Placement</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>dp_allocate_media_budget_1</td>\n",
-       "      <td>media_budget_allocation</td>\n",
-       "      <td>allocated_budget</td>\n",
-       "      <td>0.82</td>\n",
-       "      <td>yahoo_mail_display_standard</td>\n",
-       "      <td>Yahoo Mail</td>\n",
-       "      <td>display</td>\n",
-       "      <td>Standard</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              src_decision_id        src_decision_type         edge_type  \\\n",
-       "0  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "1  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "2  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "3  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "4  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "5  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "6  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "7  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "8  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "9  dp_allocate_media_budget_1  media_budget_allocation  allocated_budget   \n",
-       "\n",
-       "   mako_scoreValue                    dst_adUnitId  dst_adUnitName  \\\n",
-       "0             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
-       "1             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
-       "2             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
-       "3             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
-       "4             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
-       "5             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
-       "6             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
-       "7             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
-       "8             1.23  yahoo_homepage_display_premium  Yahoo Homepage   \n",
-       "9             0.82     yahoo_mail_display_standard      Yahoo Mail   \n",
-       "\n",
-       "  dst_adUnitSize dst_adUnitPosition  \n",
-       "0        display           Standard  \n",
-       "1        display  Premium Placement  \n",
-       "2        display           Standard  \n",
-       "3        display  Premium Placement  \n",
-       "4        display  Premium Placement  \n",
-       "5        display           Standard  \n",
-       "6        display           Standard  \n",
-       "7        display  Premium Placement  \n",
-       "8        display  Premium Placement  \n",
-       "9        display           Standard  "
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "from google.cloud import bigquery as bq_client_mod\n",
-    "\n",
-    "bq = bq_client_mod.Client(project=PROJECT_ID)\n",
-    "job = bq.query(gql, job_config=bq_client_mod.QueryJobConfig(\n",
-    "    query_parameters=[\n",
-    "        bq_client_mod.ScalarQueryParameter(\"session_id\", \"STRING\", SESSION_IDS[0]),\n",
-    "        bq_client_mod.ScalarQueryParameter(\"result_limit\", \"INT64\", 50),\n",
-    "    ]\n",
-    "))\n",
+    "# Execute the forward traversal GQL\n",
+    "job = bq.query(\n",
+    "    showcase_gql,\n",
+    "    job_config=bigquery.QueryJobConfig(\n",
+    "        query_parameters=[\n",
+    "            bigquery.ScalarQueryParameter(\"session_id\", \"STRING\", SESSION_IDS[0]),\n",
+    "            bigquery.ScalarQueryParameter(\"result_limit\", \"INT64\", 50),\n",
+    "        ]\n",
+    "    ),\n",
+    ")\n",
     "results = job.to_dataframe()\n",
     "print(f\"Forward traversal: {len(results)} rows\")\n",
-    "results.head(10)"
+    "if len(results) > 0:\n",
+    "    print(results.head(10))\n",
+    "else:\n",
+    "    print(\"No rows returned\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cell30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-14T05:52:43.599967Z",
+     "iopub.status.busy": "2026-04-14T05:52:43.599874Z",
+     "iopub.status.idle": "2026-04-14T05:52:43.729863Z",
+     "shell.execute_reply": "2026-04-14T05:52:43.729275Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Lineage GQL ===\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
+      "MATCH\n",
+      "  (prior:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(current:sup_YahooAdUnit)\n",
+      "WHERE current.session_id = @session_id\n",
+      "RETURN\n",
+      "  prior.adUnitId AS prior_adUnitId,\n",
+      "  prior.adUnitName AS prior_adUnitName,\n",
+      "  prior.adUnitSize AS prior_adUnitSize,\n",
+      "  prior.adUnitPosition AS prior_adUnitPosition,\n",
+      "  eyauef.from_session_id,\n",
+      "  eyauef.to_session_id,\n",
+      "  eyauef.event_time,\n",
+      "  eyauef.changed_properties,\n",
+      "  current.adUnitId AS current_adUnitId,\n",
+      "  current.adUnitName AS current_adUnitName,\n",
+      "  current.adUnitSize AS current_adUnitSize,\n",
+      "  current.adUnitPosition AS current_adUnitPosition\n",
+      "ORDER BY eyauef.event_time DESC\n",
+      "LIMIT @result_limit\n",
+      "\n",
+      "Lineage query failed: 400 Syntax error: Expected \")\" but got keyword CURRENT at [3:65]; reason: invalidQuery, location: query, message: Syntax error: Expected \")\" but got keyword CURRENT at [3:65]\n",
+      "\n",
+      "Location: US\n",
+      "Job ID: 0b53cded-6b12-436d-bbbe-7f3821ce4b92\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "lineage_gql = compile_lineage_gql(spec=spec, project_id=PROJECT_ID, dataset_id=SCRATCH_DATASET, relationship_name=\"sup_YahooAdUnitEvolvedFrom\")\n",
+    "print(\"=== Lineage GQL ===\")\n",
+    "print(lineage_gql)\n",
+    "\n",
+    "try:\n",
+    "    job = bq.query(lineage_gql, job_config=bigquery.QueryJobConfig(\n",
+    "        query_parameters=[\n",
+    "            bigquery.ScalarQueryParameter(\"session_id\", \"STRING\", \"sess-synthetic-B\"),\n",
+    "            bigquery.ScalarQueryParameter(\"result_limit\", \"INT64\", 50),\n",
+    "        ]\n",
+    "    ))\n",
+    "    lineage_results = job.to_dataframe()\n",
+    "    print(f\"\\nLineage traversal: {len(lineage_results)} rows\")\n",
+    "    if len(lineage_results) > 0:\n",
+    "        print(lineage_results.head(10))\n",
+    "    else:\n",
+    "        print(\"No lineage rows returned\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Lineage query failed: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "cell31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-14T05:52:43.731223Z",
+     "iopub.status.busy": "2026-04-14T05:52:43.731127Z",
+     "iopub.status.idle": "2026-04-14T05:52:44.166407Z",
+     "shell.execute_reply": "2026-04-14T05:52:44.165609Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted scratch dataset: agent_analytics_v5_7e508241\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Clean up the scratch dataset\n",
+    "bq.delete_dataset(\n",
+    "    f\"{PROJECT_ID}.{SCRATCH_DATASET}\",\n",
+    "    delete_contents=True,\n",
+    "    not_found_ok=True,\n",
+    ")\n",
+    "print(f\"Deleted scratch dataset: {SCRATCH_DATASET}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dbe8bd3a",
+   "id": "cell32",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
-    "The V5 Context Graph pipeline extends V4 with three new capabilities:\n",
+    "This notebook demonstrated the **Context Graph V5** pipeline end-to-end:\n",
     "\n",
-    "| Feature | V4 | V5 |\n",
-    "|---------|----|----|  \n",
-    "| **Ontology Source** | Hand-authored YAML only | YAML + OWL/Turtle import via `ttl_import`/`ttl_resolve` |\n",
-    "| **Extraction** | AI-only (`AI.GENERATE`) | Mixed: structured extractors + AI for unhandled spans |\n",
-    "| **Scope** | Single-session graph | Cross-session temporal lineage via `detect_lineage_edges` |\n",
-    "| **GQL** | `compile_showcase_gql` (forward traversal) | + `compile_lineage_gql` (self-edge evolution queries) |\n",
-    "| **Spec Format** | Entities + relationships | + lineage self-edge relationships with session columns |\n",
+    "| Step | What it does | Key API |\n",
+    "|------|-------------|---------|\n",
+    "| **TTL Import** | Bootstrap a GraphSpec YAML from an OWL/Turtle file | `ttl_import()`, `ttl_resolve()` |\n",
+    "| **Mixed Extraction** | Combine deterministic structured extractors with AI.GENERATE | `OntologyGraphManager(extractors=...)` |\n",
+    "| **Batch Materialization** | Insert rows via staging tables with full status reporting | `OntologyMaterializer(write_mode=\"batch_load\")`, `materialize_with_status()` |\n",
+    "| **Temporal Lineage** | Detect and materialize cross-session entity evolution | `detect_lineage_edges()` |\n",
+    "| **GQL Queries** | Forward traversal and lineage traversal over the property graph | `compile_showcase_gql()`, `compile_lineage_gql()` |\n",
     "\n",
-    "### What this notebook verified\n",
+    "**What was verified:**\n",
+    "- TTL import produces valid YAML with entities, relationships, and primary keys.\n",
+    "- `ttl_resolve` replaces FILL_IN placeholders with user-supplied keys.\n",
+    "- The BKA structured extractor produces deterministic `ExtractedNode` instances.\n",
+    "- `batch_load` mode materializes rows via staging tables with `TableStatus` reporting.\n",
+    "- `detect_lineage_edges` finds shared-key entities with changed properties across sessions.\n",
+    "- Lineage edges are materialized and queryable via `compile_lineage_gql`.\n",
     "\n",
-    "- **TTL import**: two-phase import/resolve produces a valid `GraphSpec` from OWL/Turtle\n",
-    "- **Structured extraction**: `extract_bka_decision_event` correctly handles BKA events; `OntologyGraphManager(extractors=...)` accepts the registry\n",
-    "- **Schema filtering**: `_route_node`/`_route_edge` drop non-schema properties before insert, preventing cross-entity field leakage from AI.GENERATE\n",
-    "- **DDL compilation**: lineage edge table DDL uses `from_session_column`/`to_session_column` overrides for SOURCE/DESTINATION KEY\n",
-    "- **GQL compilation**: both forward traversal and lineage GQL compile correctly\n",
-    "- **Forward traversal GQL**: executed successfully against BigQuery\n",
-    "\n",
-    "### Known limitations in this execution\n",
-    "\n",
-    "- **Row counts are not a clean correctness signal.** The materializer uses `DELETE`-then-`INSERT` for session-scoped idempotency, but BigQuery streaming-buffer tables reject `DELETE` on recently streamed rows. The materializer logs and swallows these failures, then inserts new rows — resulting in stale duplicates from prior runs. The forward traversal row count reflects accumulated data, not just the current extraction.\n",
-    "- **Lineage GQL not executed.** `compile_lineage_gql` output is shown but not executed against BigQuery because sessions A and B extracted different ad units (no shared `adUnitId`), producing 0 lineage edges to query. Lineage detection logic is validated by unit tests with controlled fixtures.\n",
-    "- **Idempotency strategy.** Reliable session-scoped cleanup requires either (a) waiting for the streaming buffer to flush before `DELETE`, (b) using `MERGE` instead of `DELETE`+`INSERT`, or (c) loading via `load_table_from_json` (non-streaming) instead of `insert_rows_json`. This is a pre-existing V4 limitation, not a V5 regression.\n",
-    "\n",
-    "### Key APIs introduced in V5\n",
-    "\n",
-    "- `bigquery_agent_analytics.ttl_importer.ttl_import` — Phase 1 OWL-to-YAML import\n",
-    "- `bigquery_agent_analytics.ttl_importer.ttl_resolve` — Phase 2 placeholder resolution\n",
-    "- `bigquery_agent_analytics.structured_extraction.extract_bka_decision_event` — Example structured extractor\n",
-    "- `bigquery_agent_analytics.structured_extraction.run_structured_extractors` — Extractor runner\n",
-    "- `bigquery_agent_analytics.ontology_graph.detect_lineage_edges` — Cross-session evolution detection\n",
-    "- `bigquery_agent_analytics.ontology_orchestrator.compile_lineage_gql` — Lineage GQL compiler\n",
-    "- `OntologyGraphManager(extractors=...)` — New parameter to register structured extractors\n"
+    "**Limitations:**\n",
+    "- The lineage demo uses a synthetic Session B; real lineage requires multiple real sessions.\n",
+    "- GQL query results depend on the actual data extracted from your ADK telemetry.\n",
+    "- The scratch dataset auto-expires tables after 1 hour, but explicit cleanup is still recommended."
    ]
   }
  ],

--- a/examples/ontology_graph_v5_demo.ipynb
+++ b/examples/ontology_graph_v5_demo.ipynb
@@ -6,10 +6,10 @@
    "id": "cell01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:00.557503Z",
-     "iopub.status.busy": "2026-04-14T05:51:00.557271Z",
-     "iopub.status.idle": "2026-04-14T05:51:00.561760Z",
-     "shell.execute_reply": "2026-04-14T05:51:00.560983Z"
+     "iopub.execute_input": "2026-04-14T05:58:18.648306Z",
+     "iopub.status.busy": "2026-04-14T05:58:18.648125Z",
+     "iopub.status.idle": "2026-04-14T05:58:18.652376Z",
+     "shell.execute_reply": "2026-04-14T05:58:18.651632Z"
     }
    },
    "outputs": [],
@@ -97,10 +97,10 @@
    "id": "cell05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:00.564140Z",
-     "iopub.status.busy": "2026-04-14T05:51:00.564010Z",
-     "iopub.status.idle": "2026-04-14T05:51:01.258177Z",
-     "shell.execute_reply": "2026-04-14T05:51:01.257497Z"
+     "iopub.execute_input": "2026-04-14T05:58:18.654443Z",
+     "iopub.status.busy": "2026-04-14T05:58:18.654335Z",
+     "iopub.status.idle": "2026-04-14T05:58:19.528354Z",
+     "shell.execute_reply": "2026-04-14T05:58:19.527553Z"
     }
    },
    "outputs": [
@@ -144,10 +144,10 @@
    "id": "cell07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:01.260594Z",
-     "iopub.status.busy": "2026-04-14T05:51:01.260428Z",
-     "iopub.status.idle": "2026-04-14T05:51:01.265400Z",
-     "shell.execute_reply": "2026-04-14T05:51:01.264969Z"
+     "iopub.execute_input": "2026-04-14T05:58:19.530467Z",
+     "iopub.status.busy": "2026-04-14T05:58:19.530344Z",
+     "iopub.status.idle": "2026-04-14T05:58:19.534968Z",
+     "shell.execute_reply": "2026-04-14T05:58:19.534502Z"
     }
    },
    "outputs": [
@@ -192,10 +192,10 @@
    "id": "cell08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:01.266952Z",
-     "iopub.status.busy": "2026-04-14T05:51:01.266846Z",
-     "iopub.status.idle": "2026-04-14T05:51:04.035016Z",
-     "shell.execute_reply": "2026-04-14T05:51:04.033869Z"
+     "iopub.execute_input": "2026-04-14T05:58:19.536293Z",
+     "iopub.status.busy": "2026-04-14T05:58:19.536204Z",
+     "iopub.status.idle": "2026-04-14T05:58:22.521979Z",
+     "shell.execute_reply": "2026-04-14T05:58:22.520691Z"
     }
    },
    "outputs": [
@@ -203,7 +203,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scratch dataset: agent_analytics_v5_7e508241\n",
+      "Scratch dataset: agent_analytics_v5_8ec7050a\n",
       "Tables auto-expire in 1 hour\n"
      ]
     }
@@ -243,10 +243,10 @@
    "id": "cell10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:04.038277Z",
-     "iopub.status.busy": "2026-04-14T05:51:04.037894Z",
-     "iopub.status.idle": "2026-04-14T05:51:04.045612Z",
-     "shell.execute_reply": "2026-04-14T05:51:04.044781Z"
+     "iopub.execute_input": "2026-04-14T05:58:22.524773Z",
+     "iopub.status.busy": "2026-04-14T05:58:22.524492Z",
+     "iopub.status.idle": "2026-04-14T05:58:22.530350Z",
+     "shell.execute_reply": "2026-04-14T05:58:22.529689Z"
     }
    },
    "outputs": [
@@ -360,10 +360,10 @@
    "id": "cell11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:04.047610Z",
-     "iopub.status.busy": "2026-04-14T05:51:04.047446Z",
-     "iopub.status.idle": "2026-04-14T05:51:05.795709Z",
-     "shell.execute_reply": "2026-04-14T05:51:05.795251Z"
+     "iopub.execute_input": "2026-04-14T05:58:22.532260Z",
+     "iopub.status.busy": "2026-04-14T05:58:22.532133Z",
+     "iopub.status.idle": "2026-04-14T05:58:24.252558Z",
+     "shell.execute_reply": "2026-04-14T05:58:24.252079Z"
     }
    },
    "outputs": [
@@ -415,10 +415,10 @@
    "id": "cell12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:05.797597Z",
-     "iopub.status.busy": "2026-04-14T05:51:05.797360Z",
-     "iopub.status.idle": "2026-04-14T05:51:05.799573Z",
-     "shell.execute_reply": "2026-04-14T05:51:05.799015Z"
+     "iopub.execute_input": "2026-04-14T05:58:24.254726Z",
+     "iopub.status.busy": "2026-04-14T05:58:24.254435Z",
+     "iopub.status.idle": "2026-04-14T05:58:24.256694Z",
+     "shell.execute_reply": "2026-04-14T05:58:24.256257Z"
     }
    },
    "outputs": [
@@ -429,7 +429,7 @@
       "ontology_import:\n",
       "  status: unresolved\n",
       "  source_file: /Users/haiyuancao/BigQuery-Agent-Analytics-SDK/examples/yamo_sample.ttl\n",
-      "  import_timestamp: '2026-04-14T05:51:05.791802+00:00'\n",
+      "  import_timestamp: '2026-04-14T05:58:24.248815+00:00'\n",
       "  placeholders_remaining: 1\n",
       "graph:\n",
       "  name: yamo_imported\n",
@@ -541,10 +541,10 @@
    "id": "cell14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:05.800894Z",
-     "iopub.status.busy": "2026-04-14T05:51:05.800802Z",
-     "iopub.status.idle": "2026-04-14T05:51:05.815366Z",
-     "shell.execute_reply": "2026-04-14T05:51:05.814957Z"
+     "iopub.execute_input": "2026-04-14T05:58:24.258221Z",
+     "iopub.status.busy": "2026-04-14T05:58:24.258125Z",
+     "iopub.status.idle": "2026-04-14T05:58:24.271839Z",
+     "shell.execute_reply": "2026-04-14T05:58:24.271406Z"
     }
    },
    "outputs": [
@@ -605,10 +605,10 @@
    "id": "cell16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:05.816781Z",
-     "iopub.status.busy": "2026-04-14T05:51:05.816676Z",
-     "iopub.status.idle": "2026-04-14T05:51:05.824227Z",
-     "shell.execute_reply": "2026-04-14T05:51:05.823751Z"
+     "iopub.execute_input": "2026-04-14T05:58:24.273229Z",
+     "iopub.status.busy": "2026-04-14T05:58:24.273164Z",
+     "iopub.status.idle": "2026-04-14T05:58:24.279839Z",
+     "shell.execute_reply": "2026-04-14T05:58:24.279484Z"
     }
    },
    "outputs": [
@@ -737,10 +737,10 @@
    "id": "cell17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:05.825656Z",
-     "iopub.status.busy": "2026-04-14T05:51:05.825570Z",
-     "iopub.status.idle": "2026-04-14T05:51:05.828369Z",
-     "shell.execute_reply": "2026-04-14T05:51:05.827982Z"
+     "iopub.execute_input": "2026-04-14T05:58:24.280960Z",
+     "iopub.status.busy": "2026-04-14T05:58:24.280881Z",
+     "iopub.status.idle": "2026-04-14T05:58:24.283539Z",
+     "shell.execute_reply": "2026-04-14T05:58:24.283139Z"
     }
    },
    "outputs": [
@@ -792,10 +792,10 @@
    "id": "cell18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:05.829554Z",
-     "iopub.status.busy": "2026-04-14T05:51:05.829479Z",
-     "iopub.status.idle": "2026-04-14T05:51:08.680095Z",
-     "shell.execute_reply": "2026-04-14T05:51:08.678386Z"
+     "iopub.execute_input": "2026-04-14T05:58:24.284555Z",
+     "iopub.status.busy": "2026-04-14T05:58:24.284477Z",
+     "iopub.status.idle": "2026-04-14T05:58:26.586851Z",
+     "shell.execute_reply": "2026-04-14T05:58:26.585888Z"
     }
    },
    "outputs": [
@@ -868,10 +868,10 @@
    "id": "cell20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:51:08.684595Z",
-     "iopub.status.busy": "2026-04-14T05:51:08.684297Z",
-     "iopub.status.idle": "2026-04-14T05:52:06.759019Z",
-     "shell.execute_reply": "2026-04-14T05:52:06.758102Z"
+     "iopub.execute_input": "2026-04-14T05:58:26.589250Z",
+     "iopub.status.busy": "2026-04-14T05:58:26.589083Z",
+     "iopub.status.idle": "2026-04-14T05:58:58.683366Z",
+     "shell.execute_reply": "2026-04-14T05:58:58.682386Z"
     }
    },
    "outputs": [
@@ -880,12 +880,12 @@
      "output_type": "stream",
      "text": [
       "Tables created:\n",
-      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics_v5_7e508241.decision_points\n",
-      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units\n",
-      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics_v5_7e508241.rejection_reasons\n",
-      "  CandidateEdge -> test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges\n",
-      "  ForCandidate -> test-project-0728-467323.agent_analytics_v5_7e508241.rejection_mappings\n",
-      "  sup_YahooAdUnitEvolvedFrom -> test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage\n"
+      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics_v5_8ec7050a.decision_points\n",
+      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics_v5_8ec7050a.yahoo_ad_units\n",
+      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics_v5_8ec7050a.rejection_reasons\n",
+      "  CandidateEdge -> test-project-0728-467323.agent_analytics_v5_8ec7050a.candidate_edges\n",
+      "  ForCandidate -> test-project-0728-467323.agent_analytics_v5_8ec7050a.rejection_mappings\n",
+      "  sup_YahooAdUnitEvolvedFrom -> test-project-0728-467323.agent_analytics_v5_8ec7050a.sup_yahoo_ad_unit_lineage\n"
      ]
     },
     {
@@ -894,9 +894,9 @@
      "text": [
       "\n",
       "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 1, 'CandidateEdge': 2}\n",
-      "  test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units: cleanup=deleted insert=inserted idempotent=True\n",
-      "  test-project-0728-467323.agent_analytics_v5_7e508241.decision_points: cleanup=deleted insert=inserted idempotent=True\n",
-      "  test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges: cleanup=deleted insert=inserted idempotent=True\n"
+      "  test-project-0728-467323.agent_analytics_v5_8ec7050a.yahoo_ad_units: cleanup=deleted insert=inserted idempotent=True\n",
+      "  test-project-0728-467323.agent_analytics_v5_8ec7050a.decision_points: cleanup=deleted insert=inserted idempotent=True\n",
+      "  test-project-0728-467323.agent_analytics_v5_8ec7050a.candidate_edges: cleanup=deleted insert=inserted idempotent=True\n"
      ]
     }
    ],
@@ -929,10 +929,10 @@
    "id": "cell21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:06.761046Z",
-     "iopub.status.busy": "2026-04-14T05:52:06.760893Z",
-     "iopub.status.idle": "2026-04-14T05:52:06.763938Z",
-     "shell.execute_reply": "2026-04-14T05:52:06.763167Z"
+     "iopub.execute_input": "2026-04-14T05:58:58.686365Z",
+     "iopub.status.busy": "2026-04-14T05:58:58.686161Z",
+     "iopub.status.idle": "2026-04-14T05:58:58.690103Z",
+     "shell.execute_reply": "2026-04-14T05:58:58.689331Z"
     }
    },
    "outputs": [
@@ -940,9 +940,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
+      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics_v5_8ec7050a.YMGO_Context_Graph_V3`\n",
       "  NODE TABLES (\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.decision_points` AS mako_DecisionPoint\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.decision_points` AS mako_DecisionPoint\n",
       "      KEY (decision_id, session_id)\n",
       "      LABEL mako_DecisionPoint\n",
       "      PROPERTIES (\n",
@@ -951,7 +951,7 @@
       "        session_id,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.yahoo_ad_units` AS sup_YahooAdUnit\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.yahoo_ad_units` AS sup_YahooAdUnit\n",
       "      KEY (adUnitId, session_id)\n",
       "      LABEL sup_YahooAdUnit\n",
       "      LABEL mako_Candidate\n",
@@ -963,7 +963,7 @@
       "        session_id,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.rejection_reasons` AS mako_RejectionReason\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.rejection_reasons` AS mako_RejectionReason\n",
       "      KEY (rejection_id, session_id)\n",
       "      LABEL mako_RejectionReason\n",
       "      PROPERTIES (\n",
@@ -975,7 +975,7 @@
       "      )\n",
       "  )\n",
       "  EDGE TABLES (\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.candidate_edges` AS CandidateEdge\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.candidate_edges` AS CandidateEdge\n",
       "      KEY (decision_id, adUnitId, session_id)\n",
       "      SOURCE KEY (decision_id, session_id) REFERENCES mako_DecisionPoint (decision_id, session_id)\n",
       "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -985,7 +985,7 @@
       "        mako_scoreValue,\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.rejection_mappings` AS ForCandidate\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.rejection_mappings` AS ForCandidate\n",
       "      KEY (rejection_id, adUnitId, session_id)\n",
       "      SOURCE KEY (rejection_id, session_id) REFERENCES mako_RejectionReason (rejection_id, session_id)\n",
       "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -993,7 +993,7 @@
       "      PROPERTIES (\n",
       "        extracted_at\n",
       "      ),\n",
-      "    `test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage` AS sup_YahooAdUnitEvolvedFrom\n",
+      "    `test-project-0728-467323.agent_analytics_v5_8ec7050a.sup_yahoo_ad_unit_lineage` AS sup_YahooAdUnitEvolvedFrom\n",
       "      KEY (adUnitId, from_session_id, to_session_id, session_id)\n",
       "      SOURCE KEY (adUnitId, from_session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
       "      DESTINATION KEY (adUnitId, to_session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
@@ -1022,10 +1022,10 @@
    "id": "cell22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:06.765498Z",
-     "iopub.status.busy": "2026-04-14T05:52:06.765386Z",
-     "iopub.status.idle": "2026-04-14T05:52:08.887700Z",
-     "shell.execute_reply": "2026-04-14T05:52:08.886766Z"
+     "iopub.execute_input": "2026-04-14T05:58:58.692049Z",
+     "iopub.status.busy": "2026-04-14T05:58:58.691888Z",
+     "iopub.status.idle": "2026-04-14T05:59:01.032346Z",
+     "shell.execute_reply": "2026-04-14T05:59:01.030852Z"
     }
    },
    "outputs": [
@@ -1070,10 +1070,10 @@
    "id": "cell24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:08.890273Z",
-     "iopub.status.busy": "2026-04-14T05:52:08.890090Z",
-     "iopub.status.idle": "2026-04-14T05:52:21.064561Z",
-     "shell.execute_reply": "2026-04-14T05:52:21.063461Z"
+     "iopub.execute_input": "2026-04-14T05:59:01.035664Z",
+     "iopub.status.busy": "2026-04-14T05:59:01.035459Z",
+     "iopub.status.idle": "2026-04-14T05:59:10.447016Z",
+     "shell.execute_reply": "2026-04-14T05:59:10.445725Z"
     }
    },
    "outputs": [
@@ -1123,10 +1123,10 @@
    "id": "cell25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:21.067078Z",
-     "iopub.status.busy": "2026-04-14T05:52:21.066887Z",
-     "iopub.status.idle": "2026-04-14T05:52:21.071544Z",
-     "shell.execute_reply": "2026-04-14T05:52:21.071010Z"
+     "iopub.execute_input": "2026-04-14T05:59:10.449915Z",
+     "iopub.status.busy": "2026-04-14T05:59:10.449704Z",
+     "iopub.status.idle": "2026-04-14T05:59:10.455054Z",
+     "shell.execute_reply": "2026-04-14T05:59:10.454071Z"
     }
    },
    "outputs": [
@@ -1138,7 +1138,7 @@
       "  sess-synthetic-B:sup_YahooAdUnitEvolvedFrom:adcp-033c95d7a97d:adUnitId=yahoo_homepage_display_premium\n",
       "    from_session_id = adcp-033c95d7a97d\n",
       "    to_session_id = sess-synthetic-B\n",
-      "    event_time = 2026-04-14T05:52:21.069343+00:00\n",
+      "    event_time = 2026-04-14T05:59:10.452196+00:00\n",
       "    changed_properties = adUnitName,adUnitPosition\n"
      ]
     }
@@ -1166,10 +1166,10 @@
    "id": "cell26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:21.073951Z",
-     "iopub.status.busy": "2026-04-14T05:52:21.073781Z",
-     "iopub.status.idle": "2026-04-14T05:52:40.292497Z",
-     "shell.execute_reply": "2026-04-14T05:52:40.291544Z"
+     "iopub.execute_input": "2026-04-14T05:59:10.457365Z",
+     "iopub.status.busy": "2026-04-14T05:59:10.457174Z",
+     "iopub.status.idle": "2026-04-14T05:59:20.744146Z",
+     "shell.execute_reply": "2026-04-14T05:59:20.743572Z"
     }
    },
    "outputs": [
@@ -1178,7 +1178,7 @@
      "output_type": "stream",
      "text": [
       "Lineage rows: {'sup_YahooAdUnitEvolvedFrom': 1}\n",
-      "  test-project-0728-467323.agent_analytics_v5_7e508241.sup_yahoo_ad_unit_lineage: cleanup=deleted insert=inserted idempotent=True\n"
+      "  test-project-0728-467323.agent_analytics_v5_8ec7050a.sup_yahoo_ad_unit_lineage: cleanup=deleted insert=inserted idempotent=True\n"
      ]
     }
    ],
@@ -1214,10 +1214,10 @@
    "id": "cell28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:40.295242Z",
-     "iopub.status.busy": "2026-04-14T05:52:40.295073Z",
-     "iopub.status.idle": "2026-04-14T05:52:40.299011Z",
-     "shell.execute_reply": "2026-04-14T05:52:40.298229Z"
+     "iopub.execute_input": "2026-04-14T05:59:20.745974Z",
+     "iopub.status.busy": "2026-04-14T05:59:20.745843Z",
+     "iopub.status.idle": "2026-04-14T05:59:20.748784Z",
+     "shell.execute_reply": "2026-04-14T05:59:20.748290Z"
     }
    },
    "outputs": [
@@ -1226,7 +1226,7 @@
      "output_type": "stream",
      "text": [
       "=== Showcase GQL ===\n",
-      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_8ec7050a.YMGO_Context_Graph_V3`\n",
       "MATCH\n",
       "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
       "WHERE dp.session_id = @session_id\n",
@@ -1244,23 +1244,23 @@
       "\n",
       "\n",
       "=== Lineage GQL ===\n",
-      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_8ec7050a.YMGO_Context_Graph_V3`\n",
       "MATCH\n",
-      "  (prior:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(current:sup_YahooAdUnit)\n",
-      "WHERE current.session_id = @session_id\n",
+      "  (prev:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(cur:sup_YahooAdUnit)\n",
+      "WHERE cur.session_id = @session_id\n",
       "RETURN\n",
-      "  prior.adUnitId AS prior_adUnitId,\n",
-      "  prior.adUnitName AS prior_adUnitName,\n",
-      "  prior.adUnitSize AS prior_adUnitSize,\n",
-      "  prior.adUnitPosition AS prior_adUnitPosition,\n",
+      "  prev.adUnitId AS prior_adUnitId,\n",
+      "  prev.adUnitName AS prior_adUnitName,\n",
+      "  prev.adUnitSize AS prior_adUnitSize,\n",
+      "  prev.adUnitPosition AS prior_adUnitPosition,\n",
       "  eyauef.from_session_id,\n",
       "  eyauef.to_session_id,\n",
       "  eyauef.event_time,\n",
       "  eyauef.changed_properties,\n",
-      "  current.adUnitId AS current_adUnitId,\n",
-      "  current.adUnitName AS current_adUnitName,\n",
-      "  current.adUnitSize AS current_adUnitSize,\n",
-      "  current.adUnitPosition AS current_adUnitPosition\n",
+      "  cur.adUnitId AS current_adUnitId,\n",
+      "  cur.adUnitName AS current_adUnitName,\n",
+      "  cur.adUnitSize AS current_adUnitSize,\n",
+      "  cur.adUnitPosition AS current_adUnitPosition\n",
       "ORDER BY eyauef.event_time DESC\n",
       "LIMIT @result_limit\n",
       "\n"
@@ -1295,10 +1295,10 @@
    "id": "cell29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:40.300953Z",
-     "iopub.status.busy": "2026-04-14T05:52:40.300822Z",
-     "iopub.status.idle": "2026-04-14T05:52:43.598632Z",
-     "shell.execute_reply": "2026-04-14T05:52:43.598080Z"
+     "iopub.execute_input": "2026-04-14T05:59:20.750403Z",
+     "iopub.status.busy": "2026-04-14T05:59:20.750281Z",
+     "iopub.status.idle": "2026-04-14T05:59:24.204733Z",
+     "shell.execute_reply": "2026-04-14T05:59:24.203784Z"
     }
    },
    "outputs": [
@@ -1346,10 +1346,10 @@
    "id": "cell30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:43.599967Z",
-     "iopub.status.busy": "2026-04-14T05:52:43.599874Z",
-     "iopub.status.idle": "2026-04-14T05:52:43.729863Z",
-     "shell.execute_reply": "2026-04-14T05:52:43.729275Z"
+     "iopub.execute_input": "2026-04-14T05:59:24.206983Z",
+     "iopub.status.busy": "2026-04-14T05:59:24.206791Z",
+     "iopub.status.idle": "2026-04-14T05:59:27.275167Z",
+     "shell.execute_reply": "2026-04-14T05:59:27.274554Z"
     }
    },
    "outputs": [
@@ -1358,31 +1358,48 @@
      "output_type": "stream",
      "text": [
       "=== Lineage GQL ===\n",
-      "GRAPH `test-project-0728-467323.agent_analytics_v5_7e508241.YMGO_Context_Graph_V3`\n",
+      "GRAPH `test-project-0728-467323.agent_analytics_v5_8ec7050a.YMGO_Context_Graph_V3`\n",
       "MATCH\n",
-      "  (prior:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(current:sup_YahooAdUnit)\n",
-      "WHERE current.session_id = @session_id\n",
+      "  (prev:sup_YahooAdUnit)-[eyauef:sup_YahooAdUnitEvolvedFrom]->(cur:sup_YahooAdUnit)\n",
+      "WHERE cur.session_id = @session_id\n",
       "RETURN\n",
-      "  prior.adUnitId AS prior_adUnitId,\n",
-      "  prior.adUnitName AS prior_adUnitName,\n",
-      "  prior.adUnitSize AS prior_adUnitSize,\n",
-      "  prior.adUnitPosition AS prior_adUnitPosition,\n",
+      "  prev.adUnitId AS prior_adUnitId,\n",
+      "  prev.adUnitName AS prior_adUnitName,\n",
+      "  prev.adUnitSize AS prior_adUnitSize,\n",
+      "  prev.adUnitPosition AS prior_adUnitPosition,\n",
       "  eyauef.from_session_id,\n",
       "  eyauef.to_session_id,\n",
       "  eyauef.event_time,\n",
       "  eyauef.changed_properties,\n",
-      "  current.adUnitId AS current_adUnitId,\n",
-      "  current.adUnitName AS current_adUnitName,\n",
-      "  current.adUnitSize AS current_adUnitSize,\n",
-      "  current.adUnitPosition AS current_adUnitPosition\n",
+      "  cur.adUnitId AS current_adUnitId,\n",
+      "  cur.adUnitName AS current_adUnitName,\n",
+      "  cur.adUnitSize AS current_adUnitSize,\n",
+      "  cur.adUnitPosition AS current_adUnitPosition\n",
       "ORDER BY eyauef.event_time DESC\n",
       "LIMIT @result_limit\n",
-      "\n",
-      "Lineage query failed: 400 Syntax error: Expected \")\" but got keyword CURRENT at [3:65]; reason: invalidQuery, location: query, message: Syntax error: Expected \")\" but got keyword CURRENT at [3:65]\n",
-      "\n",
-      "Location: US\n",
-      "Job ID: 0b53cded-6b12-436d-bbbe-7f3821ce4b92\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Lineage traversal: 1 rows\n",
+      "                   prior_adUnitId prior_adUnitName prior_adUnitSize  \\\n",
+      "0  yahoo_homepage_display_premium   Yahoo Homepage          display   \n",
+      "\n",
+      "  prior_adUnitPosition    from_session_id     to_session_id  \\\n",
+      "0    Premium Placement  adcp-033c95d7a97d  sess-synthetic-B   \n",
+      "\n",
+      "                        event_time         changed_properties  \\\n",
+      "0 2026-04-14 05:59:10.452196+00:00  adUnitName,adUnitPosition   \n",
+      "\n",
+      "                 current_adUnitId           current_adUnitName  \\\n",
+      "0  yahoo_homepage_display_premium  Yahoo Homepage (Redesigned)   \n",
+      "\n",
+      "  current_adUnitSize current_adUnitPosition  \n",
+      "0            display                    BTF  \n"
      ]
     }
    ],
@@ -1414,10 +1431,10 @@
    "id": "cell31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-14T05:52:43.731223Z",
-     "iopub.status.busy": "2026-04-14T05:52:43.731127Z",
-     "iopub.status.idle": "2026-04-14T05:52:44.166407Z",
-     "shell.execute_reply": "2026-04-14T05:52:44.165609Z"
+     "iopub.execute_input": "2026-04-14T05:59:27.277100Z",
+     "iopub.status.busy": "2026-04-14T05:59:27.276954Z",
+     "iopub.status.idle": "2026-04-14T05:59:27.669541Z",
+     "shell.execute_reply": "2026-04-14T05:59:27.668789Z"
     }
    },
    "outputs": [
@@ -1425,7 +1442,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deleted scratch dataset: agent_analytics_v5_7e508241\n"
+      "Deleted scratch dataset: agent_analytics_v5_8ec7050a\n"
      ]
     }
    ],

--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -420,9 +420,13 @@ except ImportError as e:
 
 # Ontology Materializer
 try:
+  from .ontology_materializer import MaterializationResult
   from .ontology_materializer import OntologyMaterializer
+  from .ontology_materializer import TableStatus
 
-  __all__.append("OntologyMaterializer")
+  __all__.extend(
+      ["MaterializationResult", "OntologyMaterializer", "TableStatus"]
+  )
 except ImportError as e:
   logger.debug(
       "Could not import ontology materializer: %s.",

--- a/src/bigquery_agent_analytics/ontology_materializer.py
+++ b/src/bigquery_agent_analytics/ontology_materializer.py
@@ -47,9 +47,11 @@ Example usage::
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 from typing import Optional
+import uuid
 
 from google.cloud import bigquery
 
@@ -62,6 +64,46 @@ from .ontology_models import PropertySpec
 from .ontology_models import RelationshipSpec
 
 logger = logging.getLogger("bigquery_agent_analytics." + __name__)
+
+
+# ------------------------------------------------------------------ #
+# Materialization status dataclasses                                   #
+# ------------------------------------------------------------------ #
+
+
+@dataclasses.dataclass
+class TableStatus:
+  """Status of a single table materialization operation.
+
+  Attributes:
+      table_ref: Fully qualified BigQuery table reference.
+      rows_attempted: Number of rows attempted for insert.
+      rows_inserted: Number of rows successfully inserted.
+      cleanup_status: One of 'deleted', 'delete_failed', or 'skipped'.
+      insert_status: One of 'inserted' or 'insert_failed'.
+      idempotent: True only if cleanup succeeded before insert.
+  """
+
+  table_ref: str
+  rows_attempted: int
+  rows_inserted: int
+  cleanup_status: str  # 'deleted' | 'delete_failed' | 'skipped'
+  insert_status: str  # 'inserted' | 'insert_failed'
+  idempotent: bool  # True only if cleanup succeeded before insert
+
+
+@dataclasses.dataclass
+class MaterializationResult:
+  """Result of a materialization operation.
+
+  Attributes:
+      row_counts: Name to count mapping (backward compatible).
+      table_statuses: Table ref to TableStatus mapping.
+  """
+
+  row_counts: dict[str, int]  # name -> count (backward compat)
+  table_statuses: dict[str, TableStatus]  # table_ref -> status
+
 
 # ------------------------------------------------------------------ #
 # Type mapping: YAML property types -> BQ DDL types                    #
@@ -322,6 +364,9 @@ class OntologyMaterializer:
       spec: A validated ``GraphSpec``.
       bq_client: Optional pre-configured BigQuery client.
       location: BigQuery location.
+      write_mode: Write strategy — ``'streaming'`` (default) uses
+          ``insert_rows_json``; ``'batch_load'`` uses
+          ``load_table_from_json`` with a staging table.
   """
 
   def __init__(
@@ -331,11 +376,18 @@ class OntologyMaterializer:
       spec: GraphSpec,
       bq_client: Optional[bigquery.Client] = None,
       location: Optional[str] = None,
+      write_mode: str = "streaming",
   ) -> None:
+    if write_mode not in ("streaming", "batch_load"):
+      raise ValueError(
+          f"write_mode must be 'streaming' or 'batch_load', "
+          f"got {write_mode!r}."
+      )
     self.project_id = project_id
     self.dataset_id = dataset_id
     self.spec = spec
     self.location = location
+    self.write_mode = write_mode
     self._bq_client = bq_client
 
   @property
@@ -466,10 +518,13 @@ class OntologyMaterializer:
 
   # ---- Materialization --------------------------------------------
 
-  def _delete_for_sessions(
-      self, table_ref: str, session_ids: list[str]
-  ) -> None:
-    """Delete rows for given sessions from a table."""
+  def _delete_for_sessions(self, table_ref: str, session_ids: list[str]) -> str:
+    """Delete rows for given sessions from a table.
+
+    Returns:
+        ``'deleted'`` on success, ``'skipped'`` if the table does not
+        exist, or ``'delete_failed'`` on other errors.
+    """
     job_config = bigquery.QueryJobConfig(
         query_parameters=[
             bigquery.ArrayQueryParameter("session_ids", "STRING", session_ids),
@@ -481,35 +536,110 @@ class OntologyMaterializer:
           job_config=job_config,
       )
       job.result()
+      return "deleted"
     except Exception as e:
       err_msg = str(e).lower()
       if "not found" in err_msg or "does not exist" in err_msg:
         logger.debug("Table %s does not exist yet: %s", table_ref, e)
+        return "skipped"
       else:
         logger.warning("Delete for sessions failed on %s: %s", table_ref, e)
+        return "delete_failed"
 
-  def materialize(
+  def _batch_load_table(
+      self,
+      table_ref: str,
+      rows: list[dict],
+      session_ids: list[str],
+  ) -> TableStatus:
+    """Load rows via ``load_table_from_json`` with a staging table.
+
+    Steps:
+      1. Load rows into a staging table (``table_ref + '_staging_<hex>'``).
+      2. DELETE existing rows for *session_ids* from the target table.
+      3. INSERT INTO target FROM staging.
+      4. DROP staging table.
+
+    Args:
+        table_ref: Fully qualified target table reference.
+        rows: Row dicts to insert.
+        session_ids: Sessions to delete before insert.
+
+    Returns:
+        A ``TableStatus`` describing the outcome.
+    """
+    staging_suffix = uuid.uuid4().hex[:8]
+    staging_ref = f"{table_ref}_staging_{staging_suffix}"
+    cleanup_status = "skipped"
+    insert_status = "insert_failed"
+    rows_inserted = 0
+
+    try:
+      # Retrieve the target table schema for the load job.
+      target_table = self.bq_client.get_table(table_ref)
+      schema = target_table.schema
+
+      # Step 1: Load rows into the staging table.
+      job_config = bigquery.LoadJobConfig(
+          write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+          autodetect=False,
+          schema=schema,
+      )
+      load_job = self.bq_client.load_table_from_json(
+          rows,
+          staging_ref,
+          job_config=job_config,
+      )
+      load_job.result()
+
+      # Step 2: Delete existing rows for session_ids from target.
+      cleanup_status = self._delete_for_sessions(table_ref, session_ids)
+
+      # Step 3: Insert from staging into target.
+      insert_sql = f"INSERT INTO `{table_ref}` SELECT * FROM `{staging_ref}`"
+      try:
+        insert_job = self.bq_client.query(insert_sql)
+        insert_job.result()
+        insert_status = "inserted"
+        rows_inserted = len(rows)
+      except Exception as e:
+        logger.warning(
+            "Batch insert from staging failed for %s: %s",
+            table_ref,
+            e,
+        )
+        insert_status = "insert_failed"
+
+    except Exception as e:
+      logger.warning(
+          "Batch load to staging failed for %s: %s",
+          table_ref,
+          e,
+      )
+
+    # Step 4: Always try to drop the staging table.
+    try:
+      self.bq_client.delete_table(staging_ref, not_found_ok=True)
+    except Exception as e:
+      logger.debug("Failed to drop staging table %s: %s", staging_ref, e)
+
+    return TableStatus(
+        table_ref=table_ref,
+        rows_attempted=len(rows),
+        rows_inserted=rows_inserted,
+        cleanup_status=cleanup_status,
+        insert_status=insert_status,
+        idempotent=cleanup_status in ("deleted", "skipped"),
+    )
+
+  def _materialize_impl(
       self,
       graph: ExtractedGraph,
       session_ids: list[str],
-  ) -> dict[str, int]:
-    """Materialize an ``ExtractedGraph`` into BigQuery tables.
-
-    Uses delete-then-insert for session-scoped idempotency:
-    existing rows for the given sessions are deleted before
-    inserting the new graph data.
-
-    Args:
-        graph: The extracted graph to persist.
-        session_ids: Sessions being materialized (scopes the
-            delete for idempotency).
-
-    Returns:
-        Dict mapping entity/relationship name to row count inserted.
-    """
+  ) -> MaterializationResult:
+    """Internal implementation shared by ``materialize`` and ``materialize_with_status``."""
     entity_map = {e.name: e for e in self.spec.entities}
     rel_map = {r.name: r for r in self.spec.relationships}
-    result: dict[str, int] = {}
 
     # Derive session_id for rows from the session_ids parameter.
     # For single-session extractions this is straightforward; for
@@ -555,19 +685,41 @@ class OntologyMaterializer:
       )
 
     # One delete + one insert per physical table.
+    table_statuses: dict[str, TableStatus] = {}
     inserted_tables: set[str] = set()
-    for table_ref, rows in table_rows.items():
-      self._delete_for_sessions(table_ref, session_ids)
-      try:
-        errors = self.bq_client.insert_rows_json(table_ref, rows)
-        if errors:
-          logger.error("Insert errors for %s: %s", table_ref, errors)
-        else:
-          inserted_tables.add(table_ref)
-      except Exception as e:
-        logger.warning("Failed to insert rows for %s: %s", table_ref, e)
 
-    # Build result: only include names whose table insert succeeded.
+    for table_ref, rows in table_rows.items():
+      if self.write_mode == "batch_load":
+        status = self._batch_load_table(table_ref, rows, session_ids)
+        table_statuses[table_ref] = status
+        if status.insert_status == "inserted":
+          inserted_tables.add(table_ref)
+      else:
+        # Streaming insert path.
+        cleanup_status = self._delete_for_sessions(table_ref, session_ids)
+        insert_status = "insert_failed"
+        rows_inserted = 0
+        try:
+          errors = self.bq_client.insert_rows_json(table_ref, rows)
+          if errors:
+            logger.error("Insert errors for %s: %s", table_ref, errors)
+          else:
+            insert_status = "inserted"
+            rows_inserted = len(rows)
+            inserted_tables.add(table_ref)
+        except Exception as e:
+          logger.warning("Failed to insert rows for %s: %s", table_ref, e)
+        table_statuses[table_ref] = TableStatus(
+            table_ref=table_ref,
+            rows_attempted=len(rows),
+            rows_inserted=rows_inserted,
+            cleanup_status=cleanup_status,
+            insert_status=insert_status,
+            idempotent=cleanup_status in ("deleted", "skipped"),
+        )
+
+    # Build row_counts: only include names whose table insert succeeded.
+    row_counts: dict[str, int] = {}
     for name, count in name_counts.items():
       entity = entity_map.get(name)
       rel = rel_map.get(name)
@@ -578,6 +730,52 @@ class OntologyMaterializer:
       else:
         continue
       if ref in inserted_tables:
-        result[name] = count
+        row_counts[name] = count
 
-    return result
+    return MaterializationResult(
+        row_counts=row_counts,
+        table_statuses=table_statuses,
+    )
+
+  def materialize(
+      self,
+      graph: ExtractedGraph,
+      session_ids: list[str],
+  ) -> dict[str, int]:
+    """Materialize an ``ExtractedGraph`` into BigQuery tables.
+
+    Uses delete-then-insert for session-scoped idempotency:
+    existing rows for the given sessions are deleted before
+    inserting the new graph data.
+
+    Args:
+        graph: The extracted graph to persist.
+        session_ids: Sessions being materialized (scopes the
+            delete for idempotency).
+
+    Returns:
+        Dict mapping entity/relationship name to row count inserted.
+    """
+    return self._materialize_impl(graph, session_ids).row_counts
+
+  def materialize_with_status(
+      self,
+      graph: ExtractedGraph,
+      session_ids: list[str],
+  ) -> MaterializationResult:
+    """Materialize an ``ExtractedGraph`` with full status reporting.
+
+    Same behavior as ``materialize()`` but returns a
+    ``MaterializationResult`` with per-table ``TableStatus``
+    information in addition to the backward-compatible row counts.
+
+    Args:
+        graph: The extracted graph to persist.
+        session_ids: Sessions being materialized (scopes the
+            delete for idempotency).
+
+    Returns:
+        A ``MaterializationResult`` containing row counts and
+        per-table status details.
+    """
+    return self._materialize_impl(graph, session_ids)

--- a/src/bigquery_agent_analytics/ontology_orchestrator.py
+++ b/src/bigquery_agent_analytics/ontology_orchestrator.py
@@ -231,8 +231,8 @@ def compile_lineage_gql(
   name = graph_name or spec.name
   graph_ref = f"{project_id}.{dataset_id}.{name}"
 
-  prior_alias = "prior"
-  current_alias = "current"
+  prior_alias = "prev"
+  current_alias = "cur"
   edge_alias = _short_alias(rel.name, prefix="e")
 
   where_clause = ""

--- a/tests/test_v5_golden.py
+++ b/tests/test_v5_golden.py
@@ -954,3 +954,132 @@ class TestDDLSessionColumnsInProperties:
     props_section = clause.split("PROPERTIES")[1]
     assert "from_session_id" in props_section
     assert "to_session_id" in props_section
+
+
+# ------------------------------------------------------------------ #
+# TestMaterializerWriteMode                                            #
+# ------------------------------------------------------------------ #
+
+
+class TestMaterializerWriteMode:
+  """Materializer write_mode and status reporting."""
+
+  def test_default_write_mode_is_streaming(self):
+    """Default write_mode is 'streaming' for backward compatibility."""
+    from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer
+
+    spec = _demo_spec()
+    mat = OntologyMaterializer(
+        project_id="p",
+        dataset_id="d",
+        spec=spec,
+    )
+    assert mat.write_mode == "streaming"
+
+  def test_batch_load_write_mode_accepted(self):
+    """write_mode='batch_load' is accepted without error."""
+    from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer
+
+    spec = _demo_spec()
+    mat = OntologyMaterializer(
+        project_id="p",
+        dataset_id="d",
+        spec=spec,
+        write_mode="batch_load",
+    )
+    assert mat.write_mode == "batch_load"
+
+  def test_materialize_with_status_returns_result(self):
+    """materialize_with_status returns MaterializationResult."""
+    from unittest.mock import MagicMock
+
+    from bigquery_agent_analytics.ontology_materializer import MaterializationResult
+    from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer
+
+    spec = _demo_spec()
+    mock_client = MagicMock()
+    mock_job = MagicMock()
+    mock_job.result.return_value = None
+    mock_client.query.return_value = mock_job
+    mock_client.insert_rows_json.return_value = []
+
+    mat = OntologyMaterializer(
+        project_id="p",
+        dataset_id="d",
+        spec=spec,
+        bq_client=mock_client,
+    )
+
+    graph = ExtractedGraph(
+        name="test",
+        nodes=[
+            ExtractedNode(
+                node_id="s1:mako_DecisionPoint:decision_id=d1",
+                entity_name="mako_DecisionPoint",
+                labels=["mako_DecisionPoint"],
+                properties=[
+                    ExtractedProperty(name="decision_id", value="d1"),
+                    ExtractedProperty(name="decision_type", value="q"),
+                ],
+            )
+        ],
+    )
+
+    result = mat.materialize_with_status(graph, ["s1"])
+    assert isinstance(result, MaterializationResult)
+    assert result.row_counts.get("mako_DecisionPoint", 0) >= 1
+    assert len(result.table_statuses) >= 1
+
+  def test_delete_failure_surfaces_non_idempotent(self):
+    """When DELETE fails, table status shows non-idempotent."""
+    from unittest.mock import MagicMock
+
+    from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer
+
+    spec = _demo_spec()
+    mock_client = MagicMock()
+    mock_job = MagicMock()
+
+    call_count = [0]
+
+    def side_effect(query, **kwargs):
+      call_count[0] += 1
+      if "DELETE" in query:
+        raise Exception("streaming buffer active")
+      return mock_job
+
+    mock_job.result.return_value = None
+    mock_client.query.side_effect = side_effect
+    mock_client.insert_rows_json.return_value = []
+
+    mat = OntologyMaterializer(
+        project_id="p",
+        dataset_id="d",
+        spec=spec,
+        bq_client=mock_client,
+    )
+
+    graph = ExtractedGraph(
+        name="test",
+        nodes=[
+            ExtractedNode(
+                node_id="s1:mako_DecisionPoint:decision_id=d1",
+                entity_name="mako_DecisionPoint",
+                labels=["mako_DecisionPoint"],
+                properties=[
+                    ExtractedProperty(name="decision_id", value="d1"),
+                ],
+            )
+        ],
+    )
+
+    result = mat.materialize_with_status(graph, ["s1"])
+    # Find the table status — cleanup should have failed.
+    failed_tables = [
+        ts
+        for ts in result.table_statuses.values()
+        if ts.cleanup_status == "delete_failed"
+    ]
+    assert len(failed_tables) >= 1
+    for ts in failed_tables:
+      assert ts.idempotent is False

--- a/tests/test_v5_golden.py
+++ b/tests/test_v5_golden.py
@@ -783,12 +783,15 @@ class TestLineageGQL:
         dataset_id="ds",
         relationship_name="sup_YahooAdUnitEvolvedFrom",
     )
-    assert "prior" in gql
-    assert "current" in gql
+    assert "prev" in gql
+    assert "cur" in gql
+    # Aliases must not use BigQuery GQL reserved keywords.
+    assert "(current:" not in gql
+    assert "(prior:" not in gql
     assert "sup_YahooAdUnit" in gql
     assert "sup_YahooAdUnitEvolvedFrom" in gql
-    assert "prior_adUnitId" in gql or "prior.adUnitId" in gql
-    assert "current_adUnitName" in gql or "current.adUnitName" in gql
+    assert "prev_adUnitId" in gql or "prev.adUnitId" in gql
+    assert "cur_adUnitName" in gql or "cur.adUnitName" in gql
     assert "event_time" in gql
     assert "ORDER BY" in gql
 


### PR DESCRIPTION
## Summary
- **Materializer `write_mode="batch_load"`**: Non-streaming writes via staging tables. DELETE works reliably (no streaming buffer conflicts). `materialize_with_status()` returns `MaterializationResult` with per-table `TableStatus` including `idempotent` flag.
- **Deterministic notebook**: Run-scoped scratch dataset, batch_load mode, synthetic lineage Session B, both GQL queries executed end-to-end, cleanup at exit.

### Executed notebook results
| Step | Output |
|------|--------|
| Scratch dataset | `agent_analytics_v5_7e508241`, 1h TTL |
| TTL import | 5 classes, 9 props, 2 rels, 1 placeholder, 1 type warning |
| Batch materialize | All tables `idempotent=True`, exact row counts |
| Lineage detection | 1 edge: `adUnitName` + `adUnitPosition` changed |
| Forward GQL | 2 rows |
| **Lineage GQL** | **Executed against BQ with populated lineage data** |
| Cleanup | Scratch dataset deleted |

## Test plan
- [x] 1444 tests pass (4 new materializer tests)
- [x] Notebook executes end-to-end via `jupyter nbconvert --execute`
- [x] All `TableStatus.idempotent == True` in batch_load mode
- [x] Lineage GQL returns >0 rows from synthetic Session B
- [x] Scratch dataset cleaned up after run