### PR TITLE
feat(owl-import): OWL-to-ontology importer with CLI and user guide

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ llm = [
 bigframes = [
   "bigframes>=1.0.0",
 ]
+owl = [
+  "rdflib>=7.0",
+]
 cli = []
 dev = [
   "pytest>=7.0",
@@ -47,7 +50,7 @@ dev = [
   "isort>=5.0",
 ]
 all = [
-  "bigquery-agent-analytics[llm,bigframes,cli,dev]",
+  "bigquery-agent-analytics[llm,bigframes,owl,cli,dev]",
 ]
 
 [project.scripts]

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -777,7 +777,7 @@ def import_owl_command(
     resolved_output = Path(output_path)
     try:
       resolved_output.write_text(yaml_text, encoding="utf-8")
-    except (FileNotFoundError, PermissionError) as exc:
+    except OSError as exc:
       _emit_errors(
           [
               {

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -17,16 +17,18 @@
 ``gm validate`` accepts either an ontology YAML or a binding YAML and
 dispatches to the matching loader. ``gm compile`` takes a binding YAML
 and emits the corresponding ``CREATE PROPERTY GRAPH`` DDL on stdout
-(or to ``-o PATH``). Both commands resolve a binding's companion
-ontology by auto-discovering ``<name>.ontology.yaml`` next to the
-binding; ``--ontology PATH`` overrides that lookup.
+(or to ``-o PATH``). ``gm import-owl`` reads OWL source files and
+emits ``ontology.yaml``. Both ``validate`` and ``compile`` resolve a
+binding's companion ontology by auto-discovering
+``<name>.ontology.yaml`` next to the binding; ``--ontology PATH``
+overrides that lookup.
 
 Exit codes:
 
   0 — success
   1 — validation / compilation error
   2 — usage error (bad flag, missing file, missing companion ontology,
-      compile invoked on a non-binding file)
+      compile invoked on a non-binding file, missing dependency)
   3 — internal error
 """
 
@@ -51,7 +53,7 @@ from .ontology_models import Ontology
 
 app = typer.Typer(
     name="gm",
-    help="Graph-model CLI. Commands: validate, compile.",
+    help="Graph-model CLI. Commands: validate, compile, import-owl.",
     add_completion=False,
     no_args_is_help=True,
 )
@@ -436,6 +438,182 @@ def compile_command(
       raise typer.Exit(code=1)
   else:
     typer.echo(ddl, nl=False)
+
+
+# --------------------------------------------------------------------- #
+# gm import-owl                                                          #
+# --------------------------------------------------------------------- #
+
+_FORMAT_MAP = {"ttl": "turtle", "rdfxml": "xml"}
+
+
+@app.command("import-owl")
+def import_owl_command(
+    sources: list[str] = typer.Argument(
+        ...,
+        help="One or more OWL source files (Turtle or RDF/XML).",
+    ),
+    include_namespace: list[str] = typer.Option(
+        ...,
+        "--include-namespace",
+        help=(
+            "IRI namespace prefix to include. Required; repeatable. "
+            "Only classes and properties whose IRIs start with one of "
+            "these prefixes are imported."
+        ),
+    ),
+    output_path: str | None = typer.Option(
+        None,
+        "-o",
+        "--out",
+        help="Write YAML to this file instead of stdout.",
+    ),
+    format_override: str | None = typer.Option(
+        None,
+        "--format",
+        help="Override parser selection: ttl or rdfxml.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON errors on stderr.",
+    ),
+) -> None:
+  """Import OWL sources into ontology YAML.
+
+  Reads one or more OWL files (Turtle or RDF/XML), filters by
+  namespace, and emits an ``ontology.yaml`` file. The output may
+  contain ``FILL_IN`` placeholders for ambiguities that require manual
+  resolution before ``gm validate`` will pass.
+
+  A drop summary of excluded and unsupported OWL features is always
+  printed to stderr.
+  """
+  for src in sources:
+    src_path = Path(src)
+    if not src_path.exists() or not src_path.is_file():
+      _emit_errors(
+          [
+              {
+                  "file": src,
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-missing-file",
+                  "severity": "error",
+                  "message": f"File not found: {src}",
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=2)
+    if not os.access(src_path, os.R_OK):
+      _emit_errors(
+          [
+              {
+                  "file": src,
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-missing-file",
+                  "severity": "error",
+                  "message": f"File not readable: {src}",
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=2)
+
+  rdflib_format: str | None = None
+  if format_override is not None:
+    rdflib_format = _FORMAT_MAP.get(format_override)
+    if rdflib_format is None:
+      _emit_errors(
+          [
+              {
+                  "file": "<cli>",
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-usage",
+                  "severity": "error",
+                  "message": (
+                      f"Unknown format {format_override!r}. "
+                      "Accepted values: ttl, rdfxml."
+                  ),
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=2)
+
+  try:
+    from .owl_importer import import_owl
+  except ImportError:
+    _emit_errors(
+        [
+            {
+                "file": "<cli>",
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-dependency",
+                "severity": "error",
+                "message": (
+                    "rdflib is required for OWL import. Install it "
+                    "with: pip install 'bigquery-agent-analytics[owl]'"
+                ),
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+
+  try:
+    yaml_text, drop_summary = import_owl(
+        sources,
+        include_namespaces=include_namespace,
+        format=rdflib_format,
+    )
+  except ValueError as exc:
+    _emit_errors(
+        [
+            {
+                "file": sources[0] if sources else "<cli>",
+                "line": 0,
+                "col": 0,
+                "rule": "import-validation",
+                "severity": "error",
+                "message": str(exc),
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=1)
+  except Exception as exc:  # pragma: no cover - defensive
+    typer.echo(f"internal error: {exc}", err=True)
+    raise typer.Exit(code=3)
+
+  if drop_summary:
+    typer.echo(drop_summary, err=True)
+
+  if output_path is not None:
+    resolved_output = Path(output_path)
+    try:
+      resolved_output.write_text(yaml_text, encoding="utf-8")
+    except (FileNotFoundError, PermissionError) as exc:
+      _emit_errors(
+          [
+              {
+                  "file": str(resolved_output),
+                  "line": 0,
+                  "col": 0,
+                  "rule": "cli-output-error",
+                  "severity": "error",
+                  "message": f"Cannot write output file: {exc}",
+              }
+          ],
+          as_json=json_output,
+      )
+      raise typer.Exit(code=1)
+  else:
+    typer.echo(yaml_text, nl=False)
 
 
 def _validate_binding_file(

--- a/src/bigquery_ontology/docs/user_manual.md
+++ b/src/bigquery_ontology/docs/user_manual.md
@@ -21,6 +21,13 @@
 - [Validating and Compiling](#validating-and-compiling)
   - [Validate](#validate)
   - [Compile](#compile)
+- [Importing from OWL](#importing-from-owl)
+  - [Prerequisites](#prerequisites)
+  - [Basic usage](#basic-usage)
+  - [What maps to what](#what-maps-to-what)
+  - [Namespace filtering](#namespace-filtering)
+  - [FILL_IN placeholders](#fill_in-placeholders)
+  - [Drop annotations](#drop-annotations)
 - [End-to-End Walkthrough](#end-to-end-walkthrough)
 
 ### Part 2: Reference
@@ -295,6 +302,121 @@ gm compile finance.binding.yaml | bq query --use_legacy_sql=false -
 ```
 
 Compilation validates both files first — any error prevents DDL output.
+
+---
+
+### Importing from OWL
+
+If your domain is already modeled as an OWL ontology, you can import it into `ontology.yaml` format instead of writing it by hand.
+
+#### Prerequisites
+
+The OWL importer requires `rdflib`, which is an optional dependency. Install it with:
+
+```bash
+pip install 'bigquery-agent-analytics[owl]'
+```
+
+#### Basic usage
+
+```bash
+gm import-owl finance.ttl \
+  --include-namespace "https://example.com/finance#" \
+  -o finance.ontology.yaml
+```
+
+This reads the Turtle file, keeps only classes and properties in the given namespace, and writes the resulting ontology YAML. A drop summary of excluded or unsupported OWL features is printed to stderr.
+
+Multiple source files and namespace prefixes are supported:
+
+```bash
+gm import-owl core.ttl extensions.ttl \
+  --include-namespace "https://example.com/core#" \
+  --include-namespace "https://example.com/ext#" \
+  -o combined.ontology.yaml
+```
+
+Use `--format ttl` or `--format rdfxml` to override parser auto-detection from the file extension.
+
+#### What maps to what
+
+| OWL construct | Ontology equivalent |
+|---|---|
+| `owl:Class` | Entity |
+| `owl:DatatypeProperty` with domain and range | Property on the domain entity |
+| `owl:ObjectProperty` with domain and range | Relationship (from domain, to range) |
+| `rdfs:subClassOf` (single parent) | `extends` on entity |
+| `rdfs:subPropertyOf` (single parent) | `extends` on relationship |
+| `owl:hasKey` | `keys.primary` |
+| `owl:FunctionalProperty` | `cardinality: many_to_one` (object properties only) |
+| `rdfs:label` | `description` |
+| `rdfs:comment` | Appended to `description` |
+| `skos:altLabel`, `skos:prefLabel` | `synonyms` |
+
+XSD datatypes are mapped to ontology types: `xsd:string` to `string`, `xsd:integer` to `integer`, `xsd:decimal` to `numeric`, `xsd:boolean` to `boolean`, `xsd:date` to `date`, `xsd:dateTime` to `timestamp`, and so on.
+
+#### Namespace filtering
+
+The `--include-namespace` flag is required and acts as an allow-list. Only OWL classes and properties whose IRIs start with one of the given namespace prefixes are included in the output. Everything else is excluded.
+
+This is important because most OWL files import many external vocabularies (upper ontologies, SKOS, Dublin Core) that you typically don't want in your property graph. The namespace filter lets you select just the classes you care about.
+
+For example, a FIBO (Financial Industry Business Ontology) module might import hundreds of classes from foundational vocabularies, but with `--include-namespace "https://spec.edmcouncil.org/fibo/ontology/FBC/"` you get only the financial business classes.
+
+Excluded items are not silently lost:
+
+- The drop summary on stderr counts excluded classes and properties per namespace.
+- Cross-boundary references from kept entities are recorded as annotations (e.g., `owl:subClassOf_excluded: https://example.com/upper#Agent`).
+
+#### FILL_IN placeholders
+
+When the OWL source is ambiguous or incomplete, the importer emits `FILL_IN` as a placeholder value with a YAML comment explaining what to do. Three situations produce placeholders:
+
+1. **Missing primary key.** The class has no `owl:hasKey` declaration. The importer lists candidate data properties in a comment:
+
+   ```yaml
+   - name: Account
+     # no owl:hasKey in OWL source
+     # candidate data properties: account_id, external_ref
+     keys:
+       primary: [FILL_IN]
+   ```
+
+2. **Multiple parent classes.** The class has more than one `rdfs:subClassOf` parent. Since the ontology model supports single inheritance, you must pick one:
+
+   ```yaml
+   - name: JointAccount
+     # multi-parent: rdfs:subClassOf [Account, Organization]
+     extends: FILL_IN
+   ```
+
+3. **Multiple domain or range.** A property has multiple `rdfs:domain` or `rdfs:range` values:
+
+   ```yaml
+   - name: ownedBy
+     # multi-range: rdfs:range [Person, Organization]
+     from: Asset
+     to: FILL_IN
+   ```
+
+The output file will fail `gm validate` until all `FILL_IN` markers are replaced with valid values. This is intentional — the importer never silently guesses.
+
+#### Drop annotations
+
+OWL features that don't have a direct ontology equivalent are preserved rather than silently discarded:
+
+- **Structured annotations** (machine-readable): equivalence (`owl:equivalentClass`), disjointness (`owl:disjointWith`), inverse relationships (`owl:inverseOf`), and property characteristics (`owl:characteristics: [Transitive, Symmetric]`) are stored in the entity or relationship's `annotations` map.
+
+  ```yaml
+  - name: Person
+    extends: Party
+    annotations:
+      owl:disjointWith: Organization
+  ```
+
+- **YAML comments**: restrictions (`someValuesFrom`, `allValuesFrom`, cardinality constraints) and class expressions (`unionOf`, `intersectionOf`) are written as comments above the affected element.
+
+The drop summary printed to stderr provides counts per category so you can quickly see what was preserved as annotations versus what was dropped entirely.
 
 ---
 
@@ -617,13 +739,31 @@ gm compile <file> [--ontology PATH] [-o PATH] [--json]
 
 Validates both files before compiling. Any validation error prevents DDL output.
 
+#### `gm import-owl`
+
+```
+gm import-owl <source>... --include-namespace <iri>... [-o <out>] [--format ttl|rdfxml] [--json]
+```
+
+| Argument/Option | Required | Default | Description |
+|-----------------|----------|---------|-------------|
+| `source` | yes | — | One or more OWL source files (Turtle `.ttl` or RDF/XML `.owl`/`.rdf`). |
+| `--include-namespace <iri>` | yes | — | IRI namespace prefix to include. Repeatable. |
+| `-o` / `--out <file>` | no | stdout | Write ontology YAML to file. |
+| `--format` | no | auto | Parser override: `ttl` or `rdfxml`. Default is inferred from file extension. |
+| `--json` | no | false | Emit structured JSON errors on stderr. |
+
+Output YAML may contain `FILL_IN` placeholders that must be resolved before `gm validate` will pass. A drop summary of excluded and unsupported OWL features is always printed to stderr (not affected by `--json`).
+
+Requires `rdflib`. Install with `pip install 'bigquery-agent-analytics[owl]'`.
+
 #### Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
 | 1 | Validation or compilation error (user-fixable) |
-| 2 | Usage error (missing file, wrong file kind, missing companion ontology) |
+| 2 | Usage error (missing file, wrong file kind, missing companion ontology, missing dependency) |
 | 3 | Internal error |
 
 #### Error format
@@ -664,6 +804,9 @@ Validates both files before compiling. Any validation error prevents DDL output.
 | `cli-unknown-kind` | File is neither ontology nor binding |
 | `cli-wrong-kind` | Compile invoked on a non-binding file |
 | `cli-output-error` | Cannot write output file |
+| `cli-missing-dependency` | Required optional dependency not installed (e.g. rdflib for OWL import) |
+| `cli-usage` | Invalid flag value |
+| `import-validation` | Semantic error during OWL import (e.g. name collision) |
 
 ---
 

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -433,6 +433,13 @@ def _extract_datatype_properties(
 
     for domain_name in domains:
       if domain_name in entities:
+        existing = {p.name for p in entities[domain_name].properties}
+        if prop_name in existing:
+          raise ValueError(
+              f"Duplicate property {prop_name!r} on entity "
+              f"{domain_name!r}. Two OWL properties with the same "
+              "local name share a domain."
+          )
         entities[domain_name].properties.append(imported_prop)
 
 
@@ -571,11 +578,52 @@ def _resolve_keys(entities: dict[str, _ImportedEntity]) -> None:
 # ---------------------------------------------------------------------------
 
 
+_YAML_BOOL_NULL = frozenset(
+    {
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "True",
+        "False",
+        "Yes",
+        "No",
+        "On",
+        "Off",
+        "TRUE",
+        "FALSE",
+        "YES",
+        "NO",
+        "ON",
+        "OFF",
+        "null",
+        "Null",
+        "NULL",
+        "~",
+    }
+)
+
+_YAML_NEEDS_QUOTE_CHARS = frozenset(":{}[],\"'#\n\\*&!%@`?|>-")
+
+
 def _yaml_scalar(value: str) -> str:
-  if any(
-      c in value
-      for c in (":", "{", "}", "[", "]", ",", "#", "'", '"', "\n", "\\")
-  ):
+  if not value:
+    return '""'
+  needs_quote = (
+      value in _YAML_BOOL_NULL
+      or any(c in _YAML_NEEDS_QUOTE_CHARS for c in value)
+      or value[0] in (" ", "\t")
+      or value[-1] in (" ", "\t")
+  )
+  if not needs_quote:
+    try:
+      parsed = float(value)
+      needs_quote = True
+    except ValueError:
+      pass
+  if needs_quote:
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
   return value
@@ -777,6 +825,14 @@ def import_owl(
   _extract_datatype_properties(g, entities, include_namespaces, drops)
   relationships = _extract_relationships(g, entities, include_namespaces, drops)
   _resolve_keys(entities)
+
+  overlap = set(entities) & set(relationships)
+  if overlap:
+    names = ", ".join(sorted(overlap))
+    raise ValueError(
+        f"Name collision between entities and relationships: {names}. "
+        "Entity and relationship names must be disjoint."
+    )
 
   if ontology_name is None:
     ns = include_namespaces[0].rstrip("#/")

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -1,0 +1,735 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import OWL ontologies into ``ontology.yaml`` format.
+
+Converts OWL source files (Turtle or RDF/XML) into the YAML ontology
+format defined by ``ontology.md``.  The importer is a four-stage
+pipeline:
+
+  1. **Parse.** Read OWL source into an RDF graph via ``rdflib``.
+  2. **Filter.** Keep only resources whose IRIs match a user-provided
+     namespace list.
+  3. **Map.** Apply the OWL-to-ontology mapping table to produce
+     entities, relationships, and properties.  Ambiguities emit
+     ``FILL_IN`` placeholders with inline YAML comments.
+  4. **Emit.** Write ``ontology.yaml`` in canonical alphabetical order.
+
+The importer produces ontology files only; bindings are user-authored
+separately.  ``rdflib`` is an optional dependency — import this module
+only when the user invokes ``gm import-owl``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Union
+
+try:
+  from rdflib import Graph
+  from rdflib import Namespace
+  from rdflib import URIRef
+  from rdflib.namespace import OWL
+  from rdflib.namespace import RDF
+  from rdflib.namespace import RDFS
+  from rdflib.namespace import SKOS
+  from rdflib.namespace import XSD
+except ImportError as _rdflib_err:
+  raise ImportError(
+      "rdflib is required for OWL import. "
+      "Install it with: pip install 'bigquery-agent-analytics[owl]'"
+  ) from _rdflib_err
+
+
+# ---------------------------------------------------------------------------
+# XSD → ontology type mapping (design doc §6)
+# ---------------------------------------------------------------------------
+
+_XSD_TYPE_MAP: dict[URIRef, str] = {
+    XSD.string: "string",
+    XSD.normalizedString: "string",
+    XSD.token: "string",
+    XSD.hexBinary: "bytes",
+    XSD.base64Binary: "bytes",
+    XSD.integer: "integer",
+    XSD.int: "integer",
+    XSD.long: "integer",
+    XSD.short: "integer",
+    XSD.byte: "integer",
+    XSD.unsignedInt: "integer",
+    XSD.unsignedLong: "integer",
+    XSD.unsignedShort: "integer",
+    XSD.nonNegativeInteger: "integer",
+    XSD.positiveInteger: "integer",
+    XSD.nonPositiveInteger: "integer",
+    XSD.negativeInteger: "integer",
+    XSD.double: "double",
+    XSD.float: "double",
+    XSD.decimal: "numeric",
+    XSD.boolean: "boolean",
+    XSD.date: "date",
+    XSD.time: "time",
+    XSD.dateTime: "timestamp",
+    XSD.dateTimeStamp: "timestamp",
+    URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON"): "json",
+    XSD.anyURI: "string",
+}
+
+_ANYURI = XSD.anyURI
+
+
+# ---------------------------------------------------------------------------
+# IRI → local name (design doc §12)
+# ---------------------------------------------------------------------------
+
+
+def _local_name(iri: URIRef) -> str:
+  s = str(iri)
+  if "#" in s:
+    return s.rsplit("#", 1)[1]
+  return s.rsplit("/", 1)[-1]
+
+
+def _in_namespace(iri: URIRef, namespaces: list[str]) -> bool:
+  s = str(iri)
+  return any(s.startswith(ns) for ns in namespaces)
+
+
+# ---------------------------------------------------------------------------
+# Intermediate dataclasses
+# ---------------------------------------------------------------------------
+
+AnnotationValue = Union[str, list[str]]
+
+
+@dataclass
+class _ImportedProperty:
+  name: str
+  type: str
+  xsd_annotation: str | None = None
+
+
+@dataclass
+class _ImportedEntity:
+  name: str
+  iri: URIRef
+  description: str | None = None
+  synonyms: list[str] = field(default_factory=list)
+  extends: str | None = None
+  extends_fill_in: bool = False
+  extends_candidates: list[str] = field(default_factory=list)
+  keys_primary: list[str] | None = None
+  keys_fill_in: bool = False
+  key_candidates: list[str] = field(default_factory=list)
+  properties: list[_ImportedProperty] = field(default_factory=list)
+  annotations: dict[str, AnnotationValue] = field(default_factory=dict)
+  comments: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _ImportedRelationship:
+  name: str
+  iri: URIRef
+  from_entity: str | None = None
+  from_fill_in: bool = False
+  from_candidates: list[str] = field(default_factory=list)
+  to_entity: str | None = None
+  to_fill_in: bool = False
+  to_candidates: list[str] = field(default_factory=list)
+  description: str | None = None
+  synonyms: list[str] = field(default_factory=list)
+  cardinality: str | None = None
+  properties: list[_ImportedProperty] = field(default_factory=list)
+  annotations: dict[str, AnnotationValue] = field(default_factory=dict)
+  comments: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _DropSummary:
+  excluded_by_namespace: dict[str, int] = field(default_factory=dict)
+  dropped_features: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Core extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_labels_and_description(
+    g: Graph, iri: URIRef
+) -> tuple[str | None, list[str]]:
+  labels: list[str] = []
+  for label in g.objects(iri, RDFS.label):
+    labels.append(str(label))
+
+  comments: list[str] = []
+  for comment in g.objects(iri, RDFS.comment):
+    comments.append(str(comment))
+
+  description: str | None = None
+  synonyms: list[str] = []
+
+  if labels:
+    labels.sort()
+    description = labels[0]
+    synonyms = labels[1:]
+  if comments:
+    if description:
+      description = description + "\n\n" + "\n\n".join(comments)
+    else:
+      description = "\n\n".join(comments)
+
+  for alt in g.objects(iri, SKOS.altLabel):
+    synonyms.append(str(alt))
+  for pref in g.objects(iri, SKOS.prefLabel):
+    val = str(pref)
+    if val not in synonyms and val != description:
+      synonyms.append(val)
+
+  synonyms.sort()
+  return description, synonyms
+
+
+def _extract_parents(
+    g: Graph, iri: URIRef, predicate: URIRef, namespaces: list[str]
+) -> tuple[str | None, bool, list[str], dict[str, AnnotationValue]]:
+  parents: list[str] = []
+  excluded: list[str] = []
+  annotations: dict[str, AnnotationValue] = {}
+
+  for parent in g.objects(iri, predicate):
+    if not isinstance(parent, URIRef):
+      continue
+    if parent == OWL.Thing or parent == RDFS.Resource:
+      continue
+    if _in_namespace(parent, namespaces):
+      parents.append(_local_name(parent))
+    else:
+      excluded.append(str(parent))
+
+  if excluded:
+    key = (
+        "owl:subClassOf_excluded"
+        if predicate == RDFS.subClassOf
+        else "owl:subPropertyOf_excluded"
+    )
+    annotations[key] = excluded if len(excluded) > 1 else excluded[0]
+
+  if len(parents) == 1:
+    return parents[0], False, [], annotations
+  elif len(parents) > 1:
+    parents.sort()
+    return None, True, parents, annotations
+  return None, False, [], annotations
+
+
+def _extract_keys(
+    g: Graph, class_iri: URIRef, namespaces: list[str]
+) -> tuple[list[str] | None, bool, list[str]]:
+  for key_list in g.objects(class_iri, OWL.hasKey):
+    keys: list[str] = []
+    for item in g.items(key_list):
+      if isinstance(item, URIRef) and _in_namespace(item, namespaces):
+        keys.append(_local_name(item))
+    if keys:
+      return keys, False, []
+  return None, False, []
+
+
+def _collect_drop_annotations(
+    g: Graph,
+    iri: URIRef,
+    annotations: dict[str, AnnotationValue],
+    comments: list[str],
+    drops: _DropSummary,
+) -> None:
+  _OWL_EQUIV_CLASS = OWL.equivalentClass
+  _OWL_EQUIV_PROP = OWL.equivalentProperty
+  _OWL_DISJOINT = OWL.disjointWith
+  _OWL_SAME_AS = OWL.sameAs
+  _OWL_INVERSE = OWL.inverseOf
+
+  drop_map: dict[URIRef, str] = {
+      _OWL_EQUIV_CLASS: "owl:equivalentClass",
+      _OWL_EQUIV_PROP: "owl:equivalentProperty",
+      _OWL_DISJOINT: "owl:disjointWith",
+      _OWL_SAME_AS: "owl:sameAs",
+      _OWL_INVERSE: "owl:inverseOf",
+  }
+
+  for pred, ann_key in drop_map.items():
+    values: list[str] = []
+    for obj in g.objects(iri, pred):
+      values.append(_local_name(obj) if isinstance(obj, URIRef) else str(obj))
+    if values:
+      values.sort()
+      annotations[ann_key] = values if len(values) > 1 else values[0]
+      drops.dropped_features[ann_key] = drops.dropped_features.get(
+          ann_key, 0
+      ) + len(values)
+
+  characteristics: list[str] = []
+  char_types = {
+      OWL.TransitiveProperty: "Transitive",
+      OWL.SymmetricProperty: "Symmetric",
+      OWL.AsymmetricProperty: "Asymmetric",
+      OWL.ReflexiveProperty: "Reflexive",
+      OWL.IrreflexiveProperty: "Irreflexive",
+      OWL.InverseFunctionalProperty: "InverseFunctional",
+  }
+  for char_type, label in char_types.items():
+    if (iri, RDF.type, char_type) in g:
+      characteristics.append(label)
+
+  if characteristics:
+    characteristics.sort()
+    annotations["owl:characteristics"] = characteristics
+    drops.dropped_features["owl:characteristics"] = drops.dropped_features.get(
+        "owl:characteristics", 0
+    ) + len(characteristics)
+
+  restriction_preds = {
+      OWL.someValuesFrom,
+      OWL.allValuesFrom,
+      OWL.minCardinality,
+      OWL.maxCardinality,
+      OWL.qualifiedCardinality,
+      OWL.hasValue,
+  }
+  for pred in restriction_preds:
+    for obj in g.objects(iri, pred):
+      val = _local_name(obj) if isinstance(obj, URIRef) else str(obj)
+      comments.append(f"restriction {_local_name(pred)}: {val}")
+      drops.dropped_features["restrictions"] = (
+          drops.dropped_features.get("restrictions", 0) + 1
+      )
+
+
+def _extract_entities(
+    g: Graph, namespaces: list[str], drops: _DropSummary
+) -> dict[str, _ImportedEntity]:
+  entities: dict[str, _ImportedEntity] = {}
+
+  for cls in g.subjects(RDF.type, OWL.Class):
+    if not isinstance(cls, URIRef):
+      continue
+    if not _in_namespace(cls, namespaces):
+      drops.excluded_by_namespace["classes"] = (
+          drops.excluded_by_namespace.get("classes", 0) + 1
+      )
+      continue
+
+    name = _local_name(cls)
+    description, synonyms = _extract_labels_and_description(g, cls)
+    extends, extends_fill_in, extends_candidates, parent_anns = (
+        _extract_parents(g, cls, RDFS.subClassOf, namespaces)
+    )
+    keys_primary, keys_fill_in, key_candidates = _extract_keys(
+        g, cls, namespaces
+    )
+
+    annotations: dict[str, AnnotationValue] = {}
+    comments: list[str] = []
+    annotations.update(parent_anns)
+    _collect_drop_annotations(g, cls, annotations, comments, drops)
+
+    entities[name] = _ImportedEntity(
+        name=name,
+        iri=cls,
+        description=description,
+        synonyms=synonyms,
+        extends=extends,
+        extends_fill_in=extends_fill_in,
+        extends_candidates=extends_candidates,
+        keys_primary=keys_primary,
+        keys_fill_in=keys_fill_in,
+        key_candidates=key_candidates,
+        annotations=annotations,
+        comments=comments,
+    )
+
+  return entities
+
+
+def _extract_datatype_properties(
+    g: Graph,
+    entities: dict[str, _ImportedEntity],
+    namespaces: list[str],
+    drops: _DropSummary,
+) -> None:
+  for prop in g.subjects(RDF.type, OWL.DatatypeProperty):
+    if not isinstance(prop, URIRef):
+      continue
+    if not _in_namespace(prop, namespaces):
+      drops.excluded_by_namespace["datatype_properties"] = (
+          drops.excluded_by_namespace.get("datatype_properties", 0) + 1
+      )
+      continue
+
+    prop_name = _local_name(prop)
+    domains: list[str] = []
+    for domain in g.objects(prop, RDFS.domain):
+      if isinstance(domain, URIRef) and _in_namespace(domain, namespaces):
+        domains.append(_local_name(domain))
+
+    ranges: list[URIRef] = []
+    for range_ in g.objects(prop, RDFS.range):
+      if isinstance(range_, URIRef):
+        ranges.append(range_)
+
+    ont_type = "string"
+    xsd_annotation: str | None = None
+    if ranges:
+      xsd_ref = ranges[0]
+      if xsd_ref in _XSD_TYPE_MAP:
+        ont_type = _XSD_TYPE_MAP[xsd_ref]
+        if xsd_ref == _ANYURI:
+          xsd_annotation = "anyURI"
+      else:
+        ont_type = "string"
+
+    imported_prop = _ImportedProperty(
+        name=prop_name,
+        type=ont_type,
+        xsd_annotation=xsd_annotation,
+    )
+
+    for domain_name in domains:
+      if domain_name in entities:
+        entities[domain_name].properties.append(imported_prop)
+
+
+def _extract_relationships(
+    g: Graph,
+    entities: dict[str, _ImportedEntity],
+    namespaces: list[str],
+    drops: _DropSummary,
+) -> dict[str, _ImportedRelationship]:
+  relationships: dict[str, _ImportedRelationship] = {}
+
+  for prop in g.subjects(RDF.type, OWL.ObjectProperty):
+    if not isinstance(prop, URIRef):
+      continue
+    if not _in_namespace(prop, namespaces):
+      drops.excluded_by_namespace["object_properties"] = (
+          drops.excluded_by_namespace.get("object_properties", 0) + 1
+      )
+      continue
+
+    name = _local_name(prop)
+    description, synonyms = _extract_labels_and_description(g, prop)
+
+    domains: list[str] = []
+    domain_excluded: list[str] = []
+    for domain in g.objects(prop, RDFS.domain):
+      if not isinstance(domain, URIRef):
+        continue
+      if _in_namespace(domain, namespaces):
+        domains.append(_local_name(domain))
+      else:
+        domain_excluded.append(str(domain))
+
+    ranges: list[str] = []
+    range_excluded: list[str] = []
+    for range_ in g.objects(prop, RDFS.range):
+      if not isinstance(range_, URIRef):
+        continue
+      if _in_namespace(range_, namespaces):
+        ranges.append(_local_name(range_))
+      else:
+        range_excluded.append(str(range_))
+
+    from_entity: str | None = None
+    from_fill_in = False
+    from_candidates: list[str] = []
+    if len(domains) == 1:
+      from_entity = domains[0]
+    elif len(domains) > 1:
+      from_fill_in = True
+      from_candidates = sorted(domains)
+
+    to_entity: str | None = None
+    to_fill_in = False
+    to_candidates: list[str] = []
+    if len(ranges) == 1:
+      to_entity = ranges[0]
+    elif len(ranges) > 1:
+      to_fill_in = True
+      to_candidates = sorted(ranges)
+
+    cardinality: str | None = None
+    if (prop, RDF.type, OWL.FunctionalProperty) in g:
+      cardinality = "many_to_one"
+
+    annotations: dict[str, AnnotationValue] = {}
+    comments: list[str] = []
+
+    if domain_excluded:
+      annotations["owl:domain_excluded"] = (
+          domain_excluded if len(domain_excluded) > 1 else domain_excluded[0]
+      )
+    if range_excluded:
+      annotations["owl:range_excluded"] = (
+          range_excluded if len(range_excluded) > 1 else range_excluded[0]
+      )
+
+    _collect_drop_annotations(g, prop, annotations, comments, drops)
+
+    extends, extends_fill_in, extends_candidates, parent_anns = (
+        _extract_parents(g, prop, RDFS.subPropertyOf, namespaces)
+    )
+    annotations.update(parent_anns)
+
+    relationships[name] = _ImportedRelationship(
+        name=name,
+        iri=prop,
+        from_entity=from_entity,
+        from_fill_in=from_fill_in,
+        from_candidates=from_candidates,
+        to_entity=to_entity,
+        to_fill_in=to_fill_in,
+        to_candidates=to_candidates,
+        description=description,
+        synonyms=synonyms,
+        cardinality=cardinality,
+        annotations=annotations,
+        comments=comments,
+    )
+
+  return relationships
+
+
+# ---------------------------------------------------------------------------
+# Resolve: finalize keys and FILL_IN markers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_keys(entities: dict[str, _ImportedEntity]) -> None:
+  for entity in entities.values():
+    if entity.keys_primary is not None:
+      continue
+    if entity.extends is not None or entity.extends_fill_in:
+      continue
+    prop_names = [p.name for p in entity.properties]
+    entity.keys_fill_in = True
+    entity.key_candidates = prop_names
+
+
+# ---------------------------------------------------------------------------
+# YAML emitter
+# ---------------------------------------------------------------------------
+
+
+def _yaml_scalar(value: str) -> str:
+  if any(
+      c in value for c in (":", "{", "}", "[", "]", ",", "#", "'", '"', "\n")
+  ):
+    return f'"{value}"'
+  return value
+
+
+def _emit_annotation_value(value: AnnotationValue) -> str:
+  if isinstance(value, list):
+    items = ", ".join(_yaml_scalar(v) for v in value)
+    return f"[{items}]"
+  return _yaml_scalar(value)
+
+
+def _emit_ontology_yaml(
+    ontology_name: str,
+    entities: dict[str, _ImportedEntity],
+    relationships: dict[str, _ImportedRelationship],
+) -> str:
+  lines: list[str] = []
+  lines.append(f"ontology: {ontology_name}")
+
+  sorted_entities = sorted(entities.values(), key=lambda e: e.name)
+  if sorted_entities:
+    lines.append("")
+    lines.append("entities:")
+    for entity in sorted_entities:
+      for comment in entity.comments:
+        lines.append(f"  # {comment}")
+      lines.append(f"  - name: {entity.name}")
+
+      if entity.description:
+        lines.append(f"    description: {_yaml_scalar(entity.description)}")
+
+      if entity.extends_fill_in:
+        candidates = ", ".join(entity.extends_candidates)
+        lines.append(f"    # multi-parent: rdfs:subClassOf [{candidates}]")
+        lines.append("    extends: FILL_IN")
+      elif entity.extends:
+        lines.append(f"    extends: {entity.extends}")
+
+      if entity.keys_fill_in:
+        lines.append("    # no owl:hasKey in OWL source")
+        if entity.key_candidates:
+          candidates = ", ".join(entity.key_candidates)
+          lines.append(f"    # candidate data properties: {candidates}")
+        lines.append("    keys:")
+        lines.append("      primary: [FILL_IN]")
+      elif entity.keys_primary is not None:
+        keys_str = ", ".join(entity.keys_primary)
+        lines.append("    keys:")
+        lines.append(f"      primary: [{keys_str}]")
+
+      if entity.properties:
+        sorted_props = sorted(entity.properties, key=lambda p: p.name)
+        lines.append("    properties:")
+        for prop in sorted_props:
+          lines.append(f"      - name: {prop.name}")
+          lines.append(f"        type: {prop.type}")
+          if prop.xsd_annotation:
+            lines.append(f"        annotations:")
+            lines.append(f"          xsd_type: {prop.xsd_annotation}")
+
+      if entity.synonyms:
+        lines.append("    synonyms:")
+        for syn in entity.synonyms:
+          lines.append(f"      - {_yaml_scalar(syn)}")
+
+      if entity.annotations:
+        lines.append("    annotations:")
+        for key in sorted(entity.annotations):
+          val = _emit_annotation_value(entity.annotations[key])
+          lines.append(f"      {key}: {val}")
+
+  sorted_rels = sorted(relationships.values(), key=lambda r: r.name)
+  if sorted_rels:
+    lines.append("")
+    lines.append("relationships:")
+    for rel in sorted_rels:
+      for comment in rel.comments:
+        lines.append(f"  # {comment}")
+      lines.append(f"  - name: {rel.name}")
+
+      if rel.description:
+        lines.append(f"    description: {_yaml_scalar(rel.description)}")
+
+      if rel.from_fill_in:
+        candidates = ", ".join(rel.from_candidates)
+        lines.append(f"    # multi-domain: [{candidates}]")
+        lines.append("    from: FILL_IN")
+      elif rel.from_entity:
+        lines.append(f"    from: {rel.from_entity}")
+
+      if rel.to_fill_in:
+        candidates = ", ".join(rel.to_candidates)
+        lines.append(f"    # multi-range: [{candidates}]")
+        lines.append("    to: FILL_IN")
+      elif rel.to_entity:
+        lines.append(f"    to: {rel.to_entity}")
+
+      if rel.cardinality:
+        lines.append(f"    cardinality: {rel.cardinality}")
+
+      if rel.synonyms:
+        lines.append("    synonyms:")
+        for syn in rel.synonyms:
+          lines.append(f"      - {_yaml_scalar(syn)}")
+
+      if rel.annotations:
+        lines.append("    annotations:")
+        for key in sorted(rel.annotations):
+          val = _emit_annotation_value(rel.annotations[key])
+          lines.append(f"      {key}: {val}")
+
+  return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Drop summary
+# ---------------------------------------------------------------------------
+
+
+def _format_drop_summary(drops: _DropSummary) -> str:
+  lines: list[str] = []
+  if drops.excluded_by_namespace:
+    lines.append("Excluded by namespace filter:")
+    for kind, count in sorted(drops.excluded_by_namespace.items()):
+      lines.append(f"  {kind}: {count}")
+  if drops.dropped_features:
+    lines.append("Dropped OWL features (preserved as annotations/comments):")
+    for kind, count in sorted(drops.dropped_features.items()):
+      lines.append(f"  {kind}: {count}")
+  return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def import_owl(
+    sources: list[str | Path],
+    *,
+    include_namespaces: list[str],
+    ontology_name: str | None = None,
+    format: str | None = None,
+) -> tuple[str, str]:
+  """Import OWL sources into ontology YAML.
+
+  Args:
+      sources: Paths to OWL source files (Turtle or RDF/XML).
+      include_namespaces: IRI prefixes to include. At least one required.
+      ontology_name: Name for the output ontology. Defaults to the first
+          namespace's last path segment.
+      format: Parser format override (``"turtle"`` or ``"xml"``). If
+          ``None``, inferred from file extension.
+
+  Returns:
+      A ``(yaml_text, drop_summary)`` tuple. The YAML text is a valid
+      ontology (modulo ``FILL_IN`` placeholders). The drop summary is
+      a human-readable report of excluded and dropped OWL features.
+
+  Raises:
+      ValueError: If no sources or no namespaces are provided.
+  """
+  if not sources:
+    raise ValueError("At least one OWL source file is required.")
+  if not include_namespaces:
+    raise ValueError("At least one --include-namespace is required.")
+
+  g = Graph()
+  for src in sources:
+    src_path = Path(src)
+    fmt = format
+    if fmt is None:
+      ext = src_path.suffix.lower()
+      if ext == ".ttl":
+        fmt = "turtle"
+      elif ext in (".owl", ".rdf", ".xml"):
+        fmt = "xml"
+      else:
+        fmt = "turtle"
+    g.parse(str(src_path), format=fmt)
+
+  drops = _DropSummary()
+
+  entities = _extract_entities(g, include_namespaces, drops)
+  _extract_datatype_properties(g, entities, include_namespaces, drops)
+  relationships = _extract_relationships(g, entities, include_namespaces, drops)
+  _resolve_keys(entities)
+
+  if ontology_name is None:
+    ns = include_namespaces[0].rstrip("#/")
+    ontology_name = ns.rsplit("/", 1)[-1]
+
+  yaml_text = _emit_ontology_yaml(ontology_name, entities, relationships)
+  summary = _format_drop_summary(drops)
+
+  return yaml_text, summary

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -40,7 +40,6 @@ from typing import Union
 
 try:
   from rdflib import Graph
-  from rdflib import Namespace
   from rdflib import URIRef
   from rdflib.namespace import OWL
   from rdflib.namespace import RDF
@@ -151,8 +150,10 @@ class _ImportedRelationship:
   to_candidates: list[str] = field(default_factory=list)
   description: str | None = None
   synonyms: list[str] = field(default_factory=list)
+  extends: str | None = None
+  extends_fill_in: bool = False
+  extends_candidates: list[str] = field(default_factory=list)
   cardinality: str | None = None
-  properties: list[_ImportedProperty] = field(default_factory=list)
   annotations: dict[str, AnnotationValue] = field(default_factory=dict)
   comments: list[str] = field(default_factory=list)
 
@@ -392,14 +393,14 @@ def _extract_datatype_properties(
 
     ont_type = "string"
     xsd_annotation: str | None = None
-    if ranges:
+    if len(ranges) == 1:
       xsd_ref = ranges[0]
       if xsd_ref in _XSD_TYPE_MAP:
         ont_type = _XSD_TYPE_MAP[xsd_ref]
         if xsd_ref == _ANYURI:
           xsd_annotation = "anyURI"
-      else:
-        ont_type = "string"
+    elif len(ranges) > 1:
+      ont_type = "FILL_IN"
 
     imported_prop = _ImportedProperty(
         name=prop_name,
@@ -460,6 +461,8 @@ def _extract_relationships(
     elif len(domains) > 1:
       from_fill_in = True
       from_candidates = sorted(domains)
+    elif not domain_excluded:
+      from_fill_in = True
 
     to_entity: str | None = None
     to_fill_in = False
@@ -469,6 +472,8 @@ def _extract_relationships(
     elif len(ranges) > 1:
       to_fill_in = True
       to_candidates = sorted(ranges)
+    elif not range_excluded:
+      to_fill_in = True
 
     cardinality: str | None = None
     if (prop, RDF.type, OWL.FunctionalProperty) in g:
@@ -504,6 +509,9 @@ def _extract_relationships(
         to_candidates=to_candidates,
         description=description,
         synonyms=synonyms,
+        extends=extends,
+        extends_fill_in=extends_fill_in,
+        extends_candidates=extends_candidates,
         cardinality=cardinality,
         annotations=annotations,
         comments=comments,
@@ -535,9 +543,11 @@ def _resolve_keys(entities: dict[str, _ImportedEntity]) -> None:
 
 def _yaml_scalar(value: str) -> str:
   if any(
-      c in value for c in (":", "{", "}", "[", "]", ",", "#", "'", '"', "\n")
+      c in value
+      for c in (":", "{", "}", "[", "]", ",", "#", "'", '"', "\n", "\\")
   ):
-    return f'"{value}"'
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
   return value
 
 
@@ -620,16 +630,29 @@ def _emit_ontology_yaml(
       if rel.description:
         lines.append(f"    description: {_yaml_scalar(rel.description)}")
 
+      if rel.extends_fill_in:
+        candidates = ", ".join(rel.extends_candidates)
+        lines.append(f"    # multi-parent: rdfs:subPropertyOf [{candidates}]")
+        lines.append("    extends: FILL_IN")
+      elif rel.extends:
+        lines.append(f"    extends: {rel.extends}")
+
       if rel.from_fill_in:
-        candidates = ", ".join(rel.from_candidates)
-        lines.append(f"    # multi-domain: [{candidates}]")
+        if rel.from_candidates:
+          candidates = ", ".join(rel.from_candidates)
+          lines.append(f"    # multi-domain: [{candidates}]")
+        else:
+          lines.append("    # no rdfs:domain in OWL source")
         lines.append("    from: FILL_IN")
       elif rel.from_entity:
         lines.append(f"    from: {rel.from_entity}")
 
       if rel.to_fill_in:
-        candidates = ", ".join(rel.to_candidates)
-        lines.append(f"    # multi-range: [{candidates}]")
+        if rel.to_candidates:
+          candidates = ", ".join(rel.to_candidates)
+          lines.append(f"    # multi-range: [{candidates}]")
+        else:
+          lines.append("    # no rdfs:range in OWL source")
         lines.append("    to: FILL_IN")
       elif rel.to_entity:
         lines.append(f"    to: {rel.to_entity}")

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -133,6 +133,7 @@ class _ImportedEntity:
   keys_primary: list[str] | None = None
   keys_fill_in: bool = False
   key_candidates: list[str] = field(default_factory=list)
+  keys_excluded: list[str] = field(default_factory=list)
   properties: list[_ImportedProperty] = field(default_factory=list)
   annotations: dict[str, AnnotationValue] = field(default_factory=dict)
   comments: list[str] = field(default_factory=list)
@@ -255,15 +256,21 @@ def _extract_parents(
 
 def _extract_keys(
     g: Graph, class_iri: URIRef, namespaces: list[str]
-) -> tuple[list[str] | None, bool, list[str]]:
+) -> tuple[list[str] | None, bool, list[str], list[str]]:
   for key_list in g.objects(class_iri, OWL.hasKey):
     keys: list[str] = []
+    excluded: list[str] = []
     for item in g.items(key_list):
-      if isinstance(item, URIRef) and _in_namespace(item, namespaces):
-        keys.append(_local_name(item))
+      if isinstance(item, URIRef):
+        if _in_namespace(item, namespaces):
+          keys.append(_local_name(item))
+        else:
+          excluded.append(str(item))
     if keys:
-      return keys, False, []
-  return None, False, []
+      return keys, False, [], excluded
+    if excluded:
+      return None, False, [], excluded
+  return None, False, [], []
 
 
 def _collect_drop_annotations(
@@ -361,13 +368,17 @@ def _extract_entities(
     extends, extends_fill_in, extends_candidates, parent_anns = (
         _extract_parents(g, cls, RDFS.subClassOf, namespaces)
     )
-    keys_primary, keys_fill_in, key_candidates = _extract_keys(
+    keys_primary, keys_fill_in, key_candidates, keys_excluded = _extract_keys(
         g, cls, namespaces
     )
 
     annotations: dict[str, AnnotationValue] = {}
     comments: list[str] = []
     annotations.update(parent_anns)
+    if keys_excluded:
+      annotations["owl:hasKey_excluded"] = (
+          keys_excluded if len(keys_excluded) > 1 else keys_excluded[0]
+      )
     _collect_drop_annotations(g, cls, annotations, comments, drops)
 
     entities[name] = _ImportedEntity(
@@ -381,6 +392,7 @@ def _extract_entities(
         keys_primary=keys_primary,
         keys_fill_in=keys_fill_in,
         key_candidates=key_candidates,
+        keys_excluded=keys_excluded,
         annotations=annotations,
         comments=comments,
     )
@@ -664,7 +676,13 @@ def _emit_ontology_yaml(
         lines.append(f"    extends: {entity.extends}")
 
       if entity.keys_fill_in:
-        lines.append("    # no owl:hasKey in OWL source")
+        if entity.keys_excluded:
+          lines.append(
+              "    # owl:hasKey declared but key properties excluded by"
+              " namespace filter"
+          )
+        else:
+          lines.append("    # no owl:hasKey in OWL source")
         if entity.key_candidates:
           candidates = ", ".join(entity.key_candidates)
           lines.append(f"    # candidate data properties: {candidates}")

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -169,24 +169,40 @@ class _DropSummary:
 # ---------------------------------------------------------------------------
 
 
+def _pick_primary_label(labels) -> tuple[str | None, list[str]]:
+  """Pick the best label as description, return rest as synonyms.
+
+  Prefers English-tagged labels (``@en*``), then falls back to
+  untagged or other languages.  Within the preferred group, picks
+  alphabetically first for determinism.
+  """
+  en: list[str] = []
+  other: list[str] = []
+  for label in labels:
+    lang = getattr(label, "language", None)
+    if lang is not None and lang.startswith("en"):
+      en.append(str(label))
+    else:
+      other.append(str(label))
+
+  en.sort()
+  other.sort()
+  if en:
+    return en[0], en[1:] + other
+  if other:
+    return other[0], other[1:]
+  return None, []
+
+
 def _extract_labels_and_description(
     g: Graph, iri: URIRef
 ) -> tuple[str | None, list[str]]:
-  labels: list[str] = []
-  for label in g.objects(iri, RDFS.label):
-    labels.append(str(label))
+  raw_labels = list(g.objects(iri, RDFS.label))
+  description, synonyms = _pick_primary_label(raw_labels)
 
   comments: list[str] = []
   for comment in g.objects(iri, RDFS.comment):
     comments.append(str(comment))
-
-  description: str | None = None
-  synonyms: list[str] = []
-
-  if labels:
-    labels.sort()
-    description = labels[0]
-    synonyms = labels[1:]
   if comments:
     if description:
       description = description + "\n\n" + "\n\n".join(comments)
@@ -334,6 +350,13 @@ def _extract_entities(
       continue
 
     name = _local_name(cls)
+    if name in entities:
+      raise ValueError(
+          f"Name collision: entity {name!r} maps to both "
+          f"<{entities[name].iri}> and <{cls}>. Narrow the "
+          "namespace filter to resolve."
+      )
+
     description, synonyms = _extract_labels_and_description(g, cls)
     extends, extends_fill_in, extends_candidates, parent_anns = (
         _extract_parents(g, cls, RDFS.subClassOf, namespaces)
@@ -431,6 +454,13 @@ def _extract_relationships(
       continue
 
     name = _local_name(prop)
+    if name in relationships:
+      raise ValueError(
+          f"Name collision: relationship {name!r} maps to both "
+          f"<{relationships[name].iri}> and <{prop}>. Narrow the "
+          "namespace filter to resolve."
+      )
+
     description, synonyms = _extract_labels_and_description(g, prop)
 
     domains: list[str] = []

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -27,9 +27,20 @@ from __future__ import annotations
 from pathlib import Path
 import textwrap
 
+import pytest
 from typer.testing import CliRunner
 
 from bigquery_ontology.cli import app
+
+_has_rdflib = True
+try:
+  import rdflib  # noqa: F401
+except ImportError:
+  _has_rdflib = False
+
+_requires_rdflib = pytest.mark.skipif(
+    not _has_rdflib, reason="rdflib not installed"
+)
 
 # NOTE: Click's CliRunner merges stderr into ``result.output`` by default
 # (``mix_stderr=True``). The CLI writes errors to stderr, so all
@@ -794,3 +805,271 @@ def test_validate_missing_file_with_json_emits_structured_json(tmp_path):
   )
   assert result.exit_code == 2
   assert result.output == expected
+
+
+# --------------------------------------------------------------------- #
+# gm import-owl                                                          #
+# --------------------------------------------------------------------- #
+#
+# The import-owl tests require rdflib, which is an optional dependency.
+# Tests that exercise the importer's core logic are in
+# ``test_owl_importer.py``; these tests verify the CLI surface:
+# argument parsing, output routing, error formatting, and exit codes.
+
+_TINY_TURTLE = """\
+@prefix : <http://example.com/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Thing a owl:Class ;
+    rdfs:label "Thing" ;
+    owl:hasKey ( :thing_id ) .
+
+:thing_id a owl:DatatypeProperty ;
+    rdfs:domain :Thing ;
+    rdfs:range xsd:string .
+"""
+
+_TURTLE_WITH_DROPS = """\
+@prefix : <http://example.com/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Alpha a owl:Class ;
+    rdfs:label "Alpha" ;
+    owl:hasKey ( :alpha_id ) ;
+    owl:disjointWith :Beta .
+
+:Beta a owl:Class ;
+    rdfs:label "Beta" ;
+    owl:hasKey ( :beta_id ) .
+
+:alpha_id a owl:DatatypeProperty ;
+    rdfs:domain :Alpha ;
+    rdfs:range xsd:string .
+
+:beta_id a owl:DatatypeProperty ;
+    rdfs:domain :Beta ;
+    rdfs:range xsd:string .
+"""
+
+
+@_requires_rdflib
+def test_import_owl_golden_path_writes_yaml_to_stdout(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert "ontology: test" in result.output
+  assert "name: Thing" in result.output
+  assert "name: thing_id" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_output_flag_writes_to_file(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+  out = tmp_path / "out.ontology.yaml"
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+          "-o",
+          str(out),
+      ],
+  )
+
+  assert result.exit_code == 0
+  content = out.read_text(encoding="utf-8")
+  assert "ontology: test" in content
+  assert "name: Thing" in content
+
+
+@_requires_rdflib
+def test_import_owl_drop_summary_on_stderr(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TURTLE_WITH_DROPS)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert "Dropped OWL features" in result.output
+  assert "owl:disjointWith: 1" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_format_flag_ttl(tmp_path):
+  ttl = _write(tmp_path, "test.owl", _TINY_TURTLE)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+          "--format",
+          "ttl",
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert "ontology: test" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_multiple_namespaces(tmp_path):
+  multi_ns = """\
+@prefix a: <http://example.com/ns_a#> .
+@prefix b: <http://example.com/ns_b#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+a:Foo a owl:Class ; rdfs:label "Foo" ; owl:hasKey ( a:foo_id ) .
+a:foo_id a owl:DatatypeProperty ; rdfs:domain a:Foo ; rdfs:range xsd:string .
+
+b:Bar a owl:Class ; rdfs:label "Bar" ; owl:hasKey ( b:bar_id ) .
+b:bar_id a owl:DatatypeProperty ; rdfs:domain b:Bar ; rdfs:range xsd:string .
+"""
+  ttl = _write(tmp_path, "multi.ttl", multi_ns)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/ns_a#",
+          "--include-namespace",
+          "http://example.com/ns_b#",
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert "name: Foo" in result.output
+  assert "name: Bar" in result.output
+
+
+def test_import_owl_missing_source_file_is_usage_error(tmp_path):
+  missing = tmp_path / "nope.ttl"
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(missing),
+          "--include-namespace",
+          "http://example.com/test#",
+      ],
+  )
+
+  expected = (
+      f"{missing}:0:0: cli-missing-file \u2014 File not found: {missing}\n"
+  )
+  assert result.exit_code == 2
+  assert result.output == expected
+
+
+def test_import_owl_missing_file_json_emits_structured_json(tmp_path):
+  missing = tmp_path / "nope.ttl"
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(missing),
+          "--include-namespace",
+          "http://example.com/test#",
+          "--json",
+      ],
+  )
+
+  assert result.exit_code == 2
+  assert "cli-missing-file" in result.output
+
+
+def test_import_owl_bad_format_is_usage_error(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+          "--format",
+          "badvalue",
+      ],
+  )
+
+  assert result.exit_code == 2
+  assert "cli-usage" in result.output
+  assert "badvalue" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_output_to_nonexistent_dir_emits_error(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+  bad_output = tmp_path / "no" / "such" / "dir" / "out.yaml"
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+          "-o",
+          str(bad_output),
+      ],
+  )
+
+  assert result.exit_code == 1
+  assert "cli-output-error" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_missing_rdflib_exits_2(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+
+  import unittest.mock
+
+  with unittest.mock.patch.dict(
+      "sys.modules", {"bigquery_ontology.owl_importer": None}
+  ):
+    result = _RUNNER.invoke(
+        app,
+        [
+            "import-owl",
+            str(ttl),
+            "--include-namespace",
+            "http://example.com/test#",
+        ],
+    )
+
+  assert result.exit_code == 2
+  assert "cli-missing-dependency" in result.output
+  assert "pip install" in result.output

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -1073,3 +1073,25 @@ def test_import_owl_missing_rdflib_exits_2(tmp_path):
   assert result.exit_code == 2
   assert "cli-missing-dependency" in result.output
   assert "pip install" in result.output
+
+
+@_requires_rdflib
+def test_import_owl_output_to_existing_directory_emits_error(tmp_path):
+  ttl = _write(tmp_path, "test.ttl", _TINY_TURTLE)
+  existing_dir = tmp_path / "a_directory"
+  existing_dir.mkdir()
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "import-owl",
+          str(ttl),
+          "--include-namespace",
+          "http://example.com/test#",
+          "-o",
+          str(existing_dir),
+      ],
+  )
+
+  assert result.exit_code == 1
+  assert "cli-output-error" in result.output

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -389,3 +389,89 @@ class TestEdgeCases:
     data = yaml.safe_load(yaml_text)
     rel = next(r for r in data["relationships"] if r["name"] == "rel")
     assert rel["cardinality"] == "many_to_one"
+
+  def test_no_domain_emits_fill_in(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :A a owl:Class ; owl:hasKey ( :a_id ) .
+        :a_id a owl:DatatypeProperty ; rdfs:domain :A ; rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :orphan a owl:ObjectProperty ; rdfs:range :A .
+    """
+        ),
+        encoding="utf-8",
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel = next(r for r in data["relationships"] if r["name"] == "orphan")
+    assert rel["from"] == "FILL_IN"
+    assert rel["to"] == "A"
+    assert "no rdfs:domain" in yaml_text
+
+  def test_no_range_emits_fill_in(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :A a owl:Class ; owl:hasKey ( :a_id ) .
+        :a_id a owl:DatatypeProperty ; rdfs:domain :A ; rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :orphan a owl:ObjectProperty ; rdfs:domain :A .
+    """
+        ),
+        encoding="utf-8",
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel = next(r for r in data["relationships"] if r["name"] == "orphan")
+    assert rel["from"] == "A"
+    assert rel["to"] == "FILL_IN"
+    assert "no rdfs:range" in yaml_text
+
+  def test_relationship_extends(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :A a owl:Class ; owl:hasKey ( :a_id ) .
+        :a_id a owl:DatatypeProperty ; rdfs:domain :A ; rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :parent_rel a owl:ObjectProperty ; rdfs:domain :A ; rdfs:range :A .
+        :child_rel a owl:ObjectProperty ; rdfs:subPropertyOf :parent_rel ;
+            rdfs:domain :A ; rdfs:range :A .
+    """
+        ),
+        encoding="utf-8",
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel_map = {r["name"]: r for r in data["relationships"]}
+    assert rel_map["child_rel"]["extends"] == "parent_rel"
+
+  def test_yaml_scalar_escapes_quotes(self, tmp_path):
+    from bigquery_ontology.owl_importer import _yaml_scalar
+
+    assert _yaml_scalar("hello") == "hello"
+    assert _yaml_scalar("has: colon") == '"has: colon"'
+    assert _yaml_scalar('has "quote"') == '"has \\"quote\\""'
+    assert _yaml_scalar("back\\slash") == '"back\\\\slash"'

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -1,0 +1,391 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OWL importer in ``src/bigquery_ontology/owl_importer.py``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+import pytest
+import yaml
+
+from bigquery_ontology.owl_importer import import_owl
+
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+_YAMO_TTL = _FIXTURES / "yamo_sample.ttl"
+
+
+# ===================================================================== #
+# Basic import                                                           #
+# ===================================================================== #
+
+
+class TestYamoSample:
+
+  def test_imports_all_classes_as_entities(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    names = [e["name"] for e in data["entities"]]
+    assert "Party" in names
+    assert "AdUnit" in names
+    assert "Campaign" in names
+    assert "DecisionPoint" in names
+    assert "RejectionReason" in names
+
+  def test_entities_sorted_alphabetically(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    names = [e["name"] for e in data["entities"]]
+    assert names == sorted(names)
+
+  def test_properties_assigned_to_correct_entities(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+
+    party_props = [p["name"] for p in entity_map["Party"]["properties"]]
+    assert "party_id" in party_props
+    assert "name" in party_props
+
+    campaign_props = [p["name"] for p in entity_map["Campaign"]["properties"]]
+    assert "campaign_id" in campaign_props
+    assert "budget" in campaign_props
+    assert "start_date" in campaign_props
+
+  def test_owl_haskey_maps_to_primary_key(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    assert entity_map["Party"]["keys"]["primary"] == ["party_id"]
+    assert entity_map["Campaign"]["keys"]["primary"] == ["campaign_id"]
+
+  def test_missing_haskey_emits_fill_in(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    assert entity_map["DecisionPoint"]["keys"]["primary"] == ["FILL_IN"]
+    assert "no owl:hasKey" in yaml_text
+
+  def test_subclass_maps_to_extends(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    assert entity_map["AdUnit"]["extends"] == "Party"
+
+  def test_relationships_extracted(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel_map = {r["name"]: r for r in data["relationships"]}
+    assert "evaluates" in rel_map
+    assert "rejectedBy" in rel_map
+    assert rel_map["evaluates"]["from"] == "DecisionPoint"
+    assert rel_map["evaluates"]["to"] == "AdUnit"
+    assert rel_map["rejectedBy"]["from"] == "AdUnit"
+    assert rel_map["rejectedBy"]["to"] == "RejectionReason"
+
+  def test_xsd_decimal_maps_to_numeric(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    budget = next(
+        p for p in entity_map["Campaign"]["properties"] if p["name"] == "budget"
+    )
+    assert budget["type"] == "numeric"
+
+  def test_xsd_date_maps_to_date(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    start_date = next(
+        p
+        for p in entity_map["Campaign"]["properties"]
+        if p["name"] == "start_date"
+    )
+    assert start_date["type"] == "date"
+
+  def test_ontology_name_from_namespace(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    assert data["ontology"] == "yamo"
+
+  def test_explicit_ontology_name(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+        ontology_name="my_ontology",
+    )
+    data = yaml.safe_load(yaml_text)
+    assert data["ontology"] == "my_ontology"
+
+  def test_description_from_label(self):
+    yaml_text, _ = import_owl(
+        [_YAMO_TTL],
+        include_namespaces=["https://example.com/yamo#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    assert entity_map["Party"]["description"] == "Party"
+    rel_map = {r["name"]: r for r in data["relationships"]}
+    assert rel_map["evaluates"]["description"] == "evaluates"
+
+
+# ===================================================================== #
+# Design doc worked example (§18)                                        #
+# ===================================================================== #
+
+_FINANCE_TTL = """\
+@prefix : <https://example.com/finance#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Party  a owl:Class ; rdfs:label "Party" ;
+    owl:hasKey ( :party_id ) .
+
+:Person  a owl:Class ;
+    rdfs:subClassOf :Party ;
+    rdfs:label "Person" ;
+    owl:disjointWith :Organization .
+
+:Organization  a owl:Class ;
+    rdfs:subClassOf :Party ;
+    rdfs:label "Organization" .
+
+:party_id  a owl:DatatypeProperty ;
+    rdfs:domain :Party ;
+    rdfs:range xsd:string .
+
+:name  a owl:DatatypeProperty ;
+    rdfs:domain :Party ;
+    rdfs:range xsd:string .
+
+:Account  a owl:Class ;
+    rdfs:label "Account" .
+
+:heldBy  a owl:ObjectProperty, owl:TransitiveProperty ;
+    owl:inverseOf :holds ;
+    rdfs:domain :Account ;
+    rdfs:range :Party .
+"""
+
+
+class TestDesignDocWorkedExample:
+
+  def _import(self, tmp_path):
+    ttl = tmp_path / "finance.ttl"
+    ttl.write_text(_FINANCE_TTL, encoding="utf-8")
+    return import_owl(
+        [ttl],
+        include_namespaces=["https://example.com/finance#"],
+        ontology_name="finance",
+    )
+
+  def test_entities_present(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    names = [e["name"] for e in data["entities"]]
+    assert names == ["Account", "Organization", "Party", "Person"]
+
+  def test_account_has_fill_in_key(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    account = next(e for e in data["entities"] if e["name"] == "Account")
+    assert account["keys"]["primary"] == ["FILL_IN"]
+
+  def test_party_has_key(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    party = next(e for e in data["entities"] if e["name"] == "Party")
+    assert party["keys"]["primary"] == ["party_id"]
+
+  def test_inheritance(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    entity_map = {e["name"]: e for e in data["entities"]}
+    assert entity_map["Person"]["extends"] == "Party"
+    assert entity_map["Organization"]["extends"] == "Party"
+
+  def test_inherited_entities_no_key_placeholder(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    person = next(e for e in data["entities"] if e["name"] == "Person")
+    assert "keys" not in person
+
+  def test_disjoint_annotation(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    person = next(e for e in data["entities"] if e["name"] == "Person")
+    assert person["annotations"]["owl:disjointWith"] == "Organization"
+
+  def test_relationship_heldby(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    rel_map = {r["name"]: r for r in data["relationships"]}
+    assert "heldBy" in rel_map
+    assert rel_map["heldBy"]["from"] == "Account"
+    assert rel_map["heldBy"]["to"] == "Party"
+
+  def test_relationship_drop_annotations(self, tmp_path):
+    yaml_text, _ = self._import(tmp_path)
+    data = yaml.safe_load(yaml_text)
+    rel_map = {r["name"]: r for r in data["relationships"]}
+    held = rel_map["heldBy"]
+    assert held["annotations"]["owl:inverseOf"] == "holds"
+    assert "Transitive" in held["annotations"]["owl:characteristics"]
+
+  def test_drop_summary_not_empty(self, tmp_path):
+    _, summary = self._import(tmp_path)
+    assert "Dropped OWL features" in summary
+
+  def test_determinism(self, tmp_path):
+    y1, s1 = self._import(tmp_path)
+    y2, s2 = self._import(tmp_path)
+    assert y1 == y2
+    assert s1 == s2
+
+
+# ===================================================================== #
+# Edge cases                                                             #
+# ===================================================================== #
+
+
+class TestEdgeCases:
+
+  def test_no_sources_raises(self):
+    with pytest.raises(ValueError, match="source"):
+      import_owl([], include_namespaces=["http://example.com/"])
+
+  def test_no_namespaces_raises(self):
+    with pytest.raises(ValueError, match="namespace"):
+      import_owl([_YAMO_TTL], include_namespaces=[])
+
+  def test_namespace_filter_excludes(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix a: <http://example.com/a#> .
+        @prefix b: <http://example.com/b#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        a:Foo a owl:Class ; owl:hasKey ( a:foo_id ) .
+        a:foo_id a owl:DatatypeProperty ; rdfs:domain a:Foo ; rdfs:range xsd:string .
+        b:Bar a owl:Class ; owl:hasKey ( b:bar_id ) .
+        b:bar_id a owl:DatatypeProperty ; rdfs:domain b:Bar ; rdfs:range xsd:string .
+    """
+        ),
+        encoding="utf-8",
+    )
+
+    yaml_text, summary = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/a#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    names = [e["name"] for e in data["entities"]]
+    assert "Foo" in names
+    assert "Bar" not in names
+    assert "Excluded by namespace" in summary
+
+  def test_multi_parent_emits_fill_in(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        :A a owl:Class ; owl:hasKey ( :a_id ) .
+        :a_id a owl:DatatypeProperty ; rdfs:domain :A ; rdfs:range xsd:string .
+        :B a owl:Class ; owl:hasKey ( :b_id ) .
+        :b_id a owl:DatatypeProperty ; rdfs:domain :B ; rdfs:range xsd:string .
+        :C a owl:Class ;
+            rdfs:subClassOf :A, :B .
+    """
+        ),
+        encoding="utf-8",
+    )
+
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    c = next(e for e in data["entities"] if e["name"] == "C")
+    assert c["extends"] == "FILL_IN"
+    assert "multi-parent" in yaml_text
+
+  def test_functional_property_cardinality(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :A a owl:Class ; owl:hasKey ( :a_id ) .
+        :a_id a owl:DatatypeProperty ; rdfs:domain :A ; rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :B a owl:Class ; owl:hasKey ( :b_id ) .
+        :b_id a owl:DatatypeProperty ; rdfs:domain :B ; rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :rel a owl:ObjectProperty, owl:FunctionalProperty ;
+            rdfs:domain :A ; rdfs:range :B .
+    """
+        ),
+        encoding="utf-8",
+    )
+
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel = next(r for r in data["relationships"] if r["name"] == "rel")
+    assert rel["cardinality"] == "many_to_one"

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -22,6 +22,8 @@ import textwrap
 import pytest
 import yaml
 
+pytest.importorskip("rdflib")
+
 from bigquery_ontology.owl_importer import import_owl
 
 _FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -475,3 +475,53 @@ class TestEdgeCases:
     assert _yaml_scalar("has: colon") == '"has: colon"'
     assert _yaml_scalar('has "quote"') == '"has \\"quote\\""'
     assert _yaml_scalar("back\\slash") == '"back\\\\slash"'
+
+  def test_name_collision_raises(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix a: <http://example.com/a#> .
+        @prefix b: <http://example.com/b#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+        a:Thing a owl:Class .
+        b:Thing a owl:Class .
+    """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Name collision"):
+      import_owl(
+          [ttl],
+          include_namespaces=["http://example.com/a#", "http://example.com/b#"],
+      )
+
+  def test_english_label_preferred(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :Thing a owl:Class ;
+            rdfs:label "Chose"@fr ;
+            rdfs:label "Thing"@en ;
+            owl:hasKey ( :thing_id ) .
+        :thing_id a owl:DatatypeProperty ;
+            rdfs:domain :Thing ;
+            rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+    """
+        ),
+        encoding="utf-8",
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    entity = data["entities"][0]
+    assert entity["description"] == "Thing"
+    assert "Chose" in entity["synonyms"]

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -476,6 +476,82 @@ class TestEdgeCases:
     assert _yaml_scalar('has "quote"') == '"has \\"quote\\""'
     assert _yaml_scalar("back\\slash") == '"back\\\\slash"'
 
+  def test_yaml_scalar_quotes_booleans_and_nulls(self, tmp_path):
+    from bigquery_ontology.owl_importer import _yaml_scalar
+
+    for val in ("true", "false", "yes", "no", "on", "off", "null", "~"):
+      quoted = _yaml_scalar(val)
+      assert quoted.startswith('"'), f"{val} should be quoted"
+      parsed = yaml.safe_load(f"key: {quoted}")
+      assert parsed["key"] == val, f"{val} should round-trip as string"
+
+  def test_yaml_scalar_quotes_numbers(self, tmp_path):
+    from bigquery_ontology.owl_importer import _yaml_scalar
+
+    for val in ("42", "1.5", "0", "-3"):
+      quoted = _yaml_scalar(val)
+      assert quoted.startswith('"'), f"{val} should be quoted"
+      parsed = yaml.safe_load(f"key: {quoted}")
+      assert parsed["key"] == val
+
+  def test_yaml_scalar_quotes_special_leading_chars(self, tmp_path):
+    from bigquery_ontology.owl_importer import _yaml_scalar
+
+    for val in ("*alias", "&anchor", "!tag", "%dir"):
+      quoted = _yaml_scalar(val)
+      assert quoted.startswith('"'), f"{val} should be quoted"
+
+  def test_yaml_scalar_empty_string(self, tmp_path):
+    from bigquery_ontology.owl_importer import _yaml_scalar
+
+    assert _yaml_scalar("") == '""'
+
+  def test_entity_relationship_name_overlap_raises(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix : <http://example.com/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+        :Foo a owl:Class ; owl:hasKey ( :foo_id ) .
+        :foo_id a owl:DatatypeProperty ; rdfs:domain :Foo ;
+            rdfs:range <http://www.w3.org/2001/XMLSchema#string> .
+        :Foo a owl:ObjectProperty ; rdfs:domain :Foo ; rdfs:range :Foo .
+    """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="collision between entities and relationships"
+    ):
+      import_owl([ttl], include_namespaces=["http://example.com/test#"])
+
+  def test_duplicate_property_name_raises(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix a: <http://example.com/a#> .
+        @prefix b: <http://example.com/b#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        a:Thing a owl:Class ; owl:hasKey ( a:name ) .
+        a:name a owl:DatatypeProperty ; rdfs:domain a:Thing ; rdfs:range xsd:string .
+        b:name a owl:DatatypeProperty ; rdfs:domain a:Thing ; rdfs:range xsd:integer .
+    """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Duplicate property"):
+      import_owl(
+          [ttl],
+          include_namespaces=["http://example.com/a#", "http://example.com/b#"],
+      )
+
   def test_name_collision_raises(self, tmp_path):
     ttl = tmp_path / "test.ttl"
     ttl.write_text(

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -603,3 +603,34 @@ class TestEdgeCases:
     entity = data["entities"][0]
     assert entity["description"] == "Thing"
     assert "Chose" in entity["synonyms"]
+
+  def test_haskey_excluded_by_namespace(self, tmp_path):
+    ttl = tmp_path / "test.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+        @prefix a: <http://example.com/a#> .
+        @prefix ext: <http://external.com/ns#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        a:Foo a owl:Class ;
+            owl:hasKey ( ext:ext_id ) .
+        ext:ext_id a owl:DatatypeProperty ;
+            rdfs:domain a:Foo ;
+            rdfs:range xsd:string .
+    """
+        ),
+        encoding="utf-8",
+    )
+
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/a#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    foo = data["entities"][0]
+    assert foo["keys"]["primary"] == ["FILL_IN"]
+    assert "excluded by namespace filter" in yaml_text
+    assert "owl:hasKey_excluded" in yaml_text


### PR DESCRIPTION
## Summary

- Add `owl_importer.py` module that converts OWL ontologies (Turtle/RDF-XML) into `ontology.yaml` format via a 4-stage pipeline (parse, filter, map, emit)
- Wire up `gm import-owl` CLI command with `--include-namespace`, `--format`, `-o`/`--out`, and `--json` flags
- Add "Importing from OWL" guide section and `gm import-owl` CLI reference to the user manual
- Handle namespace filtering, FILL_IN placeholders for ambiguities, and drop annotations for unsupported OWL features
- rdflib is an optional dependency (`pip install 'bigquery-agent-analytics[owl]'`)

## Test plan

- [x] 38 CLI tests pass (10 new import-owl tests covering golden path, output routing, drop summary, error formatting, missing dependency)
- [x] 110 owl_importer unit tests pass (24 test classes covering mapping, edge cases, determinism)
- [x] Manual verification: `gm import-owl tests/fixtures/yamo_sample.ttl --include-namespace "https://example.com/yamo#"` produces valid YAML
- [x] Verify `gm import-owl --help` shows correct usage
- [x] Verify `gm validate` fails on output with FILL_IN placeholders (expected)