### PR TITLE
docs(examples): add CI-gate reference workflow (cherry-pick from fork#39)

### DIFF
--- a/examples/ci/README.md
+++ b/examples/ci/README.md
@@ -1,0 +1,42 @@
+# `examples/ci/`
+
+Reference CI artifacts for agent quality gates backed by
+BigQuery Agent Analytics.
+
+## `evaluate_thresholds.yml`
+
+Drop-in GitHub Actions workflow that runs four deterministic
+budgets (latency, token usage, tool error rate, turn count) on
+every PR, scoring the last 24 hours of production traces from an
+`agent_events` BigQuery table. Exits non-zero when any session
+breaches its budget, so a bad merge lights up the PR status
+before code ships.
+
+See the companion Medium post, *Your Agent Events Table Is Also a
+Test Suite*, for the narrative, threshold-setting guidance, and
+the companion categorical-eval gate that pairs naturally with
+this workflow.
+
+### Quick start
+
+1. Copy `evaluate_thresholds.yml` to `.github/workflows/` in
+   your agent repo.
+2. Set repository variables `PROJECT_ID` and `DATASET_ID` to the
+   GCP project + BigQuery dataset where your `agent_events` table
+   lives.
+3. Set the repository secret `GCP_SA_KEY` to a service-account JSON
+   with `bigquery.jobUser` + `bigquery.dataViewer` on the dataset.
+4. Replace `calendar_assistant` with your agent's name in all four
+   `--agent-id` flags inside the workflow.
+5. Tune the four `--threshold` numbers against your own production
+   distribution. A defensible starting point for each is "p95 of
+   the last 30 days + 10% buffer"; revisit after week one of CI
+   gating.
+
+### Requirements
+
+- `bigquery-agent-analytics >= 0.2.2` — earlier releases shipped
+  normalized `1.0 - observed/budget` gate scoring with a `0.5`
+  pass cutoff, which fires every gate at roughly half the budget
+  the user typed. 0.2.2 switched to raw-budget binary gates so
+  the `--threshold` value means what it says.

--- a/examples/ci/evaluate_thresholds.yml
+++ b/examples/ci/evaluate_thresholds.yml
@@ -1,0 +1,78 @@
+# .github/workflows/evaluate_thresholds.yml
+#
+# Reference GitHub Actions workflow that gates every PR against the
+# last 24 hours of production traces stored in an `agent_events`
+# BigQuery table. Four deterministic budgets run as separate steps
+# so a red PR status tells you which gate regressed.
+#
+# Companion to the Medium post "Your Agent Events Table Is Also a
+# Test Suite." See the post for the narrative and for the sidebar
+# on picking initial threshold values from 30-day production data.
+#
+# Requires bigquery-agent-analytics >= 0.2.2 — the first release
+# with the raw-budget `--threshold` semantics and the tight
+# `--exit-code` failure output this workflow depends on.
+#
+# To adopt this workflow in your own agent repo:
+#   1. Copy this file to .github/workflows/evaluate_thresholds.yml.
+#   2. Set repo variables PROJECT_ID and DATASET_ID to the GCP
+#      project + BigQuery dataset where your agent_events table
+#      lives.
+#   3. Set the repo secret GCP_SA_KEY to a service account JSON
+#      with bigquery.jobUser + bigquery.dataViewer on the dataset.
+#   4. Replace `calendar_assistant` with your agent's name in all
+#      four --agent-id flags.
+#   5. Tune the four --threshold numbers against your own
+#      production distribution. A defensible starting point for
+#      each is "p95 of last 30 days + 10% buffer"; revisit after
+#      week one of CI gating.
+
+name: Agent quality gate
+
+on:
+  pull_request:
+    paths:
+      - 'agents/**'
+      - 'prompts/**'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install 'bigquery-agent-analytics>=0.2.2,<0.3.0'
+      - uses: google-github-actions/auth@v2
+        with: { credentials_json: '${{ secrets.GCP_SA_KEY }}' }
+      - name: Latency budget
+        run: >
+          bq-agent-sdk evaluate --evaluator=latency --threshold=5000
+          --last=24h --agent-id=calendar_assistant --exit-code
+          --project-id=${{ vars.PROJECT_ID }}
+          --dataset-id=${{ vars.DATASET_ID }}
+      - name: Token budget
+        # Tune this to your agent's real token distribution. A short
+        # system prompt + few-turn sessions will land in the low
+        # thousands; production agents with longer instructions and
+        # multi-turn tool chains typically want tens of thousands.
+        # Run `bq-agent-sdk evaluate --evaluator=token_efficiency
+        # --last=30d` without `--exit-code` once to see your own
+        # baseline before picking a number.
+        run: >
+          bq-agent-sdk evaluate --evaluator=token_efficiency --threshold=5000
+          --last=24h --agent-id=calendar_assistant --exit-code
+          --project-id=${{ vars.PROJECT_ID }}
+          --dataset-id=${{ vars.DATASET_ID }}
+      - name: Tool error rate
+        run: >
+          bq-agent-sdk evaluate --evaluator=error_rate --threshold=0.1
+          --last=24h --agent-id=calendar_assistant --exit-code
+          --project-id=${{ vars.PROJECT_ID }}
+          --dataset-id=${{ vars.DATASET_ID }}
+      - name: Turn count
+        run: >
+          bq-agent-sdk evaluate --evaluator=turn_count --threshold=10
+          --last=24h --agent-id=calendar_assistant --exit-code
+          --project-id=${{ vars.PROJECT_ID }}
+          --dataset-id=${{ vars.DATASET_ID }}


### PR DESCRIPTION
## Summary

Cherry-pick of [haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork#39](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/39) onto upstream `main`. Adds a drop-in GitHub Actions workflow that agent teams can fork from this repo to gate every PR against the last 24 hours of production traces.

- `examples/ci/evaluate_thresholds.yml` — runs four deterministic budgets (latency, token usage, tool error rate, turn count) as separate steps so a red PR status tells the reader *which* budget regressed.
- `examples/ci/README.md` — quick-start checklist: copy the file, set two repo variables + one secret, swap the four `--agent-id` values, tune the four `--threshold` numbers.

## Why

This is the canonical "fork this workflow" landing target referenced from the Medium blog series tracked in [#77](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/77). Readers going from the post straight to the SDK repo land on an authoritative, maintainable copy of the workflow rather than a Gist that can drift out of sync.

## What's in the file

- Pins `bigquery-agent-analytics>=0.2.2,<0.3.0` — the first release with raw-budget `--threshold` semantics and the `--exit-code` failure output the workflow depends on. A pre-0.2.2 SDK would fire every gate at roughly half the budget the user typed (per the fix in #79 / #81).
- Four `bq-agent-sdk evaluate --exit-code` steps, each on its own metric, so the GitHub Actions run view shows which budget regressed when one blows.
- Uses `google-github-actions/auth@v2` with a `GCP_SA_KEY` secret. Readers supply their own service-account JSON with `bigquery.jobUser` + `bigquery.dataViewer` on the dataset.
- Inline comments in the YAML point at the blog post's threshold-setting sidebar so the README stays focused on adoption steps.
- Token budget set to 5000 + threshold-tuning comment ("tune against your own `--last=30d` distribution") to give readers a smaller, reproducible demo number; production agents with longer prompts will want tens of thousands.

## Provenance

- **Source PR (merged):** [haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork#39](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/39)
- **Source merge commit:** `c625f2aad3086cd027d8f2177cbb656eba52a15b`
- **Squash content:** two commits from the original PR (workflow + token-budget tuning), squashed at merge.
- This branch is `git cherry-pick -x c625f2aa` against current upstream `main`. The `(cherry picked from commit ...)` trailer is preserved on the resulting commit.

## Test plan

- [x] `git diff` against `origin/main` adds only `examples/ci/evaluate_thresholds.yml` + `examples/ci/README.md` (`+120/-0`).
- [x] Cherry-pick applied cleanly with no conflicts (no `examples/ci/` previously existed on upstream `main`).
- [x] Commands in the workflow match the current SDK CLI surface.
- [ ] Live smoke deferred — workflow has been exercised against the original demo agent in the companion blog post; same content here.

## Related

- Blog series tracking: #77
- SDK CLI behavior the workflow depends on: #79 / #81 (raw-threshold semantics shipped in 0.2.2).
