### PR TITLE
feat(owl-import): SKOS support alongside OWL

### DIFF
--- a/docs/ontology/binding.md
+++ b/docs/ontology/binding.md
@@ -221,9 +221,10 @@ correctly).
 2. The ontology named by `ontology:` exists and loads without errors.
 3. `target.backend` is supported; backend-specific required fields are
    present.
-4. Every `EntityBinding.name` names an entity declared in the ontology.
+4. Every `EntityBinding.name` names an entity declared in the ontology,
+   and the entity must not be abstract (see `ontology.md` §3a).
 5. Every `RelationshipBinding.name` names a relationship declared in the
-   ontology.
+   ontology, and the relationship must not be abstract.
 6. No duplicate entity or relationship names within the binding.
 7. For every bound entity, every non-derived property (including
    inherited) has exactly one `PropertyBinding` with a non-empty `column`.

--- a/docs/ontology/cli.md
+++ b/docs/ontology/cli.md
@@ -166,10 +166,15 @@ Read OWL sources and emit a `*.ontology.yaml` (see `owl-import.md`).
 
 ```
 gm import-owl <source>... --include-namespace <iri>... [-o <out>]
+              [--format ttl|rdfxml] [--language <tag>] [--json]
 ```
 
 - One or more OWL source files (Turtle, RDF/XML).
 - At least one `--include-namespace` required; multiple allowed.
+- Recognizes both OWL and SKOS constructs; SKOS concepts become
+  abstract entities, SKOS graph predicates become abstract
+  relationships, and SKOS literals become annotations. See
+  `owl-import.md` §19 for the full mapping.
 - Output uses `FILL_IN` for ambiguities and annotations for dropped OWL
   features (see `owl-import.md` §11, §13). `FILL_IN` causes
   `gm validate` to fail until resolved.
@@ -181,9 +186,14 @@ gm import-owl <source>... --include-namespace <iri>... [-o <out>]
 | `--include-namespace <iri>` | Required, repeatable. |
 | `-o <file>`, `--out <file>` | Write YAML to file instead of stdout. |
 | `--format ttl\|rdfxml` | Override parser selection from file extension. |
+| `--language <tag>` | BCP-47 language tag for label selection (default `en`). Other-language labels become language-suffixed annotations. |
 | `--json` | Structured drop-and-placeholder summary. |
 
-Drop summary is printed to stderr regardless of `--json`.
+Drop summary is printed to stderr regardless of `--json`. It includes
+SKOS counts (concepts imported as abstract, relationships imported as
+abstract, annotations preserved, labels discarded by language
+selection, external match targets, generic literal annotations) and a
+hint when every imported entity is abstract.
 
 ## 7. Open questions
 

--- a/docs/ontology/compilation.md
+++ b/docs/ontology/compilation.md
@@ -276,6 +276,11 @@ On top of ontology-level (`ontology.md` §10) and binding-level
 3. No cycles among derived properties.
 4. Every logical property type is supported by the target backend
    (`ontology.md` §7).
+5. **No abstract elements in bindings.** The binding loader already
+   rejects bindings that target abstract entities or relationships
+   (`ontology.md` §3a). The compiler guards against this as
+   defense-in-depth so a hand-constructed `Binding` object that skips
+   the loader still raises rather than emitting unresolvable DDL.
 
 Warnings: bound entity referenced by no relationship.
 

--- a/docs/ontology/ontology.md
+++ b/docs/ontology/ontology.md
@@ -173,27 +173,66 @@ additional: [<string>, ...]             # relationships only, mode 2: extends (f
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `name` | string | yes | Unique within the ontology. |
+| `abstract` | boolean | no | Defaults to `false`. See §3a. |
 | `extends` | string | no | Name of the parent entity. Single-parent. |
-| `keys` | Keys | yes | See §6. |
+| `keys` | Keys | yes on concrete; optional on abstract | See §6. |
 | `properties` | list\<Property\> | no | See §5. |
 | `description` | string | no | Free-form. |
 | `synonyms` | list\<string\> | no | Alternate names for search / LLM grounding. |
 | `annotations` | map\<string, string \| list\<string\>\> | no | Free-form metadata. Values may be a string or a list of strings. |
 
+## 3a. Abstract elements
+
+An element with `abstract: true` is declared in the ontology but is
+**not bound to a physical table**. Abstract elements are informational:
+documentation, taxonomy structure, or cross-vocabulary mappings that
+don't back any row data. The field exists primarily to let the OWL
+importer represent standalone SKOS concepts (see `owl-import.md` §19),
+but it is part of the core ontology model and may be used by
+hand-authored ontologies as well.
+
+Rules:
+
+- **Abstract entities** do not require `keys.primary`. Declared keys
+  still follow the shape rules in §6.
+- **Abstract relationships** must not use `extends`; see §4. Declared
+  keys still follow the shape rules in §6.
+- A **concrete relationship** cannot have an **abstract endpoint**:
+  a relationship that will be materialized needs bindable endpoints
+  on both sides.
+- An **abstract relationship** may point at concrete entities,
+  abstract entities, or any combination.
+- A concrete relationship and an abstract relationship cannot share a
+  name.
+- Bindings that target an abstract entity or abstract relationship are
+  rejected by the binding loader. `gm scaffold` skips abstract
+  elements entirely when emitting DDL and binding stubs.
+
 ## 4. Relationship
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `name` | string | yes | Unique within the ontology. |
-| `extends` | string | no | Name of the parent relationship. Single-parent. |
+| `name` | string | yes | See §4a for uniqueness rules. |
+| `abstract` | boolean | no | Defaults to `false`. See §3a. |
+| `extends` | string | no | Name of the parent relationship. Single-parent. Forbidden on abstract relationships. |
 | `keys` | Keys | no | See §6. |
-| `from` | string | yes | Source entity name. |
-| `to` | string | yes | Target entity name. |
+| `from` | string | yes | Source entity name. Concrete relationships require a concrete source. |
+| `to` | string | yes | Target entity name. Concrete relationships require a concrete target. |
 | `cardinality` | enum | no | `one_to_one` \| `one_to_many` \| `many_to_one` \| `many_to_many`. |
 | `properties` | list\<Property\> | no | See §5. |
 | `description` | string | no | |
 | `synonyms` | list\<string\> | no | |
 | `annotations` | map\<string, string \| list\<string\>\> | no | |
+
+### 4a. Relationship name uniqueness
+
+- **Concrete relationships** require unique `(name,)` within the
+  ontology (same rule as entities).
+- **Abstract relationships** require unique `(name, from, to)`. Two
+  abstract relationships with the same name but different endpoints
+  are legal — this is what lets an imported taxonomy emit multiple
+  `skos_broader` edges without synthetic naming.
+- Concrete and abstract relationships cannot share a name.
 
 ## 5. Property
 
@@ -339,10 +378,14 @@ child `alumni: Person → School` is valid iff `Person extends Party` and
 
 Enforced by the ontology loader before any downstream stage runs.
 
-1. Every entity and relationship name is unique within the ontology.
+1. Entity names are unique within the ontology. Concrete relationship
+   names are unique. Abstract relationships are unique by
+   `(name, from, to)`. A concrete and abstract relationship cannot
+   share a name. Entities and relationships cannot share a name.
 2. Every property name is unique within its entity or relationship.
 3. `extends` must resolve to a declared entity (entity-to-entity) or
    relationship (relationship-to-relationship) of the correct kind.
+   Abstract relationships must not use `extends`.
 4. No cycles in `extends` chains.
 5. Redeclaring an inherited property (by name) is an error.
 6. Redeclaring inherited keys is an error.
@@ -354,9 +397,13 @@ Enforced by the ontology loader before any downstream stage runs.
    On entities, `additional` is not allowed.
 10. Relationships with `extends`: `from` / `to` satisfy covariant narrowing
     against the parent's endpoints.
-11. Every entity must declare `keys.primary`.
+11. Every **concrete** entity must declare `keys.primary`. Abstract
+    entities may omit it.
 12. Property `type` is one of the valid types (§7).
 13. Unknown YAML keys anywhere in the spec are an error (`extra="forbid"`).
+14. Relationship endpoints must reference declared entities (concrete
+    or abstract). A concrete relationship cannot point at an abstract
+    entity.
 
 ## 11. Out of scope / future docs
 
@@ -371,11 +418,6 @@ Enforced by the ontology loader before any downstream stage runs.
 
 ## 12. Open questions
 
-- **Reintroduce `abstract`?** Dropped from v0 because it leaks binding-layer
-  semantics into the ontology — an unbound entity in a given environment is
-  effectively abstract for that environment, and the binding layer can warn
-  on "unbound entity with no bound descendants." Revisit if that check proves
-  insufficient in practice.
 - **Cardinality narrowing under inheritance.** Currently specified as
   "inherited unchanged." Narrowing (e.g., parent `many_to_many`, child
   `one_to_many`) has obvious modeling value but raises enforcement questions;

--- a/docs/ontology/ontology.md
+++ b/docs/ontology/ontology.md
@@ -214,7 +214,7 @@ Rules:
 |---|---|---|---|
 | `name` | string | yes | See §4a for uniqueness rules. |
 | `abstract` | boolean | no | Defaults to `false`. See §3a. |
-| `extends` | string | no | Name of the parent relationship. Single-parent. Forbidden on abstract relationships. |
+| `extends` | string | no | Name of the parent relationship. Single-parent. Forbidden on abstract relationships — `extends` is a bare name reference, and abstract relationship names are not unique on their own (§4a), so a bare name cannot unambiguously identify the parent. |
 | `keys` | Keys | no | See §6. |
 | `from` | string | yes | Source entity name. Concrete relationships require a concrete source. |
 | `to` | string | yes | Target entity name. Concrete relationships require a concrete target. |
@@ -228,10 +228,17 @@ Rules:
 
 - **Concrete relationships** require unique `(name,)` within the
   ontology (same rule as entities).
-- **Abstract relationships** require unique `(name, from, to)`. Two
-  abstract relationships with the same name but different endpoints
-  are legal — this is what lets an imported taxonomy emit multiple
-  `skos_broader` edges without synthetic naming.
+- **Abstract relationships** require unique `(name, from, to)`. The
+  relaxation is necessary because abstract relationships model
+  informational predicates from external vocabularies (e.g. SKOS
+  `broader`, `related`) where the same predicate name connects many
+  different pairs of node types. Requiring name uniqueness alone would
+  force synthetic names (`skos_broader_1`, `skos_broader_2`, …) that
+  diverge from the source vocabulary and make the ontology harder to
+  read. The cost of the relaxation is that `extends` becomes
+  unresolvable for abstract relationships — a bare name no longer
+  identifies a single relationship — which is why `extends` is
+  forbidden on abstract relationships.
 - Concrete and abstract relationships cannot share a name.
 
 ## 5. Property

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -110,8 +110,8 @@ for dropping.
 | `owl:hasKey` | `keys.primary` |
 | `rdfs:label` | `description` (first) or appended to `synonyms` |
 | `rdfs:comment` | `description` (if no label, or appended) |
-| `skos:altLabel`, `skos:prefLabel` | `synonyms` |
 | `owl:FunctionalProperty` | Relationship `cardinality: many_to_one` (object prop); ignored for datatype prop |
+| `skos:Concept` / `skos:broader` / `skos:definition` / etc. | See §19 |
 
 Everything else is dropped; see §13.
 
@@ -159,15 +159,19 @@ values, interpreted as "the intersection of these."
 
 ## 9. Annotations
 
-- `rdfs:label` (prefLabel, if multiple pick English first, else
-  alphabetically first) → `description`.
+- `rdfs:label` in the selected language (see §19.5, default `en`) →
+  `description`. Additional selected-language labels are appended to
+  `synonyms`; untagged labels follow as a tiebreaker.
+- `rdfs:label` in **other** languages → annotations keyed
+  `rdfs:label@<lang>` (one entry per language tag).
 - `rdfs:comment` → appended to `description` with a blank-line separator
   when a label is also present.
-- `skos:altLabel` and additional `rdfs:label`s in other languages →
-  `synonyms`.
+- SKOS labels (`skos:prefLabel`, `skos:altLabel`, `skos:hiddenLabel`)
+  and literal-valued SKOS predicates: see §19.
 - Custom annotation properties outside the recognized set (RDF, RDFS,
   OWL, SKOS) → collected as `annotations: { <local_name>: <value> }`
-  when the value is a literal. Non-literal values are dropped.
+  when the value is a literal. Multiple values for the same predicate
+  merge into a sorted list. Non-literal values are dropped.
 
 ## 10. Primary keys
 
@@ -361,10 +365,13 @@ actionable issues.
   the import with a clear message pointing at the offending IRI.
 - **`owl:imports` fetch policy.** Follow remote imports over HTTP, or
   only local filesystem? Network access raises reproducibility concerns.
-- **Annotation property preservation.** Currently kept as
-  `annotations: {iri: value}` for literal values; non-literal
-  annotations are dropped. Revisit if ontologies lean heavily on SKOS
-  hierarchies or Dublin Core metadata.
+- **`skos:ConceptScheme` as ontology-level metadata.** Currently
+  dropped. A future extension could surface it under the ontology's
+  top-level `annotations`.
+- **Promoting SKOS to structural semantics.** `skos:broader` is
+  informational by default (§19). An opt-in flag to treat it as
+  subsumption was considered and deferred; revisit if real users
+  request it.
 
 ## 17. Out of scope
 
@@ -490,33 +497,68 @@ Notes on this output:
 - This output uses `extends`, so the v0 compiler will reject it; that
   is expected for a faithful import.
 
-## 17. SKOS support
+## 19. SKOS support
 
-The importer recognizes SKOS constructs alongside OWL. SKOS is
-informational by default: SKOS predicates never flow into structural
-fields (`extends`, `description`). Instead, they produce abstract
-entities, abstract relationships, and annotations.
+The importer recognizes SKOS constructs alongside OWL. The guiding
+principle is **informational by default**: SKOS and OWL make different
+kinds of claims, and the importer preserves the distinction.
 
-### 17.1 Abstract elements
+- **OWL** makes *formal* claims. `rdfs:subClassOf` means every
+  instance of the child is an instance of the parent — drives
+  inheritance, keys, substitutability.
+- **SKOS** makes *informational* claims. `skos:broader` means "this is
+  a narrower topic" — explicitly *not* subsumption per the W3C SKOS
+  Primer. Drives documentation, browsing, search.
+
+Consequences for the importer:
+
+1. OWL constructs flow into structural fields (`extends`, `from`/`to`,
+   `keys`, `properties`).
+2. SKOS graph-shaped predicates (`skos:broader`, `skos:related`,
+   `skos:*Match`) flow into **abstract relationships** — edges
+   declared in the ontology but not backed by BigQuery tables.
+3. SKOS literal predicates (`skos:definition`, `skos:notation`, etc.)
+   flow into **annotations**.
+4. Nothing from SKOS flows into `extends` or `description`. The
+   ontology never claims inheritance or human-readable descriptions
+   that the source author did not assert via OWL/RDFS core vocabulary.
+
+### 19.1 Abstract elements
 
 An element with `abstract: true` is declared in the ontology but not
 bound to a BigQuery table. Primary keys are not required on abstract
-entities. `gm validate` does not demand them; `gm scaffold` skips them;
-the compiler rejects bindings that target them.
+entities.
 
-### 17.2 Naming convention
+Downstream behavior:
+
+- **`gm validate`** accepts abstract entities with no primary key.
+  Shape rules for declared keys still apply (see §19.4).
+- **`gm scaffold`** skips abstract entities and abstract relationships
+  entirely; generated `table_ddl.sql` and `binding.yaml` cover only
+  concrete elements.
+- **`gm compile`** (via `binding_loader`) rejects any binding that
+  targets an abstract entity or abstract relationship with a clear
+  error message.
+
+### 19.2 Naming convention
 
 - **Pure SKOS entity** (typed only as `skos:Concept`): name prefixed
   `skos_` (e.g., `skos_Banking`).
 - **Mixed OWL+SKOS entity** (typed as both `owl:Class` and
   `skos:Concept`): name unprefixed. OWL provides structure, so it wins
-  the name.
+  the name; SKOS contributes annotations and synonyms.
 - **SKOS relationship** (always abstract): name prefixed `skos_` (e.g.,
   `skos_broader`, `skos_related`, `skos_exactMatch`).
 - **SKOS annotation keys**: use `skos:` colon prefix (e.g.,
   `skos:definition`, `skos:notation`), matching the `owl:` convention.
 
-### 17.3 SKOS mapping table
+The split between `skos_` in element names and `skos:` in annotation
+keys tracks the identifier/metadata boundary: names flow into YAML
+parse keys, BigQuery labels, GQL syntax, and SQL code, where colons
+are unsafe or already syntactic. Annotation keys are free-form map
+keys where colons parse cleanly.
+
+### 19.3 SKOS mapping table
 
 Entity typing:
 
@@ -574,23 +616,261 @@ Match predicates (relationship if target imported, annotation otherwise):
 | `skos:narrowMatch` | Abstract `skos_narrowMatch` / annotation `skos:narrowMatch` | |
 | `skos:relatedMatch` | Abstract `skos_relatedMatch` / annotation `skos:relatedMatch` | External IRI stored verbatim |
 
-### 17.4 Relationship uniqueness
+### 19.4 Validation rules for abstract elements
+
+Abstract entities and relationships are legal ontology elements, not
+second-class placeholders. Most shape rules still apply:
+
+- **Abstract entities**
+  - Primary key not required.
+  - If keys are declared, they must follow the same shape rules as
+    concrete entities (no `additional`, key columns must reference
+    declared properties, alternate-key shape rules).
+  - May use `extends` (taxonomy inheritance is allowed).
+
+- **Abstract relationships**
+  - Must reference declared entity names in `from` / `to`; endpoint
+    existence is enforced.
+  - **May point at concrete or abstract entities** in any combination.
+  - **Must not use `extends`**. Abstract relationships are
+    informational; the mixed concrete/abstract parent-map would have
+    ambiguous uniqueness. If keys are declared, they still follow
+    shape rules.
+  - Uniqueness is relaxed to `(name, from, to)` instead of `(name,)`
+    alone — so multiple `skos_broader` edges with different endpoints
+    are legal (see §19.5).
+
+- **Concrete relationships**
+  - **Must have concrete endpoints.** A concrete relationship with an
+    abstract endpoint is rejected — the binding step has nothing to
+    bind on the abstract side.
+
+- **Name collisions**
+  - A concrete relationship and an abstract relationship cannot share
+    a name, even if endpoints differ.
+  - Entity and relationship namespaces remain disjoint: an abstract
+    entity cannot share a name with any relationship (concrete or
+    abstract), and vice versa.
+
+### 19.5 Relationship uniqueness
 
 Abstract relationships use relaxed uniqueness: `(name, from, to)` must
-be unique, rather than `(name)` alone. This allows multiple
-`skos_broader` edges with different endpoints without synthetic naming.
-Concrete relationships retain strict `(name)` uniqueness.
+be unique, rather than `(name)` alone. Concrete relationships retain
+strict `(name)` uniqueness. This relaxation is what allows multiple
+`skos_broader` edges to share a name without synthetic suffixes.
 
-### 17.5 Language selection (`--language`)
+The relaxation is deliberately narrow: `compile_graph` and `gm bind`
+only operate on concrete elements, and concrete uniqueness is
+unchanged. The emitted DDL and GQL surfaces are unaffected.
 
-The `--language` flag (default `en`) selects labels by BCP-47 tag:
+### 19.6 Language selection (`--language`)
 
-- Labels matching the selected language populate names and synonyms.
-- Labels in non-selected languages become language-suffixed annotations
-  (e.g., `skos:prefLabel@fr: Banque`).
+The `--language` flag (default `en`) selects labels by BCP-47 tag.
+The tag is matched by prefix, so `en` covers `en`, `en-US`, `en-GB`.
 
-### 17.6 Generic literal annotations
+- Labels matching the selected language populate description and
+  synonyms.
+- Labels in non-selected languages become language-suffixed
+  annotations:
+  - `rdfs:label` → `rdfs:label@<lang>`
+  - `skos:prefLabel` → `skos:prefLabel@<lang>`
+  - `skos:altLabel` → `skos:altLabel@<lang>`
+  - `skos:hiddenLabel` → `skos:hiddenLabel@<lang>`
+- Untagged labels are treated as a fallback for the selected language.
+
+### 19.7 Generic literal annotations
 
 Unknown literal-valued predicates (not RDF, RDFS, OWL, or SKOS) are
-preserved as `annotations: { <local_name>: <value> }`. This covers
-Dublin Core and custom annotation properties without special handling.
+preserved as `annotations: { <local_name>: <value> }`. Multiple values
+for the same predicate merge into a sorted list.
+
+This covers Dublin Core (`dc:title`, `dcterms:creator`), Schema.org
+literals, and custom annotation properties without special handling.
+Full IRI is preserved in the drop summary when the local name is
+ambiguous across source vocabularies.
+
+### 19.8 Drop summary additions
+
+The `stderr` drop summary from `gm import-owl` reports, in addition to
+the OWL counts:
+
+- `SKOS concepts imported as abstract entities: N`
+- `SKOS relationships imported as abstract: N`
+- `SKOS predicates mapped to annotations: N`
+- `Labels in non-selected languages (preserved as annotations): N`
+- `SKOS match targets outside imported namespaces (preserved as annotations): N`
+- `Generic literal annotations preserved: N`
+- A note when every entity is abstract: *"all entities are abstract
+  (SKOS-only). No concrete entities are available for binding.
+  Consider representing the taxonomy as dimension columns instead of
+  entity types."*
+
+### 19.9 Worked examples
+
+#### Example 1 — Mixed OWL + SKOS
+
+Input:
+
+```turtle
+@prefix : <https://example.com/finance#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:Account a owl:Class, skos:Concept ;
+    rdfs:label "Account" ;
+    skos:altLabel "Acct"@en ;
+    skos:definition "A record of financial transactions."@en ;
+    skos:related :Ledger ;
+    skos:exactMatch <http://fibo.org/ontology/FBC/Account> ;
+    owl:hasKey ( :account_id ) .
+
+:Ledger a owl:Class ;
+    rdfs:label "Ledger" ;
+    owl:hasKey ( :ledger_id ) .
+```
+
+Output:
+
+```yaml
+entities:
+  - name: Account
+    description: Account
+    keys:
+      primary: [account_id]
+    properties:
+      - name: account_id
+        type: string
+    synonyms: [Acct]
+    annotations:
+      skos:definition: A record of financial transactions.
+      skos:exactMatch: "http://fibo.org/ontology/FBC/Account"
+
+  - name: Ledger
+    description: Ledger
+    keys:
+      primary: [ledger_id]
+    properties:
+      - name: ledger_id
+        type: string
+
+relationships:
+  - name: skos_related
+    abstract: true
+    from: Account
+    to: Ledger
+```
+
+Both entities concrete (OWL built the structure, names unprefixed).
+`skos:related` becomes an abstract relationship. `skos:definition` and
+the external `skos:exactMatch` IRI become annotations with provenance
+preserved.
+
+#### Example 2 — Pure SKOS taxonomy
+
+Input:
+
+```turtle
+@prefix : <https://example.com/taxonomy#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:Banking a skos:Concept ;
+    skos:prefLabel "Banking"@en ;
+    skos:definition "Activities of financial institutions."@en .
+
+:RetailBanking a skos:Concept ;
+    skos:prefLabel "Retail Banking"@en ;
+    skos:altLabel "Consumer Banking"@en ;
+    skos:broader :Banking ;
+    skos:notation "RB" .
+
+:InvestmentBanking a skos:Concept ;
+    skos:prefLabel "Investment Banking"@en ;
+    skos:broader :Banking .
+```
+
+Output:
+
+```yaml
+entities:
+  - name: skos_Banking
+    abstract: true
+    synonyms: [Banking]
+    annotations:
+      skos:definition: Activities of financial institutions.
+
+  - name: skos_InvestmentBanking
+    abstract: true
+    synonyms: [Investment Banking]
+
+  - name: skos_RetailBanking
+    abstract: true
+    synonyms: [Consumer Banking, Retail Banking]
+    annotations:
+      skos:notation: RB
+
+relationships:
+  - name: skos_broader
+    abstract: true
+    from: skos_InvestmentBanking
+    to: skos_Banking
+
+  - name: skos_broader
+    abstract: true
+    from: skos_RetailBanking
+    to: skos_Banking
+```
+
+All entities are prefixed (pure SKOS, informational), all
+relationships are `skos_broader` with different endpoints (legal under
+the scoped uniqueness relaxation), and `description` is empty on every
+entity because the SKOS source offered no `rdfs:label` or
+`rdfs:comment`. The drop summary prints the taxonomy hint.
+
+#### Example 3 — Cross-kind reference
+
+A concrete OWL class pointing to a pure-SKOS concept via `skos:broader`:
+
+```turtle
+:Account a owl:Class ;
+    rdfs:label "Account" ;
+    skos:broader :FinancialProduct ;
+    owl:hasKey ( :account_id ) .
+
+:FinancialProduct a skos:Concept ;
+    skos:prefLabel "Financial Product"@en .
+```
+
+Output:
+
+```yaml
+entities:
+  - name: Account
+    description: Account
+    keys:
+      primary: [account_id]
+    properties:
+      - name: account_id
+        type: string
+
+  - name: skos_FinancialProduct
+    abstract: true
+    synonyms: [Financial Product]
+
+relationships:
+  - name: skos_broader
+    abstract: true
+    from: Account
+    to: skos_FinancialProduct
+```
+
+Concrete entity, abstract entity, abstract relationship. The `skos_`
+name prefix travels with the element wherever it is referenced, so
+provenance is visible at every reference site.
+
+The inverse case — an OWL `owl:ObjectProperty` whose `rdfs:range` is a
+pure SKOS concept — is imported faithfully (the endpoint resolves to
+the prefixed name) but validation then rejects it: a concrete
+relationship cannot have an abstract endpoint (§19.4). The user must
+either make the target a proper `owl:Class` in their source or promote
+the OWL property to SKOS.

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -165,9 +165,9 @@ values, interpreted as "the intersection of these."
   when a label is also present.
 - `skos:altLabel` and additional `rdfs:label`s in other languages →
   `synonyms`.
-- Custom annotation properties outside our recognized set → collected as
-  `annotations: { <iri>: <value> }` when the value is a literal; dropped
-  silently when not.
+- Custom annotation properties outside the recognized set (RDF, RDFS,
+  OWL, SKOS) → collected as `annotations: { <local_name>: <value> }`
+  when the value is a literal. Non-literal values are dropped.
 
 ## 10. Primary keys
 
@@ -489,3 +489,65 @@ Notes on this output:
 - Alphabetical ordering: `Account`, `Organization`, `Party`, `Person`.
 - This output uses `extends`, so the v0 compiler will reject it; that
   is expected for a faithful import.
+
+## 17. SKOS support
+
+The importer recognizes SKOS constructs alongside OWL. SKOS is
+informational by default: SKOS predicates never flow into structural
+fields (`extends`, `description`). Instead, they produce abstract
+entities, abstract relationships, and annotations.
+
+### 17.1 Abstract elements
+
+An element with `abstract: true` is declared in the ontology but not
+bound to a BigQuery table. Primary keys are not required on abstract
+entities. `gm validate` does not demand them; `gm scaffold` skips them;
+the compiler rejects bindings that target them.
+
+### 17.2 Naming convention
+
+- **Pure SKOS entity** (typed only as `skos:Concept`): name prefixed
+  `skos_` (e.g., `skos_Banking`).
+- **Mixed OWL+SKOS entity** (typed as both `owl:Class` and
+  `skos:Concept`): name unprefixed. OWL provides structure, so it wins
+  the name.
+- **SKOS relationship** (always abstract): name prefixed `skos_` (e.g.,
+  `skos_broader`, `skos_related`, `skos_exactMatch`).
+- **SKOS annotation keys**: use `skos:` colon prefix (e.g.,
+  `skos:definition`, `skos:notation`), matching the `owl:` convention.
+
+### 17.3 SKOS mapping table
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
+| `skos:Concept` (no `owl:Class`) | Abstract entity with `skos_` prefix | Keys not required |
+| `owl:Class` + `skos:Concept` | Concrete entity, unprefixed | OWL provides structure |
+| `skos:prefLabel` | `synonyms` (when different from name) | Label data |
+| `skos:altLabel`, `skos:hiddenLabel` | `synonyms` | Label data |
+| `skos:definition` | Annotation `skos:definition` | Not promoted to description |
+| `skos:broader`, `skos:narrower` | Abstract relationship `skos_broader` (narrower normalized) | |
+| `skos:related` | Abstract relationship `skos_related` | |
+| `skos:exactMatch` etc. | Abstract relationship if target imported; annotation if external IRI | |
+| `skos:notation`, `skos:scopeNote`, etc. | Annotation with `skos:` prefix | |
+| `skos:inScheme`, `skos:topConceptOf` | Annotation with `skos:` prefix | |
+
+### 17.4 Relationship uniqueness
+
+Abstract relationships use relaxed uniqueness: `(name, from, to)` must
+be unique, rather than `(name)` alone. This allows multiple
+`skos_broader` edges with different endpoints without synthetic naming.
+Concrete relationships retain strict `(name)` uniqueness.
+
+### 17.5 Language selection (`--language`)
+
+The `--language` flag (default `en`) selects labels by BCP-47 tag:
+
+- Labels matching the selected language populate names and synonyms.
+- Labels in non-selected languages become language-suffixed annotations
+  (e.g., `skos:prefLabel@fr: Banque`).
+
+### 17.6 Generic literal annotations
+
+Unknown literal-valued predicates (not RDF, RDFS, OWL, or SKOS) are
+preserved as `annotations: { <local_name>: <value> }`. This covers
+Dublin Core and custom annotation properties without special handling.

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -169,9 +169,12 @@ values, interpreted as "the intersection of these."
 - SKOS labels (`skos:prefLabel`, `skos:altLabel`, `skos:hiddenLabel`)
   and literal-valued SKOS predicates: see §19.
 - Custom annotation properties outside the recognized set (RDF, RDFS,
-  OWL, SKOS) → collected as `annotations: { <local_name>: <value> }`
-  when the value is a literal. Multiple values for the same predicate
-  merge into a sorted list. Non-literal values are dropped.
+  OWL, SKOS) → collected as `annotations: { <key>: <value> }` when the
+  value is a literal, where `<key>` is `prefix:local` when the
+  predicate's namespace has a bound prefix and the full IRI otherwise.
+  Bare local names would collide across vocabularies (e.g. `dc:title`
+  vs. `dcterms:title`). Multiple values for the same predicate merge
+  into a sorted list. Non-literal values are dropped.
 
 ## 10. Primary keys
 
@@ -591,12 +594,14 @@ Literal-valued predicates (all preserved as annotations, colon-prefixed):
 | `skos:editorialNote` | Annotation `skos:editorialNote` | |
 | `skos:changeNote` | Annotation `skos:changeNote` | |
 
-Reference predicates (IRI target stored as local name):
+Reference predicates (IRI target stored verbatim — full IRI preserved
+so scheme identity survives when local names collide across
+vocabularies):
 
 | SKOS construct | Ontology equivalent | Notes |
 |---|---|---|
-| `skos:inScheme` | Annotation `skos:inScheme` | |
-| `skos:topConceptOf` | Annotation `skos:topConceptOf` | |
+| `skos:inScheme` | Annotation `skos:inScheme` | Full IRI preserved |
+| `skos:topConceptOf` | Annotation `skos:topConceptOf` | Full IRI preserved |
 
 Graph-shaped predicates (abstract relationships):
 
@@ -690,13 +695,16 @@ The tag is matched by prefix, so `en` covers `en`, `en-US`, `en-GB`.
 ### 19.7 Generic literal annotations
 
 Unknown literal-valued predicates (not RDF, RDFS, OWL, or SKOS) are
-preserved as `annotations: { <local_name>: <value> }`. Multiple values
-for the same predicate merge into a sorted list.
+preserved as `annotations: { <key>: <value> }`, where `<key>` is
+`prefix:local` when the predicate's namespace has a bound prefix and
+the full IRI otherwise. Multiple values for the same predicate merge
+into a sorted list.
 
 This covers Dublin Core (`dc:title`, `dcterms:creator`), Schema.org
 literals, and custom annotation properties without special handling.
-Full IRI is preserved in the drop summary when the local name is
-ambiguous across source vocabularies.
+Retaining the prefix (or full IRI) keeps vocabularies with colliding
+local names — `dc:title` vs. `dcterms:title` — distinguishable at the
+annotation level, not just in the drop summary.
 
 ### 19.8 Drop summary additions
 

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -518,18 +518,61 @@ the compiler rejects bindings that target them.
 
 ### 17.3 SKOS mapping table
 
+Entity typing:
+
 | SKOS construct | Ontology equivalent | Notes |
 |---|---|---|
 | `skos:Concept` (no `owl:Class`) | Abstract entity with `skos_` prefix | Keys not required |
 | `owl:Class` + `skos:Concept` | Concrete entity, unprefixed | OWL provides structure |
-| `skos:prefLabel` | `synonyms` (when different from name) | Label data |
-| `skos:altLabel`, `skos:hiddenLabel` | `synonyms` | Label data |
+| `skos:ConceptScheme` | Currently dropped | Not emitted; deferred |
+
+Labels and synonyms (language selection applies — see 17.5):
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
+| `skos:prefLabel` (selected language) | `synonyms` (when different from name) | Label data |
+| `skos:altLabel` (selected language) | `synonyms` | Label data |
+| `skos:hiddenLabel` (selected language) | `synonyms` | Label data |
+| `skos:prefLabel` (other language) | Annotation `skos:prefLabel@<lang>` | Preserved verbatim |
+| `skos:altLabel` (other language) | Annotation `skos:altLabel@<lang>` | Preserved verbatim |
+| `skos:hiddenLabel` (other language) | Annotation `skos:hiddenLabel@<lang>` | Preserved verbatim |
+
+Literal-valued predicates (all preserved as annotations, colon-prefixed):
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
 | `skos:definition` | Annotation `skos:definition` | Not promoted to description |
-| `skos:broader`, `skos:narrower` | Abstract relationship `skos_broader` (narrower normalized) | |
-| `skos:related` | Abstract relationship `skos_related` | |
-| `skos:exactMatch` etc. | Abstract relationship if target imported; annotation if external IRI | |
-| `skos:notation`, `skos:scopeNote`, etc. | Annotation with `skos:` prefix | |
-| `skos:inScheme`, `skos:topConceptOf` | Annotation with `skos:` prefix | |
+| `skos:notation` | Annotation `skos:notation` | |
+| `skos:scopeNote` | Annotation `skos:scopeNote` | |
+| `skos:example` | Annotation `skos:example` | |
+| `skos:historyNote` | Annotation `skos:historyNote` | |
+| `skos:editorialNote` | Annotation `skos:editorialNote` | |
+| `skos:changeNote` | Annotation `skos:changeNote` | |
+
+Reference predicates (IRI target stored as local name):
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
+| `skos:inScheme` | Annotation `skos:inScheme` | |
+| `skos:topConceptOf` | Annotation `skos:topConceptOf` | |
+
+Graph-shaped predicates (abstract relationships):
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
+| `skos:broader` | Abstract relationship `skos_broader` | |
+| `skos:narrower` | Abstract relationship `skos_broader` (endpoints swapped) | Normalized to broader |
+| `skos:related` | Abstract relationship `skos_related` | Emitted once per subject–object pair |
+
+Match predicates (relationship if target imported, annotation otherwise):
+
+| SKOS construct | Ontology equivalent | Notes |
+|---|---|---|
+| `skos:exactMatch` | Abstract `skos_exactMatch` / annotation `skos:exactMatch` | |
+| `skos:closeMatch` | Abstract `skos_closeMatch` / annotation `skos:closeMatch` | |
+| `skos:broadMatch` | Abstract `skos_broadMatch` / annotation `skos:broadMatch` | |
+| `skos:narrowMatch` | Abstract `skos_narrowMatch` / annotation `skos:narrowMatch` | |
+| `skos:relatedMatch` | Abstract `skos_relatedMatch` / annotation `skos:relatedMatch` | External IRI stored verbatim |
 
 ### 17.4 Relationship uniqueness
 

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -632,10 +632,11 @@ second-class placeholders. Most shape rules still apply:
   - Must reference declared entity names in `from` / `to`; endpoint
     existence is enforced.
   - **May point at concrete or abstract entities** in any combination.
-  - **Must not use `extends`**. Abstract relationships are
-    informational; the mixed concrete/abstract parent-map would have
-    ambiguous uniqueness. If keys are declared, they still follow
-    shape rules.
+  - **Must not use `extends`**. `extends` is a bare name reference,
+    but abstract relationship names are not unique on their own — two
+    abstract relationships may share a name if their endpoints differ.
+    A bare name cannot unambiguously identify the parent, so `extends`
+    is forbidden. If keys are declared, they still follow shape rules.
   - Uniqueness is relaxed to `(name, from, to)` instead of `(name,)`
     alone — so multiple `skos_broader` edges with different endpoints
     are legal (see §19.5).
@@ -655,13 +656,21 @@ second-class placeholders. Most shape rules still apply:
 ### 19.5 Relationship uniqueness
 
 Abstract relationships use relaxed uniqueness: `(name, from, to)` must
-be unique, rather than `(name)` alone. Concrete relationships retain
-strict `(name)` uniqueness. This relaxation is what allows multiple
-`skos_broader` edges to share a name without synthetic suffixes.
+be unique, rather than `(name)` alone. The relaxation is necessary
+because external vocabularies like SKOS use a single predicate name
+(`broader`, `related`) across many different node-type pairs. Requiring
+name uniqueness alone would force synthetic names
+(`skos_broader_1`, `skos_broader_2`, …) that diverge from the source
+vocabulary and make the ontology harder to read.
 
-The relaxation is deliberately narrow: `compile_graph` and `gm bind`
-only operate on concrete elements, and concrete uniqueness is
-unchanged. The emitted DDL and GQL surfaces are unaffected.
+The cost of the relaxation is that `extends` becomes unresolvable for
+abstract relationships — a bare name no longer identifies a single
+relationship — so `extends` is forbidden on abstract relationships.
+
+Concrete relationships retain strict `(name)` uniqueness. The
+relaxation is deliberately narrow: the compiler and binding layer only
+operate on concrete elements, so the emitted DDL and GQL surfaces are
+unaffected.
 
 ### 19.6 Language selection (`--language`)
 

--- a/docs/ontology/scaffold.md
+++ b/docs/ontology/scaffold.md
@@ -68,6 +68,13 @@ Each step produces a file whose name states what kind of DDL it is.
 Scaffold refuses to write into a non-empty `--out` directory. The user
 deletes or moves the previous output if they want to regenerate.
 
+**Abstract elements** (see `ontology.md` §3a) are skipped entirely.
+Abstract entities produce no `CREATE TABLE` statement and no
+`entities:` entry in the generated binding; abstract relationships
+produce no edge table and no `relationships:` entry. They exist in
+the ontology for documentation or taxonomy purposes and have no
+physical representation to scaffold.
+
 ## 3. Node (entity) table convention
 
 Scaffold derives every structural element from the ontology. No column

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -228,8 +228,13 @@ def _check_binding_names_resolve(
       )
     if entity_map[eb.name].abstract:
       raise ValueError(
-          f"Entity binding {eb.name!r} targets an abstract entity, "
-          f"which cannot be bound to a physical table."
+          f"Entity binding {eb.name!r} targets an abstract entity "
+          f"(declared for documentation but not backed by a table). "
+          f"Abstract entities typically come from SKOS-only concepts or "
+          f"ontologies that declare structure without physical "
+          f"realization. Remove this binding, or promote {eb.name!r} in "
+          f"the ontology (drop ``abstract: true`` and give it keys) to "
+          f"back it with a table."
       )
   for rb in binding.relationships:
     if rb.name not in rel_map:
@@ -240,7 +245,13 @@ def _check_binding_names_resolve(
     if rel_map[rb.name].abstract:
       raise ValueError(
           f"Relationship binding {rb.name!r} targets an abstract "
-          f"relationship, which cannot be bound to a physical table."
+          f"relationship (declared for documentation but not backed by "
+          f"an edge table). Abstract relationships typically come from "
+          f"SKOS graph predicates (e.g. ``skos:broader``) or from "
+          f"relationships whose endpoints are abstract. Remove this "
+          f"binding, or promote {rb.name!r} in the ontology (drop "
+          f"``abstract: true`` and ensure its endpoints are concrete) "
+          f"to back it with an edge table."
       )
 
 

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -226,11 +226,21 @@ def _check_binding_names_resolve(
           f"Entity binding {eb.name!r} does not name a declared entity "
           f"in ontology {binding.ontology!r}."
       )
+    if entity_map[eb.name].abstract:
+      raise ValueError(
+          f"Entity binding {eb.name!r} targets an abstract entity, "
+          f"which cannot be bound to a physical table."
+      )
   for rb in binding.relationships:
     if rb.name not in rel_map:
       raise ValueError(
           f"Relationship binding {rb.name!r} does not name a declared "
           f"relationship in ontology {binding.ontology!r}."
+      )
+    if rel_map[rb.name].abstract:
+      raise ValueError(
+          f"Relationship binding {rb.name!r} targets an abstract "
+          f"relationship, which cannot be bound to a physical table."
       )
 
 

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -653,6 +653,16 @@ def import_owl_command(
         "--format",
         help="Override parser selection: ttl or rdfxml.",
     ),
+    language: str = typer.Option(
+        "en",
+        "--language",
+        help=(
+            "BCP-47 language tag for label selection (default: en). "
+            "Labels in the selected language are used for names and "
+            "synonyms; labels in other languages become "
+            "language-suffixed annotations."
+        ),
+    ),
     json_output: bool = typer.Option(
         False,
         "--json",
@@ -750,6 +760,7 @@ def import_owl_command(
         sources,
         include_namespaces=include_namespace,
         format=rdflib_format,
+        language=language,
     )
   except ValueError as exc:
     _emit_errors(

--- a/src/bigquery_ontology/docs/user_manual.md
+++ b/src/bigquery_ontology/docs/user_manual.md
@@ -384,7 +384,8 @@ Use `--format ttl` or `--format rdfxml` to override parser auto-detection from t
 | `owl:FunctionalProperty` | `cardinality: many_to_one` (object properties only) |
 | `rdfs:label` | `description` |
 | `rdfs:comment` | Appended to `description` |
-| `skos:altLabel`, `skos:prefLabel` | `synonyms` |
+| `skos:Concept`, `skos:broader`, `skos:definition`, etc. | See **Importing SKOS** below |
+| Dublin Core / other literal predicates | `annotations` (by local name) |
 
 XSD datatypes are mapped to ontology types: `xsd:string` to `string`, `xsd:integer` to `integer`, `xsd:decimal` to `numeric`, `xsd:boolean` to `boolean`, `xsd:date` to `date`, `xsd:dateTime` to `timestamp`, and so on.
 
@@ -450,6 +451,86 @@ OWL features that don't have a direct ontology equivalent are preserved rather t
 - **YAML comments**: restrictions (`someValuesFrom`, `allValuesFrom`, cardinality constraints) and class expressions (`unionOf`, `intersectionOf`) are written as comments above the affected element.
 
 The drop summary printed to stderr provides counts per category so you can quickly see what was preserved as annotations versus what was dropped entirely.
+
+#### Importing SKOS
+
+Many real-world ontologies mix OWL (formal classes and properties) with SKOS (human-readable labels, taxonomies, cross-vocabulary mappings). `gm import-owl` recognizes both; no extra flag is required to enable SKOS handling.
+
+**Informational by default.** OWL constructs flow into structural fields (`extends`, `keys`, `properties`, `from`/`to`). SKOS predicates never do — they produce abstract entities, abstract relationships, and annotations. `skos:broader` is *not* subsumption, so it never maps to `extends`.
+
+**Abstract elements.** A standalone `skos:Concept` (no `owl:Class` typing) becomes an abstract entity with a `skos_` name prefix. A class typed as both `owl:Class` and `skos:Concept` stays concrete and unprefixed — OWL provides the structure, SKOS contributes annotations and synonyms.
+
+Abstract elements are declared but not bound to BigQuery tables:
+
+- Primary keys are optional on abstract entities.
+- `gm scaffold` skips them when generating DDL and binding.
+- `gm compile` rejects any binding that targets them.
+
+**SKOS mapping (summary):**
+
+| SKOS construct | Result |
+|---|---|
+| `skos:Concept` (standalone) | Abstract entity `skos_<name>` |
+| `owl:Class` + `skos:Concept` | Concrete entity, unprefixed |
+| `skos:prefLabel`, `skos:altLabel`, `skos:hiddenLabel` (selected language) | `synonyms` |
+| `skos:prefLabel` etc. (other languages) | Annotation `skos:prefLabel@<lang>` |
+| `skos:definition`, `notation`, `scopeNote`, `example`, `historyNote`, `editorialNote`, `changeNote` | Annotation `skos:<pred>` |
+| `skos:inScheme`, `skos:topConceptOf` | Annotation `skos:<pred>` |
+| `skos:broader` / `skos:narrower` | Abstract relationship `skos_broader` (narrower normalized) |
+| `skos:related` | Abstract relationship `skos_related` |
+| `skos:exactMatch` / `closeMatch` / `broadMatch` / `narrowMatch` / `relatedMatch` | Abstract relationship if target is imported; annotation with full IRI otherwise |
+
+See `docs/ontology/owl-import.md` §19 for the full table and worked examples.
+
+**Multilingual labels.** The `--language` flag (default `en`) selects labels by BCP-47 tag. Labels in the selected language populate description/synonyms; labels in other languages become language-suffixed annotations:
+
+```bash
+gm import-owl concepts.ttl \
+  --include-namespace "https://example.com/concepts#" \
+  --language fr \
+  -o concepts.ontology.yaml
+```
+
+**Duplicate `skos_broader` edges.** Abstract relationships use relaxed uniqueness: `(name, from, to)` must be unique rather than `(name,)` alone. Multiple `skos_broader` edges with different endpoints are legal in the same ontology without synthetic naming.
+
+**Worked example — pure SKOS taxonomy:**
+
+```turtle
+:Banking a skos:Concept ;
+    skos:prefLabel "Banking"@en ;
+    skos:definition "Activities of financial institutions."@en .
+
+:RetailBanking a skos:Concept ;
+    skos:prefLabel "Retail Banking"@en ;
+    skos:altLabel "Consumer Banking"@en ;
+    skos:broader :Banking ;
+    skos:notation "RB" .
+```
+
+becomes:
+
+```yaml
+entities:
+  - name: skos_Banking
+    abstract: true
+    synonyms: [Banking]
+    annotations:
+      skos:definition: Activities of financial institutions.
+  - name: skos_RetailBanking
+    abstract: true
+    synonyms: [Consumer Banking, Retail Banking]
+    annotations:
+      skos:notation: RB
+relationships:
+  - name: skos_broader
+    abstract: true
+    from: skos_RetailBanking
+    to: skos_Banking
+```
+
+If every entity ends up abstract, the drop summary emits a hint: *"all entities are abstract (SKOS-only). No concrete entities are available for binding. Consider representing the taxonomy as dimension columns instead of entity types."*
+
+**Generic literal annotations.** Literal-valued predicates outside the RDF/RDFS/OWL/SKOS namespaces — Dublin Core (`dc:title`, `dcterms:creator`), Schema.org, custom vocabularies — are preserved as `annotations: { <local_name>: <value> }`. Multiple values for the same predicate merge into a sorted list.
 
 ---
 
@@ -825,7 +906,8 @@ Validates both files before compiling. Any validation error prevents DDL output.
 #### `gm import-owl`
 
 ```
-gm import-owl <source>... --include-namespace <iri>... [-o <out>] [--format ttl|rdfxml] [--json]
+gm import-owl <source>... --include-namespace <iri>... [-o <out>]
+              [--format ttl|rdfxml] [--language <tag>] [--json]
 ```
 
 | Argument/Option | Required | Default | Description |
@@ -834,9 +916,12 @@ gm import-owl <source>... --include-namespace <iri>... [-o <out>] [--format ttl|
 | `--include-namespace <iri>` | yes | — | IRI namespace prefix to include. Repeatable. |
 | `-o` / `--out <file>` | no | stdout | Write ontology YAML to file. |
 | `--format` | no | auto | Parser override: `ttl` or `rdfxml`. Default is inferred from file extension. |
+| `--language <tag>` | no | `en` | BCP-47 language tag for label selection. Labels in the selected language populate names and synonyms; labels in other languages become language-suffixed annotations (e.g., `skos:prefLabel@fr`). |
 | `--json` | no | false | Emit structured JSON errors on stderr. |
 
-Output YAML may contain `FILL_IN` placeholders that must be resolved before `gm validate` will pass. A drop summary of excluded and unsupported OWL features is always printed to stderr (not affected by `--json`).
+Output YAML may contain `FILL_IN` placeholders that must be resolved before `gm validate` will pass. A drop summary of excluded and unsupported OWL/SKOS features is always printed to stderr (not affected by `--json`).
+
+The importer recognizes both OWL and SKOS constructs. See the **Importing SKOS** subsection above for the mapping table, abstract-element semantics, and worked examples.
 
 Requires `rdflib`. Install with `pip install 'bigquery-agent-analytics[owl]'`.
 

--- a/src/bigquery_ontology/docs/user_manual.md
+++ b/src/bigquery_ontology/docs/user_manual.md
@@ -385,7 +385,7 @@ Use `--format ttl` or `--format rdfxml` to override parser auto-detection from t
 | `rdfs:label` | `description` |
 | `rdfs:comment` | Appended to `description` |
 | `skos:Concept`, `skos:broader`, `skos:definition`, etc. | See **Importing SKOS** below |
-| Dublin Core / other literal predicates | `annotations` (by local name) |
+| Dublin Core / other literal predicates | `annotations` (keyed `prefix:local`, or full IRI when the namespace has no bound prefix) |
 
 XSD datatypes are mapped to ontology types: `xsd:string` to `string`, `xsd:integer` to `integer`, `xsd:decimal` to `numeric`, `xsd:boolean` to `boolean`, `xsd:date` to `date`, `xsd:dateTime` to `timestamp`, and so on.
 
@@ -475,7 +475,7 @@ Abstract elements are declared but not bound to BigQuery tables:
 | `skos:prefLabel`, `skos:altLabel`, `skos:hiddenLabel` (selected language) | `synonyms` |
 | `skos:prefLabel` etc. (other languages) | Annotation `skos:prefLabel@<lang>` |
 | `skos:definition`, `notation`, `scopeNote`, `example`, `historyNote`, `editorialNote`, `changeNote` | Annotation `skos:<pred>` |
-| `skos:inScheme`, `skos:topConceptOf` | Annotation `skos:<pred>` |
+| `skos:inScheme`, `skos:topConceptOf` | Annotation `skos:<pred>` (IRI target stored verbatim) |
 | `skos:broader` / `skos:narrower` | Abstract relationship `skos_broader` (narrower normalized) |
 | `skos:related` | Abstract relationship `skos_related` |
 | `skos:exactMatch` / `closeMatch` / `broadMatch` / `narrowMatch` / `relatedMatch` | Abstract relationship if target is imported; annotation with full IRI otherwise |
@@ -530,7 +530,7 @@ relationships:
 
 If every entity ends up abstract, the drop summary emits a hint: *"all entities are abstract (SKOS-only). No concrete entities are available for binding. Consider representing the taxonomy as dimension columns instead of entity types."*
 
-**Generic literal annotations.** Literal-valued predicates outside the RDF/RDFS/OWL/SKOS namespaces — Dublin Core (`dc:title`, `dcterms:creator`), Schema.org, custom vocabularies — are preserved as `annotations: { <local_name>: <value> }`. Multiple values for the same predicate merge into a sorted list.
+**Generic literal annotations.** Literal-valued predicates outside the RDF/RDFS/OWL/SKOS namespaces — Dublin Core (`dc:title`, `dcterms:creator`), Schema.org, custom vocabularies — are preserved as `annotations: { <key>: <value> }`, where `<key>` is `prefix:local` when the predicate's namespace has a bound prefix and the full IRI otherwise. Retaining the prefix keeps `dc:title` and `dcterms:title` distinguishable. Multiple values for the same predicate merge into a sorted list.
 
 ---
 

--- a/src/bigquery_ontology/graph_ddl_compiler.py
+++ b/src/bigquery_ontology/graph_ddl_compiler.py
@@ -106,6 +106,19 @@ def _resolve(ontology: Ontology, binding: Binding) -> ResolvedGraph:
       eb.name: eb for eb in binding.entities
   }
 
+  # Defense-in-depth: abstract elements must never reach the compiler
+  # (the binding loader rejects them).
+  for eb in binding.entities:
+    if entity_map[eb.name].abstract:
+      raise ValueError(
+          f"Internal error: abstract entity {eb.name!r} in binding."
+      )
+  for rb in binding.relationships:
+    if rel_map[rb.name].abstract:
+      raise ValueError(
+          f"Internal error: abstract relationship {rb.name!r} in binding."
+      )
+
   # Build node tables first. Edge tables reference node tables by
   # alias/key-columns, so node tables have to exist before we can
   # resolve edges.

--- a/src/bigquery_ontology/graph_ddl_compiler.py
+++ b/src/bigquery_ontology/graph_ddl_compiler.py
@@ -106,19 +106,6 @@ def _resolve(ontology: Ontology, binding: Binding) -> ResolvedGraph:
       eb.name: eb for eb in binding.entities
   }
 
-  # Defense-in-depth: abstract elements must never reach the compiler
-  # (the binding loader rejects them).
-  for eb in binding.entities:
-    if entity_map[eb.name].abstract:
-      raise ValueError(
-          f"Internal error: abstract entity {eb.name!r} in binding."
-      )
-  for rb in binding.relationships:
-    if rel_map[rb.name].abstract:
-      raise ValueError(
-          f"Internal error: abstract relationship {rb.name!r} in binding."
-      )
-
   # Build node tables first. Edge tables reference node tables by
   # alias/key-columns, so node tables have to exist before we can
   # resolve edges.

--- a/src/bigquery_ontology/ontology_loader.py
+++ b/src/bigquery_ontology/ontology_loader.py
@@ -77,10 +77,26 @@ def load_ontology_from_string(yaml_string: str) -> Ontology:
 def _validate_ontology(ont: Ontology) -> None:
   """Run cross-element semantic validation over a parsed ontology."""
   entity_map = _check_unique_names(ont.entities, "entity")
-  rel_map = _check_unique_names(ont.relationships, "relationship")
+
+  # Relationships: concrete require unique (name,); abstract require
+  # unique (name, from, to).  No name shared between the two groups.
+  concrete_rels = [r for r in ont.relationships if not r.abstract]
+  abstract_rels = [r for r in ont.relationships if r.abstract]
+  rel_map = _check_unique_names(concrete_rels, "relationship")
+  _check_unique_abstract_relationships(abstract_rels)
+  abstract_rel_names = {r.name for r in abstract_rels}
+  concrete_abstract_overlap = set(rel_map) & abstract_rel_names
+  if concrete_abstract_overlap:
+    name = sorted(concrete_abstract_overlap)[0]
+    raise ValueError(
+        f"Relationship name {name!r} is used by both a concrete and an "
+        "abstract relationship; names must not be shared across the two."
+    )
+
   # Names live in a single ontology-wide namespace: an entity and a
   # relationship cannot share a name.
-  collisions = set(entity_map) & set(rel_map)
+  all_rel_names = set(rel_map) | abstract_rel_names
+  collisions = set(entity_map) & all_rel_names
   if collisions:
     name = sorted(collisions)[0]
     raise ValueError(
@@ -94,20 +110,42 @@ def _validate_ontology(ont: Ontology) -> None:
     _check_property_names_unique(rel.properties, f"relationship {rel.name!r}")
 
   _check_extends_targets(ont.entities, entity_map, "entity")
-  _check_extends_targets(ont.relationships, rel_map, "relationship")
+  # extends targets only checked for concrete relationships (abstract
+  # relationships do not participate in inheritance chains).
+  _check_extends_targets(concrete_rels, rel_map, "relationship")
   _check_no_extends_cycles(ont.entities, "entity")
-  _check_no_extends_cycles(ont.relationships, "relationship")
+  _check_no_extends_cycles(concrete_rels, "relationship")
 
   _check_no_property_redeclaration(ont.entities, entity_map, "entity")
-  _check_no_property_redeclaration(ont.relationships, rel_map, "relationship")
+  _check_no_property_redeclaration(concrete_rels, rel_map, "relationship")
   _check_no_key_redeclaration(ont.entities, entity_map, "entity")
-  _check_no_key_redeclaration(ont.relationships, rel_map, "relationship")
+  _check_no_key_redeclaration(concrete_rels, rel_map, "relationship")
 
   for ent in ont.entities:
-    _check_entity_keys(ent, entity_map)
+    if not ent.abstract:
+      _check_entity_keys(ent, entity_map)
+    elif ent.keys is not None:
+      # Abstract entities don't require keys, but if keys are declared
+      # they must still follow the shape rules.
+      _check_entity_key_shape(ent, ent.keys, entity_map)
+  # Endpoint existence and the abstract-endpoint rule apply to all
+  # relationships; key and covariant-narrowing checks only to concrete.
   for rel in ont.relationships:
-    _check_relationship_keys(rel, rel_map)
     _check_relationship_endpoints(rel, entity_map)
+  for rel in abstract_rels:
+    # Abstract relationships are informational. They must not use
+    # ``extends`` (that would require resolving through a mixed
+    # concrete/abstract parent map with ambiguous uniqueness), and
+    # their keys — if declared — must still follow shape rules.
+    if rel.extends is not None:
+      raise ValueError(
+          f"Relationship {rel.name!r} is abstract and must not use "
+          f"'extends'."
+      )
+    if rel.keys is not None:
+      _check_relationship_key_shape(rel, rel.keys)
+  for rel in concrete_rels:
+    _check_relationship_keys(rel, rel_map)
     _check_covariant_narrowing(rel, rel_map, entity_map)
 
 
@@ -126,6 +164,21 @@ def _check_unique_names(
       raise ValueError(f"Duplicate {kind} name: {item.name!r}")
     out[item.name] = item
   return out
+
+
+def _check_unique_abstract_relationships(
+    rels: Iterable[Relationship],
+) -> None:
+  """Abstract relationships must be unique by ``(name, from, to)``."""
+  seen: set[tuple[str, str, str]] = set()
+  for r in rels:
+    key = (r.name, r.from_, r.to)
+    if key in seen:
+      raise ValueError(
+          f"Duplicate abstract relationship: "
+          f"({r.name!r}, from={r.from_!r}, to={r.to!r})"
+      )
+    seen.add(key)
 
 
 def _check_property_names_unique(
@@ -293,6 +346,17 @@ def _check_entity_keys(entity: Entity, entity_map: dict[str, Entity]) -> None:
   keys = _effective_keys(entity, entity_map)
   if keys is None or not keys.primary:
     raise ValueError(f"Entity {entity.name!r}: keys.primary is required.")
+  _check_entity_key_shape(entity, keys, entity_map)
+
+
+def _check_entity_key_shape(
+    entity: Entity, keys: Keys, entity_map: dict[str, Entity]
+) -> None:
+  """Shape-only entity key checks: forbid ``additional``, verify that
+  key columns reference declared properties, and validate alternate
+  keys. These apply whether or not the entity is abstract; only the
+  ``primary is required`` rule is relaxed for abstract entities.
+  """
   if keys.additional is not None:
     raise ValueError(f"Entity {entity.name!r}: keys.additional is not allowed.")
   props = _effective_properties(entity, entity_map)
@@ -308,19 +372,33 @@ def _check_relationship_keys(
   keys = _effective_keys(rel, rel_map)
   if keys is None:
     return  # no uniqueness constraint; multi-edges permitted.
+  _check_relationship_key_mode(rel, keys)
+  props = _effective_properties(rel, rel_map)
+  _check_key_columns_known(keys, props, f"Relationship {rel.name!r}")
+  _check_alternate_keys(keys, f"Relationship {rel.name!r}")
+
+
+def _check_relationship_key_mode(rel: Relationship, keys: Keys) -> None:
   if keys.primary and keys.additional:
     raise ValueError(
         f"Relationship {rel.name!r}: primary and additional are "
         f"mutually exclusive."
     )
   if keys.additional is not None and keys.alternate:
-    # Largely overlaps with ``_check_alternate_keys`` (which catches the
-    # "primary missing" case), but emits a relationship-specific message
-    # for the additional+alternate combination instead of the generic one.
     raise ValueError(
         f"Relationship {rel.name!r}: alternate keys require a primary key."
     )
-  props = _effective_properties(rel, rel_map)
+
+
+def _check_relationship_key_shape(rel: Relationship, keys: Keys) -> None:
+  """Shape-only key validation for abstract relationships.
+
+  Abstract rels do not participate in inheritance, so key columns and
+  alternate keys are resolved against the relationship's own
+  declared properties rather than an effective (inherited) set.
+  """
+  _check_relationship_key_mode(rel, keys)
+  props = {p.name: p for p in rel.properties}
   _check_key_columns_known(keys, props, f"Relationship {rel.name!r}")
   _check_alternate_keys(keys, f"Relationship {rel.name!r}")
 
@@ -328,7 +406,12 @@ def _check_relationship_keys(
 def _check_relationship_endpoints(
     rel: Relationship, entity_map: dict[str, Entity]
 ) -> None:
-  """Endpoints must reference declared entities."""
+  """Endpoints must reference declared entities.
+
+  Concrete relationships must have concrete endpoints — binding a
+  relationship requires bindable endpoints. Abstract relationships
+  may reference any combination (concrete, abstract, or mixed).
+  """
   if rel.from_ not in entity_map:
     raise ValueError(
         f"Relationship {rel.name!r}: from {rel.from_!r} is not a "
@@ -338,6 +421,19 @@ def _check_relationship_endpoints(
     raise ValueError(
         f"Relationship {rel.name!r}: to {rel.to!r} is not a declared entity."
     )
+  if not rel.abstract:
+    if entity_map[rel.from_].abstract:
+      raise ValueError(
+          f"Relationship {rel.name!r} is concrete but its 'from' "
+          f"endpoint {rel.from_!r} is abstract. A concrete "
+          f"relationship cannot have an abstract endpoint."
+      )
+    if entity_map[rel.to].abstract:
+      raise ValueError(
+          f"Relationship {rel.name!r} is concrete but its 'to' "
+          f"endpoint {rel.to!r} is abstract. A concrete "
+          f"relationship cannot have an abstract endpoint."
+      )
 
 
 def _is_entity_subtype(

--- a/src/bigquery_ontology/ontology_models.py
+++ b/src/bigquery_ontology/ontology_models.py
@@ -148,6 +148,7 @@ class Entity(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   name: str
+  abstract: bool = False
   extends: Optional[str] = None
   keys: Optional[Keys] = None
   properties: list[Property] = Field(default_factory=list)
@@ -175,6 +176,7 @@ class Relationship(BaseModel):
   model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
   name: str
+  abstract: bool = False
   extends: Optional[str] = None
   keys: Optional[Keys] = None
   from_: str = Field(alias="from")

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -967,13 +967,16 @@ def _extract_skos_relationships(
       _add_rel("skos_broader", from_name, to_name, _SKOS_BROADER)
 
   # skos:related — symmetric, emit one direction per pair.
+  # Sort endpoints so mutual assertions (:a related :b AND :b related :a)
+  # collapse to a single edge under the ordered dedupe key.
   for subj, obj in g.subject_objects(_SKOS_RELATED):
     if not isinstance(subj, URIRef) or not isinstance(obj, URIRef):
       continue
     from_name = iri_to_name.get(str(subj))
     to_name = iri_to_name.get(str(obj))
     if from_name and to_name:
-      _add_rel("skos_related", from_name, to_name, _SKOS_RELATED)
+      a, b = sorted((from_name, to_name))
+      _add_rel("skos_related", a, b, _SKOS_RELATED)
 
   # Match predicates — relationship if target is imported, else annotation.
   # Collect external matches per (entity, predicate) to allow sort before

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -125,6 +125,7 @@ class _ImportedProperty:
 class _ImportedEntity:
   name: str
   iri: URIRef
+  abstract: bool = False
   description: str | None = None
   synonyms: list[str] = field(default_factory=list)
   extends: str | None = None
@@ -143,6 +144,7 @@ class _ImportedEntity:
 class _ImportedRelationship:
   name: str
   iri: URIRef
+  abstract: bool = False
   from_entity: str | None = None
   from_fill_in: bool = False
   from_candidates: list[str] = field(default_factory=list)
@@ -163,6 +165,12 @@ class _ImportedRelationship:
 class _DropSummary:
   excluded_by_namespace: dict[str, int] = field(default_factory=dict)
   dropped_features: dict[str, int] = field(default_factory=dict)
+  skos_annotations: int = 0
+  skos_labels_discarded_by_language: int = 0
+  skos_external_matches: int = 0
+  skos_concepts_imported: int = 0
+  skos_relationships_imported: int = 0
+  generic_annotations: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -170,36 +178,52 @@ class _DropSummary:
 # ---------------------------------------------------------------------------
 
 
-def _pick_primary_label(labels) -> tuple[str | None, list[str]]:
+def _pick_primary_label(
+    labels, language: str = "en",
+) -> tuple[str | None, list[str], dict[str, str]]:
   """Pick the best label as description, return rest as synonyms.
 
-  Prefers English-tagged labels (``@en*``), then falls back to
-  untagged or other languages.  Within the preferred group, picks
-  alphabetically first for determinism.
+  Prefers labels matching ``language``, then falls back to untagged or
+  other languages. Within the preferred group, picks alphabetically
+  first for determinism. Returns ``(primary, synonyms, lang_annotations)``
+  where ``lang_annotations`` maps ``predicate@lang`` keys to values for
+  labels in non-selected languages.
   """
-  en: list[str] = []
-  other: list[str] = []
+  selected: list[str] = []
+  untagged: list[str] = []
+  other_lang: dict[str, str] = {}
   for label in labels:
     lang = getattr(label, "language", None)
-    if lang is not None and lang.startswith("en"):
-      en.append(str(label))
+    if lang is not None and lang.startswith(language):
+      selected.append(str(label))
+    elif lang is None or lang == "":
+      untagged.append(str(label))
     else:
-      other.append(str(label))
+      other_lang[f"@{lang}"] = str(label)
 
-  en.sort()
-  other.sort()
-  if en:
-    return en[0], en[1:] + other
-  if other:
-    return other[0], other[1:]
-  return None, []
+  selected.sort()
+  untagged.sort()
+  if selected:
+    return selected[0], selected[1:] + untagged, other_lang
+  if untagged:
+    return untagged[0], untagged[1:], other_lang
+  return None, [], other_lang
 
 
 def _extract_labels_and_description(
-    g: Graph, iri: URIRef
-) -> tuple[str | None, list[str]]:
+    g: Graph, iri: URIRef, language: str = "en",
+) -> tuple[str | None, list[str], dict[str, str]]:
+  """Extract rdfs:label → description, SKOS labels → synonyms.
+
+  Returns ``(description, synonyms, lang_annotations)`` where
+  ``lang_annotations`` maps keys like ``rdfs:label@fr`` to values for
+  labels in non-selected languages.
+  """
   raw_labels = list(g.objects(iri, RDFS.label))
-  description, synonyms = _pick_primary_label(raw_labels)
+  description, synonyms, lang_anns = _pick_primary_label(raw_labels, language)
+  label_lang_anns: dict[str, str] = {
+      f"rdfs:label{k}": v for k, v in lang_anns.items()
+  }
 
   comments: list[str] = []
   for comment in g.objects(iri, RDFS.comment):
@@ -211,14 +235,27 @@ def _extract_labels_and_description(
       description = "\n\n".join(comments)
 
   for alt in g.objects(iri, SKOS.altLabel):
-    synonyms.append(str(alt))
+    lang = getattr(alt, "language", None)
+    if lang is not None and not lang.startswith(language) and lang != "":
+      label_lang_anns[f"skos:altLabel@{lang}"] = str(alt)
+    else:
+      synonyms.append(str(alt))
   for pref in g.objects(iri, SKOS.prefLabel):
+    lang = getattr(pref, "language", None)
     val = str(pref)
-    if val not in synonyms and val != description:
+    if lang is not None and not lang.startswith(language) and lang != "":
+      label_lang_anns[f"skos:prefLabel@{lang}"] = val
+    elif val not in synonyms and val != description:
       synonyms.append(val)
+  for hidden in g.objects(iri, SKOS.hiddenLabel):
+    lang = getattr(hidden, "language", None)
+    if lang is not None and not lang.startswith(language) and lang != "":
+      label_lang_anns[f"skos:hiddenLabel@{lang}"] = str(hidden)
+    else:
+      synonyms.append(str(hidden))
 
   synonyms.sort()
-  return description, synonyms
+  return description, synonyms, label_lang_anns
 
 
 def _extract_parents(
@@ -343,7 +380,8 @@ def _collect_drop_annotations(
 
 
 def _extract_entities(
-    g: Graph, namespaces: list[str], drops: _DropSummary
+    g: Graph, namespaces: list[str], drops: _DropSummary,
+    language: str = "en",
 ) -> dict[str, _ImportedEntity]:
   entities: dict[str, _ImportedEntity] = {}
 
@@ -364,7 +402,10 @@ def _extract_entities(
           "namespace filter to resolve."
       )
 
-    description, synonyms = _extract_labels_and_description(g, cls)
+    description, synonyms, lang_anns = _extract_labels_and_description(
+        g, cls, language,
+    )
+    drops.skos_labels_discarded_by_language += len(lang_anns)
     extends, extends_fill_in, extends_candidates, parent_anns = (
         _extract_parents(g, cls, RDFS.subClassOf, namespaces)
     )
@@ -374,6 +415,7 @@ def _extract_entities(
 
     annotations: dict[str, AnnotationValue] = {}
     comments: list[str] = []
+    annotations.update(lang_anns)
     annotations.update(parent_anns)
     if keys_excluded:
       annotations["owl:hasKey_excluded"] = (
@@ -405,6 +447,7 @@ def _extract_datatype_properties(
     entities: dict[str, _ImportedEntity],
     namespaces: list[str],
     drops: _DropSummary,
+    iri_to_name: dict[str, str] | None = None,
 ) -> None:
   for prop in g.subjects(RDF.type, OWL.DatatypeProperty):
     if not isinstance(prop, URIRef):
@@ -419,7 +462,12 @@ def _extract_datatype_properties(
     domains: list[str] = []
     for domain in g.objects(prop, RDFS.domain):
       if isinstance(domain, URIRef) and _in_namespace(domain, namespaces):
-        domains.append(_local_name(domain))
+        # Resolve IRI through iri_to_name when available (handles SKOS
+        # concepts whose entity name carries a ``skos_`` prefix).
+        if iri_to_name is not None and str(domain) in iri_to_name:
+          domains.append(iri_to_name[str(domain)])
+        else:
+          domains.append(_local_name(domain))
 
     ranges: list[URIRef] = []
     for range_ in g.objects(prop, RDFS.range):
@@ -460,8 +508,17 @@ def _extract_relationships(
     entities: dict[str, _ImportedEntity],
     namespaces: list[str],
     drops: _DropSummary,
+    language: str = "en",
+    iri_to_name: dict[str, str] | None = None,
 ) -> dict[str, _ImportedRelationship]:
   relationships: dict[str, _ImportedRelationship] = {}
+
+  def _resolve_endpoint(iri: URIRef) -> str:
+    """Resolve an IRI to an entity name, using iri_to_name when
+    available (handles SKOS concepts with ``skos_`` name prefixes)."""
+    if iri_to_name is not None and str(iri) in iri_to_name:
+      return iri_to_name[str(iri)]
+    return _local_name(iri)
 
   for prop in g.subjects(RDF.type, OWL.ObjectProperty):
     if not isinstance(prop, URIRef):
@@ -480,7 +537,10 @@ def _extract_relationships(
           "namespace filter to resolve."
       )
 
-    description, synonyms = _extract_labels_and_description(g, prop)
+    description, synonyms, lang_anns = _extract_labels_and_description(
+        g, prop, language,
+    )
+    drops.skos_labels_discarded_by_language += len(lang_anns)
 
     domains: list[str] = []
     domain_excluded: list[str] = []
@@ -488,7 +548,7 @@ def _extract_relationships(
       if not isinstance(domain, URIRef):
         continue
       if _in_namespace(domain, namespaces):
-        domains.append(_local_name(domain))
+        domains.append(_resolve_endpoint(domain))
       else:
         domain_excluded.append(str(domain))
 
@@ -498,7 +558,7 @@ def _extract_relationships(
       if not isinstance(range_, URIRef):
         continue
       if _in_namespace(range_, namespaces):
-        ranges.append(_local_name(range_))
+        ranges.append(_resolve_endpoint(range_))
       else:
         range_excluded.append(str(range_))
 
@@ -529,6 +589,7 @@ def _extract_relationships(
       cardinality = "many_to_one"
 
     annotations: dict[str, AnnotationValue] = {}
+    annotations.update(lang_anns)
     comments: list[str] = []
 
     if domain_excluded:
@@ -578,11 +639,317 @@ def _resolve_keys(entities: dict[str, _ImportedEntity]) -> None:
   for entity in entities.values():
     if entity.keys_primary is not None:
       continue
+    if entity.abstract:
+      continue
     if entity.extends is not None or entity.extends_fill_in:
       continue
     prop_names = [p.name for p in entity.properties]
     entity.keys_fill_in = True
     entity.key_candidates = prop_names
+
+
+# ---------------------------------------------------------------------------
+# SKOS extraction
+# ---------------------------------------------------------------------------
+
+# SKOS literal predicates that map to annotations with ``skos:`` prefix.
+_SKOS_LITERAL_PREDICATES: dict[URIRef, str] = {}
+# Populated lazily after rdflib is imported (SKOS namespace is module-level).
+
+def _skos_literal_preds() -> dict[URIRef, str]:
+  if not _SKOS_LITERAL_PREDICATES:
+    _SKOS_LITERAL_PREDICATES.update({
+        SKOS.definition: "skos:definition",
+        SKOS.notation: "skos:notation",
+        SKOS.scopeNote: "skos:scopeNote",
+        SKOS.example: "skos:example",
+        SKOS.historyNote: "skos:historyNote",
+        SKOS.editorialNote: "skos:editorialNote",
+        SKOS.changeNote: "skos:changeNote",
+    })
+  return _SKOS_LITERAL_PREDICATES
+
+# SKOS reference predicates that map to annotations (IRI target stored as
+# string value).
+_SKOS_REF_ANNOTATION_PREDICATES: dict[URIRef, str] = {}
+
+def _skos_ref_ann_preds() -> dict[URIRef, str]:
+  if not _SKOS_REF_ANNOTATION_PREDICATES:
+    _SKOS_REF_ANNOTATION_PREDICATES.update({
+        SKOS.inScheme: "skos:inScheme",
+        SKOS.topConceptOf: "skos:topConceptOf",
+    })
+  return _SKOS_REF_ANNOTATION_PREDICATES
+
+# SKOS graph-shaped predicates that produce abstract relationships.
+_SKOS_BROADER = SKOS.broader
+_SKOS_NARROWER = SKOS.narrower
+_SKOS_RELATED = SKOS.related
+
+_SKOS_MATCH_PREDICATES: dict[URIRef, str] = {}
+
+def _skos_match_preds() -> dict[URIRef, str]:
+  if not _SKOS_MATCH_PREDICATES:
+    _SKOS_MATCH_PREDICATES.update({
+        SKOS.exactMatch: "skos_exactMatch",
+        SKOS.closeMatch: "skos_closeMatch",
+        SKOS.broadMatch: "skos_broadMatch",
+        SKOS.narrowMatch: "skos_narrowMatch",
+        SKOS.relatedMatch: "skos_relatedMatch",
+    })
+  return _SKOS_MATCH_PREDICATES
+
+
+def _extract_skos_annotations(
+    g: Graph,
+    iri: URIRef,
+    annotations: dict[str, AnnotationValue],
+    drops: _DropSummary,
+) -> None:
+  """Extract SKOS literal and reference predicates as annotations."""
+  for pred, ann_key in _skos_literal_preds().items():
+    values: list[str] = []
+    for obj in g.objects(iri, pred):
+      values.append(str(obj))
+    if values:
+      values.sort()
+      annotations[ann_key] = values if len(values) > 1 else values[0]
+      drops.skos_annotations += len(values)
+
+  for pred, ann_key in _skos_ref_ann_preds().items():
+    values = []
+    for obj in g.objects(iri, pred):
+      values.append(
+          _local_name(obj) if isinstance(obj, URIRef) else str(obj)
+      )
+    if values:
+      values.sort()
+      annotations[ann_key] = values if len(values) > 1 else values[0]
+      drops.skos_annotations += len(values)
+
+
+def _extract_skos_concepts(
+    g: Graph,
+    entities: dict[str, _ImportedEntity],
+    namespaces: list[str],
+    drops: _DropSummary,
+    language: str = "en",
+) -> dict[str, str]:
+  """Import standalone ``skos:Concept`` resources as abstract entities.
+
+  Resources already imported as ``owl:Class`` are enriched with SKOS
+  metadata but remain concrete. Returns a mapping from SKOS concept
+  IRI (as string) to entity name, for use by relationship extraction.
+  """
+  concept_iri_to_name: dict[str, str] = {}
+
+  # First, register OWL entities that are also SKOS concepts.
+  for entity in entities.values():
+    if (entity.iri, RDF.type, SKOS.Concept) in g:
+      concept_iri_to_name[str(entity.iri)] = entity.name
+      _extract_skos_annotations(g, entity.iri, entity.annotations, drops)
+
+  # Then, import standalone SKOS concepts (not owl:Class).
+  for concept in g.subjects(RDF.type, SKOS.Concept):
+    if not isinstance(concept, URIRef):
+      continue
+    if not _in_namespace(concept, namespaces):
+      drops.excluded_by_namespace["skos_concepts"] = (
+          drops.excluded_by_namespace.get("skos_concepts", 0) + 1
+      )
+      continue
+
+    iri_str = str(concept)
+    if iri_str in concept_iri_to_name:
+      continue  # Already handled as OWL+SKOS above.
+
+    local = _local_name(concept)
+    name = f"skos_{local}"
+
+    if name in entities:
+      raise ValueError(
+          f"Name collision: SKOS concept {name!r} collides with an "
+          f"existing entity. Narrow the namespace filter to resolve."
+      )
+
+    # rdfs:label and rdfs:comment still populate description if
+    # present on a pure SKOS concept; skos:* labels go to synonyms or
+    # language annotations per the label extractor.
+    description, synonyms, lang_anns = _extract_labels_and_description(
+        g, concept, language,
+    )
+    drops.skos_labels_discarded_by_language += len(lang_anns)
+
+    annotations: dict[str, AnnotationValue] = {}
+    annotations.update(lang_anns)
+    _extract_skos_annotations(g, concept, annotations, drops)
+
+    entities[name] = _ImportedEntity(
+        name=name,
+        iri=concept,
+        abstract=True,
+        description=description,
+        synonyms=synonyms,
+        annotations=annotations,
+    )
+    concept_iri_to_name[iri_str] = name
+    drops.skos_concepts_imported += 1
+
+  return concept_iri_to_name
+
+
+def _extract_skos_relationships(
+    g: Graph,
+    entities: dict[str, _ImportedEntity],
+    iri_to_name: dict[str, str],
+    namespaces: list[str],
+    drops: _DropSummary,
+) -> list[_ImportedRelationship]:
+  """Extract SKOS graph-shaped predicates as abstract relationships.
+
+  ``iri_to_name`` must cover all imported entities (OWL + SKOS). SKOS
+  predicates whose subject or object is not in the map are silently
+  skipped (external targets for match predicates are handled further
+  below as annotations).
+
+  Returns a list (not dict) because abstract relationships may share
+  names with different endpoint pairs.
+  """
+  skos_rels: list[_ImportedRelationship] = []
+  seen: set[tuple[str, str, str]] = set()  # (name, from, to)
+
+  # A sentinel IRI for SKOS-sourced relationships (they have no single
+  # OWL IRI; we use the predicate IRI as a reasonable stand-in).
+  def _add_rel(
+      rel_name: str, from_name: str, to_name: str, pred_iri: URIRef,
+  ) -> None:
+    key = (rel_name, from_name, to_name)
+    if key in seen:
+      return  # Deduplicate (e.g. broader + inverse narrower).
+    seen.add(key)
+    skos_rels.append(_ImportedRelationship(
+        name=rel_name,
+        iri=pred_iri,
+        abstract=True,
+        from_entity=from_name,
+        to_entity=to_name,
+    ))
+    drops.skos_relationships_imported += 1
+
+  # skos:broader — from child to parent.
+  for subj, obj in g.subject_objects(_SKOS_BROADER):
+    if not isinstance(subj, URIRef) or not isinstance(obj, URIRef):
+      continue
+    from_name = iri_to_name.get(str(subj))
+    to_name = iri_to_name.get(str(obj))
+    if from_name and to_name:
+      _add_rel("skos_broader", from_name, to_name, _SKOS_BROADER)
+
+  # skos:narrower — normalize to broader (swap direction).
+  for subj, obj in g.subject_objects(_SKOS_NARROWER):
+    if not isinstance(subj, URIRef) or not isinstance(obj, URIRef):
+      continue
+    from_name = iri_to_name.get(str(obj))
+    to_name = iri_to_name.get(str(subj))
+    if from_name and to_name:
+      _add_rel("skos_broader", from_name, to_name, _SKOS_BROADER)
+
+  # skos:related — symmetric, emit one direction per pair.
+  for subj, obj in g.subject_objects(_SKOS_RELATED):
+    if not isinstance(subj, URIRef) or not isinstance(obj, URIRef):
+      continue
+    from_name = iri_to_name.get(str(subj))
+    to_name = iri_to_name.get(str(obj))
+    if from_name and to_name:
+      _add_rel("skos_related", from_name, to_name, _SKOS_RELATED)
+
+  # Match predicates — relationship if target is imported, else annotation.
+  # Collect external matches per (entity, predicate) to allow sort before
+  # assignment (determinism).
+  external_matches: dict[tuple[str, str], list[str]] = {}
+  for pred, rel_name in _skos_match_preds().items():
+    ann_key = rel_name.replace("skos_", "skos:")  # skos_exactMatch → skos:exactMatch
+    for subj, obj in g.subject_objects(pred):
+      if not isinstance(subj, URIRef):
+        continue
+      from_name = iri_to_name.get(str(subj))
+      if not from_name:
+        continue
+      if isinstance(obj, URIRef) and str(obj) in iri_to_name:
+        to_name = iri_to_name[str(obj)]
+        _add_rel(rel_name, from_name, to_name, pred)
+      else:
+        # External IRI or literal → annotation on the source entity.
+        val = str(obj) if isinstance(obj, URIRef) else str(obj)
+        external_matches.setdefault((from_name, ann_key), []).append(val)
+        drops.skos_external_matches += 1
+
+  for (from_name, ann_key), values in external_matches.items():
+    values.sort()
+    entity = entities[from_name]
+    if ann_key in entity.annotations:
+      existing = entity.annotations[ann_key]
+      existing_list = existing if isinstance(existing, list) else [existing]
+      merged = sorted(set(existing_list) | set(values))
+      entity.annotations[ann_key] = (
+          merged if len(merged) > 1 else merged[0]
+      )
+    else:
+      entity.annotations[ann_key] = (
+          values if len(values) > 1 else values[0]
+      )
+
+  return skos_rels
+
+
+def _extract_generic_annotations(
+    g: Graph,
+    elements: dict[str, _ImportedEntity | _ImportedRelationship],
+    drops: _DropSummary,
+) -> None:
+  """Preserve unknown literal-valued predicates as annotations.
+
+  Predicates already handled by specific extraction passes (RDF, RDFS,
+  OWL, SKOS) are skipped. This fixes the gap where
+  ``docs/ontology/owl-import.md`` claims literal annotations are
+  preserved but the code only handled a fixed OWL allowlist.
+  """
+  # Predicates handled by other passes — skip these.
+  _HANDLED_PREFIXES = (
+      str(RDF),
+      str(RDFS),
+      str(OWL),
+      str(SKOS),
+  )
+
+  from rdflib import Literal
+
+  for elem in elements.values():
+    # Collect values per predicate first, then sort for determinism.
+    collected: dict[str, list[str]] = {}
+    for pred, obj in g.predicate_objects(elem.iri):
+      if not isinstance(obj, Literal):
+        continue
+      pred_str = str(pred)
+      if any(pred_str.startswith(pfx) for pfx in _HANDLED_PREFIXES):
+        continue
+      ann_key = _local_name(pred)
+      collected.setdefault(ann_key, []).append(str(obj))
+
+    for ann_key, values in collected.items():
+      values.sort()
+      if ann_key in elem.annotations:
+        existing = elem.annotations[ann_key]
+        existing_list = existing if isinstance(existing, list) else [existing]
+        merged = sorted(set(existing_list) | set(values))
+        elem.annotations[ann_key] = (
+            merged if len(merged) > 1 else merged[0]
+        )
+      else:
+        elem.annotations[ann_key] = (
+            values if len(values) > 1 else values[0]
+        )
+      drops.generic_annotations += len(values)
 
 
 # ---------------------------------------------------------------------------
@@ -651,7 +1018,7 @@ def _emit_annotation_value(value: AnnotationValue) -> str:
 def _emit_ontology_yaml(
     ontology_name: str,
     entities: dict[str, _ImportedEntity],
-    relationships: dict[str, _ImportedRelationship],
+    all_relationships: list[_ImportedRelationship],
 ) -> str:
   lines: list[str] = []
   lines.append(f"ontology: {ontology_name}")
@@ -664,6 +1031,9 @@ def _emit_ontology_yaml(
       for comment in entity.comments:
         lines.append(f"  # {comment}")
       lines.append(f"  - name: {entity.name}")
+
+      if entity.abstract:
+        lines.append("    abstract: true")
 
       if entity.description:
         lines.append(f"    description: {_yaml_scalar(entity.description)}")
@@ -714,7 +1084,12 @@ def _emit_ontology_yaml(
           val = _emit_annotation_value(entity.annotations[key])
           lines.append(f"      {key}: {val}")
 
-  sorted_rels = sorted(relationships.values(), key=lambda r: r.name)
+  # Sort relationships by (name, from, to) for stable output when
+  # multiple abstract relationships share a name.
+  sorted_rels = sorted(
+      all_relationships,
+      key=lambda r: (r.name, r.from_entity or "", r.to_entity or ""),
+  )
   if sorted_rels:
     lines.append("")
     lines.append("relationships:")
@@ -722,6 +1097,9 @@ def _emit_ontology_yaml(
       for comment in rel.comments:
         lines.append(f"  # {comment}")
       lines.append(f"  - name: {rel.name}")
+
+      if rel.abstract:
+        lines.append("    abstract: true")
 
       if rel.description:
         lines.append(f"    description: {_yaml_scalar(rel.description)}")
@@ -775,7 +1153,10 @@ def _emit_ontology_yaml(
 # ---------------------------------------------------------------------------
 
 
-def _format_drop_summary(drops: _DropSummary) -> str:
+def _format_drop_summary(
+    drops: _DropSummary,
+    entities: dict[str, _ImportedEntity],
+) -> str:
   lines: list[str] = []
   if drops.excluded_by_namespace:
     lines.append("Excluded by namespace filter:")
@@ -785,6 +1166,31 @@ def _format_drop_summary(drops: _DropSummary) -> str:
     lines.append("Dropped OWL features (preserved as annotations/comments):")
     for kind, count in sorted(drops.dropped_features.items()):
       lines.append(f"  {kind}: {count}")
+  if drops.skos_concepts_imported:
+    lines.append(f"SKOS concepts imported as abstract entities: "
+                 f"{drops.skos_concepts_imported}")
+  if drops.skos_relationships_imported:
+    lines.append(f"SKOS relationships imported as abstract: "
+                 f"{drops.skos_relationships_imported}")
+  if drops.skos_annotations:
+    lines.append(f"SKOS predicates mapped to annotations: "
+                 f"{drops.skos_annotations}")
+  if drops.skos_labels_discarded_by_language:
+    lines.append(f"Labels in non-selected languages (preserved as "
+                 f"annotations): {drops.skos_labels_discarded_by_language}")
+  if drops.skos_external_matches:
+    lines.append(f"SKOS match targets outside imported namespaces "
+                 f"(preserved as annotations): {drops.skos_external_matches}")
+  if drops.generic_annotations:
+    lines.append(f"Generic literal annotations preserved: "
+                 f"{drops.generic_annotations}")
+  # Hint for all-abstract ontologies.
+  if entities and all(e.abstract for e in entities.values()):
+    lines.append(
+        "Note: all entities are abstract (SKOS-only). No concrete "
+        "entities are available for binding. Consider representing "
+        "the taxonomy as dimension columns instead of entity types."
+    )
   return "\n".join(lines)
 
 
@@ -799,6 +1205,7 @@ def import_owl(
     include_namespaces: list[str],
     ontology_name: str | None = None,
     format: str | None = None,
+    language: str = "en",
 ) -> tuple[str, str]:
   """Import OWL sources into ontology YAML.
 
@@ -809,11 +1216,14 @@ def import_owl(
           namespace's last path segment.
       format: Parser format override (``"turtle"`` or ``"xml"``). If
           ``None``, inferred from file extension.
+      language: BCP-47 language tag for label selection (default ``"en"``).
+          Labels in the selected language are used for names and synonyms;
+          labels in other languages become language-suffixed annotations.
 
   Returns:
       A ``(yaml_text, drop_summary)`` tuple. The YAML text is a valid
       ontology (modulo ``FILL_IN`` placeholders). The drop summary is
-      a human-readable report of excluded and dropped OWL features.
+      a human-readable report of excluded and dropped OWL/SKOS features.
 
   Raises:
       ValueError: If no sources or no namespaces are provided.
@@ -839,14 +1249,70 @@ def import_owl(
 
   drops = _DropSummary()
 
-  entities = _extract_entities(g, include_namespaces, drops)
-  _extract_datatype_properties(g, entities, include_namespaces, drops)
-  relationships = _extract_relationships(g, entities, include_namespaces, drops)
+  # Stage 1: OWL entity extraction.
+  entities = _extract_entities(g, include_namespaces, drops, language)
+
+  # Stage 2: SKOS concept extraction — runs BEFORE datatype properties
+  # and OWL relationships so that endpoints referring to SKOS-only
+  # concepts resolve to the correct ``skos_<name>`` entity name.
+  concept_iri_to_name = _extract_skos_concepts(
+      g, entities, include_namespaces, drops, language,
+  )
+
+  # Build a full IRI→entity-name map (OWL + SKOS) for endpoint resolution.
+  iri_to_name: dict[str, str] = dict(concept_iri_to_name)
+  for entity in entities.values():
+    iri_str = str(entity.iri)
+    iri_to_name.setdefault(iri_str, entity.name)
+
+  # Stage 3: OWL datatype properties and object properties, with SKOS
+  # concepts already visible to endpoint resolution.
+  _extract_datatype_properties(
+      g, entities, include_namespaces, drops, iri_to_name=iri_to_name,
+  )
+  owl_relationships = _extract_relationships(
+      g, entities, include_namespaces, drops, language,
+      iri_to_name=iri_to_name,
+  )
+
+  # Stage 4: SKOS graph-shaped predicates → abstract relationships.
+  skos_rels = _extract_skos_relationships(
+      g, entities, iri_to_name, include_namespaces, drops,
+  )
+
+  # Stage 3: Generic literal-annotation pass (covers Dublin Core, etc.).
+  _extract_generic_annotations(g, entities, drops)
+  # Note: OWL relationships are in a dict; generic annotation pass
+  # needs the same interface. SKOS rels are abstract with no IRI-based
+  # predicates to extract, so we skip them.
+  _extract_generic_annotations(g, owl_relationships, drops)
+
+  # Finalize keys (skip abstract entities).
   _resolve_keys(entities)
 
-  overlap = set(entities) & set(relationships)
-  if overlap:
-    names = ", ".join(sorted(overlap))
+  # Merge OWL and SKOS relationships into a single list.
+  all_relationships: list[_ImportedRelationship] = list(
+      owl_relationships.values()
+  ) + skos_rels
+
+  # Name collision checks.
+  owl_rel_names = set(owl_relationships)
+  skos_rel_names = {r.name for r in skos_rels}
+  entity_names = set(entities)
+
+  owl_skos_rel_overlap = owl_rel_names & skos_rel_names
+  if owl_skos_rel_overlap:
+    names = ", ".join(sorted(owl_skos_rel_overlap))
+    raise ValueError(
+        f"Name collision between OWL and SKOS relationships: {names}. "
+        "OWL relationship names and SKOS relationship names must be "
+        "disjoint."
+    )
+
+  all_rel_names = owl_rel_names | skos_rel_names
+  entity_rel_overlap = entity_names & all_rel_names
+  if entity_rel_overlap:
+    names = ", ".join(sorted(entity_rel_overlap))
     raise ValueError(
         f"Name collision between entities and relationships: {names}. "
         "Entity and relationship names must be disjoint."
@@ -856,7 +1322,7 @@ def import_owl(
     ns = include_namespaces[0].rstrip("#/")
     ontology_name = ns.rsplit("/", 1)[-1]
 
-  yaml_text = _emit_ontology_yaml(ontology_name, entities, relationships)
-  summary = _format_drop_summary(drops)
+  yaml_text = _emit_ontology_yaml(ontology_name, entities, all_relationships)
+  summary = _format_drop_summary(drops, entities)
 
   return yaml_text, summary

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -179,7 +179,8 @@ class _DropSummary:
 
 
 def _pick_primary_label(
-    labels, language: str = "en",
+    labels,
+    language: str = "en",
 ) -> tuple[str | None, list[str], dict[str, str]]:
   """Pick the best label as description, return rest as synonyms.
 
@@ -211,7 +212,9 @@ def _pick_primary_label(
 
 
 def _extract_labels_and_description(
-    g: Graph, iri: URIRef, language: str = "en",
+    g: Graph,
+    iri: URIRef,
+    language: str = "en",
 ) -> tuple[str | None, list[str], dict[str, str]]:
   """Extract rdfs:label → description, SKOS labels → synonyms.
 
@@ -380,7 +383,9 @@ def _collect_drop_annotations(
 
 
 def _extract_entities(
-    g: Graph, namespaces: list[str], drops: _DropSummary,
+    g: Graph,
+    namespaces: list[str],
+    drops: _DropSummary,
     language: str = "en",
 ) -> dict[str, _ImportedEntity]:
   entities: dict[str, _ImportedEntity] = {}
@@ -403,7 +408,9 @@ def _extract_entities(
       )
 
     description, synonyms, lang_anns = _extract_labels_and_description(
-        g, cls, language,
+        g,
+        cls,
+        language,
     )
     drops.skos_labels_discarded_by_language += len(lang_anns)
     extends, extends_fill_in, extends_candidates, parent_anns = (
@@ -538,7 +545,9 @@ def _extract_relationships(
       )
 
     description, synonyms, lang_anns = _extract_labels_and_description(
-        g, prop, language,
+        g,
+        prop,
+        language,
     )
     drops.skos_labels_discarded_by_language += len(lang_anns)
 
@@ -656,30 +665,38 @@ def _resolve_keys(entities: dict[str, _ImportedEntity]) -> None:
 _SKOS_LITERAL_PREDICATES: dict[URIRef, str] = {}
 # Populated lazily after rdflib is imported (SKOS namespace is module-level).
 
+
 def _skos_literal_preds() -> dict[URIRef, str]:
   if not _SKOS_LITERAL_PREDICATES:
-    _SKOS_LITERAL_PREDICATES.update({
-        SKOS.definition: "skos:definition",
-        SKOS.notation: "skos:notation",
-        SKOS.scopeNote: "skos:scopeNote",
-        SKOS.example: "skos:example",
-        SKOS.historyNote: "skos:historyNote",
-        SKOS.editorialNote: "skos:editorialNote",
-        SKOS.changeNote: "skos:changeNote",
-    })
+    _SKOS_LITERAL_PREDICATES.update(
+        {
+            SKOS.definition: "skos:definition",
+            SKOS.notation: "skos:notation",
+            SKOS.scopeNote: "skos:scopeNote",
+            SKOS.example: "skos:example",
+            SKOS.historyNote: "skos:historyNote",
+            SKOS.editorialNote: "skos:editorialNote",
+            SKOS.changeNote: "skos:changeNote",
+        }
+    )
   return _SKOS_LITERAL_PREDICATES
+
 
 # SKOS reference predicates that map to annotations (IRI target stored as
 # string value).
 _SKOS_REF_ANNOTATION_PREDICATES: dict[URIRef, str] = {}
 
+
 def _skos_ref_ann_preds() -> dict[URIRef, str]:
   if not _SKOS_REF_ANNOTATION_PREDICATES:
-    _SKOS_REF_ANNOTATION_PREDICATES.update({
-        SKOS.inScheme: "skos:inScheme",
-        SKOS.topConceptOf: "skos:topConceptOf",
-    })
+    _SKOS_REF_ANNOTATION_PREDICATES.update(
+        {
+            SKOS.inScheme: "skos:inScheme",
+            SKOS.topConceptOf: "skos:topConceptOf",
+        }
+    )
   return _SKOS_REF_ANNOTATION_PREDICATES
+
 
 # SKOS graph-shaped predicates that produce abstract relationships.
 _SKOS_BROADER = SKOS.broader
@@ -688,15 +705,18 @@ _SKOS_RELATED = SKOS.related
 
 _SKOS_MATCH_PREDICATES: dict[URIRef, str] = {}
 
+
 def _skos_match_preds() -> dict[URIRef, str]:
   if not _SKOS_MATCH_PREDICATES:
-    _SKOS_MATCH_PREDICATES.update({
-        SKOS.exactMatch: "skos_exactMatch",
-        SKOS.closeMatch: "skos_closeMatch",
-        SKOS.broadMatch: "skos_broadMatch",
-        SKOS.narrowMatch: "skos_narrowMatch",
-        SKOS.relatedMatch: "skos_relatedMatch",
-    })
+    _SKOS_MATCH_PREDICATES.update(
+        {
+            SKOS.exactMatch: "skos_exactMatch",
+            SKOS.closeMatch: "skos_closeMatch",
+            SKOS.broadMatch: "skos_broadMatch",
+            SKOS.narrowMatch: "skos_narrowMatch",
+            SKOS.relatedMatch: "skos_relatedMatch",
+        }
+    )
   return _SKOS_MATCH_PREDICATES
 
 
@@ -719,9 +739,7 @@ def _extract_skos_annotations(
   for pred, ann_key in _skos_ref_ann_preds().items():
     values = []
     for obj in g.objects(iri, pred):
-      values.append(
-          _local_name(obj) if isinstance(obj, URIRef) else str(obj)
-      )
+      values.append(_local_name(obj) if isinstance(obj, URIRef) else str(obj))
     if values:
       values.sort()
       annotations[ann_key] = values if len(values) > 1 else values[0]
@@ -776,7 +794,9 @@ def _extract_skos_concepts(
     # present on a pure SKOS concept; skos:* labels go to synonyms or
     # language annotations per the label extractor.
     description, synonyms, lang_anns = _extract_labels_and_description(
-        g, concept, language,
+        g,
+        concept,
+        language,
     )
     drops.skos_labels_discarded_by_language += len(lang_anns)
 
@@ -821,19 +841,24 @@ def _extract_skos_relationships(
   # A sentinel IRI for SKOS-sourced relationships (they have no single
   # OWL IRI; we use the predicate IRI as a reasonable stand-in).
   def _add_rel(
-      rel_name: str, from_name: str, to_name: str, pred_iri: URIRef,
+      rel_name: str,
+      from_name: str,
+      to_name: str,
+      pred_iri: URIRef,
   ) -> None:
     key = (rel_name, from_name, to_name)
     if key in seen:
       return  # Deduplicate (e.g. broader + inverse narrower).
     seen.add(key)
-    skos_rels.append(_ImportedRelationship(
-        name=rel_name,
-        iri=pred_iri,
-        abstract=True,
-        from_entity=from_name,
-        to_entity=to_name,
-    ))
+    skos_rels.append(
+        _ImportedRelationship(
+            name=rel_name,
+            iri=pred_iri,
+            abstract=True,
+            from_entity=from_name,
+            to_entity=to_name,
+        )
+    )
     drops.skos_relationships_imported += 1
 
   # skos:broader — from child to parent.
@@ -868,7 +893,9 @@ def _extract_skos_relationships(
   # assignment (determinism).
   external_matches: dict[tuple[str, str], list[str]] = {}
   for pred, rel_name in _skos_match_preds().items():
-    ann_key = rel_name.replace("skos_", "skos:")  # skos_exactMatch → skos:exactMatch
+    ann_key = rel_name.replace(
+        "skos_", "skos:"
+    )  # skos_exactMatch → skos:exactMatch
     for subj, obj in g.subject_objects(pred):
       if not isinstance(subj, URIRef):
         continue
@@ -891,13 +918,9 @@ def _extract_skos_relationships(
       existing = entity.annotations[ann_key]
       existing_list = existing if isinstance(existing, list) else [existing]
       merged = sorted(set(existing_list) | set(values))
-      entity.annotations[ann_key] = (
-          merged if len(merged) > 1 else merged[0]
-      )
+      entity.annotations[ann_key] = merged if len(merged) > 1 else merged[0]
     else:
-      entity.annotations[ann_key] = (
-          values if len(values) > 1 else values[0]
-      )
+      entity.annotations[ann_key] = values if len(values) > 1 else values[0]
 
   return skos_rels
 
@@ -942,13 +965,9 @@ def _extract_generic_annotations(
         existing = elem.annotations[ann_key]
         existing_list = existing if isinstance(existing, list) else [existing]
         merged = sorted(set(existing_list) | set(values))
-        elem.annotations[ann_key] = (
-            merged if len(merged) > 1 else merged[0]
-        )
+        elem.annotations[ann_key] = merged if len(merged) > 1 else merged[0]
       else:
-        elem.annotations[ann_key] = (
-            values if len(values) > 1 else values[0]
-        )
+        elem.annotations[ann_key] = values if len(values) > 1 else values[0]
       drops.generic_annotations += len(values)
 
 
@@ -1167,23 +1186,34 @@ def _format_drop_summary(
     for kind, count in sorted(drops.dropped_features.items()):
       lines.append(f"  {kind}: {count}")
   if drops.skos_concepts_imported:
-    lines.append(f"SKOS concepts imported as abstract entities: "
-                 f"{drops.skos_concepts_imported}")
+    lines.append(
+        f"SKOS concepts imported as abstract entities: "
+        f"{drops.skos_concepts_imported}"
+    )
   if drops.skos_relationships_imported:
-    lines.append(f"SKOS relationships imported as abstract: "
-                 f"{drops.skos_relationships_imported}")
+    lines.append(
+        f"SKOS relationships imported as abstract: "
+        f"{drops.skos_relationships_imported}"
+    )
   if drops.skos_annotations:
-    lines.append(f"SKOS predicates mapped to annotations: "
-                 f"{drops.skos_annotations}")
+    lines.append(
+        f"SKOS predicates mapped to annotations: " f"{drops.skos_annotations}"
+    )
   if drops.skos_labels_discarded_by_language:
-    lines.append(f"Labels in non-selected languages (preserved as "
-                 f"annotations): {drops.skos_labels_discarded_by_language}")
+    lines.append(
+        f"Labels in non-selected languages (preserved as "
+        f"annotations): {drops.skos_labels_discarded_by_language}"
+    )
   if drops.skos_external_matches:
-    lines.append(f"SKOS match targets outside imported namespaces "
-                 f"(preserved as annotations): {drops.skos_external_matches}")
+    lines.append(
+        f"SKOS match targets outside imported namespaces "
+        f"(preserved as annotations): {drops.skos_external_matches}"
+    )
   if drops.generic_annotations:
-    lines.append(f"Generic literal annotations preserved: "
-                 f"{drops.generic_annotations}")
+    lines.append(
+        f"Generic literal annotations preserved: "
+        f"{drops.generic_annotations}"
+    )
   # Hint for all-abstract ontologies.
   if entities and all(e.abstract for e in entities.values()):
     lines.append(
@@ -1256,7 +1286,11 @@ def import_owl(
   # and OWL relationships so that endpoints referring to SKOS-only
   # concepts resolve to the correct ``skos_<name>`` entity name.
   concept_iri_to_name = _extract_skos_concepts(
-      g, entities, include_namespaces, drops, language,
+      g,
+      entities,
+      include_namespaces,
+      drops,
+      language,
   )
 
   # Build a full IRI→entity-name map (OWL + SKOS) for endpoint resolution.
@@ -1268,16 +1302,28 @@ def import_owl(
   # Stage 3: OWL datatype properties and object properties, with SKOS
   # concepts already visible to endpoint resolution.
   _extract_datatype_properties(
-      g, entities, include_namespaces, drops, iri_to_name=iri_to_name,
+      g,
+      entities,
+      include_namespaces,
+      drops,
+      iri_to_name=iri_to_name,
   )
   owl_relationships = _extract_relationships(
-      g, entities, include_namespaces, drops, language,
+      g,
+      entities,
+      include_namespaces,
+      drops,
+      language,
       iri_to_name=iri_to_name,
   )
 
   # Stage 4: SKOS graph-shaped predicates → abstract relationships.
   skos_rels = _extract_skos_relationships(
-      g, entities, iri_to_name, include_namespaces, drops,
+      g,
+      entities,
+      iri_to_name,
+      include_namespaces,
+      drops,
   )
 
   # Stage 3: Generic literal-annotation pass (covers Dublin Core, etc.).
@@ -1291,9 +1337,9 @@ def import_owl(
   _resolve_keys(entities)
 
   # Merge OWL and SKOS relationships into a single list.
-  all_relationships: list[_ImportedRelationship] = list(
-      owl_relationships.values()
-  ) + skos_rels
+  all_relationships: list[_ImportedRelationship] = (
+      list(owl_relationships.values()) + skos_rels
+  )
 
   # Name collision checks.
   owl_rel_names = set(owl_relationships)

--- a/src/bigquery_ontology/owl_importer.py
+++ b/src/bigquery_ontology/owl_importer.py
@@ -107,6 +107,21 @@ def _in_namespace(iri: URIRef, namespaces: list[str]) -> bool:
   return any(s.startswith(ns) for ns in namespaces)
 
 
+def _qname_or_iri(g: "Graph", iri: URIRef) -> str:
+  """Return ``prefix:local`` for a predicate whose namespace has a
+  bound prefix; otherwise return the full IRI.
+
+  Bare local names collide across vocabularies (``dc:title`` and
+  ``dcterms:title`` both have local ``title``), so the annotation key
+  must retain enough of the IRI to disambiguate.
+  """
+  try:
+    prefix, _, local = g.namespace_manager.compute_qname(iri, generate=False)
+    return f"{prefix}:{local}"
+  except (KeyError, ValueError):
+    return str(iri)
+
+
 # ---------------------------------------------------------------------------
 # Intermediate dataclasses
 # ---------------------------------------------------------------------------
@@ -178,21 +193,47 @@ class _DropSummary:
 # ---------------------------------------------------------------------------
 
 
+def _count_lang_labels(lang_anns: dict[str, AnnotationValue]) -> int:
+  """Total number of label values (across keys and list entries)."""
+  total = 0
+  for v in lang_anns.values():
+    total += len(v) if isinstance(v, list) else 1
+  return total
+
+
+def _collapse_lang_anns(
+    lang_anns: dict[str, list[str]],
+) -> dict[str, AnnotationValue]:
+  """Collapse a multi-valued language-annotation map to annotation form.
+
+  Values are sorted and deduplicated; a single value becomes a scalar,
+  multiple values become a sorted list. Non-selected-language labels
+  can legitimately repeat per ``(predicate, language)`` (e.g. two French
+  ``skos:altLabel``s), so the intermediate representation is list-valued
+  to prevent silent overwrites.
+  """
+  out: dict[str, AnnotationValue] = {}
+  for key, vals in lang_anns.items():
+    uniq = sorted(set(vals))
+    out[key] = uniq[0] if len(uniq) == 1 else uniq
+  return out
+
+
 def _pick_primary_label(
     labels,
     language: str = "en",
-) -> tuple[str | None, list[str], dict[str, str]]:
+) -> tuple[str | None, list[str], dict[str, list[str]]]:
   """Pick the best label as description, return rest as synonyms.
 
   Prefers labels matching ``language``, then falls back to untagged or
   other languages. Within the preferred group, picks alphabetically
   first for determinism. Returns ``(primary, synonyms, lang_annotations)``
-  where ``lang_annotations`` maps ``predicate@lang`` keys to values for
-  labels in non-selected languages.
+  where ``lang_annotations`` maps ``@lang`` keys to the list of label
+  values seen in that non-selected language.
   """
   selected: list[str] = []
   untagged: list[str] = []
-  other_lang: dict[str, str] = {}
+  other_lang: dict[str, list[str]] = {}
   for label in labels:
     lang = getattr(label, "language", None)
     if lang is not None and lang.startswith(language):
@@ -200,7 +241,7 @@ def _pick_primary_label(
     elif lang is None or lang == "":
       untagged.append(str(label))
     else:
-      other_lang[f"@{lang}"] = str(label)
+      other_lang.setdefault(f"@{lang}", []).append(str(label))
 
   selected.sort()
   untagged.sort()
@@ -215,17 +256,18 @@ def _extract_labels_and_description(
     g: Graph,
     iri: URIRef,
     language: str = "en",
-) -> tuple[str | None, list[str], dict[str, str]]:
+) -> tuple[str | None, list[str], dict[str, AnnotationValue]]:
   """Extract rdfs:label → description, SKOS labels → synonyms.
 
   Returns ``(description, synonyms, lang_annotations)`` where
-  ``lang_annotations`` maps keys like ``rdfs:label@fr`` to values for
-  labels in non-selected languages.
+  ``lang_annotations`` maps keys like ``rdfs:label@fr`` to a scalar
+  value (single label) or a sorted list (multiple labels in the same
+  predicate+language combination).
   """
   raw_labels = list(g.objects(iri, RDFS.label))
   description, synonyms, lang_anns = _pick_primary_label(raw_labels, language)
-  label_lang_anns: dict[str, str] = {
-      f"rdfs:label{k}": v for k, v in lang_anns.items()
+  label_lang_anns: dict[str, list[str]] = {
+      f"rdfs:label{k}": list(v) for k, v in lang_anns.items()
   }
 
   comments: list[str] = []
@@ -240,29 +282,35 @@ def _extract_labels_and_description(
   for alt in g.objects(iri, SKOS.altLabel):
     lang = getattr(alt, "language", None)
     if lang is not None and not lang.startswith(language) and lang != "":
-      label_lang_anns[f"skos:altLabel@{lang}"] = str(alt)
+      label_lang_anns.setdefault(f"skos:altLabel@{lang}", []).append(str(alt))
     else:
       synonyms.append(str(alt))
   for pref in g.objects(iri, SKOS.prefLabel):
     lang = getattr(pref, "language", None)
     val = str(pref)
     if lang is not None and not lang.startswith(language) and lang != "":
-      label_lang_anns[f"skos:prefLabel@{lang}"] = val
+      label_lang_anns.setdefault(f"skos:prefLabel@{lang}", []).append(val)
     elif val not in synonyms and val != description:
       synonyms.append(val)
   for hidden in g.objects(iri, SKOS.hiddenLabel):
     lang = getattr(hidden, "language", None)
     if lang is not None and not lang.startswith(language) and lang != "":
-      label_lang_anns[f"skos:hiddenLabel@{lang}"] = str(hidden)
+      label_lang_anns.setdefault(f"skos:hiddenLabel@{lang}", []).append(
+          str(hidden)
+      )
     else:
       synonyms.append(str(hidden))
 
   synonyms.sort()
-  return description, synonyms, label_lang_anns
+  return description, synonyms, _collapse_lang_anns(label_lang_anns)
 
 
 def _extract_parents(
-    g: Graph, iri: URIRef, predicate: URIRef, namespaces: list[str]
+    g: Graph,
+    iri: URIRef,
+    predicate: URIRef,
+    namespaces: list[str],
+    iri_to_name: dict[str, str] | None = None,
 ) -> tuple[str | None, bool, list[str], dict[str, AnnotationValue]]:
   parents: list[str] = []
   excluded: list[str] = []
@@ -274,7 +322,13 @@ def _extract_parents(
     if parent == OWL.Thing or parent == RDFS.Resource:
       continue
     if _in_namespace(parent, namespaces):
-      parents.append(_local_name(parent))
+      # Resolve through iri_to_name so cross-kind parents (e.g. an
+      # owl:Class whose subClassOf target is a pure SKOS concept
+      # renamed to ``skos_<name>``) emit the correct name.
+      if iri_to_name is not None and str(parent) in iri_to_name:
+        parents.append(iri_to_name[str(parent)])
+      else:
+        parents.append(_local_name(parent))
     else:
       excluded.append(str(parent))
 
@@ -382,11 +436,36 @@ def _collect_drop_annotations(
       )
 
 
+def _precompute_iri_to_name(g: Graph, namespaces: list[str]) -> dict[str, str]:
+  """Build an IRI→future-entity-name map for every in-namespace OWL class
+  and SKOS concept.
+
+  Pre-computed *before* extraction so passes that resolve references
+  (rdfs:subClassOf, rdfs:subPropertyOf, rdfs:domain, rdfs:range) can
+  emit the same name the concept will ultimately carry — including the
+  ``skos_`` prefix applied to SKOS-only concepts. Without this, an OWL
+  class that extends a pure SKOS concept would emit ``extends:
+  Category`` while the concept itself is imported as ``skos_Category``.
+  """
+  mapping: dict[str, str] = {}
+  for cls in g.subjects(RDF.type, OWL.Class):
+    if isinstance(cls, URIRef) and _in_namespace(cls, namespaces):
+      mapping[str(cls)] = _local_name(cls)
+  for concept in g.subjects(RDF.type, SKOS.Concept):
+    if isinstance(concept, URIRef) and _in_namespace(concept, namespaces):
+      iri_str = str(concept)
+      if iri_str in mapping:
+        continue
+      mapping[iri_str] = f"skos_{_local_name(concept)}"
+  return mapping
+
+
 def _extract_entities(
     g: Graph,
     namespaces: list[str],
     drops: _DropSummary,
     language: str = "en",
+    iri_to_name: dict[str, str] | None = None,
 ) -> dict[str, _ImportedEntity]:
   entities: dict[str, _ImportedEntity] = {}
 
@@ -412,9 +491,11 @@ def _extract_entities(
         cls,
         language,
     )
-    drops.skos_labels_discarded_by_language += len(lang_anns)
+    drops.skos_labels_discarded_by_language += _count_lang_labels(lang_anns)
     extends, extends_fill_in, extends_candidates, parent_anns = (
-        _extract_parents(g, cls, RDFS.subClassOf, namespaces)
+        _extract_parents(
+            g, cls, RDFS.subClassOf, namespaces, iri_to_name=iri_to_name
+        )
     )
     keys_primary, keys_fill_in, key_candidates, keys_excluded = _extract_keys(
         g, cls, namespaces
@@ -549,7 +630,7 @@ def _extract_relationships(
         prop,
         language,
     )
-    drops.skos_labels_discarded_by_language += len(lang_anns)
+    drops.skos_labels_discarded_by_language += _count_lang_labels(lang_anns)
 
     domains: list[str] = []
     domain_excluded: list[str] = []
@@ -613,7 +694,9 @@ def _extract_relationships(
     _collect_drop_annotations(g, prop, annotations, comments, drops)
 
     extends, extends_fill_in, extends_candidates, parent_anns = (
-        _extract_parents(g, prop, RDFS.subPropertyOf, namespaces)
+        _extract_parents(
+            g, prop, RDFS.subPropertyOf, namespaces, iri_to_name=iri_to_name
+        )
     )
     annotations.update(parent_anns)
 
@@ -739,7 +822,11 @@ def _extract_skos_annotations(
   for pred, ann_key in _skos_ref_ann_preds().items():
     values = []
     for obj in g.objects(iri, pred):
-      values.append(_local_name(obj) if isinstance(obj, URIRef) else str(obj))
+      # Preserve the full IRI — collapsing to local name loses identity
+      # when two schemes share a local name (e.g. ``ns1/Scheme`` vs.
+      # ``ns2/Scheme``) and defeats downstream consumers that look up
+      # scheme membership by IRI.
+      values.append(str(obj))
     if values:
       values.sort()
       annotations[ann_key] = values if len(values) > 1 else values[0]
@@ -798,7 +885,7 @@ def _extract_skos_concepts(
         concept,
         language,
     )
-    drops.skos_labels_discarded_by_language += len(lang_anns)
+    drops.skos_labels_discarded_by_language += _count_lang_labels(lang_anns)
 
     annotations: dict[str, AnnotationValue] = {}
     annotations.update(lang_anns)
@@ -956,7 +1043,11 @@ def _extract_generic_annotations(
       pred_str = str(pred)
       if any(pred_str.startswith(pfx) for pfx in _HANDLED_PREFIXES):
         continue
-      ann_key = _local_name(pred)
+      # Build a ``prefix:local`` key so callers can disambiguate
+      # vocabularies with colliding local names (e.g. ``dc:title`` vs.
+      # ``dcterms:title``). Fall back to the full IRI when no prefix is
+      # bound for the predicate's namespace.
+      ann_key = _qname_or_iri(g, pred)
       collected.setdefault(ann_key, []).append(str(obj))
 
     for ann_key, values in collected.items():
@@ -1279,12 +1370,20 @@ def import_owl(
 
   drops = _DropSummary()
 
-  # Stage 1: OWL entity extraction.
-  entities = _extract_entities(g, include_namespaces, drops, language)
+  # Pre-compute IRI→future-entity-name for every in-namespace OWL class
+  # and SKOS concept. Passes that resolve references (subClassOf,
+  # subPropertyOf, domain, range) use this to emit the correct name
+  # even when the target is a SKOS-only concept that will be renamed
+  # to ``skos_<name>``.
+  iri_to_name: dict[str, str] = _precompute_iri_to_name(g, include_namespaces)
 
-  # Stage 2: SKOS concept extraction — runs BEFORE datatype properties
-  # and OWL relationships so that endpoints referring to SKOS-only
-  # concepts resolve to the correct ``skos_<name>`` entity name.
+  # Stage 1: OWL entity extraction (extends is resolved through iri_to_name).
+  entities = _extract_entities(
+      g, include_namespaces, drops, language, iri_to_name=iri_to_name
+  )
+
+  # Stage 2: SKOS concept extraction — adds abstract entities for
+  # SKOS-only concepts and enriches existing OWL+SKOS entities.
   concept_iri_to_name = _extract_skos_concepts(
       g,
       entities,
@@ -1293,11 +1392,11 @@ def import_owl(
       language,
   )
 
-  # Build a full IRI→entity-name map (OWL + SKOS) for endpoint resolution.
-  iri_to_name: dict[str, str] = dict(concept_iri_to_name)
-  for entity in entities.values():
-    iri_str = str(entity.iri)
-    iri_to_name.setdefault(iri_str, entity.name)
+  # Reconcile: SKOS concepts may have been promoted to abstract entities
+  # under ``skos_<name>``. Fold their IRIs into iri_to_name so the later
+  # passes use the same names.
+  for iri_str, name in concept_iri_to_name.items():
+    iri_to_name[iri_str] = name
 
   # Stage 3: OWL datatype properties and object properties, with SKOS
   # concepts already visible to endpoint resolution.
@@ -1335,6 +1434,21 @@ def import_owl(
 
   # Finalize keys (skip abstract entities).
   _resolve_keys(entities)
+
+  # Propagate abstractness: a concrete relationship with an abstract
+  # endpoint cannot round-trip through the loader (concrete relationships
+  # require concrete endpoints). Mark such relationships abstract so the
+  # emitted ontology is loadable. This primarily catches OWL
+  # ObjectProperties whose rdfs:range is a pure SKOS concept.
+  for rel in owl_relationships.values():
+    if rel.abstract:
+      continue
+    from_abstract = (
+        rel.from_entity in entities and entities[rel.from_entity].abstract
+    )
+    to_abstract = rel.to_entity in entities and entities[rel.to_entity].abstract
+    if from_abstract or to_abstract:
+      rel.abstract = True
 
   # Merge OWL and SKOS relationships into a single list.
   all_relationships: list[_ImportedRelationship] = (

--- a/src/bigquery_ontology/scaffold.py
+++ b/src/bigquery_ontology/scaffold.py
@@ -516,8 +516,14 @@ def scaffold(
   ddl_text = "\n".join(ddl_parts)
 
   binding_text = _emit_binding_yaml(
-      ontology.ontology, concrete_entities, concrete_rels,
-      entity_tables, rel_tables, dataset, project, naming,
+      ontology.ontology,
+      concrete_entities,
+      concrete_rels,
+      entity_tables,
+      rel_tables,
+      dataset,
+      project,
+      naming,
   )
 
   return ddl_text, binding_text

--- a/src/bigquery_ontology/scaffold.py
+++ b/src/bigquery_ontology/scaffold.py
@@ -89,21 +89,6 @@ _ONTOLOGY_TO_BQ_TYPE: dict[PropertyType, str] = {
 # ---------------------------------------------------------------------------
 
 
-def _reject_extends(ontology: Ontology) -> None:
-  for entity in ontology.entities:
-    if entity.extends is not None:
-      raise ValueError(
-          f"Entity {entity.name!r} uses 'extends'; v0 scaffold "
-          "does not support inheritance."
-      )
-  for rel in ontology.relationships:
-    if rel.extends is not None:
-      raise ValueError(
-          f"Relationship {rel.name!r} uses 'extends'; v0 scaffold "
-          "does not support inheritance."
-      )
-
-
 def _reject_derived_keys(
     keys: Keys,
     prop_map: dict[str, object],
@@ -425,7 +410,9 @@ def _emit_rel_ddl(table: _ScaffoldRelTable) -> str:
 
 
 def _emit_binding_yaml(
-    ontology: Ontology,
+    ontology_name: str,
+    entities: list[Entity],
+    relationships: list[Relationship],
     entity_tables: list[_ScaffoldEntityTable],
     rel_tables: list[_ScaffoldRelTable],
     dataset: str,
@@ -438,7 +425,7 @@ def _emit_binding_yaml(
       "This file is user-owned \u2014 edit freely."
   )
   lines.append(f"binding: {dataset}")
-  lines.append(f"ontology: {ontology.ontology}")
+  lines.append(f"ontology: {ontology_name}")
   lines.append("target:")
   lines.append("  backend: bigquery")
   lines.append(f"  project: {project}")
@@ -446,7 +433,7 @@ def _emit_binding_yaml(
 
   if entity_tables:
     lines.append("entities:")
-    for entity, et in zip(ontology.entities, entity_tables):
+    for entity, et in zip(entities, entity_tables):
       lines.append(f"  - name: {entity.name}")
       lines.append(f"    source: {et.table_name}")
       non_derived = [p for p in entity.properties if p.expr is None]
@@ -458,7 +445,7 @@ def _emit_binding_yaml(
 
   if rel_tables:
     lines.append("relationships:")
-    for rel, rt in zip(ontology.relationships, rel_tables):
+    for rel, rt in zip(relationships, rel_tables):
       from_fk, to_fk = rt.foreign_keys
       lines.append(f"  - name: {rel.name}")
       lines.append(f"    source: {rt.table_name}")
@@ -492,17 +479,33 @@ def scaffold(
       ValueError: If the ontology uses ``extends`` or an endpoint-column
           name collision is detected on a relationship.
   """
-  _reject_extends(ontology)
+  # Abstract elements are informational only and have no physical
+  # backing — skip them in scaffold output.
+  concrete_entities = [e for e in ontology.entities if not e.abstract]
+  concrete_rels = [r for r in ontology.relationships if not r.abstract]
 
-  entity_map = {e.name: e for e in ontology.entities}
+  for entity in concrete_entities:
+    if entity.extends is not None:
+      raise ValueError(
+          f"Entity {entity.name!r} uses 'extends'; v0 scaffold "
+          "does not support inheritance."
+      )
+  for rel in concrete_rels:
+    if rel.extends is not None:
+      raise ValueError(
+          f"Relationship {rel.name!r} uses 'extends'; v0 scaffold "
+          "does not support inheritance."
+      )
+
+  entity_map = {e.name: e for e in concrete_entities}
 
   entity_tables = [
       _resolve_entity_table(e, dataset, project, naming)
-      for e in ontology.entities
+      for e in concrete_entities
   ]
   rel_tables = [
       _resolve_rel_table(r, entity_map, dataset, project, naming)
-      for r in ontology.relationships
+      for r in concrete_rels
   ]
 
   ddl_parts: list[str] = []
@@ -513,7 +516,8 @@ def scaffold(
   ddl_text = "\n".join(ddl_parts)
 
   binding_text = _emit_binding_yaml(
-      ontology, entity_tables, rel_tables, dataset, project, naming
+      ontology.ontology, concrete_entities, concrete_rels,
+      entity_tables, rel_tables, dataset, project, naming,
   )
 
   return ddl_text, binding_text

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -761,7 +761,8 @@ class TestPureSkosImport:
     broader = [r for r in rels if r["name"] == "skos_broader"]
     # InvestmentBanking broader WealthManagement (via narrower inverse)
     inv_wm = [
-        r for r in broader
+        r
+        for r in broader
         if r["from"] == "skos_InvestmentBanking"
         and r["to"] == "skos_WealthManagement"
     ]
@@ -821,7 +822,8 @@ class TestMixedOwlSkos:
     data = yaml.safe_load(yaml_text)
     rels = data["relationships"]
     broader = [
-        r for r in rels
+        r
+        for r in rels
         if r["name"] == "skos_broader"
         and r["from"] == "Account"
         and r["to"] == "skos_FinancialProduct"
@@ -848,7 +850,8 @@ class TestMixedOwlSkos:
     data = yaml.safe_load(yaml_text)
     rels = data["relationships"]
     related = [
-        r for r in rels
+        r
+        for r in rels
         if r["name"] == "skos_related"
         and r["from"] == "Account"
         and r["to"] == "Ledger"
@@ -887,7 +890,9 @@ class TestAbstractOntologyValidation:
 
   def test_abstract_entity_no_keys_passes(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_abstract
       entities:
         - name: ConcreteEntity
@@ -896,13 +901,16 @@ class TestAbstractOntologyValidation:
             - {name: id, type: string}
         - name: skos_AbstractEntity
           abstract: true
-    """)
+    """
+    )
     ont = load_ontology_from_string(yaml_str)
     assert ont.entities[1].abstract is True
 
   def test_abstract_rel_duplicate_names_different_endpoints(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_abstract_rels
       entities:
         - name: A
@@ -926,13 +934,16 @@ class TestAbstractOntologyValidation:
           abstract: true
           from: A
           to: C
-    """)
+    """
+    )
     ont = load_ontology_from_string(yaml_str)
     assert len(ont.relationships) == 2
 
   def test_abstract_rel_duplicate_name_same_endpoints_fails(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_dup
       entities:
         - name: A
@@ -952,7 +963,8 @@ class TestAbstractOntologyValidation:
           abstract: true
           from: A
           to: B
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="Duplicate abstract relationship"):
       load_ontology_from_string(yaml_str)
 
@@ -960,7 +972,9 @@ class TestAbstractOntologyValidation:
     """A concrete relationship cannot have an abstract endpoint —
     there is nothing to bind."""
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_concrete_abstract_endpoint
       entities:
         - name: Concrete
@@ -973,14 +987,17 @@ class TestAbstractOntologyValidation:
         - name: pointsAt
           from: Concrete
           to: skos_AbstractTarget
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="abstract endpoint"):
       load_ontology_from_string(yaml_str)
 
   def test_abstract_relationship_abstract_endpoint_allowed(self):
     """An abstract relationship may have abstract endpoints."""
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_abstract_abstract_endpoint
       entities:
         - name: Concrete
@@ -996,14 +1013,17 @@ class TestAbstractOntologyValidation:
           abstract: true
           from: skos_AbstractSource
           to: skos_AbstractTarget
-    """)
+    """
+    )
     ont = load_ontology_from_string(yaml_str)
     assert len(ont.relationships) == 1
 
   def test_abstract_relationship_endpoint_must_exist(self):
     """Endpoint existence is still enforced on abstract relationships."""
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_missing_endpoint
       entities:
         - name: A
@@ -1015,13 +1035,16 @@ class TestAbstractOntologyValidation:
           abstract: true
           from: A
           to: DoesNotExist
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="DoesNotExist"):
       load_ontology_from_string(yaml_str)
 
   def test_concrete_abstract_name_collision_fails(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test_collision
       entities:
         - name: A
@@ -1040,7 +1063,8 @@ class TestAbstractOntologyValidation:
           abstract: true
           from: A
           to: B
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="concrete and an abstract"):
       load_ontology_from_string(yaml_str)
 
@@ -1051,7 +1075,10 @@ class TestAbstractBindingRejection:
   def test_binding_abstract_entity_fails(self):
     from bigquery_ontology import load_ontology_from_string
     from bigquery_ontology.binding_loader import load_binding_from_string
-    ont = load_ontology_from_string(textwrap.dedent("""\
+
+    ont = load_ontology_from_string(
+        textwrap.dedent(
+            """\
       ontology: test
       entities:
         - name: Concrete
@@ -1060,8 +1087,11 @@ class TestAbstractBindingRejection:
             - {name: id, type: string}
         - name: Abstract
           abstract: true
-    """))
-    binding_yaml = textwrap.dedent("""\
+    """
+        )
+    )
+    binding_yaml = textwrap.dedent(
+        """\
       binding: test_bind
       ontology: test
       target:
@@ -1073,14 +1103,18 @@ class TestAbstractBindingRejection:
           source: tbl
           properties:
             - {name: id, column: id}
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="abstract entity"):
       load_binding_from_string(binding_yaml, ontology=ont)
 
   def test_binding_abstract_relationship_fails(self):
     from bigquery_ontology import load_ontology_from_string
     from bigquery_ontology.binding_loader import load_binding_from_string
-    ont = load_ontology_from_string(textwrap.dedent("""\
+
+    ont = load_ontology_from_string(
+        textwrap.dedent(
+            """\
       ontology: test
       entities:
         - name: A
@@ -1096,8 +1130,11 @@ class TestAbstractBindingRejection:
           abstract: true
           from: A
           to: B
-    """))
-    binding_yaml = textwrap.dedent("""\
+    """
+        )
+    )
+    binding_yaml = textwrap.dedent(
+        """\
       binding: test_bind
       ontology: test
       target:
@@ -1118,7 +1155,8 @@ class TestAbstractBindingRejection:
           source: tbl_rel
           from_columns: [a_id]
           to_columns: [b_id]
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="abstract relationship"):
       load_binding_from_string(binding_yaml, ontology=ont)
 
@@ -1129,7 +1167,10 @@ class TestAbstractScaffold:
   def test_scaffold_skips_abstract(self):
     from bigquery_ontology import load_ontology_from_string
     from bigquery_ontology.scaffold import scaffold
-    ont = load_ontology_from_string(textwrap.dedent("""\
+
+    ont = load_ontology_from_string(
+        textwrap.dedent(
+            """\
       ontology: test
       entities:
         - name: Concrete
@@ -1143,7 +1184,9 @@ class TestAbstractScaffold:
           abstract: true
           from: Concrete
           to: skos_Abstract
-    """))
+    """
+        )
+    )
     ddl, binding_yaml = scaffold(ont, dataset="ds", project="proj")
     assert "concrete" in ddl
     assert "skos_abstract" not in ddl
@@ -1158,7 +1201,9 @@ class TestOwlRefToSkosConcept:
 
   def test_owl_objectproperty_range_on_skos_concept(self, tmp_path):
     ttl = tmp_path / "ref.ttl"
-    ttl.write_text(textwrap.dedent("""\
+    ttl.write_text(
+        textwrap.dedent(
+            """\
       @prefix : <http://example.com/test#> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -1173,7 +1218,9 @@ class TestOwlRefToSkosConcept:
       :account_id a owl:DatatypeProperty ;
           rdfs:domain :Account ;
           rdfs:range xsd:string .
-    """))
+    """
+        )
+    )
     yaml_text, _ = import_owl(
         [ttl],
         include_namespaces=["http://example.com/test#"],
@@ -1181,11 +1228,16 @@ class TestOwlRefToSkosConcept:
     # When added, an OWL ObjectProperty pointing at :Category should
     # emit ``to: skos_Category``, not ``to: Category``.
     # Add a probe ObjectProperty and reparse.
-    ttl.write_text(ttl.read_text() + textwrap.dedent("""
+    ttl.write_text(
+        ttl.read_text()
+        + textwrap.dedent(
+            """
       :belongsTo a owl:ObjectProperty ;
           rdfs:domain :Account ;
           rdfs:range :Category .
-    """))
+    """
+        )
+    )
     yaml_text, _ = import_owl(
         [ttl],
         include_namespaces=["http://example.com/test#"],
@@ -1201,7 +1253,9 @@ class TestAbstractKeyShapeValidation:
 
   def test_abstract_entity_key_column_must_exist(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test
       entities:
         - name: Real
@@ -1212,13 +1266,16 @@ class TestAbstractKeyShapeValidation:
           abstract: true
           keys:
             primary: [nonexistent]
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="nonexistent"):
       load_ontology_from_string(yaml_str)
 
   def test_abstract_entity_forbids_additional_keys(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test
       entities:
         - name: Real
@@ -1232,13 +1289,16 @@ class TestAbstractKeyShapeValidation:
           keys:
             primary: [x]
             additional: [x]
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="additional is not allowed"):
       load_ontology_from_string(yaml_str)
 
   def test_abstract_relationship_cannot_use_extends(self):
     from bigquery_ontology import load_ontology_from_string
-    yaml_str = textwrap.dedent("""\
+
+    yaml_str = textwrap.dedent(
+        """\
       ontology: test
       entities:
         - name: A
@@ -1258,7 +1318,8 @@ class TestAbstractKeyShapeValidation:
           extends: parentRel
           from: A
           to: B
-    """)
+    """
+    )
     with pytest.raises(ValueError, match="abstract.*must not use 'extends'"):
       load_ontology_from_string(yaml_str)
 
@@ -1268,6 +1329,7 @@ class TestRoundTrip:
 
   def test_pure_skos_roundtrip(self):
     from bigquery_ontology import load_ontology_from_string
+
     yaml_text, _ = import_owl(
         [_SKOS_TTL],
         include_namespaces=["http://example.com/taxonomy#"],
@@ -1278,6 +1340,7 @@ class TestRoundTrip:
 
   def test_mixed_owl_skos_roundtrip(self):
     from bigquery_ontology import load_ontology_from_string
+
     yaml_text, _ = import_owl(
         [_MIXED_TTL],
         include_namespaces=["http://example.com/finance#"],

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -1245,6 +1245,52 @@ class TestOwlRefToSkosConcept:
     data = yaml.safe_load(yaml_text)
     rel = next(r for r in data["relationships"] if r["name"] == "belongsTo")
     assert rel["to"] == "skos_Category"
+    # Endpoint is abstract → relationship must be marked abstract too,
+    # or the loader rejects the ontology.
+    assert rel.get("abstract") is True
+
+    # Verify the emitted YAML actually round-trips through the loader.
+    from bigquery_ontology import load_ontology_from_string
+
+    load_ontology_from_string(yaml_text)
+
+  def test_owl_subclassof_skos_concept_extends_resolves(self, tmp_path):
+    """An OWL class whose rdfs:subClassOf target is a pure SKOS concept
+    must emit ``extends: skos_<name>`` so the YAML loads."""
+    ttl = tmp_path / "subclass.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/test#> .
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+      :Category a skos:Concept ;
+          skos:prefLabel "Category"@en .
+
+      :Account a owl:Class ;
+          rdfs:subClassOf :Category ;
+          owl:hasKey ( :account_id ) .
+      :account_id a owl:DatatypeProperty ;
+          rdfs:domain :Account ;
+          rdfs:range xsd:string .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    account = next(e for e in data["entities"] if e["name"] == "Account")
+    assert account["extends"] == "skos_Category"
+
+    # Round-trip through loader — proves the extends target resolves.
+    from bigquery_ontology import load_ontology_from_string
+
+    load_ontology_from_string(yaml_text)
 
 
 class TestAbstractKeyShapeValidation:
@@ -1350,3 +1396,170 @@ class TestRoundTrip:
     abstract_entities = [e for e in ont.entities if e.abstract]
     assert len(concrete_entities) >= 2  # Account, Ledger
     assert len(abstract_entities) >= 1  # skos_FinancialProduct
+
+  def test_concrete_entity_no_abstract_key_emitted(self, tmp_path):
+    """Concrete entities must not emit ``abstract: false`` (default is
+    False; emitting the default bloats every real-world ontology file)."""
+    ttl = tmp_path / "simple.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/t#> .
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+      :A a owl:Class ; owl:hasKey ( :a_id ) .
+      :a_id a owl:DatatypeProperty ;
+          rdfs:domain :A ; rdfs:range xsd:string .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl], include_namespaces=["http://example.com/t#"]
+    )
+    assert "abstract: false" not in yaml_text
+
+  def test_omitted_abstract_key_loads_as_false(self):
+    """YAML that omits ``abstract`` must parse back to ``abstract=False``,
+    so the emitter's suppression of the default is safe."""
+    from bigquery_ontology import load_ontology_from_string
+
+    ont = load_ontology_from_string(
+        textwrap.dedent(
+            """\
+      ontology: t
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: rel
+          from: A
+          to: A
+    """
+        )
+    )
+    assert ont.entities[0].abstract is False
+    assert ont.relationships[0].abstract is False
+
+
+class TestSkosSchemeAnnotationPreservation:
+  """``skos:inScheme`` / ``skos:topConceptOf`` must preserve full IRIs."""
+
+  def test_in_scheme_preserves_full_iri(self, tmp_path):
+    ttl = tmp_path / "schemes.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/tax#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+      :c1 a skos:Concept ;
+          skos:inScheme <http://ns1.example/Scheme> ,
+                        <http://ns2.example/Scheme> ;
+          skos:prefLabel "C1"@en .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl], include_namespaces=["http://example.com/tax#"]
+    )
+    data = yaml.safe_load(yaml_text)
+    concept = next(e for e in data["entities"] if e["name"] == "skos_c1")
+    schemes = concept["annotations"]["skos:inScheme"]
+    # Both full IRIs preserved, not collapsed to the shared local name.
+    assert "http://ns1.example/Scheme" in schemes
+    assert "http://ns2.example/Scheme" in schemes
+
+  def test_top_concept_of_preserves_full_iri(self, tmp_path):
+    ttl = tmp_path / "top.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/tax#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+      :c1 a skos:Concept ;
+          skos:topConceptOf <http://ns1.example/Scheme> ;
+          skos:prefLabel "C1"@en .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl], include_namespaces=["http://example.com/tax#"]
+    )
+    data = yaml.safe_load(yaml_text)
+    concept = next(e for e in data["entities"] if e["name"] == "skos_c1")
+    assert (
+        concept["annotations"]["skos:topConceptOf"]
+        == "http://ns1.example/Scheme"
+    )
+
+
+class TestMultiLabelNonSelectedLanguage:
+  """Multiple labels in the same non-selected (predicate, language)
+  must be preserved — not silently overwritten."""
+
+  def test_two_french_alt_labels_both_preserved(self, tmp_path):
+    ttl = tmp_path / "multi.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/tax#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+      :c1 a skos:Concept ;
+          skos:prefLabel "C1"@en ;
+          skos:altLabel "alpha-fr"@fr , "beta-fr"@fr ;
+          skos:hiddenLabel "hidden-fr"@fr .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl], include_namespaces=["http://example.com/tax#"]
+    )
+    data = yaml.safe_load(yaml_text)
+    anns = next(e for e in data["entities"] if e["name"] == "skos_c1")[
+        "annotations"
+    ]
+    # Both French altLabels survive as a list, not collapsed to one.
+    assert sorted(anns["skos:altLabel@fr"]) == ["alpha-fr", "beta-fr"]
+    assert anns["skos:hiddenLabel@fr"] == "hidden-fr"
+
+
+class TestGenericAnnotationNamespacePrefix:
+  """Generic literal-annotation keys must retain their namespace prefix
+  so vocabularies with colliding local names don't merge."""
+
+  def test_dc_and_dcterms_title_do_not_collide(self, tmp_path):
+    ttl = tmp_path / "dc.ttl"
+    ttl.write_text(
+        textwrap.dedent(
+            """\
+      @prefix : <http://example.com/t#> .
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      @prefix dc: <http://purl.org/dc/elements/1.1/> .
+      @prefix dcterms: <http://purl.org/dc/terms/> .
+
+      :A a owl:Class ;
+          owl:hasKey ( :a_id ) ;
+          dc:title "DC Title" ;
+          dcterms:title "DCterms Title" .
+      :a_id a owl:DatatypeProperty ;
+          rdfs:domain :A ; rdfs:range xsd:string .
+    """
+        )
+    )
+    yaml_text, _ = import_owl(
+        [ttl], include_namespaces=["http://example.com/t#"]
+    )
+    data = yaml.safe_load(yaml_text)
+    anns = next(e for e in data["entities"] if e["name"] == "A")["annotations"]
+    # Keys retain their prefix and don't collapse to a single "title".
+    assert anns.get("dc:title") == "DC Title"
+    assert anns.get("dcterms:title") == "DCterms Title"
+    assert "title" not in anns

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -602,7 +602,7 @@ class TestEdgeCases:
     data = yaml.safe_load(yaml_text)
     entity = data["entities"][0]
     assert entity["description"] == "Thing"
-    assert "Chose" in entity["synonyms"]
+    assert entity["annotations"]["rdfs:label@fr"] == "Chose"
 
   def test_haskey_excluded_by_namespace(self, tmp_path):
     ttl = tmp_path / "test.ttl"
@@ -634,3 +634,656 @@ class TestEdgeCases:
     assert foo["keys"]["primary"] == ["FILL_IN"]
     assert "excluded by namespace filter" in yaml_text
     assert "owl:hasKey_excluded" in yaml_text
+
+
+# ------------------------------------------------------------------ #
+# SKOS import tests                                                    #
+# ------------------------------------------------------------------ #
+
+_SKOS_TTL = _FIXTURES / "skos_taxonomy.ttl"
+_MIXED_TTL = _FIXTURES / "mixed_owl_skos.ttl"
+
+
+class TestPureSkosImport:
+  """Import a pure SKOS taxonomy with concepts, broader, related, match."""
+
+  def test_all_entities_are_abstract_with_prefix(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    for entity in data["entities"]:
+      assert entity["abstract"] is True, f"{entity['name']} should be abstract"
+      assert entity["name"].startswith("skos_"), entity["name"]
+
+  def test_broader_relationships_are_abstract(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    broader = [r for r in rels if r["name"] == "skos_broader"]
+    assert len(broader) >= 2
+    for r in broader:
+      assert r["abstract"] is True
+
+  def test_related_relationship(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    related = [r for r in rels if r["name"] == "skos_related"]
+    assert len(related) >= 1
+    assert related[0]["abstract"] is True
+
+  def test_skos_annotations_preserved(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    banking = next(e for e in data["entities"] if e["name"] == "skos_Banking")
+    assert banking["annotations"]["skos:definition"] == (
+        "Activities of financial institutions."
+    )
+
+  def test_synonyms_from_altlabel(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    retail = next(
+        e for e in data["entities"] if e["name"] == "skos_RetailBanking"
+    )
+    assert "Consumer Banking" in retail["synonyms"]
+
+  def test_notation_annotation(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    retail = next(
+        e for e in data["entities"] if e["name"] == "skos_RetailBanking"
+    )
+    assert retail["annotations"]["skos:notation"] == "RB"
+
+  def test_external_match_becomes_annotation(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    wm = next(
+        e for e in data["entities"] if e["name"] == "skos_WealthManagement"
+    )
+    assert "skos:exactMatch" in wm["annotations"]
+
+  def test_no_description_for_pure_skos(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    for entity in data["entities"]:
+      assert "description" not in entity
+
+  def test_no_keys_on_abstract_entities(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    for entity in data["entities"]:
+      assert "keys" not in entity
+
+  def test_all_abstract_hint_in_summary(self):
+    _, summary = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    assert "all entities are abstract" in summary.lower()
+
+  def test_narrower_normalized_to_broader(self):
+    """skos:narrower on WealthManagement → InvestmentBanking should
+    produce a skos_broader from InvestmentBanking to WealthManagement."""
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    broader = [r for r in rels if r["name"] == "skos_broader"]
+    # InvestmentBanking broader WealthManagement (via narrower inverse)
+    inv_wm = [
+        r for r in broader
+        if r["from"] == "skos_InvestmentBanking"
+        and r["to"] == "skos_WealthManagement"
+    ]
+    assert len(inv_wm) == 1
+
+
+class TestMixedOwlSkos:
+  """Import files with both OWL classes and SKOS concepts."""
+
+  def test_owl_skos_entity_is_concrete(self):
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    account = next(e for e in data["entities"] if e["name"] == "Account")
+    assert "abstract" not in account or account.get("abstract") is False
+
+  def test_pure_skos_entity_is_abstract(self):
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    fp = next(
+        e for e in data["entities"] if e["name"] == "skos_FinancialProduct"
+    )
+    assert fp["abstract"] is True
+
+  def test_owl_entity_enriched_with_skos_metadata(self):
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    account = next(e for e in data["entities"] if e["name"] == "Account")
+    assert account["annotations"]["skos:definition"] == (
+        "A record of financial transactions."
+    )
+    assert "Acct" in account["synonyms"]
+
+  def test_external_exactmatch_is_annotation(self):
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    account = next(e for e in data["entities"] if e["name"] == "Account")
+    assert "skos:exactMatch" in account["annotations"]
+
+  def test_cross_kind_broader(self):
+    """Account (concrete OWL) → skos:broader → FinancialProduct (abstract SKOS)."""
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    broader = [
+        r for r in rels
+        if r["name"] == "skos_broader"
+        and r["from"] == "Account"
+        and r["to"] == "skos_FinancialProduct"
+    ]
+    assert len(broader) == 1
+    assert broader[0]["abstract"] is True
+
+  def test_owl_relationship_stays_concrete(self):
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    holds = next(r for r in rels if r["name"] == "holds")
+    assert "abstract" not in holds or holds.get("abstract") is False
+
+  def test_skos_related_between_owl_entities(self):
+    """Account (OWL+SKOS) skos:related Ledger (OWL) → abstract rel."""
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rels = data["relationships"]
+    related = [
+        r for r in rels
+        if r["name"] == "skos_related"
+        and r["from"] == "Account"
+        and r["to"] == "Ledger"
+    ]
+    assert len(related) == 1
+    assert related[0]["abstract"] is True
+
+
+class TestLanguageSelection:
+  """Multilingual label handling via --language."""
+
+  def test_default_english(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    banking = next(e for e in data["entities"] if e["name"] == "skos_Banking")
+    assert "skos:prefLabel@fr" in banking["annotations"]
+    assert banking["annotations"]["skos:prefLabel@fr"] == "Banque"
+
+  def test_french_selection(self):
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+        language="fr",
+    )
+    data = yaml.safe_load(yaml_text)
+    banking = next(e for e in data["entities"] if e["name"] == "skos_Banking")
+    # French selected → English goes to annotation
+    assert "skos:prefLabel@en" in banking["annotations"]
+
+
+class TestAbstractOntologyValidation:
+  """Ontology loader handles abstract entities and relationships."""
+
+  def test_abstract_entity_no_keys_passes(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_abstract
+      entities:
+        - name: ConcreteEntity
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_AbstractEntity
+          abstract: true
+    """)
+    ont = load_ontology_from_string(yaml_str)
+    assert ont.entities[1].abstract is True
+
+  def test_abstract_rel_duplicate_names_different_endpoints(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_abstract_rels
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: B
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: C
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: B
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: C
+    """)
+    ont = load_ontology_from_string(yaml_str)
+    assert len(ont.relationships) == 2
+
+  def test_abstract_rel_duplicate_name_same_endpoints_fails(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_dup
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: B
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: B
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: B
+    """)
+    with pytest.raises(ValueError, match="Duplicate abstract relationship"):
+      load_ontology_from_string(yaml_str)
+
+  def test_concrete_relationship_abstract_endpoint_fails(self):
+    """A concrete relationship cannot have an abstract endpoint —
+    there is nothing to bind."""
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_concrete_abstract_endpoint
+      entities:
+        - name: Concrete
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_AbstractTarget
+          abstract: true
+      relationships:
+        - name: pointsAt
+          from: Concrete
+          to: skos_AbstractTarget
+    """)
+    with pytest.raises(ValueError, match="abstract endpoint"):
+      load_ontology_from_string(yaml_str)
+
+  def test_abstract_relationship_abstract_endpoint_allowed(self):
+    """An abstract relationship may have abstract endpoints."""
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_abstract_abstract_endpoint
+      entities:
+        - name: Concrete
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_AbstractSource
+          abstract: true
+        - name: skos_AbstractTarget
+          abstract: true
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: skos_AbstractSource
+          to: skos_AbstractTarget
+    """)
+    ont = load_ontology_from_string(yaml_str)
+    assert len(ont.relationships) == 1
+
+  def test_abstract_relationship_endpoint_must_exist(self):
+    """Endpoint existence is still enforced on abstract relationships."""
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_missing_endpoint
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: DoesNotExist
+    """)
+    with pytest.raises(ValueError, match="DoesNotExist"):
+      load_ontology_from_string(yaml_str)
+
+  def test_concrete_abstract_name_collision_fails(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test_collision
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: B
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: rel
+          from: A
+          to: B
+        - name: rel
+          abstract: true
+          from: A
+          to: B
+    """)
+    with pytest.raises(ValueError, match="concrete and an abstract"):
+      load_ontology_from_string(yaml_str)
+
+
+class TestAbstractBindingRejection:
+  """Binding loader rejects abstract targets."""
+
+  def test_binding_abstract_entity_fails(self):
+    from bigquery_ontology import load_ontology_from_string
+    from bigquery_ontology.binding_loader import load_binding_from_string
+    ont = load_ontology_from_string(textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: Concrete
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: Abstract
+          abstract: true
+    """))
+    binding_yaml = textwrap.dedent("""\
+      binding: test_bind
+      ontology: test
+      target:
+        backend: bigquery
+        project: p
+        dataset: d
+      entities:
+        - name: Abstract
+          source: tbl
+          properties:
+            - {name: id, column: id}
+    """)
+    with pytest.raises(ValueError, match="abstract entity"):
+      load_binding_from_string(binding_yaml, ontology=ont)
+
+  def test_binding_abstract_relationship_fails(self):
+    from bigquery_ontology import load_ontology_from_string
+    from bigquery_ontology.binding_loader import load_binding_from_string
+    ont = load_ontology_from_string(textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: B
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: A
+          to: B
+    """))
+    binding_yaml = textwrap.dedent("""\
+      binding: test_bind
+      ontology: test
+      target:
+        backend: bigquery
+        project: p
+        dataset: d
+      entities:
+        - name: A
+          source: tbl_a
+          properties:
+            - {name: id, column: id}
+        - name: B
+          source: tbl_b
+          properties:
+            - {name: id, column: id}
+      relationships:
+        - name: skos_broader
+          source: tbl_rel
+          from_columns: [a_id]
+          to_columns: [b_id]
+    """)
+    with pytest.raises(ValueError, match="abstract relationship"):
+      load_binding_from_string(binding_yaml, ontology=ont)
+
+
+class TestAbstractScaffold:
+  """Scaffold skips abstract entities and relationships."""
+
+  def test_scaffold_skips_abstract(self):
+    from bigquery_ontology import load_ontology_from_string
+    from bigquery_ontology.scaffold import scaffold
+    ont = load_ontology_from_string(textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: Concrete
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_Abstract
+          abstract: true
+      relationships:
+        - name: skos_broader
+          abstract: true
+          from: Concrete
+          to: skos_Abstract
+    """))
+    ddl, binding_yaml = scaffold(ont, dataset="ds", project="proj")
+    assert "concrete" in ddl
+    assert "skos_abstract" not in ddl
+    assert "skos_broader" not in ddl
+    assert "skos_Abstract" not in binding_yaml
+    assert "skos_broader" not in binding_yaml
+
+
+class TestOwlRefToSkosConcept:
+  """An OWL ObjectProperty whose rdfs:range is a pure SKOS concept
+  must resolve to the correct ``skos_`` prefixed entity name."""
+
+  def test_owl_objectproperty_range_on_skos_concept(self, tmp_path):
+    ttl = tmp_path / "ref.ttl"
+    ttl.write_text(textwrap.dedent("""\
+      @prefix : <http://example.com/test#> .
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+      :Category a skos:Concept ;
+          skos:prefLabel "Category"@en .
+
+      :Account a owl:Class ;
+          owl:hasKey ( :account_id ) .
+      :account_id a owl:DatatypeProperty ;
+          rdfs:domain :Account ;
+          rdfs:range xsd:string .
+    """))
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    # When added, an OWL ObjectProperty pointing at :Category should
+    # emit ``to: skos_Category``, not ``to: Category``.
+    # Add a probe ObjectProperty and reparse.
+    ttl.write_text(ttl.read_text() + textwrap.dedent("""
+      :belongsTo a owl:ObjectProperty ;
+          rdfs:domain :Account ;
+          rdfs:range :Category .
+    """))
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/test#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    rel = next(r for r in data["relationships"] if r["name"] == "belongsTo")
+    assert rel["to"] == "skos_Category"
+
+
+class TestAbstractKeyShapeValidation:
+  """Abstract entities/relationships with declared keys must still
+  satisfy shape rules."""
+
+  def test_abstract_entity_key_column_must_exist(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: Real
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_Bad
+          abstract: true
+          keys:
+            primary: [nonexistent]
+    """)
+    with pytest.raises(ValueError, match="nonexistent"):
+      load_ontology_from_string(yaml_str)
+
+  def test_abstract_entity_forbids_additional_keys(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: Real
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: skos_Bad
+          abstract: true
+          properties:
+            - {name: x, type: string}
+          keys:
+            primary: [x]
+            additional: [x]
+    """)
+    with pytest.raises(ValueError, match="additional is not allowed"):
+      load_ontology_from_string(yaml_str)
+
+  def test_abstract_relationship_cannot_use_extends(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_str = textwrap.dedent("""\
+      ontology: test
+      entities:
+        - name: A
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+        - name: B
+          keys: {primary: [id]}
+          properties:
+            - {name: id, type: string}
+      relationships:
+        - name: parentRel
+          from: A
+          to: B
+        - name: childRel
+          abstract: true
+          extends: parentRel
+          from: A
+          to: B
+    """)
+    with pytest.raises(ValueError, match="abstract.*must not use 'extends'"):
+      load_ontology_from_string(yaml_str)
+
+
+class TestRoundTrip:
+  """Emitted YAML with abstract elements loads and validates."""
+
+  def test_pure_skos_roundtrip(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_text, _ = import_owl(
+        [_SKOS_TTL],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    ont = load_ontology_from_string(yaml_text)
+    assert all(e.abstract for e in ont.entities)
+    assert all(r.abstract for r in ont.relationships)
+
+  def test_mixed_owl_skos_roundtrip(self):
+    from bigquery_ontology import load_ontology_from_string
+    yaml_text, _ = import_owl(
+        [_MIXED_TTL],
+        include_namespaces=["http://example.com/finance#"],
+    )
+    ont = load_ontology_from_string(yaml_text)
+    concrete_entities = [e for e in ont.entities if not e.abstract]
+    abstract_entities = [e for e in ont.entities if e.abstract]
+    assert len(concrete_entities) >= 2  # Account, Ledger
+    assert len(abstract_entities) >= 1  # skos_FinancialProduct

--- a/tests/bigquery_ontology/test_owl_importer.py
+++ b/tests/bigquery_ontology/test_owl_importer.py
@@ -680,6 +680,25 @@ class TestPureSkosImport:
     assert len(related) >= 1
     assert related[0]["abstract"] is True
 
+  def test_related_is_symmetric_single_edge(self, tmp_path):
+    # skos:related is symmetric; mutual assertions must collapse to one edge.
+    ttl = tmp_path / "mutual_related.ttl"
+    ttl.write_text(
+        "@prefix : <http://example.com/taxonomy#> .\n"
+        "@prefix skos: <http://www.w3.org/2004/02/skos/core#> .\n"
+        ":c1 a skos:Concept ; skos:related :c2 .\n"
+        ":c2 a skos:Concept ; skos:related :c1 .\n",
+        encoding="utf-8",
+    )
+    yaml_text, _ = import_owl(
+        [ttl],
+        include_namespaces=["http://example.com/taxonomy#"],
+    )
+    data = yaml.safe_load(yaml_text)
+    related = [r for r in data["relationships"] if r["name"] == "skos_related"]
+    assert len(related) == 1
+    assert {related[0]["from"], related[0]["to"]} == {"skos_c1", "skos_c2"}
+
   def test_skos_annotations_preserved(self):
     yaml_text, _ = import_owl(
         [_SKOS_TTL],

--- a/tests/fixtures/mixed_owl_skos.ttl
+++ b/tests/fixtures/mixed_owl_skos.ttl
@@ -1,0 +1,41 @@
+@prefix : <http://example.com/finance#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Mixed OWL+SKOS entity — OWL structure wins, stays concrete.
+:Account a owl:Class, skos:Concept ;
+    rdfs:label "Account" ;
+    skos:altLabel "Acct"@en ;
+    skos:definition "A record of financial transactions."@en ;
+    skos:related :Ledger ;
+    skos:exactMatch <http://fibo.org/ontology/FBC/Account> ;
+    owl:hasKey ( :account_id ) .
+
+:account_id a owl:DatatypeProperty ;
+    rdfs:domain :Account ;
+    rdfs:range xsd:string .
+
+# Pure OWL entity — no SKOS typing.
+:Ledger a owl:Class ;
+    rdfs:label "Ledger" ;
+    owl:hasKey ( :ledger_id ) .
+
+:ledger_id a owl:DatatypeProperty ;
+    rdfs:domain :Ledger ;
+    rdfs:range xsd:string .
+
+# Pure SKOS concept — abstract entity.
+:FinancialProduct a skos:Concept ;
+    skos:prefLabel "Financial Product"@en ;
+    skos:definition "Any product offered by a financial institution."@en .
+
+# Cross-kind: OWL class → SKOS broader → SKOS concept.
+:Account skos:broader :FinancialProduct .
+
+# OWL relationship (concrete).
+:holds a owl:ObjectProperty ;
+    rdfs:label "holds" ;
+    rdfs:domain :Account ;
+    rdfs:range :Ledger .

--- a/tests/fixtures/skos_taxonomy.ttl
+++ b/tests/fixtures/skos_taxonomy.ttl
@@ -1,0 +1,27 @@
+@prefix : <http://example.com/taxonomy#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:BankingScheme a skos:ConceptScheme ;
+    skos:prefLabel "Banking Taxonomy"@en .
+
+:Banking a skos:Concept ;
+    skos:prefLabel "Banking"@en ;
+    skos:prefLabel "Banque"@fr ;
+    skos:definition "Activities of financial institutions."@en ;
+    skos:inScheme :BankingScheme .
+
+:RetailBanking a skos:Concept ;
+    skos:prefLabel "Retail Banking"@en ;
+    skos:altLabel "Consumer Banking"@en ;
+    skos:broader :Banking ;
+    skos:notation "RB" .
+
+:InvestmentBanking a skos:Concept ;
+    skos:prefLabel "Investment Banking"@en ;
+    skos:broader :Banking ;
+    skos:related :RetailBanking .
+
+:WealthManagement a skos:Concept ;
+    skos:prefLabel "Wealth Management"@en ;
+    skos:narrower :InvestmentBanking ;
+    skos:exactMatch <http://external.org/ontology/WM> .


### PR DESCRIPTION
## Summary

Implements the ontology-layer portion of the SKOS import design in #57. Hybrid OWL+SKOS sources (FIBO, SNOMED excerpts, library vocabularies) no longer silently drop descriptive metadata and taxonomy structure.

- `Entity` and `Relationship` gain `abstract: bool = False`. Abstract elements are declared but not bound to a BigQuery table; keys are optional on abstract entities; bindings that target abstract elements are rejected.
- `skos:Concept` (without `owl:Class`) → abstract entity with `skos_` name prefix. Mixed `owl:Class` + `skos:Concept` → concrete entity unprefixed (OWL wins structure).
- `skos:broader`/`narrower` → abstract `skos_broader` (narrower normalized). `skos:related` → abstract `skos_related`. `skos:exactMatch` etc. → abstract relationship if target imported, annotation with full IRI if external.
- `skos:definition`, `notation`, `scopeNote`, etc. → annotations with `skos:` prefix.
- New `--language` CLI flag (default `en`) selects labels by BCP-47 tag; non-selected languages become language-suffixed annotations.
- Generic literal-annotation pass closes the silent-drop gap for Dublin Core and other non-OWL/SKOS literal predicates (previously docs claimed this but code only handled a fixed OWL allowlist).

## Scope

This PR covers the **ontology package only** (`src/bigquery_ontology/`). The SDK runtime choke-point filter (`bigquery_agent_analytics.runtime_spec`) called out in the issue's reviewer comment is **not** included — it belongs in a follow-up PR.

## Validation rules added

- Concrete relationships must have concrete endpoints (cannot bind a rel to an abstract entity).
- Abstract relationships use relaxed uniqueness: `(name, from, to)` instead of `(name,)`.
- Abstract relationships forbid `extends` (the mixed concrete/abstract parent-map has ambiguous uniqueness; informational-only elements don't need inheritance).
- Abstract entities/relationships with declared keys still follow shape rules.
- Endpoint existence still enforced on abstract relationships.

## Test plan

- [x] `pytest tests/bigquery_ontology/` — 235 passed (199 existing + 36 new)
- [x] `pytest tests/` — 1952 passed, 4 skipped (full repo, no regressions)
- [x] Pure SKOS taxonomy fixture imports cleanly: `tests/fixtures/skos_taxonomy.ttl`
- [x] Mixed OWL+SKOS fixture imports cleanly: `tests/fixtures/mixed_owl_skos.ttl`
- [x] Regression: OWL ObjectProperty with range on pure SKOS concept resolves to `skos_<name>` endpoint via shared IRI→name map
- [x] Multilingual label selection with `--language fr`
- [x] Emitted YAML round-trips through `load_ontology_from_string`

## Follow-ups (not in this PR)

- SDK runtime adapter filter (`runtime_spec.graph_spec_from_ontology_binding`) to exclude abstract elements before building name-indexed maps (issue's reviewer comment, Step 2 in their suggested sequence).
- `skos:ConceptScheme` as ontology-level annotation (noted in issue mapping table, deferred here).
- Opt-in promotion of `skos:broader` → `extends` (issue's open question 9; conservative default is no promotion).