### PR TITLE
fix(llm-judge): full prompt parity + execution_mode/fallback_reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LLM-as-Judge AI.GENERATE / ML.GENERATE_TEXT now uses the full Python
+  prompt template.** Previously both BQ-native paths sent only
+  ``prompt_template.split('{trace_text}')[0]`` to BigQuery, silently
+  dropping every instruction that followed the placeholders — including
+  the per-criterion output-format spec the judge model needs to score
+  consistently with the API-fallback path. The two BQ paths and the
+  Python API path now produce comparable scores against the same prompt.
+
+### Added
+
+- ``EvaluationReport.details["execution_mode"]`` is now populated for
+  LLM-as-Judge runs with one of ``ai_generate``, ``ml_generate_text``,
+  ``api_fallback``, or ``no_op`` — matching the value space the
+  categorical evaluator already exposes. When an earlier tier raised
+  before a later tier succeeded, ``details["fallback_reason"]`` carries
+  the chained exception messages in attempt order, so CI and dashboards
+  can audit which path actually ran.
+- ``evaluators.split_judge_prompt_template(prompt_template)`` is the
+  helper the SQL paths use to safely substitute the template into
+  ``CONCAT()``; exposed publicly for downstream code that needs the
+  same shape.
+
 ## [0.2.2] - 2026-04-24
 
 ### Changed (breaking)

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -80,6 +80,7 @@ from .evaluators import LLM_JUDGE_BATCH_QUERY
 from .evaluators import LLMAsJudge
 from .evaluators import SESSION_SUMMARY_QUERY
 from .evaluators import SessionScore
+from .evaluators import split_judge_prompt_template
 from .feedback import AnalysisConfig
 from .feedback import compute_drift
 from .feedback import compute_question_distribution
@@ -975,14 +976,27 @@ class Client:
     then falls back to the Gemini API.  Each path evaluates
     every criterion in the evaluator and merges the per-session
     scores into a single report.
+
+    Stamps ``report.details["execution_mode"]`` with one of
+    ``ai_generate``, ``ml_generate_text``, ``api_fallback`` so the
+    caller (and CI gates) can audit which path actually ran.
+    When an earlier tier raised before a later tier succeeded,
+    ``report.details["fallback_reason"]`` carries the chained
+    exception messages in attempt order. (The naming mirrors the
+    categorical evaluator's ``execution_mode`` value space for
+    consistency.)
     """
     criteria = evaluator._criteria
     if not criteria:
-      return _build_report(
+      report = _build_report(
           evaluator_name=evaluator.name,
           dataset=f"{self._table_ref} WHERE {where}",
           session_scores=[],
       )
+      report.details["execution_mode"] = "no_op"
+      return report
+
+    fallback_reasons: list[str] = []
 
     # Try AI.GENERATE (new path) when endpoint is not a legacy ref
     if not self._is_legacy_model_ref(self.endpoint):
@@ -997,17 +1011,20 @@ class Client:
               params,
           )
           criterion_reports.append((criterion, report))
-        return _merge_criterion_reports(
+        merged = _merge_criterion_reports(
             evaluator.name,
             f"{self._table_ref} WHERE {where}",
             criteria,
             criterion_reports,
         )
+        merged.details["execution_mode"] = "ai_generate"
+        return merged
       except Exception as e:
         logger.debug(
             "AI.GENERATE judge failed, trying legacy: %s",
             e,
         )
+        fallback_reasons.append(f"ai_generate: {e}")
 
     # Try legacy BQML batch evaluation
     text_model = (
@@ -1028,20 +1045,29 @@ class Client:
             text_model,
         )
         criterion_reports.append((criterion, report))
-      return _merge_criterion_reports(
+      merged = _merge_criterion_reports(
           evaluator.name,
           f"{self._table_ref} WHERE {where}",
           criteria,
           criterion_reports,
       )
+      merged.details["execution_mode"] = "ml_generate_text"
+      if fallback_reasons:
+        merged.details["fallback_reason"] = "; ".join(fallback_reasons)
+      return merged
     except Exception as e:
       logger.debug(
           "BQML judge failed, falling back to API: %s",
           e,
       )
+      fallback_reasons.append(f"ml_generate_text: {e}")
 
     # Fallback: fetch traces using same table/filter, evaluate via API
-    return self._api_judge(evaluator, table, where, params)
+    api_report = self._api_judge(evaluator, table, where, params)
+    api_report.details["execution_mode"] = "api_fallback"
+    if fallback_reasons:
+      api_report.details["fallback_reason"] = "; ".join(fallback_reasons)
+    return api_report
 
   def _ai_generate_judge(
       self,
@@ -1054,12 +1080,13 @@ class Client:
     """Evaluates using BigQuery AI.GENERATE with typed output."""
     from google.cloud import bigquery as bq
 
+    prefix, middle, suffix = split_judge_prompt_template(
+        criterion.prompt_template
+    )
     judge_params = list(params) + [
-        bq.ScalarQueryParameter(
-            "judge_prompt",
-            "STRING",
-            criterion.prompt_template.split("{trace_text}")[0],
-        ),
+        bq.ScalarQueryParameter("judge_prompt_prefix", "STRING", prefix),
+        bq.ScalarQueryParameter("judge_prompt_middle", "STRING", middle),
+        bq.ScalarQueryParameter("judge_prompt_suffix", "STRING", suffix),
     ]
 
     query = AI_GENERATE_JUDGE_BATCH_QUERY.format(
@@ -1121,12 +1148,13 @@ class Client:
     """Evaluates using BigQuery ML.GENERATE_TEXT."""
     from google.cloud import bigquery as bq
 
+    prefix, middle, suffix = split_judge_prompt_template(
+        criterion.prompt_template
+    )
     judge_params = list(params) + [
-        bq.ScalarQueryParameter(
-            "judge_prompt",
-            "STRING",
-            criterion.prompt_template.split("{trace_text}")[0],
-        ),
+        bq.ScalarQueryParameter("judge_prompt_prefix", "STRING", prefix),
+        bq.ScalarQueryParameter("judge_prompt_middle", "STRING", middle),
+        bq.ScalarQueryParameter("judge_prompt_suffix", "STRING", suffix),
     ]
 
     query = LLM_JUDGE_BATCH_QUERY.format(

--- a/src/bigquery_agent_analytics/evaluators.py
+++ b/src/bigquery_agent_analytics/evaluators.py
@@ -894,9 +894,15 @@ SELECT
   result.*
 FROM session_traces,
 AI.GENERATE(
+  -- Substitute the full Python prompt_template at SQL time:
+  -- prefix ++ trace_text ++ middle ++ final_response ++ suffix.
+  -- Each segment is a separate query parameter so we preserve the
+  -- exact Python template (including the per-criterion output-format
+  -- spec) that the API-fallback path uses.
   prompt => CONCAT(
-    @judge_prompt, '\\nTrace:\\n', trace_text,
-    '\\nResponse:\\n', COALESCE(final_response, 'N/A')
+    @judge_prompt_prefix, trace_text,
+    @judge_prompt_middle, COALESCE(final_response, 'N/A'),
+    @judge_prompt_suffix
   ),
   endpoint => '{endpoint}',
   model_params => JSON '{{"temperature": 0.1, "max_output_tokens": 500}}',
@@ -938,9 +944,13 @@ SELECT
   ML.GENERATE_TEXT(
     MODEL `{model}`,
     STRUCT(
-      CONCAT(@judge_prompt, '\\nTrace:\\n', trace_text,
-             '\\nResponse:\\n', COALESCE(final_response, 'N/A'))
-      AS prompt
+      -- Same prefix/middle/suffix substitution as the AI.GENERATE
+      -- path; preserves the full Python prompt_template.
+      CONCAT(
+        @judge_prompt_prefix, trace_text,
+        @judge_prompt_middle, COALESCE(final_response, 'N/A'),
+        @judge_prompt_suffix
+      ) AS prompt
     ),
     STRUCT(0.1 AS temperature, 500 AS max_output_tokens)
   ).ml_generate_text_result AS evaluation
@@ -949,6 +959,99 @@ FROM session_traces
 
 # Keep backward-compatible alias.
 LLM_JUDGE_BATCH_QUERY = _LEGACY_LLM_JUDGE_BATCH_QUERY
+
+
+_TRACE_SENTINEL = "\x00__BQAA_JUDGE_TRACE__\x00"
+_RESPONSE_SENTINEL = "\x00__BQAA_JUDGE_RESPONSE__\x00"
+
+
+def split_judge_prompt_template(prompt_template: str) -> tuple[str, str, str]:
+  """Split a Python judge prompt into ``(prefix, middle, suffix)``.
+
+  The Python ``LLMAsJudge`` prompt template uses ``{trace_text}`` and
+  ``{final_response}`` placeholders (in that order) to interpolate
+  per-session inputs. The BigQuery-native ``AI.GENERATE`` and
+  ``ML.GENERATE_TEXT`` paths can't use Python ``str.format`` — they
+  build the prompt at SQL time. This helper returns the three
+  literal segments those SQL paths need to ``CONCAT`` together with
+  the SQL-side ``trace_text`` and ``final_response`` columns,
+  preserving the exact full template (including the per-criterion
+  output-format spec that follows the placeholders).
+
+  Internally the helper format()s the template once with sentinel
+  values, so any literal ``{{...}}`` braces in the source template
+  (e.g. the JSON output spec ``{{"correctness": <score>, ...}}``)
+  are correctly un-escaped before splitting. The SQL paths see the
+  same string the API-fallback path's ``str.format(...)`` would
+  produce.
+
+  Args:
+      prompt_template: The Python prompt template, expected to
+          contain both ``{trace_text}`` and ``{final_response}``
+          placeholders in that order.
+
+  Returns:
+      ``(prefix, middle, suffix)`` such that
+      ``prefix + trace_text + middle + final_response + suffix``
+      reproduces ``prompt_template.format(trace_text=..., final_response=...)``
+      for any inputs. When a placeholder is missing, the helper
+      synthesizes a labeled section for the missing input and
+      places the label *immediately before* the injected value
+      (label first, then value), so the model reads
+      ``...Trace:\n<TRACE>\nResponse:\n<RESPONSE>...`` rather than
+      the value followed by an orphan label.
+  """
+  has_trace = "{trace_text}" in prompt_template
+  has_response = "{final_response}" in prompt_template
+
+  # Reminder for the fallback branches below: the SQL CONCAT runs
+  #   prefix ++ trace_text ++ middle ++ final_response ++ suffix
+  # so any label we synthesize for an absent placeholder must end
+  # up *next to* the value it labels (label first, then value),
+  # not on the far side of it. Earlier versions appended labels
+  # *after* the values, which produced ``<TRACE>\nTrace:\n...``.
+
+  if not has_trace and not has_response:
+    # No placeholders at all. Append a labeled trace + response
+    # block after the user's instructions. The labels precede the
+    # values so the model reads them in order.
+    return (
+        prompt_template + "\nTrace:\n",
+        "\nResponse:\n",
+        "",
+    )
+
+  if not has_trace:
+    # final_response placeholder only. Honor the user's structure
+    # and inject a labeled trace block right before the response,
+    # so the trace label sits next to the trace.
+    formatted = prompt_template.format(final_response=_RESPONSE_SENTINEL)
+    before_response, _, after_response = formatted.partition(_RESPONSE_SENTINEL)
+    return (
+        before_response + "\nTrace:\n",
+        "\n",
+        after_response,
+    )
+
+  if not has_response:
+    # trace_text placeholder only. Append a labeled response block
+    # after the original template's tail, so the response label
+    # sits next to the response value (not after it).
+    formatted = prompt_template.format(trace_text=_TRACE_SENTINEL)
+    prefix, _, after_trace = formatted.partition(_TRACE_SENTINEL)
+    return (
+        prefix,
+        after_trace + "\nResponse:\n",
+        "",
+    )
+
+  formatted = prompt_template.format(
+      trace_text=_TRACE_SENTINEL,
+      final_response=_RESPONSE_SENTINEL,
+  )
+  prefix, _, rest = formatted.partition(_TRACE_SENTINEL)
+  middle, _, suffix = rest.partition(_RESPONSE_SENTINEL)
+  return prefix, middle, suffix
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -482,6 +482,298 @@ class TestAIGenerateJudge:
     query_str = call_args[0][0]
     assert "AI.GENERATE" in query_str
 
+  def test_ai_generate_passes_full_prompt_template(self):
+    """AI.GENERATE judge passes the full Python template, not a truncated split.
+
+    Regression guard for the prompt-parity bug — earlier versions
+    sent only ``prompt_template.split('{trace_text}')[0]`` to AI.GENERATE,
+    silently dropping the per-criterion output-format spec that
+    follows the placeholders. This test asserts the BQ query receives
+    three parameters (prefix/middle/suffix) and that, concatenated
+    with the SQL trace_text/final_response columns, they reproduce
+    the exact Python template.
+    """
+    mock_bq = _mock_bq_client()
+    mock_rows = [
+        _make_mock_row(
+            {
+                "session_id": "s1",
+                "trace_text": "USER: hi",
+                "final_response": "hello",
+                "score": 8,
+                "justification": "ok",
+            }
+        ),
+    ]
+    mock_job = MagicMock()
+    mock_job.result.return_value = mock_rows
+    mock_bq.query.return_value = mock_job
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+    evaluator = LLMAsJudge.correctness(threshold=0.5)
+    criterion = evaluator._criteria[0]
+    client._ai_generate_judge(evaluator, criterion, "agent_events", "TRUE", [])
+
+    # Inspect the QueryJobConfig.query_parameters that landed on the
+    # BigQuery client.
+    call_kwargs = mock_bq.query.call_args.kwargs
+    job_config = call_kwargs["job_config"]
+    by_name = {p.name: p.value for p in job_config.query_parameters}
+    assert "judge_prompt_prefix" in by_name
+    assert "judge_prompt_middle" in by_name
+    assert "judge_prompt_suffix" in by_name
+    # ``judge_prompt`` (the old single-segment param) must no longer
+    # appear — its presence would mean a caller is still on the
+    # truncated-split path.
+    assert "judge_prompt" not in by_name
+    # Concatenation reproduces the full template when the
+    # placeholders are filled in.
+    reconstructed = (
+        by_name["judge_prompt_prefix"]
+        + "TRACE_HERE"
+        + by_name["judge_prompt_middle"]
+        + "RESPONSE_HERE"
+        + by_name["judge_prompt_suffix"]
+    )
+    expected = criterion.prompt_template.format(
+        trace_text="TRACE_HERE", final_response="RESPONSE_HERE"
+    )
+    assert reconstructed == expected
+    # The Python template's per-criterion output-format spec must
+    # survive the round trip — that's the whole point of the fix.
+    assert "JSON object" in by_name["judge_prompt_suffix"]
+
+  def test_bqml_judge_passes_full_prompt_template(self):
+    """ML.GENERATE_TEXT path uses the same prefix/middle/suffix params."""
+    mock_bq = _mock_bq_client()
+    mock_rows = [
+        _make_mock_row(
+            {
+                "session_id": "s1",
+                "trace_text": "USER: hi",
+                "final_response": "hello",
+                "evaluation": '{"correctness": 8, "justification": "ok"}',
+            }
+        ),
+    ]
+    mock_job = MagicMock()
+    mock_job.result.return_value = mock_rows
+    mock_bq.query.return_value = mock_job
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+    evaluator = LLMAsJudge.correctness(threshold=0.5)
+    criterion = evaluator._criteria[0]
+    client._bqml_judge(
+        evaluator,
+        criterion,
+        "agent_events",
+        "TRUE",
+        [],
+        text_model="proj.ds.gemini_text_model",
+    )
+
+    job_config = mock_bq.query.call_args.kwargs["job_config"]
+    names = {p.name for p in job_config.query_parameters}
+    assert {
+        "judge_prompt_prefix",
+        "judge_prompt_middle",
+        "judge_prompt_suffix",
+    }.issubset(names)
+    assert "judge_prompt" not in names
+
+  def test_ai_generate_success_sets_execution_mode(self):
+    """When AI.GENERATE succeeds, report.details says so explicitly."""
+    mock_bq = _mock_bq_client()
+    mock_rows = [
+        _make_mock_row(
+            {
+                "session_id": "s1",
+                "trace_text": "USER: hi",
+                "final_response": "hello",
+                "score": 8,
+                "justification": "ok",
+            }
+        ),
+    ]
+    mock_job = MagicMock()
+    mock_job.result.return_value = mock_rows
+    mock_bq.query.return_value = mock_job
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+    report = client._evaluate_llm_judge(
+        LLMAsJudge.correctness(), "agent_events", "TRUE", []
+    )
+    assert report.details["execution_mode"] == "ai_generate"
+    # No fallback fired -> no fallback_reason on the report.
+    assert "fallback_reason" not in report.details
+
+  def test_ai_generate_failure_falls_back_to_ml_generate_text(self):
+    """AI.GENERATE failure -> BQML path takes over, mode reflects it."""
+    mock_bq = _mock_bq_client()
+
+    # First query call raises (AI.GENERATE), subsequent calls return
+    # a BQML-shaped row.
+    bqml_rows = [
+        _make_mock_row(
+            {
+                "session_id": "s1",
+                "trace_text": "USER: hi",
+                "final_response": "hello",
+                "evaluation": '{"correctness": 8, "justification": "ok"}',
+            }
+        ),
+    ]
+    bqml_job = MagicMock()
+    bqml_job.result.return_value = bqml_rows
+    mock_bq.query.side_effect = [
+        Exception("AI.GENERATE not available in this region"),
+        bqml_job,
+    ]
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+    report = client._evaluate_llm_judge(
+        LLMAsJudge.correctness(), "agent_events", "TRUE", []
+    )
+    assert report.details["execution_mode"] == "ml_generate_text"
+    assert "ai_generate" in report.details["fallback_reason"]
+    assert "AI.GENERATE not available" in report.details["fallback_reason"]
+
+  def test_both_bq_paths_fail_falls_back_to_api(self):
+    """AI.GENERATE + ML.GENERATE_TEXT both fail -> Gemini API fallback."""
+    mock_bq = _mock_bq_client()
+    mock_bq.query.side_effect = Exception("connection missing")
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    # Stub _api_judge to avoid an actual google-genai call. The
+    # method exists on the client; we just want execution_mode set.
+    from bigquery_agent_analytics.evaluators import EvaluationReport
+    from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+    stub_report = EvaluationReport(
+        dataset="proj.ds.agent_events WHERE TRUE",
+        evaluator_name="correctness_judge",
+        total_sessions=0,
+    )
+    with patch.object(client, "_api_judge", return_value=stub_report):
+      report = client._evaluate_llm_judge(
+          LLMAsJudge.correctness(), "agent_events", "TRUE", []
+      )
+    assert report.details["execution_mode"] == "api_fallback"
+    # Both upstream tiers should be named in the fallback chain.
+    assert "ai_generate" in report.details["fallback_reason"]
+    assert "ml_generate_text" in report.details["fallback_reason"]
+
+
+class TestSplitJudgePromptTemplate:
+  """Tests for evaluators.split_judge_prompt_template."""
+
+  def test_full_template_round_trips(self):
+    from bigquery_agent_analytics.evaluators import split_judge_prompt_template
+
+    tmpl = (
+        "You are a judge.\n## Trace\n{trace_text}\n## Response\n"
+        "{final_response}\n## Score\nReturn JSON."
+    )
+    prefix, middle, suffix = split_judge_prompt_template(tmpl)
+    rebuilt = prefix + "TT" + middle + "FR" + suffix
+    assert rebuilt == tmpl.format(trace_text="TT", final_response="FR")
+
+  def test_missing_final_response_keeps_label_next_to_response(self):
+    """Custom template with {trace_text} only — Response: label must
+    precede the appended response value.
+
+    The SQL CONCAT runs prefix ++ trace_text ++ middle ++
+    final_response ++ suffix, so a synthesized label for the
+    missing placeholder belongs *immediately before* the value it
+    labels — not on the far side of it.
+    """
+    from bigquery_agent_analytics.evaluators import split_judge_prompt_template
+
+    tmpl = "Prefix\n{trace_text}\nThen something."
+    prefix, middle, suffix = split_judge_prompt_template(tmpl)
+    rebuilt = prefix + "TRACE" + middle + "RESPONSE" + suffix
+    assert "Response:\nRESPONSE" in rebuilt
+    # Whatever followed {trace_text} in the original template
+    # appears before the synthesized response label.
+    assert "Then something." in rebuilt
+    assert rebuilt.index("Then something.") < rebuilt.index(
+        "Response:\nRESPONSE"
+    )
+
+  def test_missing_trace_text_keeps_label_next_to_trace(self):
+    """Custom template with {final_response} only — Trace: label must
+    precede the appended trace value.
+
+    Regression guard for the reviewer-flagged bug: earlier versions
+    returned ``("", "\\nTrace:\\n" + before_response, suffix)`` which
+    injected ``<TRACE>\\nTrace:\\n<original prompt>...`` — trace
+    landed on the wrong side of the label, and the user's prompt
+    text appeared after the trace instead of before it.
+    """
+    from bigquery_agent_analytics.evaluators import split_judge_prompt_template
+
+    tmpl = "Custom rules.\n{final_response}\nDone."
+    prefix, middle, suffix = split_judge_prompt_template(tmpl)
+    rebuilt = prefix + "TRACE" + middle + "RESPONSE" + suffix
+    # User's "Custom rules." prose appears before the synthesized
+    # Trace: label, and the trace value sits right after the label.
+    assert "Custom rules.\n" in rebuilt
+    assert "Trace:\nTRACE" in rebuilt
+    assert rebuilt.index("Custom rules.") < rebuilt.index("Trace:\nTRACE")
+    # Response follows the trace, and the user's "Done." tail
+    # appears after the response.
+    assert rebuilt.index("Trace:\nTRACE") < rebuilt.index("RESPONSE")
+    assert rebuilt.index("RESPONSE") < rebuilt.index("Done.")
+
+  def test_no_placeholders_appends_labeled_trace_then_response(self):
+    """Template with neither placeholder — labels precede their values.
+
+    Original instructions stay first; trace block comes next with
+    its label; response block comes last with its label.
+    """
+    from bigquery_agent_analytics.evaluators import split_judge_prompt_template
+
+    tmpl = "Just instructions, no placeholders."
+    prefix, middle, suffix = split_judge_prompt_template(tmpl)
+    rebuilt = prefix + "TRACE" + middle + "RESPONSE" + suffix
+    assert rebuilt.startswith(tmpl)
+    assert "Trace:\nTRACE" in rebuilt
+    assert "Response:\nRESPONSE" in rebuilt
+    assert rebuilt.index("Trace:\nTRACE") < rebuilt.index("Response:\nRESPONSE")
+
 
 class TestMultiCriterionJudge:
   """Tests for multi-criterion LLM judge (Fix #1)."""


### PR DESCRIPTION
## Summary

Cherry-picks the LLM-judge prompt-parity + execution-mode reporting fix from the development fork (haiyuan-eng-google PR #42 — already merged downstream and live-verified) into the canonical repo. First of three coupled PRs that together unblock the upcoming \"semantic CI gate\" Medium post.

### Prompt parity

\`_ai_generate_judge\` and \`_bqml_judge\` previously sent only \`prompt_template.split('{trace_text}')[0]\` to BigQuery — silently dropping every instruction after the placeholders, including the per-criterion JSON output spec the judge model needs to score consistently. The Python API-fallback path uses the whole template via \`str.format(...)\`, so the two BQ paths and the Python path were scoring against different prompts.

- New helper \`evaluators.split_judge_prompt_template(template)\` format()s with sentinel placeholders, then partitions into \`(prefix, middle, suffix)\`. Sentinels avoid clashing with literal template content; the format pass un-escapes \`{{...}}\` so the SQL CONCAT sees the same string the API path produces.
- Both batch query templates now \`CONCAT(@judge_prompt_prefix, trace_text, @judge_prompt_middle, COALESCE(final_response, 'N/A'), @judge_prompt_suffix)\` — three parameters instead of one.
- Both judge methods in \`client.py\` swap the single \`judge_prompt\` param for the three new ones.

### \`execution_mode\` + \`fallback_reason\`

\`_evaluate_llm_judge\` stamps \`report.details[\"execution_mode\"]\` with one of \`ai_generate\`, \`ml_generate_text\`, \`api_fallback\`, or \`no_op\` — matching the value space \`evaluate_categorical\` already uses. When an earlier tier raises before a later tier succeeds, \`details[\"fallback_reason\"]\` carries the chained exception messages in attempt order. Same vocabulary across both evaluator families is intentional.

### Tests (8 new)

- \`test_ai_generate_passes_full_prompt_template\` / \`test_bqml_judge_passes_full_prompt_template\` — three params instead of one, concatenation reproduces the full Python template including the JSON output spec.
- Three execution-mode tests covering each cascade outcome plus chained \`fallback_reason\`.
- \`TestSplitJudgePromptTemplate\` — round-trip, missing-placeholder fallback, no-placeholders fallback (with the reviewer-flagged \`{final_response}\`-only edge case fixed).

### PR series context

This is **PR 1 of 3** for the semantic-CI-gate blog post:

1. **#42 (this PR)** — runtime behavior: prompt parity + execution_mode reporting.
2. **#44 (next)** — CLI/reporting UX: LLM-judge \`--exit-code\` FAIL output with bounded \`feedback=\"...\"\` snippet + \`--strict\` doc rewrite.
3. **#45 (last)** — AI.GENERATE template scalar rewrite + gated live BigQuery integration test.

Each PR was reviewed and merged on the development fork; live-verified end-to-end against a real BigQuery sandbox before the cherry-pick. Suggest merging in order — #44 and #45 build on this PR's report shape.

## Test plan

- [x] \`pytest tests/\` -> 2025 passed, 4 skipped on this branch
- [x] Live verification end-to-end on the dev fork: \`client.evaluate(LLMAsJudge.correctness())\` returns real scores + justifications, \`execution_mode='ai_generate'\`, no fallback
- [x] \`bash autoformat.sh\` clean

## Origin

Cherry-picked from \`haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork\` PR #42 (squash commit \`ba7ada22\`). All review threads resolved on the fork; final reviewer signoff: \"No further findings — fallback branches now match the SQL rebuild order, and the reviewer-flagged \`{final_response}\`-only case is covered correctly.\"