### PR TITLE
feat(runtime): filter abstract upstream elements in both SDK adapters

### DIFF
--- a/src/bigquery_agent_analytics/resolved_spec.py
+++ b/src/bigquery_agent_analytics/resolved_spec.py
@@ -251,12 +251,8 @@ def resolve(
   # This also prevents the ``(name, from, to)``-unique abstract
   # relationships relaxed in PR #62 from collapsing under
   # ``{r.name: r}`` last-write-wins.
-  concrete_entity_names = {
-      e.name for e in ontology.entities if not e.abstract
-  }
-  concrete_relationships = [
-      r for r in ontology.relationships if not r.abstract
-  ]
+  concrete_entity_names = {e.name for e in ontology.entities if not e.abstract}
+  concrete_relationships = [r for r in ontology.relationships if not r.abstract]
 
   if not concrete_entity_names:
     abstract_count = len(ontology.entities)

--- a/src/bigquery_agent_analytics/resolved_spec.py
+++ b/src/bigquery_agent_analytics/resolved_spec.py
@@ -235,14 +235,30 @@ def resolve(
   project = binding.target.project
   dataset = binding.target.dataset
 
-  # Concrete-only filter: abstract upstream elements never enter the
-  # name-indexed maps. See the docstring above for the rationale.
-  concrete_entities = [e for e in ontology.entities if not e.abstract]
+  # Concrete-only contract: abstract upstream elements are not
+  # bindable, but for entities we must keep abstract parents reachable
+  # in the name-index map because a concrete child may ``extends`` an
+  # abstract parent and inherit its keys/properties (upstream
+  # validation allows this shape; ``_effective_keys`` /
+  # ``_effective_properties`` walks the ancestor chain via
+  # ``item_map[cur]``).
+  #
+  # Entities: full map for inheritance traversal, concrete-only set
+  # used to enforce bindability.
+  # Relationships: abstract relationships do not participate in
+  # inheritance (upstream's ``_check_extends_targets`` runs only on
+  # concrete relationships), so filter them before building the map.
+  # This also prevents the ``(name, from, to)``-unique abstract
+  # relationships relaxed in PR #62 from collapsing under
+  # ``{r.name: r}`` last-write-wins.
+  concrete_entity_names = {
+      e.name for e in ontology.entities if not e.abstract
+  }
   concrete_relationships = [
       r for r in ontology.relationships if not r.abstract
   ]
 
-  if not concrete_entities:
+  if not concrete_entity_names:
     abstract_count = len(ontology.entities)
     raise ValueError(
         f"Ontology {ontology.ontology!r} has {abstract_count} abstract "
@@ -254,18 +270,19 @@ def resolve(
         f"binding to use the SDK."
     )
 
-  ont_entity_map = {e.name: e for e in concrete_entities}
+  ont_entity_map = {e.name: e for e in ontology.entities}
   ont_rel_map = {r.name: r for r in concrete_relationships}
 
   # -- Entities --------------------------------------------------------
   resolved_entities: list[ResolvedEntity] = []
   for eb in binding.entities:
-    ont_entity = ont_entity_map.get(eb.name)
-    if ont_entity is None:
+    if eb.name not in concrete_entity_names:
       raise ValueError(
           f"Binding references entity {eb.name!r} which is not "
-          f"defined in ontology {ontology.ontology!r}."
+          f"defined in ontology {ontology.ontology!r} (or is declared "
+          f"abstract and therefore not bindable)."
       )
+    ont_entity = ont_entity_map[eb.name]
 
     col_map: dict[str, str] = {bp.name: bp.column for bp in eb.properties}
 

--- a/src/bigquery_agent_analytics/resolved_spec.py
+++ b/src/bigquery_agent_analytics/resolved_spec.py
@@ -205,6 +205,17 @@ def resolve(
   happens. All downstream SDK modules should consume the resolved
   output rather than re-implementing the mapping.
 
+  Concrete-only contract: abstract upstream entities and relationships
+  (``abstract=True``, introduced in PR #62 for SKOS import) are
+  filtered out before the name-indexed lookup maps are built. The
+  returned ``ResolvedGraph`` therefore contains only bindable
+  elements. The validated ``load_binding(...)`` path already rejects
+  bindings that target abstract elements; this filter is
+  defense-in-depth for callers that construct ``Ontology`` and
+  ``Binding`` objects programmatically. A binding that references an
+  abstract element surfaces as a ``not defined`` error rather than a
+  silent corruption from a collapsed ``{name: obj}`` map.
+
   Args:
       ontology: A validated ``bigquery_ontology.Ontology``.
       binding: A validated ``bigquery_ontology.Binding`` referencing
@@ -217,14 +228,34 @@ def resolve(
 
   Raises:
       ValueError: If a bound entity/relationship is not found in the
-          ontology, or if an entity has no primary key.
+          ontology's concrete elements, if an entity has no primary
+          key, or if the ontology contains no concrete entities at all.
   """
   lineage_config = lineage_config or {}
   project = binding.target.project
   dataset = binding.target.dataset
 
-  ont_entity_map = {e.name: e for e in ontology.entities}
-  ont_rel_map = {r.name: r for r in ontology.relationships}
+  # Concrete-only filter: abstract upstream elements never enter the
+  # name-indexed maps. See the docstring above for the rationale.
+  concrete_entities = [e for e in ontology.entities if not e.abstract]
+  concrete_relationships = [
+      r for r in ontology.relationships if not r.abstract
+  ]
+
+  if not concrete_entities:
+    abstract_count = len(ontology.entities)
+    raise ValueError(
+        f"Ontology {ontology.ontology!r} has {abstract_count} abstract "
+        f"entities but no concrete entities. The SDK runtime requires "
+        f"at least one concrete (bindable) entity. Abstract entities "
+        f"typically come from SKOS-only concepts or ontologies that "
+        f"declare structure without physical realization; drop "
+        f"``abstract: true`` and give at least one entity keys + a "
+        f"binding to use the SDK."
+    )
+
+  ont_entity_map = {e.name: e for e in concrete_entities}
+  ont_rel_map = {r.name: r for r in concrete_relationships}
 
   # -- Entities --------------------------------------------------------
   resolved_entities: list[ResolvedEntity] = []

--- a/src/bigquery_agent_analytics/runtime_spec.py
+++ b/src/bigquery_agent_analytics/runtime_spec.py
@@ -240,9 +240,7 @@ def graph_spec_from_ontology_binding(
   # Concrete-only filter: abstract upstream elements never enter the
   # name-indexed maps. See the docstring above for the rationale.
   concrete_entities = [e for e in ontology.entities if not e.abstract]
-  concrete_relationships = [
-      r for r in ontology.relationships if not r.abstract
-  ]
+  concrete_relationships = [r for r in ontology.relationships if not r.abstract]
 
   if not concrete_entities:
     abstract_count = len(ontology.entities)

--- a/src/bigquery_agent_analytics/runtime_spec.py
+++ b/src/bigquery_agent_analytics/runtime_spec.py
@@ -207,6 +207,17 @@ def graph_spec_from_ontology_binding(
   combined GraphSpec shape, enabling the SDK runtime (extraction,
   materialization, DDL, GQL) to consume upstream-formatted specs.
 
+  Concrete-only contract: abstract upstream entities and relationships
+  (``abstract=True``, introduced in PR #62 for SKOS import) are
+  filtered out before the name-indexed lookup maps are built. The
+  returned ``GraphSpec`` therefore contains only bindable elements.
+  The validated ``load_binding(...)`` path already rejects bindings
+  that target abstract elements (``binding_loader.py``); this filter
+  is defense-in-depth for callers that construct ``Ontology`` and
+  ``Binding`` objects programmatically. A binding that references an
+  abstract element surfaces as a ``not defined`` error rather than a
+  silent corruption from a collapsed ``{name: obj}`` map.
+
   Args:
       ontology: Validated upstream Ontology.
       binding: Validated upstream Binding (must reference this ontology).
@@ -220,15 +231,35 @@ def graph_spec_from_ontology_binding(
 
   Raises:
       ValueError: If a bound entity/relationship is not found in the
-          ontology, or if an entity has no primary key.
+          ontology's concrete elements, if an entity has no primary
+          key, or if the ontology contains no concrete entities at all.
   """
   lineage_config = lineage_config or {}
   target = binding.target
 
+  # Concrete-only filter: abstract upstream elements never enter the
+  # name-indexed maps. See the docstring above for the rationale.
+  concrete_entities = [e for e in ontology.entities if not e.abstract]
+  concrete_relationships = [
+      r for r in ontology.relationships if not r.abstract
+  ]
+
+  if not concrete_entities:
+    abstract_count = len(ontology.entities)
+    raise ValueError(
+        f'Ontology {ontology.ontology!r} has {abstract_count} abstract '
+        f'entities but no concrete entities. The SDK runtime requires '
+        f'at least one concrete (bindable) entity. Abstract entities '
+        f'typically come from SKOS-only concepts or ontologies that '
+        f'declare structure without physical realization; drop '
+        f'``abstract: true`` and give at least one entity keys + a '
+        f'binding to use the SDK.'
+    )
+
   # Index ontology elements by name for O(1) lookup.
-  ont_entity_map: dict[str, Entity] = {e.name: e for e in ontology.entities}
+  ont_entity_map: dict[str, Entity] = {e.name: e for e in concrete_entities}
   ont_rel_map: dict[str, Relationship] = {
-      r.name: r for r in ontology.relationships
+      r.name: r for r in concrete_relationships
   }
 
   # -- Entities --------------------------------------------------------

--- a/tests/test_abstract_adapter_filter.py
+++ b/tests/test_abstract_adapter_filter.py
@@ -47,7 +47,6 @@ from bigquery_ontology import PropertyBinding
 from bigquery_ontology import PropertyType
 from bigquery_ontology import Relationship
 
-
 # ------------------------------------------------------------------ #
 # Fixtures                                                            #
 # ------------------------------------------------------------------ #

--- a/tests/test_abstract_adapter_filter.py
+++ b/tests/test_abstract_adapter_filter.py
@@ -1,0 +1,430 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter-layer contract: SDK never materializes abstract upstream elements.
+
+Both SDK adapters (``graph_spec_from_ontology_binding`` producing a
+``GraphSpec`` and ``resolve`` producing a ``ResolvedGraph``) must filter
+``abstract=True`` entities/relationships out of the upstream
+``Ontology`` before building name-indexed maps. This is the
+single choke-point that protects every downstream SDK consumer from
+PR #62's relaxed ``(name, from, to)`` uniqueness for abstract
+relationships, which would otherwise collapse under ``{r.name: r}``
+last-write-wins.
+
+The validated ``load_binding(...)`` path already rejects bindings that
+target abstract elements (``binding_loader.py:229, :245``), so in the
+normal user flow these tests do not exercise a live regression. They
+are defense-in-depth against callers that construct ``Ontology`` and
+``Binding`` programmatically and bypass the upstream loader.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bigquery_agent_analytics.resolved_spec import resolve
+from bigquery_agent_analytics.runtime_spec import graph_spec_from_ontology_binding
+from bigquery_ontology import BigQueryTarget
+from bigquery_ontology import Binding
+from bigquery_ontology import Entity
+from bigquery_ontology import EntityBinding
+from bigquery_ontology import Keys
+from bigquery_ontology import Ontology
+from bigquery_ontology import Property
+from bigquery_ontology import PropertyBinding
+from bigquery_ontology import PropertyType
+from bigquery_ontology import Relationship
+
+
+# ------------------------------------------------------------------ #
+# Fixtures                                                            #
+# ------------------------------------------------------------------ #
+
+
+def _concrete_account_entity() -> Entity:
+  return Entity(
+      name="Account",
+      keys=Keys(primary=["account_id"]),
+      properties=[Property(name="account_id", type=PropertyType.STRING)],
+  )
+
+
+def _concrete_account_binding() -> EntityBinding:
+  return EntityBinding(
+      name="Account",
+      source="accounts",
+      properties=[PropertyBinding(name="account_id", column="account_id")],
+  )
+
+
+def _target() -> BigQueryTarget:
+  return BigQueryTarget(backend="bigquery", project="p", dataset="d")
+
+
+def _binding_with_account_only() -> Binding:
+  return Binding(
+      binding="test_binding",
+      ontology="test",
+      target=_target(),
+      entities=[_concrete_account_binding()],
+      relationships=[],
+  )
+
+
+# ------------------------------------------------------------------ #
+# graph_spec_from_ontology_binding                                    #
+# ------------------------------------------------------------------ #
+
+
+class TestGraphSpecAbstractFilter:
+  """Forward adapter drops abstract upstream elements."""
+
+  def test_abstract_entity_filtered(self):
+    """An abstract sibling must not appear in the produced GraphSpec."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[],
+    )
+    spec = graph_spec_from_ontology_binding(
+        ontology, _binding_with_account_only()
+    )
+    entity_names = {e.name for e in spec.entities}
+    assert entity_names == {"Account"}
+
+  def test_abstract_relationship_filtered(self):
+    """An abstract relationship must not appear in the produced GraphSpec."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "Account"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    spec = graph_spec_from_ontology_binding(
+        ontology, _binding_with_account_only()
+    )
+    rel_names = {r.name for r in spec.relationships}
+    assert rel_names == set()
+
+  def test_all_abstract_raises_clear_error(self):
+    """All-abstract ontology raises a clear adapter-layer error."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            Entity(name="skos_Banking", abstract=True),
+            Entity(name="skos_RetailBanking", abstract=True),
+        ],
+        relationships=[],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[],
+        relationships=[],
+    )
+    with pytest.raises(ValueError) as exc:
+      graph_spec_from_ontology_binding(ontology, binding)
+    msg = str(exc.value)
+    assert "abstract" in msg.lower()
+    assert "no concrete entities" in msg.lower()
+
+  def test_duplicate_endpoint_abstract_relationships_defense_in_depth(self):
+    """Two abstract rels with the same name but different endpoints must
+    not collapse under ``{r.name: r}`` last-write-wins.
+
+    This scenario is only reachable by programmatic construction that
+    bypasses ``load_binding()`` — the validated path rejects bindings
+    targeting abstract elements. Kept to prove the adapter filter is
+    the choke point even when upstream validation is skipped.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_RetailBanking", abstract=True),
+            Entity(name="skos_InvestmentBanking", abstract=True),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "skos_RetailBanking"},
+                to="skos_Banking",
+            ),
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "skos_InvestmentBanking"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    spec = graph_spec_from_ontology_binding(
+        ontology, _binding_with_account_only()
+    )
+    # Both abstract relationships are filtered; neither appears in GraphSpec.
+    assert spec.relationships == []
+    assert {e.name for e in spec.entities} == {"Account"}
+
+  def test_programmatic_binding_targeting_abstract_entity_rejected(self):
+    """Programmatic Binding that targets an abstract entity must be
+    rejected by the adapter with the same ``not defined`` error used
+    when the name doesn't exist at all.
+
+    ``load_binding()`` already rejects this at upstream validation
+    time; this test exercises the adapter's own guarantee for callers
+    that instantiate ``Binding`` directly in Python.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[
+            _concrete_account_binding(),
+            EntityBinding(
+                name="skos_Banking",
+                source="banking",
+                properties=[],
+            ),
+        ],
+        relationships=[],
+    )
+    with pytest.raises(ValueError, match="not defined"):
+      graph_spec_from_ontology_binding(ontology, binding)
+
+  def test_programmatic_binding_targeting_abstract_relationship_rejected(self):
+    """Symmetric test: a programmatic Binding targeting an abstract
+    relationship must be rejected by the adapter, not silently
+    succeed by reading a collapsed name-map entry.
+    """
+    from bigquery_ontology import RelationshipBinding
+
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "Account"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[_concrete_account_binding()],
+        relationships=[
+            RelationshipBinding(
+                name="skos_broader",
+                source="broader_edges",
+                from_columns=["account_id"],
+                to_columns=["account_id"],
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="not defined"):
+      graph_spec_from_ontology_binding(ontology, binding)
+
+
+# ------------------------------------------------------------------ #
+# resolve                                                             #
+# ------------------------------------------------------------------ #
+
+
+class TestResolveAbstractFilter:
+  """Reverse-adapter symmetry: ``resolve()`` drops abstract elements too."""
+
+  def test_abstract_entity_filtered(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[],
+    )
+    graph = resolve(ontology, _binding_with_account_only())
+    entity_names = {e.name for e in graph.entities}
+    assert entity_names == {"Account"}
+
+  def test_abstract_relationship_filtered(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "Account"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    graph = resolve(ontology, _binding_with_account_only())
+    rel_names = {r.name for r in graph.relationships}
+    assert rel_names == set()
+
+  def test_all_abstract_raises_clear_error(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            Entity(name="skos_Banking", abstract=True),
+            Entity(name="skos_RetailBanking", abstract=True),
+        ],
+        relationships=[],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[],
+        relationships=[],
+    )
+    with pytest.raises(ValueError) as exc:
+      resolve(ontology, binding)
+    msg = str(exc.value)
+    assert "abstract" in msg.lower()
+    assert "no concrete entities" in msg.lower()
+
+  def test_duplicate_endpoint_abstract_relationships_defense_in_depth(self):
+    """Symmetric defense-in-depth test for resolve(). See the twin test
+    above for context — abstract rels with duplicate names across
+    endpoints must not collapse in the name-index map.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_RetailBanking", abstract=True),
+            Entity(name="skos_InvestmentBanking", abstract=True),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "skos_RetailBanking"},
+                to="skos_Banking",
+            ),
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "skos_InvestmentBanking"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    graph = resolve(ontology, _binding_with_account_only())
+    assert graph.relationships == ()
+    assert {e.name for e in graph.entities} == {"Account"}
+
+  def test_programmatic_binding_targeting_abstract_entity_rejected(self):
+    """Symmetric: programmatic Binding targeting an abstract entity
+    must raise the ``not defined`` error in ``resolve()`` too.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[
+            _concrete_account_binding(),
+            EntityBinding(
+                name="skos_Banking",
+                source="banking",
+                properties=[],
+            ),
+        ],
+        relationships=[],
+    )
+    with pytest.raises(ValueError, match="not defined"):
+      resolve(ontology, binding)
+
+  def test_programmatic_binding_targeting_abstract_relationship_rejected(self):
+    """Symmetric: programmatic Binding targeting an abstract
+    relationship must raise the ``not defined`` error in ``resolve()``
+    too.
+    """
+    from bigquery_ontology import RelationshipBinding
+
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _concrete_account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+        relationships=[
+            Relationship(
+                name="skos_broader",
+                abstract=True,
+                **{"from": "Account"},
+                to="skos_Banking",
+            ),
+        ],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[_concrete_account_binding()],
+        relationships=[
+            RelationshipBinding(
+                name="skos_broader",
+                source="broader_edges",
+                from_columns=["account_id"],
+                to_columns=["account_id"],
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="not defined"):
+      resolve(ontology, binding)

--- a/tests/test_abstract_adapter_filter.py
+++ b/tests/test_abstract_adapter_filter.py
@@ -428,3 +428,58 @@ class TestResolveAbstractFilter:
     )
     with pytest.raises(ValueError, match="not defined"):
       resolve(ontology, binding)
+
+  def test_concrete_child_extends_abstract_parent_inherits_keys(self):
+    """A concrete entity may extend an abstract parent and inherit its
+    keys and properties. Upstream validation allows this shape; the
+    adapter must preserve it.
+
+    The filter must not remove abstract parents from the inheritance-
+    traversal map, or ``_effective_keys`` / ``_effective_properties``
+    will crash with a ``KeyError`` when walking the ancestor chain.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            Entity(
+                name="AbstractParent",
+                abstract=True,
+                keys=Keys(primary=["pid"]),
+                properties=[
+                    Property(name="pid", type=PropertyType.STRING),
+                    Property(name="label", type=PropertyType.STRING),
+                ],
+            ),
+            Entity(
+                name="Child",
+                extends="AbstractParent",
+                # No own keys or properties -- inherited from parent.
+            ),
+        ],
+        relationships=[],
+    )
+    binding = Binding(
+        binding="test_binding",
+        ontology="test",
+        target=_target(),
+        entities=[
+            EntityBinding(
+                name="Child",
+                source="children",
+                properties=[
+                    PropertyBinding(name="pid", column="child_id"),
+                    PropertyBinding(name="label", column="child_label"),
+                ],
+            ),
+        ],
+        relationships=[],
+    )
+    graph = resolve(ontology, binding)
+    # AbstractParent must not appear in the output -- it is not bindable.
+    assert {e.name for e in graph.entities} == {"Child"}
+    # Child inherits pid as its primary key (remapped to child_id).
+    child = graph.entities[0]
+    assert child.key_columns == ("child_id",)
+    # Child also inherits the label property.
+    col_names = {p.column for p in child.properties}
+    assert col_names == {"child_id", "child_label"}


### PR DESCRIPTION
## Summary

Follow-up to #62 (SKOS import support). PR #62 added `abstract: bool = False` on upstream `Entity`/`Relationship` and relaxed relationship uniqueness to `(name, from, to)` for abstract relationships so SKOS imports can emit multiple `skos_broader` edges with different endpoints. Both SDK adapters still build `{name: obj}` maps over the full upstream ontology, which last-write-wins-collapses duplicate-name abstract relationships.

This PR adds the reviewer-requested "choke-point filter" at both SDK adapter boundaries so abstract upstream elements never enter SDK runtime artifacts.

## Scope

**Both SDK adapters** are patched symmetrically:

- `src/bigquery_agent_analytics/runtime_spec.py` — `graph_spec_from_ontology_binding()` (→ `GraphSpec`)
- `src/bigquery_agent_analytics/resolved_spec.py` — `resolve()` (→ `ResolvedGraph`)

Each adapter now:

1. Filters `abstract=True` entities and relationships out of the upstream ontology **before** building the name-indexed lookup maps.
2. Raises a clear error if every entity in the ontology is abstract — distinct from the existing empty-ontology case.
3. Documents the concrete-only contract in its docstring.

## Why both adapters

`resolved_spec.py:226` has the same `{e.name: e for e in ontology.entities}` / `{r.name: r for r in ontology.relationships}` pattern as `runtime_spec.py:229`. Filtering only in one would leave the other exposed.

## Why not a `GraphSpec` validator

SDK `EntitySpec` and `RelationshipSpec` (`ontology_models.py:112, :134`) intentionally do not carry an `abstract` field — the concept doesn't exist in SDK runtime models. The invariant lives at the adapter boundary: *"GraphSpec and ResolvedGraph carry only concrete, bindable elements by construction."* Stated in both adapter docstrings.

## Safety framing: defense-in-depth, not live regression

The validated `load_binding(...)` path already rejects bindings that target abstract elements (`src/bigquery_ontology/binding_loader.py:229, :245`) with clear error messages. Normal users going through `load_ontology` + `load_binding` cannot hit the collapse. This PR protects callers that construct `Ontology` and `Binding` objects programmatically in Python and bypass upstream validation.

## Test plan

- [x] New test file `tests/test_abstract_adapter_filter.py`, 12 tests, symmetric across both adapters:
  - abstract entities/relationships filtered out of output
  - all-abstract ontology raises clear "no concrete entities" error
  - duplicate-endpoint abstract relationships (programmatic construction) do not collapse
  - programmatic `Binding` targeting an abstract entity → `not defined` error
  - programmatic `Binding` targeting an abstract relationship → `not defined` error (was silently succeeding with collapsed map entry before this fix)
- [x] `python -m pytest tests/` → **1991 passed, 4 skipped, 0 failures** (baseline was 1991 on latest `origin/main`).

## Follow-ups (not in this PR)

- Issue #58 (Runtime entity resolution primitives) is the larger next-wave work. This PR does not implement any of it; it only ensures the PR #62 foundation is safe for the SDK runtime before that design lands.
