### PR TITLE
fix: add ORDER BY before LIMIT for deterministic session ordering

### DIFF
--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -249,6 +249,7 @@ FROM `{project}.{dataset}.{table}`
 WHERE {where}
 GROUP BY session_id
 HAVING LENGTH(transcript) > 10
+ORDER BY MAX(timestamp) DESC, session_id
 LIMIT @trace_limit
 """
 
@@ -275,7 +276,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
-  ORDER BY MAX(timestamp) DESC
+  ORDER BY MAX(timestamp) DESC, session_id
   LIMIT @trace_limit
 )
 SELECT
@@ -397,7 +398,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
-  ORDER BY MAX(timestamp) DESC
+  ORDER BY MAX(timestamp) DESC, session_id
   LIMIT @trace_limit
 )
 SELECT
@@ -468,7 +469,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
-  ORDER BY MAX(timestamp) DESC
+  ORDER BY MAX(timestamp) DESC, session_id
   LIMIT @trace_limit
 )
 SELECT

--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -275,6 +275,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
+  ORDER BY MAX(timestamp) DESC
   LIMIT @trace_limit
 )
 SELECT
@@ -396,6 +397,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
+  ORDER BY MAX(timestamp) DESC
   LIMIT @trace_limit
 )
 SELECT
@@ -466,6 +468,7 @@ WITH session_transcripts AS (
   WHERE {where}
   GROUP BY session_id
   HAVING LENGTH(transcript) > 10
+  ORDER BY MAX(timestamp) DESC
   LIMIT @trace_limit
 )
 SELECT

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -135,9 +135,11 @@ ORDER BY timestamp ASC
 
 _LIST_TRACES_QUERY = """\
 WITH trace_sessions AS (
-  SELECT DISTINCT session_id
+  SELECT session_id, MAX(timestamp) AS latest_ts
   FROM `{project}.{dataset}.{table}`
   WHERE {where}
+  GROUP BY session_id
+  ORDER BY latest_ts DESC
   LIMIT @trace_limit
 )
 SELECT

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -135,11 +135,11 @@ ORDER BY timestamp ASC
 
 _LIST_TRACES_QUERY = """\
 WITH trace_sessions AS (
-  SELECT session_id, MAX(timestamp) AS latest_ts
+  SELECT session_id
   FROM `{project}.{dataset}.{table}`
   WHERE {where}
   GROUP BY session_id
-  ORDER BY latest_ts DESC
+  ORDER BY MAX(timestamp) DESC, session_id
   LIMIT @trace_limit
 )
 SELECT

--- a/tests/test_categorical_evaluator.py
+++ b/tests/test_categorical_evaluator.py
@@ -1902,3 +1902,61 @@ class TestRetryFailedSessions:
     assert len(results) == 2
     assert retry_meta["failed_count"] == 1
     assert retry_meta["retry_attempted"] is True
+
+
+# ------------------------------------------------------------------ #
+# ORDER BY before LIMIT — regression tests (#55)                       #
+# ------------------------------------------------------------------ #
+
+
+class TestQueryOrderByBeforeLimit:
+  """Ensure all session-fetching query templates have ORDER BY before LIMIT."""
+
+  def test_transcript_query_orders_before_limit(self):
+    sql = CATEGORICAL_TRANSCRIPT_QUERY
+    order_pos = sql.index("ORDER BY MAX(timestamp)")
+    limit_pos = sql.index("LIMIT @trace_limit")
+    assert order_pos < limit_pos
+
+  def test_ai_generate_query_orders_before_limit(self):
+    sql = CATEGORICAL_AI_GENERATE_QUERY
+    order_pos = sql.index("ORDER BY MAX(timestamp)")
+    limit_pos = sql.index("LIMIT @trace_limit")
+    assert order_pos < limit_pos
+
+  def test_ai_classify_query_orders_before_limit(self):
+    config = _make_config()
+    sql = build_ai_classify_query(config, "proj", "ds", "tbl", "1=1")
+    order_pos = sql.index("ORDER BY MAX(timestamp)")
+    limit_pos = sql.index("LIMIT @trace_limit")
+    assert order_pos < limit_pos
+
+  def test_ai_generate_dynamic_query_orders_before_limit(self):
+    sql = build_ai_generate_query(
+        "proj", "ds", "tbl", "1=1", "gemini-2.5-flash", 0.0
+    )
+    order_pos = sql.index("ORDER BY MAX(timestamp)")
+    limit_pos = sql.index("LIMIT @trace_limit")
+    assert order_pos < limit_pos
+
+  def test_all_queries_have_session_id_tiebreaker(self):
+    """ORDER BY should include session_id for full determinism."""
+    config = _make_config()
+    queries = [
+        ("CATEGORICAL_TRANSCRIPT_QUERY", CATEGORICAL_TRANSCRIPT_QUERY),
+        ("CATEGORICAL_AI_GENERATE_QUERY", CATEGORICAL_AI_GENERATE_QUERY),
+        (
+            "build_ai_classify_query",
+            build_ai_classify_query(config, "p", "d", "t", "1=1"),
+        ),
+        (
+            "build_ai_generate_query",
+            build_ai_generate_query(
+                "p", "d", "t", "1=1", "gemini-2.5-flash", 0.0
+            ),
+        ),
+    ]
+    for name, sql in queries:
+      assert (
+          "ORDER BY MAX(timestamp) DESC, session_id" in sql
+      ), f"{name} missing session_id tiebreaker in ORDER BY"


### PR DESCRIPTION
## Summary
- Adds `ORDER BY MAX(timestamp) DESC` before `LIMIT` in all session-fetching queries so that `--limit N` consistently returns the N most recent sessions
- Without this fix, BigQuery returns an arbitrary subset, causing different results on consecutive runs with identical data

## Changed files
- `categorical_evaluator.py` — 4 query templates: `CATEGORICAL_TRANSCRIPT_QUERY`, `CATEGORICAL_AI_GENERATE_QUERY`, `build_ai_classify_query()`, `build_ai_generate_query()`
- `client.py` — `_LIST_TRACES_QUERY`

Fixes #55

## Test plan
- [x] Run `quality_report.sh --limit 100` twice consecutively — verify same agent distribution
- [x] Verify sessions are ordered by recency (most recent first)
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)