### PR TITLE
fix: extract A2A_INTERACTION content in categorical evaluation transcripts

### DIFF
--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -230,6 +230,7 @@ SELECT
       COALESCE(
         JSON_VALUE(content, '$.text_summary'),
         JSON_VALUE(content, '$.response'),
+        JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
         JSON_VALUE(content, '$.tool'),
         ''
       )
@@ -255,6 +256,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )
@@ -375,6 +377,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )
@@ -443,6 +446,7 @@ WITH session_transcripts AS (
         COALESCE(
           JSON_VALUE(content, '$.text_summary'),
           JSON_VALUE(content, '$.response'),
+          JSON_VALUE(content, '$.artifacts[0].parts[0].text'),
           JSON_VALUE(content, '$.tool'),
           ''
         )


### PR DESCRIPTION
## Summary

Adds `JSON_VALUE(content, '$.artifacts[0].parts[0].text')` to the COALESCE chain in all 4 transcript-building SQL queries in `categorical_evaluator.py`, fixing categorical evaluation for sessions that use remote A2A agents.

Fixes #40

## Background: How Categorical Evaluation Works

The SDK's `evaluate_categorical()` classifies agent sessions by:

1. **Building a transcript** — SQL query groups events by `session_id`, extracts text from each event's `content` JSON column via COALESCE, and concatenates into one string per session
2. **Sending to AI.GENERATE** — BigQuery's `AI.GENERATE` calls an LLM (e.g. gemini-2.5-flash) inside BigQuery with: `classification_prompt + transcript`
3. **Parsing the result** — the LLM returns a JSON array of `{metric_name, category, justification}` per session

The transcript-building COALESCE currently extracts text from these JSON paths:
```sql
COALESCE(
  JSON_VALUE(content, '$.text_summary'),
  JSON_VALUE(content, '$.response'),
  JSON_VALUE(content, '$.tool'),
  ''
)
```

## Problem

`A2A_INTERACTION` events (logged by ADK when using `RemoteA2aAgent` via `TransferToAgentTool`) store the remote agent's response in a nested structure that none of the existing paths match:

```
JSON_VALUE(content, '$.text_summary')  => null
JSON_VALUE(content, '$.response')      => null
JSON_VALUE(content, '$.tool')          => null
```

The transcript for A2A sessions shows the user's question but not the agent's answer:

```
USER_MESSAGE_RECEIVED [knowledge_supervisor]: How many PTO days do I have?
LLM_RESPONSE [knowledge_supervisor]: call: transfer_to_agent
TOOL_STARTING [knowledge_supervisor]: transfer_to_agent
A2A_INTERACTION [knowledge_supervisor]:              <-- EMPTY, content not extracted
AGENT_COMPLETED [pto_agent]:
```

AI.GENERATE sees a question with no answer, cannot classify, and returns NULL. The session gets `parse_error=True` with `category=None`.

## Real A2A_INTERACTION content payload from BigQuery

The `content` column for an `A2A_INTERACTION` event is the full A2A Task response object. Here is a real row from our dataset:

```json
{
  "artifacts": [
    {
      "artifactId": "<id>",
      "parts": [
        {
          "kind": "text",
          "text": "Alright, let's see what the PTO gods have divined for you!..."
        }
      ]
    }
  ],
  "contextId": "<id>",
  "history": [ ... ],
  "id": "<id>",
  "kind": "task",
  "metadata": {
    "adk_app_name": "pto_agent",
    "adk_author": "pto_agent",
    ...
  },
  "status": { "state": "completed" }
}
```

The response text lives at `artifacts[0].parts[0].text`. This path comes from the [A2A protocol's Task schema](https://google.github.io/A2A/#/documentation?id=task), where `artifacts` contains the agent's output parts — this is the standard A2A response structure, not an observed shape.

**Extraction proof from BigQuery:**
```
JSON_VALUE(content, '$.text_summary')              => null
JSON_VALUE(content, '$.response')                   => null
JSON_VALUE(content, '$.tool')                       => null
JSON_VALUE(content, '$.artifacts[0].parts[0].text') => "Alright, let's see what the PTO gods..."
```

## Impact

From our production dataset:

| Metric | Value |
|---|---|
| Total sessions | 770 |
| Sessions with A2A_INTERACTION | 329 (42.7%) |
| All A2A sessions unclassifiable | Yes — 100% get `parse_error=True` |

## Fix

Add `JSON_VALUE(content, '$.artifacts[0].parts[0].text')` to the COALESCE chain in all 4 transcript-building locations:

```sql
COALESCE(
  JSON_VALUE(content, '$.text_summary'),
  JSON_VALUE(content, '$.response'),
  JSON_VALUE(content, '$.artifacts[0].parts[0].text'),   -- NEW: A2A_INTERACTION
  JSON_VALUE(content, '$.tool'),
  ''
)
```

**Changed locations in `categorical_evaluator.py`:**
1. `CATEGORICAL_TRANSCRIPT_QUERY` (line ~233)
2. `CATEGORICAL_AI_GENERATE_QUERY` (line ~259)
3. `build_ai_classify_query()` (line ~380)
4. `build_ai_generate_query()` (line ~449)

**With the fix**, the transcript becomes complete:
```
USER_MESSAGE_RECEIVED [knowledge_supervisor]: How many PTO days do I have?
LLM_RESPONSE [knowledge_supervisor]: call: transfer_to_agent
TOOL_STARTING [knowledge_supervisor]: transfer_to_agent
A2A_INTERACTION [knowledge_supervisor]: Alright, let's see what the PTO gods...
AGENT_COMPLETED [pto_agent]:
```

AI.GENERATE can now see both the question and the answer, and classifies successfully.

## Scope Note

This PR fixes only the 4 categorical evaluation SQL sites. As noted in the [issue discussion](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/40), the same missing-A2A extraction pattern exists in other modules (`insights.py`, `views.py`, `trace.py`, etc.) and in the shared Python extractor (`udf_kernels.py`). Those are a broader fix and should be addressed in a follow-up.

## Test plan

- [ ] Run `evaluate_categorical()` on a dataset containing A2A sessions (using `RemoteA2aAgent`)
- [ ] Verify A2A session transcripts include the remote agent's response text
- [ ] Confirm parse error rate drops from ~40% to near 0% for A2A sessions
- [ ] Verify non-A2A sessions are unaffected (COALESCE falls through as before)