### PR TITLE
fix: extract A2A_INTERACTION content in categorical evaluation transcripts

### DIFF
--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -230,6 +230,7 @@ SELECT
       COALESCE(
         JSON_VALUE(content, '$.text_summary'),
         JSON_VALUE(content, '$.response'),
+        JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
         JSON_VALUE(content, '$.tool'),
         ''
       )
@@ -255,6 +256,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )
@@ -375,6 +377,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )
@@ -443,6 +446,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )


### PR DESCRIPTION
## Summary

- Adds `JSON_VALUE(content, '$.artifacts[0].parts[0].text')` to the COALESCE chain in all 4 transcript-building SQL queries in `categorical_evaluator.py`
- `A2A_INTERACTION` events (from ADK's `RemoteA2aAgent` via `TransferToAgentTool`) store the remote agent's response under `artifacts[0].parts[0].text`, which was not being extracted
- Without this fix, AI.GENERATE sees a question with no answer and returns NULL for ~40% of sessions that use A2A agents

## Details

The transcript-building SQL uses `COALESCE` to extract text from event content:

```sql
COALESCE(
  JSON_VALUE(content, '$.text_summary'),
  JSON_VALUE(content, '$.response'),
  JSON_VALUE(content, '$.tool'),
  ''
)
```

However, `A2A_INTERACTION` events (introduced in [google/adk-python#5325](https://github.com/google/adk-python/pull/5325)) store the remote agent's response under a different JSON structure:

```json
{
  "artifacts": [{"parts": [{"kind": "text", "text": "The actual agent response..."}]}],
  "contextId": "...",
  "history": [...]
}
```

None of the existing JSON paths match. The fix adds `JSON_VALUE(content, '$.artifacts[0].parts[0].text')` before the `$.tool` fallback in all 4 locations:

1. `CATEGORICAL_TRANSCRIPT_QUERY` (line 233)
2. `CATEGORICAL_AI_GENERATE_QUERY` (line 259)
3. `build_ai_classify_query()` (line 380)
4. `build_ai_generate_query()` (line 449)

Fixes #40

## Test plan

- [ ] Run `evaluate_categorical()` on a dataset containing A2A sessions (using `RemoteA2aAgent`)
- [ ] Verify A2A session transcripts now include the remote agent's response text
- [ ] Confirm parse error rate drops from ~40% to near 0% for A2A sessions
- [ ] Verify non-A2A sessions are unaffected (COALESCE falls through as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)