### PR TITLE
Fix evaluation logic for prebuilt gates and failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to `bigquery-agent-analytics` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed (breaking)
+
+- **Prebuilt `CodeEvaluator` gates now compare raw observed values
+  directly against the user-supplied budget.** `CodeEvaluator.latency`,
+  `.turn_count`, `.error_rate`, `.token_efficiency`, `.ttft`, and
+  `.cost_per_session` return `1.0` when the observed metric is within
+  budget and `0.0` otherwise. The previous implementation scored sessions
+  on a normalized `1.0 - (observed / budget)` scale against a `0.5` pass
+  cutoff, which effectively fired every gate at roughly half the budget
+  the user typed (e.g. `latency(threshold_ms=5000)` failed sessions at
+  `avg_latency_ms > 2500`). Users relying on the old sub-budget fail
+  behavior should lower their budgets to match their intent.
+- The scheduled streaming evaluator (`streaming_observability_v1`) uses
+  the same raw-budget gate semantics for consistency with the prebuilt
+  `CodeEvaluator` factories.
+
+### Added
+
+- `CodeEvaluator.add_metric` accepts `observed_key`, `observed_fn`, and
+  `budget` arguments that flow into `SessionScore.details[f"metric_{name}"]`
+  for downstream reporting. The CLI uses these to emit readable failure
+  lines without re-running the scorer.
+- `bq-agent-sdk evaluate --exit-code` now prints a per-session failure
+  summary on stderr before exiting non-zero. Each line names the
+  session_id, failing metric, observed value, and the budget it blew
+  through. Output is capped at the first 10 failing sessions to keep
+  CI logs scannable.
+
+## [0.2.1]
+
+- See `git log` for prior changes.

--- a/docs/design.md
+++ b/docs/design.md
@@ -408,15 +408,36 @@ _metrics: list[dict]  # [{"name": str, "fn": Callable[[dict], float], "threshold
 
 Each metric function receives a session summary dict (aggregated from BigQuery) and returns a score in `[0.0, 1.0]`.
 
-**Pre-built factory methods:**
+**Pre-built factory methods** (Python path — raw-budget binary gates):
 
-| Factory | Metric Logic | Default Threshold |
-|---------|-------------|-------------------|
-| `latency(threshold_ms)` | `1.0 - min(avg_latency_ms / threshold_ms, 1.0)` | 0.5 |
-| `turn_count(max_turns)` | `1.0 - min(turn_count / max_turns, 1.0)` | 0.5 |
-| `error_rate(max_error_rate)` | `1.0 - min(actual_rate / max_rate, 1.0)` | 0.5 |
-| `token_efficiency(max_tokens)` | `1.0 - min(total_tokens / max_tokens, 1.0)` | 0.5 |
-| `cost_per_session(max_cost_usd, ...)` | `1.0 - min(computed_cost / max_cost, 1.0)` | 0.5 |
+Since v0.2.2 the Python prebuilts compare the observed metric directly
+against the user-supplied budget: `score = 1.0 if observed <= budget
+else 0.0`, with `threshold = 1.0`. A session fails iff the observed
+value strictly exceeds the budget.
+
+| Factory | Observed Value | Pass Condition |
+|---------|----------------|----------------|
+| `latency(threshold_ms)` | `avg_latency_ms` | `observed <= threshold_ms` |
+| `turn_count(max_turns)` | `turn_count` | `observed <= max_turns` |
+| `error_rate(max_error_rate)` | `tool_errors / tool_calls` (0 when no calls) | `observed <= max_error_rate` |
+| `token_efficiency(max_tokens)` | `total_tokens` | `observed <= max_tokens` |
+| `ttft(threshold_ms)` | `avg_ttft_ms` | `observed <= threshold_ms` |
+| `cost_per_session(max_cost_usd, ...)` | `(input_tokens/1K)*input_rate + (output_tokens/1K)*output_rate` | `observed <= max_cost_usd` |
+
+> **Prior to v0.2.2** these factories used a normalized score
+> `1.0 - min(observed / budget, 1.0)` with a `0.5` pass cutoff, which
+> effectively fired every gate at roughly half the budget the user
+> typed (e.g. `latency(threshold_ms=5000)` failed at `avg_latency_ms >
+> 2500`). See `CHANGELOG.md` for the migration note.
+
+**SQL-native UDF path** (`udf_kernels.score_*`, used by
+`udf_sql_templates.py`):
+
+Unchanged — keeps the normalized `1.0 - min(observed / budget, 1.0)`
+score because BigQuery SQL callers (e.g. scorecard dashboards) may
+already interpret the normalized value. The divergence from the Python
+path is intentional: Python prebuilts are binary CI gates; SQL UDFs
+are normalized metrics for analytical workloads.
 
 **`evaluate_session(session_summary) -> SessionScore`:**
 

--- a/src/bigquery_agent_analytics/_streaming_evaluation.py
+++ b/src/bigquery_agent_analytics/_streaming_evaluation.py
@@ -70,31 +70,60 @@ class StreamingTrigger:
 
 
 def build_streaming_observability_evaluator() -> CodeEvaluator:
-  """Build the fixed launch evaluator profile for streaming observability."""
+  """Build the fixed launch evaluator profile for streaming observability.
+
+  Uses raw-budget gates (a session passes iff the observed metric is
+  within the configured budget) for consistency with
+  ``CodeEvaluator.latency`` / ``.error_rate`` / ``.turn_count``.
+  Prior implementation used normalized scores with a 0.5 pass cutoff,
+  which caused gates to fire at roughly half the configured budget.
+  """
 
   def _score_latency(session_summary: dict[str, Any]) -> float:
-    return udf_kernels.score_latency(
-        session_summary.get("avg_latency_ms", 0),
-        _LATENCY_THRESHOLD_MS,
-    )
+    observed = session_summary.get("avg_latency_ms", 0) or 0
+    return 1.0 if observed <= _LATENCY_THRESHOLD_MS else 0.0
+
+  def _observed_error_rate(session_summary: dict[str, Any]) -> float:
+    calls = session_summary.get("tool_calls", 0) or 0
+    errors = session_summary.get("tool_errors", 0) or 0
+    if calls <= 0:
+      return 0.0
+    return errors / calls
 
   def _score_error_rate(session_summary: dict[str, Any]) -> float:
-    return udf_kernels.score_error_rate(
-        session_summary.get("tool_calls", 0),
-        session_summary.get("tool_errors", 0),
-        _MAX_ERROR_RATE,
+    calls = session_summary.get("tool_calls", 0) or 0
+    if calls <= 0:
+      return 1.0
+    return (
+        1.0 if _observed_error_rate(session_summary) <= _MAX_ERROR_RATE else 0.0
     )
 
   def _score_turn_count(session_summary: dict[str, Any]) -> float:
-    return udf_kernels.score_turn_count(
-        session_summary.get("turn_count", 0),
-        _MAX_TURNS,
-    )
+    observed = session_summary.get("turn_count", 0) or 0
+    return 1.0 if observed <= _MAX_TURNS else 0.0
 
   evaluator = CodeEvaluator(name=STREAMING_EVALUATOR_PROFILE)
-  evaluator.add_metric("latency", _score_latency, threshold=0.5)
-  evaluator.add_metric("error_rate", _score_error_rate, threshold=0.5)
-  evaluator.add_metric("turn_count", _score_turn_count, threshold=0.5)
+  evaluator.add_metric(
+      "latency",
+      _score_latency,
+      threshold=1.0,
+      observed_key="avg_latency_ms",
+      budget=_LATENCY_THRESHOLD_MS,
+  )
+  evaluator.add_metric(
+      "error_rate",
+      _score_error_rate,
+      threshold=1.0,
+      observed_fn=_observed_error_rate,
+      budget=_MAX_ERROR_RATE,
+  )
+  evaluator.add_metric(
+      "turn_count",
+      _score_turn_count,
+      threshold=1.0,
+      observed_key="turn_count",
+      budget=_MAX_TURNS,
+  )
   return evaluator
 
 

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -40,6 +40,7 @@ from typing import Optional
 import typer
 
 from .evaluators import CodeEvaluator
+from .evaluators import EvaluationReport
 from .evaluators import LLMAsJudge
 from .formatter import format_output
 from .trace import TraceFilter
@@ -358,12 +359,70 @@ def evaluate(
     typer.echo(format_output(report, fmt))
 
     if exit_code and report.pass_rate < 1.0:
+      _emit_evaluate_failures(report)
       raise typer.Exit(code=1)
   except typer.Exit:
     raise
   except Exception as exc:
     typer.echo(f"Error: {exc}", err=True)
     raise typer.Exit(code=2)
+
+
+def _emit_evaluate_failures(
+    report: EvaluationReport, max_sessions: int = 10
+) -> None:
+  """Emit readable FAIL lines for failing sessions before --exit-code exits.
+
+  One line per (session_id, metric_name) that failed its threshold, with
+  the raw observed value and budget when the metric declared them via
+  ``observed_key`` / ``budget``. Capped at ``max_sessions`` most-recent
+  failures so CI logs stay scannable.
+  """
+  failed = [s for s in report.session_scores if not s.passed]
+  if not failed:
+    return
+  typer.echo("", err=True)
+  typer.echo(
+      f"--exit-code: {len(failed)} session(s) failed (of "
+      f"{report.total_sessions} evaluated)",
+      err=True,
+  )
+  shown = failed[:max_sessions]
+  for s in shown:
+    for metric_name, score in s.scores.items():
+      detail = s.details.get(f"metric_{metric_name}") or {}
+      observed = detail.get("observed")
+      budget = detail.get("budget")
+      # Consider both the per-metric detail's passed field (when set)
+      # and the raw score-vs-threshold fallback for custom metrics.
+      if detail:
+        if detail.get("passed", True):
+          continue
+      else:
+        # Custom metric with no observed/budget metadata — infer pass/fail
+        # from the score. Default threshold on _MetricDef is 0.5, so we
+        # can't know the exact threshold here; skip unless the score is
+        # a clean 0.0 (the binary-scorer pattern the prebuilts use now).
+        if score != 0.0:
+          continue
+      parts = [f"FAIL session={s.session_id} metric={metric_name}"]
+      if observed is not None:
+        if isinstance(observed, float):
+          parts.append(f"observed={observed:.4g}")
+        else:
+          parts.append(f"observed={observed}")
+      if budget is not None:
+        if isinstance(budget, float):
+          parts.append(f"budget={budget:.4g}")
+        else:
+          parts.append(f"budget={budget}")
+      typer.echo("  " + " ".join(parts), err=True)
+  if len(failed) > len(shown):
+    typer.echo(
+        f"  ... {len(failed) - len(shown)} more failing session(s) "
+        f"(raise --limit or see --format=json for full list)",
+        err=True,
+    )
 
 
 @app.command()

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -373,10 +373,14 @@ def _emit_evaluate_failures(
 ) -> None:
   """Emit readable FAIL lines for failing sessions before --exit-code exits.
 
-  One line per (session_id, metric_name) that failed its threshold, with
-  the raw observed value and budget when the metric declared them via
-  ``observed_key`` / ``budget``. Capped at ``max_sessions`` most-recent
-  failures so CI logs stay scannable.
+  One line per (session_id, metric_name) that failed its threshold.
+  Prefers the raw observed + budget pair (``CodeEvaluator`` prebuilts);
+  falls back to score + threshold when the metric didn't declare
+  observed/budget (custom ``add_metric`` users, ``LLMAsJudge``
+  criteria). A failing session is guaranteed to produce at least one
+  FAIL line — never just the summary header.
+
+  Capped at ``max_sessions`` most-recent failures so CI logs stay scannable.
   """
   failed = [s for s in report.session_scores if not s.passed]
   if not failed:
@@ -389,22 +393,29 @@ def _emit_evaluate_failures(
   )
   shown = failed[:max_sessions]
   for s in shown:
+    emitted_for_session = False
     for metric_name, score in s.scores.items():
       detail = s.details.get(f"metric_{metric_name}") or {}
-      observed = detail.get("observed")
-      budget = detail.get("budget")
-      # Consider both the per-metric detail's passed field (when set)
-      # and the raw score-vs-threshold fallback for custom metrics.
-      if detail:
-        if detail.get("passed", True):
+      passed_field = detail.get("passed")
+      threshold = detail.get("threshold")
+      # Decide pass/fail for this metric. Prefer the stashed ``passed``
+      # flag; fall back to score vs threshold when the detail isn't
+      # populated (older custom evaluators).
+      if passed_field is not None:
+        if passed_field:
+          continue
+      elif threshold is not None:
+        if score >= threshold:
           continue
       else:
-        # Custom metric with no observed/budget metadata — infer pass/fail
-        # from the score. Default threshold on _MetricDef is 0.5, so we
-        # can't know the exact threshold here; skip unless the score is
-        # a clean 0.0 (the binary-scorer pattern the prebuilts use now).
-        if score != 0.0:
+        # No per-metric metadata at all. Since the session is in the
+        # failed bucket, we still want to name the metric; assume it
+        # failed unless the score is a perfect 1.0.
+        if score >= 1.0:
           continue
+
+      observed = detail.get("observed")
+      budget = detail.get("budget")
       parts = [f"FAIL session={s.session_id} metric={metric_name}"]
       if observed is not None:
         if isinstance(observed, float):
@@ -416,7 +427,24 @@ def _emit_evaluate_failures(
           parts.append(f"budget={budget:.4g}")
         else:
           parts.append(f"budget={budget}")
+      # Always include score + threshold so the reader has numeric
+      # context even when observed / budget weren't declared (custom
+      # metrics, LLM judges).
+      parts.append(f"score={score:.4g}")
+      if threshold is not None and isinstance(threshold, (int, float)):
+        parts.append(f"threshold={threshold:.4g}")
       typer.echo("  " + " ".join(parts), err=True)
+      emitted_for_session = True
+
+    # Safety net: a failing session must produce at least one FAIL line.
+    # This triggers only if every metric's details claim passed=True
+    # while the session itself is flagged failed (a bug upstream) — we
+    # still point the reader at the session id.
+    if not emitted_for_session:
+      typer.echo(
+          f"  FAIL session={s.session_id} (no per-metric detail available)",
+          err=True,
+      )
   if len(failed) > len(shown):
     typer.echo(
         f"  ... {len(failed) - len(shown)} more failing session(s) "

--- a/src/bigquery_agent_analytics/evaluators.py
+++ b/src/bigquery_agent_analytics/evaluators.py
@@ -261,24 +261,27 @@ class CodeEvaluator:
         metric_passed = False
         passed = False
 
-      # Stash per-metric reporting detail when the metric declared its
-      # observed-key / budget. Keys under ``details`` are prefixed with
-      # ``metric_`` to avoid colliding with other details callers may add.
-      if metric.observed_key is not None or metric.observed_fn is not None:
-        if metric.observed_fn is not None:
-          try:
-            observed_value = metric.observed_fn(session_summary)
-          except Exception:  # pylint: disable=broad-except
-            observed_value = None
-        else:
-          observed_value = session_summary.get(metric.observed_key)
-        details[f"metric_{metric.name}"] = {
-            "observed": observed_value,
-            "budget": metric.budget,
-            "threshold": metric.threshold,
-            "score": scores[metric.name],
-            "passed": metric_passed,
-        }
+      # Stash per-metric reporting detail for *every* metric so the CLI
+      # ``--exit-code`` failure output always has a threshold / score /
+      # passed triple to emit, even for custom metrics that didn't
+      # declare observed_key / observed_fn. Observed / budget are only
+      # included when the metric supplied them. Keys are prefixed with
+      # ``metric_`` to avoid colliding with other details callers.
+      observed_value: Optional[Any] = None
+      if metric.observed_fn is not None:
+        try:
+          observed_value = metric.observed_fn(session_summary)
+        except Exception:  # pylint: disable=broad-except
+          observed_value = None
+      elif metric.observed_key is not None:
+        observed_value = session_summary.get(metric.observed_key)
+      details[f"metric_{metric.name}"] = {
+          "observed": observed_value,
+          "budget": metric.budget,
+          "threshold": metric.threshold,
+          "score": scores[metric.name],
+          "passed": metric_passed,
+      }
 
     return SessionScore(
         session_id=session_summary.get("session_id", "unknown"),

--- a/src/bigquery_agent_analytics/evaluators.py
+++ b/src/bigquery_agent_analytics/evaluators.py
@@ -136,11 +136,29 @@ class EvaluationReport(BaseModel):
 
 @dataclass
 class _MetricDef:
-  """Internal definition of a code metric."""
+  """Internal definition of a code metric.
+
+  ``observed_key``, ``observed_fn``, and ``budget`` are optional
+  reporting metadata used by the prebuilt evaluators (latency,
+  error_rate, turn_count, …) to surface the raw observed value and
+  the user-supplied budget in ``SessionScore.details``. They don't
+  affect pass/fail computation — that still goes through ``fn`` +
+  ``threshold`` — but they let downstream consumers (CLI
+  ``--exit-code`` output, dashboards) emit readable failure lines
+  without having to re-run the scorer.
+
+  When ``observed_fn`` is set it takes precedence over
+  ``observed_key``; use it for metrics whose observed value is
+  computed from multiple summary fields (e.g. ``tool_errors /
+  tool_calls`` for error rate).
+  """
 
   name: str
   fn: Callable[[dict[str, Any]], float]
   threshold: float = 0.5
+  observed_key: Optional[str] = None
+  budget: Optional[float] = None
+  observed_fn: Optional[Callable[[dict[str, Any]], Any]] = None
 
 
 class CodeEvaluator:
@@ -177,13 +195,29 @@ class CodeEvaluator:
       name: str,
       fn: Callable[[dict[str, Any]], float],
       threshold: float = 0.5,
+      observed_key: Optional[str] = None,
+      budget: Optional[float] = None,
+      observed_fn: Optional[Callable[[dict[str, Any]], Any]] = None,
   ) -> CodeEvaluator:
     """Adds a custom metric function.
 
     Args:
         name: Metric name.
         fn: Function taking session summary, returning 0-1 score.
-        threshold: Pass/fail threshold.
+            The score is compared to ``threshold``; a session passes
+            the metric when ``score >= threshold``.
+        threshold: Pass/fail threshold applied to ``fn``'s score.
+        observed_key: Optional session-summary key whose value is the
+            raw observed metric (e.g. ``"avg_latency_ms"``). When set,
+            ``evaluate_session`` stashes the observed value + ``budget``
+            under ``SessionScore.details`` for downstream reporting.
+        budget: Optional raw-budget value corresponding to the metric
+            (e.g. the latency-ms threshold the user supplied). Reported
+            alongside ``observed_key``; not used for pass/fail.
+        observed_fn: Optional callable that derives the observed value
+            from the session summary. Used when the observed metric is
+            computed (e.g. ``tool_errors/tool_calls``) rather than
+            stored directly. Takes precedence over ``observed_key``.
 
     Returns:
         Self for chaining.
@@ -193,6 +227,9 @@ class CodeEvaluator:
             name=name,
             fn=fn,
             threshold=threshold,
+            observed_key=observed_key,
+            budget=budget,
+            observed_fn=observed_fn,
         )
     )
     return self
@@ -207,6 +244,7 @@ class CodeEvaluator:
         SessionScore with computed scores.
     """
     scores: dict[str, float] = {}
+    details: dict[str, Any] = {}
     passed = True
 
     for metric in self._metrics:
@@ -214,26 +252,61 @@ class CodeEvaluator:
         score = metric.fn(session_summary)
         score = max(0.0, min(1.0, float(score)))
         scores[metric.name] = score
-        if score < metric.threshold:
+        metric_passed = score >= metric.threshold
+        if not metric_passed:
           passed = False
       except Exception as e:
         logger.warning("Metric %s failed: %s", metric.name, e)
         scores[metric.name] = 0.0
+        metric_passed = False
         passed = False
+
+      # Stash per-metric reporting detail when the metric declared its
+      # observed-key / budget. Keys under ``details`` are prefixed with
+      # ``metric_`` to avoid colliding with other details callers may add.
+      if metric.observed_key is not None or metric.observed_fn is not None:
+        if metric.observed_fn is not None:
+          try:
+            observed_value = metric.observed_fn(session_summary)
+          except Exception:  # pylint: disable=broad-except
+            observed_value = None
+        else:
+          observed_value = session_summary.get(metric.observed_key)
+        details[f"metric_{metric.name}"] = {
+            "observed": observed_value,
+            "budget": metric.budget,
+            "threshold": metric.threshold,
+            "score": scores[metric.name],
+            "passed": metric_passed,
+        }
 
     return SessionScore(
         session_id=session_summary.get("session_id", "unknown"),
         scores=scores,
         passed=passed,
+        details=details,
     )
 
   # ---- Pre-built evaluators ---- #
+
+  # The prebuilt evaluators below use raw-budget gates: they fail iff
+  # the observed metric exceeds the user-supplied budget. Historically
+  # these ran the normalized ``udf_kernels.score_*`` functions under a
+  # 0.5 score cutoff, which caused ``--threshold=5000`` on latency to
+  # fail near 2500ms — the gate was at half the budget the user typed.
+  # See CHANGELOG and the related blog-post-#2 plan (#77) for context.
+  # ``udf_kernels.score_*`` is unchanged; it still powers the SQL-native
+  # UDF path in ``udf_sql_templates.py``, which has its own semantics.
 
   @staticmethod
   def latency(
       threshold_ms: float = 5000.0,
   ) -> CodeEvaluator:
-    """Pre-built evaluator that checks average latency.
+    """Pre-built evaluator that fails when average latency exceeds the budget.
+
+    Pass/fail is a raw comparison: ``avg_latency_ms <= threshold_ms``
+    passes, strictly greater fails. The returned evaluator's score for
+    a session is ``1.0`` on pass and ``0.0`` on fail.
 
     Args:
         threshold_ms: Maximum acceptable average latency in ms.
@@ -243,15 +316,25 @@ class CodeEvaluator:
     """
 
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_latency(s.get("avg_latency_ms", 0), threshold_ms)
+      observed = s.get("avg_latency_ms", 0) or 0
+      return 1.0 if observed <= threshold_ms else 0.0
 
     evaluator = CodeEvaluator(name="latency_evaluator")
-    evaluator.add_metric("latency", _score, threshold=0.5)
+    evaluator.add_metric(
+        "latency",
+        _score,
+        threshold=1.0,
+        observed_key="avg_latency_ms",
+        budget=threshold_ms,
+    )
     return evaluator
 
   @staticmethod
   def turn_count(max_turns: int = 10) -> CodeEvaluator:
-    """Pre-built evaluator that checks turn count.
+    """Pre-built evaluator that fails when turn count exceeds the budget.
+
+    Pass/fail is a raw comparison: ``turn_count <= max_turns`` passes,
+    strictly greater fails.
 
     Args:
         max_turns: Maximum acceptable number of turns.
@@ -261,17 +344,28 @@ class CodeEvaluator:
     """
 
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_turn_count(s.get("turn_count", 0), max_turns)
+      observed = s.get("turn_count", 0) or 0
+      return 1.0 if observed <= max_turns else 0.0
 
     evaluator = CodeEvaluator(name="turn_count_evaluator")
-    evaluator.add_metric("turn_count", _score, threshold=0.5)
+    evaluator.add_metric(
+        "turn_count",
+        _score,
+        threshold=1.0,
+        observed_key="turn_count",
+        budget=max_turns,
+    )
     return evaluator
 
   @staticmethod
   def error_rate(
       max_error_rate: float = 0.1,
   ) -> CodeEvaluator:
-    """Pre-built evaluator that checks tool error rate.
+    """Pre-built evaluator that fails when tool error rate exceeds the budget.
+
+    Pass/fail is a raw comparison: ``(tool_errors / tool_calls) <= max_error_rate``
+    passes, strictly greater fails. Sessions with zero tool calls pass
+    trivially (nothing to fail).
 
     Args:
         max_error_rate: Maximum acceptable tool error fraction.
@@ -280,22 +374,37 @@ class CodeEvaluator:
         CodeEvaluator configured for error rate checking.
     """
 
+    def _observed(s: dict[str, Any]) -> float:
+      calls = s.get("tool_calls", 0) or 0
+      errors = s.get("tool_errors", 0) or 0
+      if calls <= 0:
+        return 0.0
+      return errors / calls
+
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_error_rate(
-          s.get("tool_calls", 0),
-          s.get("tool_errors", 0),
-          max_error_rate,
-      )
+      calls = s.get("tool_calls", 0) or 0
+      if calls <= 0:
+        return 1.0
+      return 1.0 if _observed(s) <= max_error_rate else 0.0
 
     evaluator = CodeEvaluator(name="error_rate_evaluator")
-    evaluator.add_metric("error_rate", _score, threshold=0.5)
+    evaluator.add_metric(
+        "error_rate",
+        _score,
+        threshold=1.0,
+        observed_fn=_observed,
+        budget=max_error_rate,
+    )
     return evaluator
 
   @staticmethod
   def token_efficiency(
       max_tokens: int = 50000,
   ) -> CodeEvaluator:
-    """Pre-built evaluator that checks total token usage.
+    """Pre-built evaluator that fails when total tokens exceed the budget.
+
+    Pass/fail is a raw comparison: ``total_tokens <= max_tokens``
+    passes, strictly greater fails.
 
     Args:
         max_tokens: Maximum acceptable total token count.
@@ -305,19 +414,27 @@ class CodeEvaluator:
     """
 
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_token_efficiency(
-          s.get("total_tokens", 0), max_tokens
-      )
+      observed = s.get("total_tokens", 0) or 0
+      return 1.0 if observed <= max_tokens else 0.0
 
     evaluator = CodeEvaluator(name="token_efficiency_evaluator")
-    evaluator.add_metric("token_efficiency", _score, threshold=0.5)
+    evaluator.add_metric(
+        "token_efficiency",
+        _score,
+        threshold=1.0,
+        observed_key="total_tokens",
+        budget=max_tokens,
+    )
     return evaluator
 
   @staticmethod
   def ttft(
       threshold_ms: float = 1000.0,
   ) -> CodeEvaluator:
-    """Pre-built evaluator that checks average time-to-first-token.
+    """Pre-built evaluator that fails when TTFT exceeds the budget.
+
+    Pass/fail is a raw comparison: ``avg_ttft_ms <= threshold_ms``
+    passes, strictly greater fails.
 
     Args:
         threshold_ms: Maximum acceptable average TTFT in ms.
@@ -327,10 +444,17 @@ class CodeEvaluator:
     """
 
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_ttft(s.get("avg_ttft_ms", 0) or 0, threshold_ms)
+      observed = s.get("avg_ttft_ms", 0) or 0
+      return 1.0 if observed <= threshold_ms else 0.0
 
     evaluator = CodeEvaluator(name="ttft_evaluator")
-    evaluator.add_metric("ttft", _score, threshold=0.5)
+    evaluator.add_metric(
+        "ttft",
+        _score,
+        threshold=1.0,
+        observed_key="avg_ttft_ms",
+        budget=threshold_ms,
+    )
     return evaluator
 
   @staticmethod
@@ -339,7 +463,10 @@ class CodeEvaluator:
       input_cost_per_1k: float = 0.00025,
       output_cost_per_1k: float = 0.00125,
   ) -> CodeEvaluator:
-    """Pre-built evaluator that checks estimated cost.
+    """Pre-built evaluator that fails when per-session cost exceeds the budget.
+
+    Pass/fail is a raw comparison: ``estimated_cost_usd <= max_cost_usd``
+    passes, strictly greater fails.
 
     Args:
         max_cost_usd: Maximum acceptable cost in USD.
@@ -350,17 +477,24 @@ class CodeEvaluator:
         CodeEvaluator configured for cost checking.
     """
 
+    def _observed(s: dict[str, Any]) -> float:
+      input_tokens = s.get("input_tokens", 0) or 0
+      output_tokens = s.get("output_tokens", 0) or 0
+      return (input_tokens / 1000.0) * input_cost_per_1k + (
+          output_tokens / 1000.0
+      ) * output_cost_per_1k
+
     def _score(s: dict[str, Any]) -> float:
-      return udf_kernels.score_cost(
-          s.get("input_tokens", 0),
-          s.get("output_tokens", 0),
-          max_cost_usd,
-          input_cost_per_1k,
-          output_cost_per_1k,
-      )
+      return 1.0 if _observed(s) <= max_cost_usd else 0.0
 
     evaluator = CodeEvaluator(name="cost_evaluator")
-    evaluator.add_metric("cost", _score, threshold=0.5)
+    evaluator.add_metric(
+        "cost",
+        _score,
+        threshold=1.0,
+        observed_fn=_observed,
+        budget=max_cost_usd,
+    )
     return evaluator
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,6 +249,78 @@ class TestEvaluate:
     assert result.exit_code == 1
 
   @patch("bigquery_agent_analytics.cli._build_client")
+  def test_evaluate_exit_code_emits_failure_lines(self, mock_build):
+    """--exit-code failure path emits one FAIL line per failing session.
+
+    Regression guard: prior output did not point the reader at which
+    threshold regressed and by how much. The new path stashes the raw
+    observed value + budget in ``SessionScore.details`` and prints
+    them on stderr before raising Exit(code=1).
+    """
+    report = EvaluationReport(
+        dataset="test",
+        evaluator_name="latency_evaluator",
+        total_sessions=2,
+        passed_sessions=1,
+        failed_sessions=1,
+        created_at=_NOW,
+        session_scores=[
+            SessionScore(
+                session_id="good",
+                scores={"latency": 1.0},
+                passed=True,
+                details={
+                    "metric_latency": {
+                        "observed": 1200,
+                        "budget": 5000,
+                        "threshold": 1.0,
+                        "score": 1.0,
+                        "passed": True,
+                    }
+                },
+            ),
+            SessionScore(
+                session_id="bad",
+                scores={"latency": 0.0},
+                passed=False,
+                details={
+                    "metric_latency": {
+                        "observed": 7500,
+                        "budget": 5000,
+                        "threshold": 1.0,
+                        "score": 0.0,
+                        "passed": False,
+                    }
+                },
+            ),
+        ],
+    )
+    client = MagicMock()
+    client.evaluate.return_value = report
+    mock_build.return_value = client
+
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            "--evaluator=latency",
+            "--exit-code",
+        ],
+    )
+    assert result.exit_code == 1
+    combined = (result.stderr or "") + (result.output or "")
+    assert "--exit-code" in combined
+    assert "1 session(s) failed" in combined
+    assert "FAIL session=bad" in combined
+    assert "metric=latency" in combined
+    assert "observed=7500" in combined
+    assert "budget=5000" in combined
+    # Passing sessions must not emit a FAIL line.
+    assert "session=good" not in combined
+
+  @patch("bigquery_agent_analytics.cli._build_client")
   def test_evaluate_exit_code_on_pass(self, mock_build):
     client = MagicMock()
     client.evaluate.return_value = _mock_report(10, 10)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,6 +321,106 @@ class TestEvaluate:
     assert "session=good" not in combined
 
   @patch("bigquery_agent_analytics.cli._build_client")
+  def test_evaluate_exit_code_emits_fallback_for_custom_metric(
+      self, mock_build
+  ):
+    """Custom metric without observed/budget still gets a FAIL line.
+
+    Regression guard: previously the emitter only printed a line when
+    the score was exactly 0.0, so a custom ``add_metric(threshold=0.7)``
+    or LLM judge scoring 0.6 for a failing session silently produced
+    only the summary header. That left CI logs unhelpful.
+    """
+    report = EvaluationReport(
+        dataset="test",
+        evaluator_name="custom_eval",
+        total_sessions=1,
+        passed_sessions=0,
+        failed_sessions=1,
+        created_at=_NOW,
+        session_scores=[
+            SessionScore(
+                session_id="bad",
+                scores={"helpfulness": 0.6},
+                passed=False,
+                details={
+                    "metric_helpfulness": {
+                        "observed": None,
+                        "budget": None,
+                        "threshold": 0.7,
+                        "score": 0.6,
+                        "passed": False,
+                    }
+                },
+            ),
+        ],
+    )
+    client = MagicMock()
+    client.evaluate.return_value = report
+    mock_build.return_value = client
+
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            "--evaluator=latency",
+            "--exit-code",
+        ],
+    )
+    assert result.exit_code == 1
+    combined = (result.stderr or "") + (result.output or "")
+    assert "FAIL session=bad" in combined
+    assert "metric=helpfulness" in combined
+    assert "score=0.6" in combined
+    assert "threshold=0.7" in combined
+
+  @patch("bigquery_agent_analytics.cli._build_client")
+  def test_evaluate_exit_code_emits_fallback_with_no_details(self, mock_build):
+    """Failing session with empty details still emits a FAIL line.
+
+    Safety-net guard: if an upstream evaluator doesn't populate
+    per-metric details, we still name the session and metric rather
+    than printing only the summary header.
+    """
+    report = EvaluationReport(
+        dataset="test",
+        evaluator_name="legacy_eval",
+        total_sessions=1,
+        passed_sessions=0,
+        failed_sessions=1,
+        created_at=_NOW,
+        session_scores=[
+            SessionScore(
+                session_id="bad",
+                scores={"legacy_metric": 0.3},
+                passed=False,
+                details={},
+            ),
+        ],
+    )
+    client = MagicMock()
+    client.evaluate.return_value = report
+    mock_build.return_value = client
+
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            "--evaluator=latency",
+            "--exit-code",
+        ],
+    )
+    assert result.exit_code == 1
+    combined = (result.stderr or "") + (result.output or "")
+    assert "FAIL session=bad" in combined
+    assert "metric=legacy_metric" in combined
+    assert "score=0.3" in combined
+
+  @patch("bigquery_agent_analytics.cli._build_client")
   def test_evaluate_exit_code_on_pass(self, mock_build):
     client = MagicMock()
     client.evaluate.return_value = _mock_report(10, 10)

--- a/tests/test_sdk_evaluators.py
+++ b/tests/test_sdk_evaluators.py
@@ -116,7 +116,7 @@ class TestCodeEvaluatorPrebuilt:
         }
     )
     assert score.passed is True
-    assert score.scores["latency"] > 0.5
+    assert score.scores["latency"] == 1.0
 
   def test_latency_fail(self):
     evaluator = CodeEvaluator.latency(threshold_ms=1000)
@@ -148,7 +148,7 @@ class TestCodeEvaluatorPrebuilt:
         }
     )
     assert score.passed is True
-    assert score.scores["turn_count"] > 0.5
+    assert score.scores["turn_count"] == 1.0
 
   def test_turn_count_fail(self):
     evaluator = CodeEvaluator.turn_count(max_turns=5)
@@ -192,6 +192,150 @@ class TestCodeEvaluatorPrebuilt:
         }
     )
     assert score.scores["error_rate"] == 1.0
+
+
+class TestPrebuiltRawBudgetBoundaries:
+  """Regression tests: prebuilt gates compare raw observed <= budget.
+
+  Prior implementation used normalized scores with a 0.5 pass cutoff,
+  which caused every gate to effectively fire at ``budget / 2`` (e.g.
+  ``CodeEvaluator.latency(threshold_ms=5000)`` failed at observed >
+  2500 ms). These tests lock in the new raw-budget semantics and
+  guard against regressions.
+  """
+
+  def test_latency_boundary_inclusive(self):
+    evaluator = CodeEvaluator.latency(threshold_ms=5000)
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "avg_latency_ms": 5000}
+    )
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "avg_latency_ms": 5001}
+    )
+    # Observed == budget must PASS (regression: old impl failed here at
+    # any value strictly above budget/2 = 2500).
+    assert at_budget.passed is True
+    assert at_budget.scores["latency"] == 1.0
+    assert just_over.passed is False
+    assert just_over.scores["latency"] == 0.0
+
+  def test_latency_old_midpoint_now_passes(self):
+    # The old normalized impl failed at 2501ms with threshold=5000; under
+    # the new impl this is nowhere near the budget and must pass.
+    evaluator = CodeEvaluator.latency(threshold_ms=5000)
+    score = evaluator.evaluate_session(
+        {"session_id": "s1", "avg_latency_ms": 2501}
+    )
+    assert score.passed is True
+    assert score.scores["latency"] == 1.0
+
+  def test_turn_count_boundary_inclusive(self):
+    evaluator = CodeEvaluator.turn_count(max_turns=10)
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "turn_count": 10}
+    )
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "turn_count": 11}
+    )
+    assert at_budget.passed is True
+    assert just_over.passed is False
+
+  def test_turn_count_old_midpoint_now_passes(self):
+    evaluator = CodeEvaluator.turn_count(max_turns=10)
+    score = evaluator.evaluate_session({"session_id": "s1", "turn_count": 6})
+    # Old impl: 1.0 - 6/10 = 0.4 -> fail. New: 6 <= 10 -> pass.
+    assert score.passed is True
+
+  def test_error_rate_boundary_inclusive(self):
+    evaluator = CodeEvaluator.error_rate(max_error_rate=0.1)
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "tool_calls": 10, "tool_errors": 1}
+    )
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "tool_calls": 10, "tool_errors": 2}
+    )
+    assert at_budget.passed is True
+    assert just_over.passed is False
+
+  def test_token_efficiency_boundary_inclusive(self):
+    evaluator = CodeEvaluator.token_efficiency(max_tokens=50000)
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "total_tokens": 50000}
+    )
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "total_tokens": 50001}
+    )
+    assert at_budget.passed is True
+    assert just_over.passed is False
+
+  def test_ttft_boundary_inclusive(self):
+    evaluator = CodeEvaluator.ttft(threshold_ms=1000)
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "avg_ttft_ms": 1000}
+    )
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "avg_ttft_ms": 1001}
+    )
+    assert at_budget.passed is True
+    assert just_over.passed is False
+
+  def test_cost_per_session_boundary_inclusive(self):
+    evaluator = CodeEvaluator.cost_per_session(
+        max_cost_usd=0.01,
+        input_cost_per_1k=0.001,
+        output_cost_per_1k=0.001,
+    )
+    # Cost at budget: (5000/1000 + 5000/1000) * 0.001 = 0.01 exactly.
+    at_budget = evaluator.evaluate_session(
+        {"session_id": "s1", "input_tokens": 5000, "output_tokens": 5000}
+    )
+    # Cost just over: 10001 input tokens at 0.001/1K -> 0.010001.
+    just_over = evaluator.evaluate_session(
+        {"session_id": "s2", "input_tokens": 10001, "output_tokens": 0}
+    )
+    assert at_budget.passed is True
+    assert just_over.passed is False
+
+  def test_observed_key_and_budget_in_details(self):
+    """Per-metric detail must expose observed/budget for CLI output."""
+    evaluator = CodeEvaluator.latency(threshold_ms=5000)
+    score = evaluator.evaluate_session(
+        {"session_id": "s1", "avg_latency_ms": 6000}
+    )
+    detail = score.details.get("metric_latency")
+    assert detail is not None
+    assert detail["observed"] == 6000
+    assert detail["budget"] == 5000
+    assert detail["passed"] is False
+
+  def test_error_rate_observed_fn_in_details(self):
+    """Computed observed (errors/calls) surfaces in details via observed_fn."""
+    evaluator = CodeEvaluator.error_rate(max_error_rate=0.1)
+    score = evaluator.evaluate_session(
+        {"session_id": "s1", "tool_calls": 10, "tool_errors": 5}
+    )
+    detail = score.details.get("metric_error_rate")
+    assert detail is not None
+    assert detail["observed"] == pytest.approx(0.5)
+    assert detail["budget"] == pytest.approx(0.1)
+    assert detail["passed"] is False
+
+  def test_cost_observed_fn_in_details(self):
+    """Computed cost surfaces in details via observed_fn."""
+    evaluator = CodeEvaluator.cost_per_session(
+        max_cost_usd=0.01,
+        input_cost_per_1k=0.001,
+        output_cost_per_1k=0.001,
+    )
+    score = evaluator.evaluate_session(
+        {"session_id": "s1", "input_tokens": 20000, "output_tokens": 0}
+    )
+    detail = score.details.get("metric_cost")
+    assert detail is not None
+    # 20000 / 1000 * 0.001 = 0.02
+    assert detail["observed"] == pytest.approx(0.02)
+    assert detail["budget"] == pytest.approx(0.01)
+    assert detail["passed"] is False
 
 
 class TestLLMAsJudgePrebuilt:
@@ -364,8 +508,8 @@ class TestTokenEfficiencyPrebuilt:
             "total_tokens": 10000,
         }
     )
-    # 1.0 - 10000/50000 = 0.8
-    assert score.scores["token_efficiency"] == pytest.approx(0.8)
+    # Binary gate: observed <= budget -> 1.0
+    assert score.scores["token_efficiency"] == 1.0
     assert score.passed is True
 
   def test_over_budget(self):
@@ -387,8 +531,9 @@ class TestTokenEfficiencyPrebuilt:
             "total_tokens": 50000,
         }
     )
-    assert score.scores["token_efficiency"] == 0.0
-    assert score.passed is False
+    # Boundary is inclusive (observed <= budget).
+    assert score.scores["token_efficiency"] == 1.0
+    assert score.passed is True
 
 
 class TestCostPerSessionPrebuilt:
@@ -412,8 +557,7 @@ class TestCostPerSessionPrebuilt:
         input_cost_per_1k=0.001,
         output_cost_per_1k=0.002,
     )
-    # Cost = (10000/1000)*0.001 + (5000/1000)*0.002
-    #      = 10*0.001 + 5*0.002 = 0.01 + 0.01 = 0.02
+    # Estimated cost = 0.02 USD, well under 1.0 USD budget -> 1.0
     score = evaluator.evaluate_session(
         {
             "session_id": "s1",
@@ -421,7 +565,7 @@ class TestCostPerSessionPrebuilt:
             "output_tokens": 5000,
         }
     )
-    assert score.scores["cost"] == pytest.approx(0.98)
+    assert score.scores["cost"] == 1.0
     assert score.passed is True
 
   def test_over_budget(self):
@@ -473,7 +617,7 @@ class TestTTFTPrebuilt:
             "avg_ttft_ms": 400,
         }
     )
-    assert score.scores["ttft"] == pytest.approx(0.6)
+    assert score.scores["ttft"] == 1.0
     assert score.passed is True
 
   def test_over_threshold(self):

--- a/tests/test_udf_kernels.py
+++ b/tests/test_udf_kernels.py
@@ -17,10 +17,16 @@
 Tests are organized in two sections:
 
 1. **Direct kernel tests** — verify each pure function in isolation
-   with typed scalar inputs, including edge cases.
-2. **Parity tests** — verify that calling a kernel directly produces
-   the same result as going through the ``CodeEvaluator`` factory,
-   proving the refactor did not change behavior.
+   with typed scalar inputs, including edge cases. The ``udf_kernels``
+   module powers the SQL-native UDF path in ``udf_sql_templates.py``
+   and intentionally keeps the normalized ``1.0 - (observed / budget)``
+   score for BigQuery SQL compatibility.
+2. **Prebuilt divergence tests** — document that the Python
+   ``CodeEvaluator.{latency, error_rate, ...}`` prebuilts *no longer*
+   mirror the SQL kernel scores. They return a binary 1.0/0.0 gate
+   against the raw observed value instead, so the same input yields
+   different numeric scores via the two paths while the pass/fail
+   outcome matches the user's budget intent.
 """
 
 import pytest
@@ -258,124 +264,144 @@ class TestScoreCost:
 
 
 # ------------------------------------------------------------------ #
-# Parity Tests: kernel results == CodeEvaluator results                #
+# Prebuilt divergence: CodeEvaluator prebuilts are binary gates,
+# ``udf_kernels`` stays on the normalized ``1.0 - observed/budget``.
+# These two paths now intentionally disagree on the numeric score;
+# they still agree on the user-intent boundary (observed <= budget).
 # ------------------------------------------------------------------ #
 
 
-class TestParityLatency:
-  """Prove score_latency() == CodeEvaluator.latency() for all cases."""
+class TestPrebuiltBinaryLatency:
+  """CodeEvaluator.latency returns 1.0/0.0 against the raw budget."""
 
   @pytest.mark.parametrize(
-      "avg,threshold",
+      "avg,threshold,expected_score,expected_pass",
       [
-          (0, 5000),
-          (-100, 5000),
-          (2500, 5000),
-          (5000, 5000),
-          (10000, 5000),
-          (1234.5, 3000),
+          (0, 5000, 1.0, True),
+          (2500, 5000, 1.0, True),  # old normalized impl: 0.5 -> fail
+          (5000, 5000, 1.0, True),  # boundary inclusive
+          (5001, 5000, 0.0, False),
+          (10000, 5000, 0.0, False),
       ],
   )
-  def test_parity(self, avg, threshold):
-    kernel_score = score_latency(avg, threshold)
+  def test_binary(self, avg, threshold, expected_score, expected_pass):
     ev = CodeEvaluator.latency(threshold_ms=threshold)
     result = ev.evaluate_session({"session_id": "s1", "avg_latency_ms": avg})
-    assert result.scores["latency"] == pytest.approx(kernel_score)
+    assert result.scores["latency"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
+
+  def test_sql_kernel_unchanged(self):
+    """score_latency stays on the normalized score used by SQL UDFs."""
+    assert score_latency(2500, 5000) == pytest.approx(0.5)
+    assert score_latency(5000, 5000) == pytest.approx(0.0)
 
 
-class TestParityErrorRate:
+class TestPrebuiltBinaryErrorRate:
 
   @pytest.mark.parametrize(
-      "calls,errors,max_rate",
+      "calls,errors,max_rate,expected_score,expected_pass",
       [
-          (0, 0, 0.1),
-          (10, 0, 0.1),
-          (10, 1, 0.1),
-          (10, 5, 0.1),
-          (100, 5, 0.1),
-          (50, 3, 0.2),
+          (0, 0, 0.1, 1.0, True),
+          (10, 0, 0.1, 1.0, True),
+          (10, 1, 0.1, 1.0, True),  # exactly at budget passes
+          (10, 2, 0.1, 0.0, False),
+          (100, 5, 0.1, 1.0, True),
+          (50, 3, 0.2, 1.0, True),
       ],
   )
-  def test_parity(self, calls, errors, max_rate):
-    kernel_score = score_error_rate(calls, errors, max_rate)
+  def test_binary(self, calls, errors, max_rate, expected_score, expected_pass):
     ev = CodeEvaluator.error_rate(max_error_rate=max_rate)
     result = ev.evaluate_session(
         {"session_id": "s1", "tool_calls": calls, "tool_errors": errors}
     )
-    assert result.scores["error_rate"] == pytest.approx(kernel_score)
+    assert result.scores["error_rate"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
 
 
-class TestParityTurnCount:
+class TestPrebuiltBinaryTurnCount:
 
   @pytest.mark.parametrize(
-      "turns,max_t",
+      "turns,max_t,expected_score,expected_pass",
       [
-          (0, 10),
-          (-1, 10),
-          (5, 10),
-          (10, 10),
-          (20, 10),
-          (3, 7),
+          (0, 10, 1.0, True),
+          (5, 10, 1.0, True),
+          (10, 10, 1.0, True),
+          (11, 10, 0.0, False),
+          (20, 10, 0.0, False),
       ],
   )
-  def test_parity(self, turns, max_t):
-    kernel_score = score_turn_count(turns, max_t)
+  def test_binary(self, turns, max_t, expected_score, expected_pass):
     ev = CodeEvaluator.turn_count(max_turns=max_t)
     result = ev.evaluate_session({"session_id": "s1", "turn_count": turns})
-    assert result.scores["turn_count"] == pytest.approx(kernel_score)
+    assert result.scores["turn_count"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
 
 
-class TestParityTokenEfficiency:
+class TestPrebuiltBinaryTokenEfficiency:
 
   @pytest.mark.parametrize(
-      "tokens,max_t",
+      "tokens,max_t,expected_score,expected_pass",
       [
-          (0, 50000),
-          (-100, 50000),
-          (25000, 50000),
-          (50000, 50000),
-          (100000, 50000),
+          (0, 50000, 1.0, True),
+          (25000, 50000, 1.0, True),  # old normalized impl: 0.5 -> fail
+          (50000, 50000, 1.0, True),
+          (50001, 50000, 0.0, False),
+          (100000, 50000, 0.0, False),
       ],
   )
-  def test_parity(self, tokens, max_t):
-    kernel_score = score_token_efficiency(tokens, max_t)
+  def test_binary(self, tokens, max_t, expected_score, expected_pass):
     ev = CodeEvaluator.token_efficiency(max_tokens=max_t)
     result = ev.evaluate_session({"session_id": "s1", "total_tokens": tokens})
-    assert result.scores["token_efficiency"] == pytest.approx(kernel_score)
+    assert result.scores["token_efficiency"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
 
 
-class TestParityTtft:
+class TestPrebuiltBinaryTtft:
 
   @pytest.mark.parametrize(
-      "avg,threshold",
+      "avg,threshold,expected_score,expected_pass",
       [
-          (0, 1000),
-          (-50, 1000),
-          (500, 1000),
-          (1000, 1000),
-          (2000, 1000),
+          (0, 1000, 1.0, True),
+          (500, 1000, 1.0, True),  # old normalized impl: 0.5 -> fail
+          (1000, 1000, 1.0, True),
+          (1001, 1000, 0.0, False),
+          (2000, 1000, 0.0, False),
       ],
   )
-  def test_parity(self, avg, threshold):
-    kernel_score = score_ttft(avg, threshold)
+  def test_binary(self, avg, threshold, expected_score, expected_pass):
     ev = CodeEvaluator.ttft(threshold_ms=threshold)
     result = ev.evaluate_session({"session_id": "s1", "avg_ttft_ms": avg})
-    assert result.scores["ttft"] == pytest.approx(kernel_score)
+    assert result.scores["ttft"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
 
 
-class TestParityCost:
+class TestPrebuiltBinaryCost:
 
   @pytest.mark.parametrize(
-      "inp,out,max_c,inp_rate,out_rate",
+      "inp,out,max_c,inp_rate,out_rate,expected_score,expected_pass",
       [
-          (0, 0, 1.0, 0.00025, 0.00125),
-          (10000, 10000, 1.0, 0.00025, 0.00125),
-          (1000000, 200000, 0.5, 0.00025, 0.00125),
-          (1000, 1000, 0.01, 0.001, 0.002),
+          # cost = 0.0, budget = 1.0 -> pass
+          (0, 0, 1.0, 0.00025, 0.00125, 1.0, True),
+          # cost ≈ 0.015, budget = 1.0 -> pass
+          (10000, 10000, 1.0, 0.00025, 0.00125, 1.0, True),
+          # cost = 0.5 exactly at budget -> pass (inclusive boundary)
+          (1000000, 200000, 0.5, 0.00025, 0.00125, 1.0, True),
+          # cost = 0.003, budget = 0.01 -> pass
+          (1000, 1000, 0.01, 0.001, 0.002, 1.0, True),
+          # cost = 2.0, budget = 0.01 -> fail
+          (1000, 1000, 0.01, 1.0, 1.0, 0.0, False),
       ],
   )
-  def test_parity(self, inp, out, max_c, inp_rate, out_rate):
-    kernel_score = score_cost(inp, out, max_c, inp_rate, out_rate)
+  def test_binary(
+      self,
+      inp,
+      out,
+      max_c,
+      inp_rate,
+      out_rate,
+      expected_score,
+      expected_pass,
+  ):
     ev = CodeEvaluator.cost_per_session(
         max_cost_usd=max_c,
         input_cost_per_1k=inp_rate,
@@ -384,7 +410,8 @@ class TestParityCost:
     result = ev.evaluate_session(
         {"session_id": "s1", "input_tokens": inp, "output_tokens": out}
     )
-    assert result.scores["cost"] == pytest.approx(kernel_score)
+    assert result.scores["cost"] == pytest.approx(expected_score)
+    assert result.passed is expected_pass
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Blog post #2 (#77) publish blocker.

- **Breaking semantics change**: `CodeEvaluator.{latency, turn_count, error_rate, token_efficiency, ttft, cost_per_session}` now return `1.0` when observed is within budget and `0.0` otherwise. Previously they scored on a normalized `1.0 - observed/budget` scale with a `0.5` pass cutoff, which fired every gate at roughly half the budget the user typed (e.g. `latency(threshold_ms=5000)` failed at `avg_latency_ms > 2500`). The streaming observability evaluator (`streaming_observability_v1`) uses the matching binary-gate semantics.
- **Tighter `--exit-code` output**: `bq-agent-sdk evaluate --exit-code` now prints one `FAIL session=... metric=... observed=... budget=...` line per failing (session, metric) pair on stderr before exiting non-zero. Capped at the first 10 failing sessions. Observed + budget flow through a new `SessionScore.details` stash populated by `CodeEvaluator.add_metric(observed_key=..., observed_fn=..., budget=...)`.
- **Unchanged**: the SQL-native UDF path in `udf_kernels` + `udf_sql_templates` keeps the normalized `1.0 - observed/budget` score for BigQuery SQL compatibility. The old parity tests between the Python and SQL paths are replaced with `TestPrebuiltBinary*` classes that document the intentional divergence.

## Why

The SDK's `CodeEvaluator` prebuilts are the substrate for the CI-gate narrative in blog post #2 (\"your `agent_events` table is also a test suite\"). Before this PR, recommending `bq-agent-sdk evaluate --evaluator=latency --threshold-latency-p95=5000 --exit-code` as the minimum agent quality gate was misleading: the gate actually fired at `>2500ms`. The demo can't ship until the raw-budget semantics match user intent and the failure output points readers at the specific metric that blew through its budget.

## What changed

- `src/bigquery_agent_analytics/evaluators.py`
  - `_MetricDef` gets `observed_key`, `observed_fn`, `budget` reporting fields.
  - `CodeEvaluator.add_metric` accepts the new fields; `evaluate_session` stashes per-metric `observed`/`budget`/`threshold`/`score`/`passed` under `SessionScore.details[f\"metric_{name}\"]`.
  - Six prebuilt factories rewritten as binary 1.0/0.0 scorers with `threshold=1.0` and raw-budget comparisons. `error_rate` and `cost_per_session` use `observed_fn` because their observed values are computed.
- `src/bigquery_agent_analytics/_streaming_evaluation.py`
  - `build_streaming_observability_evaluator()` uses the same binary-gate pattern.
- `src/bigquery_agent_analytics/cli.py`
  - New `_emit_evaluate_failures(report, max_sessions=10)` helper.
  - `evaluate` command calls it before `Exit(code=1)`.
- `CHANGELOG.md`
  - New file. Calls out the breaking behavior change under Unreleased.
- Tests
  - Old `TestParity*` classes in `tests/test_udf_kernels.py` (which locked in the bad behavior) replaced with `TestPrebuiltBinary*` classes covering pass, boundary, and fail cases with both expected score and expected pass/fail.
  - `TestPrebuiltRawBudgetBoundaries` in `tests/test_sdk_evaluators.py` proves the old midpoint fail behavior is gone for all six prebuilts.
  - CLI test `test_evaluate_exit_code_emits_failure_lines` verifies stderr output shape.

## Test plan

- [x] `pytest tests/test_sdk_evaluators.py` (63 passed)
- [x] `pytest tests/test_udf_kernels.py` (103 passed)
- [x] `pytest tests/test_cli.py` (85 passed)
- [x] Full suite: `pytest tests/` → 1991 passed, 4 skipped
- [x] `bash autoformat.sh` clean
- [ ] Manual smoke: run a real `bq-agent-sdk evaluate --evaluator=latency --threshold=5000 --exit-code` against the sandbox dataset and confirm the failure summary looks right in CI output.

## Ref

- Blocks: #77 (\"your `agent_events` table is also a test suite\" — post #2 publish).
- Downstream: the post's YAML workflow and threshold table reference exact `--threshold-latency-p95=5000` semantics that now match.