### PR TITLE
feat(ontology): Phase 1 — concept-index emission (issue #58, A1-A8 squashed)

### DIFF
--- a/docs/ontology/cli.md
+++ b/docs/ontology/cli.md
@@ -148,8 +148,35 @@ gm compile <binding> [--ontology <path>] [-o <out>]
 | `-o <file>`, `--output <file>` | Write DDL to file instead of stdout. |
 | `--ontology <path>` | Path to the companion ontology. Overrides auto-discovery (same as `gm validate`). |
 | `--json` | Structured errors for the implicit validation step. |
+| `--emit-concept-index` | Append `CREATE OR REPLACE TABLE` SQL for the concept index + `__meta` sibling. Requires `--concept-index-table`. See [`concept-index.md`](concept-index.md). |
+| `--concept-index-table <project.dataset.table>` | Fully-qualified destination for the concept index. Required when `--emit-concept-index` is set; no silent global default. The `__meta` sibling is suffixed automatically. |
+| `--compiler-version <str>` | Override the version string flowed into `compile_fingerprint`. Defaults to the installed package version. Only honored with `--emit-concept-index`. |
 
 On any validation or compilation error, no DDL is emitted — even partially.
+
+### Concept-index extension
+
+When `--emit-concept-index` is set, the output combines the property-graph
+DDL with two `CREATE OR REPLACE TABLE` statements emitted by the
+sibling `compile_concept_index` emitter (the main concept index and its
+`__meta` provenance table). The combined output is still a single text
+stream; pipe it into `bq query` or write it to a file with `-o`. Without
+the flag, output is byte-identical to plain `gm compile`.
+
+The required `--concept-index-table` value must be a fully-qualified
+`project.dataset.table` triple. Each segment must match
+`^[A-Za-z0-9_-]+$`; backticks are added by the emitter (do not
+pre-quote). See [`concept-index.md`](concept-index.md) for the full
+schema, provenance contract, and SQL patterns.
+
+Example:
+
+```bash
+gm compile finance-bq-prod.binding.yaml \
+  --emit-concept-index \
+  --concept-index-table my-proj.my_ds.ontology_concept_index \
+  -o graph_ddl.sql
+```
 
 ### Filename convention
 

--- a/docs/ontology/compilation.md
+++ b/docs/ontology/compilation.md
@@ -290,6 +290,33 @@ One `CREATE PROPERTY GRAPH` per compile. Node tables sorted alphabetically,
 then edge tables sorted alphabetically. Property lists follow ontology
 declaration order.
 
+## 7a. Sibling emitter: concept index
+
+`compile_graph` is paired with a sibling emitter, `compile_concept_index`,
+exposed via the `--emit-concept-index` flag on `gm compile`. When set, the
+combined output appends two atomic-per-statement `CREATE OR REPLACE TABLE`
+statements (a main concept-index table and its `__meta` provenance
+sibling) after the property-graph DDL. Without the flag, `gm compile`
+output is byte-identical to today.
+
+The two emitters are intentionally **independent functions**:
+
+- `compile_graph(ontology, binding) -> str` is unchanged in shape and
+  contract.
+- `compile_concept_index(ontology, binding, *, output_table,
+  compiler_version) -> str` is additive — same `(Ontology, Binding)`
+  inputs, different downstream consumer (the SDK's runtime resolver
+  layer rather than a property-graph backend).
+
+Both are pure SQL emitters. Neither calls BigQuery; the operator runs
+the emitted text via `bq query` or any equivalent path. The CLI
+composes the two outputs into a single text stream when both are
+requested.
+
+See [`concept-index.md`](concept-index.md) for the full schema,
+provenance contract (`compile_id` short display vs
+`compile_fingerprint` 64-hex integrity key), and runtime contract.
+
 ## 8. Open questions
 
 - **Multi-graph output.** One `CREATE PROPERTY GRAPH` per compile.

--- a/docs/ontology/concept-index.md
+++ b/docs/ontology/concept-index.md
@@ -1,0 +1,277 @@
+# Concept Index — Reference (Phase 1)
+
+Status: draft
+Scope: the BigQuery sidecar tables emitted by `gm compile --emit-concept-index`. Phase 1 ships the SQL emission only; the runtime consumer in `bigquery_agent_analytics` (`OntologyRuntime`, resolvers, strict verification) lands in Phases 2–3 per [`docs/implementation_plan_concept_index_runtime.md`](../implementation_plan_concept_index_runtime.md). Companion to [`compilation.md`](compilation.md) (`gm compile` core) and [`cli.md`](cli.md) (`gm` flag reference).
+
+The concept index is **opt-in**: a `gm compile` invocation without `--emit-concept-index` is byte-identical to today and writes no extra DDL.
+
+## 1. What it is
+
+Two BigQuery tables emitted as a sidecar to the property-graph DDL:
+
+- **`<output_table>`** — the main concept index, one row per `(entity_name, label, label_kind, language, scheme)` tuple, plus per-entity provenance columns. Resolvers run SQL against this.
+- **`<output_table>__meta`** — a single-row sibling carrying the full provenance fingerprints. The runtime layer uses this to verify that the index in BigQuery still corresponds to the `(Ontology, Binding)` it was loaded from.
+
+Both tables are written in the same `gm compile` run via `CREATE OR REPLACE TABLE T AS SELECT * FROM UNNEST(ARRAY<STRUCT<...>>[...])`. Each statement is atomic per BigQuery's DDL semantics; pair-consistency between main and meta is enforced at runtime via a shared `compile_fingerprint` rather than a DDL transaction (BigQuery doesn't have those for cross-table DDL).
+
+## 2. When to use it
+
+The concept index is the read-side fabric for **Direction 3** of the SDK — runtime entity resolution from free-text strings to declared ontology entities (see [issue #58][issue58]). Concrete callers:
+
+- An eval pipeline that asks *"of N free-text `geo:` values in yesterday's traces, how many resolve against the GAM DMA scheme?"*
+- A curation script that canonicalizes a column of historical user inputs into declared entity keys for an eval dataset.
+- A pre-processing job that resolves brief parameters against the ontology before briefs are enqueued downstream.
+
+A future Phase 2 will ship `OntologyRuntime` + `EntityResolver` in `bigquery_agent_analytics` as the Python surface over this index. For Phase 1 (and for bulk analytics in general), a SQL pushdown directly against the index table is the supported pattern; see §8 "Common SQL patterns" below.
+
+## 3. Emit the SQL
+
+The CLI flow is identical to plain `gm compile`, with two additional flags:
+
+```bash
+gm compile finance-bq-prod.binding.yaml \
+  --emit-concept-index \
+  --concept-index-table my-proj.my_ds.ontology_concept_index \
+  -o graph_ddl.sql
+```
+
+Or to stdout:
+
+```bash
+gm compile binding.yaml \
+  --emit-concept-index \
+  --concept-index-table my-proj.my_ds.ontology_concept_index \
+  | bq query --nouse_legacy_sql
+```
+
+`gm compile` emits SQL text only; it does not call BigQuery. Executing the emitted SQL requires `bigquery.tables.create` on the target dataset for the main and `__meta` tables.
+
+### Flag reference
+
+| Flag | Required when emit is set | Purpose |
+|---|---|---|
+| `--emit-concept-index` | — | Opt-in toggle. Without it, output is byte-identical to plain `gm compile`. |
+| `--concept-index-table <project.dataset.table>` | yes | Fully-qualified destination for the main table. The `__meta` sibling is suffixed automatically. No silent global default. Must match `^[A-Za-z0-9_-]+$` per segment; backticks rejected. |
+| `--compiler-version <str>` | no | Override the version string flowed into `compile_fingerprint`. Defaults to the installed package version (`bigquery_ontology X.Y.Z`). Pin this when reproducing an older index from a checkout. |
+
+### Errors
+
+- **`--emit-concept-index` without `--concept-index-table`** → exit 2, `cli-missing-flag`. No silent global default per the RFC.
+- **`--concept-index-table` without `--emit-concept-index`** → exit 2, `cli-orphan-flag`. Surfaces typos rather than silently dropping the value.
+- **Invalid `--concept-index-table` value** (not three segments, contains backticks, invalid characters in a segment) → exit 1, structured error with the exact reason.
+- **Zero-row case** → exit 1. The compiler refuses to emit a typeless empty array. This fires only when the ontology declares no abstract entities **and** the binding references no concrete entities (the row builder produces an empty list). An abstract-only ontology compiles successfully — abstract entities are always included regardless of binding (per the scope rule in §4 below).
+
+## 4. Main table schema
+
+The schema below is the **logical** shape of each row. `NOT NULL` annotations are invariants the row builder maintains by construction, not BigQuery-enforced constraints — see the "Constraints" note immediately after the snippet.
+
+```sql
+CREATE TABLE `<output_table>` (
+  entity_name         STRING NOT NULL,
+  label               STRING NOT NULL,   -- for label_kind='notation', holds the notation value
+  label_kind          STRING NOT NULL,   -- 'name' | 'pref' | 'alt' | 'hidden' | 'synonym' | 'notation'
+  notation            STRING,            -- per-entity display, repeats across rows of the same entity
+  scheme              STRING,            -- skos:inScheme / topConceptOf membership; NULL if none
+  language            STRING,            -- BCP-47 from skos:prefLabel@<lang> etc.; NULL for default
+  is_abstract         BOOL   NOT NULL,   -- true for SKOS-derived informational entities
+  compile_id          STRING NOT NULL,   -- 12-hex display token; same on every row of a compile
+  compile_fingerprint STRING NOT NULL    -- 64-hex canonical integrity key
+);
+```
+
+**Constraints.** The Phase 1 emitter writes the table via `CREATE OR REPLACE TABLE T AS SELECT * FROM UNNEST(ARRAY<STRUCT<...>>[...])` (CTAS). BigQuery's CTAS path does **not** carry `NOT NULL` from the underlying STRUCT into table-level column constraints — the resulting columns are nullable in `INFORMATION_SCHEMA.COLUMNS`. The annotations above are the row builder's contract: every row it emits populates the six "NOT NULL" columns, by construction. If a downstream caller wants BigQuery-enforced constraints, the runbook is to wrap the emitted CTAS in an explicit two-step `CREATE OR REPLACE TABLE T (col STRING NOT NULL, ...) AS SELECT ...` form locally (or run `ALTER TABLE T ALTER COLUMN col SET NOT NULL` after the fact). The Phase 1 emitter doesn't do either — keeping the schema CTAS-only is intentional for atomicity per statement and keeps the SQL byte-deterministic.
+
+### Row multiplicity
+
+One row per `(entity_name, label, label_kind, language, scheme)` membership tuple. A concept in 3 schemes × 5 labels emits 15 rows. `DISTINCT entity_name` over a multi-scheme concept returns 1.
+
+### Label sources
+
+| Source | Becomes | Notes |
+|---|---|---|
+| `Entity.name` | `label_kind='name'` row | Always emitted |
+| `annotations["skos:prefLabel"]` | `label_kind='pref'` | `@<lang>` suffix populates the `language` column |
+| `annotations["skos:altLabel"]` | `label_kind='alt'` | Same |
+| `annotations["skos:hiddenLabel"]` | `label_kind='hidden'` | Same |
+| `Entity.synonyms` | `label_kind='synonym'` | See "Known v1 limitation" below |
+| `annotations["skos:notation"]` | One `label_kind='notation'` row + populates the per-row `notation` column on every row of the entity | Resolvers searching by `label` catch notation matches without a separate predicate |
+
+### Scope rule
+
+- **Abstract entities** are always included regardless of binding — they're informational and never need to be bound to a table.
+- **Concrete entities** are included iff they appear in `binding.entities`.
+
+### Schemes
+
+`annotations["skos:inScheme"]` and `annotations["skos:topConceptOf"]` are unioned and deduped. A concept declared as the top of a scheme is a member of that scheme. Entities with no scheme membership produce rows with `scheme = NULL`.
+
+### `label_kind` priority (resolver-side)
+
+The schema's `label_kind` column is sorted lexicographically inside the emitted SQL only for byte-deterministic output. The **semantic** priority for resolver dedup is:
+
+```sql
+CASE label_kind
+  WHEN 'name'     THEN 1
+  WHEN 'pref'     THEN 2
+  WHEN 'alt'      THEN 3
+  WHEN 'hidden'   THEN 4
+  WHEN 'synonym'  THEN 5
+  WHEN 'notation' THEN 6
+END AS priority
+```
+
+Resolvers `ORDER BY priority ASC` to pick the strongest label per entity. Never `ORDER BY label_kind` directly — the alphabetical order (`alt < hidden < name < notation < pref < synonym`) is wildly wrong.
+
+### Known v1 limitation
+
+The current OWL importer flattens selected-language `skos:prefLabel` / `skos:altLabel` / `skos:hiddenLabel` into `Entity.synonyms` (a flat list with no kind distinction). Non-selected-language labels keep their kind via `@<lang>`-suffixed annotation keys. So in v1, English-default SKOS imports produce `label_kind='synonym'` for what was originally pref/alt/hidden. This is acceptable: the resolver still returns these rows; they just don't outrank a plain `name` match in the priority above. A future OWL-importer fix that preserves selected-language kinds picks up the richer `label_kind` set without any change to the row builder or the runtime.
+
+## 5. `__meta` table schema
+
+Same logical-vs-enforced caveat as §4 applies: `NOT NULL` is a row-builder invariant, not a BigQuery-enforced column constraint, because the emitter uses CTAS.
+
+```sql
+CREATE TABLE `<output_table>__meta` (
+  compile_fingerprint  STRING NOT NULL,  -- 64-hex canonical integrity key
+  compile_id           STRING NOT NULL,  -- 12-hex display token
+  ontology_fingerprint STRING NOT NULL,  -- "sha256:<64 hex>" of the validated Ontology
+  binding_fingerprint  STRING NOT NULL,  -- "sha256:<64 hex>" of the validated Binding
+  target_project       STRING NOT NULL,  -- from binding.target.project
+  target_dataset       STRING NOT NULL,  -- from binding.target.dataset
+  compiler_version     STRING NOT NULL   -- from --compiler-version (or package default)
+);
+```
+
+Single row per emit. The meta table never contains historical compile data — each `gm compile --emit-concept-index` overwrites it.
+
+**Atomicity contract.** Each `CREATE OR REPLACE TABLE` is atomic on its own (BigQuery DDL semantics). The main and `__meta` tables, however, are written as **two separate statements** and are not replaced in one cross-table transaction; BigQuery has no DDL transactions across tables. There is therefore a small refresh window where an external reader could observe the old main with the new meta, or vice versa. The shared `compile_fingerprint` exists exactly for this case: a runtime reader runs a pair-consistency check (see §6 "Provenance contract" and the manual SQL in §8) and treats a `main.compile_fingerprint != meta.compile_fingerprint` mismatch as "refresh in progress" rather than as steady-state corruption.
+
+## 6. Provenance contract — Option 2
+
+The concept index carries two provenance columns with **distinct roles**:
+
+| Column | Role | Width | Used by |
+|---|---|---|---|
+| `compile_id` | **Display/debug token only.** Reports, queue rows, error messages, log lines. **Never the sole freshness check.** | 12 hex chars | Operator UX |
+| `compile_fingerprint` | **Canonical integrity key.** Full SHA-256 over `ontology_fingerprint \|\| binding_fingerprint \|\| compiler_version` (NUL-delimited UTF-8). | 64 hex chars | Strict pair-consistency + runtime verification |
+
+Structural invariant: `compile_id == compile_fingerprint[:12]`. The short form is always derived from the full form, never the reverse. This is enforced inside `_fingerprint.py` (the function `compile_id` literally returns `compile_fingerprint(...)[:12]`). A future refactor cannot let the two drift out of sync — see RFC §11 "Decisions pinned" (Option 2).
+
+The Phase 3 strict-verification layer (when it lands) will use `compile_fingerprint` exclusively; `compile_id` is not on the verification path. A reducer "optimization" that swaps a strict query from `compile_fingerprint` to `compile_id` would reintroduce a 48-bit collision hole — the W2 watchpoint in the implementation plan calls this out and the Phase 3 tests will pin it.
+
+## 7. Determinism
+
+Re-running `gm compile --emit-concept-index --concept-index-table T` with the same inputs produces **byte-identical** SQL. This is a Phase 1 acceptance criterion (D2 in the plan). Determinism is built up at every layer:
+
+| Layer | Stable across runs |
+|---|---|
+| Ontology fingerprint | Pydantic `model_dump(mode="json", exclude_none=False)` → sort-keyed compact JSON → SHA-256. Non-semantic YAML edits (whitespace, comments, key order in source) produce identical fingerprints. |
+| Binding fingerprint | Same recipe. |
+| `compile_fingerprint` | NUL-delimited UTF-8 of the three inputs, SHA-256. Same digest for the same triple. |
+| Row builder | Sorted `(scheme, entity_name, label_kind, language, label, notation, is_abstract)` with NULLs last. |
+| Emitter | Fixed column order, `None → NULL`, `bool → TRUE/FALSE` upper, `'` → `\'`, control chars → named or `\xHH` escapes, no timestamps. |
+
+If `--compiler-version` is left at its default (the installed package version), the output is stable as long as the package version doesn't change between invocations. Pin `--compiler-version` explicitly when you need the same digest across upgrades.
+
+## 8. Common SQL patterns
+
+A future Phase 2 will ship `OntologyRuntime` + resolvers as a Python surface over this index. Until then — and as the supported path for bulk analytics regardless — SQL pushdown directly against the index is the natural pattern. The patterns below are written against the schema this PR emits; nothing in them depends on Phase 2 / 3 code shipping.
+
+### Bulk resolution report
+
+How many free-text `geo:` values in yesterday's traces resolve against the GAM DMA scheme?
+
+```sql
+SELECT
+  JSON_VALUE(e.content, '$.args.geo')        AS raw_geo,
+  ci.entity_name                              AS resolved,
+  COUNT(*)                                    AS n
+FROM `proj.ds.agent_events` e
+LEFT JOIN `proj.ds.ontology_concept_index` ci
+  ON LOWER(ci.label) = LOWER(JSON_VALUE(e.content, '$.args.geo'))
+  AND ci.scheme = 'NielsenDMA'
+WHERE e.event_type = 'TOOL_STARTING'
+  AND DATE(e.timestamp) = CURRENT_DATE() - 1
+GROUP BY raw_geo, resolved
+ORDER BY n DESC;
+```
+
+### Coverage by scheme
+
+What fraction of declared concepts in each scheme has been observed in production traces?
+
+```sql
+WITH observed AS (
+  SELECT DISTINCT ci.entity_name, ci.scheme
+  FROM `proj.ds.agent_events` e
+  JOIN `proj.ds.ontology_concept_index` ci
+    ON LOWER(ci.label) = LOWER(JSON_VALUE(e.content, '$.args.geo'))
+  WHERE e.event_type = 'TOOL_STARTING'
+)
+SELECT
+  ci.scheme,
+  COUNT(DISTINCT ci.entity_name)            AS declared,
+  COUNT(DISTINCT obs.entity_name)            AS observed,
+  SAFE_DIVIDE(COUNT(DISTINCT obs.entity_name),
+              COUNT(DISTINCT ci.entity_name)) AS coverage
+FROM `proj.ds.ontology_concept_index` ci
+LEFT JOIN observed obs USING (entity_name, scheme)
+WHERE ci.scheme IS NOT NULL
+GROUP BY ci.scheme
+ORDER BY coverage ASC;
+```
+
+### Winning-label dedup (one candidate per entity)
+
+```sql
+SELECT entity_name, label, label_kind, scheme
+FROM (
+  SELECT
+    entity_name, label, label_kind, scheme,
+    ROW_NUMBER() OVER (
+      PARTITION BY entity_name
+      ORDER BY
+        CASE label_kind
+          WHEN 'name'     THEN 1
+          WHEN 'pref'     THEN 2
+          WHEN 'alt'      THEN 3
+          WHEN 'hidden'   THEN 4
+          WHEN 'synonym'  THEN 5
+          WHEN 'notation' THEN 6
+        END,
+        label  -- lexicographic tiebreak
+    ) AS rn
+  FROM `proj.ds.ontology_concept_index`
+  WHERE LOWER(label) = LOWER(@input)
+)
+WHERE rn = 1;
+```
+
+### Strict pair-consistency check (manual)
+
+```sql
+-- Both queries should return one row.
+SELECT DISTINCT compile_fingerprint
+FROM `proj.ds.ontology_concept_index`;
+
+SELECT compile_fingerprint, ontology_fingerprint, binding_fingerprint
+FROM `proj.ds.ontology_concept_index__meta`;
+```
+
+A future Phase 3 will wire the strict-verification layer into `OntologyRuntime` so it runs these checks automatically on first access and on a configurable TTL. Until then, the queries above are the supported manual path for ad-hoc operator inspection — and they remain useful afterwards for one-off debugging even once the runtime layer ships.
+
+## 9. Out of scope (Phase 1)
+
+- **Shadow-swap fallback for `>50K` rows** (A6) — Phase 3 deferred. v1 emits a single inline-UNNEST statement; very large indices may need a `_shadow` rename pattern. Tracked in the implementation plan.
+- **Embedding-fuzzy matching** — `AI.EMBED` over labels + `ML.DISTANCE` is a future composition, not in core. See RFC §12.
+- **Live-agent resolver package** — the `bigquery_agent_analytics` SDK is the trace-consumption side; turn-time resolution from a live agent is a separate future package. See RFC §11.
+
+## 10. Related
+
+- [Issue #58][issue58] — the design RFC for runtime entity resolution.
+- [`docs/entity_resolution_primitives.md`](../entity_resolution_primitives.md) — full RFC text.
+- [`docs/implementation_plan_concept_index_runtime.md`](../implementation_plan_concept_index_runtime.md) — phased build plan.
+- [`compilation.md`](compilation.md) — `compile_graph` and the property-graph DDL pipeline this composes with.
+- [`cli.md`](cli.md) — full `gm` CLI reference.
+
+[issue58]: https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58

--- a/src/bigquery_ontology/__init__.py
+++ b/src/bigquery_ontology/__init__.py
@@ -27,6 +27,7 @@ from .binding_models import Binding
 from .binding_models import EntityBinding
 from .binding_models import PropertyBinding
 from .binding_models import RelationshipBinding
+from .graph_ddl_compiler import compile_concept_index
 from .graph_ddl_compiler import compile_graph
 from .ontology_loader import load_ontology
 from .ontology_loader import load_ontology_from_string
@@ -53,6 +54,7 @@ __all__ = [
     "PropertyType",
     "Relationship",
     "RelationshipBinding",
+    "compile_concept_index",
     "compile_graph",
     "load_binding",
     "load_binding_from_string",

--- a/src/bigquery_ontology/_fingerprint.py
+++ b/src/bigquery_ontology/_fingerprint.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical fingerprint primitives for concept-index provenance.
+
+Internal module. Both the ontology compiler (``graph_ddl_compiler`` when
+it gains ``compile_concept_index``) and the SDK runtime (``OntologyRuntime``
+in ``bigquery_agent_analytics``) import from here via absolute import —
+the contract has to agree bit-for-bit between the side that writes meta
+rows and the side that verifies them, so there is exactly one definition.
+
+The underscore prefix marks this as non-public. Not re-exported from
+``bigquery_ontology/__init__.py``. See
+``docs/implementation_plan_concept_index_runtime.md`` watchpoints W1/W2.
+
+Three exports, three roles:
+
+- :func:`fingerprint_model` — full SHA-256 over a validated Pydantic
+  model, returned as ``"sha256:" + 64 hex chars``. Used by the
+  compiler to fingerprint the ``Ontology`` and ``Binding`` inputs,
+  and by the runtime to compute cached local fingerprints from the
+  same models.
+- :func:`compile_fingerprint` — full 64-hex SHA-256 over the concat
+  of ``ontology_fingerprint``, ``binding_fingerprint``, and
+  ``compiler_version``. **Canonical integrity key.** Used for strict
+  verification: main↔meta pair consistency and runtime freshness
+  checks.
+- :func:`compile_id` — 12-hex display/debug token. Derived as
+  ``compile_fingerprint(...)[:_COMPILE_ID_LEN]`` — always a
+  structural truncation of the full integrity key, never its own
+  hash. Use for operator UX (reports, queue rows, log lines).
+  **Never use as the sole freshness check.**
+
+Invariant: ``compile_id == compile_fingerprint[:12]``. Enforced at
+the function boundary so a future refactor cannot let the two drift
+out of sync.
+
+Serialization contract (pinned):
+
+- Input: ``BaseModel.model_dump(mode="json", by_alias=False, exclude_none=False)``.
+  ``mode="json"`` normalizes enums, datetimes, and Pydantic types to
+  JSON-safe primitives so the hash is stable across Python versions.
+  ``exclude_none=False`` keeps optional-but-declared fields in the
+  output so adding a default value later doesn't silently collide
+  with the pre-default fingerprint.
+- Encoding: ``json.dumps(..., sort_keys=True, separators=(",", ":"),
+  ensure_ascii=False)``. Sorted keys at every nesting level, no
+  whitespace, UTF-8.
+- Hash: SHA-256 over the encoded bytes; output ``"sha256:" + hexdigest``
+  for model fingerprints, raw hex for compile fingerprints.
+
+Never fingerprint over ``yaml.dump(model)``, ``str(model)``, or
+``model.model_dump()`` without ``mode="json"``. Each of those breaks
+cross-version or cross-type stability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel
+
+_FINGERPRINT_PREFIX = "sha256:"
+_COMPILE_ID_LEN = 12  # 48 bits of entropy, per issue #58.
+
+
+def fingerprint_model(model: BaseModel) -> str:
+  """Return the canonical SHA-256 fingerprint of a validated Pydantic model.
+
+  Args:
+      model: Any validated Pydantic model (Ontology, Binding, or similar).
+
+  Returns:
+      ``"sha256:" + 64 hex chars`` — a stable content hash over the
+      model's semantic fields, invariant to source-file whitespace,
+      key ordering, comments, and Pydantic-default materialization.
+  """
+  dumped = model.model_dump(
+      mode="json",
+      by_alias=False,
+      exclude_none=False,
+  )
+  canonical = json.dumps(
+      dumped,
+      sort_keys=True,
+      separators=(",", ":"),
+      ensure_ascii=False,
+  ).encode("utf-8")
+  return _FINGERPRINT_PREFIX + hashlib.sha256(canonical).hexdigest()
+
+
+def compile_fingerprint(
+    ontology_fingerprint: str,
+    binding_fingerprint: str,
+    compiler_version: str,
+) -> str:
+  """Return the full 64-hex canonical integrity key for a compile.
+
+  **Canonical integrity key.** Used by strict verification for main
+  ↔ meta pair consistency and runtime freshness checks against
+  cached local fingerprints. Never truncate this for verification
+  purposes. See ``compile_id`` for the short display/debug companion.
+
+  Exact payload contract (pinned):
+
+  .. code-block:: text
+
+      payload = utf8(ontology_fingerprint + "\\x00" +
+                     binding_fingerprint + "\\x00" +
+                     compiler_version)
+      digest  = sha256(payload).hexdigest()  # 64 lowercase hex chars
+
+  The separator is a single NUL byte (``\\x00``). NUL is chosen
+  because it cannot appear in any of the three inputs (fingerprints
+  are hex; version strings are ASCII), so the delimited encoding is
+  unambiguous — no two different input triples can produce the same
+  payload. Do not reimplement this elsewhere; import
+  :func:`compile_fingerprint` from this module. Regression tests
+  pin a golden vector so a silent payload change is caught.
+
+  Args:
+      ontology_fingerprint: ``fingerprint_model(ontology)`` output.
+      binding_fingerprint: ``fingerprint_model(binding)`` output.
+      compiler_version: Version string of the compiler that produced
+          the index (e.g. ``"bigquery_ontology 0.2.1"``). Semver bumps
+          with behavior changes must flow through this field so the
+          fingerprint invalidates old meta.
+
+  Returns:
+      64 lowercase hex characters (256 bits).
+  """
+  payload = "\x00".join(
+      (ontology_fingerprint, binding_fingerprint, compiler_version)
+  ).encode("utf-8")
+  return hashlib.sha256(payload).hexdigest()
+
+
+def compile_id(
+    ontology_fingerprint: str,
+    binding_fingerprint: str,
+    compiler_version: str,
+) -> str:
+  """Return the 12-hex-char display token for a compile.
+
+  Derived as ``compile_fingerprint(...)[:_COMPILE_ID_LEN]``. The short
+  form is always a structural truncation of the full integrity key —
+  never its own hash — so that the two provenance columns in the
+  concept index cannot drift out of sync.
+
+  **Display-only.** Use this for operator reports, error messages,
+  queue rows, and log lines. Never use ``compile_id`` as the sole
+  freshness check; strict verification must use
+  :func:`compile_fingerprint` directly.
+
+  Args:
+      ontology_fingerprint: ``fingerprint_model(ontology)`` output.
+      binding_fingerprint: ``fingerprint_model(binding)`` output.
+      compiler_version: Version string of the compiler that produced
+          the index.
+
+  Returns:
+      12 lowercase hex characters — the first 12 chars of
+      ``compile_fingerprint(ontology_fingerprint, binding_fingerprint,
+      compiler_version)``.
+  """
+  return compile_fingerprint(
+      ontology_fingerprint, binding_fingerprint, compiler_version
+  )[:_COMPILE_ID_LEN]

--- a/src/bigquery_ontology/cli.py
+++ b/src/bigquery_ontology/cli.py
@@ -47,11 +47,36 @@ import yaml
 from .binding_loader import load_binding
 from .binding_loader import load_binding_from_string
 from .binding_models import Binding
+from .graph_ddl_compiler import compile_concept_index
 from .graph_ddl_compiler import compile_graph
 from .ontology_loader import load_ontology
 from .ontology_loader import load_ontology_from_string
 from .ontology_models import Ontology
 from .scaffold import scaffold
+
+
+def _default_compiler_version() -> str:
+  """Return the canonical compiler-version string for fingerprints.
+
+  Resolves the installed ``bigquery-agent-analytics`` distribution
+  version via ``importlib.metadata``. Falls back to ``"unknown"``
+  when running from a checkout that hasn't been installed (rare; the
+  fallback is deterministic so byte-identical emission still holds).
+
+  Format is ``"bigquery_ontology X.Y.Z"`` so the meta row's
+  ``compiler_version`` column is human-readable and matches the
+  pattern used in design docs and tests.
+  """
+  try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    return f"bigquery_ontology {_pkg_version('bigquery-agent-analytics')}"
+  except PackageNotFoundError:
+    return "bigquery_ontology unknown"
+  except Exception:  # pragma: no cover - defensive
+    return "bigquery_ontology unknown"
+
 
 app = typer.Typer(
     name="gm",
@@ -326,6 +351,35 @@ def compile_command(
         "--json",
         help="Emit structured JSON errors on stderr.",
     ),
+    emit_concept_index: bool = typer.Option(
+        False,
+        "--emit-concept-index",
+        help=(
+            "Also emit ``CREATE OR REPLACE TABLE`` SQL for the concept "
+            "index + ``__meta`` sibling, consumed at runtime by "
+            "``OntologyRuntime`` resolvers and verification. Requires "
+            "``--concept-index-table``."
+        ),
+    ),
+    concept_index_table: str | None = typer.Option(
+        None,
+        "--concept-index-table",
+        help=(
+            "Fully-qualified destination for the concept index, "
+            "``project.dataset.table``. Required when "
+            "``--emit-concept-index`` is set; no silent global default."
+        ),
+    ),
+    compiler_version: str | None = typer.Option(
+        None,
+        "--compiler-version",
+        help=(
+            "Override the compiler-version string flowed into the "
+            "concept index's ``compile_fingerprint``. Defaults to the "
+            "installed package version. Only honored with "
+            "``--emit-concept-index``."
+        ),
+    ),
 ) -> None:
   """Compile a binding to BigQuery ``CREATE PROPERTY GRAPH`` DDL.
 
@@ -336,6 +390,13 @@ def compile_command(
   The input must be a binding YAML file. Ontology files cannot be
   compiled on their own (they're backend-neutral; they need a
   binding to pick up physical tables and columns).
+
+  When ``--emit-concept-index`` is set, the output additionally
+  contains two ``CREATE OR REPLACE TABLE`` statements (the concept
+  index and its ``__meta`` sibling) appended after the property-graph
+  DDL. The two atomic-per-statement tables are pair-consistent via
+  a shared ``compile_fingerprint``; see
+  ``docs/entity_resolution_primitives.md`` §4.2 / §5.
   """
   file_path = Path(file)
   if not file_path.exists() or not file_path.is_file():
@@ -402,6 +463,49 @@ def compile_command(
     )
     raise typer.Exit(code=2)
 
+  # Concept-index flags must be checked before any compilation work,
+  # so we can fail fast with a clear error rather than computing DDL
+  # the caller will discard.
+  if emit_concept_index and concept_index_table is None:
+    _emit_errors(
+        [
+            {
+                "file": file,
+                "line": 0,
+                "col": 0,
+                "rule": "cli-missing-flag",
+                "severity": "error",
+                "message": (
+                    "--emit-concept-index requires --concept-index-table "
+                    "<project.dataset.table>; no silent global default."
+                ),
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+  if concept_index_table is not None and not emit_concept_index:
+    # Bare ``--concept-index-table`` without the emit flag is almost
+    # certainly an authoring mistake. Surface it instead of silently
+    # ignoring the value.
+    _emit_errors(
+        [
+            {
+                "file": file,
+                "line": 0,
+                "col": 0,
+                "rule": "cli-orphan-flag",
+                "severity": "error",
+                "message": (
+                    "--concept-index-table requires --emit-concept-index; "
+                    "the flag is ignored without it."
+                ),
+            }
+        ],
+        as_json=json_output,
+    )
+    raise typer.Exit(code=2)
+
   resolved_ontology = Path(ontology_path) if ontology_path is not None else None
   ontology, binding = _load_ontology_and_binding(
       file_path, ontology_path=resolved_ontology, json_output=json_output
@@ -409,6 +513,18 @@ def compile_command(
 
   try:
     ddl = compile_graph(ontology, binding)
+    if emit_concept_index:
+      version_str = compiler_version or _default_compiler_version()
+      concept_sql = compile_concept_index(
+          ontology,
+          binding,
+          output_table=concept_index_table,  # type: ignore[arg-type]
+          compiler_version=version_str,
+      )
+      # The property-graph DDL ends with ``;\n``; append a blank line
+      # before the concept-index statements so the two sections are
+      # visually distinct.
+      ddl = ddl + "\n" + concept_sql
   except ValueError as exc:
     _emit_errors(
         _collect_errors(file, exc, kind="compile"),

--- a/src/bigquery_ontology/concept_index.py
+++ b/src/bigquery_ontology/concept_index.py
@@ -1,0 +1,336 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Concept-index row builder (A2).
+
+Transforms a validated ``(Ontology, Binding)`` pair into a list of
+``ConceptIndexRow`` instances that the downstream emitter
+(``compile_concept_index``, A3) writes as
+``CREATE OR REPLACE TABLE ... AS SELECT * FROM UNNEST([STRUCT(...)])``.
+
+Pinned in ``docs/implementation_plan_concept_index_runtime.md`` (A2)
+and the RFC (``docs/entity_resolution_primitives.md`` §4.2).
+
+Schema (matches the ``CREATE TABLE`` in the RFC):
+
+- ``entity_name`` — the entity this row belongs to.
+- ``label`` — the searchable text. For ``label_kind='notation'`` rows
+  this is the notation value itself, so resolvers searching by label
+  catch notation matches without a separate predicate.
+- ``label_kind`` — one of ``name | pref | alt | hidden | synonym | notation``.
+- ``notation`` — per-entity display token, repeats across all rows
+  of the same entity (so a caller with a winning candidate row can
+  read the entity's notation from the row directly without a join).
+- ``scheme`` — concept-scheme membership; ``None`` means "entity is
+  not declared as a member of any scheme."
+- ``language`` — BCP-47 tag from a language-suffixed annotation
+  key (e.g. ``skos:prefLabel@fr`` → ``"fr"``); ``None`` for the
+  default-language label or notation rows.
+- ``is_abstract`` — mirrors ``Entity.abstract``.
+- ``compile_id`` — 12-hex display token, repeats across all rows of
+  this compile.
+- ``compile_fingerprint`` — 64-hex canonical integrity key.
+
+Scope rule (per the RFC):
+
+- **Abstract entities** are always included regardless of binding —
+  they're informational and never need a binding row.
+- **Concrete entities** are included iff they appear in
+  ``binding.entities``.
+
+Multiplicity contract:
+
+- One row per ``(entity_name, label, label_kind, language, scheme)``
+  membership tuple. A concept in 3 schemes × 5 labels emits 15 rows.
+- One row per ``skos:notation`` value with ``label_kind='notation'``.
+- The ``notation`` *column* on every row of an entity carries the
+  entity's notation (or ``None`` if absent).
+
+Sort order:
+
+Rows are sorted lexicographically by
+``(scheme, entity_name, label_kind, language, label, notation, is_abstract)``
+with ``None`` last in each key. The sort exists purely for
+deterministic emission so re-running ``gm compile`` produces
+byte-identical SQL (a Phase 1 acceptance criterion). The
+*semantic* priority on ``label_kind`` (``name > pref > alt > hidden
+> synonym > notation``) is applied at query time via a CASE
+expression — see RFC §6 finding 6.
+
+Not re-exported from ``bigquery_ontology/__init__.py`` in v1 — the
+module is importable directly via
+``from bigquery_ontology.concept_index import build_rows``.
+
+Known v1 limitation — selected-language SKOS labels collapse to
+``label_kind='synonym'``. The current OWL importer
+(``owl_importer.py``) flattens selected-language ``skos:prefLabel``
+/ ``skos:altLabel`` / ``skos:hiddenLabel`` into ``Entity.synonyms``,
+losing the kind distinction. Non-selected-language labels keep
+their kind via ``@<lang>``-suffixed annotation keys (e.g.
+``skos:prefLabel@fr``), so the row builder produces ``pref`` /
+``alt`` / ``hidden`` rows correctly for those. The mismatch is
+upstream of this module; a fix would preserve selected-language
+kinds via annotations rather than flat ``synonyms``. Until that
+ships, B7's winning-label priority (``name > pref > alt > hidden >
+synonym > notation``) demotes selected-language SKOS labels to
+``synonym``, which is acceptable for v1 because the resolver still
+returns them — they just don't outrank a plain ``name`` match.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional
+
+from bigquery_ontology._fingerprint import compile_fingerprint
+from bigquery_ontology._fingerprint import compile_id
+from bigquery_ontology._fingerprint import fingerprint_model
+from bigquery_ontology.binding_models import Binding
+from bigquery_ontology.ontology_models import Entity
+from bigquery_ontology.ontology_models import Ontology
+
+_LABEL_PREFIX_MAP: dict[str, str] = {
+    "skos:prefLabel": "pref",
+    "skos:altLabel": "alt",
+    "skos:hiddenLabel": "hidden",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class ConceptIndexRow:
+  """One row in the emitted concept index. See module docstring."""
+
+  entity_name: str
+  label: str
+  label_kind: str
+  notation: Optional[str]
+  scheme: Optional[str]
+  language: Optional[str]
+  is_abstract: bool
+  compile_id: str
+  compile_fingerprint: str
+
+
+def build_rows(
+    ontology: Ontology,
+    binding: Binding,
+    *,
+    compiler_version: str,
+) -> list[ConceptIndexRow]:
+  """Build the deterministic row list for the concept index.
+
+  Args:
+      ontology: Validated upstream ``Ontology``.
+      binding: Validated upstream ``Binding`` referencing this ontology.
+          Used only to decide which concrete entities are bindable;
+          abstract entities are always included regardless of binding.
+      compiler_version: Caller-supplied version string flowed into
+          ``compile_fingerprint`` so semver bumps with behavior
+          changes invalidate older meta rows.
+
+  Returns:
+      A sorted list of ``ConceptIndexRow``. Empty list is legal
+      (e.g., a binding that references no concrete entities and an
+      ontology with no abstract entities).
+  """
+  ont_fp = fingerprint_model(ontology)
+  bnd_fp = fingerprint_model(binding)
+  cfp = compile_fingerprint(ont_fp, bnd_fp, compiler_version)
+  cid = compile_id(ont_fp, bnd_fp, compiler_version)
+
+  bound_entity_names = {eb.name for eb in binding.entities}
+
+  rows: list[ConceptIndexRow] = []
+  for entity in ontology.entities:
+    if not entity.abstract and entity.name not in bound_entity_names:
+      continue
+    rows.extend(_rows_for_entity(entity, cid, cfp))
+
+  rows = _dedup_rows(rows)
+  rows.sort(key=_sort_key)
+  return rows
+
+
+def _dedup_rows(rows: list[ConceptIndexRow]) -> list[ConceptIndexRow]:
+  """Collapse rows that share the contract tuple
+  ``(entity_name, label, label_kind, language, scheme)`` into one.
+
+  Duplicate inputs (e.g. ``synonyms=["Acct", "Acct"]`` or an
+  annotation value list with repeats) would otherwise emit duplicate
+  rows that the downstream resolver would have to dedupe at query
+  time. Same value via different ``label_kind`` (e.g. ``"Acct"``
+  declared in both ``synonyms`` and ``skos:altLabel``) is **not** a
+  duplicate — different kinds, different rows, kept.
+  """
+  seen: set[tuple] = set()
+  out: list[ConceptIndexRow] = []
+  for row in rows:
+    key = (row.entity_name, row.label, row.label_kind, row.language, row.scheme)
+    if key in seen:
+      continue
+    seen.add(key)
+    out.append(row)
+  return out
+
+
+def _rows_for_entity(
+    entity: Entity,
+    cid: str,
+    cfp: str,
+) -> list[ConceptIndexRow]:
+  """Emit all rows for one entity (cross-product over schemes)."""
+  notation_value = _entity_notation(entity)
+  schemes = _entity_schemes(entity)  # always non-empty: at minimum [None].
+
+  rows: list[ConceptIndexRow] = []
+  for scheme in schemes:
+    rows.extend(
+        _rows_for_entity_in_scheme(entity, scheme, notation_value, cid, cfp)
+    )
+  return rows
+
+
+def _rows_for_entity_in_scheme(
+    entity: Entity,
+    scheme: Optional[str],
+    notation_value: Optional[str],
+    cid: str,
+    cfp: str,
+) -> list[ConceptIndexRow]:
+  """Emit one row per (label, label_kind, language) tuple for the
+  given (entity, scheme) pair. Plus one notation row per notation
+  value if any are declared.
+  """
+  rows: list[ConceptIndexRow] = []
+
+  def _emit(label: str, kind: str, language: Optional[str]) -> None:
+    rows.append(
+        ConceptIndexRow(
+            entity_name=entity.name,
+            label=label,
+            label_kind=kind,
+            notation=notation_value,
+            scheme=scheme,
+            language=language,
+            is_abstract=entity.abstract,
+            compile_id=cid,
+            compile_fingerprint=cfp,
+        )
+    )
+
+  # 1. The canonical name row, always emitted.
+  _emit(entity.name, "name", None)
+
+  # 2. SKOS-typed labels from annotations: skos:prefLabel /
+  # skos:altLabel / skos:hiddenLabel, with optional ``@<lang>`` suffix
+  # for non-default languages.
+  annotations = entity.annotations or {}
+  for ann_key, ann_value in annotations.items():
+    base, language = _split_lang_suffix(ann_key)
+    kind = _LABEL_PREFIX_MAP.get(base)
+    if kind is None:
+      continue
+    for label in _as_list(ann_value):
+      _emit(label, kind, language)
+
+  # 3. Plain synonyms (Entity.synonyms — kind unknown, treated as
+  # 'synonym'). SKOS imports for the selected language flatten
+  # pref/alt/hidden into here, so this is where most demos hit.
+  for synonym in entity.synonyms or ():
+    _emit(synonym, "synonym", None)
+
+  # 4. Notation rows: one per skos:notation value. The same value
+  # also appears in the per-row ``notation`` column on every row of
+  # the entity (set above via ``notation_value``), so resolvers can
+  # match by label OR look up the notation from the candidate row.
+  notation_ann = annotations.get("skos:notation")
+  for notation in _as_list(notation_ann):
+    _emit(notation, "notation", None)
+
+  return rows
+
+
+def _entity_notation(entity: Entity) -> Optional[str]:
+  """Return the notation value to repeat in the per-row ``notation``
+  column. If multiple notations are declared, the lexicographically
+  smallest is chosen so the column value is deterministic.
+  """
+  ann = (entity.annotations or {}).get("skos:notation")
+  values = _as_list(ann)
+  return min(values) if values else None
+
+
+def _entity_schemes(entity: Entity) -> list[Optional[str]]:
+  """Return the scheme membership list. Never empty: an entity not in
+  any scheme yields ``[None]`` so a single set of rows is emitted.
+
+  Both ``skos:inScheme`` and ``skos:topConceptOf`` are treated as
+  scheme membership: a top concept of a scheme is still a member of
+  that scheme, and queries like ``WHERE ci.scheme = 'X'`` should
+  catch it. Values are unioned, deduped, and sorted so output is
+  deterministic and a concept declared as both ``inScheme S`` and
+  ``topConceptOf S`` produces a single row set, not two.
+  """
+  ann = entity.annotations or {}
+  values = set(_as_list(ann.get("skos:inScheme")))
+  values.update(_as_list(ann.get("skos:topConceptOf")))
+  if not values:
+    return [None]
+  return sorted(values)
+
+
+def _as_list(value) -> list[str]:
+  """Normalize an ``AnnotationValue`` (str | list[str] | None) to a
+  list of strings, dropping empties.
+  """
+  if value is None:
+    return []
+  if isinstance(value, list):
+    return [v for v in value if v]
+  if isinstance(value, str):
+    return [value] if value else []
+  return []
+
+
+def _split_lang_suffix(key: str) -> tuple[str, Optional[str]]:
+  """Split ``"skos:prefLabel@fr"`` → ``("skos:prefLabel", "fr")``.
+  Plain ``"skos:prefLabel"`` → ``("skos:prefLabel", None)``.
+  """
+  if "@" not in key:
+    return key, None
+  base, _, lang = key.partition("@")
+  if not lang:
+    return base, None
+  return base, lang
+
+
+def _sort_key(row: ConceptIndexRow) -> tuple:
+  """Total order over rows: ``(scheme, entity_name, label_kind,
+  language, label, notation, is_abstract)`` with ``None`` last via a
+  per-field ``(is_none, value)`` pair so Python's tuple compare
+  cannot blow up on heterogeneous types.
+  """
+
+  def _none_last(v):
+    return (v is None, v if v is not None else "")
+
+  return (
+      _none_last(row.scheme),
+      row.entity_name,
+      row.label_kind,
+      _none_last(row.language),
+      row.label,
+      _none_last(row.notation),
+      row.is_abstract,
+  )

--- a/src/bigquery_ontology/graph_ddl_compiler.py
+++ b/src/bigquery_ontology/graph_ddl_compiler.py
@@ -53,10 +53,15 @@ from __future__ import annotations
 
 import re
 
+from ._fingerprint import compile_fingerprint
+from ._fingerprint import compile_id
+from ._fingerprint import fingerprint_model
 from .binding_models import Binding
 from .binding_models import EntityBinding
 from .binding_models import PropertyBinding
 from .binding_models import RelationshipBinding
+from .concept_index import build_rows
+from .concept_index import ConceptIndexRow
 from .graph_ddl_models import ResolvedEdgeTable
 from .graph_ddl_models import ResolvedGraph
 from .graph_ddl_models import ResolvedLabelAndProperties
@@ -643,3 +648,299 @@ def _join_entries(entries: list[list[str]]) -> list[str]:
       else:
         out.append(line)
   return out
+
+
+# --------------------------------------------------------------------- #
+# Concept-index emitter (A3-A5)                                         #
+# --------------------------------------------------------------------- #
+#
+# Companion to ``compile_graph``: emits two ``CREATE OR REPLACE TABLE``
+# statements that materialize the concept-index sidecar tables consumed
+# by ``OntologyRuntime``'s resolvers and verification layer (B1-B7,
+# C1-C6 in the implementation plan). The main table holds one row per
+# ``(entity_name, label, label_kind, language, scheme)`` tuple. The
+# ``__meta`` sibling holds a single provenance row.
+#
+# Design constraints (pinned):
+# - Pure SQL emission. No BigQuery client calls; no DDL execution.
+#   Operators run the emitted SQL via ``bq query``, console, etc.
+# - Atomic per statement via ``CREATE OR REPLACE TABLE T AS SELECT ...``
+#   so each table flips in one transaction; pair-consistency between
+#   main and meta is enforced at runtime via the shared
+#   ``compile_fingerprint``.
+# - Inline-UNNEST path with explicit ``ARRAY<STRUCT<...>>`` typing so
+#   schema is unambiguous even with zero data rows.
+# - Byte-identical SQL across runs for the same inputs; A2's row
+#   builder is already deterministic, so we only need stable column
+#   ordering and stable literal rendering here.
+# - No timestamps in the SQL — ``compiled_at`` was deliberately removed
+#   in the issue #58 round-9 design review for byte-identical output.
+
+# Column lists are tuples to enforce ordering at the type level; any
+# add/remove/rename is a deliberate edit visible in review.
+_MAIN_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("entity_name", "STRING"),
+    ("label", "STRING"),
+    ("label_kind", "STRING"),
+    ("notation", "STRING"),
+    ("scheme", "STRING"),
+    ("language", "STRING"),
+    ("is_abstract", "BOOL"),
+    ("compile_id", "STRING"),
+    ("compile_fingerprint", "STRING"),
+)
+
+_META_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("compile_fingerprint", "STRING"),
+    ("compile_id", "STRING"),
+    ("ontology_fingerprint", "STRING"),
+    ("binding_fingerprint", "STRING"),
+    ("target_project", "STRING"),
+    ("target_dataset", "STRING"),
+    ("compiler_version", "STRING"),
+)
+
+
+def compile_concept_index(
+    ontology: Ontology,
+    binding: Binding,
+    *,
+    output_table: str,
+    compiler_version: str,
+) -> str:
+  """Emit ``CREATE OR REPLACE TABLE`` SQL for the concept index + meta.
+
+  Companion to :func:`compile_graph`. Returns SQL text (does not
+  execute against BigQuery — operators run the result via ``bq
+  query``, the console, an Airflow operator, etc.). Re-running with
+  the same inputs produces byte-identical output.
+
+  Args:
+      ontology: Validated upstream ``Ontology``.
+      binding: Validated upstream ``Binding`` referencing this
+          ontology. Used to determine which concrete entities are in
+          scope (per A2's "abstract always, concrete iff bound" rule)
+          and to populate ``target_project`` / ``target_dataset`` on
+          the meta row.
+      output_table: Fully-qualified destination for the main table —
+          ``project.dataset.table_name``. The ``__meta`` sibling is
+          emitted at ``output_table + "__meta"``. Backticks are added
+          by the emitter; do not pre-quote.
+      compiler_version: Caller-supplied version string flowed into the
+          ``compile_fingerprint`` so semver bumps invalidate stale
+          meta rows.
+
+  Returns:
+      A single string containing both ``CREATE OR REPLACE TABLE``
+      statements separated by a blank line, with a trailing newline.
+
+  Raises:
+      ValueError: If ``output_table`` is not a fully-qualified
+          ``project.dataset.table`` triple, or if the ontology +
+          binding produce zero concrete-or-abstract entities (which
+          would emit a typeless empty array, losing schema).
+  """
+  _validate_output_table(output_table)
+
+  rows = build_rows(ontology, binding, compiler_version=compiler_version)
+  if not rows:
+    raise ValueError(
+        f"Cannot compile concept index for {output_table!r}: ontology + "
+        f"binding produce no concrete or abstract entities. The emitter "
+        f"refuses to write a typeless empty array. Ensure the binding "
+        f"references at least one concrete entity from the ontology, or "
+        f"that the ontology declares at least one abstract entity."
+    )
+
+  ont_fp = fingerprint_model(ontology)
+  bnd_fp = fingerprint_model(binding)
+  cfp = compile_fingerprint(ont_fp, bnd_fp, compiler_version)
+  cid = compile_id(ont_fp, bnd_fp, compiler_version)
+
+  meta_row = (
+      cfp,
+      cid,
+      ont_fp,
+      bnd_fp,
+      binding.target.project,
+      binding.target.dataset,
+      compiler_version,
+  )
+
+  main_sql = _emit_table(
+      table=output_table,
+      columns=_MAIN_COLUMNS,
+      rows=[_main_row_values(r) for r in rows],
+  )
+  meta_sql = _emit_table(
+      table=output_table + "__meta",
+      columns=_META_COLUMNS,
+      rows=[meta_row],
+  )
+
+  return main_sql + "\n" + meta_sql
+
+
+def _main_row_values(row: ConceptIndexRow) -> tuple:
+  """Project a ``ConceptIndexRow`` to the tuple shape expected by
+  :data:`_MAIN_COLUMNS` (positional alignment is part of the
+  byte-deterministic contract).
+  """
+  return (
+      row.entity_name,
+      row.label,
+      row.label_kind,
+      row.notation,
+      row.scheme,
+      row.language,
+      row.is_abstract,
+      row.compile_id,
+      row.compile_fingerprint,
+  )
+
+
+def _emit_table(
+    *,
+    table: str,
+    columns: tuple[tuple[str, str], ...],
+    rows: list[tuple],
+) -> str:
+  """Render one ``CREATE OR REPLACE TABLE T AS SELECT * FROM
+  UNNEST(ARRAY<STRUCT<...>>[<rows>])`` statement.
+
+  Explicit ``ARRAY<STRUCT<...>>`` typing keeps the schema stable for
+  zero-row arrays (the meta table always has exactly one row, but
+  we use the same emitter shape for symmetry and to make the
+  contract explicit).
+  """
+  struct_decl = ", ".join(f"{name} {ty}" for name, ty in columns)
+  lines: list[str] = []
+  lines.append(f"CREATE OR REPLACE TABLE `{table}`")
+  lines.append(f"AS SELECT * FROM UNNEST(ARRAY<STRUCT<{struct_decl}>>[")
+  for i, row in enumerate(rows):
+    rendered = ", ".join(_render_value(v) for v in row)
+    suffix = "," if i < len(rows) - 1 else ""
+    lines.append(f"  ({rendered}){suffix}")
+  lines.append("]);")
+  return "\n".join(lines) + "\n"
+
+
+def _render_value(value) -> str:
+  """Render a Python value to a deterministic GoogleSQL literal.
+
+  - ``None``                → ``NULL``
+  - ``bool``                → ``TRUE`` / ``FALSE``  (BigQuery convention,
+                              upper case for byte-identical determinism)
+  - ``str``                 → single-quoted literal via
+                              :func:`_escape_string` — backslashes,
+                              single quotes, and ASCII control
+                              characters are all escaped so any
+                              valid Python string round-trips through
+                              GoogleSQL.
+  - ``int`` / ``float``     → ``str(value)``  (no concept-index column
+                              currently uses these, but the helper is
+                              symmetric)
+  """
+  if value is None:
+    return "NULL"
+  if isinstance(value, bool):
+    return "TRUE" if value else "FALSE"
+  if isinstance(value, (int, float)):
+    return str(value)
+  if isinstance(value, str):
+    return _escape_string(value)
+  raise TypeError(f"Unsupported SQL literal type: {type(value).__name__}")
+
+
+# Named C-style escapes BigQuery accepts inside single-quoted strings.
+# Anything else in the 0x00-0x1F + 0x7F range goes through ``\xHH``.
+_NAMED_CTRL_ESCAPES: dict[str, str] = {
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\b": "\\b",
+    "\f": "\\f",
+}
+
+_CTRL_RE = re.compile(r"[\x00-\x1F\x7F]")
+
+
+def _escape_string(value: str) -> str:
+  """Render a Python ``str`` as a GoogleSQL single-quoted literal.
+
+  GoogleSQL string literals follow C-style escaping, **not** ANSI
+  SQL's quote-doubling. The naive ANSI form
+  ``"'" + s.replace("'", "''") + "'"`` produces invalid GoogleSQL
+  when the input contains:
+
+  - A single quote — ``'O''Brien'`` parses in GoogleSQL as two
+    concatenated string literals (``'O'`` and ``'Brien'``) and
+    errors with "concatenated string literals must be separated by
+    whitespace or comments." GoogleSQL's escape for ``'`` inside a
+    single-quoted literal is ``\\'``.
+  - A literal backslash — ``"C:\\Users"`` → ``'C:\\Users'`` →
+    BigQuery parses ``\\U`` as the 8-hex-digit Unicode escape and
+    fails with "Illegal escape sequence."
+  - An unrecognized escape in the input — ``"foo\\qbar"`` →
+    ``\\q`` is rejected by the lexer.
+  - A raw newline / carriage return / tab — these split the literal
+    across source lines and break the surrounding SQL.
+
+  Escape order matters: backslashes first (so the quote and
+  control-char escapes added below aren't re-escaped), then single
+  quotes via ``\\'``, then control characters.
+  """
+  out = value.replace("\\", "\\\\")
+  out = out.replace("'", "\\'")
+  out = _CTRL_RE.sub(_escape_ctrl_char, out)
+  return "'" + out + "'"
+
+
+def _escape_ctrl_char(match: re.Match) -> str:
+  ch = match.group(0)
+  if ch in _NAMED_CTRL_ESCAPES:
+    return _NAMED_CTRL_ESCAPES[ch]
+  return f"\\x{ord(ch):02x}"
+
+
+# Each segment of a fully-qualified BigQuery identifier (project,
+# dataset, table) accepts letters, digits, hyphens, and underscores.
+# Hyphens are valid in project IDs; underscores in datasets/tables.
+# The validator is intentionally a bit broader than the strictest
+# interpretation so legitimate names aren't rejected, but it does
+# reject characters that would let a caller break out of the
+# backtick-wrapped emission (whitespace, slashes, semicolons,
+# backticks, dots beyond the three segments).
+_OUTPUT_TABLE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_output_table(output_table: str) -> None:
+  """Reject anything that's not a clean ``project.dataset.table`` triple.
+
+  Backtick-quoting is added by the emitter, so the input must be
+  the unquoted dotted form. The validator rejects:
+
+  - Inputs containing backticks (caller should not pre-quote — and a
+    stray backtick would terminate our outer quoting and break SQL).
+  - Anything that doesn't split into exactly three non-empty
+    dot-separated segments.
+  - Segments containing characters outside ``[A-Za-z0-9_-]`` —
+    spaces, slashes, semicolons, etc., that could otherwise produce
+    malformed SQL inside the emitter's backtick wrapping.
+  """
+  if "`" in output_table:
+    raise ValueError(
+        f"output_table must not contain backticks; the emitter adds "
+        f"them. Got {output_table!r}."
+    )
+  parts = output_table.split(".")
+  if len(parts) != 3 or any(not p for p in parts):
+    raise ValueError(
+        f"output_table must be 'project.dataset.table'; got {output_table!r}"
+    )
+  for part in parts:
+    if not _OUTPUT_TABLE_SEGMENT_RE.match(part):
+      raise ValueError(
+          f"output_table segment {part!r} contains invalid characters; "
+          f"each segment must match [A-Za-z0-9_-]+. Got {output_table!r}."
+      )

--- a/tests/bigquery_ontology/test_cli.py
+++ b/tests/bigquery_ontology/test_cli.py
@@ -1095,3 +1095,185 @@ def test_import_owl_output_to_existing_directory_emits_error(tmp_path):
 
   assert result.exit_code == 1
   assert "cli-output-error" in result.output
+
+
+# --------------------------------------------------------------------- #
+# gm compile --emit-concept-index (A7)                                  #
+# --------------------------------------------------------------------- #
+
+
+def test_compile_without_emit_concept_index_is_byte_identical(tmp_path):
+  """Regression guard: omitting ``--emit-concept-index`` produces the
+  exact same DDL as before A7 landed.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  result = _RUNNER.invoke(app, ["compile", str(binding)])
+
+  assert result.exit_code == 0
+  assert result.output == _COMPILE_EXPECTED_DDL
+
+
+def test_compile_emit_concept_index_requires_table_flag(tmp_path):
+  """``--emit-concept-index`` with no ``--concept-index-table`` is
+  rejected — no silent global default per the RFC.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(
+      app, ["compile", str(binding), "--emit-concept-index"]
+  )
+
+  assert result.exit_code != 0
+  assert "--concept-index-table" in result.output
+
+
+def test_compile_emit_concept_index_appends_two_create_or_replace_statements(
+    tmp_path,
+):
+  """Happy path: both the property-graph DDL and the concept-index
+  SQL (main + meta) appear on stdout.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "compile",
+          str(binding),
+          "--emit-concept-index",
+          "--concept-index-table",
+          "p.d.tiny_concept_index",
+      ],
+  )
+
+  assert result.exit_code == 0
+  # Property-graph DDL comes first, unchanged.
+  assert "CREATE PROPERTY GRAPH" in result.output
+  # Then two concept-index CREATE OR REPLACE statements (main + meta).
+  assert result.output.count("CREATE OR REPLACE TABLE") == 2
+  assert "`p.d.tiny_concept_index`" in result.output
+  assert "`p.d.tiny_concept_index__meta`" in result.output
+
+
+def test_compile_emit_concept_index_with_output_flag_writes_combined_sql(
+    tmp_path,
+):
+  """``-o PATH`` with the emit flag lands the combined SQL in the
+  named file and leaves stdout empty.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  out_path = tmp_path / "combined.sql"
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "compile",
+          str(binding),
+          "--emit-concept-index",
+          "--concept-index-table",
+          "p.d.tiny_concept_index",
+          "-o",
+          str(out_path),
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert result.output == ""
+  body = out_path.read_text(encoding="utf-8")
+  assert "CREATE PROPERTY GRAPH" in body
+  assert body.count("CREATE OR REPLACE TABLE") == 2
+
+
+def test_compile_emit_concept_index_invalid_table_path_fails(tmp_path):
+  """An ``--concept-index-table`` value that fails A3-A5 validation
+  surfaces as a clean compile-time error.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "compile",
+          str(binding),
+          "--emit-concept-index",
+          "--concept-index-table",
+          "not-three-segments",
+      ],
+  )
+
+  assert result.exit_code == 1
+  assert "project.dataset.table" in result.output
+
+
+def test_compile_emit_concept_index_is_deterministic_across_runs(tmp_path):
+  """D2 round-trip: re-running with the same inputs produces
+  byte-identical combined output.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  flags = [
+      "compile",
+      str(binding),
+      "--emit-concept-index",
+      "--concept-index-table",
+      "p.d.tiny_concept_index",
+  ]
+  out1 = _RUNNER.invoke(app, flags).output
+  out2 = _RUNNER.invoke(app, flags).output
+  assert out1 == out2
+
+
+def test_compile_emit_concept_index_with_explicit_compiler_version(tmp_path):
+  """``--compiler-version`` overrides the default. The version string
+  flows into ``compile_fingerprint`` so the meta row reflects it.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+
+  result = _RUNNER.invoke(
+      app,
+      [
+          "compile",
+          str(binding),
+          "--emit-concept-index",
+          "--concept-index-table",
+          "p.d.tiny_concept_index",
+          "--compiler-version",
+          "test-pin-1.2.3",
+      ],
+  )
+
+  assert result.exit_code == 0
+  # The version string appears in the meta row's compiler_version column.
+  assert "'test-pin-1.2.3'" in result.output
+
+
+def test_compile_emit_concept_index_default_compiler_version_is_stable(
+    tmp_path,
+):
+  """Without ``--compiler-version`` the default is the package
+  version; same default → same fingerprint → byte-identical SQL.
+  """
+  _write(tmp_path, "tiny.ontology.yaml", _COMPILE_ONTOLOGY)
+  binding = _write(tmp_path, "tiny.binding.yaml", _COMPILE_BINDING)
+  flags = [
+      "compile",
+      str(binding),
+      "--emit-concept-index",
+      "--concept-index-table",
+      "p.d.tiny_concept_index",
+  ]
+  out1 = _RUNNER.invoke(app, flags).output
+  out2 = _RUNNER.invoke(app, flags).output
+  assert out1 == out2
+  # The meta row carries some non-empty compiler_version string.
+  meta_section = out1[out1.index("__meta") :]
+  # Find a quoted compiler-version-shaped value (heuristic: any
+  # non-empty string literal in the meta section that isn't a
+  # fingerprint or short id).
+  assert "'" in meta_section

--- a/tests/bigquery_ontology/test_compile_concept_index.py
+++ b/tests/bigquery_ontology/test_compile_concept_index.py
@@ -1,0 +1,473 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the concept-index emitter (A3-A5).
+
+``compile_concept_index(ontology, binding, *, output_table,
+compiler_version)`` consumes A2's row builder and emits two
+``CREATE OR REPLACE TABLE ... AS SELECT * FROM UNNEST(...)`` statements
+(main + ``__meta`` sibling). Pinned in
+``docs/implementation_plan_concept_index_runtime.md`` (A3-A5) and
+``docs/entity_resolution_primitives.md`` §4.2 / §5.
+
+Test coverage:
+
+- D2  byte-identical SQL across runs.
+- D3  scope rule round-trips through the SQL row count.
+- D5  notation row carries ``label_kind='notation'``.
+- D14 main + meta both written, both carry the same ``compile_id`` /
+      ``compile_fingerprint``.
+- Plus: NULL/BOOL rendering, string escaping, meta-row schema,
+  empty-rows handling, output-table fully-qualified path appears in
+  both statements.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from bigquery_ontology import BigQueryTarget
+from bigquery_ontology import Binding
+from bigquery_ontology import Entity
+from bigquery_ontology import EntityBinding
+from bigquery_ontology import Keys
+from bigquery_ontology import Ontology
+from bigquery_ontology import Property
+from bigquery_ontology import PropertyBinding
+from bigquery_ontology import PropertyType
+from bigquery_ontology._fingerprint import compile_fingerprint
+from bigquery_ontology._fingerprint import compile_id
+from bigquery_ontology._fingerprint import fingerprint_model
+from bigquery_ontology.graph_ddl_compiler import compile_concept_index
+
+_COMPILER_VERSION = "bigquery_ontology test"
+_OUTPUT_TABLE = "proj.ds.ontology_concept_index"
+
+
+def _account_entity(**kw) -> Entity:
+  return Entity(
+      name="Account",
+      keys=Keys(primary=["account_id"]),
+      properties=[Property(name="account_id", type=PropertyType.STRING)],
+      **kw,
+  )
+
+
+def _account_binding() -> EntityBinding:
+  return EntityBinding(
+      name="Account",
+      source="accounts",
+      properties=[PropertyBinding(name="account_id", column="account_id")],
+  )
+
+
+def _binding(*entities: EntityBinding) -> Binding:
+  return Binding(
+      binding="test_binding",
+      ontology="test",
+      target=BigQueryTarget(backend="bigquery", project="proj", dataset="ds"),
+      entities=list(entities),
+      relationships=[],
+  )
+
+
+def _compile(
+    *,
+    entities=None,
+    bindings=None,
+    output_table=_OUTPUT_TABLE,
+) -> str:
+  ontology = Ontology(
+      ontology="test",
+      entities=entities or [_account_entity()],
+  )
+  binding = _binding(*(bindings or [_account_binding()]))
+  return compile_concept_index(
+      ontology,
+      binding,
+      output_table=output_table,
+      compiler_version=_COMPILER_VERSION,
+  )
+
+
+# ------------------------------------------------------------------ #
+# Output shape                                                         #
+# ------------------------------------------------------------------ #
+
+
+class TestOutputShape:
+
+  def test_emits_two_create_or_replace_statements(self):
+    """One for the main index, one for the ``__meta`` sibling."""
+    sql = _compile()
+    statements = re.findall(r"CREATE OR REPLACE TABLE", sql)
+    assert len(statements) == 2
+
+  def test_main_and_meta_table_paths_are_backtick_quoted(self):
+    sql = _compile(output_table="my-proj.my_ds.idx")
+    assert "`my-proj.my_ds.idx`" in sql
+    assert "`my-proj.my_ds.idx__meta`" in sql
+
+  def test_main_table_carries_all_nine_columns(self):
+    sql = _compile()
+    main = sql.split("__meta")[0]  # everything before meta statement
+    for col in (
+        "entity_name",
+        "label",
+        "label_kind",
+        "notation",
+        "scheme",
+        "language",
+        "is_abstract",
+        "compile_id",
+        "compile_fingerprint",
+    ):
+      assert col in main, f"missing column {col!r} in main table emission"
+
+  def test_meta_table_carries_seven_provenance_columns(self):
+    sql = _compile()
+    # everything after first __meta occurrence
+    meta = sql[sql.index("__meta") :]
+    for col in (
+        "compile_fingerprint",
+        "compile_id",
+        "ontology_fingerprint",
+        "binding_fingerprint",
+        "target_project",
+        "target_dataset",
+        "compiler_version",
+    ):
+      assert col in meta, f"missing column {col!r} in meta table emission"
+
+  def test_uses_inline_unnest_path(self):
+    """Default emission path is atomic per-statement
+    ``CREATE OR REPLACE TABLE ... AS SELECT * FROM UNNEST(...)``.
+    """
+    sql = _compile()
+    assert "AS SELECT * FROM UNNEST" in sql
+
+
+# ------------------------------------------------------------------ #
+# Provenance — main and meta carry the same compile id/fingerprint    #
+# ------------------------------------------------------------------ #
+
+
+class TestProvenance:
+
+  def test_compile_fingerprint_appears_in_both_main_and_meta(self):
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    binding = _binding(_account_binding())
+    expected_cfp = compile_fingerprint(
+        fingerprint_model(ontology),
+        fingerprint_model(binding),
+        _COMPILER_VERSION,
+    )
+    sql = _compile()
+    # The 64-hex string must appear at least twice — once per row in
+    # main (here we have 1+ rows), once in meta.
+    assert sql.count(expected_cfp) >= 2
+
+  def test_compile_id_appears_in_both_main_and_meta(self):
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    binding = _binding(_account_binding())
+    expected_cid = compile_id(
+        fingerprint_model(ontology),
+        fingerprint_model(binding),
+        _COMPILER_VERSION,
+    )
+    sql = _compile()
+    assert sql.count(expected_cid) >= 2
+
+  def test_meta_carries_target_project_and_dataset_from_binding(self):
+    sql = _compile()
+    meta = sql[sql.index("__meta") :]
+    assert "'proj'" in meta
+    assert "'ds'" in meta
+
+  def test_meta_carries_compiler_version_string(self):
+    sql = _compile()
+    meta = sql[sql.index("__meta") :]
+    assert f"'{_COMPILER_VERSION}'" in meta
+
+
+# ------------------------------------------------------------------ #
+# Determinism (D2)                                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestDeterminism:
+
+  def test_byte_identical_across_runs(self):
+    """Same inputs must produce byte-for-byte identical SQL."""
+    sql1 = _compile()
+    sql2 = _compile()
+    assert sql1 == sql2
+
+  def test_byte_identical_for_complex_ontology(self):
+    """Multi-entity, multi-scheme, multi-label ontology is also
+    byte-deterministic.
+    """
+    entities = [
+        _account_entity(
+            synonyms=["Acct", "AC"],
+            annotations={
+                "skos:notation": "807",
+                "skos:inScheme": ["BankingTaxonomy", "FinancialProducts"],
+                "skos:prefLabel": "Bank Account",
+            },
+        ),
+        Entity(
+            name="skos_Banking",
+            abstract=True,
+            annotations={"skos:prefLabel": "Banking"},
+        ),
+    ]
+    sql1 = _compile(entities=entities)
+    sql2 = _compile(entities=entities)
+    assert sql1 == sql2
+
+
+# ------------------------------------------------------------------ #
+# Value rendering                                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestValueRendering:
+
+  def test_none_values_render_as_null_literal(self):
+    """Account has no scheme, language, or notation → NULLs in SQL."""
+    sql = _compile()
+    main = sql.split("__meta")[0]
+    # At least one row contains explicit NULL for the optional columns.
+    assert "NULL" in main
+
+  def test_booleans_render_as_uppercase_true_false(self):
+    """BigQuery convention; also keeps the byte-identical contract
+    stable across runs.
+    """
+    entities = [
+        _account_entity(),
+        Entity(name="skos_Banking", abstract=True),
+    ]
+    sql = _compile(entities=entities)
+    assert "TRUE" in sql or "true" in sql
+    assert "FALSE" in sql or "false" in sql
+    # Pin uppercase per contract:
+    main = sql.split("__meta")[0]
+    assert "TRUE" in main
+    assert "FALSE" in main
+
+  def test_string_with_single_quote_is_backslash_escaped(self):
+    """GoogleSQL escapes single quotes as ``\\'`` inside single-quoted
+    literals, **not** as ``''``. ANSI SQL (and PostgreSQL) accept the
+    quote-doubling form, but GoogleSQL rejects it: ``'O''Brien'``
+    parses as two concatenated literals (``'O'`` and ``'Brien'``)
+    and errors with "concatenated string literals must be separated
+    by whitespace or comments." The emitter must use the backslash
+    form.
+    """
+    entities = [_account_entity(synonyms=["O'Brien Bank"])]
+    sql = _compile(entities=entities)
+    # Python literal ``"'O\\'Brien Bank'"`` is the 17-character SQL
+    # text: apostrophe, O, backslash, apostrophe, Brien, space, Bank,
+    # apostrophe.
+    assert "'O\\'Brien Bank'" in sql
+    # And the broken doubled-quote form must NOT appear.
+    assert "'O''Brien" not in sql
+
+  def test_backslash_is_escaped(self):
+    """GoogleSQL **does** treat ``\\`` as an escape character inside
+    single-quoted strings. ``'C:\\Users'`` would parse as ``\\U``
+    (the 8-hex-digit Unicode escape) and fail with "Illegal escape
+    sequence." The emitter must double backslashes so the source
+    string round-trips correctly.
+    """
+    entities = [_account_entity(synonyms=["C:\\Users"])]
+    sql = _compile(entities=entities)
+    # BigQuery reads ``'C:\\\\Users'`` as ``C:\Users``.
+    assert "'C:\\\\Users'" in sql
+
+  def test_unrecognized_escape_in_input_is_safely_doubled(self):
+    """``\\q`` is not a valid GoogleSQL escape. The input should be
+    rendered with the backslash doubled so BigQuery sees ``\\\\q``
+    (escaped backslash + literal q).
+    """
+    entities = [_account_entity(synonyms=["foo\\qbar"])]
+    sql = _compile(entities=entities)
+    assert "'foo\\\\qbar'" in sql
+
+  def test_literal_newline_is_escaped(self):
+    """A literal newline character inside a string would otherwise
+    split the SQL across two lines and break the literal. Must be
+    escaped as ``\\n``.
+    """
+    entities = [_account_entity(synonyms=["line1\nline2"])]
+    sql = _compile(entities=entities)
+    assert "'line1\\nline2'" in sql
+    # Sanity: no raw newline character inside any literal.
+    for line in sql.splitlines():
+      # A literal-broken line would contain text after a quote-open
+      # without a matching close on the same line. Cheap proxy:
+      # every line should have an even number of unescaped quotes.
+      pass  # not foolproof; the substring assert above is the real check.
+
+  def test_carriage_return_and_tab_are_escaped(self):
+    entities = [_account_entity(synonyms=["a\rb", "x\ty"])]
+    sql = _compile(entities=entities)
+    assert "'a\\rb'" in sql
+    assert "'x\\ty'" in sql
+
+
+# ------------------------------------------------------------------ #
+# Scope round-trip + notation row (D3, D5)                            #
+# ------------------------------------------------------------------ #
+
+
+class TestScopeAndNotation:
+
+  def test_unbound_concrete_entity_does_not_appear_in_sql(self):
+    """D3: concrete unbound entities are filtered by build_rows;
+    their names should not appear in the emitted SQL.
+    """
+    entities = [
+        _account_entity(),
+        Entity(
+            name="Ledger",
+            keys=Keys(primary=["ledger_id"]),
+            properties=[Property(name="ledger_id", type=PropertyType.STRING)],
+        ),
+    ]
+    sql = _compile(entities=entities)
+    main = sql.split("__meta")[0]
+    assert "'Ledger'" not in main
+
+  def test_abstract_entity_is_emitted(self):
+    entities = [
+        _account_entity(),
+        Entity(name="skos_Banking", abstract=True),
+    ]
+    sql = _compile(entities=entities)
+    main = sql.split("__meta")[0]
+    assert "'skos_Banking'" in main
+
+  def test_notation_value_appears_as_label_kind_notation_row(self):
+    """D5: ``skos:notation`` value '807' gets a row where
+    ``label_kind = 'notation'`` and ``label = '807'``.
+    """
+    entities = [
+        _account_entity(annotations={"skos:notation": "807"}),
+    ]
+    sql = _compile(entities=entities)
+    main = sql.split("__meta")[0]
+    assert "'notation'" in main
+    assert "'807'" in main
+
+
+# ------------------------------------------------------------------ #
+# Empty rows                                                           #
+# ------------------------------------------------------------------ #
+
+
+class TestOutputTableValidation:
+  """Reject inputs that would produce malformed SQL once
+  backtick-wrapped by the emitter.
+  """
+
+  def _compile_with_table(self, output_table: str) -> str:
+    return compile_concept_index(
+        Ontology(ontology="test", entities=[_account_entity()]),
+        _binding(_account_binding()),
+        output_table=output_table,
+        compiler_version=_COMPILER_VERSION,
+    )
+
+  def test_rejects_pre_quoted_table(self):
+    with pytest.raises(ValueError, match="backtick"):
+      self._compile_with_table("`proj.ds.idx`")
+
+  def test_rejects_internal_backtick(self):
+    """Even one stray backtick would terminate our outer quoting."""
+    with pytest.raises(ValueError, match="backtick"):
+      self._compile_with_table("proj.ds.idx`malicious`")
+
+  def test_rejects_segment_with_invalid_characters(self):
+    """Segments must use BigQuery identifier-compatible chars."""
+    with pytest.raises(ValueError, match="invalid"):
+      self._compile_with_table("proj.ds.idx malicious")
+
+  def test_rejects_segment_with_slash(self):
+    with pytest.raises(ValueError, match="invalid"):
+      self._compile_with_table("proj.ds.idx/with/slashes")
+
+  def test_rejects_two_segment_path(self):
+    with pytest.raises(ValueError, match="project.dataset.table"):
+      self._compile_with_table("ds.idx")
+
+  def test_rejects_four_segment_path(self):
+    with pytest.raises(ValueError, match="project.dataset.table"):
+      self._compile_with_table("a.b.c.d")
+
+  def test_accepts_valid_three_segment_path(self):
+    """Project IDs may contain hyphens (BigQuery convention); dataset
+    and table identifiers may use underscores. Both must be accepted.
+    """
+    sql = self._compile_with_table("my-proj-123.my_dataset.my_table_v2")
+    assert "`my-proj-123.my_dataset.my_table_v2`" in sql
+
+
+class TestEmptyRows:
+
+  def test_zero_concrete_zero_abstract_raises(self):
+    """An ontology with no abstract entities and a binding that
+    references no concrete entities yields zero rows in the main
+    index. The emitter should reject this with a clear error
+    rather than emit a typeless empty array (which would lose the
+    schema).
+    """
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    # Binding doesn't reference Account at all.
+    binding = _binding()
+    with pytest.raises(ValueError, match="no concrete"):
+      compile_concept_index(
+          ontology,
+          binding,
+          output_table=_OUTPUT_TABLE,
+          compiler_version=_COMPILER_VERSION,
+      )
+
+
+# ------------------------------------------------------------------ #
+# Public surface                                                       #
+# ------------------------------------------------------------------ #
+
+
+class TestPublicSurface:
+
+  def test_compile_concept_index_re_exported_at_package_root(self):
+    """Per the implementation plan, ``compile_concept_index`` is
+    public and re-exported alongside ``compile_graph``.
+    """
+    import bigquery_ontology
+
+    assert hasattr(bigquery_ontology, "compile_concept_index")
+
+  def test_compile_graph_unchanged(self):
+    """The existing ``compile_graph`` byte-identical contract is
+    preserved by this PR — sanity check by importing it.
+    """
+    from bigquery_ontology import compile_graph
+
+    assert callable(compile_graph)

--- a/tests/bigquery_ontology/test_concept_index.py
+++ b/tests/bigquery_ontology/test_concept_index.py
@@ -1,0 +1,550 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the concept-index row builder (A2).
+
+Pinned in `docs/implementation_plan_concept_index_runtime.md` and the
+RFC. Each row is a `(entity_name, label, label_kind, language, scheme)`
+membership tuple plus per-entity `notation` and provenance columns
+(`compile_id` short display + `compile_fingerprint` 64-hex integrity).
+
+Test coverage maps to plan items:
+
+- D1 fingerprint determinism (covered in test_fingerprint.py).
+- D2 build_rows produces identical output across runs.
+- D3 row scope (abstract always included; concrete iff bound).
+- D4 multi-scheme denormalization.
+- D5 notation as first-class row.
+- Plus row-shape, sort determinism, provenance columns.
+"""
+
+from __future__ import annotations
+
+from bigquery_ontology import BigQueryTarget
+from bigquery_ontology import Binding
+from bigquery_ontology import Entity
+from bigquery_ontology import EntityBinding
+from bigquery_ontology import Keys
+from bigquery_ontology import Ontology
+from bigquery_ontology import Property
+from bigquery_ontology import PropertyBinding
+from bigquery_ontology import PropertyType
+from bigquery_ontology._fingerprint import compile_fingerprint
+from bigquery_ontology._fingerprint import compile_id
+from bigquery_ontology._fingerprint import fingerprint_model
+from bigquery_ontology.concept_index import build_rows
+from bigquery_ontology.concept_index import ConceptIndexRow
+
+_COMPILER_VERSION = "bigquery_ontology test"
+
+
+def _account_entity(**kwargs) -> Entity:
+  return Entity(
+      name="Account",
+      keys=Keys(primary=["account_id"]),
+      properties=[Property(name="account_id", type=PropertyType.STRING)],
+      **kwargs,
+  )
+
+
+def _account_binding() -> EntityBinding:
+  return EntityBinding(
+      name="Account",
+      source="accounts",
+      properties=[PropertyBinding(name="account_id", column="account_id")],
+  )
+
+
+def _binding(*entities: EntityBinding) -> Binding:
+  return Binding(
+      binding="test_binding",
+      ontology="test",
+      target=BigQueryTarget(backend="bigquery", project="p", dataset="d"),
+      entities=list(entities),
+      relationships=[],
+  )
+
+
+# ------------------------------------------------------------------ #
+# Row shape                                                            #
+# ------------------------------------------------------------------ #
+
+
+class TestRowShape:
+
+  def test_concrete_entity_emits_name_row(self):
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    name_rows = [r for r in rows if r.label_kind == "name"]
+    assert len(name_rows) == 1
+    row = name_rows[0]
+    assert row.entity_name == "Account"
+    assert row.label == "Account"
+    assert row.is_abstract is False
+    assert row.language is None
+    assert row.scheme is None
+    assert row.notation is None
+
+  def test_synonyms_emit_synonym_rows(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[_account_entity(synonyms=["Acct", "AC"])],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    syn = sorted(r.label for r in rows if r.label_kind == "synonym")
+    assert syn == ["AC", "Acct"]
+
+  def test_notation_emits_first_class_row_and_column(self):
+    """D5: every entity with skos:notation gets a row with
+    ``label_kind='notation'`` and ``label = notation_value``. The
+    ``notation`` column on EVERY row of that entity also carries the
+    notation value (per-entity display, repeats across rows).
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                synonyms=["Acct"],
+                annotations={"skos:notation": "807"},
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    # The `notation` column repeats on every row for Account.
+    for r in rows:
+      assert r.notation == "807"
+    # Exactly one row has label_kind='notation' with label='807'.
+    notation_rows = [r for r in rows if r.label_kind == "notation"]
+    assert len(notation_rows) == 1
+    assert notation_rows[0].label == "807"
+
+  def test_skos_label_annotations_emit_typed_rows(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                annotations={
+                    "skos:prefLabel": "Bank Account",
+                    "skos:altLabel": "Acct",
+                    "skos:hiddenLabel": "AC",
+                }
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    by_kind = {r.label_kind: r.label for r in rows}
+    assert by_kind["pref"] == "Bank Account"
+    assert by_kind["alt"] == "Acct"
+    assert by_kind["hidden"] == "AC"
+
+  def test_language_tagged_label_annotations(self):
+    """Annotations with `@<lang>` suffix populate the language column."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                annotations={
+                    "skos:prefLabel": "Bank Account",
+                    "skos:prefLabel@fr": "Compte Bancaire",
+                    "skos:altLabel@de": "Bankkonto",
+                }
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    # Default-language pref row has language=None.
+    en = [r for r in rows if r.label_kind == "pref" and r.language is None]
+    assert len(en) == 1 and en[0].label == "Bank Account"
+    # French pref row.
+    fr = [r for r in rows if r.label_kind == "pref" and r.language == "fr"]
+    assert len(fr) == 1 and fr[0].label == "Compte Bancaire"
+    # German alt row.
+    de = [r for r in rows if r.label_kind == "alt" and r.language == "de"]
+    assert len(de) == 1 and de[0].label == "Bankkonto"
+
+  def test_provenance_columns_match_fingerprint_exports(self):
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    binding = _binding(_account_binding())
+    rows = build_rows(ontology, binding, compiler_version=_COMPILER_VERSION)
+
+    expected_fp = compile_fingerprint(
+        fingerprint_model(ontology),
+        fingerprint_model(binding),
+        _COMPILER_VERSION,
+    )
+    expected_cid = compile_id(
+        fingerprint_model(ontology),
+        fingerprint_model(binding),
+        _COMPILER_VERSION,
+    )
+    assert all(r.compile_fingerprint == expected_fp for r in rows)
+    assert all(r.compile_id == expected_cid for r in rows)
+    assert all(len(r.compile_fingerprint) == 64 for r in rows)
+    assert all(len(r.compile_id) == 12 for r in rows)
+
+
+# ------------------------------------------------------------------ #
+# Scope rule (D3)                                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestScopeRule:
+  """Abstract entities always included; concrete iff bound."""
+
+  def test_abstract_entity_always_included(self):
+    """Abstract entities are informational and never need a binding."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+    )
+    # Binding does NOT cover skos_Banking; it's abstract so it's still in.
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    names = {r.entity_name for r in rows}
+    assert "skos_Banking" in names
+    assert "Account" in names
+
+  def test_concrete_entity_excluded_if_unbound(self):
+    """A concrete entity not present in the binding is excluded."""
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(),
+            Entity(
+                name="Ledger",
+                keys=Keys(primary=["ledger_id"]),
+                properties=[
+                    Property(name="ledger_id", type=PropertyType.STRING)
+                ],
+            ),
+        ],
+    )
+    # Binding only has Account; Ledger is concrete but unbound → excluded.
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    names = {r.entity_name for r in rows}
+    assert names == {"Account"}
+
+  def test_abstract_row_marks_is_abstract_true(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    for r in rows:
+      if r.entity_name == "skos_Banking":
+        assert r.is_abstract is True
+      else:
+        assert r.is_abstract is False
+
+
+# ------------------------------------------------------------------ #
+# Multi-scheme denormalization (D4)                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestMultiScheme:
+  """A concept in N schemes emits N rows per label."""
+
+  def test_single_scheme_membership(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(annotations={"skos:inScheme": "BankingTaxonomy"})
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    schemes = {r.scheme for r in rows}
+    assert schemes == {"BankingTaxonomy"}
+
+  def test_multi_scheme_membership(self):
+    """A concept in 2 schemes × 1 name label = 2 name rows. The
+    name + a synonym in 2 schemes = 4 rows total.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                synonyms=["Acct"],
+                annotations={
+                    "skos:inScheme": ["BankingTaxonomy", "FinancialProducts"]
+                },
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    # 2 schemes × (1 name + 1 synonym) = 4 rows.
+    assert len(rows) == 4
+    schemes = sorted({r.scheme for r in rows})
+    assert schemes == ["BankingTaxonomy", "FinancialProducts"]
+    # DISTINCT entity_name returns 1 (per the multi-scheme contract).
+    assert len({r.entity_name for r in rows}) == 1
+
+  def test_no_scheme_yields_null_column(self):
+    ontology = Ontology(ontology="test", entities=[_account_entity()])
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    assert all(r.scheme is None for r in rows)
+
+  def test_top_concept_of_contributes_scheme_membership(self):
+    """A concept declared as the top of a scheme via
+    ``skos:topConceptOf`` is still a member of that scheme. Without
+    this, queries like ``WHERE ci.scheme = 'Banking'`` miss the
+    scheme's top concepts.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                annotations={"skos:topConceptOf": "BankingTaxonomy"}
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    schemes = {r.scheme for r in rows}
+    assert schemes == {"BankingTaxonomy"}
+
+  def test_in_scheme_and_top_concept_of_unioned_and_deduped(self):
+    """If both annotations name the same scheme, only one set of
+    rows should be emitted for that scheme. If they name different
+    schemes, both should be present.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                annotations={
+                    "skos:inScheme": "BankingTaxonomy",
+                    "skos:topConceptOf": [
+                        "BankingTaxonomy",  # duplicate of inScheme — dedupe
+                        "FinancialProducts",  # additional scheme — keep
+                    ],
+                }
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    schemes = sorted({r.scheme for r in rows})
+    assert schemes == ["BankingTaxonomy", "FinancialProducts"]
+    # Exactly one name row per scheme — the duplicate did not double-emit.
+    name_rows = [r for r in rows if r.label_kind == "name"]
+    assert len(name_rows) == 2
+
+
+# ------------------------------------------------------------------ #
+# Row deduplication                                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestRowDedup:
+  """Per the contract: one row per
+  ``(entity_name, label, label_kind, language, scheme)`` tuple.
+  Duplicate input values for the same tuple must collapse to one row;
+  the same value via different sources (different ``label_kind``) is
+  not a duplicate and must keep both rows.
+  """
+
+  def test_duplicate_synonyms_collapse_to_one_row(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[_account_entity(synonyms=["Acct", "Acct", "Acct"])],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    syn_rows = [r for r in rows if r.label_kind == "synonym"]
+    assert len(syn_rows) == 1
+    assert syn_rows[0].label == "Acct"
+
+  def test_duplicate_annotation_values_collapse(self):
+    """If the same annotation value appears twice in the source list,
+    the index emits a single row.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                annotations={"skos:altLabel": ["X", "X", "X"]},
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    alt_rows = [r for r in rows if r.label_kind == "alt"]
+    assert len(alt_rows) == 1
+    assert alt_rows[0].label == "X"
+
+  def test_same_value_different_kinds_keeps_both_rows(self):
+    """``"Acct"`` as both ``Entity.synonyms`` and
+    ``annotations["skos:altLabel"]`` is two different tuples (kinds
+    differ), so both rows are kept. This is the resolver's job to
+    rank, not the row builder's job to dedupe.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                synonyms=["Acct"],
+                annotations={"skos:altLabel": "Acct"},
+            )
+        ],
+    )
+    rows = build_rows(
+        ontology,
+        _binding(_account_binding()),
+        compiler_version=_COMPILER_VERSION,
+    )
+    same_label = [r for r in rows if r.label == "Acct"]
+    kinds = sorted(r.label_kind for r in same_label)
+    assert kinds == ["alt", "synonym"]
+
+
+# ------------------------------------------------------------------ #
+# Determinism (D2)                                                    #
+# ------------------------------------------------------------------ #
+
+
+class TestDeterminism:
+  """Same inputs → byte-identical row sequence across runs."""
+
+  def test_repeated_calls_produce_identical_rows(self):
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(
+                synonyms=["Acct", "AC"],
+                annotations={
+                    "skos:notation": "807",
+                    "skos:inScheme": ["BankingTaxonomy", "FinancialProducts"],
+                },
+            ),
+            Entity(name="skos_Banking", abstract=True),
+        ],
+    )
+    binding = _binding(_account_binding())
+    rows1 = build_rows(ontology, binding, compiler_version=_COMPILER_VERSION)
+    rows2 = build_rows(ontology, binding, compiler_version=_COMPILER_VERSION)
+    assert rows1 == rows2
+
+  def test_sort_order_is_total(self):
+    """For deterministic SQL emission, the row list must be in a
+    total order. Building the same ontology twice (constructed
+    identically) must produce the exact same sequence — including
+    when there are ties on early sort keys.
+    """
+    ontology = Ontology(
+        ontology="test",
+        entities=[
+            _account_entity(synonyms=["Acct", "AC", "Bank Account"]),
+        ],
+    )
+    binding = _binding(_account_binding())
+    rows = build_rows(ontology, binding, compiler_version=_COMPILER_VERSION)
+    # Synonym rows should appear in sorted order by label.
+    syn_labels = [r.label for r in rows if r.label_kind == "synonym"]
+    assert syn_labels == sorted(syn_labels)
+
+
+# ------------------------------------------------------------------ #
+# Public surface                                                       #
+# ------------------------------------------------------------------ #
+
+
+class TestPublicSurface:
+
+  def test_concept_index_row_is_dataclass_with_expected_fields(self):
+    fields = ConceptIndexRow.__dataclass_fields__
+    expected = {
+        "entity_name",
+        "label",
+        "label_kind",
+        "notation",
+        "scheme",
+        "language",
+        "is_abstract",
+        "compile_id",
+        "compile_fingerprint",
+    }
+    assert set(fields.keys()) == expected
+
+  def test_concept_index_module_not_re_exported_at_root(self):
+    """v1 keeps `concept_index` out of `bigquery_ontology/__init__.py`
+    per the implementation plan ("Package-level re-export can be added
+    later if a concrete caller appears"). Importable directly via
+    absolute path.
+    """
+    import bigquery_ontology
+
+    assert not hasattr(bigquery_ontology, "build_rows")
+    assert not hasattr(bigquery_ontology, "ConceptIndexRow")

--- a/tests/bigquery_ontology/test_fingerprint.py
+++ b/tests/bigquery_ontology/test_fingerprint.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the internal fingerprint module used by concept-index provenance.
+
+The contract is pinned in `docs/implementation_plan_concept_index_runtime.md`
+(W1/W2) and in the issue #58 body under "Fingerprint algorithm":
+
+- Input: `BaseModel.model_dump(mode="json", by_alias=False, exclude_none=False)`.
+- Canonical JSON: `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)`.
+- ``fingerprint_model``: SHA-256, returned as ``"sha256:"`` + 64 hex chars.
+- ``compile_fingerprint``: full 64-hex SHA-256 over
+  ``ontology_fingerprint || binding_fingerprint || compiler_version``.
+  Canonical integrity key; used by strict verification.
+- ``compile_id``: 12-hex display token derived as
+  ``compile_fingerprint(...)[:12]``. Never used as the sole
+  freshness check.
+
+Invariant: ``compile_id == compile_fingerprint[:12]``.
+
+These tests pin the serialization contract (so a future "optimizer"
+cannot silently replace it with ``yaml.dump`` or ``str(model)`` or
+``model.model_dump()`` without ``mode="json"``, all of which would
+break cross-package agreement between the compiler-side writer and
+the runtime-side verifier) and the Option 2 column contract from
+issue #58 (so the short and long forms cannot drift apart).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology._fingerprint import compile_fingerprint
+from bigquery_ontology._fingerprint import compile_id
+from bigquery_ontology._fingerprint import fingerprint_model
+
+_SIMPLE_ONTOLOGY_YAML = textwrap.dedent(
+    """\
+    ontology: finance
+    entities:
+      - name: Account
+        keys:
+          primary: [account_id]
+        properties:
+          - name: account_id
+            type: string
+          - name: opened_at
+            type: timestamp
+    """
+)
+
+
+_SIMPLE_BINDING_YAML = textwrap.dedent(
+    """\
+    binding: finance-bq-prod
+    ontology: finance
+    target:
+      backend: bigquery
+      project: my-proj
+      dataset: finance
+    entities:
+      - name: Account
+        source: raw.accounts
+        properties:
+          - {name: account_id, column: acct_id}
+          - {name: opened_at, column: created_ts}
+    """
+)
+
+
+# ------------------------------------------------------------------ #
+# fingerprint_model                                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestFingerprintModel:
+  """Canonical-JSON SHA-256 over Pydantic models."""
+
+  def test_returns_sha256_prefixed_hex(self):
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    fp = fingerprint_model(ont)
+    assert fp.startswith("sha256:")
+    # 64 hex chars after the prefix = 256 bits.
+    digest = fp[len("sha256:") :]
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+  def test_deterministic_across_calls(self):
+    """Same model, same fingerprint, every time."""
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    fp1 = fingerprint_model(ont)
+    fp2 = fingerprint_model(ont)
+    assert fp1 == fp2
+
+  def test_non_semantic_yaml_edits_produce_identical_fingerprint(self):
+    """Whitespace, comments, and key-ordering changes must not shift the
+    fingerprint. This is the entire justification for fingerprinting at
+    the validated-model layer rather than over raw YAML text.
+    """
+    edited_yaml = textwrap.dedent(
+        """\
+        # A leading comment.
+        ontology: finance
+
+
+        entities:
+            - name: Account
+              keys:
+                  primary: [account_id]
+              properties:
+                  - name: account_id
+                    type: string
+                  - name: opened_at
+                    type: timestamp
+        """
+    )
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(edited_yaml)
+    assert fingerprint_model(ont1) == fingerprint_model(ont2)
+
+  def test_semantic_rename_changes_fingerprint(self):
+    """Changing an entity name is a semantic edit; fingerprint differs."""
+    renamed = _SIMPLE_ONTOLOGY_YAML.replace("name: Account", "name: Ledger")
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(renamed)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+  def test_semantic_type_change_changes_fingerprint(self):
+    """Property type change must surface as a different fingerprint."""
+    retyped = _SIMPLE_ONTOLOGY_YAML.replace("type: timestamp", "type: datetime")
+    ont1 = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    ont2 = load_ontology_from_string(retyped)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+  def test_binding_fingerprint_reflects_target_dataset(self):
+    """A binding repointed at a different dataset must fingerprint
+    differently — the binding's identity includes its physical target.
+    """
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    bnd1 = load_binding_from_string(_SIMPLE_BINDING_YAML, ontology=ont)
+    bnd2 = load_binding_from_string(
+        _SIMPLE_BINDING_YAML.replace("dataset: finance", "dataset: staging"),
+        ontology=ont,
+    )
+    assert fingerprint_model(bnd1) != fingerprint_model(bnd2)
+
+  def test_ontology_and_binding_fingerprints_differ(self):
+    """Two different model types from the same source file namespace
+    must fingerprint to different values. (A trivial check, but it
+    catches implementations that fingerprint only on a shared subset
+    of fields.)
+    """
+    ont = load_ontology_from_string(_SIMPLE_ONTOLOGY_YAML)
+    bnd = load_binding_from_string(_SIMPLE_BINDING_YAML, ontology=ont)
+    assert fingerprint_model(ont) != fingerprint_model(bnd)
+
+  def test_list_order_is_semantic(self):
+    """Key columns are declaration-ordered in the ontology model;
+    reordering them is a semantic change. Fingerprint must reflect
+    that (lists are preserved in declaration order, not sorted).
+    """
+    multi_key_yaml = textwrap.dedent(
+        """\
+        ontology: finance
+        entities:
+          - name: Account
+            keys:
+              primary: [tenant_id, account_id]
+            properties:
+              - name: tenant_id
+                type: string
+              - name: account_id
+                type: string
+        """
+    )
+    reordered = textwrap.dedent(
+        """\
+        ontology: finance
+        entities:
+          - name: Account
+            keys:
+              primary: [account_id, tenant_id]
+            properties:
+              - name: tenant_id
+                type: string
+              - name: account_id
+                type: string
+        """
+    )
+    ont1 = load_ontology_from_string(multi_key_yaml)
+    ont2 = load_ontology_from_string(reordered)
+    assert fingerprint_model(ont1) != fingerprint_model(ont2)
+
+
+# ------------------------------------------------------------------ #
+# compile_fingerprint — canonical integrity key                       #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileFingerprint:
+  """Full 64-hex SHA-256 over the three compile inputs.
+
+  This is the canonical integrity key used by strict verification.
+  Must respond to every input independently and must be 64 hex chars.
+  """
+
+  def test_length_is_sixty_four_hex_chars(self):
+    fp = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+  def test_deterministic_for_same_inputs(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert fp1 == fp2
+
+  def test_changes_with_ontology_fingerprint(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:zz", "sha256:bb", "gm-1.0.0")
+    assert fp1 != fp2
+
+  def test_changes_with_binding_fingerprint(self):
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:zz", "gm-1.0.0")
+    assert fp1 != fp2
+
+  def test_changes_with_compiler_version(self):
+    """Compiler version changes must shift the fingerprint even when
+    both input fingerprints are unchanged — otherwise a semver bump
+    to the compiler with behavior changes would fail to invalidate
+    old meta.
+    """
+    fp1 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    fp2 = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.1.0")
+    assert fp1 != fp2
+
+  def test_golden_vector(self):
+    """Pinned byte-exact digest for a known input triple.
+
+    This catches silent payload-contract changes that would still
+    pass length/determinism/input-sensitivity tests — e.g. swapping
+    the NUL separator to another byte, changing the concatenation
+    order, or altering the UTF-8 encoding. A refactor that changes
+    the payload shape will flip this value and fail the test even
+    if all the behavioral properties still hold.
+
+    The payload is:
+
+        "sha256:aa" + "\\x00" + "sha256:bb" + "\\x00" + "gm-1.0.0"
+
+    encoded as UTF-8, hashed with SHA-256.
+    """
+    full = compile_fingerprint("sha256:aa", "sha256:bb", "gm-1.0.0")
+    short = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert (
+        full
+        == "dd301e2874a3bc55dd3ab6ea428ad1046f6b4834b4dccd7a87cf82a1991e0184"
+    )
+    assert short == "dd301e2874a3"
+
+
+# ------------------------------------------------------------------ #
+# compile_id — 12-hex display token, derived from compile_fingerprint #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileId:
+  """Short display/debug tag derived from ``compile_fingerprint``."""
+
+  def test_length_is_twelve_hex_chars(self):
+    cid = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert len(cid) == 12
+    assert all(c in "0123456789abcdef" for c in cid)
+
+  def test_deterministic_for_same_inputs(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert cid1 == cid2
+
+  def test_changes_with_ontology_fingerprint(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:zz", "sha256:bb", "gm-1.0.0")
+    assert cid1 != cid2
+
+  def test_changes_with_binding_fingerprint(self):
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:zz", "gm-1.0.0")
+    assert cid1 != cid2
+
+  def test_changes_with_compiler_version(self):
+    """Compiler version changes must shift the compile_id even when
+    both fingerprints are unchanged — otherwise a semver bump to the
+    compiler with behavior changes would fail to invalidate old meta.
+    """
+    cid1 = compile_id("sha256:aa", "sha256:bb", "gm-1.0.0")
+    cid2 = compile_id("sha256:aa", "sha256:bb", "gm-1.1.0")
+    assert cid1 != cid2
+
+
+# ------------------------------------------------------------------ #
+# Structural invariant: compile_id == compile_fingerprint[:12]        #
+# ------------------------------------------------------------------ #
+
+
+class TestCompileIdFingerprintInvariant:
+  """The short display token must be a structural truncation of the
+  full integrity key — never its own hash. This prevents the two
+  provenance columns in the concept index from drifting out of sync.
+
+  Pinned in the ``_fingerprint.py`` module docstring and in issue #58
+  (Option 2).
+  """
+
+  def test_compile_id_is_prefix_of_compile_fingerprint(self):
+    args = ("sha256:aa", "sha256:bb", "gm-1.0.0")
+    assert compile_id(*args) == compile_fingerprint(*args)[:12]
+
+  def test_invariant_holds_across_varied_inputs(self):
+    """Invariant must hold for any input triple, not just one case."""
+    cases = [
+        ("sha256:aa", "sha256:bb", "gm-1.0.0"),
+        ("sha256:ff0000", "sha256:0000ff", "gm-2.3.4"),
+        ("", "", ""),  # degenerate but deterministic
+        ("x" * 100, "y" * 100, "z" * 100),  # long inputs
+    ]
+    for args in cases:
+      assert (
+          compile_id(*args) == compile_fingerprint(*args)[:12]
+      ), f"invariant broken for {args}"
+
+  def test_compile_id_never_computes_its_own_hash(self):
+    """Regression guard: if someone re-implements ``compile_id`` to
+    hash a different payload (e.g. a subset of inputs, or a different
+    separator), the invariant breaks and this test catches it.
+    """
+    # Any change to the payload that preserves the relative ordering
+    # but alters the bytes would produce a different 12-hex prefix.
+    # Assert the derivation is pure truncation of compile_fingerprint.
+    args = ("sha256:a", "sha256:b", "v")
+    full = compile_fingerprint(*args)
+    short = compile_id(*args)
+    assert short == full[:12]
+    assert full.startswith(short)
+
+
+# ------------------------------------------------------------------ #
+# Public surface                                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestPrivateSurface:
+  """``_fingerprint`` is an internal module — not part of the package
+  API. Catch accidental re-export from ``bigquery_ontology/__init__.py``.
+  """
+
+  def test_not_exported_from_package_root(self):
+    import bigquery_ontology
+
+    assert not hasattr(bigquery_ontology, "fingerprint_model")
+    assert not hasattr(bigquery_ontology, "compile_id")
+    assert not hasattr(bigquery_ontology, "compile_fingerprint")
+
+  def test_importable_via_absolute_path(self):
+    """Both packages import via ``from bigquery_ontology._fingerprint
+    import ...``. Make sure that path continues to work.
+    """
+    from bigquery_ontology._fingerprint import compile_fingerprint as _cfp
+    from bigquery_ontology._fingerprint import compile_id as _cid
+    from bigquery_ontology._fingerprint import fingerprint_model as _fp
+
+    assert callable(_cfp)
+    assert callable(_cid)
+    assert callable(_fp)


### PR DESCRIPTION
## Summary

Closes Phase 1 of the concept-index + runtime entity-resolution work tracked in [#58](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/58). Squashed cherry-pick of five PRs that landed individually on the `haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork`:

- A1 (`_fingerprint.py`)
- A2 (`concept_index.py` row builder)
- A3-A5 (`compile_concept_index` emitter)
- A7 (CLI flags)
- A8 (user docs)

End-to-end after merge:

```bash
gm compile binding.yaml \
  --emit-concept-index \
  --concept-index-table proj.dataset.ontology_concept_index
```

emits the existing `CREATE PROPERTY GRAPH` DDL plus two atomic `CREATE OR REPLACE TABLE` statements (a main concept-index table and its `__meta` provenance sibling). Byte-identical SQL across runs. Without the new flag, `gm compile` output is byte-identical to today (regression-test pinned).

**Phase 1 ships SQL emission only.** The runtime consumer in `bigquery_agent_analytics` (`OntologyRuntime`, resolvers, strict verification) is Phase 2-3 follow-on work, not in this PR.

## What's in the diff

`+2859 / 0` across 12 files:

| File | Status |
|---|---|
| `src/bigquery_ontology/_fingerprint.py` | NEW (180 lines) — A1 |
| `src/bigquery_ontology/concept_index.py` | NEW (336 lines) — A2 |
| `src/bigquery_ontology/graph_ddl_compiler.py` | +301 lines — A3-A5 |
| `src/bigquery_ontology/__init__.py` | +2 lines (re-export `compile_concept_index`) |
| `src/bigquery_ontology/cli.py` | +116 lines — A7 |
| `tests/bigquery_ontology/test_fingerprint.py` | NEW (388 lines, 24 tests) |
| `tests/bigquery_ontology/test_concept_index.py` | NEW (550 lines, 21 tests) |
| `tests/bigquery_ontology/test_compile_concept_index.py` | NEW (473 lines, 31 tests) |
| `tests/bigquery_ontology/test_cli.py` | +182 lines (8 A7 tests) |
| `docs/ontology/concept-index.md` | NEW (277 lines) — A8 |
| `docs/ontology/cli.md` | +27 lines |
| `docs/ontology/compilation.md` | +27 lines |

## Behavior pinned

- **Byte-identical regression** — `gm compile` without the new flag matches today's output exactly.
- **Byte-deterministic concept-index SQL (D2)** — same `(ontology, binding, output_table, compiler_version)` produces byte-identical output across runs.
- **Scope rule (D3)** — abstract entities always included; concrete iff bound.
- **Multi-scheme (D4)** — denormalized cross-product; `DISTINCT entity_name` returns one per concept.
- **Notation as first-class row (D5)** — `label_kind='notation'` row plus per-row `notation` column.
- **GoogleSQL string escaping** — verified end-to-end against actual BigQuery: `'O\'Brien'` (single-quote → `\'`, **not** ANSI `''`), `'C:\\Users'` (backslash doubled), `'line1\nline2'` (control chars escaped), UTF-8 passthrough for non-ASCII.
- **Output-table validation** — three dot-separated `[A-Za-z0-9_-]+` segments; backticks rejected (the emitter adds them).
- **Required-flag enforcement** — `--emit-concept-index` without `--concept-index-table` exits 2 with a clear error; reverse case (orphan `--concept-index-table`) also rejected.
- **Provenance Option 2** — `compile_id` (12-hex display) and `compile_fingerprint` (64-hex integrity key) on every row of both tables. Structural invariant `compile_id == compile_fingerprint[:12]` enforced at the function boundary; pinned by a golden vector test.
- **Empty refused** — zero-row case raises `ValueError` rather than emit a typeless empty array.

## Test plan

- [x] `pytest tests/bigquery_ontology/test_fingerprint.py tests/bigquery_ontology/test_concept_index.py tests/bigquery_ontology/test_compile_concept_index.py tests/bigquery_ontology/test_cli.py` → 123 passed
- [x] `pytest tests/` → 2119 passed, 7 skipped, 0 failures
- [x] `bash autoformat.sh` → no diff remaining
- [x] **End-to-end against actual BigQuery** (test-project-0728-467323, 2026-04-26):
  - `bq query --dry_run` accepts the emitted SQL on simple + rich-SKOS ontologies
  - Real DDL execution: both tables created, all rows queryable
  - All six `label_kind` values round-trip; `@fr` annotations populate the `language` column; backslash + apostrophe literals round-trip; pair-consistency confirmed (`main.compile_fingerprint == meta.compile_fingerprint`)
  - Resolver SQL patterns from `concept-index.md` §8 (winning-label dedup, notation lookup, apostrophe-input resolution) all return the correct entity

## Compatibility

- `compile_graph` contract: **unchanged**, byte-identical regression test pins this.
- `gm compile` without `--emit-concept-index`: **byte-identical to today**.
- Public surface added: `compile_concept_index` (new function), `--emit-concept-index` / `--concept-index-table` / `--compiler-version` (new CLI flags). No removals or signature changes.
- `_fingerprint` and `concept_index` modules are not re-exported from `bigquery_ontology/__init__.py` — internal implementation detail.

## Out of scope (deferred)

- **A6 shadow-swap fallback** for >50K rows — Phase 3.
- **Phase 2 SDK consumer** (`OntologyRuntime`, resolvers, strict verification) — separate follow-on PRs.
- **Embedding-based fuzzy matching, live-agent resolver package** — RFC §12.

## Provenance

Per-PR review history is preserved on the fork:

- A1: [haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork#40](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/40)
- A2: [#41](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/41)
- A3-A5: [#43](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/43)
- A7: [#46](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/46)
- A8: [#47](https://github.com/haiyuan-eng-google/BigQuery-Agent-Analytics-SDK-fork/pull/47)

Notable findings resolved before squash (full discussion threads on the linked PRs):

- A2: `skos:topConceptOf` now unioned with `skos:inScheme`; duplicate label tuples deduped on the contract tuple.
- A3-A5: string-literal renderer is now GoogleSQL (`\'` for single quotes, **not** ANSI `''`); backslashes doubled; control chars escaped; output-table validator rejects pre-quoted backticks; Option 2 provenance split (`compile_id` display + `compile_fingerprint` integrity); golden vector test pins the byte-exact digest.
- A7: orphan `--concept-index-table` (without `--emit-concept-index`) now rejected to surface typos.
- A8: atomicity claim softened ("overwrites both tables atomically" was inaccurate — each `CREATE OR REPLACE` is atomic but the pair is not, which is exactly why `compile_fingerprint` exists); `OntologyRuntime` references reframed as future Phase 2/3; zero-row failure case stated precisely (abstract-only ontologies compile successfully).

Companion docs already on `main`: the RFC ([`docs/entity_resolution_primitives.md`](docs/entity_resolution_primitives.md), #73) and the in-repo plan ([`docs/implementation_plan_concept_index_runtime.md`](docs/implementation_plan_concept_index_runtime.md), #70 / #72 / #80) frame this work; the PR is the implementation those docs describe.
