### PR TITLE
docs(changelog): roll [Unreleased] entries under [0.2.3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-27
+
 ### Fixed
 
 - **LLM-as-Judge AI.GENERATE path now executes against current


### PR DESCRIPTION
0.2.3 was published to PyPI when PRs #85, #86, and #87 landed, but the CHANGELOG entries stayed under `[Unreleased]`. This PR moves them under a dated `[0.2.3] - 2026-04-27` header and leaves a fresh empty `[Unreleased]` stub above. No content changes — same Fixed / Added / Changed bullets, just under the right version heading.