### PR TITLE
feat(ontology): A1 — internal _fingerprint module for concept-index provenance

### DIFF
--- a/src/bigquery_ontology/_fingerprint.py
+++ b/src/bigquery_ontology/_fingerprint.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical model fingerprint + compile_id for concept-index provenance.
+
+Internal module. Both the ontology compiler (``graph_ddl_compiler`` when
+it gains ``compile_concept_index``) and the SDK runtime (``OntologyRuntime``
+in ``bigquery_agent_analytics``) import from here via absolute import —
+the contract has to agree bit-for-bit between the side that writes meta
+rows and the side that verifies them, so there is exactly one definition.
+
+The underscore prefix marks this as non-public. Not re-exported from
+``bigquery_ontology/__init__.py``. See
+``docs/implementation_plan_concept_index_runtime.md`` watchpoint W1.
+
+Serialization contract (pinned):
+
+- Input: ``BaseModel.model_dump(mode="json", by_alias=False, exclude_none=False)``.
+  ``mode="json"`` normalizes enums, datetimes, and Pydantic types to
+  JSON-safe primitives so the hash is stable across Python versions.
+  ``exclude_none=False`` keeps optional-but-declared fields in the
+  output so adding a default value later doesn't silently collide
+  with the pre-default fingerprint.
+- Encoding: ``json.dumps(..., sort_keys=True, separators=(",", ":"),
+  ensure_ascii=False)``. Sorted keys at every nesting level, no
+  whitespace, UTF-8.
+- Hash: SHA-256 over the encoded bytes; output ``"sha256:" + hexdigest``.
+
+Never fingerprint over ``yaml.dump(model)``, ``str(model)``, or
+``model.model_dump()`` without ``mode="json"``. Each of those breaks
+cross-version or cross-type stability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel
+
+_FINGERPRINT_PREFIX = "sha256:"
+_COMPILE_ID_LEN = 12  # 48 bits of entropy, per issue #58.
+
+
+def fingerprint_model(model: BaseModel) -> str:
+  """Return the canonical SHA-256 fingerprint of a validated Pydantic model.
+
+  Args:
+      model: Any validated Pydantic model (Ontology, Binding, or similar).
+
+  Returns:
+      ``"sha256:" + 64 hex chars`` — a stable content hash over the
+      model's semantic fields, invariant to source-file whitespace,
+      key ordering, comments, and Pydantic-default materialization.
+  """
+  dumped = model.model_dump(
+      mode="json",
+      by_alias=False,
+      exclude_none=False,
+  )
+  canonical = json.dumps(
+      dumped,
+      sort_keys=True,
+      separators=(",", ":"),
+      ensure_ascii=False,
+  ).encode("utf-8")
+  return _FINGERPRINT_PREFIX + hashlib.sha256(canonical).hexdigest()
+
+
+def compile_id(
+    ontology_fingerprint: str,
+    binding_fingerprint: str,
+    compiler_version: str,
+) -> str:
+  """Return the 12-hex-char pair-consistency tag used by the concept index.
+
+  Derived deterministically from the three compile inputs so that the
+  main concept-index table and its ``__meta`` sibling can be tied
+  together without requiring DDL-level transactions. 48 bits is
+  sufficient for pair consistency within a single ``output_table``;
+  full-fingerprint freshness is checked separately against the meta
+  row.
+
+  Args:
+      ontology_fingerprint: ``fingerprint_model(ontology)`` output.
+      binding_fingerprint: ``fingerprint_model(binding)`` output.
+      compiler_version: Version string of the compiler that produced
+          the index (e.g. ``"bigquery_ontology 0.2.1"``). Semver bumps
+          with behavior changes must flow through this field so the
+          tag invalidates old meta.
+
+  Returns:
+      12 lowercase hex characters.
+  """
+  payload = "\x00".join(
+      (ontology_fingerprint, binding_fingerprint, compiler_version)
+  ).encode("utf-8")
+  return hashlib.sha256(payload).hexdigest()[:_COMPILE_ID_LEN]

--- a/src/bigquery_ontology/_fingerprint.py
+++ b/src/bigquery_ontology/_fingerprint.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Canonical model fingerprint + compile_id for concept-index provenance.
+"""Canonical fingerprint primitives for concept-index provenance.
 
 Internal module. Both the ontology compiler (``graph_ddl_compiler`` when
 it gains ``compile_concept_index``) and the SDK runtime (``OntologyRuntime``
@@ -22,7 +22,29 @@ rows and the side that verifies them, so there is exactly one definition.
 
 The underscore prefix marks this as non-public. Not re-exported from
 ``bigquery_ontology/__init__.py``. See
-``docs/implementation_plan_concept_index_runtime.md`` watchpoint W1.
+``docs/implementation_plan_concept_index_runtime.md`` watchpoints W1/W2.
+
+Three exports, three roles:
+
+- :func:`fingerprint_model` — full SHA-256 over a validated Pydantic
+  model, returned as ``"sha256:" + 64 hex chars``. Used by the
+  compiler to fingerprint the ``Ontology`` and ``Binding`` inputs,
+  and by the runtime to compute cached local fingerprints from the
+  same models.
+- :func:`compile_fingerprint` — full 64-hex SHA-256 over the concat
+  of ``ontology_fingerprint``, ``binding_fingerprint``, and
+  ``compiler_version``. **Canonical integrity key.** Used for strict
+  verification: main↔meta pair consistency and runtime freshness
+  checks.
+- :func:`compile_id` — 12-hex display/debug token. Derived as
+  ``compile_fingerprint(...)[:_COMPILE_ID_LEN]`` — always a
+  structural truncation of the full integrity key, never its own
+  hash. Use for operator UX (reports, queue rows, log lines).
+  **Never use as the sole freshness check.**
+
+Invariant: ``compile_id == compile_fingerprint[:12]``. Enforced at
+the function boundary so a future refactor cannot let the two drift
+out of sync.
 
 Serialization contract (pinned):
 
@@ -35,7 +57,8 @@ Serialization contract (pinned):
 - Encoding: ``json.dumps(..., sort_keys=True, separators=(",", ":"),
   ensure_ascii=False)``. Sorted keys at every nesting level, no
   whitespace, UTF-8.
-- Hash: SHA-256 over the encoded bytes; output ``"sha256:" + hexdigest``.
+- Hash: SHA-256 over the encoded bytes; output ``"sha256:" + hexdigest``
+  for model fingerprints, raw hex for compile fingerprints.
 
 Never fingerprint over ``yaml.dump(model)``, ``str(model)``, or
 ``model.model_dump()`` without ``mode="json"``. Each of those breaks
@@ -78,19 +101,21 @@ def fingerprint_model(model: BaseModel) -> str:
   return _FINGERPRINT_PREFIX + hashlib.sha256(canonical).hexdigest()
 
 
-def compile_id(
+def compile_fingerprint(
     ontology_fingerprint: str,
     binding_fingerprint: str,
     compiler_version: str,
 ) -> str:
-  """Return the 12-hex-char pair-consistency tag used by the concept index.
+  """Return the full 64-hex canonical integrity key for a compile.
 
-  Derived deterministically from the three compile inputs so that the
-  main concept-index table and its ``__meta`` sibling can be tied
-  together without requiring DDL-level transactions. 48 bits is
-  sufficient for pair consistency within a single ``output_table``;
-  full-fingerprint freshness is checked separately against the meta
-  row.
+  Full SHA-256 over
+  ``ontology_fingerprint || binding_fingerprint || compiler_version``.
+  This is the **canonical integrity key** used by strict verification
+  for main-table ↔ meta-table pair consistency and for runtime
+  freshness checks against cached local fingerprints.
+
+  Never truncate this for verification purposes. See ``compile_id``
+  for the short display/debug companion.
 
   Args:
       ontology_fingerprint: ``fingerprint_model(ontology)`` output.
@@ -98,12 +123,45 @@ def compile_id(
       compiler_version: Version string of the compiler that produced
           the index (e.g. ``"bigquery_ontology 0.2.1"``). Semver bumps
           with behavior changes must flow through this field so the
-          tag invalidates old meta.
+          fingerprint invalidates old meta.
 
   Returns:
-      12 lowercase hex characters.
+      64 lowercase hex characters (256 bits).
   """
   payload = "\x00".join(
       (ontology_fingerprint, binding_fingerprint, compiler_version)
   ).encode("utf-8")
-  return hashlib.sha256(payload).hexdigest()[:_COMPILE_ID_LEN]
+  return hashlib.sha256(payload).hexdigest()
+
+
+def compile_id(
+    ontology_fingerprint: str,
+    binding_fingerprint: str,
+    compiler_version: str,
+) -> str:
+  """Return the 12-hex-char display token for a compile.
+
+  Derived as ``compile_fingerprint(...)[:_COMPILE_ID_LEN]``. The short
+  form is always a structural truncation of the full integrity key —
+  never its own hash — so that the two provenance columns in the
+  concept index cannot drift out of sync.
+
+  **Display-only.** Use this for operator reports, error messages,
+  queue rows, and log lines. Never use ``compile_id`` as the sole
+  freshness check; strict verification must use
+  :func:`compile_fingerprint` directly.
+
+  Args:
+      ontology_fingerprint: ``fingerprint_model(ontology)`` output.
+      binding_fingerprint: ``fingerprint_model(binding)`` output.
+      compiler_version: Version string of the compiler that produced
+          the index.
+
+  Returns:
+      12 lowercase hex characters — the first 12 chars of
+      ``compile_fingerprint(ontology_fingerprint, binding_fingerprint,
+      compiler_version)``.
+  """
+  return compile_fingerprint(
+      ontology_fingerprint, binding_fingerprint, compiler_version
+  )[:_COMPILE_ID_LEN]

--- a/src/bigquery_ontology/_fingerprint.py
+++ b/src/bigquery_ontology/_fingerprint.py
@@ -108,14 +108,27 @@ def compile_fingerprint(
 ) -> str:
   """Return the full 64-hex canonical integrity key for a compile.
 
-  Full SHA-256 over
-  ``ontology_fingerprint || binding_fingerprint || compiler_version``.
-  This is the **canonical integrity key** used by strict verification
-  for main-table ↔ meta-table pair consistency and for runtime
-  freshness checks against cached local fingerprints.
+  **Canonical integrity key.** Used by strict verification for main
+  ↔ meta pair consistency and runtime freshness checks against
+  cached local fingerprints. Never truncate this for verification
+  purposes. See ``compile_id`` for the short display/debug companion.
 
-  Never truncate this for verification purposes. See ``compile_id``
-  for the short display/debug companion.
+  Exact payload contract (pinned):
+
+  .. code-block:: text
+
+      payload = utf8(ontology_fingerprint + "\\x00" +
+                     binding_fingerprint + "\\x00" +
+                     compiler_version)
+      digest  = sha256(payload).hexdigest()  # 64 lowercase hex chars
+
+  The separator is a single NUL byte (``\\x00``). NUL is chosen
+  because it cannot appear in any of the three inputs (fingerprints
+  are hex; version strings are ASCII), so the delimited encoding is
+  unambiguous — no two different input triples can produce the same
+  payload. Do not reimplement this elsewhere; import
+  :func:`compile_fingerprint` from this module. Regression tests
+  pin a golden vector so a silent payload change is caught.
 
   Args:
       ontology_fingerprint: ``fingerprint_model(ontology)`` output.

--- a/tests/bigquery_ontology/test_fingerprint.py
+++ b/tests/bigquery_ontology/test_fingerprint.py
@@ -14,20 +14,27 @@
 
 """Tests for the internal fingerprint module used by concept-index provenance.
 
-The fingerprint contract is pinned in `docs/implementation_plan_concept_index_runtime.md`
-(W1) and in the issue #58 body under "Fingerprint algorithm":
+The contract is pinned in `docs/implementation_plan_concept_index_runtime.md`
+(W1/W2) and in the issue #58 body under "Fingerprint algorithm":
 
 - Input: `BaseModel.model_dump(mode="json", by_alias=False, exclude_none=False)`.
 - Canonical JSON: `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
-- Hash: SHA-256, returned as ``"sha256:"`` + 64 hex chars.
-- ``compile_id``: first 12 hex chars of
-  ``SHA-256(ontology_fingerprint || binding_fingerprint || compiler_version)``.
+- ``fingerprint_model``: SHA-256, returned as ``"sha256:"`` + 64 hex chars.
+- ``compile_fingerprint``: full 64-hex SHA-256 over
+  ``ontology_fingerprint || binding_fingerprint || compiler_version``.
+  Canonical integrity key; used by strict verification.
+- ``compile_id``: 12-hex display token derived as
+  ``compile_fingerprint(...)[:12]``. Never used as the sole
+  freshness check.
 
-These tests pin the contract so a future "optimizer" cannot silently
-replace the serialization with ``yaml.dump`` or ``str(model)`` or
+Invariant: ``compile_id == compile_fingerprint[:12]``.
+
+These tests pin the serialization contract (so a future "optimizer"
+cannot silently replace it with ``yaml.dump`` or ``str(model)`` or
 ``model.model_dump()`` without ``mode="json"``, all of which would
 break cross-package agreement between the compiler-side writer and
-the runtime-side verifier.
+the runtime-side verifier) and the Option 2 column contract from
+issue #58 (so the short and long forms cannot drift apart).
 """
 
 from __future__ import annotations
@@ -38,6 +45,7 @@ import pytest
 
 from bigquery_ontology import load_binding_from_string
 from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology._fingerprint import compile_fingerprint
 from bigquery_ontology._fingerprint import compile_id
 from bigquery_ontology._fingerprint import fingerprint_model
 
@@ -200,12 +208,55 @@ class TestFingerprintModel:
 
 
 # ------------------------------------------------------------------ #
-# compile_id                                                          #
+# compile_fingerprint — canonical integrity key                       #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileFingerprint:
+  """Full 64-hex SHA-256 over the three compile inputs.
+
+  This is the canonical integrity key used by strict verification.
+  Must respond to every input independently and must be 64 hex chars.
+  """
+
+  def test_length_is_sixty_four_hex_chars(self):
+    fp = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+  def test_deterministic_for_same_inputs(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert fp1 == fp2
+
+  def test_changes_with_ontology_fingerprint(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:zz", "sha256:bb", "gm-1.0.0")
+    assert fp1 != fp2
+
+  def test_changes_with_binding_fingerprint(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:zz", "gm-1.0.0")
+    assert fp1 != fp2
+
+  def test_changes_with_compiler_version(self):
+    """Compiler version changes must shift the fingerprint even when
+    both input fingerprints are unchanged — otherwise a semver bump
+    to the compiler with behavior changes would fail to invalidate
+    old meta.
+    """
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.1.0")
+    assert fp1 != fp2
+
+
+# ------------------------------------------------------------------ #
+# compile_id — 12-hex display token, derived from compile_fingerprint #
 # ------------------------------------------------------------------ #
 
 
 class TestCompileId:
-  """Short pair-consistency tag derived from the three compile inputs."""
+  """Short display/debug tag derived from ``compile_fingerprint``."""
 
   def test_length_is_twelve_hex_chars(self):
     cid = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
@@ -238,6 +289,52 @@ class TestCompileId:
 
 
 # ------------------------------------------------------------------ #
+# Structural invariant: compile_id == compile_fingerprint[:12]        #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileIdFingerprintInvariant:
+  """The short display token must be a structural truncation of the
+  full integrity key — never its own hash. This prevents the two
+  provenance columns in the concept index from drifting out of sync.
+
+  Pinned in the ``_fingerprint.py`` module docstring and in issue #58
+  (Option 2).
+  """
+
+  def test_compile_id_is_prefix_of_compile_fingerprint(self):
+    args = ("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert compile_id(*args) == compile_fingerprint(*args)[:12]
+
+  def test_invariant_holds_across_varied_inputs(self):
+    """Invariant must hold for any input triple, not just one case."""
+    cases = [
+        ("sha256:aa", "sha256:bb", "gm-1.0.0"),
+        ("sha256:ff0000", "sha256:0000ff", "gm-2.3.4"),
+        ("", "", ""),  # degenerate but deterministic
+        ("x" * 100, "y" * 100, "z" * 100),  # long inputs
+    ]
+    for args in cases:
+      assert (
+          compile_id(*args) == compile_fingerprint(*args)[:12]
+      ), f"invariant broken for {args}"
+
+  def test_compile_id_never_computes_its_own_hash(self):
+    """Regression guard: if someone re-implements ``compile_id`` to
+    hash a different payload (e.g. a subset of inputs, or a different
+    separator), the invariant breaks and this test catches it.
+    """
+    # Any change to the payload that preserves the relative ordering
+    # but alters the bytes would produce a different 12-hex prefix.
+    # Assert the derivation is pure truncation of compile_fingerprint.
+    args = ("sha256:a", "sha256:b", "v")
+    full = compile_fingerprint(*args)
+    short = compile_id(*args)
+    assert short == full[:12]
+    assert full.startswith(short)
+
+
+# ------------------------------------------------------------------ #
 # Public surface                                                      #
 # ------------------------------------------------------------------ #
 
@@ -252,13 +349,16 @@ class TestPrivateSurface:
 
     assert not hasattr(bigquery_ontology, "fingerprint_model")
     assert not hasattr(bigquery_ontology, "compile_id")
+    assert not hasattr(bigquery_ontology, "compile_fingerprint")
 
   def test_importable_via_absolute_path(self):
     """Both packages import via ``from bigquery_ontology._fingerprint
     import ...``. Make sure that path continues to work.
     """
+    from bigquery_ontology._fingerprint import compile_fingerprint as _cfp
     from bigquery_ontology._fingerprint import compile_id as _cid
     from bigquery_ontology._fingerprint import fingerprint_model as _fp
 
+    assert callable(_cfp)
     assert callable(_cid)
     assert callable(_fp)

--- a/tests/bigquery_ontology/test_fingerprint.py
+++ b/tests/bigquery_ontology/test_fingerprint.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the internal fingerprint module used by concept-index provenance.
+
+The fingerprint contract is pinned in `docs/implementation_plan_concept_index_runtime.md`
+(W1) and in the issue #58 body under "Fingerprint algorithm":
+
+- Input: `BaseModel.model_dump(mode="json", by_alias=False, exclude_none=False)`.
+- Canonical JSON: `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
+- Hash: SHA-256, returned as ``"sha256:"`` + 64 hex chars.
+- ``compile_id``: first 12 hex chars of
+  ``SHA-256(ontology_fingerprint || binding_fingerprint || compiler_version)``.
+
+These tests pin the contract so a future "optimizer" cannot silently
+replace the serialization with ``yaml.dump`` or ``str(model)`` or
+``model.model_dump()`` without ``mode="json"``, all of which would
+break cross-package agreement between the compiler-side writer and
+the runtime-side verifier.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology._fingerprint import compile_id
+from bigquery_ontology._fingerprint import fingerprint_model
+
+_SIMPLE_ONTOLOGY_YAML = textwrap.dedent(
+    """\
+    ontology: finance
+    entities:
+      - name: Account
+        keys:
+          primary: [account_id]
+        properties:
+          - name: account_id
+            type: string
+          - name: opened_at
+            type: timestamp
+    """
+)
+
+
+_SIMPLE_BINDING_YAML = textwrap.dedent(
+    """\
+    binding: finance-bq-prod
+    ontology: finance
+    target:
+      backend: bigquery
+      project: my-proj
+      dataset: finance
+    entities:
+      - name: Account
+        source: raw.accounts
+        properties:
+          - {name: account_id, column: acct_id}
+          - {name: opened_at, column: created_ts}
+    """
+)
+
+
+# ------------------------------------------------------------------ #
+# fingerprint_model                                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestFingerprintModel:
+  """Canonical-JSON SHA-256 over Pydantic models."""
+
+  def test_returns_sha256_prefixed_hex(self):
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    fp = fingerprint_model(ont)
+    assert fp.startswith("sha256:")
+    # 64 hex chars after the prefix = 256 bits.
+    digest = fp[len("sha256:") :]
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+  def test_deterministic_across_calls(self):
+    """Same model, same fingerprint, every time."""
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    fp1 = fingerprint_model(ont)
+    fp2 = fingerprint_model(ont)
+    assert fp1 == fp2
+
+  def test_non_semantic_yaml_edits_produce_identical_fingerprint(self):
+    """Whitespace, comments, and key-ordering changes must not shift the
+    fingerprint. This is the entire justification for fingerprinting at
+    the validated-model layer rather than over raw YAML text.
+    """
+    edited_yaml = textwrap.dedent(
+        """\
+        # A leading comment.
+        ontology: finance
+
+
+        entities:
+            - name: Account
+              keys:
+                  primary: [account_id]
+              properties:
+                  - name: account_id
+                    type: string
+                  - name: opened_at
+                    type: timestamp
+        """
+    )
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(edited_yaml)
+    assert fingerprint_model(ont1) == fingerprint_model(ont2)
+
+  def test_semantic_rename_changes_fingerprint(self):
+    """Changing an entity name is a semantic edit; fingerprint differs."""
+    renamed = _SIMPLE_ONTOLOGY_YAML.replace("name: Account", "name: Ledger")
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(renamed)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+  def test_semantic_type_change_changes_fingerprint(self):
+    """Property type change must surface as a different fingerprint."""
+    retyped = _SIMPLE_ONTOLOGY_YAML.replace("type: timestamp", "type: datetime")
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(retyped)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+  def test_binding_fingerprint_reflects_target_dataset(self):
+    """A binding repointed at a different dataset must fingerprint
+    differently — the binding's identity includes its physical target.
+    """
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    bnd1 = load_binding_from_string(_SIMPLE_BINDING_YAML, ontology=ont)
+    bnd2 = load_binding_from_string(
+        _SIMPLE_BINDING_YAML.replace("dataset: finance", "dataset: staging"),
+        ontology=ont,
+    )
+    assert fingerprint_model(bnd1) != fingerprint_model(bnd2)
+
+  def test_ontology_and_binding_fingerprints_differ(self):
+    """Two different model types from the same source file namespace
+    must fingerprint to different values. (A trivial check, but it
+    catches implementations that fingerprint only on a shared subset
+    of fields.)
+    """
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    bnd = load_binding_from_string(_SIMPLE_BINDING_YAML, ontology=ont)
+    assert fingerprint_model(ont) != fingerprint_model(bnd)
+
+  def test_list_order_is_semantic(self):
+    """Key columns are declaration-ordered in the ontology model;
+    reordering them is a semantic change. Fingerprint must reflect
+    that (lists are preserved in declaration order, not sorted).
+    """
+    multi_key_yaml = textwrap.dedent(
+        """\
+        ontology: finance
+        entities:
+          - name: Account
+            keys:
+              primary: [tenant_id, account_id]
+            properties:
+              - name: tenant_id
+                type: string
+              - name: account_id
+                type: string
+        """
+    )
+    reordered = textwrap.dedent(
+        """\
+        ontology: finance
+        entities:
+          - name: Account
+            keys:
+              primary: [account_id, tenant_id]
+            properties:
+              - name: tenant_id
+                type: string
+              - name: account_id
+                type: string
+        """
+    )
+    ont1 = load_ontology_from_string(multi_key_yaml)
+    ont2 = load_ontology_from_string(reordered)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+
+# ------------------------------------------------------------------ #
+# compile_id                                                          #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileId:
+  """Short pair-consistency tag derived from the three compile inputs."""
+
+  def test_length_is_twelve_hex_chars(self):
+    cid = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert len(cid) == 12
+    assert all(c in "0123456789abcdef" for c in cid)
+
+  def test_deterministic_for_same_inputs(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert cid1 == cid2
+
+  def test_changes_with_ontology_fingerprint(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:zz", "sha256:bb", "gm-1.0.0")
+    assert cid1 != cid2
+
+  def test_changes_with_binding_fingerprint(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:zz", "gm-1.0.0")
+    assert cid1 != cid2
+
+  def test_changes_with_compiler_version(self):
+    """Compiler version changes must shift the compile_id even when
+    both fingerprints are unchanged — otherwise a semver bump to the
+    compiler with behavior changes would fail to invalidate old meta.
+    """
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:bb", "gm-1.1.0")
+    assert cid1 != cid2
+
+
+# ------------------------------------------------------------------ #
+# Public surface                                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestPrivateSurface:
+  """``_fingerprint`` is an internal module — not part of the package
+  API. Catch accidental re-export from ``bigquery_ontology/__init__.py``.
+  """
+
+  def test_not_exported_from_package_root(self):
+    import bigquery_ontology
+
+    assert not hasattr(bigquery_ontology, "fingerprint_model")
+    assert not hasattr(bigquery_ontology, "compile_id")
+
+  def test_importable_via_absolute_path(self):
+    """Both packages import via ``from bigquery_ontology._fingerprint
+    import ...``. Make sure that path continues to work.
+    """
+    from bigquery_ontology._fingerprint import compile_id as _cid
+    from bigquery_ontology._fingerprint import fingerprint_model as _fp
+
+    assert callable(_cid)
+    assert callable(_fp)

--- a/tests/bigquery_ontology/test_fingerprint.py
+++ b/tests/bigquery_ontology/test_fingerprint.py
@@ -249,6 +249,30 @@ class TestCompileFingerprint:
     fp2 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.1.0")
     assert fp1 != fp2
 
+  def test_golden_vector(self):
+    """Pinned byte-exact digest for a known input triple.
+
+    This catches silent payload-contract changes that would still
+    pass length/determinism/input-sensitivity tests — e.g. swapping
+    the NUL separator to another byte, changing the concatenation
+    order, or altering the UTF-8 encoding. A refactor that changes
+    the payload shape will flip this value and fail the test even
+    if all the behavioral properties still hold.
+
+    The payload is:
+
+        "sha256:aa" + "\\x00" + "sha256:bb" + "\\x00" + "gm-1.0.0"
+
+    encoded as UTF-8, hashed with SHA-256.
+    """
+    full = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    short = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert (
+        full
+        == "dd301e2874a3bc55dd3ab6ea428ad1046f6b4834b4dccd7a87cf82a1991e0184"
+    )
+    assert short == "dd301e2874a3"
+
 
 # ------------------------------------------------------------------ #
 # compile_id — 12-hex display token, derived from compile_fingerprint #


### PR DESCRIPTION
## Summary

First code slice of the concept index + runtime entity resolution work (issue #58). Per the [in-repo implementation plan](docs/implementation_plan_concept_index_runtime.md) — item **A1** in the work breakdown.

Adds `src/bigquery_ontology/_fingerprint.py` — the **single source of truth** for the canonical model fingerprint and the 12-hex-char `compile_id` pair-consistency tag. Both the ontology compiler (writer, landing in A3) and the SDK runtime (verifier, landing in B1) import from here via absolute import so the contract is guaranteed to agree bit-for-bit between writer and reader.

## API

Two functions, both internal (underscore-prefix module, not re-exported):

```python
from bigquery_ontology._fingerprint import fingerprint_model, compile_id

ont_fp = fingerprint_model(ontology)
# "sha256:6f9a…"  (64 hex chars)

bnd_fp = fingerprint_model(binding)
# "sha256:3c2e…"

cid = compile_id(ont_fp, bnd_fp, "bigquery_ontology 0.2.1")
# "a1b2c3d4e5f6"  (12 hex chars, 48 bits)
```

## Contract pinning (W1 watchpoint)

The serialization contract is pinned in the module docstring:

- `model_dump(mode="json", by_alias=False, exclude_none=False)` — normalizes enums, datetimes, and Pydantic types to JSON-safe primitives so the hash is stable across Python versions; keeps optional-but-declared fields in the output so adding a default later doesn't silently collide with the pre-default fingerprint.
- `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)` — sort keys at every nesting level, no whitespace, UTF-8.
- SHA-256 over the encoded bytes; output `"sha256:" + hexdigest`.

The docstring explicitly calls out the three downgrade paths that must **never** be taken: `yaml.dump(model)`, `str(model)`, or `model.model_dump()` without `mode="json"`. All three break cross-version or cross-type stability.

## Why underscore

- Non-public — module path pins the semver-unstable status for the functions.
- Renaming `fingerprint_model` / `compile_id` or changing their signatures does not trigger a package minor bump.
- Matches the existing pattern for other internal modules.

Not re-exported from `bigquery_ontology/__init__.py`; a test case pins that.

## Tests

`tests/bigquery_ontology/test_fingerprint.py` — 15 tests, all new.

**Determinism (what must stay stable):**
- Same model → same fingerprint across repeated calls.
- Non-semantic YAML edits (whitespace, comments, indentation, blank lines) → identical fingerprint.

**Semantic sensitivity (what must shift):**
- Entity rename.
- Property type change.
- Binding target dataset change.
- Key-column order change (lists are declaration-ordered, not sorted — per the plan).

**`compile_id`:**
- 12 hex chars, lowercase.
- Deterministic given same inputs.
- Responds independently to each of the three inputs (`ontology_fingerprint`, `binding_fingerprint`, `compiler_version`).

**Private surface:**
- Not exposed at `bigquery_ontology.*` top level.
- Still importable via the pinned absolute path.

## Test plan

- [x] `python -m pytest tests/bigquery_ontology/test_fingerprint.py -v` → 15 passed.
- [x] `python -m pytest tests/` → 2007 passed, 4 skipped, 0 failures.
- [x] `bash autoformat.sh` → no diff remaining.

## Scope

Phase 1 of the implementation plan. This is A1 only; the subsequent PRs stack cleanly on top:

- **A2** — `concept_index.py` row builder (depends on A1 and #57's `abstract` field; both now in place).
- **A3-A5** — `compile_concept_index` + inline-UNNEST SQL emission.
- **A7** — CLI flags `--emit-concept-index` + `--concept-index-table`.
- **A8** — user-facing `docs/ontology/concept-index.md`.

None of those are in this PR.