### PR TITLE
feat(scaffold): add scaffold generator for table DDL and binding stubs

### DIFF
--- a/src/bigquery_ontology/__init__.py
+++ b/src/bigquery_ontology/__init__.py
@@ -29,7 +29,6 @@ from .binding_models import PropertyBinding
 from .binding_models import RelationshipBinding
 from .graph_ddl_compiler import compile_graph
 from .ontology_loader import load_ontology
-from .scaffold import scaffold
 from .ontology_loader import load_ontology_from_string
 from .ontology_models import Cardinality
 from .ontology_models import Entity
@@ -38,6 +37,7 @@ from .ontology_models import Ontology
 from .ontology_models import Property
 from .ontology_models import PropertyType
 from .ontology_models import Relationship
+from .scaffold import scaffold
 
 __all__ = [
     "Backend",

--- a/src/bigquery_ontology/__init__.py
+++ b/src/bigquery_ontology/__init__.py
@@ -29,6 +29,7 @@ from .binding_models import PropertyBinding
 from .binding_models import RelationshipBinding
 from .graph_ddl_compiler import compile_graph
 from .ontology_loader import load_ontology
+from .scaffold import scaffold
 from .ontology_loader import load_ontology_from_string
 from .ontology_models import Cardinality
 from .ontology_models import Entity
@@ -57,4 +58,5 @@ __all__ = [
     "load_binding_from_string",
     "load_ontology",
     "load_ontology_from_string",
+    "scaffold",
 ]

--- a/src/bigquery_ontology/scaffold.py
+++ b/src/bigquery_ontology/scaffold.py
@@ -40,8 +40,8 @@ after generation.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+import re
 
 from .ontology_models import Entity
 from .ontology_models import Keys
@@ -53,9 +53,7 @@ from .ontology_models import Relationship
 # Naming
 # ---------------------------------------------------------------------------
 
-_SNAKE_RE = re.compile(
-    r"(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])"
-)
+_SNAKE_RE = re.compile(r"(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])")
 
 
 def _to_snake_case(name: str) -> str:
@@ -167,20 +165,24 @@ def _resolve_entity_table(
 
   for pk_name in entity.keys.primary:
     prop = prop_map[pk_name]
-    pk_columns.append(_ScaffoldColumn(
-        name=_apply_naming(prop.name, naming),
-        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
-        not_null=True,
-    ))
+    pk_columns.append(
+        _ScaffoldColumn(
+            name=_apply_naming(prop.name, naming),
+            bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+            not_null=True,
+        )
+    )
 
   for prop in entity.properties:
     if prop.name in pk_set or prop.expr is not None:
       continue
-    other_columns.append(_ScaffoldColumn(
-        name=_apply_naming(prop.name, naming),
-        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
-        not_null=False,
-    ))
+    other_columns.append(
+        _ScaffoldColumn(
+            name=_apply_naming(prop.name, naming),
+            bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+            not_null=False,
+        )
+    )
 
   table_name = _qualify(dataset, _apply_naming(entity.name, naming), project)
   columns = tuple(pk_columns + other_columns)
@@ -209,11 +211,13 @@ def _endpoint_columns(
   for pk_name in entity.keys.primary:
     prop = prop_map[pk_name]
     col_name = f"{prefix}_{_apply_naming(prop.name, naming)}"
-    cols.append(_ScaffoldColumn(
-        name=col_name,
-        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
-        not_null=True,
-    ))
+    cols.append(
+        _ScaffoldColumn(
+            name=col_name,
+            bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+            not_null=True,
+        )
+    )
   return cols
 
 
@@ -243,11 +247,13 @@ def _resolve_rel_table(
           f"(column {col_name!r}) collides with a generated endpoint "
           "column. Rename the property or the entity key to resolve."
       )
-    prop_columns.append(_ScaffoldColumn(
-        name=col_name,
-        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
-        not_null=False,
-    ))
+    prop_columns.append(
+        _ScaffoldColumn(
+            name=col_name,
+            bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+            not_null=False,
+        )
+    )
 
   keys: Keys | None = rel.keys
   pk_col_names: tuple[str, ...] | None = None
@@ -258,11 +264,13 @@ def _resolve_rel_table(
     rel_pk_cols: list[_ScaffoldColumn] = []
     for pk_name in keys.primary:
       prop = pk_prop_map[pk_name]
-      rel_pk_cols.append(_ScaffoldColumn(
-          name=_apply_naming(prop.name, naming),
-          bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
-          not_null=True,
-      ))
+      rel_pk_cols.append(
+          _ScaffoldColumn(
+              name=_apply_naming(prop.name, naming),
+              bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+              not_null=True,
+          )
+      )
     # Remove PK props from prop_columns (they go first).
     pk_names_set = {_apply_naming(n, naming) for n in keys.primary}
     prop_columns = [c for c in prop_columns if c.name not in pk_names_set]
@@ -276,9 +284,13 @@ def _resolve_rel_table(
     remaining: list[_ScaffoldColumn] = []
     for c in prop_columns:
       if c.name in add_names_set:
-        additional_cols.append(_ScaffoldColumn(
-            name=c.name, bq_type=c.bq_type, not_null=True,
-        ))
+        additional_cols.append(
+            _ScaffoldColumn(
+                name=c.name,
+                bq_type=c.bq_type,
+                not_null=True,
+            )
+        )
       else:
         remaining.append(c)
     columns = tuple(from_cols + to_cols + additional_cols + remaining)
@@ -307,9 +319,7 @@ def _resolve_rel_table(
   from_ref_cols = tuple(
       _apply_naming(n, naming) for n in from_entity.keys.primary
   )
-  to_ref_cols = tuple(
-      _apply_naming(n, naming) for n in to_entity.keys.primary
-  )
+  to_ref_cols = tuple(_apply_naming(n, naming) for n in to_entity.keys.primary)
 
   foreign_keys = (
       _ScaffoldFK(
@@ -343,9 +353,7 @@ def _emit_entity_ddl(table: _ScaffoldEntityTable) -> str:
   for col in table.columns:
     nn = " NOT NULL" if col.not_null else ""
     parts.append(f"  {col.name} {col.bq_type}{nn}")
-  parts.append(
-      f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED"
-  )
+  parts.append(f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED")
   lines.append(",\n".join(parts))
   lines.append(");")
   return "\n".join(lines) + "\n"
@@ -358,9 +366,7 @@ def _emit_rel_ddl(table: _ScaffoldRelTable) -> str:
     nn = " NOT NULL" if col.not_null else ""
     parts.append(f"  {col.name} {col.bq_type}{nn}")
   if table.pk_columns is not None:
-    parts.append(
-        f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED"
-    )
+    parts.append(f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED")
   for fk in table.foreign_keys:
     fk_cols = ", ".join(fk.columns)
     ref_cols = ", ".join(fk.ref_columns)
@@ -404,57 +410,27 @@ def _emit_binding_yaml(
     for entity, et in zip(ontology.entities, entity_tables):
       lines.append(f"  - name: {entity.name}")
       lines.append(f"    source: {et.table_name}")
-      non_derived = [
-          p for p in entity.properties if p.expr is None
-      ]
+      non_derived = [p for p in entity.properties if p.expr is None]
       if non_derived:
         lines.append("    properties:")
         for prop in non_derived:
           col = _apply_naming(prop.name, naming)
-          lines.append(
-              "      - {"
-              f"name: {prop.name}, column: {col}"
-              "}"
-          )
+          lines.append("      - {" f"name: {prop.name}, column: {col}" "}")
 
   if rel_tables:
     lines.append("relationships:")
     for rel, rt in zip(ontology.relationships, rel_tables):
-      from_entity = next(
-          e for e in ontology.entities if e.name == rel.from_
-      )
-      to_entity = next(
-          e for e in ontology.entities if e.name == rel.to
-      )
-      assert from_entity.keys and from_entity.keys.primary
-      assert to_entity.keys and to_entity.keys.primary
-
-      from_col_names = [
-          f"from_{_apply_naming(n, naming)}"
-          for n in from_entity.keys.primary
-      ]
-      to_col_names = [
-          f"to_{_apply_naming(n, naming)}"
-          for n in to_entity.keys.primary
-      ]
+      from_fk, to_fk = rt.foreign_keys
       lines.append(f"  - name: {rel.name}")
       lines.append(f"    source: {rt.table_name}")
-      lines.append(
-          f"    from_columns: [{', '.join(from_col_names)}]"
-      )
-      lines.append(
-          f"    to_columns: [{', '.join(to_col_names)}]"
-      )
+      lines.append(f"    from_columns: [{', '.join(from_fk.columns)}]")
+      lines.append(f"    to_columns: [{', '.join(to_fk.columns)}]")
       non_derived = [p for p in rel.properties if p.expr is None]
       if non_derived:
         lines.append("    properties:")
         for prop in non_derived:
           col = _apply_naming(prop.name, naming)
-          lines.append(
-              "      - {"
-              f"name: {prop.name}, column: {col}"
-              "}"
-          )
+          lines.append("      - {" f"name: {prop.name}, column: {col}" "}")
 
   return "\n".join(lines) + "\n"
 

--- a/src/bigquery_ontology/scaffold.py
+++ b/src/bigquery_ontology/scaffold.py
@@ -136,6 +136,7 @@ class _ScaffoldRelTable:
   columns: tuple[_ScaffoldColumn, ...]
   pk_columns: tuple[str, ...] | None
   foreign_keys: tuple[_ScaffoldFK, ...]
+  suggested_pk_columns: tuple[str, ...] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +305,12 @@ def _resolve_rel_table(
     # No keys block.
     columns = tuple(from_cols + to_cols + prop_columns)
 
+  suggested_pk: tuple[str, ...] | None = None
+  if pk_col_names is None:
+    suggested_pk = tuple(c.name for c in from_cols) + tuple(
+        c.name for c in to_cols
+    )
+
   table_name = _qualify(dataset, _apply_naming(rel.name, naming), project)
 
   from_entity_table = _qualify(
@@ -339,6 +346,7 @@ def _resolve_rel_table(
       columns=columns,
       pk_columns=pk_col_names,
       foreign_keys=foreign_keys,
+      suggested_pk_columns=suggested_pk,
   )
 
 
@@ -347,12 +355,18 @@ def _resolve_rel_table(
 # ---------------------------------------------------------------------------
 
 
+def _pad_columns(columns: tuple[_ScaffoldColumn, ...]) -> list[str]:
+  name_width = max(len(c.name) for c in columns)
+  padded: list[str] = []
+  for col in columns:
+    nn = " NOT NULL" if col.not_null else ""
+    padded.append(f"  {col.name:<{name_width}}  {col.bq_type}{nn}")
+  return padded
+
+
 def _emit_entity_ddl(table: _ScaffoldEntityTable) -> str:
   lines = [f"CREATE TABLE `{table.table_name}` ("]
-  parts: list[str] = []
-  for col in table.columns:
-    nn = " NOT NULL" if col.not_null else ""
-    parts.append(f"  {col.name} {col.bq_type}{nn}")
+  parts = _pad_columns(table.columns)
   parts.append(f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED")
   lines.append(",\n".join(parts))
   lines.append(");")
@@ -361,12 +375,15 @@ def _emit_entity_ddl(table: _ScaffoldEntityTable) -> str:
 
 def _emit_rel_ddl(table: _ScaffoldRelTable) -> str:
   lines = [f"CREATE TABLE `{table.table_name}` ("]
-  parts: list[str] = []
-  for col in table.columns:
-    nn = " NOT NULL" if col.not_null else ""
-    parts.append(f"  {col.name} {col.bq_type}{nn}")
+  parts = _pad_columns(table.columns)
   if table.pk_columns is not None:
     parts.append(f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED")
+  if table.suggested_pk_columns is not None:
+    suggested = ", ".join(table.suggested_pk_columns)
+    parts.append(
+        f"  -- TODO: uncomment if ({suggested}) is unique per row\n"
+        f"  -- PRIMARY KEY ({suggested}) NOT ENFORCED"
+    )
   for fk in table.foreign_keys:
     fk_cols = ", ".join(fk.columns)
     ref_cols = ", ".join(fk.ref_columns)

--- a/src/bigquery_ontology/scaffold.py
+++ b/src/bigquery_ontology/scaffold.py
@@ -1,0 +1,504 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One-shot scaffold generator for BigQuery table DDL and binding stubs.
+
+Given an ontology, a dataset name, and a naming convention, this module
+emits two artifacts:
+
+  1. ``table_ddl.sql`` — ``CREATE TABLE`` statements for every entity
+     and relationship.
+  2. ``binding.yaml`` — a matching binding stub that is immediately
+     valid as input to ``gm compile``.
+
+The generator is split into two stages following the same pattern as
+``graph_ddl_compiler``:
+
+  1. **Resolve.** Walk the ontology and produce intermediate
+     ``_ScaffoldEntityTable`` / ``_ScaffoldRelTable`` dataclasses that
+     capture every physical decision (column names, types, nullability,
+     keys, foreign keys).
+  2. **Emit.** Render each resolved table into DDL text and the whole
+     set into a binding YAML string. The emitters are mechanical — all
+     interesting decisions happen in stage 1.
+
+Scaffold does *not* execute DDL, introspect BigQuery, or participate
+in the compile pipeline. Its outputs are user-owned and hand-edited
+after generation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .ontology_models import Entity
+from .ontology_models import Keys
+from .ontology_models import Ontology
+from .ontology_models import PropertyType
+from .ontology_models import Relationship
+
+# ---------------------------------------------------------------------------
+# Naming
+# ---------------------------------------------------------------------------
+
+_SNAKE_RE = re.compile(
+    r"(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])"
+)
+
+
+def _to_snake_case(name: str) -> str:
+  return _SNAKE_RE.sub(r"_\1\2", name).lower()
+
+
+def _apply_naming(name: str, naming: str) -> str:
+  if naming == "snake":
+    return _to_snake_case(name)
+  return name
+
+
+# ---------------------------------------------------------------------------
+# Type mapping
+# ---------------------------------------------------------------------------
+
+_ONTOLOGY_TO_BQ_TYPE: dict[PropertyType, str] = {
+    PropertyType.STRING: "STRING",
+    PropertyType.BYTES: "BYTES",
+    PropertyType.INTEGER: "INT64",
+    PropertyType.DOUBLE: "FLOAT64",
+    PropertyType.NUMERIC: "NUMERIC",
+    PropertyType.BOOLEAN: "BOOL",
+    PropertyType.DATE: "DATE",
+    PropertyType.TIME: "TIME",
+    PropertyType.DATETIME: "DATETIME",
+    PropertyType.TIMESTAMP: "TIMESTAMP",
+    PropertyType.JSON: "JSON",
+}
+
+# ---------------------------------------------------------------------------
+# Inheritance gate
+# ---------------------------------------------------------------------------
+
+
+def _reject_extends(ontology: Ontology) -> None:
+  for entity in ontology.entities:
+    if entity.extends is not None:
+      raise ValueError(
+          f"Entity {entity.name!r} uses 'extends'; v0 scaffold "
+          "does not support inheritance."
+      )
+  for rel in ontology.relationships:
+    if rel.extends is not None:
+      raise ValueError(
+          f"Relationship {rel.name!r} uses 'extends'; v0 scaffold "
+          "does not support inheritance."
+      )
+
+
+# ---------------------------------------------------------------------------
+# Intermediate dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ScaffoldColumn:
+  name: str
+  bq_type: str
+  not_null: bool
+
+
+@dataclass(frozen=True)
+class _ScaffoldFK:
+  columns: tuple[str, ...]
+  ref_table: str
+  ref_columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ScaffoldEntityTable:
+  table_name: str
+  columns: tuple[_ScaffoldColumn, ...]
+  pk_columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ScaffoldRelTable:
+  table_name: str
+  columns: tuple[_ScaffoldColumn, ...]
+  pk_columns: tuple[str, ...] | None
+  foreign_keys: tuple[_ScaffoldFK, ...]
+
+
+# ---------------------------------------------------------------------------
+# Resolve — entity tables
+# ---------------------------------------------------------------------------
+
+
+def _qualify(dataset: str, table: str, project: str | None) -> str:
+  if project:
+    return f"{project}.{dataset}.{table}"
+  return f"{dataset}.{table}"
+
+
+def _resolve_entity_table(
+    entity: Entity,
+    dataset: str,
+    project: str | None,
+    naming: str,
+) -> _ScaffoldEntityTable:
+  assert entity.keys is not None and entity.keys.primary is not None
+  pk_set = set(entity.keys.primary)
+
+  pk_columns: list[_ScaffoldColumn] = []
+  other_columns: list[_ScaffoldColumn] = []
+
+  prop_map = {p.name: p for p in entity.properties}
+
+  for pk_name in entity.keys.primary:
+    prop = prop_map[pk_name]
+    pk_columns.append(_ScaffoldColumn(
+        name=_apply_naming(prop.name, naming),
+        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+        not_null=True,
+    ))
+
+  for prop in entity.properties:
+    if prop.name in pk_set or prop.expr is not None:
+      continue
+    other_columns.append(_ScaffoldColumn(
+        name=_apply_naming(prop.name, naming),
+        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+        not_null=False,
+    ))
+
+  table_name = _qualify(dataset, _apply_naming(entity.name, naming), project)
+  columns = tuple(pk_columns + other_columns)
+  pk_col_names = tuple(c.name for c in pk_columns)
+
+  return _ScaffoldEntityTable(
+      table_name=table_name,
+      columns=columns,
+      pk_columns=pk_col_names,
+  )
+
+
+# ---------------------------------------------------------------------------
+# Resolve — relationship tables
+# ---------------------------------------------------------------------------
+
+
+def _endpoint_columns(
+    prefix: str,
+    entity: Entity,
+    naming: str,
+) -> list[_ScaffoldColumn]:
+  assert entity.keys is not None and entity.keys.primary is not None
+  cols: list[_ScaffoldColumn] = []
+  prop_map = {p.name: p for p in entity.properties}
+  for pk_name in entity.keys.primary:
+    prop = prop_map[pk_name]
+    col_name = f"{prefix}_{_apply_naming(prop.name, naming)}"
+    cols.append(_ScaffoldColumn(
+        name=col_name,
+        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+        not_null=True,
+    ))
+  return cols
+
+
+def _resolve_rel_table(
+    rel: Relationship,
+    entity_map: dict[str, Entity],
+    dataset: str,
+    project: str | None,
+    naming: str,
+) -> _ScaffoldRelTable:
+  from_entity = entity_map[rel.from_]
+  to_entity = entity_map[rel.to]
+
+  from_cols = _endpoint_columns("from", from_entity, naming)
+  to_cols = _endpoint_columns("to", to_entity, naming)
+
+  endpoint_col_names = {c.name for c in from_cols} | {c.name for c in to_cols}
+
+  prop_columns: list[_ScaffoldColumn] = []
+  for prop in rel.properties:
+    if prop.expr is not None:
+      continue
+    col_name = _apply_naming(prop.name, naming)
+    if col_name in endpoint_col_names:
+      raise ValueError(
+          f"Relationship {rel.name!r}: property {prop.name!r} "
+          f"(column {col_name!r}) collides with a generated endpoint "
+          "column. Rename the property or the entity key to resolve."
+      )
+    prop_columns.append(_ScaffoldColumn(
+        name=col_name,
+        bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+        not_null=False,
+    ))
+
+  keys: Keys | None = rel.keys
+  pk_col_names: tuple[str, ...] | None = None
+
+  if keys is not None and keys.primary is not None:
+    # Mode 1: relationship has its own identity.
+    pk_prop_map = {p.name: p for p in rel.properties}
+    rel_pk_cols: list[_ScaffoldColumn] = []
+    for pk_name in keys.primary:
+      prop = pk_prop_map[pk_name]
+      rel_pk_cols.append(_ScaffoldColumn(
+          name=_apply_naming(prop.name, naming),
+          bq_type=_ONTOLOGY_TO_BQ_TYPE[prop.type],
+          not_null=True,
+      ))
+    # Remove PK props from prop_columns (they go first).
+    pk_names_set = {_apply_naming(n, naming) for n in keys.primary}
+    prop_columns = [c for c in prop_columns if c.name not in pk_names_set]
+    columns = tuple(rel_pk_cols + from_cols + to_cols + prop_columns)
+    pk_col_names = tuple(c.name for c in rel_pk_cols)
+
+  elif keys is not None and keys.additional is not None:
+    # Mode 2: effective key = (from_*, to_*, *additional).
+    add_names_set = {_apply_naming(n, naming) for n in keys.additional}
+    additional_cols: list[_ScaffoldColumn] = []
+    remaining: list[_ScaffoldColumn] = []
+    for c in prop_columns:
+      if c.name in add_names_set:
+        additional_cols.append(_ScaffoldColumn(
+            name=c.name, bq_type=c.bq_type, not_null=True,
+        ))
+      else:
+        remaining.append(c)
+    columns = tuple(from_cols + to_cols + additional_cols + remaining)
+    pk_col_names = (
+        tuple(c.name for c in from_cols)
+        + tuple(c.name for c in to_cols)
+        + tuple(c.name for c in additional_cols)
+    )
+
+  else:
+    # No keys block.
+    columns = tuple(from_cols + to_cols + prop_columns)
+
+  table_name = _qualify(dataset, _apply_naming(rel.name, naming), project)
+
+  from_entity_table = _qualify(
+      dataset, _apply_naming(from_entity.name, naming), project
+  )
+  to_entity_table = _qualify(
+      dataset, _apply_naming(to_entity.name, naming), project
+  )
+
+  assert from_entity.keys is not None and from_entity.keys.primary is not None
+  assert to_entity.keys is not None and to_entity.keys.primary is not None
+
+  from_ref_cols = tuple(
+      _apply_naming(n, naming) for n in from_entity.keys.primary
+  )
+  to_ref_cols = tuple(
+      _apply_naming(n, naming) for n in to_entity.keys.primary
+  )
+
+  foreign_keys = (
+      _ScaffoldFK(
+          columns=tuple(c.name for c in from_cols),
+          ref_table=from_entity_table,
+          ref_columns=from_ref_cols,
+      ),
+      _ScaffoldFK(
+          columns=tuple(c.name for c in to_cols),
+          ref_table=to_entity_table,
+          ref_columns=to_ref_cols,
+      ),
+  )
+
+  return _ScaffoldRelTable(
+      table_name=table_name,
+      columns=columns,
+      pk_columns=pk_col_names,
+      foreign_keys=foreign_keys,
+  )
+
+
+# ---------------------------------------------------------------------------
+# Emit — DDL
+# ---------------------------------------------------------------------------
+
+
+def _emit_entity_ddl(table: _ScaffoldEntityTable) -> str:
+  lines = [f"CREATE TABLE `{table.table_name}` ("]
+  parts: list[str] = []
+  for col in table.columns:
+    nn = " NOT NULL" if col.not_null else ""
+    parts.append(f"  {col.name} {col.bq_type}{nn}")
+  parts.append(
+      f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED"
+  )
+  lines.append(",\n".join(parts))
+  lines.append(");")
+  return "\n".join(lines) + "\n"
+
+
+def _emit_rel_ddl(table: _ScaffoldRelTable) -> str:
+  lines = [f"CREATE TABLE `{table.table_name}` ("]
+  parts: list[str] = []
+  for col in table.columns:
+    nn = " NOT NULL" if col.not_null else ""
+    parts.append(f"  {col.name} {col.bq_type}{nn}")
+  if table.pk_columns is not None:
+    parts.append(
+        f"  PRIMARY KEY ({', '.join(table.pk_columns)}) NOT ENFORCED"
+    )
+  for fk in table.foreign_keys:
+    fk_cols = ", ".join(fk.columns)
+    ref_cols = ", ".join(fk.ref_columns)
+    parts.append(
+        f"  FOREIGN KEY ({fk_cols}) "
+        f"REFERENCES `{fk.ref_table}`({ref_cols}) NOT ENFORCED"
+    )
+  lines.append(",\n".join(parts))
+  lines.append(");")
+  return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Emit — binding YAML
+# ---------------------------------------------------------------------------
+
+
+def _emit_binding_yaml(
+    ontology: Ontology,
+    entity_tables: list[_ScaffoldEntityTable],
+    rel_tables: list[_ScaffoldRelTable],
+    dataset: str,
+    project: str | None,
+    naming: str,
+) -> str:
+  lines: list[str] = []
+  lines.append(
+      "# Generated by gm scaffold. "
+      "This file is user-owned \u2014 edit freely."
+  )
+  lines.append(f"binding: {dataset}")
+  lines.append(f"ontology: {ontology.ontology}")
+  lines.append("target:")
+  lines.append("  backend: bigquery")
+  if project:
+    lines.append(f"  project: {project}")
+  lines.append(f"  dataset: {dataset}")
+
+  if entity_tables:
+    lines.append("entities:")
+    for entity, et in zip(ontology.entities, entity_tables):
+      lines.append(f"  - name: {entity.name}")
+      lines.append(f"    source: {et.table_name}")
+      non_derived = [
+          p for p in entity.properties if p.expr is None
+      ]
+      if non_derived:
+        lines.append("    properties:")
+        for prop in non_derived:
+          col = _apply_naming(prop.name, naming)
+          lines.append(
+              "      - {"
+              f"name: {prop.name}, column: {col}"
+              "}"
+          )
+
+  if rel_tables:
+    lines.append("relationships:")
+    for rel, rt in zip(ontology.relationships, rel_tables):
+      from_entity = next(
+          e for e in ontology.entities if e.name == rel.from_
+      )
+      to_entity = next(
+          e for e in ontology.entities if e.name == rel.to
+      )
+      assert from_entity.keys and from_entity.keys.primary
+      assert to_entity.keys and to_entity.keys.primary
+
+      from_col_names = [
+          f"from_{_apply_naming(n, naming)}"
+          for n in from_entity.keys.primary
+      ]
+      to_col_names = [
+          f"to_{_apply_naming(n, naming)}"
+          for n in to_entity.keys.primary
+      ]
+      lines.append(f"  - name: {rel.name}")
+      lines.append(f"    source: {rt.table_name}")
+      lines.append(
+          f"    from_columns: [{', '.join(from_col_names)}]"
+      )
+      lines.append(
+          f"    to_columns: [{', '.join(to_col_names)}]"
+      )
+      non_derived = [p for p in rel.properties if p.expr is None]
+      if non_derived:
+        lines.append("    properties:")
+        for prop in non_derived:
+          col = _apply_naming(prop.name, naming)
+          lines.append(
+              "      - {"
+              f"name: {prop.name}, column: {col}"
+              "}"
+          )
+
+  return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def scaffold(
+    ontology: Ontology,
+    *,
+    dataset: str,
+    project: str | None = None,
+    naming: str = "snake",
+) -> tuple[str, str]:
+  """Generate ``(ddl_text, binding_yaml_text)`` from an ontology.
+
+  Raises:
+      ValueError: If the ontology uses ``extends`` or an endpoint-column
+          name collision is detected on a relationship.
+  """
+  _reject_extends(ontology)
+
+  entity_map = {e.name: e for e in ontology.entities}
+
+  entity_tables = [
+      _resolve_entity_table(e, dataset, project, naming)
+      for e in ontology.entities
+  ]
+  rel_tables = [
+      _resolve_rel_table(r, entity_map, dataset, project, naming)
+      for r in ontology.relationships
+  ]
+
+  ddl_parts: list[str] = []
+  for et in entity_tables:
+    ddl_parts.append(_emit_entity_ddl(et))
+  for rt in rel_tables:
+    ddl_parts.append(_emit_rel_ddl(rt))
+  ddl_text = "\n".join(ddl_parts)
+
+  binding_text = _emit_binding_yaml(
+      ontology, entity_tables, rel_tables, dataset, project, naming
+  )
+
+  return ddl_text, binding_text

--- a/tests/bigquery_ontology/test_scaffold.py
+++ b/tests/bigquery_ontology/test_scaffold.py
@@ -22,10 +22,10 @@ import pytest
 
 from bigquery_ontology import load_binding_from_string
 from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology import scaffold
+from bigquery_ontology.ontology_models import PropertyType
 from bigquery_ontology.scaffold import _ONTOLOGY_TO_BQ_TYPE
 from bigquery_ontology.scaffold import _to_snake_case
-from bigquery_ontology.scaffold import scaffold
-from bigquery_ontology.ontology_models import PropertyType
 
 # ===================================================================== #
 # Step 1 — snake-case converter                                         #
@@ -118,14 +118,16 @@ class TestEntityDDL:
   def test_single_pk_entity(self):
     ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="my_dataset")
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         CREATE TABLE `my_dataset.person` (
           party_id STRING NOT NULL,
           name STRING,
           dob DATE,
           PRIMARY KEY (party_id) NOT ENFORCED
         );
-    """)
+    """
+    )
     assert ddl == expected
 
   def test_compound_pk_entity(self):
@@ -133,14 +135,16 @@ class TestEntityDDL:
         textwrap.dedent(_COMPOUND_KEY_ONTOLOGY)
     )
     ddl, _ = scaffold(ontology, dataset="my_dataset")
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         CREATE TABLE `my_dataset.account_day` (
           account_id STRING NOT NULL,
           as_of DATE NOT NULL,
           balance NUMERIC,
           PRIMARY KEY (account_id, as_of) NOT ENFORCED
         );
-    """)
+    """
+    )
     assert ddl == expected
 
   def test_derived_properties_excluded(self):
@@ -259,11 +263,10 @@ _REL_DERIVED_ONTOLOGY = """
 class TestRelationshipDDL:
 
   def test_no_keys_relationship(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_FOLLOWS_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_FOLLOWS_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="my_dataset")
-    expected_rel = textwrap.dedent("""\
+    expected_rel = textwrap.dedent(
+        """\
         CREATE TABLE `my_dataset.follows` (
           from_party_id STRING NOT NULL,
           to_party_id STRING NOT NULL,
@@ -271,15 +274,15 @@ class TestRelationshipDDL:
           FOREIGN KEY (from_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED,
           FOREIGN KEY (to_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED
         );
-    """)
+    """
+    )
     assert expected_rel in ddl
 
   def test_keys_additional_relationship(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_HOLDING_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_HOLDING_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="my_dataset")
-    expected_rel = textwrap.dedent("""\
+    expected_rel = textwrap.dedent(
+        """\
         CREATE TABLE `my_dataset.holding` (
           from_account_id STRING NOT NULL,
           from_as_of DATE NOT NULL,
@@ -290,13 +293,12 @@ class TestRelationshipDDL:
           FOREIGN KEY (from_account_id, from_as_of) REFERENCES `my_dataset.account`(account_id, as_of) NOT ENFORCED,
           FOREIGN KEY (to_isin) REFERENCES `my_dataset.security`(isin) NOT ENFORCED
         );
-    """)
+    """
+    )
     assert expected_rel in ddl
 
   def test_keys_primary_relationship(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_REL_OWN_PK_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_REL_OWN_PK_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="ds")
     assert "transfer_id STRING NOT NULL" in ddl
     assert "PRIMARY KEY (transfer_id) NOT ENFORCED" in ddl
@@ -304,16 +306,12 @@ class TestRelationshipDDL:
     assert "to_person_id STRING NOT NULL" in ddl
 
   def test_endpoint_column_collision(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_COLLISION_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_COLLISION_ONTOLOGY))
     with pytest.raises(ValueError, match="collides with a generated endpoint"):
       scaffold(ontology, dataset="ds")
 
   def test_derived_properties_excluded_from_rel(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_REL_DERIVED_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_REL_DERIVED_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="ds")
     assert "label" not in ddl
     assert "since DATE" in ddl
@@ -327,11 +325,10 @@ class TestRelationshipDDL:
 class TestBindingYAML:
 
   def test_person_follows_binding(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_FOLLOWS_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_FOLLOWS_ONTOLOGY))
     _, binding = scaffold(ontology, dataset="my_dataset")
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         # Generated by gm scaffold. This file is user-owned \u2014 edit freely.
         binding: my_dataset
         ontology: test
@@ -352,13 +349,12 @@ class TestBindingYAML:
             to_columns: [to_party_id]
             properties:
               - {name: since, column: since}
-    """)
+    """
+    )
     assert binding == expected
 
   def test_binding_round_trip(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_FOLLOWS_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_FOLLOWS_ONTOLOGY))
     _, binding_text = scaffold(
         ontology, dataset="my_dataset", project="my_project"
     )
@@ -388,9 +384,7 @@ class TestBindingYAML:
     assert "FOREIGN KEY" not in ddl
 
   def test_determinism(self):
-    ontology = load_ontology_from_string(
-        textwrap.dedent(_FOLLOWS_ONTOLOGY)
-    )
+    ontology = load_ontology_from_string(textwrap.dedent(_FOLLOWS_ONTOLOGY))
     ddl1, b1 = scaffold(ontology, dataset="ds")
     ddl2, b2 = scaffold(ontology, dataset="ds")
     assert ddl1 == ddl2
@@ -400,7 +394,8 @@ class TestBindingYAML:
 class TestRejectExtends:
 
   def test_entity_extends_rejected(self):
-    yaml = textwrap.dedent("""
+    yaml = textwrap.dedent(
+        """
       ontology: test
       entities:
         - name: Party
@@ -411,13 +406,15 @@ class TestRejectExtends:
           extends: Party
           properties:
             - {name: name, type: string}
-    """)
+    """
+    )
     ontology = load_ontology_from_string(yaml)
     with pytest.raises(ValueError, match="extends"):
       scaffold(ontology, dataset="ds")
 
   def test_relationship_extends_rejected(self):
-    yaml = textwrap.dedent("""
+    yaml = textwrap.dedent(
+        """
       ontology: test
       entities:
         - name: Person
@@ -436,7 +433,8 @@ class TestRejectExtends:
           to: Person
           properties:
             - {name: depth, type: integer}
-    """)
+    """
+    )
     ontology = load_ontology_from_string(yaml)
     with pytest.raises(ValueError, match="extends"):
       scaffold(ontology, dataset="ds")

--- a/tests/bigquery_ontology/test_scaffold.py
+++ b/tests/bigquery_ontology/test_scaffold.py
@@ -121,9 +121,9 @@ class TestEntityDDL:
     expected = textwrap.dedent(
         """\
         CREATE TABLE `my_dataset.person` (
-          party_id STRING NOT NULL,
-          name STRING,
-          dob DATE,
+          party_id  STRING NOT NULL,
+          name      STRING,
+          dob       DATE,
           PRIMARY KEY (party_id) NOT ENFORCED
         );
     """
@@ -138,9 +138,9 @@ class TestEntityDDL:
     expected = textwrap.dedent(
         """\
         CREATE TABLE `my_dataset.account_day` (
-          account_id STRING NOT NULL,
-          as_of DATE NOT NULL,
-          balance NUMERIC,
+          account_id  STRING NOT NULL,
+          as_of       DATE NOT NULL,
+          balance     NUMERIC,
           PRIMARY KEY (account_id, as_of) NOT ENFORCED
         );
     """
@@ -158,7 +158,7 @@ class TestEntityDDL:
     ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="my_dataset", naming="preserve")
     assert "`my_dataset.Person`" in ddl
-    assert "party_id STRING" in ddl
+    assert "party_id" in ddl and "STRING NOT NULL" in ddl
 
   def test_project_qualified(self):
     ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
@@ -268,9 +268,11 @@ class TestRelationshipDDL:
     expected_rel = textwrap.dedent(
         """\
         CREATE TABLE `my_dataset.follows` (
-          from_party_id STRING NOT NULL,
-          to_party_id STRING NOT NULL,
-          since DATE,
+          from_party_id  STRING NOT NULL,
+          to_party_id    STRING NOT NULL,
+          since          DATE,
+          -- TODO: uncomment if (from_party_id, to_party_id) is unique per row
+          -- PRIMARY KEY (from_party_id, to_party_id) NOT ENFORCED,
           FOREIGN KEY (from_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED,
           FOREIGN KEY (to_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED
         );
@@ -284,11 +286,11 @@ class TestRelationshipDDL:
     expected_rel = textwrap.dedent(
         """\
         CREATE TABLE `my_dataset.holding` (
-          from_account_id STRING NOT NULL,
-          from_as_of DATE NOT NULL,
-          to_isin STRING NOT NULL,
-          as_of DATE NOT NULL,
-          quantity NUMERIC,
+          from_account_id  STRING NOT NULL,
+          from_as_of       DATE NOT NULL,
+          to_isin          STRING NOT NULL,
+          as_of            DATE NOT NULL,
+          quantity         NUMERIC,
           PRIMARY KEY (from_account_id, from_as_of, to_isin, as_of) NOT ENFORCED,
           FOREIGN KEY (from_account_id, from_as_of) REFERENCES `my_dataset.account`(account_id, as_of) NOT ENFORCED,
           FOREIGN KEY (to_isin) REFERENCES `my_dataset.security`(isin) NOT ENFORCED
@@ -300,10 +302,10 @@ class TestRelationshipDDL:
   def test_keys_primary_relationship(self):
     ontology = load_ontology_from_string(textwrap.dedent(_REL_OWN_PK_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="ds")
-    assert "transfer_id STRING NOT NULL" in ddl
+    assert "transfer_id     STRING NOT NULL" in ddl
     assert "PRIMARY KEY (transfer_id) NOT ENFORCED" in ddl
-    assert "from_person_id STRING NOT NULL" in ddl
-    assert "to_person_id STRING NOT NULL" in ddl
+    assert "from_person_id  STRING NOT NULL" in ddl
+    assert "to_person_id    STRING NOT NULL" in ddl
 
   def test_endpoint_column_collision(self):
     ontology = load_ontology_from_string(textwrap.dedent(_COLLISION_ONTOLOGY))
@@ -314,7 +316,25 @@ class TestRelationshipDDL:
     ontology = load_ontology_from_string(textwrap.dedent(_REL_DERIVED_ONTOLOGY))
     ddl, _ = scaffold(ontology, dataset="ds")
     assert "label" not in ddl
-    assert "since DATE" in ddl
+    assert "since" in ddl and "DATE" in ddl
+
+  def test_no_keys_emits_suggested_pk_comment(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_FOLLOWS_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "-- TODO: uncomment if (from_party_id, to_party_id) is unique" in ddl
+    assert "-- PRIMARY KEY (from_party_id, to_party_id) NOT ENFORCED" in ddl
+
+  def test_keys_primary_has_no_suggested_pk_comment(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_REL_OWN_PK_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "-- TODO" not in ddl
+    assert "-- PRIMARY KEY" not in ddl
+
+  def test_keys_additional_has_no_suggested_pk_comment(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_HOLDING_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "-- TODO" not in ddl
+    assert "-- PRIMARY KEY" not in ddl
 
 
 # ===================================================================== #

--- a/tests/bigquery_ontology/test_scaffold.py
+++ b/tests/bigquery_ontology/test_scaffold.py
@@ -1,0 +1,442 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the scaffold generator in ``src/bigquery_ontology/scaffold.py``."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology.scaffold import _ONTOLOGY_TO_BQ_TYPE
+from bigquery_ontology.scaffold import _to_snake_case
+from bigquery_ontology.scaffold import scaffold
+from bigquery_ontology.ontology_models import PropertyType
+
+# ===================================================================== #
+# Step 1 — snake-case converter                                         #
+# ===================================================================== #
+
+
+class TestToSnakeCase:
+
+  @pytest.mark.parametrize(
+      "input_name, expected",
+      [
+          ("Person", "person"),
+          ("firstName", "first_name"),
+          ("HTTPRequest", "http_request"),
+          ("already_snake", "already_snake"),
+          ("FollowsRelation", "follows_relation"),
+          ("AccountDay", "account_day"),
+          ("XMLParser", "xml_parser"),
+          ("parseJSON", "parse_json"),
+          ("A", "a"),
+          ("myURL", "my_url"),
+          ("lowercase", "lowercase"),
+      ],
+  )
+  def test_snake_case_conversion(self, input_name, expected):
+    assert _to_snake_case(input_name) == expected
+
+
+class TestTypeMap:
+
+  def test_all_property_types_covered(self):
+    for pt in PropertyType:
+      assert pt in _ONTOLOGY_TO_BQ_TYPE, f"Missing mapping for {pt}"
+
+  @pytest.mark.parametrize(
+      "ontology_type, bq_type",
+      [
+          (PropertyType.INTEGER, "INT64"),
+          (PropertyType.DOUBLE, "FLOAT64"),
+          (PropertyType.BOOLEAN, "BOOL"),
+      ],
+  )
+  def test_non_trivial_mappings(self, ontology_type, bq_type):
+    assert _ONTOLOGY_TO_BQ_TYPE[ontology_type] == bq_type
+
+
+# ===================================================================== #
+# Step 2 — entity table DDL                                             #
+# ===================================================================== #
+
+_PERSON_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [party_id]}
+      properties:
+        - {name: party_id, type: string}
+        - {name: name, type: string}
+        - {name: dob, type: date}
+"""
+
+_COMPOUND_KEY_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: AccountDay
+      keys: {primary: [account_id, as_of]}
+      properties:
+        - {name: account_id, type: string}
+        - {name: as_of, type: date}
+        - {name: balance, type: numeric}
+"""
+
+_DERIVED_PROP_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [person_id]}
+      properties:
+        - {name: person_id, type: string}
+        - {name: first_name, type: string}
+        - {name: last_name, type: string}
+        - name: full_name
+          type: string
+          expr: "first_name || ' ' || last_name"
+"""
+
+
+class TestEntityDDL:
+
+  def test_single_pk_entity(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="my_dataset")
+    expected = textwrap.dedent("""\
+        CREATE TABLE `my_dataset.person` (
+          party_id STRING NOT NULL,
+          name STRING,
+          dob DATE,
+          PRIMARY KEY (party_id) NOT ENFORCED
+        );
+    """)
+    assert ddl == expected
+
+  def test_compound_pk_entity(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_COMPOUND_KEY_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="my_dataset")
+    expected = textwrap.dedent("""\
+        CREATE TABLE `my_dataset.account_day` (
+          account_id STRING NOT NULL,
+          as_of DATE NOT NULL,
+          balance NUMERIC,
+          PRIMARY KEY (account_id, as_of) NOT ENFORCED
+        );
+    """)
+    assert ddl == expected
+
+  def test_derived_properties_excluded(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_DERIVED_PROP_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "full_name" not in ddl
+
+  def test_preserve_naming(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="my_dataset", naming="preserve")
+    assert "`my_dataset.Person`" in ddl
+    assert "party_id STRING" in ddl
+
+  def test_project_qualified(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
+    ddl, _ = scaffold(ontology, dataset="ds", project="proj")
+    assert "`proj.ds.person`" in ddl
+
+
+# ===================================================================== #
+# Step 3 — relationship table DDL                                       #
+# ===================================================================== #
+
+_FOLLOWS_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [party_id]}
+      properties:
+        - {name: party_id, type: string}
+        - {name: name, type: string}
+        - {name: dob, type: date}
+  relationships:
+    - name: Follows
+      from: Person
+      to: Person
+      properties:
+        - {name: since, type: date}
+"""
+
+_HOLDING_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Account
+      keys: {primary: [account_id, as_of]}
+      properties:
+        - {name: account_id, type: string}
+        - {name: as_of, type: date}
+    - name: Security
+      keys: {primary: [isin]}
+      properties:
+        - {name: isin, type: string}
+  relationships:
+    - name: Holding
+      from: Account
+      to: Security
+      keys: {additional: [as_of]}
+      properties:
+        - {name: as_of, type: date}
+        - {name: quantity, type: numeric}
+"""
+
+_REL_OWN_PK_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [person_id]}
+      properties:
+        - {name: person_id, type: string}
+  relationships:
+    - name: Transfer
+      from: Person
+      to: Person
+      keys: {primary: [transfer_id]}
+      properties:
+        - {name: transfer_id, type: string}
+        - {name: amount, type: numeric}
+"""
+
+_COLLISION_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [party_id]}
+      properties:
+        - {name: party_id, type: string}
+  relationships:
+    - name: Follows
+      from: Person
+      to: Person
+      properties:
+        - {name: from_party_id, type: string}
+"""
+
+_REL_DERIVED_ONTOLOGY = """
+  ontology: test
+  entities:
+    - name: Person
+      keys: {primary: [person_id]}
+      properties:
+        - {name: person_id, type: string}
+  relationships:
+    - name: Knows
+      from: Person
+      to: Person
+      properties:
+        - {name: since, type: date}
+        - name: label
+          type: string
+          expr: "'KNOWS'"
+"""
+
+
+class TestRelationshipDDL:
+
+  def test_no_keys_relationship(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_FOLLOWS_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="my_dataset")
+    expected_rel = textwrap.dedent("""\
+        CREATE TABLE `my_dataset.follows` (
+          from_party_id STRING NOT NULL,
+          to_party_id STRING NOT NULL,
+          since DATE,
+          FOREIGN KEY (from_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED,
+          FOREIGN KEY (to_party_id) REFERENCES `my_dataset.person`(party_id) NOT ENFORCED
+        );
+    """)
+    assert expected_rel in ddl
+
+  def test_keys_additional_relationship(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_HOLDING_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="my_dataset")
+    expected_rel = textwrap.dedent("""\
+        CREATE TABLE `my_dataset.holding` (
+          from_account_id STRING NOT NULL,
+          from_as_of DATE NOT NULL,
+          to_isin STRING NOT NULL,
+          as_of DATE NOT NULL,
+          quantity NUMERIC,
+          PRIMARY KEY (from_account_id, from_as_of, to_isin, as_of) NOT ENFORCED,
+          FOREIGN KEY (from_account_id, from_as_of) REFERENCES `my_dataset.account`(account_id, as_of) NOT ENFORCED,
+          FOREIGN KEY (to_isin) REFERENCES `my_dataset.security`(isin) NOT ENFORCED
+        );
+    """)
+    assert expected_rel in ddl
+
+  def test_keys_primary_relationship(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_REL_OWN_PK_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "transfer_id STRING NOT NULL" in ddl
+    assert "PRIMARY KEY (transfer_id) NOT ENFORCED" in ddl
+    assert "from_person_id STRING NOT NULL" in ddl
+    assert "to_person_id STRING NOT NULL" in ddl
+
+  def test_endpoint_column_collision(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_COLLISION_ONTOLOGY)
+    )
+    with pytest.raises(ValueError, match="collides with a generated endpoint"):
+      scaffold(ontology, dataset="ds")
+
+  def test_derived_properties_excluded_from_rel(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_REL_DERIVED_ONTOLOGY)
+    )
+    ddl, _ = scaffold(ontology, dataset="ds")
+    assert "label" not in ddl
+    assert "since DATE" in ddl
+
+
+# ===================================================================== #
+# Step 4 — binding YAML + public scaffold()                             #
+# ===================================================================== #
+
+
+class TestBindingYAML:
+
+  def test_person_follows_binding(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_FOLLOWS_ONTOLOGY)
+    )
+    _, binding = scaffold(ontology, dataset="my_dataset")
+    expected = textwrap.dedent("""\
+        # Generated by gm scaffold. This file is user-owned \u2014 edit freely.
+        binding: my_dataset
+        ontology: test
+        target:
+          backend: bigquery
+          dataset: my_dataset
+        entities:
+          - name: Person
+            source: my_dataset.person
+            properties:
+              - {name: party_id, column: party_id}
+              - {name: name, column: name}
+              - {name: dob, column: dob}
+        relationships:
+          - name: Follows
+            source: my_dataset.follows
+            from_columns: [from_party_id]
+            to_columns: [to_party_id]
+            properties:
+              - {name: since, column: since}
+    """)
+    assert binding == expected
+
+  def test_binding_round_trip(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_FOLLOWS_ONTOLOGY)
+    )
+    _, binding_text = scaffold(
+        ontology, dataset="my_dataset", project="my_project"
+    )
+    binding = load_binding_from_string(binding_text, ontology=ontology)
+    assert binding.binding == "my_dataset"
+    assert binding.ontology == "test"
+    assert len(binding.entities) == 1
+    assert len(binding.relationships) == 1
+
+  def test_binding_with_project(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
+    _, binding = scaffold(ontology, dataset="ds", project="proj")
+    assert "project: proj" in binding
+    assert "source: proj.ds.person" in binding
+
+  def test_derived_excluded_from_binding(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_DERIVED_PROP_ONTOLOGY)
+    )
+    _, binding = scaffold(ontology, dataset="ds")
+    assert "full_name" not in binding
+
+  def test_entities_only_no_relationships(self):
+    ontology = load_ontology_from_string(textwrap.dedent(_PERSON_ONTOLOGY))
+    ddl, binding = scaffold(ontology, dataset="ds")
+    assert "relationships:" not in binding
+    assert "FOREIGN KEY" not in ddl
+
+  def test_determinism(self):
+    ontology = load_ontology_from_string(
+        textwrap.dedent(_FOLLOWS_ONTOLOGY)
+    )
+    ddl1, b1 = scaffold(ontology, dataset="ds")
+    ddl2, b2 = scaffold(ontology, dataset="ds")
+    assert ddl1 == ddl2
+    assert b1 == b2
+
+
+class TestRejectExtends:
+
+  def test_entity_extends_rejected(self):
+    yaml = textwrap.dedent("""
+      ontology: test
+      entities:
+        - name: Party
+          keys: {primary: [party_id]}
+          properties:
+            - {name: party_id, type: string}
+        - name: Person
+          extends: Party
+          properties:
+            - {name: name, type: string}
+    """)
+    ontology = load_ontology_from_string(yaml)
+    with pytest.raises(ValueError, match="extends"):
+      scaffold(ontology, dataset="ds")
+
+  def test_relationship_extends_rejected(self):
+    yaml = textwrap.dedent("""
+      ontology: test
+      entities:
+        - name: Person
+          keys: {primary: [pid]}
+          properties:
+            - {name: pid, type: string}
+      relationships:
+        - name: Knows
+          from: Person
+          to: Person
+          properties:
+            - {name: since, type: date}
+        - name: KnowsWell
+          extends: Knows
+          from: Person
+          to: Person
+          properties:
+            - {name: depth, type: integer}
+    """)
+    ontology = load_ontology_from_string(yaml)
+    with pytest.raises(ValueError, match="extends"):
+      scaffold(ontology, dataset="ds")


### PR DESCRIPTION
## Summary

- Add `scaffold()` function that generates BigQuery `CREATE TABLE` DDL and a matching `binding.yaml` stub from an ontology — for greenfield projects with no existing tables.
- Supports all three relationship key modes (no keys, `keys.primary`, `keys.additional`), compound entity keys, derived property exclusion, `--naming` (snake/preserve), and `--project` qualification.
- Keyless edge tables emit a commented-out `PRIMARY KEY` with a TODO, per [BQ best practices](https://docs.cloud.google.com/bigquery/docs/graph-schema-best-practices), so users can opt into the query optimizer hint if their data is unique.
- Column definitions are padded for vertical alignment, matching BQ documentation style.
- CLI wiring (`gm scaffold` command) is deferred to a follow-up PR.

## Test plan

- [x] 36 unit tests covering snake-case conversion, type mapping, entity DDL, relationship DDL (all three key modes), endpoint-column collision detection, binding YAML generation, round-trip validation, determinism, `extends` rejection, suggested PK comments
- [x] Round-trip test: emitted binding parses successfully via `load_binding_from_string`
- [x] Full existing test suite (134 tests) passes with zero regressions