### PR TITLE
docs(user-manual): add CLI installation section

### DIFF
--- a/src/bigquery_ontology/docs/user_manual.md
+++ b/src/bigquery_ontology/docs/user_manual.md
@@ -18,6 +18,7 @@
   - [Structure](#structure)
   - [Mapping entities](#mapping-entities)
   - [Mapping relationships](#mapping-relationships)
+- [Installing the CLI](#installing-the-cli)
 - [Validating and Compiling](#validating-and-compiling)
   - [Validate](#validate)
   - [Compile](#compile)
@@ -263,6 +264,34 @@ relationships:
 ```
 
 The arity (number of columns) of `from_columns` must match the source entity's primary key length, and likewise for `to_columns`.
+
+---
+
+### Installing the CLI
+
+Install the package to get the `gm` command:
+
+```bash
+pip install bigquery-agent-analytics
+```
+
+To verify the installation:
+
+```bash
+gm --help
+```
+
+For local development, install in editable mode from the repo root:
+
+```bash
+pip install -e .
+```
+
+If you plan to use `gm import-owl`, install with the OWL extra:
+
+```bash
+pip install bigquery-agent-analytics[owl]
+```
 
 ---
 

--- a/src/bigquery_ontology/docs/user_manual.md
+++ b/src/bigquery_ontology/docs/user_manual.md
@@ -291,6 +291,9 @@ If you plan to use `gm import-owl`, install with the OWL extra:
 
 ```bash
 pip install bigquery-agent-analytics[owl]
+
+# or, in editable mode:
+pip install -e '.[owl]'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- The user manual described `gm` commands but never explained how to install them
- Added an "Installing the CLI" section before "Validating and Compiling" with `pip install` instructions, verification step, editable-mode for development, and the OWL extra
- Added a TOC entry for the new section

## Test plan
- [x] Verify the markdown renders correctly
- [x] Confirm TOC anchor link resolves to the new section