### PR TITLE
docs: tighten scope and migration note on concept-index plan

### DIFF
--- a/docs/implementation_plan_concept_index_runtime.md
+++ b/docs/implementation_plan_concept_index_runtime.md
@@ -9,6 +9,8 @@ Two packages touched:
 - `bigquery_ontology` — compiler, CLI, fingerprint infrastructure.
 - `bigquery_agent_analytics` — `OntologyRuntime`, resolvers, verification.
 
+**Package-boundary scope.** Both packages are build-time + trace-consumption libraries. `bigquery_ontology` is offline CLI + model classes. `bigquery_agent_analytics` is the consumption-layer SDK read by evaluation, curation, and analysis pipelines over trace data the BQ AA Plugin already wrote to BigQuery. **Neither is a turn-time agent SDK**; the live-agent side is owned by the BQ AA Plugin (separate package). The word *Runtime* in this plan refers to the `OntologyRuntime` class and to library call time at the consuming pipeline, not to a live agent loop. A future agent-facing resolver package may reuse the `EntityResolver` `Protocol` introduced here, but it is out of scope for this plan.
+
 This plan assumes issue #57 is either merged or lands in parallel. The concept index's value is ~80% from SKOS annotations (`skos:notation`, `skos:prefLabel`, `skos:altLabel`, `skos:broader`) being preserved through import.
 
 ## Acceptance criteria
@@ -123,7 +125,12 @@ Tests: D9, D10, D11, D12, D14.
 
 Work: integration tests across ontology → compile → runtime → resolve; end-to-end example in `examples/`; migration note for users who had local resolution code; full doc pass.
 
-**Definition of done**: `examples/concept_index_quickstart.py` (or similar) runs end-to-end against a real BQ dataset using a fixture ontology. README section added. Migration note published.
+The migration note explicitly splits into two paths — the motivating feedback-gist resolver ran at live-agent time, and the SDK does not replace it directly:
+
+- **Trace-consumption migration** (pipelines / notebooks / curation scripts): direct drop-in. `SynonymResolver` + the compiled concept index replaces the pipeline's local resolver. This is the primary supported path.
+- **Live-agent migration**: not yet supported. Keep your existing in-agent resolver until a separate agent-facing package ships that reuses the `EntityResolver` `Protocol`. Users who want forward-compatibility can prototype against the Protocol today so that swap is mechanical when the agent-facing package lands.
+
+**Definition of done**: `examples/concept_index_quickstart.py` (or similar) runs end-to-end against a real BQ dataset using a fixture ontology. README section added. Migration note published with both paths clearly labeled.
 
 ### Phase 5 — Contrib + polish
 


### PR DESCRIPTION
## Summary

Two reader-communication fixes on [`docs/implementation_plan_concept_index_runtime.md`](docs/implementation_plan_concept_index_runtime.md) for parity with the issue #58 RFC's package-boundary framing. No change to the plan's technical content — implementers produce the same artifacts either way.

## Motivation

The issue #58 RFC ([comment](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58#issuecomment-4303044348)) was tightened to clarify that:

- `bigquery_agent_analytics` is a **consumption-layer SDK** for trace data the BQ AA Plugin already wrote to BigQuery — read by evaluation, curation, and analysis pipelines. It is not a turn-time agent SDK.
- The live-agent side (agent runtime, plugin hooks) is owned by the **BQ AA Plugin** — a separate package, not this repo.
- A future agent-facing resolver package may reuse the `EntityResolver` `Protocol` introduced here but is out of scope.

The in-repo implementation plan doc did not carry that framing. A reader arriving at the plan alone (not via the RFC) could infer live-agent intent from the word *"Runtime"* in the title, or follow the vague "migration note for users who had local resolution code" into a mis-migration if their existing resolver was live-agent code.

## Changes

**1. Add a Package-boundary scope paragraph near the top.** Explicitly states:

- `bigquery_ontology` = offline CLI + model classes.
- `bigquery_agent_analytics` = consumption-layer SDK.
- Neither package is a turn-time agent SDK.
- A future agent-facing resolver package may reuse the Protocol but is out of scope here.

**2. Split the Phase 4 migration note into two explicit paths.** The motivating feedback-gist user ran their 5-layer resolver at live-agent time; `SynonymResolver` is not a drop-in replacement for that use case. The plan now labels both paths:

- **Trace-consumption migration** (primary supported path) — direct drop-in for pipelines / notebooks / curation.
- **Live-agent migration** (not yet supported) — keep existing in-agent resolver; prototype against the Protocol for forward-compat.

## Test plan

Docs-only. No code, tests, or CI behavior changes. `+8 -1` on a single file.

## Related

- Issue #58 RFC comment: [#issuecomment-4303044348](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58#issuecomment-4303044348)
- Plan merged via PR #70
- A1 fingerprint PR #71 (open)