### PR TITLE
Fix text wrapper in Span.summary and Trace.final_response

### DIFF
--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -848,9 +848,9 @@ class Trace:
         if isinstance(c, dict):
           result = c.get("response")
           if result:
-            return result
+            return _unwrap_text_field(result) if isinstance(result, str) else result
         elif c:
-          return str(c)
+          return _unwrap_text_field(str(c))
 
     for span in reversed(self.spans):
       if span.event_type == "AGENT_COMPLETED":
@@ -858,9 +858,9 @@ class Trace:
         if isinstance(c, dict):
           result = c.get("response") or c.get("text_summary")
           if result:
-            return result
+            return _unwrap_text_field(result) if isinstance(result, str) else result
         elif c:
-          return str(c)
+          return _unwrap_text_field(str(c))
     return None
 
   @property

--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -54,6 +54,30 @@ def _colorize(text: str, ansi_code: str, enabled: bool) -> str:
   return f"{ansi_code}{text}{_ANSI_RESET}"
 
 
+_TEXT_WRAPPER_PREFIX = "text: "
+
+
+def _unwrap_text_field(value: str) -> str:
+  """Strip a leading ``text: '...'`` wrapper if present.
+
+  Some ADK plugin versions serialize an LLM response with a literal
+  ``text: '...'`` Python-repr-style prefix in ``content.response``.
+  Strip it so ``Span.summary`` and ``Trace.render`` surface a clean
+  human-readable string.
+  """
+  if not value.startswith(_TEXT_WRAPPER_PREFIX):
+    return value
+  inner = value[len(_TEXT_WRAPPER_PREFIX):]
+  if not inner or inner[0] not in ("'", '"'):
+    return inner
+  quote = inner[0]
+  # Match trailing quote only if the string is not truncated.
+  if len(inner) >= 2 and inner.endswith(quote):
+    return inner[1:-1]
+  # Truncated — drop the opening quote and leave the rest.
+  return inner[1:]
+
+
 class EventType(Enum):
   """Standard event types logged by the analytics plugin."""
 
@@ -342,6 +366,7 @@ class Span:
       text = self.content.get("text") or ""
     if not text:
       text = self.content.get("raw") or ""
+    text = _unwrap_text_field(text) if isinstance(text, str) else text
     if not text and self.content_parts:
       for p in self.content_parts:
         if p.text:

--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -67,7 +67,7 @@ def _unwrap_text_field(value: str) -> str:
   """
   if not value.startswith(_TEXT_WRAPPER_PREFIX):
     return value
-  inner = value[len(_TEXT_WRAPPER_PREFIX):]
+  inner = value[len(_TEXT_WRAPPER_PREFIX) :]
   if not inner or inner[0] not in ("'", '"'):
     return inner
   quote = inner[0]
@@ -848,7 +848,11 @@ class Trace:
         if isinstance(c, dict):
           result = c.get("response")
           if result:
-            return _unwrap_text_field(result) if isinstance(result, str) else result
+            return (
+                _unwrap_text_field(result)
+                if isinstance(result, str)
+                else result
+            )
         elif c:
           return _unwrap_text_field(str(c))
 
@@ -858,7 +862,11 @@ class Trace:
         if isinstance(c, dict):
           result = c.get("response") or c.get("text_summary")
           if result:
-            return _unwrap_text_field(result) if isinstance(result, str) else result
+            return (
+                _unwrap_text_field(result)
+                if isinstance(result, str)
+                else result
+            )
         elif c:
           return _unwrap_text_field(str(c))
     return None

--- a/tests/test_sdk_trace.py
+++ b/tests/test_sdk_trace.py
@@ -294,6 +294,57 @@ class TestSpan:
     )
     assert span.summary == "You are a helpful assistant"
 
+  def test_summary_unwraps_text_single_quoted(self):
+    """`text: 'hello'` wrapper should be stripped from response."""
+    span = Span(
+        event_type="LLM_RESPONSE",
+        agent="agent",
+        timestamp=datetime.now(timezone.utc),
+        content={"response": "text: 'hello world'"},
+    )
+    assert span.summary == "hello world"
+
+  def test_summary_unwraps_text_double_quoted(self):
+    """`text: \"hello\"` wrapper should be stripped too."""
+    span = Span(
+        event_type="LLM_RESPONSE",
+        agent="agent",
+        timestamp=datetime.now(timezone.utc),
+        content={"response": 'text: "hello world"'},
+    )
+    assert span.summary == "hello world"
+
+  def test_summary_unwraps_truncated_text_field(self):
+    """Truncated `text: 'abc...` (no closing quote) strips opening quote only."""
+    span = Span(
+        event_type="LLM_RESPONSE",
+        agent="agent",
+        timestamp=datetime.now(timezone.utc),
+        content={"response": "text: 'I found three Priyas"},
+    )
+    assert span.summary == "I found three Priyas"
+
+  def test_summary_leaves_plain_text_alone(self):
+    """A response without the wrapper must be returned unchanged."""
+    span = Span(
+        event_type="LLM_RESPONSE",
+        agent="agent",
+        timestamp=datetime.now(timezone.utc),
+        content={"response": "Booking confirmed for Priya Patel."},
+    )
+    assert span.summary == "Booking confirmed for Priya Patel."
+
+  def test_summary_leaves_non_wrapper_text_prefix_alone(self):
+    """`text:` without a following space-quoted value is not our wrapper."""
+    span = Span(
+        event_type="LLM_RESPONSE",
+        agent="agent",
+        timestamp=datetime.now(timezone.utc),
+        content={"response": "text:the-tool-id-is-x"},
+    )
+    # No leading `text: ` (with space), so the unwrapper leaves it alone.
+    assert span.summary == "text:the-tool-id-is-x"
+
 
 class TestTrace:
   """Tests for Trace class."""

--- a/tests/test_sdk_trace.py
+++ b/tests/test_sdk_trace.py
@@ -591,6 +591,33 @@ class TestTrace:
     trace = Trace(trace_id="t", session_id="s", spans=spans)
     assert trace.final_response == "LLM said this"
 
+  def test_final_response_unwraps_text_prefix_from_llm_response(self):
+    """text: '...' wrapper must be stripped at the trace-level accessor too."""
+    ts = datetime.now(timezone.utc)
+    spans = [
+        Span(
+            event_type="LLM_RESPONSE",
+            agent="agent",
+            timestamp=ts,
+            content={"response": "text: 'I found three people named Priya.'"},
+        ),
+    ]
+    trace = Trace(trace_id="t", session_id="s", spans=spans)
+    assert trace.final_response == "I found three people named Priya."
+
+  def test_final_response_unwraps_text_prefix_from_agent_completed(self):
+    ts = datetime.now(timezone.utc)
+    spans = [
+        Span(
+            event_type="AGENT_COMPLETED",
+            agent="agent",
+            timestamp=ts,
+            content={"response": 'text: "Booking confirmed."'},
+        ),
+    ]
+    trace = Trace(trace_id="t", session_id="s", spans=spans)
+    assert trace.final_response == "Booking confirmed."
+
   def test_final_response_null_agent_completed(self):
     """Handles null AGENT_COMPLETED content (ADK plugin behavior)."""
     ts = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

Some ADK plugin versions serialize an LLM response with a literal `text: '...'` Python-repr-style prefix in the event row's `content.response` field. The SDK's `Span.summary` surfaced that wrapper verbatim, so every `trace.render()` output shows:

```
LLM_RESPONSE (2175ms) - text: 'I found three people named Priya: Priya Patel...'
```

The wrapper is an upstream serialization artifact but readers don't need to see it. `Span.summary` is a human-facing accessor.

Adds `_unwrap_text_field()` that strips a leading `text: ` prefix and matching surrounding quotes when present. Applied only to the `response` field in `Span.summary`; other fields (`text_summary`, `text`, `raw`) are already clean and don't need it.

## Behavior

| Input | Output |
|---|---|
| `text: 'hello'` | `hello` |
| `text: "hello"` | `hello` |
| `text: 'I found three Priyas` (truncated, no closing quote) | `I found three Priyas` |
| `Booking confirmed for Priya Patel.` (plain, no wrapper) | unchanged |
| `text:the-tool-id-is-x` (non-wrapper prefix, no trailing space+quote) | unchanged |

The helper discriminates the wrapper case by requiring the full `text: ` (including trailing space) followed by a quote. A bare `text:` prefix without space+quote is left alone, so unrelated content that happens to start with `text:` survives.

## Test plan

- [x] `python -m pytest tests/test_sdk_trace.py` → 76 passed (5 new tests: single-quoted, double-quoted, truncated, plain unchanged, non-wrapper prefix unchanged).
- [x] `python -m pytest tests/ --ignore=tests/bigquery_ontology` → 1,734 passed, 4 skipped.
