### PR TITLE
docs: adopt Option 2 provenance columns for concept index (resolves #58 finding 1)

### DIFF
--- a/docs/entity_resolution_primitives.md
+++ b/docs/entity_resolution_primitives.md
@@ -50,7 +50,7 @@ Neither package is designed as a turn-time agent SDK. This RFC does not add an i
 
 | Direction | Who calls it | When | What happens |
 | :---- | :---- | :---- | :---- |
-| 1 | Operator / CI | Once per ontology change (build-time) | `gm compile` → DDL \+ concept-index SQL published to BQ. |
+| 1 | Operator / CI | Once per ontology change (build-time) | `gm compile` → emits DDL \+ concept-index SQL; operator executes the emitted SQL to publish the tables to BigQuery. |
 | 2 | Batch orchestrator | Scheduled over accumulated traces (post-processing) | `extract_graph` / `extract_biz_nodes` from `bigquery_agent_analytics` → `AI.GENERATE` populates entity / relationship tables. |
 | 3 | Eval / analysis / curation pipeline (this RFC) | On accumulated data, at the pipeline's cadence | Pipeline imports `OntologyRuntime` \+ a resolver from `bigquery_agent_analytics` and calls `.resolve(...)` or `.validate_against_ontology(...)`. Each call is a BQ query against the concept index. |
 

--- a/docs/entity_resolution_primitives.md
+++ b/docs/entity_resolution_primitives.md
@@ -140,7 +140,7 @@ CREATE TABLE `{dataset}.ontology_concept_index` (
 | Column | Role | Width | Used by |
 |---|---|---|---|
 | `compile_id` | Display/debug token — human-readable short tag for reports, queue rows, error messages, log lines. **Never the sole freshness check.** | 12 hex chars | Operator UX, dashboards, triage output |
-| `compile_fingerprint` | Canonical integrity key — full SHA-256 over `ontology_fingerprint \|\| binding_fingerprint \|\| compiler_version`. | 64 hex chars | Strict pair-consistency + runtime verification (§5) |
+| `compile_fingerprint` | Canonical integrity key — full SHA-256 over the NUL-delimited UTF-8 of `(ontology_fingerprint, binding_fingerprint, compiler_version)`. Consumers must call `_fingerprint.compile_fingerprint()`; do not reimplement. | 64 hex chars | Strict pair-consistency + runtime verification (§5) |
 
 Structural invariant: `compile_id == compile_fingerprint[:12]`. The short form is always derivable from the full form; never the other way around. Enforced at the `_fingerprint.py` module boundary so a future refactor cannot make them diverge.
 
@@ -238,7 +238,7 @@ Concept-index value is \~80% from SKOS annotations preserved through import (\#5
 
 | File | Change | Status |
 | :---- | :---- | :---- |
-| `_fingerprint.py` | **New internal** — `fingerprint_model`, `compile_id` | **\#71 open** |
+| `_fingerprint.py` | **New internal** — `fingerprint_model`, `compile_fingerprint` (canonical integrity key), `compile_id` (display token, derived as `compile_fingerprint(...)[:12]`) | **\#71 open** |
 | `concept_index.py` | New row builder | Pending A2 |
 | `graph_ddl_compiler.py` | Add `compile_concept_index`. `compile_graph` unchanged | Pending A3–A5 |
 | `cli.py:299` | Add `--emit-concept-index` \+ `--concept-index-table`; no-flag byte-identical | Pending A7 |

--- a/docs/entity_resolution_primitives.md
+++ b/docs/entity_resolution_primitives.md
@@ -123,16 +123,26 @@ Emitted when `gm compile --emit-concept-index --concept-index-table <fqn>` is pa
 
 ```sql
 CREATE TABLE `{dataset}.ontology_concept_index` (
-  entity_name  STRING NOT NULL,
-  label        STRING NOT NULL,   -- for label_kind='notation', holds notation value
-  label_kind   STRING NOT NULL,   -- 'name'|'pref'|'alt'|'hidden'|'synonym'|'notation'
-  notation     STRING,            -- per-entity display, repeats across rows
-  scheme       STRING,            -- NULL = not in any scheme
-  language     STRING,
-  is_abstract  BOOL   NOT NULL,
-  compile_id   STRING NOT NULL    -- 12 hex chars; pair-consistency tag
+  entity_name         STRING NOT NULL,
+  label               STRING NOT NULL,   -- for label_kind='notation', holds notation value
+  label_kind          STRING NOT NULL,   -- 'name'|'pref'|'alt'|'hidden'|'synonym'|'notation'
+  notation            STRING,            -- per-entity display, repeats across rows
+  scheme              STRING,            -- NULL = not in any scheme
+  language            STRING,
+  is_abstract         BOOL   NOT NULL,
+  compile_id          STRING NOT NULL,   -- 12 hex chars; display/debug token only
+  compile_fingerprint STRING NOT NULL    -- 64 hex chars; canonical integrity key
 );
 ```
+
+**Two provenance columns, one role each.**
+
+| Column | Role | Width | Used by |
+|---|---|---|---|
+| `compile_id` | Display/debug token — human-readable short tag for reports, queue rows, error messages, log lines. **Never the sole freshness check.** | 12 hex chars | Operator UX, dashboards, triage output |
+| `compile_fingerprint` | Canonical integrity key — full SHA-256 over `ontology_fingerprint \|\| binding_fingerprint \|\| compiler_version`. | 64 hex chars | Strict pair-consistency + runtime verification (§5) |
+
+Structural invariant: `compile_id == compile_fingerprint[:12]`. The short form is always derivable from the full form; never the other way around. Enforced at the `_fingerprint.py` module boundary so a future refactor cannot make them diverge.
 
 **Row multiplicity:** one row per `(entity_name, label, label_kind, language, scheme)` tuple — concept in 3 schemes × 5 labels \= 15 rows. Resolvers filter by scheme without JOIN.
 
@@ -201,12 +211,15 @@ Docs (`docs/ontology/concept-index.md`, from A8) will carry two or three canonic
 
 **TTL re-check queries (stale cache):**
 
-1. `SELECT DISTINCT compile_id FROM {output_table} LIMIT 2` — asserts exactly one value (pair consistency). More than one → refresh in progress.  
-2. `SELECT compile_id, ontology_fingerprint, binding_fingerprint FROM {output_table}__meta LIMIT 1` — asserts all three match cache (full-fingerprint freshness).
+1. `SELECT DISTINCT compile_fingerprint FROM {output_table} LIMIT 2` — asserts exactly one value (pair consistency at full-fingerprint resolution). More than one → refresh in progress.
+2. `SELECT compile_fingerprint, ontology_fingerprint, binding_fingerprint FROM {output_table}__meta LIMIT 1`.
+3. Require: `main.compile_fingerprint == meta.compile_fingerprint` (pair consistency) **and** `meta.ontology_fingerprint == cached.ontology_fingerprint` **and** `meta.binding_fingerprint == cached.binding_fingerprint` (component freshness).
+
+No short-ID arithmetic anywhere on the verification path. `compile_id` never appears in a strict-mode query.
 
 Main/meta disagreement → 2s one-shot retry → persistent \= `ConceptIndexInconsistentPair`. Cache drift \= `ConceptIndexRefreshed` (operator recreates `OntologyRuntime` with updated models).
 
-Why both tables, why full fingerprints: see §9 W2.
+Why full fingerprints on both tables: see §10 W2.
 
 ## **6\. Tie to issue \#57**
 
@@ -285,7 +298,7 @@ Single developer ≈ 7.5 weeks. Phases 1 \+ 2 parallelizable → \~4 weeks wall-
 | \# | Invariant | Failure mode if broken | Regression test |
 | :---- | :---- | :---- | :---- |
 | W1 | `_fingerprint.py` is the **single** source of canonical serialization; both packages import it | Compiler writes fingerprint X, runtime computes fingerprint Y, strict mode rejects every valid index | `tests/bigquery_ontology/test_fingerprint.py`: round-trip YAML → load → fingerprint; semantic edits change it, whitespace edits don't (landed in \#71) |
-| W2 | TTL re-check reads **both** tables with **full** fingerprints | Meta-only sentinel: refresh-window race → wrong data under "verified." Short-compile-id only: 48-bit collision → same class of failure | Mock race window (meta old, main new with different compile\_id but matching short prefix); assert runtime catches it. Assert single-table sentinel impl fails the test |
+| W2 | Strict verification uses `compile_fingerprint` (full 64-hex) on both tables — short `compile_id` never appears on the verification path | A reducer "optimization" to `SELECT compile_id FROM ...` would reintroduce the 48-bit collision hole under an out-of-band swap. A meta-only sentinel would reintroduce the refresh-window race | Assert strict-mode queries reference `compile_fingerprint` only; assert short-ID reducer fails a reintroduction test. Mock main/meta full-fingerprint mismatch and assert `ConceptIndexInconsistentPair` |
 | W3 | Shadow-swap is **non-self-healing**; compiler errors out and next `gm compile` resumes | Background retry loops mask partial-swap states; operator "pause traffic during shadow refresh" guidance becomes unenforceable | Inject mid-swap `DROP`/`RENAME` failure → `gm compile` errors with clear message; subsequent `gm compile` completes the swap without recompiling |
 
 ### **Deferred (tracked, not blocking)**
@@ -305,6 +318,7 @@ Single developer ≈ 7.5 weeks. Phases 1 \+ 2 parallelizable → \~4 weeks wall-
 - `scheme=` XOR `entity=` in v1. Narrower-closure in v2 only if real callers ask.  
 - `contrib/` for reference resolvers; external packages for user-owned domains.  
 - Strict verification on by default; `verify_concept_index="off"` is the explicit opt-out.
+- **Option 2 for provenance columns: `compile_fingerprint` is the canonical integrity key; `compile_id` is display-only.** Invariant `compile_id == compile_fingerprint[:12]` enforced at the `_fingerprint.py` module boundary. Short-ID arithmetic is forbidden on the strict verification path.
 
 ## **12\. Future directions — LLM composition (not in v1)**
 

--- a/docs/implementation_plan_concept_index_runtime.md
+++ b/docs/implementation_plan_concept_index_runtime.md
@@ -29,11 +29,11 @@ This plan assumes issue #57 is either merged or lands in parallel. The concept i
 
 | Item | File | Additive? | Dependencies |
 |---|---|---|---|
-| A1 | Internal fingerprint module (`_fingerprint.py`, new) — canonical model serialization + SHA-256. Shared implementation detail, not public API | new | none |
-| A2 | Concept-index row builder (`concept_index.py`, new) — iterates `(ontology, binding)`, applies abstract-always / concrete-iff-bound rule, emits sorted row list | new | A1, #57's `abstract` field |
+| A1 | Internal fingerprint module (`_fingerprint.py`, new) — canonical model serialization + SHA-256. Exposes `fingerprint_model`, `compile_fingerprint` (full 64-hex, canonical integrity key), and `compile_id` (12-hex display, derived as `compile_fingerprint(...)[:12]`). Shared implementation detail, not public API | new | none |
+| A2 | Concept-index row builder (`concept_index.py`, new) — iterates `(ontology, binding)`, applies abstract-always / concrete-iff-bound rule, emits sorted row list. Each row carries both `compile_id` and `compile_fingerprint` | new | A1, #57's `abstract` field |
 | A3 | `compile_concept_index()` in `graph_ddl_compiler.py` | additive function in existing module | A1, A2 |
-| A4 | Meta row emission inside `compile_concept_index()` | part of A3 | A1 |
-| A5 | Inline-UNNEST path SQL generation (`CREATE OR REPLACE TABLE ... AS SELECT UNNEST(...)`) with `compile_id` column | part of A3 | A4 |
+| A4 | Meta row emission inside `compile_concept_index()` — writes both `compile_id` and `compile_fingerprint` plus component `ontology_fingerprint` / `binding_fingerprint` | part of A3 | A1 |
+| A5 | Inline-UNNEST path SQL generation (`CREATE OR REPLACE TABLE ... AS SELECT UNNEST(...)`) with both `compile_id` (display) and `compile_fingerprint` (integrity) columns on main and meta | part of A3 | A4 |
 | A6 | Shadow-swap fallback for >50K rows | part of A3 | A5 |
 | A7 | CLI extension: `--emit-concept-index` + `--concept-index-table` in `cli.py:299` | edits existing command | A3 |
 | A8 | Docs: `docs/ontology/concept-index.md` (new), update `docs/ontology/cli.md` and `docs/ontology/compilation.md` | docs | A3, A7 |
@@ -57,7 +57,7 @@ This plan assumes issue #57 is either merged or lands in parallel. The concept i
 | C1 | Exception classes in `ontology_runtime.py` — `ConceptIndexMismatchError`, `ConceptIndexProvenanceMissing`, `ConceptIndexInconsistentPair`, `ConceptIndexRefreshed` | Public API surface |
 | C2 | First-call verification — read meta, compute local fingerprints, compare | Lazy (on first concept-index access, not construction) |
 | C3 | Pair-consistency check with 2s one-shot retry | Used by C2 and C4 |
-| C4 | TTL re-check with full pair-consistency + full-fingerprint freshness | Two queries per stale call: `SELECT DISTINCT compile_id FROM main LIMIT 2` + `SELECT compile_id, ontology_fingerprint, binding_fingerprint FROM meta LIMIT 1` |
+| C4 | TTL re-check uses `compile_fingerprint` (full 64-hex) on both tables; `compile_id` never appears on the verification path | Two queries per stale call: `SELECT DISTINCT compile_fingerprint FROM main LIMIT 2` + `SELECT compile_fingerprint, ontology_fingerprint, binding_fingerprint FROM meta LIMIT 1` |
 | C5 | `verify_concept_index` flag handling: `"strict"` (default), `"missing_ok"`, `"off"` | |
 | C6 | `verify_ttl_seconds` flag handling: `60` (default), `0` (every-call), `None` (snapshot-bound) | |
 
@@ -75,10 +75,10 @@ This plan assumes issue #57 is either merged or lands in parallel. The concept i
 | D8 | Scope semantics: `scheme=` and `entity=` mutually exclusive; neither = error; both = error |
 | D9 | Pair consistency: inconsistent pair triggers retry; persistent inconsistency raises `ConceptIndexInconsistentPair` |
 | D10 | TTL re-check: fresh cache skips BQ; stale cache runs full check; matching values refresh cache; differing values raise `ConceptIndexRefreshed` |
-| D11 | 48-bit collision hypothetical: full fingerprints catch the collision that short `compile_id` doesn't (can simulate by injecting a crafted meta row) |
+| D11 | `compile_id == compile_fingerprint[:12]` invariant in `_fingerprint.py`; a hypothetical reducer that swaps the strict query from `compile_fingerprint` to `compile_id` fails a grep-level runtime-SQL check |
 | D12 | First-call verification: mismatched fingerprints raise `ConceptIndexMismatchError`; missing meta raises `ConceptIndexProvenanceMissing` |
 | D13 | Validation bounded output: `known_values_sample` capped at `sample_limit`; `known_value_count` correct; `candidates=None` unless composed |
-| D14 | Shadow-path emission correctness (>50K rows → both tables shadow-swap; compile_id present in both) |
+| D14 | Shadow-path emission correctness (>50K rows → both tables shadow-swap; `compile_id` and `compile_fingerprint` both present in main and meta) |
 | D15 | Abstract-entity filter: resolver with `WHERE NOT is_abstract` returns only concrete; default returns both |
 
 ## Phase plan
@@ -142,7 +142,12 @@ Work: `bigquery_ontology/contrib/advertising/` stub with Yahoo's resolver (if co
 
 ### New files
 
-- `src/bigquery_ontology/_fingerprint.py` — **internal** module (underscore prefix) with canonical JSON serialization of Pydantic models + SHA-256. Internal function: `fingerprint_model(model: BaseModel) -> str`. Short variant for `compile_id`: `compile_id(ontology_fingerprint, binding_fingerprint, compiler_version) -> str`. Not re-exported from any `__init__.py`. Shared implementation between `compile_concept_index()` (ontology package) and `OntologyRuntime` (SDK package) via absolute import `from bigquery_ontology._fingerprint import ...`. Underscore prefix makes it clear this isn't semver-stable surface; it's an implementation detail both packages happen to need.
+- `src/bigquery_ontology/_fingerprint.py` — **internal** module (underscore prefix) with canonical JSON serialization of Pydantic models + SHA-256. Exposes:
+  - `fingerprint_model(model: BaseModel) -> str` — full SHA-256 of a validated Pydantic model, prefixed `sha256:`.
+  - `compile_fingerprint(ontology_fingerprint, binding_fingerprint, compiler_version) -> str` — full 64-hex SHA-256 over the concatenated triple. **Canonical integrity key.**
+  - `compile_id(ontology_fingerprint, binding_fingerprint, compiler_version) -> str` — 12-hex display token, derived as `compile_fingerprint(...)[:12]`. The derivation is structural; `compile_id` never computes its own hash.
+
+  Not re-exported from any `__init__.py`. Shared implementation between `compile_concept_index()` (ontology package) and `OntologyRuntime` (SDK package) via absolute import `from bigquery_ontology._fingerprint import ...`. Underscore prefix makes it clear this isn't semver-stable surface; it's an implementation detail both packages happen to need.
 - `src/bigquery_ontology/concept_index.py` — row builder. Function: `build_rows(ontology: Ontology, binding: Binding) -> list[ConceptIndexRow]`. Applies "abstract always, concrete iff bound" rule. Emits one row per `(entity_name, label, label_kind, language, scheme)` tuple plus one notation row per entity per `skos:notation`. Sorts by `(scheme, entity_name, label_kind, language, label, notation, is_abstract)` with NULLs last. **Not re-exported from `bigquery_ontology/__init__.py` in v1.** Module is importable directly (`from bigquery_ontology.concept_index import build_rows, ConceptIndexRow`) for users who need pre-SQL row access — same pattern as the existing `from bigquery_ontology.graph_ddl_compiler import compile_graph` alongside the package-root export. Package-level re-export can be added later if a concrete caller appears; keeping it out of the root for v1 avoids growing semver surface ahead of need.
 - `src/bigquery_agent_analytics/ontology_runtime.py` — `OntologyRuntime` class with classmethods, read accessors, validation, verification. Exception classes (`ConceptIndexMismatchError` etc.) live here too.
 - `src/bigquery_agent_analytics/entity_resolver.py` — `EntityResolver` Protocol, `Candidate`, `ResolveResult`, `ExactMatchResolver`, `SynonymResolver`.
@@ -184,11 +189,26 @@ The fingerprint must be computed identically on both sides. `src/bigquery_ontolo
 
 Pin specifically in the module docstring: `Pydantic.model_dump(mode="json", by_alias=False, exclude_none=False)` with keys sorted at every nesting level and `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)` for the final encoding. Never use `yaml.dump()` or `str(model)` for fingerprint input.
 
-### W2 — TTL re-check must read both tables with full fingerprints
+### W2 — Strict verification uses `compile_fingerprint` (64-hex), never `compile_id` (12-hex)
 
-A future "optimizer" might see the TTL path and try to reduce it to a single-table sentinel `SELECT compile_id FROM meta LIMIT 1`. That would silently reintroduce the old meta / new main race. Or might try to reduce to short-compile-id comparison only, reintroducing the 48-bit collision hole.
+Provenance lives in two columns with distinct roles:
 
-Guard: a regression test that mocks a race window (meta unchanged, main updated with different compile_id but matching short hash via crafted rows) and asserts the runtime catches it. Also a test that a single-table sentinel implementation fails the test. Comment in `_ttl_recheck()` citing the specific failure modes, with a link back to issue #58.
+- `compile_id` is a 12-hex display token — used in error messages, queue rows, operator reports, log lines. Never on the strict verification path.
+- `compile_fingerprint` is the 64-hex canonical integrity key — used for main↔meta pair consistency and TTL re-check.
+
+The strict TTL re-check runs exactly three checks:
+
+1. `SELECT DISTINCT compile_fingerprint FROM {main} LIMIT 2` — must return one value (pair consistency).
+2. `SELECT compile_fingerprint, ontology_fingerprint, binding_fingerprint FROM {main}__meta LIMIT 1`.
+3. Require `main.compile_fingerprint == meta.compile_fingerprint` **and** both component fingerprints match the cached values computed from the caller's `(Ontology, Binding)` models.
+
+A future "optimizer" might try to reduce this to `SELECT compile_id FROM ...` (reintroducing the 48-bit collision hole) or to a meta-only sentinel (reintroducing the refresh-window race). Neither is acceptable.
+
+Guards:
+- Invariant test in `tests/bigquery_ontology/test_fingerprint.py`: `compile_id(...) == compile_fingerprint(...)[:_COMPILE_ID_LEN]`. Structural — enforced at the function boundary.
+- Regression test in the runtime layer: assert strict-mode queries reference `compile_fingerprint` only (grep-level check on the constructed SQL); assert a hypothetical reducer that swaps in `compile_id` fails the test.
+- Regression test that mocks a main/meta `compile_fingerprint` mismatch and asserts `ConceptIndexInconsistentPair`.
+- Comment in `_ttl_recheck()` naming both failure modes (collision hole, refresh race) with a link back to issue #58.
 
 ### W3 — Shadow-path failure handling must match the documented operational contract
 

--- a/docs/implementation_plan_concept_index_runtime.md
+++ b/docs/implementation_plan_concept_index_runtime.md
@@ -144,7 +144,7 @@ Work: `bigquery_ontology/contrib/advertising/` stub with Yahoo's resolver (if co
 
 - `src/bigquery_ontology/_fingerprint.py` — **internal** module (underscore prefix) with canonical JSON serialization of Pydantic models + SHA-256. Exposes:
   - `fingerprint_model(model: BaseModel) -> str` — full SHA-256 of a validated Pydantic model, prefixed `sha256:`.
-  - `compile_fingerprint(ontology_fingerprint, binding_fingerprint, compiler_version) -> str` — full 64-hex SHA-256 over the concatenated triple. **Canonical integrity key.**
+  - `compile_fingerprint(ontology_fingerprint, binding_fingerprint, compiler_version) -> str` — full 64-hex SHA-256 over the **NUL-delimited UTF-8 encoding** of the three inputs (`ontology_fingerprint + "\x00" + binding_fingerprint + "\x00" + compiler_version`). **Canonical integrity key.** Consumers must call this function, not reimplement the payload; a golden-vector test pins the byte-exact digest so any silent payload change is caught.
   - `compile_id(ontology_fingerprint, binding_fingerprint, compiler_version) -> str` — 12-hex display token, derived as `compile_fingerprint(...)[:12]`. The derivation is structural; `compile_id` never computes its own hash.
 
   Not re-exported from any `__init__.py`. Shared implementation between `compile_concept_index()` (ontology package) and `OntologyRuntime` (SDK package) via absolute import `from bigquery_ontology._fingerprint import ...`. Underscore prefix makes it clear this isn't semver-stable surface; it's an implementation detail both packages happen to need.
@@ -222,7 +222,7 @@ Guard: keep the compiler's shadow-swap path non-self-healing. The compiler detec
 - **Ontology package version bump**: new public API (`compile_concept_index`, re-exported from `bigquery_ontology/__init__.py`) warrants a minor version bump. `_fingerprint.py` is internal and does not factor into semver.
 - **SDK version bump**: new public API (`OntologyRuntime`, `EntityResolver` + `ExactMatchResolver` + `SynonymResolver`, dataclasses, exception classes, all re-exported from `bigquery_agent_analytics/__init__.py`) warrants a minor version bump.
 - **Existing resolution code in user applications**: no deprecation. Users continue their existing resolution approach until they opt into the SDK primitive.
-- **BQ permissions**: `--emit-concept-index` requires `bigquery.tables.create` on the target dataset (existing `compile_graph()` requirement, unchanged). Runtime reading requires `bigquery.tables.getData` on the concept index and meta tables (standard).
+- **BQ permissions**: `gm compile` (with or without `--emit-concept-index`) is a pure SQL-emission command — it writes DDL to stdout or `--output` and does not call BigQuery. Only local file-system access is required at compile time. **Executing** the emitted SQL (`bq query`, console, Airflow, etc.) requires `bigquery.tables.create` on the target dataset for the main and `__meta` tables, matching the existing execute-side requirement for the `CREATE PROPERTY GRAPH` DDL emitted by `compile_graph()`. Runtime reading of the concept index via `OntologyRuntime` requires `bigquery.tables.getData` on the concept-index and meta tables (standard).
 
 ## Open watchlist (not blocking, track during implementation)
 


### PR DESCRIPTION
## Summary

Resolves the blocker from the issue #58 doc review: strict verification cannot currently prove main-table freshness because the 12-hex `compile_id` is not wide enough to serve as the integrity token, and full fingerprints live only in `__meta`.

Adopts **Option 2** (decided in [#58 comment 4311684137](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58#issuecomment-4311684137), refined in [comment 4311716470](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58#issuecomment-4311716470)): split the provenance surface into two columns with distinct roles.

## The contract

| Column | Role | Width | Used by |
|---|---|---|---|
| `compile_id` | **Display/debug token only.** Reports, queue rows, error messages, log lines. Never the sole freshness check. | 12 hex chars | Operator UX |
| `compile_fingerprint` | **Canonical integrity key.** Full SHA-256 over `ontology_fingerprint \|\| binding_fingerprint \|\| compiler_version`. | 64 hex chars | Strict pair-consistency + runtime verification |

Structural invariant: `compile_id == compile_fingerprint[:12]`. Enforced at the `_fingerprint.py` module boundary — short form is derived from full form, not the reverse. Makes it impossible to ship a row where the display token doesn't correspond to the integrity key.

## What's in this PR

Docs only. Two files touched, `+57/-23`.

**`entity_resolution_primitives.md`**:
- §4.2 schema: add `compile_fingerprint STRING NOT NULL` column; add the two-role column table; state the invariant.
- §5 verification queries: rewritten against `compile_fingerprint`. Three checks, no short-ID arithmetic on the verification path.
- §10 W2 watchpoint: rewritten under the new contract. The 48-bit collision caveat retires because strict queries never touch `compile_id`.
- §11 Decisions pinned: Option 2 recorded as a closed decision.

**`implementation_plan_concept_index_runtime.md`**:
- A1: describes the three exports (`fingerprint_model`, `compile_fingerprint`, `compile_id`) and the structural derivation.
- A2, A4, A5: both provenance columns explicitly listed in row builder / meta emission / inline-UNNEST SQL.
- C4: TTL re-check query updated to `compile_fingerprint`.
- D11: test scope rewritten — the invariant + a runtime-SQL grep-level check replace the old 48-bit-collision hypothetical.
- D14: shadow-path correctness test extended to both columns.
- W2 watchpoint (plan): rewritten to match the RFC.

**Storage math** (for the "but size" objection): 64-byte column × 100K rows ≈ 6.4 MB; × 1M rows ≈ 64 MB. ~$0.001–$0.013/month at BQ active-storage rates. Negligible.

## Downstream sequencing (unchanged)

1. **`_fingerprint.py` additive extension on PR #71** — adds `compile_fingerprint()` as the primitive; `compile_id()` becomes `compile_fingerprint(...)[:_COMPILE_ID_LEN]`. Non-breaking: `compile_id`'s existing return value is byte-identical.
2. **A2 row builder** consumes the two-column contract.
3. **A3 emission SQL** writes both columns on main and meta.
4. **B1/C4 verifier** queries `compile_fingerprint` only.

No `_fingerprint.py` changes in this PR — that lands on #71.

## Test plan

Docs only. No code, no tests changed. No CI impact beyond format check.

## Related

- Issue #58: [design issue, final decision thread](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58)
- PR #71: A1 fingerprint module (open — will get the additive `compile_fingerprint` export in a follow-up commit after this merges)
- PR #72: prior docs scope clarification (merged)
- PR #70: plan doc landing (merged)