### PR TITLE
demo: add richer decision-lineage graph dataset

### DIFF
--- a/examples/decision_lineage_demo/.gitignore
+++ b/examples/decision_lineage_demo/.gitignore
@@ -2,4 +2,5 @@
 .venv/
 bq_studio_queries.gql
 property_graph.gql
+rich_property_graph.gql
 __pycache__/

--- a/examples/decision_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
+++ b/examples/decision_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
@@ -45,8 +45,9 @@ The demo also assumes:
 3. You should see the property graph **`rich_agent_context_graph`** in
    the dataset listing. The canonical **`agent_context_graph`** and
    seven SDK backing tables are also present. The richer graph adds
-   presentation nodes for campaign runs, decision types, candidate
-   statuses, and rejection reasons.
+   ads-domain labels for campaign runs, agent steps, media entities,
+   planning decisions, decision options, option outcomes, and drop
+   reasons.
 
 > *Optional:* click the property graph itself — Studio shows the
 > schema in the details pane.
@@ -59,20 +60,20 @@ extraction landed on every layer of the graph.
 1. **+ Compose new query** in BigQuery Studio.
 2. Paste **block 1a** (CampaignRun count). **Run.** Expect 6
    campaign runs by default.
-3. Paste **block 1b** (TechNode count). **Run.** Expect a TechNode
+3. Paste **block 1b** (AgentStep count). **Run.** Expect an AgentStep
    count in the low hundreds — the live agent runs produced this
    many spans, deterministic given how many sessions ran.
-4. Paste **block 1c** (BizNode count). **Run.** Expect a positive
+4. Paste **block 1c** (MediaEntity count). **Run.** Expect a positive
    number; exact count varies with `AI.GENERATE`.
-5. Paste **block 1d** (DecisionPoint count). **Run.** Expect a
+5. Paste **block 1d** (PlanningDecision count). **Run.** Expect a
    non-zero count — typically several per session, so a few dozen
    total across 6 sessions. Some variance.
-6. Paste **block 1e** (CandidateNode count). **Run.** Expect
-   roughly 3 × the DecisionPoint count.
+6. Paste **block 1e** (DecisionOption count). **Run.** Expect
+   roughly 3 × the PlanningDecision count.
 7. Paste **blocks 1f → 1h**. **Run.** These count the richer
-   presentation labels: decision types, candidate statuses, and
-   rejection-reason nodes.
-8. Paste **block 1i** (DecisionPoints per session). **Run.** Expect
+   presentation labels: decision categories, option outcomes, and
+   drop-reason nodes.
+8. Paste **block 1i** (PlanningDecisions per session). **Run.** Expect
    one row per session that actually produced decisions, with the
    per-session decision count in the right column. Note the session
    ids — Block 2 visualizes one of them (the first by default; you
@@ -95,13 +96,13 @@ an interactive diagram.
 4. After the query completes, click the **Graph** tab in the
    results pane (next to **Table**, **JSON**, **Execution details**).
 5. The result renders as one fan-out per extracted decision in the
-   chosen session — CampaignRun → DecisionPoint → CandidateNode →
-   CandidateStatus.
-6. Click any **CandidateNode**. The right-hand properties pane
+   chosen session — CampaignRun → PlanningDecision → DecisionOption
+   → OptionOutcome.
+6. Click any **DecisionOption**. The right-hand properties pane
    shows `name`, `score`, `status`, and `rejection_rationale`.
    Click a DROPPED candidate to surface the rationale.
 7. Optionally run the second Block 2 query to show the
-   CandidateNode → RejectionReason fan-out. It keeps the main graph
+   DecisionOption → DropReason fan-out. It keeps the main graph
    readable but gives reviewers a visible "why rejected" node when
    needed.
 8. To visualize a different campaign run instead, swap the
@@ -122,7 +123,7 @@ The same GQL the SDK ships as `mgr.get_eu_audit_gql(session_id=...)`.
 3. Studio shows a tabular result: one row per (decision, candidate)
    the SDK extracted for the session, with `decision_type`,
    `candidate_name`, `candidate_score`, `candidate_status`,
-   `rejection_rationale`, and the linked TechNode span info.
+   `rejection_rationale`, and the linked AgentStep span info.
 4. Walk the room through the table from top to bottom. Roughly
    two-thirds of rows are DROPPED (the agent's prompt asked for
    one SELECTED + two DROPPED per decision, so each decision row

--- a/examples/decision_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
+++ b/examples/decision_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
@@ -21,7 +21,9 @@ Setup:
 2. Calls `mgr.build_context_graph(...)` across every session in
    `agent_events` (two `AI.GENERATE` calls — biz nodes, then
    decisions, ~30-90s).
-3. Renders `bq_studio_queries.gql` next to this file with your
+3. Builds `rich_agent_context_graph`, a SQL-only presentation graph
+   over the canonical SDK tables.
+4. Renders `bq_studio_queries.gql` next to this file with your
    project / dataset / first-session id inlined.
 
 The demo also assumes:
@@ -39,33 +41,38 @@ The demo also assumes:
 1. In a browser, open
    `https://console.cloud.google.com/bigquery?project=<YOUR_PROJECT_ID>`.
 2. In the **Explorer** pane on the left, expand the
-   `decision_lineage_demo` dataset.
-3. You should see the property graph **`agent_context_graph`** in
-   the dataset listing alongside seven backing tables
-   (`agent_events`, `extracted_biz_nodes`, `context_cross_links`,
-   `decision_points`, `candidates`, `made_decision_edges`,
-   `candidate_edges`).
+   `decision_lineage_rich_demo` dataset.
+3. You should see the property graph **`rich_agent_context_graph`** in
+   the dataset listing. The canonical **`agent_context_graph`** and
+   seven SDK backing tables are also present. The richer graph adds
+   presentation nodes for campaign runs, decision types, candidate
+   statuses, and rejection reasons.
 
 > *Optional:* click the property graph itself — Studio shows the
 > schema in the details pane.
 
 ## Step 1 — Confirm the SDK populated the graph (~45s)
 
-Run blocks 1a → 1e from `bq_studio_queries.gql` to confirm the
+Run blocks 1a → 1i from `bq_studio_queries.gql` to confirm the
 extraction landed on every layer of the graph.
 
 1. **+ Compose new query** in BigQuery Studio.
-2. Paste **block 1a** (TechNode count). **Run.** Expect a TechNode
+2. Paste **block 1a** (CampaignRun count). **Run.** Expect 6
+   campaign runs by default.
+3. Paste **block 1b** (TechNode count). **Run.** Expect a TechNode
    count in the low hundreds — the live agent runs produced this
    many spans, deterministic given how many sessions ran.
-3. Paste **block 1b** (BizNode count). **Run.** Expect a positive
+4. Paste **block 1c** (BizNode count). **Run.** Expect a positive
    number; exact count varies with `AI.GENERATE`.
-4. Paste **block 1c** (DecisionPoint count). **Run.** Expect a
+5. Paste **block 1d** (DecisionPoint count). **Run.** Expect a
    non-zero count — typically several per session, so a few dozen
    total across 6 sessions. Some variance.
-5. Paste **block 1d** (CandidateNode count). **Run.** Expect
+6. Paste **block 1e** (CandidateNode count). **Run.** Expect
    roughly 3 × the DecisionPoint count.
-6. Paste **block 1e** (DecisionPoints per session). **Run.** Expect
+7. Paste **blocks 1f → 1h**. **Run.** These count the richer
+   presentation labels: decision types, candidate statuses, and
+   rejection-reason nodes.
+8. Paste **block 1i** (DecisionPoints per session). **Run.** Expect
    one row per session that actually produced decisions, with the
    per-session decision count in the right column. Note the session
    ids — Block 2 visualizes one of them (the first by default; you
@@ -73,7 +80,7 @@ extraction landed on every layer of the graph.
 
 > Talk track: "Setup ran the live agent against six campaign briefs
 > — every span the BQ AA Plugin wrote is here, the SDK extracted
-> decisions and candidates from each session, and Block 1e shows
+> decisions and candidates from each session, and Block 1i shows
 > how many decisions came out of each campaign run."
 
 ## Step 2 — Visualize ONE session (~75s)
@@ -88,12 +95,17 @@ an interactive diagram.
 4. After the query completes, click the **Graph** tab in the
    results pane (next to **Table**, **JSON**, **Execution details**).
 5. The result renders as one fan-out per extracted decision in the
-   chosen session — TechNode → DecisionPoint → CandidateNodes.
+   chosen session — CampaignRun → DecisionPoint → CandidateNode →
+   CandidateStatus.
 6. Click any **CandidateNode**. The right-hand properties pane
    shows `name`, `score`, `status`, and `rejection_rationale`.
    Click a DROPPED candidate to surface the rationale.
-7. To visualize a different campaign run instead, swap the
-   `__SESSION_ID__` value in Block 2 with any other id Block 1e
+7. Optionally run the second Block 2 query to show the
+   CandidateNode → RejectionReason fan-out. It keeps the main graph
+   readable but gives reviewers a visible "why rejected" node when
+   needed.
+8. To visualize a different campaign run instead, swap the
+   `__SESSION_ID__` value in Block 2 with any other id Block 1i
    returned and re-run.
 
 > Talk track: "Each fan-out is one decision. Selected and dropped
@@ -147,7 +159,7 @@ explanation, bias audit, human-oversight trigger, decision
 reproducibility, and systemic-pattern audit.
 
 1. Open the **Gemini / Conversational Analytics** panel in BQ
-   Studio with the `decision_lineage_demo` dataset selected.
+   Studio with the `decision_lineage_rich_demo` dataset selected.
 2. Open [`DEMO_QUESTIONS.md`](DEMO_QUESTIONS.md) in a side editor.
 3. For each Q1-Q5, paste the natural-language prompt into BQ CA,
    run, then paste the explicit GQL into a query tab and compare.
@@ -158,11 +170,11 @@ reproducibility, and systemic-pattern audit.
 
 | Symptom | Fix |
 |---|---|
-| Block 1c (decisions) returns 0 | `AI.GENERATE` returned no decisions; re-run `./.venv/bin/python3 build_graph.py` (no need to re-run the agent) |
-| Block 1c is much smaller than 5 × session count | Some sessions had few extracted decisions; either accept it (the talk track is count-agnostic) or re-run `build_graph.py` |
+| Block 1d (decisions) returns 0 | `AI.GENERATE` returned no decisions; re-run `./.venv/bin/python3 build_graph.py` and then `./.venv/bin/python3 build_rich_graph.py` (no need to re-run the agent) |
+| Block 1d is much smaller than 5 × session count | Some sessions had few extracted decisions; either accept it (the talk track is count-agnostic) or re-run `build_graph.py` and then `build_rich_graph.py` |
 | Block 2 shows no Graph tab | Make sure the result rendered; the tab takes a second to appear after the first run |
-| Block 2 has nothing to draw | The `__SESSION_ID__` baked in by `setup.sh` may not have produced decisions — swap with a different session id from Block 1e |
-| "Property graph not found" | `setup.sh` did not finish; check that `build_graph.py` printed `property_graph_created True` |
+| Block 2 has nothing to draw | The `__SESSION_ID__` baked in by `setup.sh` may not have produced decisions — swap with a different session id from Block 1i |
+| "Property graph not found" | `setup.sh` did not finish; check that `build_graph.py` printed `property_graph_created True`, then rerun `./.venv/bin/python3 build_rich_graph.py` |
 | `run_agent.py` fails with permission errors | Missing `roles/aiplatform.user` on the running identity (the live agent calls Vertex AI) |
 | `agent_events` table is empty after `run_agent.py` | The plugin may not have flushed; re-run `./.venv/bin/python3 run_agent.py` and verify the script's "Flushing BQ AA Plugin..." line completes without warnings |
 

--- a/examples/decision_lineage_demo/DATA_LINEAGE.md
+++ b/examples/decision_lineage_demo/DATA_LINEAGE.md
@@ -1,8 +1,8 @@
-# Data Lineage — how the seven tables produce the property graph
+# Data Lineage — how the demo tables produce the rich graph
 
 A step-by-step map of how the demo's BigQuery dataset is built and
-how every node label / edge label in `agent_context_graph` traces
-back to a specific table and writer.
+how every node label / edge label in `rich_agent_context_graph`
+traces back to a specific table and writer.
 
 Useful for: explaining the architecture to leadership, onboarding
 someone running setup for the first time, or proving to a reviewer
@@ -10,7 +10,14 @@ exactly where any given graph element comes from.
 
 ---
 
-## Step 1 — Three writers populate seven tables
+The SDK first builds the canonical `agent_context_graph` from seven
+SDK tables. The demo then adds SQL-only projection tables and creates
+`rich_agent_context_graph`, the graph presenters open in BigQuery
+Studio.
+
+---
+
+## Step 1 — Three writers populate the seven SDK tables
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
@@ -103,11 +110,30 @@ Once the node tables are populated:
       `SELECTED_CANDIDATE` or `DROPPED_CANDIDATE` and the
       `rejection_rationale` carried on the edge).
 
+### 1e. `build_rich_graph.py` — SQL-only presentation layer
+
+After the SDK tables exist, `build_rich_graph.py` creates demo-only
+projection tables:
+
+  * `campaign_runs` — one row per session, joined to the campaign
+    metadata in `campaigns.py`.
+  * `rich_decision_types` — one row per normalized decision type.
+  * `rich_candidate_statuses` — normally `SELECTED` and `DROPPED`.
+  * `rich_rejection_reasons` — one row per distinct dropped-candidate
+    rationale.
+  * `rich_campaign_span_edges`, `rich_campaign_decision_edges`,
+    `rich_decision_type_edges`, `rich_candidate_status_edges`, and
+    `rich_candidate_reason_edges` — edges from those presentation
+    nodes back to the SDK-owned facts.
+
+No live agent call and no `AI.GENERATE` call happens in this step.
+It is deterministic SQL plus one load job for `campaign_runs`.
+
 ---
 
-## Step 2 — `CREATE OR REPLACE PROPERTY GRAPH` wires the tables into eight graph elements
+## Step 2 — Property graph DDL wires tables into two graph surfaces
 
-The complete contract from `property_graph.gql.tpl`:
+The SDK-shaped graph from `property_graph.gql.tpl` is compact:
 
 ```
 CREATE OR REPLACE PROPERTY GRAPH agent_context_graph
@@ -146,6 +172,21 @@ populate both a node label and an edge label.
 | **MadeDecision** | `made_decision_edges` | `span_id` → `decision_id` | which span produced which decision |
 | **CandidateEdge** | `candidate_edges` | `decision_id` → `candidate_id` | which candidates the decision weighed (with `edge_type` SELECTED/DROPPED + rationale on the edge) |
 
+The richer demo graph from `rich_property_graph.gql.tpl` keeps all
+of those labels and adds presentation labels:
+
+| Rich graph element | Comes from table | KEY column | Why it exists in the demo |
+|---|---|---|---|
+| **CampaignRun** | `campaign_runs` | `session_id` | Makes each campaign run visible as the root of a graph visualization |
+| **DecisionType** | `rich_decision_types` | `decision_type_id` | Groups equivalent decision categories for portfolio questions |
+| **CandidateStatus** | `rich_candidate_statuses` | `status_id` | Promotes SELECTED / DROPPED from a property into visible graph nodes |
+| **RejectionReason** | `rich_rejection_reasons` | `reason_id` | Promotes dropped-candidate rationale into visible "why rejected" nodes |
+| **CampaignSpan** | `rich_campaign_span_edges` | `session_id` → `span_id` | Connects a campaign run to its raw plugin spans |
+| **CampaignDecision** | `rich_campaign_decision_edges` | `session_id` → `decision_id` | Connects a campaign run directly to extracted decisions |
+| **HasDecisionType** | `rich_decision_type_edges` | `decision_id` → `decision_type_id` | Connects each decision to its normalized type |
+| **HasCandidateStatus** | `rich_candidate_status_edges` | `candidate_id` → `status_id` | Connects each candidate to SELECTED or DROPPED |
+| **RejectedBecause** | `rich_candidate_reason_edges` | `candidate_id` → `reason_id` | Connects dropped candidates to rationale nodes |
+
 ---
 
 ## Step 3 — Worked example: how Block 2 (the visualization GQL) traverses these
@@ -153,28 +194,33 @@ populate both a node label and an edge label.
 Block 2 from `bq_studio_queries.gql`:
 
 ```sql
-GRAPH `<P>.<D>.agent_context_graph`
+GRAPH `<P>.<D>.rich_agent_context_graph`
 MATCH p =
-  (s:TechNode)-[:MadeDecision]->(dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-WHERE dp.session_id = '<SESSION_ID>'
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
+    -[:CandidateEdge]->(c:CandidateNode)-[:HasCandidateStatus]->(st:CandidateStatus)
+WHERE cr.session_id = '<SESSION_ID>'
 RETURN p;
 ```
 
 What the engine does, table by table:
 
-  1. **TechNode binding** — scans `agent_events` for spans whose
-     `span_id` exists in `made_decision_edges.span_id`. (162 →
-     ~5 rows for one session.)
-  2. **MadeDecision edge** — joins `made_decision_edges` on
-     `span_id`. Each match produces one TechNode → DecisionPoint
-     pair.
+  1. **CampaignRun binding** — scans `campaign_runs` for the selected
+     `session_id`.
+  2. **CampaignDecision edge** — joins
+     `rich_campaign_decision_edges` on `session_id`; each edge points
+     at one extracted decision.
   3. **DecisionPoint binding** — joins `decision_points` on
-     `decision_id` and filters where `session_id = '<SESSION_ID>'`.
+     `decision_id`.
   4. **CandidateEdge edge** — joins `candidate_edges` on
-     `decision_id`. Each decision fans out to its candidate edges.
+     `decision_id`; each decision fans out to its selected and
+     dropped candidates.
   5. **CandidateNode binding** — joins `candidates` on
-     `candidate_id`. The terminal node of each path.
-  6. **Result** — paths bound to `p` with all four columns.
+     `candidate_id`.
+  6. **HasCandidateStatus edge** — joins
+     `rich_candidate_status_edges` so SELECTED / DROPPED appear as
+     graph nodes, not just properties.
+  7. **Result** — paths bound to `p` with campaign, decision,
+     candidate, and status nodes.
      BigQuery Studio's **Graph** tab renders these as fan-outs
      (one per decision) of branches (one per candidate), with
      `edge_type` and node properties available in the click-through
@@ -186,27 +232,31 @@ What the engine does, table by table:
 
 | Question ([`DEMO_QUESTIONS.md`](DEMO_QUESTIONS.md)) | Tables touched | Why |
 |---|---|---|
-| **Q1** Right to explanation for one campaign | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` | Per-decision, walks edges to surface SELECTED + DROPPED + rationale |
-| **Q2** Bias audit (rationales citing age / demo) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` | LIKE-filter on `candidates.rejection_rationale` (extracted from the LLM trace text by AI.GENERATE; exact wording can vary across runs — see [`README.md`](README.md)) |
-| **Q3** Human-oversight trigger (score < 0.7) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` | Filter on `candidates.score`; empty result is the audit artifact |
-| **Q4** Reproducibility (one decision's full lineage) | `agent_events` ⋈ `made_decision_edges` ⋈ `decision_points` ⋈ `candidate_edges` ⋈ `candidates` | Walks from TechNode through MadeDecision and CandidateEdge back to the evidence span (`Caused` and `Evaluated` are reachable but not used in the shipped Q4 GQL) |
-| **Q5** Pattern audit (rejection counts by type) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` | `GROUP BY decision_type` with `COUNT(c)` + `AVG(c.score)` |
+| **Q1** Right to explanation for one campaign | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ `rich_candidate_status_edges` ⋈ `rich_candidate_statuses` | Per-decision, walks edges to surface SELECTED + DROPPED + rationale |
+| **Q2** Bias audit (rationales citing age / demo) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | LIKE-filter on `candidates.rejection_rationale` (extracted from the LLM trace text by AI.GENERATE; exact wording can vary across runs — see [`README.md`](README.md)) |
+| **Q3** Human-oversight trigger (score < 0.7) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | Filter on selected candidates with `score < 0.7`; empty result is the audit artifact |
+| **Q4** Reproducibility (one decision's full lineage) | `campaign_runs` ⋈ `decision_points` plus `agent_events` ⋈ `made_decision_edges` ⋈ `candidate_edges` ⋈ `candidates` | Walks from CampaignRun and TechNode through the decision and candidates back to the evidence span (`Caused` and `Evaluated` are reachable but not used in the shipped Q4 GQL) |
+| **Q5** Pattern audit (rejection counts by type) | `decision_points` ⋈ `rich_decision_type_edges` ⋈ `rich_decision_types` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | `GROUP BY DecisionType` with `COUNT(c)` + `AVG(c.score)` |
 
 Every regulator-shaped question is a walk over a fixed subset of
-the seven tables, expressed as GQL against the eight graph
-elements — no bespoke ETL, no per-question table writes, no new
-tables to maintain. **The seven tables are the audit substrate;
-the property graph is a query view over them.**
+the SDK tables plus deterministic rich projections, expressed as GQL
+against graph labels — no bespoke ETL and no per-question table
+writes. **The seven SDK tables are the audit substrate; the rich
+property graph is the presenter-friendly query view over them.**
 
 ---
 
 ## Step 5 — Recreate the graph from existing tables
 
-If the seven backing tables are already populated (a previous
+If the seven SDK backing tables are already populated (a previous
 setup run, a clone of someone else's dataset, or a manual
 INSERT-from-SELECT into a new project) and you just need the
 graph layer, `property_graph.gql.tpl` is a standalone `CREATE OR
 REPLACE PROPERTY GRAPH` you apply with one `bq query` against the
 existing tables. `setup.sh` renders it next to
-`bq_studio_queries.gql`. See [`SETUP_NEW_PROJECT.md`](SETUP_NEW_PROJECT.md)
+`bq_studio_queries.gql`.
+
+For the richer graph, run `build_rich_graph.py` first so the
+derived tables exist, then apply `rich_property_graph.gql`. See
+[`SETUP_NEW_PROJECT.md`](SETUP_NEW_PROJECT.md)
 → "Recreate the property graph from existing tables".

--- a/examples/decision_lineage_demo/DATA_LINEAGE.md
+++ b/examples/decision_lineage_demo/DATA_LINEAGE.md
@@ -110,13 +110,25 @@ Once the node tables are populated:
       `SELECTED_CANDIDATE` or `DROPPED_CANDIDATE` and the
       `rejection_rationale` carried on the edge).
 
-### 1e. `build_rich_graph.py` — SQL-only presentation layer
+### 1e. `campaign_runs` — exact campaign/session mapping
+
+`run_agent.py` writes `campaign_runs` after all six sessions finish
+successfully. This avoids relying on timestamp order to infer which
+session belonged to which campaign. Each row stores the exact
+`session_id`, campaign name, brand, full campaign brief, run order,
+and streamed event count.
+
+### 1f. `build_rich_graph.py` — SQL-only presentation layer
 
 After the SDK tables exist, `build_rich_graph.py` creates demo-only
 projection tables:
 
-  * `campaign_runs` — one row per session, joined to the campaign
-    metadata in `campaigns.py`.
+  * `campaign_runs` — reused from `run_agent.py` when present;
+    synthesized only as a fallback for legacy or cloned datasets.
+  * `rich_agent_steps` — one row per distinct `span_id`, deduped from
+    `agent_events` so the rich graph's AgentStep / NextStep labels
+    satisfy BigQuery's KEY contract even when the raw plugin table has
+    duplicate span rows.
   * `rich_decision_types` — one row per normalized decision type.
   * `rich_candidate_statuses` — normally `SELECTED` and `DROPPED`.
   * `rich_rejection_reasons` — one row per distinct dropped-candidate
@@ -127,7 +139,8 @@ projection tables:
     nodes back to the SDK-owned facts.
 
 No live agent call and no `AI.GENERATE` call happens in this step.
-It is deterministic SQL plus one load job for `campaign_runs`.
+It is deterministic SQL, plus a fallback load job for `campaign_runs`
+only when `run_agent.py` did not already write that table.
 
 ---
 
@@ -172,20 +185,29 @@ populate both a node label and an edge label.
 | **MadeDecision** | `made_decision_edges` | `span_id` → `decision_id` | which span produced which decision |
 | **CandidateEdge** | `candidate_edges` | `decision_id` → `candidate_id` | which candidates the decision weighed (with `edge_type` SELECTED/DROPPED + rationale on the edge) |
 
-The richer demo graph from `rich_property_graph.gql.tpl` keeps all
-of those labels and adds presentation labels:
+The richer demo graph from `rich_property_graph.gql.tpl` keeps the
+same underlying tables but uses ads-domain labels for the presenter
+surface:
 
 | Rich graph element | Comes from table | KEY column | Why it exists in the demo |
 |---|---|---|---|
 | **CampaignRun** | `campaign_runs` | `session_id` | Makes each campaign run visible as the root of a graph visualization |
-| **DecisionType** | `rich_decision_types` | `decision_type_id` | Groups equivalent decision categories for portfolio questions |
-| **CandidateStatus** | `rich_candidate_statuses` | `status_id` | Promotes SELECTED / DROPPED from a property into visible graph nodes |
-| **RejectionReason** | `rich_rejection_reasons` | `reason_id` | Promotes dropped-candidate rationale into visible "why rejected" nodes |
-| **CampaignSpan** | `rich_campaign_span_edges` | `session_id` → `span_id` | Connects a campaign run to its raw plugin spans |
+| **AgentStep** | `rich_agent_steps` | `span_id` | Business-readable, key-clean name for a plugin-recorded span |
+| **MediaEntity** | `extracted_biz_nodes` | `biz_node_id` | Audience, channel, creative, budget, or other media-planning entity |
+| **PlanningDecision** | `decision_points` | `decision_id` | One choice the agent made during campaign planning |
+| **DecisionCategory** | `rich_decision_types` | `decision_type_id` | Groups equivalent decision categories for portfolio questions |
+| **DecisionOption** | `candidates` | `candidate_id` | One option the agent selected or dropped |
+| **OptionOutcome** | `rich_candidate_statuses` | `status_id` | Promotes SELECTED / DROPPED from a property into visible graph nodes |
+| **DropReason** | `rich_rejection_reasons` | `reason_id` | Promotes dropped-option rationale into visible "why rejected" nodes |
+| **CampaignActivity** | `rich_campaign_span_edges` | `session_id` → `span_id` | Connects a campaign run to its raw plugin spans |
+| **NextStep** | `rich_agent_steps` | `parent_span_id` → `span_id` | Parent → child sequence in the agent run |
+| **ConsideredEntity** | `context_cross_links` | `span_id` → `biz_node_id` | Which agent step produced or considered which media entity |
+| **DecidedAt** | `made_decision_edges` | `span_id` → `decision_id` | Span where the planning decision committed |
 | **CampaignDecision** | `rich_campaign_decision_edges` | `session_id` → `decision_id` | Connects a campaign run directly to extracted decisions |
-| **HasDecisionType** | `rich_decision_type_edges` | `decision_id` → `decision_type_id` | Connects each decision to its normalized type |
-| **HasCandidateStatus** | `rich_candidate_status_edges` | `candidate_id` → `status_id` | Connects each candidate to SELECTED or DROPPED |
-| **RejectedBecause** | `rich_candidate_reason_edges` | `candidate_id` → `reason_id` | Connects dropped candidates to rationale nodes |
+| **InCategory** | `rich_decision_type_edges` | `decision_id` → `decision_type_id` | Connects each decision to its normalized category |
+| **WeighedOption** | `candidate_edges` | `decision_id` → `candidate_id` | Connects each planning decision to the options it weighed |
+| **HasOutcome** | `rich_candidate_status_edges` | `candidate_id` → `status_id` | Connects each option to SELECTED or DROPPED |
+| **RejectedBecause** | `rich_candidate_reason_edges` | `candidate_id` → `reason_id` | Connects dropped options to rationale nodes |
 
 ---
 
@@ -196,8 +218,8 @@ Block 2 from `bq_studio_queries.gql`:
 ```sql
 GRAPH `<P>.<D>.rich_agent_context_graph`
 MATCH p =
-  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
-    -[:CandidateEdge]->(c:CandidateNode)-[:HasCandidateStatus]->(st:CandidateStatus)
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:PlanningDecision)
+    -[:WeighedOption]->(c:DecisionOption)-[:HasOutcome]->(st:OptionOutcome)
 WHERE cr.session_id = '<SESSION_ID>'
 RETURN p;
 ```
@@ -209,14 +231,14 @@ What the engine does, table by table:
   2. **CampaignDecision edge** — joins
      `rich_campaign_decision_edges` on `session_id`; each edge points
      at one extracted decision.
-  3. **DecisionPoint binding** — joins `decision_points` on
+  3. **PlanningDecision binding** — joins `decision_points` on
      `decision_id`.
-  4. **CandidateEdge edge** — joins `candidate_edges` on
+  4. **WeighedOption edge** — joins `candidate_edges` on
      `decision_id`; each decision fans out to its selected and
      dropped candidates.
-  5. **CandidateNode binding** — joins `candidates` on
+  5. **DecisionOption binding** — joins `candidates` on
      `candidate_id`.
-  6. **HasCandidateStatus edge** — joins
+  6. **HasOutcome edge** — joins
      `rich_candidate_status_edges` so SELECTED / DROPPED appear as
      graph nodes, not just properties.
   7. **Result** — paths bound to `p` with campaign, decision,
@@ -235,8 +257,8 @@ What the engine does, table by table:
 | **Q1** Right to explanation for one campaign | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ `rich_candidate_status_edges` ⋈ `rich_candidate_statuses` | Per-decision, walks edges to surface SELECTED + DROPPED + rationale |
 | **Q2** Bias audit (rationales citing age / demo) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | LIKE-filter on `candidates.rejection_rationale` (extracted from the LLM trace text by AI.GENERATE; exact wording can vary across runs — see [`README.md`](README.md)) |
 | **Q3** Human-oversight trigger (score < 0.7) | `decision_points` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | Filter on selected candidates with `score < 0.7`; empty result is the audit artifact |
-| **Q4** Reproducibility (one decision's full lineage) | `campaign_runs` ⋈ `decision_points` plus `agent_events` ⋈ `made_decision_edges` ⋈ `candidate_edges` ⋈ `candidates` | Walks from CampaignRun and TechNode through the decision and candidates back to the evidence span (`Caused` and `Evaluated` are reachable but not used in the shipped Q4 GQL) |
-| **Q5** Pattern audit (rejection counts by type) | `decision_points` ⋈ `rich_decision_type_edges` ⋈ `rich_decision_types` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | `GROUP BY DecisionType` with `COUNT(c)` + `AVG(c.score)` |
+| **Q4** Reproducibility (one decision's full lineage) | `campaign_runs` ⋈ `decision_points` plus `agent_events` ⋈ `made_decision_edges` ⋈ `candidate_edges` ⋈ `candidates` | Walks from CampaignRun and AgentStep through the decision and options back to the evidence span (`NextStep` and `ConsideredEntity` are reachable but not used in the shipped Q4 GQL) |
+| **Q5** Pattern audit (rejection counts by type) | `decision_points` ⋈ `rich_decision_type_edges` ⋈ `rich_decision_types` ⋈ `candidate_edges` ⋈ `candidates` ⋈ status tables | `GROUP BY DecisionCategory` with `COUNT(c)` + `AVG(c.score)` |
 
 Every regulator-shaped question is a walk over a fixed subset of
 the SDK tables plus deterministic rich projections, expressed as GQL

--- a/examples/decision_lineage_demo/DEMO_NARRATION.md
+++ b/examples/decision_lineage_demo/DEMO_NARRATION.md
@@ -87,10 +87,12 @@ open DEMO_QUESTIONS.md
 > The SDK's canonical graph is intentionally compact: spans,
 > business entities, decisions, candidates, and the edges between
 > them. For this demo, we add a SQL-only presentation graph on top:
-> CampaignRun, DecisionType, CandidateStatus, and RejectionReason
-> become visible nodes. That richer graph is what makes the BigQuery
-> Studio picture readable without changing the underlying audit
-> data."
+> CampaignRun, PlanningDecision, DecisionOption, OptionOutcome, and
+> DropReason become visible nodes. The edge labels read like the
+> business story too: the campaign has decisions, each decision
+> weighed options, and each option has an outcome. That richer graph
+> is what makes the BigQuery Studio picture readable without changing
+> the underlying audit data."
 
 **[Open BigQuery Studio. Run Block 2 from `bq_studio_queries.gql`.
 Click the Graph tab.]**

--- a/examples/decision_lineage_demo/DEMO_NARRATION.md
+++ b/examples/decision_lineage_demo/DEMO_NARRATION.md
@@ -26,9 +26,10 @@ cd examples/decision_lineage_demo
 ```
 
 This runs the live ADK agent against six campaign briefs, has the
-SDK extract decisions from the resulting traces, and renders the
-GQL bundle. ~5-10 minutes total. See **README.md → Setup** for
-prerequisites and override env vars.
+SDK extract decisions from the resulting traces, builds the richer
+demo presentation graph, and renders the GQL bundle. ~5-10 minutes
+total. See **README.md → Setup** for prerequisites and override env
+vars.
 
 When setup finishes, confirm:
 
@@ -81,20 +82,26 @@ open DEMO_QUESTIONS.md
 > agent produced. Twenty-seven events per session, one-sixty-two
 > total. Then a single `AI.GENERATE` call extracted the decisions
 > the agent made and every alternative it considered, with the
-> rejection rationale on each dropped option. Every node in the
-> graph you're about to see traces back to a real plugin-written
-> span."
+> rejection rationale on each dropped option.
+>
+> The SDK's canonical graph is intentionally compact: spans,
+> business entities, decisions, candidates, and the edges between
+> them. For this demo, we add a SQL-only presentation graph on top:
+> CampaignRun, DecisionType, CandidateStatus, and RejectionReason
+> become visible nodes. That richer graph is what makes the BigQuery
+> Studio picture readable without changing the underlying audit
+> data."
 
 **[Open BigQuery Studio. Run Block 2 from `bq_studio_queries.gql`.
 Click the Graph tab.]**
 
-> "This is one campaign visualized. Five fan-outs — one per
-> decision the agent made. Center of each fan-out is the decision.
-> Right side is every option the agent weighed: green for selected,
-> red for dropped, the dropped ones carrying the agent's rejection
-> reasoning right on the node properties. **This is the audit
-> surface.** From here, every regulator question we ask becomes a
-> graph traversal."
+> "This is one campaign visualized. One fan-out per extracted
+> decision. The run is on the left, the decisions are in the middle,
+> every option the agent weighed is on the right, and selected versus
+> dropped is visible as its own status node. If we run the optional
+> rationale fan-out, every dropped option links to the extracted
+> rejection reason. **This is the audit surface.** From here, every
+> regulator question we ask becomes a graph traversal."
 
 ---
 
@@ -219,7 +226,7 @@ Analytics panel and the natural-language prompt — your choice).
 
 | If they ask | Short answer |
 |---|---|
-| "How long to deploy this?" | The plugin is already on our agent path. The SDK pipeline is `mgr.build_context_graph(...)` — one method. The DDL is committed; CI runs it. We're talking days, not quarters. |
+| "How long to deploy this?" | The plugin is already on our agent path. The SDK pipeline is `mgr.build_context_graph(...)` — one method. The richer demo graph is SQL-only projection DDL over those outputs. We're talking days, not quarters. |
 | "What about agents we haven't instrumented yet?" | Same plugin, same plug-in point. The graph schema doesn't care which agent wrote the spans, only that the BQ AA Plugin wrote them. |
 | "Cost?" | Two `AI.GENERATE` calls per build run, plus standard BQ query cost. A handful of cents per build for our scale. |
 | "What happens when AI.GENERATE misses a decision?" | The build script reports per-session counts. If a session is thin we re-run extraction (no need to re-run the agent — traces are already in `agent_events`). The narration is count-agnostic for exactly this reason. |

--- a/examples/decision_lineage_demo/DEMO_QUESTIONS.md
+++ b/examples/decision_lineage_demo/DEMO_QUESTIONS.md
@@ -1,7 +1,7 @@
 # EU-Compliance Demo Questions
 
 Five business-shaped questions you can run against
-`<PROJECT_ID>.decision_lineage_demo.agent_context_graph` to demonstrate
+`<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph` to demonstrate
 the property graph as an audit surface for the **EU AI Act**, **GDPR
 Art. 22** (automated decision-making), and **DSA Art. 26**
 (advertising transparency).
@@ -28,8 +28,14 @@ Each question is paired with:
 Replace `<PROJECT_ID>` with your project (or copy the rendered
 queries straight out of [`bq_studio_queries.gql`](bq_studio_queries.gql)
 after `./setup.sh`). Session ids vary per run — list yours with
-Block 1e from `bq_studio_queries.gql` or from the `build_graph.py`
+Block 1i from `bq_studio_queries.gql` or from the `build_graph.py`
 output.
+
+The queries below target the richer demo graph. It keeps the SDK's
+canonical labels (`TechNode`, `BizNode`, `DecisionPoint`,
+`CandidateNode`) and adds presentation labels (`CampaignRun`,
+`DecisionType`, `CandidateStatus`, `RejectionReason`) so the same
+audit facts are easier to visualize and narrate in BigQuery Studio.
 
 ---
 
@@ -42,20 +48,21 @@ output.
 
 **BQ Conversational Analytics:**
 
-> "For session `<SESSION_ID>` in the agent_context_graph, show
+> "For session `<SESSION_ID>` in the rich_agent_context_graph, show
 > every audience-selection decision: the SELECTED audience, every
 > alternative DROPPED, and the rejection rationale on each."
 
 **GQL:**
 
 ```sql
-GRAPH `<PROJECT_ID>.decision_lineage_demo.agent_context_graph`
+GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
 MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
+      -[:HasCandidateStatus]->(st:CandidateStatus)
 WHERE dp.session_id = '<SESSION_ID>'
   AND LOWER(dp.decision_type) LIKE '%audience%'
 RETURN DISTINCT
-  c.status, c.name AS audience, c.score, c.rejection_rationale
-ORDER BY c.status DESC, c.score DESC;
+  st.status, c.name AS audience, c.score, c.rejection_rationale
+ORDER BY st.status DESC, c.score DESC;
 ```
 
 **Live answer (illustrative):**
@@ -83,16 +90,17 @@ demand, for any campaign.
 
 **BQ Conversational Analytics:**
 
-> "In the agent_context_graph, list every DROPPED CandidateNode
+> "In the rich_agent_context_graph, list every DROPPED CandidateNode
 > whose rejection_rationale mentions age, demographic, youth,
 > gender, or contains an explicit age range. Group by decision_type."
 
 **GQL:**
 
 ```sql
-GRAPH `<PROJECT_ID>.decision_lineage_demo.agent_context_graph`
+GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
 MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-WHERE c.status = 'DROPPED'
+      -[:HasCandidateStatus]->(st:CandidateStatus)
+WHERE st.status = 'DROPPED'
   AND (LOWER(c.rejection_rationale) LIKE '%age %'
        OR LOWER(c.rejection_rationale) LIKE '%demographic%'
        OR LOWER(c.rejection_rationale) LIKE '%youth%'
@@ -132,16 +140,17 @@ the framing is legitimate or a proxy for discrimination.
 
 **BQ Conversational Analytics:**
 
-> "Across all sessions in the agent_context_graph, find every
+> "Across all sessions in the rich_agent_context_graph, find every
 > SELECTED CandidateNode with score below 0.7. Sort by score
 > ascending."
 
 **GQL:**
 
 ```sql
-GRAPH `<PROJECT_ID>.decision_lineage_demo.agent_context_graph`
+GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
 MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-WHERE c.status = 'SELECTED'
+      -[:HasCandidateStatus]->(st:CandidateStatus)
+WHERE st.status = 'SELECTED'
   AND c.score < 0.7
 RETURN DISTINCT
   dp.session_id, dp.decision_type, c.name AS selected, c.score
@@ -178,13 +187,15 @@ nominal threshold passed.
 **GQL:**
 
 ```sql
-GRAPH `<PROJECT_ID>.decision_lineage_demo.agent_context_graph`
-MATCH (step:TechNode)-[:MadeDecision]->(dp:DecisionPoint)
+GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
+MATCH (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint),
+      (step:TechNode)-[:MadeDecision]->(dp)
       -[:CandidateEdge]->(c:CandidateNode)
 WHERE dp.session_id = '<SESSION_ID>'
   AND LOWER(dp.decision_type) LIKE '%creative%'
   AND step.event_type = 'LLM_RESPONSE'
 RETURN DISTINCT
+  cr.campaign,
   dp.span_id AS evidence_span_id,
   c.status, c.name AS theme, c.score, c.rejection_rationale
 ORDER BY c.status DESC, c.score DESC;
@@ -216,21 +227,23 @@ shape required by Art. 12 is one query, not a forensic exercise.
 
 **BQ Conversational Analytics:**
 
-> "In the agent_context_graph, count DROPPED CandidateNodes per
+> "In the rich_agent_context_graph, count DROPPED CandidateNodes per
 > decision_type and report the average dropped score. Sort by
 > rejection count descending."
 
 **GQL:**
 
 ```sql
-GRAPH `<PROJECT_ID>.decision_lineage_demo.agent_context_graph`
-MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-WHERE c.status = 'DROPPED'
+GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
+MATCH (dp:DecisionPoint)-[:HasDecisionType]->(dt:DecisionType),
+      (dp)-[:CandidateEdge]->(c:CandidateNode)
+        -[:HasCandidateStatus]->(st:CandidateStatus)
+WHERE st.status = 'DROPPED'
 RETURN
-  dp.decision_type,
+  dt.decision_type,
   COUNT(c) AS rejections,
   AVG(c.score) AS avg_dropped_score
-GROUP BY dp.decision_type
+GROUP BY dt.decision_type
 ORDER BY rejections DESC
 LIMIT 10;
 ```
@@ -243,7 +256,7 @@ If your dataset predates that fix and shows duplicate-key rows,
 reseat the table with `CREATE OR REPLACE TABLE T AS SELECT *
 EXCEPT(rn) FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY
 candidate_id) AS rn FROM T) WHERE rn = 1` and re-apply
-`property_graph.gql`.
+`rich_property_graph.gql`.
 
 **Live answer (illustrative — top categories):**
 
@@ -270,7 +283,7 @@ patterns. Loop back to **Q2** with `LOWER(dp.decision_type) LIKE
 
 ## How to demo this with BigQuery Conversational Analytics
 
-1. Open BigQuery Studio with the `decision_lineage_demo` dataset
+1. Open BigQuery Studio with the `decision_lineage_rich_demo` dataset
    selected and click the **Gemini / Conversational Analytics**
    panel.
 2. For each Q above, type the natural-language **BQ CA prompt** and

--- a/examples/decision_lineage_demo/DEMO_QUESTIONS.md
+++ b/examples/decision_lineage_demo/DEMO_QUESTIONS.md
@@ -32,10 +32,10 @@ Block 1i from `bq_studio_queries.gql` or from the `build_graph.py`
 output.
 
 The queries below target the richer demo graph. It keeps the SDK's
-canonical labels (`TechNode`, `BizNode`, `DecisionPoint`,
-`CandidateNode`) and adds presentation labels (`CampaignRun`,
-`DecisionType`, `CandidateStatus`, `RejectionReason`) so the same
-audit facts are easier to visualize and narrate in BigQuery Studio.
+canonical tables but exposes ads-domain labels (`AgentStep`,
+`MediaEntity`, `PlanningDecision`, `DecisionOption`,
+`DecisionCategory`, `OptionOutcome`, `DropReason`) so the same audit
+facts are easier to visualize and narrate in BigQuery Studio.
 
 ---
 
@@ -56,8 +56,8 @@ audit facts are easier to visualize and narrate in BigQuery Studio.
 
 ```sql
 GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
-MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-      -[:HasCandidateStatus]->(st:CandidateStatus)
+MATCH (dp:PlanningDecision)-[:WeighedOption]->(c:DecisionOption)
+      -[:HasOutcome]->(st:OptionOutcome)
 WHERE dp.session_id = '<SESSION_ID>'
   AND LOWER(dp.decision_type) LIKE '%audience%'
 RETURN DISTINCT
@@ -90,7 +90,7 @@ demand, for any campaign.
 
 **BQ Conversational Analytics:**
 
-> "In the rich_agent_context_graph, list every DROPPED CandidateNode
+> "In the rich_agent_context_graph, list every DROPPED DecisionOption
 > whose rejection_rationale mentions age, demographic, youth,
 > gender, or contains an explicit age range. Group by decision_type."
 
@@ -98,8 +98,8 @@ demand, for any campaign.
 
 ```sql
 GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
-MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-      -[:HasCandidateStatus]->(st:CandidateStatus)
+MATCH (dp:PlanningDecision)-[:WeighedOption]->(c:DecisionOption)
+      -[:HasOutcome]->(st:OptionOutcome)
 WHERE st.status = 'DROPPED'
   AND (LOWER(c.rejection_rationale) LIKE '%age %'
        OR LOWER(c.rejection_rationale) LIKE '%demographic%'
@@ -141,15 +141,15 @@ the framing is legitimate or a proxy for discrimination.
 **BQ Conversational Analytics:**
 
 > "Across all sessions in the rich_agent_context_graph, find every
-> SELECTED CandidateNode with score below 0.7. Sort by score
+> SELECTED DecisionOption with score below 0.7. Sort by score
 > ascending."
 
 **GQL:**
 
 ```sql
 GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
-MATCH (dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-      -[:HasCandidateStatus]->(st:CandidateStatus)
+MATCH (dp:PlanningDecision)-[:WeighedOption]->(c:DecisionOption)
+      -[:HasOutcome]->(st:OptionOutcome)
 WHERE st.status = 'SELECTED'
   AND c.score < 0.7
 RETURN DISTINCT
@@ -181,16 +181,16 @@ nominal threshold passed.
 **BQ Conversational Analytics:**
 
 > "For session `<SESSION_ID>`, show the LLM_RESPONSE span_id that
-> produced the creative-theme decision, plus every CandidateNode
+> produced the creative-theme decision, plus every DecisionOption
 > the agent considered with status, score, and rejection rationale."
 
 **GQL:**
 
 ```sql
 GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
-MATCH (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint),
-      (step:TechNode)-[:MadeDecision]->(dp)
-      -[:CandidateEdge]->(c:CandidateNode)
+MATCH (cr:CampaignRun)-[:CampaignDecision]->(dp:PlanningDecision),
+      (step:AgentStep)-[:DecidedAt]->(dp)
+      -[:WeighedOption]->(c:DecisionOption)
 WHERE dp.session_id = '<SESSION_ID>'
   AND LOWER(dp.decision_type) LIKE '%creative%'
   AND step.event_type = 'LLM_RESPONSE'
@@ -227,7 +227,7 @@ shape required by Art. 12 is one query, not a forensic exercise.
 
 **BQ Conversational Analytics:**
 
-> "In the rich_agent_context_graph, count DROPPED CandidateNodes per
+> "In the rich_agent_context_graph, count DROPPED DecisionOptions per
 > decision_type and report the average dropped score. Sort by
 > rejection count descending."
 
@@ -235,9 +235,9 @@ shape required by Art. 12 is one query, not a forensic exercise.
 
 ```sql
 GRAPH `<PROJECT_ID>.decision_lineage_rich_demo.rich_agent_context_graph`
-MATCH (dp:DecisionPoint)-[:HasDecisionType]->(dt:DecisionType),
-      (dp)-[:CandidateEdge]->(c:CandidateNode)
-        -[:HasCandidateStatus]->(st:CandidateStatus)
+MATCH (dp:PlanningDecision)-[:InCategory]->(dt:DecisionCategory),
+      (dp)-[:WeighedOption]->(c:DecisionOption)
+        -[:HasOutcome]->(st:OptionOutcome)
 WHERE st.status = 'DROPPED'
 RETURN
   dt.decision_type,

--- a/examples/decision_lineage_demo/README.md
+++ b/examples/decision_lineage_demo/README.md
@@ -42,8 +42,9 @@ agent_context_graph  (canonical SDK graph)
    │
    ▼
 build_rich_graph.py — SQL-only presentation layer
-   │                   (CampaignRun, DecisionType,
-   │                    CandidateStatus, RejectionReason)
+   │                   (AgentStep, MediaEntity,
+   │                    PlanningDecision, DecisionOption,
+   │                    DecisionCategory, OptionOutcome, DropReason)
    ▼
 rich_agent_context_graph  ←  query with GQL in BigQuery Studio
 ```
@@ -55,8 +56,8 @@ session inlined) holds six blocks:
 
 | Block | Surface | Scope |
 |-------|---------|-------|
-| 1 | Portfolio inventory — counts across CampaignRun, TechNode, BizNode, DecisionPoint, CandidateNode, DecisionType, CandidateStatus, RejectionReason, plus decisions per session | All sessions |
-| 2 | Visualize ONE session's reasoning — CampaignRun → DecisionPoint → CandidateNode → CandidateStatus, plus optional RejectionReason fan-out | First session |
+| 1 | Portfolio inventory — counts across CampaignRun, AgentStep, MediaEntity, PlanningDecision, DecisionOption, DecisionCategory, OptionOutcome, DropReason, plus decisions per session | All sessions |
+| 2 | Visualize ONE session's reasoning — CampaignRun → PlanningDecision → DecisionOption → OptionOutcome, plus optional DropReason fan-out | First session |
 | 3 | EU-audit traversal — same shape `mgr.get_eu_audit_gql` ships, scoped to that session | First session |
 | 4 | Dropped candidates — detail view across the portfolio | All sessions |
 | 4b | Dropped roll-up — `COUNT(cand)` + `AVG(cand.score)` by decision type | All sessions |
@@ -98,7 +99,8 @@ export PROJECT_ID=your-gcp-project   # or rely on `gcloud config`
    latency). Each invocation produces an `INVOCATION_STARTING` →
    `AGENT_STARTING` → `LLM_REQUEST`/`LLM_RESPONSE` per decision →
    `TOOL_STARTING`/`TOOL_COMPLETED` per tool call →
-   `INVOCATION_COMPLETED` chain in `agent_events`.
+   `INVOCATION_COMPLETED` chain in `agent_events`, and writes the
+   exact session → campaign mapping into `campaign_runs`.
 7. Runs `build_graph.py` — discovers every session in
    `agent_events`, calls `mgr.build_context_graph(...)`, prints
    per-session counts.
@@ -130,8 +132,9 @@ After setup:
    **`rich_agent_context_graph`**. The canonical SDK graph
    **`agent_context_graph`** is also created as the source layer.
    The dataset includes the seven SDK backing tables plus derived
-   demo tables such as `campaign_runs`, `rich_decision_types`,
-   `rich_candidate_statuses`, and `rich_rejection_reasons`.
+   demo tables such as `campaign_runs`, `rich_agent_steps`,
+   `rich_decision_types`, `rich_candidate_statuses`, and
+   `rich_rejection_reasons`.
 3. Open `bq_studio_queries.gql` in a text editor and paste each
    block (delimited by `==` headers) into a new BQ Studio query
    tab. Run them in order while you narrate.
@@ -148,8 +151,9 @@ A talk track and a click-by-click walkthrough live alongside:
   with BQ Conversational Analytics prompts and verified GQL:
   [`DEMO_QUESTIONS.md`](DEMO_QUESTIONS.md)
 - How the seven SDK backing tables feed the richer demo graph
-  (`CampaignRun`, `DecisionType`, `CandidateStatus`, and
-  `RejectionReason` included), step by step:
+  (`CampaignRun`, `AgentStep`, `PlanningDecision`,
+  `DecisionOption`, `OptionOutcome`, and `DropReason` included),
+  step by step:
   [`DATA_LINEAGE.md`](DATA_LINEAGE.md)
 
 ## File map
@@ -199,7 +203,8 @@ see:
 The canonical SDK graph structure is stable: TechNode, BizNode,
 DecisionPoint, CandidateNode + four edge labels. The demo graph is
 richer but still deterministic: `build_rich_graph.py` projects
-CampaignRun / DecisionType / CandidateStatus / RejectionReason nodes
+ads-domain labels such as CampaignRun / PlanningDecision /
+DecisionOption / OptionOutcome / DropReason nodes
 from those same tables. If a run produces zero decisions for a
 session (rare), `build_graph.py` warns and you can re-run it without
 re-running the agent.

--- a/examples/decision_lineage_demo/README.md
+++ b/examples/decision_lineage_demo/README.md
@@ -38,7 +38,14 @@ build_graph.py —  ContextGraphManager.build_context_graph(
    │                                                 (biz nodes,
    │                                                  decisions)
    ▼
-agent_context_graph  ←  query with GQL in BigQuery Studio
+agent_context_graph  (canonical SDK graph)
+   │
+   ▼
+build_rich_graph.py — SQL-only presentation layer
+   │                   (CampaignRun, DecisionType,
+   │                    CandidateStatus, RejectionReason)
+   ▼
+rich_agent_context_graph  ←  query with GQL in BigQuery Studio
 ```
 
 ## What you'll show in BigQuery Studio
@@ -48,8 +55,8 @@ session inlined) holds six blocks:
 
 | Block | Surface | Scope |
 |-------|---------|-------|
-| 1 | Portfolio inventory — five COUNT GQLs (TechNode, BizNode, DecisionPoint, CandidateNode, plus DecisionPoints per session) | All sessions |
-| 2 | Visualize ONE session's reasoning — path GQL renders as an interactive graph diagram | First session |
+| 1 | Portfolio inventory — counts across CampaignRun, TechNode, BizNode, DecisionPoint, CandidateNode, DecisionType, CandidateStatus, RejectionReason, plus decisions per session | All sessions |
+| 2 | Visualize ONE session's reasoning — CampaignRun → DecisionPoint → CandidateNode → CandidateStatus, plus optional RejectionReason fan-out | First session |
 | 3 | EU-audit traversal — same shape `mgr.get_eu_audit_gql` ships, scoped to that session | First session |
 | 4 | Dropped candidates — detail view across the portfolio | All sessions |
 | 4b | Dropped roll-up — `COUNT(cand)` + `AVG(cand.score)` by decision type | All sessions |
@@ -83,7 +90,7 @@ export PROJECT_ID=your-gcp-project   # or rely on `gcloud config`
 3. Creates a per-demo `./.venv/` and installs `google-adk`,
    `google-cloud-aiplatform`, `google-cloud-bigquery`,
    `python-dotenv`, plus the SDK editable from the repo root.
-4. Creates the `decision_lineage_demo` dataset (regional, default
+4. Creates the `decision_lineage_rich_demo` dataset (regional, default
    `us-central1` so Vertex AI calls work).
 5. Writes `.env` with project / dataset / model config.
 6. Runs `run_agent.py` — six live ADK invocations against six
@@ -95,7 +102,9 @@ export PROJECT_ID=your-gcp-project   # or rely on `gcloud config`
 7. Runs `build_graph.py` — discovers every session in
    `agent_events`, calls `mgr.build_context_graph(...)`, prints
    per-session counts.
-8. Renders `bq_studio_queries.gql` with the first session's id
+8. Runs `build_rich_graph.py` — derives demo-only presentation
+   tables and creates `rich_agent_context_graph`.
+9. Renders `bq_studio_queries.gql` with the first session's id
    inlined for paste-and-run.
 
 Override defaults via env vars before `./setup.sh`:
@@ -103,7 +112,7 @@ Override defaults via env vars before `./setup.sh`:
 | Var | Default | Used by |
 |---|---|---|
 | `PROJECT_ID` | `gcloud config get-value project` | every step |
-| `DATASET_ID` | `decision_lineage_demo` | BQ |
+| `DATASET_ID` | `decision_lineage_rich_demo` | BQ |
 | `DATASET_LOCATION` | `us-central1` | BQ |
 | `TABLE_ID` | `agent_events` | plugin + extraction |
 | `DEMO_AGENT_LOCATION` | `us-central1` | live agent |
@@ -116,11 +125,13 @@ After setup:
 
 1. Open BigQuery Studio:
    `https://console.cloud.google.com/bigquery?project=<PROJECT_ID>`
-2. In the Explorer pane, expand the `decision_lineage_demo` dataset.
-   You should see the property graph **`agent_context_graph`** plus
-   seven backing tables (`agent_events`, `extracted_biz_nodes`,
-   `context_cross_links`, `decision_points`, `candidates`,
-   `made_decision_edges`, `candidate_edges`).
+2. In the Explorer pane, expand the `decision_lineage_rich_demo` dataset.
+   You should see the demo property graph
+   **`rich_agent_context_graph`**. The canonical SDK graph
+   **`agent_context_graph`** is also created as the source layer.
+   The dataset includes the seven SDK backing tables plus derived
+   demo tables such as `campaign_runs`, `rich_decision_types`,
+   `rich_candidate_statuses`, and `rich_rejection_reasons`.
 3. Open `bq_studio_queries.gql` in a text editor and paste each
    block (delimited by `==` headers) into a new BQ Studio query
    tab. Run them in order while you narrate.
@@ -136,9 +147,9 @@ A talk track and a click-by-click walkthrough live alongside:
   audit, human oversight, reproducibility, systemic-pattern audit)
   with BQ Conversational Analytics prompts and verified GQL:
   [`DEMO_QUESTIONS.md`](DEMO_QUESTIONS.md)
-- How the seven backing tables produce the eight graph elements
-  (TechNode / BizNode / DecisionPoint / CandidateNode and the four
-  edge labels), step by step:
+- How the seven SDK backing tables feed the richer demo graph
+  (`CampaignRun`, `DecisionType`, `CandidateStatus`, and
+  `RejectionReason` included), step by step:
   [`DATA_LINEAGE.md`](DATA_LINEAGE.md)
 
 ## File map
@@ -150,7 +161,7 @@ decision_lineage_demo/
 ├── DEMO_NARRATION.md          # 5-min leadership pitch around the 5 EU questions
 ├── BQ_STUDIO_WALKTHROUGH.md   # click-by-click in BQ Studio
 ├── DEMO_QUESTIONS.md          # 5 EU-compliance questions: BQ CA vs. direct GQL
-├── DATA_LINEAGE.md            # how the 7 tables produce the 8 graph elements
+├── DATA_LINEAGE.md            # canonical graph + richer demo graph lineage
 ├── setup.sh                   # one-shot bootstrap
 ├── reset.sh                   # tear down dataset + rendered files
 ├── render_queries.sh          # sed-renders the .gql template
@@ -158,6 +169,8 @@ decision_lineage_demo/
 ├── bq_studio_queries.gql      # rendered (gitignored, by setup)
 ├── property_graph.gql.tpl     # standalone CREATE PROPERTY GRAPH DDL (placeholders)
 ├── property_graph.gql         # rendered (gitignored, by setup)
+├── rich_property_graph.gql.tpl # richer demo CREATE PROPERTY GRAPH DDL
+├── rich_property_graph.gql    # rendered (gitignored, by setup)
 ├── agent/                     # the live ADK agent
 │   ├── agent.py               # root_agent + bq_logging_plugin
 │   ├── tools.py               # 5 decision-commit tools
@@ -165,8 +178,9 @@ decision_lineage_demo/
 ├── campaigns.py               # 6 campaign briefs
 ├── run_agent.py               # multi-session driver (one session
 │                              # per brief, real plugin writes spans)
-└── build_graph.py             # mgr.build_context_graph(...) over
-                               # every session in agent_events
+├── build_graph.py             # mgr.build_context_graph(...) over
+│                              # every session in agent_events
+└── build_rich_graph.py        # SQL-only richer graph for the demo
 ```
 
 ## A note on AI.GENERATE non-determinism
@@ -179,13 +193,16 @@ see:
 - Variation in `decision_type` strings (e.g.
   `audience_selection` vs `audience_choice`).
 - Occasional missed candidates if the model under-summarizes.
-- Per-session decision counts that fluctuate around the seeded
+- Per-session decision counts that fluctuate around the prompted
   five.
 
-The graph **structure** is stable: TechNode, BizNode, DecisionPoint,
-CandidateNode + four edge labels. If a run produces zero decisions
-for a session (rare), `build_graph.py` warns and you can re-run it
-without re-running the agent.
+The canonical SDK graph structure is stable: TechNode, BizNode,
+DecisionPoint, CandidateNode + four edge labels. The demo graph is
+richer but still deterministic: `build_rich_graph.py` projects
+CampaignRun / DecisionType / CandidateStatus / RejectionReason nodes
+from those same tables. If a run produces zero decisions for a
+session (rare), `build_graph.py` warns and you can re-run it without
+re-running the agent.
 
 ## Tear down
 

--- a/examples/decision_lineage_demo/SETUP_NEW_PROJECT.md
+++ b/examples/decision_lineage_demo/SETUP_NEW_PROJECT.md
@@ -33,14 +33,14 @@ cd examples/decision_lineage_demo
 ./setup.sh
 ```
 
-`setup.sh` performs eight steps in order:
+`setup.sh` performs nine steps in order:
 
 1. Verifies `python3` and `gcloud`.
 2. Enables BigQuery + Vertex AI APIs (idempotent).
 3. Creates `./.venv/` and installs `google-adk`,
    `google-cloud-aiplatform`, `google-cloud-bigquery`,
    `python-dotenv`, plus the SDK editable from the repo root.
-4. Creates a regional dataset (default `decision_lineage_demo` in
+4. Creates a regional dataset (default `decision_lineage_rich_demo` in
    `us-central1` — Vertex AI requires regional, not multi-region).
 5. Writes `.env` with project / dataset / model config.
 6. **Runs the live ADK media-planner agent against six campaign
@@ -53,7 +53,11 @@ cd examples/decision_lineage_demo
    `agent_events` and calls `mgr.build_context_graph(
    use_ai_generate=True, include_decisions=True)`. Two
    `AI.GENERATE` calls (biz nodes, then decisions). ~30-90 seconds.
-8. Renders `bq_studio_queries.gql` with your project + dataset +
+8. Runs `build_rich_graph.py` — creates SQL-only presentation
+   tables (`campaign_runs`, `rich_decision_types`,
+   `rich_candidate_statuses`, `rich_rejection_reasons`, plus edge
+   tables) and creates `rich_agent_context_graph`.
+9. Renders `bq_studio_queries.gql` with your project + dataset +
    first-session id inlined for paste-and-run in BQ Studio.
 
 ## Override defaults (optional)
@@ -63,7 +67,7 @@ Set any of these env vars before `./setup.sh`:
 | Var | Default | Effect |
 |---|---|---|
 | `PROJECT_ID` | `gcloud config get-value project` | Target GCP project |
-| `DATASET_ID` | `decision_lineage_demo` | BigQuery dataset name |
+| `DATASET_ID` | `decision_lineage_rich_demo` | BigQuery dataset name |
 | `DATASET_LOCATION` | `us-central1` | Must be a region (multi-region `US` will break Vertex AI calls) |
 | `TABLE_ID` | `agent_events` | Plugin write target + extraction read target |
 | `DEMO_AGENT_LOCATION` | `us-central1` | Where the live agent calls Vertex AI |
@@ -88,21 +92,25 @@ Spot-check from the shell:
 ```bash
 # Fully-qualified — replace YOUR_PROJECT_ID:
 bq query --use_legacy_sql=false --location=us-central1 \
-  "SELECT COUNT(*) AS spans FROM \`YOUR_PROJECT_ID.decision_lineage_demo.agent_events\`"
+  "SELECT COUNT(*) AS spans FROM \`YOUR_PROJECT_ID.decision_lineage_rich_demo.agent_events\`"
 # Expected: ~162 (6 × ~27)
 
 bq query --use_legacy_sql=false --location=us-central1 \
-  "SELECT COUNT(*) AS decisions FROM \`YOUR_PROJECT_ID.decision_lineage_demo.decision_points\`"
+  "SELECT COUNT(*) AS decisions FROM \`YOUR_PROJECT_ID.decision_lineage_rich_demo.decision_points\`"
 # Expected: ~28-30 (5 per session × 6 sessions; varies with AI.GENERATE)
 ```
 
 In **BigQuery Studio**:
 `https://console.cloud.google.com/bigquery?project=YOUR_PROJECT_ID`
-→ expand `decision_lineage_demo` → confirm `agent_context_graph`
-shows in the Explorer alongside seven backing tables
-(`agent_events`, `extracted_biz_nodes`, `context_cross_links`,
-`decision_points`, `candidates`, `made_decision_edges`,
-`candidate_edges`).
+→ expand `decision_lineage_rich_demo` → confirm
+`rich_agent_context_graph` shows in the Explorer. The canonical
+`agent_context_graph` is also present, alongside the seven SDK
+backing tables (`agent_events`, `extracted_biz_nodes`,
+`context_cross_links`, `decision_points`, `candidates`,
+`made_decision_edges`, `candidate_edges`) and the richer demo
+projection tables (`campaign_runs`, `rich_decision_types`,
+`rich_candidate_statuses`, `rich_rejection_reasons`, and their
+edge tables).
 
 ## Run the demo
 
@@ -118,7 +126,7 @@ For the leadership-pitched five-minute version: open
 version covering the six GQL blocks plus the optional Step 6 EU
 Q&A: open `BQ_STUDIO_WALKTHROUGH.md`. Session ids in your project
 will differ from the verification run — replace `<SESSION_ID>`
-placeholders with ids from `setup.sh`'s output, or run Block 1e
+placeholders with ids from `setup.sh`'s output, or run Block 1i
 from `bq_studio_queries.gql` to list them.
 
 ## Swap in a different scenario
@@ -149,15 +157,19 @@ bundle without rewriting the SDK side:
 | `setup.sh` aborts at step 5 with `Sessions: N succeeded, M failed` | Read the per-campaign reason printed above. Typical causes: Vertex AI quota / permission denial (`roles/aiplatform.user`), the agent location not matching `DATASET_LOCATION`, or transient model-endpoint outages. Re-run `./setup.sh`. |
 | Step 7 (`build_graph.py`) fails with `Dataset ... not found in location US` | `DATASET_LOCATION` was set to multi-region `US`. Run `./reset.sh` and rerun with `DATASET_LOCATION=us-central1` (or another region). |
 | `decision_points_count` is zero | `AI.GENERATE` returned no decisions on this run. Rerun `./.venv/bin/python3 build_graph.py` (no need to rerun the agent — the traces are still in `agent_events`). |
+| `rich_agent_context_graph` is missing | Rerun `./.venv/bin/python3 build_rich_graph.py`; it is SQL-only and does not call the live agent or `AI.GENERATE`. |
 | `agent_events` is empty after step 6 | The plugin failed to flush. Re-run `./.venv/bin/python3 run_agent.py` and confirm the script's `Flushing BQ AA Plugin so all spans land in BigQuery...` line completes without warnings. |
 | BQ Studio's Graph tab is missing on Block 2 | The result needs to render once before the tab appears; rerun the query. |
 
-## Recreate the property graph from existing tables
+## Recreate the property graphs from existing tables
 
-If the seven backing tables are already populated (a prior
+If the seven SDK backing tables are already populated (a prior
 `./setup.sh` run, a clone of someone else's dataset, or a manual
-INSERT-from-SELECT into a new project) you can recreate just the
-property graph layer without rerunning the agent or `AI.GENERATE`.
+INSERT-from-SELECT into a new project) you can recreate the graph
+layers without rerunning the agent. Recreating the canonical graph
+needs only the seven SDK tables. Recreating the rich demo graph also
+needs the derived `rich_*` tables, which `build_rich_graph.py`
+creates without new AI calls.
 
 The bundle ships `property_graph.gql.tpl` — a parameterized
 `CREATE OR REPLACE PROPERTY GRAPH` DDL that wires the seven
@@ -168,6 +180,10 @@ DESTINATION KEY / LABEL / PROPERTIES — schema-equivalent to
 config; comments, wrapping, and the trailing semicolon differ
 because this file is hand-curated for paste-and-run rather than
 generated).
+
+It also ships `rich_property_graph.gql.tpl`, which wires the seven
+SDK tables plus the SQL-only demo projection tables into
+`rich_agent_context_graph`, the graph used by the walkthrough.
 
 Two ways to apply it:
 
@@ -183,6 +199,18 @@ bq query \
 # tab and click Run.
 ```
 
+For the richer presentation graph, first ensure the derived tables
+exist, then apply `rich_property_graph.gql`:
+
+```bash
+./.venv/bin/python3 build_rich_graph.py
+
+bq query \
+  --use_legacy_sql=false \
+  --location="${DATASET_LOCATION:-us-central1}" \
+  < rich_property_graph.gql
+```
+
 The DDL is a single atomic `CREATE OR REPLACE PROPERTY GRAPH`
 statement, so re-applying is safe. If your dataset uses non-default
 table names (e.g. you overrode `TABLE_ID` or chose different
@@ -190,7 +218,7 @@ table names (e.g. you overrode `TABLE_ID` or chose different
 to match before rendering — the table names are intentionally
 inlined to keep the rendered file paste-and-run.
 
-Pre-flight check that all seven tables exist:
+Pre-flight check that all seven SDK tables exist:
 
 ```bash
 bq query \
@@ -204,6 +232,22 @@ bq query \
 # Expect 7 rows. If any are missing, run setup.sh / build_graph.py
 # instead — the property graph DDL needs every backing table to
 # exist before it will compile.
+```
+
+Pre-flight check for the richer demo graph:
+
+```bash
+bq query \
+  --use_legacy_sql=false \
+  --location="${DATASET_LOCATION:-us-central1}" \
+  "SELECT table_name FROM \`${PROJECT_ID}.${DATASET_ID}\`.INFORMATION_SCHEMA.TABLES
+   WHERE table_name IN ('campaign_runs','rich_decision_types',
+                        'rich_candidate_statuses','rich_rejection_reasons',
+                        'rich_campaign_span_edges','rich_campaign_decision_edges',
+                        'rich_decision_type_edges','rich_candidate_status_edges',
+                        'rich_candidate_reason_edges')
+   ORDER BY table_name"
+# Expect 9 rows. If any are missing, run build_rich_graph.py.
 ```
 
 ## Tear down

--- a/examples/decision_lineage_demo/SETUP_NEW_PROJECT.md
+++ b/examples/decision_lineage_demo/SETUP_NEW_PROJECT.md
@@ -46,17 +46,18 @@ cd examples/decision_lineage_demo
 6. **Runs the live ADK media-planner agent against six campaign
    briefs** (the slow step — typically 3-7 minutes; six
    invocations of Gemini 2.5 Pro). The BQ AA Plugin streams every
-   span (~27 per session, ~162 total) into `agent_events`. Failures
-   abort the run via a non-zero exit so setup does not proceed
-   with a partial portfolio.
+   span (~27 per session, ~162 total) into `agent_events`.
+   `run_agent.py` also writes the exact session → campaign mapping
+   into `campaign_runs`. Failures abort the run via a non-zero exit
+   so setup does not proceed with a partial portfolio.
 7. Runs `build_graph.py` — discovers every session in
    `agent_events` and calls `mgr.build_context_graph(
    use_ai_generate=True, include_decisions=True)`. Two
    `AI.GENERATE` calls (biz nodes, then decisions). ~30-90 seconds.
 8. Runs `build_rich_graph.py` — creates SQL-only presentation
-   tables (`campaign_runs`, `rich_decision_types`,
-   `rich_candidate_statuses`, `rich_rejection_reasons`, plus edge
-   tables) and creates `rich_agent_context_graph`.
+   tables (`rich_decision_types`, `rich_candidate_statuses`,
+   `rich_rejection_reasons`, plus edge tables) and creates
+   `rich_agent_context_graph`.
 9. Renders `bq_studio_queries.gql` with your project + dataset +
    first-session id inlined for paste-and-run in BQ Studio.
 
@@ -109,8 +110,8 @@ backing tables (`agent_events`, `extracted_biz_nodes`,
 `context_cross_links`, `decision_points`, `candidates`,
 `made_decision_edges`, `candidate_edges`) and the richer demo
 projection tables (`campaign_runs`, `rich_decision_types`,
-`rich_candidate_statuses`, `rich_rejection_reasons`, and their
-edge tables).
+`rich_candidate_statuses`, `rich_rejection_reasons`,
+`rich_agent_steps`, and their edge tables).
 
 ## Run the demo
 
@@ -241,13 +242,13 @@ bq query \
   --use_legacy_sql=false \
   --location="${DATASET_LOCATION:-us-central1}" \
   "SELECT table_name FROM \`${PROJECT_ID}.${DATASET_ID}\`.INFORMATION_SCHEMA.TABLES
-   WHERE table_name IN ('campaign_runs','rich_decision_types',
+   WHERE table_name IN ('campaign_runs','rich_agent_steps','rich_decision_types',
                         'rich_candidate_statuses','rich_rejection_reasons',
                         'rich_campaign_span_edges','rich_campaign_decision_edges',
                         'rich_decision_type_edges','rich_candidate_status_edges',
                         'rich_candidate_reason_edges')
    ORDER BY table_name"
-# Expect 9 rows. If any are missing, run build_rich_graph.py.
+# Expect 10 rows. If any are missing, run build_rich_graph.py.
 ```
 
 ## Tear down

--- a/examples/decision_lineage_demo/agent/agent.py
+++ b/examples/decision_lineage_demo/agent/agent.py
@@ -54,8 +54,8 @@ if os.path.exists(_env_path):
 
 _, _auth_project = google.auth.default()
 PROJECT_ID = os.getenv("PROJECT_ID") or _auth_project
-DATASET_ID = os.getenv("DATASET_ID", "decision_lineage_demo")
-DATASET_LOCATION = os.getenv("DATASET_LOCATION", "US")
+DATASET_ID = os.getenv("DATASET_ID", "decision_lineage_rich_demo")
+DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
 TABLE_ID = os.getenv("TABLE_ID", "agent_events")
 MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-2.5-pro")
 AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "us-central1")

--- a/examples/decision_lineage_demo/bq_studio_queries.gql.tpl
+++ b/examples/decision_lineage_demo/bq_studio_queries.gql.tpl
@@ -7,11 +7,11 @@
 -- headers) into a new query tab, and run. Block 2 returns paths and
 -- renders as an interactive graph diagram.
 --
--- The graph is `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`,
--- built by `build_graph.py` calling
--- `ContextGraphManager.build_context_graph(use_ai_generate=True,
--- include_decisions=True)` against every session captured by
--- `run_agent.py`.
+-- The graph is `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`.
+-- `build_graph.py` first creates the SDK's canonical
+-- `agent_context_graph`; `build_rich_graph.py` then derives demo
+-- presentation nodes (CampaignRun, DecisionType, CandidateStatus,
+-- RejectionReason) and creates this richer graph.
 --
 -- Cross-session blocks (1, 4, 4b, 5) span every session in the
 -- dataset. Per-session blocks (2, 3) are scoped to the first
@@ -22,35 +22,55 @@
 -- ====================================================================
 -- Block 1: Portfolio inventory — what did the SDK extract?
 --
--- Counts every node label across every session. The TechNode count
--- is deterministic (= total spans the BQ AA Plugin wrote). BizNode /
--- DecisionPoint / CandidateNode counts come from AI.GENERATE and
--- vary run-to-run; the demo cares that each is non-zero and roughly
--- proportional to the session count.
+-- Counts every node label across every session. CampaignRun and
+-- TechNode are deterministic. BizNode / DecisionPoint / CandidateNode
+-- come from AI.GENERATE. DecisionType / CandidateStatus /
+-- RejectionReason are SQL-only demo projections over those extracted
+-- rows.
 -- ====================================================================
 
--- 1a. TechNodes (every span the BQ AA Plugin wrote)
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+-- 1a. CampaignRuns (one per campaign brief)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
+MATCH (n:CampaignRun)
+RETURN COUNT(n) AS campaignRuns;
+
+-- 1b. TechNodes (every span the BQ AA Plugin wrote)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:TechNode)
 RETURN COUNT(n) AS techNodes;
 
--- 1b. BizNodes (entities AI.GENERATE found across all sessions)
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+-- 1c. BizNodes (entities AI.GENERATE found across all sessions)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:BizNode)
 RETURN COUNT(n) AS bizNodes;
 
--- 1c. DecisionPoints (decisions across all sessions)
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+-- 1d. DecisionPoints (decisions across all sessions)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:DecisionPoint)
 RETURN COUNT(n) AS decisions;
 
--- 1d. CandidateNodes (every option considered, SELECTED and DROPPED)
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+-- 1e. CandidateNodes (every option considered, SELECTED and DROPPED)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:CandidateNode)
 RETURN COUNT(n) AS candidates;
 
--- 1e. DecisionPoints per session (sanity check: ~5 per session)
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+-- 1f. DecisionTypes (normalized labels AI.GENERATE assigned)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
+MATCH (n:DecisionType)
+RETURN COUNT(n) AS decisionTypes;
+
+-- 1g. CandidateStatuses (normally SELECTED and DROPPED)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
+MATCH (n:CandidateStatus)
+RETURN COUNT(n) AS candidateStatuses;
+
+-- 1h. RejectionReasons (distinct dropped-candidate rationales)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
+MATCH (n:RejectionReason)
+RETURN COUNT(n) AS rejectionReasons;
+
+-- 1i. DecisionPoints per campaign run (sanity check: ~5 per session)
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:DecisionPoint)
 RETURN n.session_id, COUNT(n) AS decisions
 GROUP BY n.session_id
@@ -59,18 +79,30 @@ ORDER BY decisions DESC;
 -- ====================================================================
 -- Block 2: Visualize ONE session's reasoning
 --
--- Returns paths from each span that made a decision, through the
--- decision, out to its candidates — all scoped to a single session
--- so the graph diagram stays readable. BigQuery Studio renders this
--- as an interactive graph.
+-- Returns a richer campaign-level path:
+-- CampaignRun -> DecisionPoint -> CandidateNode -> CandidateStatus.
+-- This promotes the accepted/rejected state into visible graph nodes
+-- instead of hiding it only as a CandidateNode property.
 --
 -- To visualize a different session, swap '__SESSION_ID__' with any
--- other id Block 1e returned.
+-- other id Block 1i returned.
 -- ====================================================================
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH p =
-  (s:TechNode)-[:MadeDecision]->(dp:DecisionPoint)-[:CandidateEdge]->(c:CandidateNode)
-WHERE dp.session_id = '__SESSION_ID__'
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
+    -[:CandidateEdge]->(c:CandidateNode)-[:HasCandidateStatus]->(st:CandidateStatus)
+WHERE cr.session_id = '__SESSION_ID__'
+RETURN p;
+
+-- Optional: dropped-candidate rationale fan-out for the same campaign.
+-- This second path keeps the main visualization readable while still
+-- making rejection reasons first-class nodes when the audience asks
+-- "why did it reject those options?"
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
+MATCH p =
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
+    -[:CandidateEdge]->(c:CandidateNode)-[:RejectedBecause]->(rr:RejectionReason)
+WHERE cr.session_id = '__SESSION_ID__'
 RETURN p;
 
 -- ====================================================================
@@ -80,7 +112,7 @@ RETURN p;
 -- one row per (decision, candidate) the SDK extracted for the
 -- session, with rejection rationale on dropped ones.
 -- ====================================================================
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
   (step:TechNode)-[md:MadeDecision]->(dp:DecisionPoint)
     -[ce:CandidateEdge]->(cand:CandidateNode)
@@ -110,7 +142,7 @@ ORDER BY dp.decision_id, cand.score DESC;
 -- rows for the same key (e.g. legacy data from before the
 -- store_decision_points dedupe fix).
 -- ====================================================================
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
   (dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)
 WHERE ce.edge_type = 'DROPPED_CANDIDATE'
@@ -137,9 +169,9 @@ ORDER BY dp.session_id, dp.decision_type, cand.score DESC;
 --   CREATE OR REPLACE TABLE T AS SELECT * EXCEPT(rn) FROM
 --     (SELECT *, ROW_NUMBER() OVER (PARTITION BY candidate_id) AS rn FROM T)
 --     WHERE rn = 1;
--- and re-apply property_graph.gql.
+-- and re-apply rich_property_graph.gql.
 -- ====================================================================
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
   (dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)
 WHERE ce.edge_type = 'DROPPED_CANDIDATE'
@@ -163,7 +195,7 @@ ORDER BY dropped_count DESC;
 -- has multiple SELECTED or DROPPED candidates that bind separately
 -- in the two MATCH legs above; without it the same close-call tuple
 -- repeats once per (sel, drop) pairing on the same DecisionPoint.
-GRAPH `__PROJECT_ID__.__DATASET_ID__.agent_context_graph`
+GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
   (dp:DecisionPoint)-[:CandidateEdge]->(sel:CandidateNode),
   (dp)-[:CandidateEdge]->(drop:CandidateNode)

--- a/examples/decision_lineage_demo/bq_studio_queries.gql.tpl
+++ b/examples/decision_lineage_demo/bq_studio_queries.gql.tpl
@@ -10,8 +10,8 @@
 -- The graph is `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`.
 -- `build_graph.py` first creates the SDK's canonical
 -- `agent_context_graph`; `build_rich_graph.py` then derives demo
--- presentation nodes (CampaignRun, DecisionType, CandidateStatus,
--- RejectionReason) and creates this richer graph.
+-- presentation nodes (CampaignRun, DecisionCategory, OptionOutcome,
+-- DropReason) and creates this richer graph.
 --
 -- Cross-session blocks (1, 4, 4b, 5) span every session in the
 -- dataset. Per-session blocks (2, 3) are scoped to the first
@@ -23,9 +23,9 @@
 -- Block 1: Portfolio inventory — what did the SDK extract?
 --
 -- Counts every node label across every session. CampaignRun and
--- TechNode are deterministic. BizNode / DecisionPoint / CandidateNode
--- come from AI.GENERATE. DecisionType / CandidateStatus /
--- RejectionReason are SQL-only demo projections over those extracted
+-- AgentStep are deterministic. MediaEntity / PlanningDecision / DecisionOption
+-- come from AI.GENERATE. DecisionCategory / OptionOutcome /
+-- DropReason are SQL-only demo projections over those extracted
 -- rows.
 -- ====================================================================
 
@@ -34,44 +34,44 @@ GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH (n:CampaignRun)
 RETURN COUNT(n) AS campaignRuns;
 
--- 1b. TechNodes (every span the BQ AA Plugin wrote)
+-- 1b. AgentSteps (every span the BQ AA Plugin wrote)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:TechNode)
-RETURN COUNT(n) AS techNodes;
+MATCH (n:AgentStep)
+RETURN COUNT(n) AS agentSteps;
 
--- 1c. BizNodes (entities AI.GENERATE found across all sessions)
+-- 1c. MediaEntities (entities AI.GENERATE found across all sessions)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:BizNode)
-RETURN COUNT(n) AS bizNodes;
+MATCH (n:MediaEntity)
+RETURN COUNT(n) AS mediaEntities;
 
--- 1d. DecisionPoints (decisions across all sessions)
+-- 1d. PlanningDecisions (decisions across all sessions)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:DecisionPoint)
+MATCH (n:PlanningDecision)
 RETURN COUNT(n) AS decisions;
 
--- 1e. CandidateNodes (every option considered, SELECTED and DROPPED)
+-- 1e. DecisionOptions (every option considered, SELECTED and DROPPED)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:CandidateNode)
-RETURN COUNT(n) AS candidates;
+MATCH (n:DecisionOption)
+RETURN COUNT(n) AS decisionOptions;
 
--- 1f. DecisionTypes (normalized labels AI.GENERATE assigned)
+-- 1f. DecisionCategories (normalized labels AI.GENERATE assigned)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:DecisionType)
-RETURN COUNT(n) AS decisionTypes;
+MATCH (n:DecisionCategory)
+RETURN COUNT(n) AS decisionCategories;
 
--- 1g. CandidateStatuses (normally SELECTED and DROPPED)
+-- 1g. OptionOutcomes (normally SELECTED and DROPPED)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:CandidateStatus)
-RETURN COUNT(n) AS candidateStatuses;
+MATCH (n:OptionOutcome)
+RETURN COUNT(n) AS optionOutcomes;
 
--- 1h. RejectionReasons (distinct dropped-candidate rationales)
+-- 1h. DropReasons (distinct dropped-candidate rationales)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:RejectionReason)
-RETURN COUNT(n) AS rejectionReasons;
+MATCH (n:DropReason)
+RETURN COUNT(n) AS dropReasons;
 
--- 1i. DecisionPoints per campaign run (sanity check: ~5 per session)
+-- 1i. PlanningDecisions per campaign run (sanity check: ~5 per session)
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
-MATCH (n:DecisionPoint)
+MATCH (n:PlanningDecision)
 RETURN n.session_id, COUNT(n) AS decisions
 GROUP BY n.session_id
 ORDER BY decisions DESC;
@@ -80,28 +80,28 @@ ORDER BY decisions DESC;
 -- Block 2: Visualize ONE session's reasoning
 --
 -- Returns a richer campaign-level path:
--- CampaignRun -> DecisionPoint -> CandidateNode -> CandidateStatus.
+-- CampaignRun -> PlanningDecision -> DecisionOption -> OptionOutcome.
 -- This promotes the accepted/rejected state into visible graph nodes
--- instead of hiding it only as a CandidateNode property.
+-- instead of hiding it only as a DecisionOption property.
 --
 -- To visualize a different session, swap '__SESSION_ID__' with any
 -- other id Block 1i returned.
 -- ====================================================================
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH p =
-  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
-    -[:CandidateEdge]->(c:CandidateNode)-[:HasCandidateStatus]->(st:CandidateStatus)
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:PlanningDecision)
+    -[:WeighedOption]->(c:DecisionOption)-[:HasOutcome]->(st:OptionOutcome)
 WHERE cr.session_id = '__SESSION_ID__'
 RETURN p;
 
 -- Optional: dropped-candidate rationale fan-out for the same campaign.
 -- This second path keeps the main visualization readable while still
--- making rejection reasons first-class nodes when the audience asks
+-- making drop reasons first-class nodes when the audience asks
 -- "why did it reject those options?"
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH p =
-  (cr:CampaignRun)-[:CampaignDecision]->(dp:DecisionPoint)
-    -[:CandidateEdge]->(c:CandidateNode)-[:RejectedBecause]->(rr:RejectionReason)
+  (cr:CampaignRun)-[:CampaignDecision]->(dp:PlanningDecision)
+    -[:WeighedOption]->(c:DecisionOption)-[:RejectedBecause]->(rr:DropReason)
 WHERE cr.session_id = '__SESSION_ID__'
 RETURN p;
 
@@ -114,8 +114,8 @@ RETURN p;
 -- ====================================================================
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
-  (step:TechNode)-[md:MadeDecision]->(dp:DecisionPoint)
-    -[ce:CandidateEdge]->(cand:CandidateNode)
+  (step:AgentStep)-[md:DecidedAt]->(dp:PlanningDecision)
+    -[ce:WeighedOption]->(cand:DecisionOption)
 WHERE dp.session_id = '__SESSION_ID__'
 RETURN
   dp.decision_id,
@@ -144,7 +144,7 @@ ORDER BY dp.decision_id, cand.score DESC;
 -- ====================================================================
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
-  (dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)
+  (dp:PlanningDecision)-[ce:WeighedOption]->(cand:DecisionOption)
 WHERE ce.edge_type = 'DROPPED_CANDIDATE'
 RETURN DISTINCT
   dp.session_id,
@@ -155,10 +155,10 @@ RETURN DISTINCT
 ORDER BY dp.session_id, dp.decision_type, cand.score DESC;
 
 -- ====================================================================
--- Block 4b: Dropped-candidate roll-up by decision_type
+-- Block 4b: Dropped-candidate roll-up by decision category
 --
 -- Same predicate as Block 4 but aggregated: COUNT(cand) and
--- AVG(cand.score) per decision_type across every session. The
+-- AVG(cand.score) per DecisionCategory across every session. The
 -- portfolio metric product teams want to track.
 --
 -- This count is correct as long as the backing `candidates` table
@@ -173,13 +173,14 @@ ORDER BY dp.session_id, dp.decision_type, cand.score DESC;
 -- ====================================================================
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
-  (dp:DecisionPoint)-[ce:CandidateEdge]->(cand:CandidateNode)
+  (dp:PlanningDecision)-[:InCategory]->(cat:DecisionCategory),
+  (dp)-[ce:WeighedOption]->(cand:DecisionOption)
 WHERE ce.edge_type = 'DROPPED_CANDIDATE'
 RETURN
-  dp.decision_type,
+  cat.decision_type,
   COUNT(cand) AS dropped_count,
   AVG(cand.score) AS avg_dropped_score
-GROUP BY dp.decision_type
+GROUP BY cat.decision_type
 ORDER BY dropped_count DESC;
 
 -- ====================================================================
@@ -191,14 +192,14 @@ ORDER BY dropped_count DESC;
 -- chosen option. Works at the portfolio level by including session
 -- and decision context.
 -- ====================================================================
--- DISTINCT collapses the cartesian product when a DecisionPoint
+-- DISTINCT collapses the cartesian product when a PlanningDecision
 -- has multiple SELECTED or DROPPED candidates that bind separately
 -- in the two MATCH legs above; without it the same close-call tuple
--- repeats once per (sel, drop) pairing on the same DecisionPoint.
+-- repeats once per (sel, drop) pairing on the same PlanningDecision.
 GRAPH `__PROJECT_ID__.__DATASET_ID__.rich_agent_context_graph`
 MATCH
-  (dp:DecisionPoint)-[:CandidateEdge]->(sel:CandidateNode),
-  (dp)-[:CandidateEdge]->(drop:CandidateNode)
+  (dp:PlanningDecision)-[:WeighedOption]->(sel:DecisionOption),
+  (dp)-[:WeighedOption]->(drop:DecisionOption)
 WHERE sel.status = 'SELECTED'
   AND drop.status = 'DROPPED'
   AND sel.score - drop.score < 0.05

--- a/examples/decision_lineage_demo/build_graph.py
+++ b/examples/decision_lineage_demo/build_graph.py
@@ -62,7 +62,7 @@ if os.path.exists(_env_path):
   load_dotenv(dotenv_path=_env_path)
 
 PROJECT_ID = os.getenv("PROJECT_ID")
-DATASET_ID = os.getenv("DATASET_ID", "decision_lineage_demo")
+DATASET_ID = os.getenv("DATASET_ID", "decision_lineage_rich_demo")
 DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
 TABLE_ID = os.getenv("TABLE_ID", "agent_events")
 ENDPOINT = os.getenv("DEMO_AI_ENDPOINT", "gemini-2.5-flash")

--- a/examples/decision_lineage_demo/build_rich_graph.py
+++ b/examples/decision_lineage_demo/build_rich_graph.py
@@ -16,7 +16,8 @@ This script adds demo-only presentation tables and creates
 ``rich_agent_context_graph`` with extra labels that make the BigQuery
 Studio visualization read like the talk track:
 
-  CampaignRun, DecisionType, CandidateStatus, RejectionReason
+  CampaignRun, AgentStep, MediaEntity, PlanningDecision,
+  DecisionCategory, DecisionOption, OptionOutcome, DropReason
 
 The derived tables are deterministic SQL/load-job projections over the
 seven SDK backing tables. No new AI calls run here.
@@ -61,7 +62,8 @@ CREATE OR REPLACE TABLE `{project}.{dataset}.campaign_runs` (
   campaign STRING,
   brand STRING,
   brief STRING,
-  run_order INT64
+  run_order INT64,
+  event_count INT64
 )
 """
 
@@ -102,6 +104,28 @@ WHERE status = 'DROPPED'
 GROUP BY reason_id, rejection_rationale, reason_excerpt
 """
 
+_CREATE_RICH_AGENT_STEPS = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_agent_steps` AS
+SELECT
+  span_id,
+  parent_span_id,
+  event_type,
+  agent,
+  timestamp,
+  session_id,
+  invocation_id,
+  content,
+  latency_ms,
+  status,
+  error_message
+FROM `{project}.{dataset}.{table}`
+WHERE span_id IS NOT NULL
+QUALIFY ROW_NUMBER() OVER (
+  PARTITION BY span_id
+  ORDER BY timestamp DESC, event_type DESC
+) = 1
+"""
+
 _CREATE_RICH_CAMPAIGN_SPAN_EDGES = """\
 CREATE OR REPLACE TABLE `{project}.{dataset}.rich_campaign_span_edges` AS
 SELECT
@@ -110,7 +134,7 @@ SELECT
   span_id,
   event_type,
   timestamp
-FROM `{project}.{dataset}.{table}`
+FROM `{project}.{dataset}.rich_agent_steps`
 WHERE session_id IS NOT NULL
   AND span_id IS NOT NULL
 """
@@ -184,9 +208,31 @@ def _fetch_sessions(client: bigquery.Client) -> list[tuple[str, int]]:
   return [(row.session_id, int(row.event_count)) for row in rows]
 
 
+def _campaign_runs_has_rows(client: bigquery.Client) -> bool:
+  query = """\
+SELECT COUNT(*) AS n
+FROM `{project}.{dataset}.INFORMATION_SCHEMA.TABLES`
+WHERE table_name = 'campaign_runs'
+""".format(
+      project=PROJECT_ID, dataset=DATASET_ID
+  )
+  rows = list(client.query(query).result())
+  if not rows or not rows[0].n:
+    return False
+
+  count_query = """\
+SELECT COUNT(*) AS n
+FROM `{project}.{dataset}.campaign_runs`
+""".format(
+      project=PROJECT_ID, dataset=DATASET_ID
+  )
+  count_rows = list(client.query(count_query).result())
+  return bool(count_rows and count_rows[0].n)
+
+
 def _campaign_rows(sessions: list[tuple[str, int]]) -> list[dict[str, object]]:
   rows: list[dict[str, object]] = []
-  for idx, (session_id, _event_count) in enumerate(sessions):
+  for idx, (session_id, event_count) in enumerate(sessions):
     brief = CAMPAIGN_BRIEFS[idx % len(CAMPAIGN_BRIEFS)]
     brand = brief.campaign.split()[0]
     rows.append(
@@ -196,6 +242,7 @@ def _campaign_rows(sessions: list[tuple[str, int]]) -> list[dict[str, object]]:
             "brand": brand,
             "brief": brief.brief,
             "run_order": idx + 1,
+            "event_count": event_count,
         }
     )
   return rows
@@ -204,6 +251,10 @@ def _campaign_rows(sessions: list[tuple[str, int]]) -> list[dict[str, object]]:
 def _write_campaign_runs(
     client: bigquery.Client, sessions: list[tuple[str, int]]
 ) -> None:
+  if _campaign_runs_has_rows(client):
+    print("  - campaign_runs (existing from run_agent.py)")
+    return
+
   print("  - campaign_runs")
   client.query(_format(_CREATE_CAMPAIGN_RUNS_TABLE)).result()
   table_ref = f"{PROJECT_ID}.{DATASET_ID}.campaign_runs"
@@ -256,6 +307,7 @@ def main() -> int:
       ("rich_decision_types", _CREATE_RICH_DECISION_TYPES),
       ("rich_candidate_statuses", _CREATE_RICH_CANDIDATE_STATUSES),
       ("rich_rejection_reasons", _CREATE_RICH_REJECTION_REASONS),
+      ("rich_agent_steps", _CREATE_RICH_AGENT_STEPS),
       ("rich_campaign_span_edges", _CREATE_RICH_CAMPAIGN_SPAN_EDGES),
       ("rich_campaign_decision_edges", _CREATE_RICH_CAMPAIGN_DECISION_EDGES),
       ("rich_decision_type_edges", _CREATE_RICH_DECISION_TYPE_EDGES),

--- a/examples/decision_lineage_demo/build_rich_graph.py
+++ b/examples/decision_lineage_demo/build_rich_graph.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Build the richer demo presentation graph.
+
+``build_graph.py`` builds the SDK's canonical decision graph:
+
+  TechNode, BizNode, DecisionPoint, CandidateNode
+
+This script adds demo-only presentation tables and creates
+``rich_agent_context_graph`` with extra labels that make the BigQuery
+Studio visualization read like the talk track:
+
+  CampaignRun, DecisionType, CandidateStatus, RejectionReason
+
+The derived tables are deterministic SQL/load-job projections over the
+seven SDK backing tables. No new AI calls run here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+from campaigns import CAMPAIGN_BRIEFS
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ENV_PATH = _SCRIPT_DIR / ".env"
+if _ENV_PATH.exists():
+  load_dotenv(dotenv_path=_ENV_PATH)
+
+PROJECT_ID = os.getenv("PROJECT_ID")
+DATASET_ID = os.getenv("DATASET_ID", "decision_lineage_rich_demo")
+DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
+TABLE_ID = os.getenv("TABLE_ID", "agent_events")
+
+RICH_GRAPH_NAME = "rich_agent_context_graph"
+
+_DISTINCT_SESSIONS_QUERY = """\
+SELECT
+  session_id,
+  COUNT(*) AS event_count,
+  MIN(timestamp) AS first_event_at
+FROM `{project}.{dataset}.{table}`
+WHERE session_id IS NOT NULL
+GROUP BY session_id
+ORDER BY first_event_at
+"""
+
+_CREATE_CAMPAIGN_RUNS_TABLE = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.campaign_runs` (
+  session_id STRING,
+  campaign STRING,
+  brand STRING,
+  brief STRING,
+  run_order INT64
+)
+"""
+
+_CREATE_RICH_DECISION_TYPES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_decision_types` AS
+SELECT
+  TO_HEX(SHA256(LOWER(TRIM(decision_type)))) AS decision_type_id,
+  LOWER(TRIM(decision_type)) AS decision_type_key,
+  ANY_VALUE(decision_type) AS decision_type,
+  COUNT(*) AS decision_count
+FROM `{project}.{dataset}.decision_points`
+WHERE decision_type IS NOT NULL AND TRIM(decision_type) != ''
+GROUP BY decision_type_id, decision_type_key
+"""
+
+_CREATE_RICH_CANDIDATE_STATUSES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_candidate_statuses` AS
+SELECT
+  status AS status_id,
+  status,
+  COUNT(*) AS candidate_count
+FROM `{project}.{dataset}.candidates`
+WHERE status IS NOT NULL AND TRIM(status) != ''
+GROUP BY status_id, status
+"""
+
+_CREATE_RICH_REJECTION_REASONS = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_rejection_reasons` AS
+SELECT
+  TO_HEX(SHA256(TRIM(rejection_rationale))) AS reason_id,
+  TRIM(rejection_rationale) AS rejection_rationale,
+  SUBSTR(TRIM(rejection_rationale), 1, 120) AS reason_excerpt,
+  COUNT(*) AS candidate_count
+FROM `{project}.{dataset}.candidates`
+WHERE status = 'DROPPED'
+  AND rejection_rationale IS NOT NULL
+  AND TRIM(rejection_rationale) != ''
+GROUP BY reason_id, rejection_rationale, reason_excerpt
+"""
+
+_CREATE_RICH_CAMPAIGN_SPAN_EDGES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_campaign_span_edges` AS
+SELECT
+  CONCAT(session_id, ':span:', span_id) AS edge_id,
+  session_id,
+  span_id,
+  event_type,
+  timestamp
+FROM `{project}.{dataset}.{table}`
+WHERE session_id IS NOT NULL
+  AND span_id IS NOT NULL
+"""
+
+_CREATE_RICH_CAMPAIGN_DECISION_EDGES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_campaign_decision_edges` AS
+SELECT
+  CONCAT(session_id, ':campaign_decision:', decision_id) AS edge_id,
+  session_id,
+  decision_id
+FROM `{project}.{dataset}.decision_points`
+WHERE session_id IS NOT NULL
+  AND decision_id IS NOT NULL
+"""
+
+_CREATE_RICH_DECISION_TYPE_EDGES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_decision_type_edges` AS
+SELECT
+  CONCAT(decision_id, ':type:', TO_HEX(SHA256(LOWER(TRIM(decision_type))))) AS edge_id,
+  decision_id,
+  TO_HEX(SHA256(LOWER(TRIM(decision_type)))) AS decision_type_id
+FROM `{project}.{dataset}.decision_points`
+WHERE decision_id IS NOT NULL
+  AND decision_type IS NOT NULL
+  AND TRIM(decision_type) != ''
+"""
+
+_CREATE_RICH_CANDIDATE_STATUS_EDGES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_candidate_status_edges` AS
+SELECT
+  CONCAT(candidate_id, ':status:', status) AS edge_id,
+  candidate_id,
+  status AS status_id
+FROM `{project}.{dataset}.candidates`
+WHERE candidate_id IS NOT NULL
+  AND status IS NOT NULL
+  AND TRIM(status) != ''
+"""
+
+_CREATE_RICH_CANDIDATE_REASON_EDGES = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.rich_candidate_reason_edges` AS
+SELECT
+  CONCAT(candidate_id, ':reason:', TO_HEX(SHA256(TRIM(rejection_rationale)))) AS edge_id,
+  candidate_id,
+  TO_HEX(SHA256(TRIM(rejection_rationale))) AS reason_id
+FROM `{project}.{dataset}.candidates`
+WHERE status = 'DROPPED'
+  AND candidate_id IS NOT NULL
+  AND rejection_rationale IS NOT NULL
+  AND TRIM(rejection_rationale) != ''
+"""
+
+
+def _format(sql: str) -> str:
+  return sql.format(
+      project=PROJECT_ID,
+      dataset=DATASET_ID,
+      table=TABLE_ID,
+      graph=RICH_GRAPH_NAME,
+  )
+
+
+def _run_query(client: bigquery.Client, sql: str, label: str) -> None:
+  print(f"  - {label}")
+  job = client.query(_format(sql))
+  job.result()
+
+
+def _fetch_sessions(client: bigquery.Client) -> list[tuple[str, int]]:
+  rows = client.query(_format(_DISTINCT_SESSIONS_QUERY)).result()
+  return [(row.session_id, int(row.event_count)) for row in rows]
+
+
+def _campaign_rows(sessions: list[tuple[str, int]]) -> list[dict[str, object]]:
+  rows: list[dict[str, object]] = []
+  for idx, (session_id, _event_count) in enumerate(sessions):
+    brief = CAMPAIGN_BRIEFS[idx % len(CAMPAIGN_BRIEFS)]
+    brand = brief.campaign.split()[0]
+    rows.append(
+        {
+            "session_id": session_id,
+            "campaign": brief.campaign,
+            "brand": brand,
+            "brief": brief.brief,
+            "run_order": idx + 1,
+        }
+    )
+  return rows
+
+
+def _write_campaign_runs(
+    client: bigquery.Client, sessions: list[tuple[str, int]]
+) -> None:
+  print("  - campaign_runs")
+  client.query(_format(_CREATE_CAMPAIGN_RUNS_TABLE)).result()
+  table_ref = f"{PROJECT_ID}.{DATASET_ID}.campaign_runs"
+  job_config = bigquery.LoadJobConfig(
+      write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+      source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+  )
+  job = client.load_table_from_json(
+      _campaign_rows(sessions), table_ref, job_config=job_config
+  )
+  job.result()
+
+
+def _create_rich_graph(client: bigquery.Client) -> None:
+  print(f"  - {RICH_GRAPH_NAME}")
+  template = (_SCRIPT_DIR / "rich_property_graph.gql.tpl").read_text(
+      encoding="utf-8"
+  )
+  sql = (
+      template.replace("__PROJECT_ID__", PROJECT_ID or "")
+      .replace("__DATASET_ID__", DATASET_ID)
+      .replace("__RICH_GRAPH_NAME__", RICH_GRAPH_NAME)
+  )
+  client.query(sql).result()
+
+
+def main() -> int:
+  if not PROJECT_ID:
+    print("ERROR: PROJECT_ID not set. Run ./setup.sh first.", file=sys.stderr)
+    return 2
+
+  print(f"Project : {PROJECT_ID}")
+  print(f"Dataset : {DATASET_ID}")
+  print(f"Graph   : {RICH_GRAPH_NAME}")
+  print()
+
+  client = bigquery.Client(project=PROJECT_ID, location=DATASET_LOCATION)
+  sessions = _fetch_sessions(client)
+  if not sessions:
+    print(
+        f"ERROR: no sessions found in {DATASET_ID}.{TABLE_ID}. "
+        "Run run_agent.py and build_graph.py first.",
+        file=sys.stderr,
+    )
+    return 1
+
+  print("Building rich demo tables:")
+  _write_campaign_runs(client, sessions)
+  for label, sql in (
+      ("rich_decision_types", _CREATE_RICH_DECISION_TYPES),
+      ("rich_candidate_statuses", _CREATE_RICH_CANDIDATE_STATUSES),
+      ("rich_rejection_reasons", _CREATE_RICH_REJECTION_REASONS),
+      ("rich_campaign_span_edges", _CREATE_RICH_CAMPAIGN_SPAN_EDGES),
+      ("rich_campaign_decision_edges", _CREATE_RICH_CAMPAIGN_DECISION_EDGES),
+      ("rich_decision_type_edges", _CREATE_RICH_DECISION_TYPE_EDGES),
+      ("rich_candidate_status_edges", _CREATE_RICH_CANDIDATE_STATUS_EDGES),
+      ("rich_candidate_reason_edges", _CREATE_RICH_CANDIDATE_REASON_EDGES),
+  ):
+    _run_query(client, sql, label)
+
+  print("Creating rich property graph:")
+  _create_rich_graph(client)
+  print()
+  print(
+      f"Rich graph: {PROJECT_ID}.{DATASET_ID}.{RICH_GRAPH_NAME} "
+      f"({len(sessions)} campaign runs)"
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/examples/decision_lineage_demo/render_queries.sh
+++ b/examples/decision_lineage_demo/render_queries.sh
@@ -14,6 +14,9 @@
 #                           rebuilds the graph from the seven
 #                           backing tables without rerunning the
 #                           agent or AI.GENERATE)
+#   rich_property_graph.gql (CREATE OR REPLACE PROPERTY GRAPH DDL —
+#                            rebuilds the richer demo presentation
+#                            graph from the base + derived tables)
 
 set -euo pipefail
 
@@ -40,6 +43,7 @@ render_one() {
   sed \
     -e "s|__PROJECT_ID__|${PROJECT_ID}|g" \
     -e "s|__DATASET_ID__|${DATASET_ID}|g" \
+    -e "s|__RICH_GRAPH_NAME__|rich_agent_context_graph|g" \
     -e "s|__SESSION_ID__|${DEMO_SESSION_ID}|g" \
     "$tpl" > "$out"
   echo "Rendered $out"
@@ -58,4 +62,9 @@ if [[ -f "$SCRIPT_DIR/property_graph.gql.tpl" ]]; then
   render_one \
     "$SCRIPT_DIR/property_graph.gql.tpl" \
     "$SCRIPT_DIR/property_graph.gql"
+fi
+if [[ -f "$SCRIPT_DIR/rich_property_graph.gql.tpl" ]]; then
+  render_one \
+    "$SCRIPT_DIR/rich_property_graph.gql.tpl" \
+    "$SCRIPT_DIR/rich_property_graph.gql"
 fi

--- a/examples/decision_lineage_demo/reset.sh
+++ b/examples/decision_lineage_demo/reset.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/.env"
 RENDERED_QUERIES="$SCRIPT_DIR/bq_studio_queries.gql"
 RENDERED_DDL="$SCRIPT_DIR/property_graph.gql"
+RENDERED_RICH_DDL="$SCRIPT_DIR/rich_property_graph.gql"
 
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "No .env found at $ENV_FILE — nothing to reset."
@@ -44,6 +45,6 @@ if [[ "$confirm_lc" != "y" && "$confirm_lc" != "yes" ]]; then
 fi
 
 bq rm -r -f --dataset "${PROJECT_ID}:${DATASET_ID}" || true
-rm -f "$ENV_FILE" "$RENDERED_QUERIES" "$RENDERED_DDL"
+rm -f "$ENV_FILE" "$RENDERED_QUERIES" "$RENDERED_DDL" "$RENDERED_RICH_DDL"
 rm -rf "$SCRIPT_DIR/.venv"
 echo "Reset complete. Re-run ./setup.sh to seed and rebuild."

--- a/examples/decision_lineage_demo/rich_property_graph.gql.tpl
+++ b/examples/decision_lineage_demo/rich_property_graph.gql.tpl
@@ -18,9 +18,9 @@ CREATE OR REPLACE PROPERTY GRAPH
         brief,
         run_order
       ),
-    `__PROJECT_ID__.__DATASET_ID__.agent_events` AS TechNode
+    `__PROJECT_ID__.__DATASET_ID__.rich_agent_steps` AS AgentStep
       KEY (span_id)
-      LABEL TechNode
+      LABEL AgentStep
       PROPERTIES (
         event_type,
         agent,
@@ -32,9 +32,9 @@ CREATE OR REPLACE PROPERTY GRAPH
         status,
         error_message
       ),
-    `__PROJECT_ID__.__DATASET_ID__.extracted_biz_nodes` AS BizNode
+    `__PROJECT_ID__.__DATASET_ID__.extracted_biz_nodes` AS MediaEntity
       KEY (biz_node_id)
-      LABEL BizNode
+      LABEL MediaEntity
       PROPERTIES (
         node_type,
         node_value,
@@ -43,26 +43,26 @@ CREATE OR REPLACE PROPERTY GRAPH
         span_id,
         artifact_uri
       ),
-    `__PROJECT_ID__.__DATASET_ID__.decision_points` AS DecisionPoint
+    `__PROJECT_ID__.__DATASET_ID__.decision_points` AS PlanningDecision
       KEY (decision_id)
-      LABEL DecisionPoint
+      LABEL PlanningDecision
       PROPERTIES (
         session_id,
         span_id,
         decision_type,
         description
       ),
-    `__PROJECT_ID__.__DATASET_ID__.rich_decision_types` AS DecisionType
+    `__PROJECT_ID__.__DATASET_ID__.rich_decision_types` AS DecisionCategory
       KEY (decision_type_id)
-      LABEL DecisionType
+      LABEL DecisionCategory
       PROPERTIES (
         decision_type_key,
         decision_type,
         decision_count
       ),
-    `__PROJECT_ID__.__DATASET_ID__.candidates` AS CandidateNode
+    `__PROJECT_ID__.__DATASET_ID__.candidates` AS DecisionOption
       KEY (candidate_id)
-      LABEL CandidateNode
+      LABEL DecisionOption
       PROPERTIES (
         decision_id,
         session_id,
@@ -71,16 +71,16 @@ CREATE OR REPLACE PROPERTY GRAPH
         status,
         rejection_rationale
       ),
-    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_statuses` AS CandidateStatus
+    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_statuses` AS OptionOutcome
       KEY (status_id)
-      LABEL CandidateStatus
+      LABEL OptionOutcome
       PROPERTIES (
         status,
         candidate_count
       ),
-    `__PROJECT_ID__.__DATASET_ID__.rich_rejection_reasons` AS RejectionReason
+    `__PROJECT_ID__.__DATASET_ID__.rich_rejection_reasons` AS DropReason
       KEY (reason_id)
-      LABEL RejectionReason
+      LABEL DropReason
       PROPERTIES (
         rejection_rationale,
         reason_excerpt,
@@ -88,71 +88,71 @@ CREATE OR REPLACE PROPERTY GRAPH
       )
   )
   EDGE TABLES (
-    `__PROJECT_ID__.__DATASET_ID__.rich_campaign_span_edges` AS CampaignSpan
+    `__PROJECT_ID__.__DATASET_ID__.rich_campaign_span_edges` AS CampaignActivity
       KEY (edge_id)
       SOURCE KEY (session_id) REFERENCES CampaignRun (session_id)
-      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
-      LABEL CampaignSpan
+      DESTINATION KEY (span_id) REFERENCES AgentStep (span_id)
+      LABEL CampaignActivity
       PROPERTIES (
         event_type,
         timestamp
       ),
 
-    `__PROJECT_ID__.__DATASET_ID__.agent_events` AS Caused
+    `__PROJECT_ID__.__DATASET_ID__.rich_agent_steps` AS NextStep
       KEY (span_id)
-      SOURCE KEY (parent_span_id) REFERENCES TechNode (span_id)
-      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
-      LABEL Caused,
+      SOURCE KEY (parent_span_id) REFERENCES AgentStep (span_id)
+      DESTINATION KEY (span_id) REFERENCES AgentStep (span_id)
+      LABEL NextStep,
 
-    `__PROJECT_ID__.__DATASET_ID__.context_cross_links` AS Evaluated
+    `__PROJECT_ID__.__DATASET_ID__.context_cross_links` AS ConsideredEntity
       KEY (link_id)
-      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
-      DESTINATION KEY (biz_node_id) REFERENCES BizNode (biz_node_id)
-      LABEL Evaluated
+      SOURCE KEY (span_id) REFERENCES AgentStep (span_id)
+      DESTINATION KEY (biz_node_id) REFERENCES MediaEntity (biz_node_id)
+      LABEL ConsideredEntity
       PROPERTIES (
         artifact_uri,
         link_type,
         created_at
       ),
 
-    `__PROJECT_ID__.__DATASET_ID__.made_decision_edges` AS MadeDecision
+    `__PROJECT_ID__.__DATASET_ID__.made_decision_edges` AS DecidedAt
       KEY (edge_id)
-      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
-      DESTINATION KEY (decision_id) REFERENCES DecisionPoint (decision_id)
-      LABEL MadeDecision,
+      SOURCE KEY (span_id) REFERENCES AgentStep (span_id)
+      DESTINATION KEY (decision_id) REFERENCES PlanningDecision (decision_id)
+      LABEL DecidedAt,
 
     `__PROJECT_ID__.__DATASET_ID__.rich_campaign_decision_edges` AS CampaignDecision
       KEY (edge_id)
       SOURCE KEY (session_id) REFERENCES CampaignRun (session_id)
-      DESTINATION KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      DESTINATION KEY (decision_id) REFERENCES PlanningDecision (decision_id)
       LABEL CampaignDecision,
 
-    `__PROJECT_ID__.__DATASET_ID__.rich_decision_type_edges` AS HasDecisionType
+    `__PROJECT_ID__.__DATASET_ID__.rich_decision_type_edges` AS InCategory
       KEY (edge_id)
-      SOURCE KEY (decision_id) REFERENCES DecisionPoint (decision_id)
-      DESTINATION KEY (decision_type_id) REFERENCES DecisionType (decision_type_id)
-      LABEL HasDecisionType,
+      SOURCE KEY (decision_id) REFERENCES PlanningDecision (decision_id)
+      DESTINATION KEY (decision_type_id) REFERENCES DecisionCategory (decision_type_id)
+      LABEL InCategory,
 
-    `__PROJECT_ID__.__DATASET_ID__.candidate_edges` AS CandidateEdge
+    `__PROJECT_ID__.__DATASET_ID__.candidate_edges` AS WeighedOption
       KEY (edge_id)
-      SOURCE KEY (decision_id) REFERENCES DecisionPoint (decision_id)
-      DESTINATION KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
-      LABEL CandidateEdge
+      SOURCE KEY (decision_id) REFERENCES PlanningDecision (decision_id)
+      DESTINATION KEY (candidate_id) REFERENCES DecisionOption (candidate_id)
+      LABEL WeighedOption
       PROPERTIES (
         edge_type,
         rejection_rationale,
         created_at
       ),
 
-    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_status_edges` AS HasCandidateStatus
+    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_status_edges` AS HasOutcome
       KEY (edge_id)
-      SOURCE KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
-      DESTINATION KEY (status_id) REFERENCES CandidateStatus (status_id)
-      LABEL HasCandidateStatus,
+      SOURCE KEY (candidate_id) REFERENCES DecisionOption (candidate_id)
+      DESTINATION KEY (status_id) REFERENCES OptionOutcome (status_id)
+      LABEL HasOutcome,
 
     `__PROJECT_ID__.__DATASET_ID__.rich_candidate_reason_edges` AS RejectedBecause
       KEY (edge_id)
-      SOURCE KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
-      DESTINATION KEY (reason_id) REFERENCES RejectionReason (reason_id)
+      SOURCE KEY (candidate_id) REFERENCES DecisionOption (candidate_id)
+      DESTINATION KEY (reason_id) REFERENCES DropReason (reason_id)
       LABEL RejectedBecause
   );

--- a/examples/decision_lineage_demo/rich_property_graph.gql.tpl
+++ b/examples/decision_lineage_demo/rich_property_graph.gql.tpl
@@ -1,0 +1,158 @@
+-- Copyright 2026 Google LLC
+-- Licensed under the Apache License, Version 2.0 (the "License").
+--
+-- Demo presentation graph. This is intentionally richer than the SDK's
+-- canonical `agent_context_graph`: it promotes campaign runs, decision
+-- types, candidate statuses, and rejection reasons into first-class
+-- nodes so BigQuery Studio has a denser visual story to render.
+
+CREATE OR REPLACE PROPERTY GRAPH
+  `__PROJECT_ID__.__DATASET_ID__.__RICH_GRAPH_NAME__`
+  NODE TABLES (
+    `__PROJECT_ID__.__DATASET_ID__.campaign_runs` AS CampaignRun
+      KEY (session_id)
+      LABEL CampaignRun
+      PROPERTIES (
+        campaign,
+        brand,
+        brief,
+        run_order
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.agent_events` AS TechNode
+      KEY (span_id)
+      LABEL TechNode
+      PROPERTIES (
+        event_type,
+        agent,
+        timestamp,
+        session_id,
+        invocation_id,
+        content,
+        latency_ms,
+        status,
+        error_message
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.extracted_biz_nodes` AS BizNode
+      KEY (biz_node_id)
+      LABEL BizNode
+      PROPERTIES (
+        node_type,
+        node_value,
+        confidence,
+        session_id,
+        span_id,
+        artifact_uri
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.decision_points` AS DecisionPoint
+      KEY (decision_id)
+      LABEL DecisionPoint
+      PROPERTIES (
+        session_id,
+        span_id,
+        decision_type,
+        description
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.rich_decision_types` AS DecisionType
+      KEY (decision_type_id)
+      LABEL DecisionType
+      PROPERTIES (
+        decision_type_key,
+        decision_type,
+        decision_count
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.candidates` AS CandidateNode
+      KEY (candidate_id)
+      LABEL CandidateNode
+      PROPERTIES (
+        decision_id,
+        session_id,
+        name,
+        score,
+        status,
+        rejection_rationale
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_statuses` AS CandidateStatus
+      KEY (status_id)
+      LABEL CandidateStatus
+      PROPERTIES (
+        status,
+        candidate_count
+      ),
+    `__PROJECT_ID__.__DATASET_ID__.rich_rejection_reasons` AS RejectionReason
+      KEY (reason_id)
+      LABEL RejectionReason
+      PROPERTIES (
+        rejection_rationale,
+        reason_excerpt,
+        candidate_count
+      )
+  )
+  EDGE TABLES (
+    `__PROJECT_ID__.__DATASET_ID__.rich_campaign_span_edges` AS CampaignSpan
+      KEY (edge_id)
+      SOURCE KEY (session_id) REFERENCES CampaignRun (session_id)
+      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
+      LABEL CampaignSpan
+      PROPERTIES (
+        event_type,
+        timestamp
+      ),
+
+    `__PROJECT_ID__.__DATASET_ID__.agent_events` AS Caused
+      KEY (span_id)
+      SOURCE KEY (parent_span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (span_id) REFERENCES TechNode (span_id)
+      LABEL Caused,
+
+    `__PROJECT_ID__.__DATASET_ID__.context_cross_links` AS Evaluated
+      KEY (link_id)
+      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (biz_node_id) REFERENCES BizNode (biz_node_id)
+      LABEL Evaluated
+      PROPERTIES (
+        artifact_uri,
+        link_type,
+        created_at
+      ),
+
+    `__PROJECT_ID__.__DATASET_ID__.made_decision_edges` AS MadeDecision
+      KEY (edge_id)
+      SOURCE KEY (span_id) REFERENCES TechNode (span_id)
+      DESTINATION KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      LABEL MadeDecision,
+
+    `__PROJECT_ID__.__DATASET_ID__.rich_campaign_decision_edges` AS CampaignDecision
+      KEY (edge_id)
+      SOURCE KEY (session_id) REFERENCES CampaignRun (session_id)
+      DESTINATION KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      LABEL CampaignDecision,
+
+    `__PROJECT_ID__.__DATASET_ID__.rich_decision_type_edges` AS HasDecisionType
+      KEY (edge_id)
+      SOURCE KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      DESTINATION KEY (decision_type_id) REFERENCES DecisionType (decision_type_id)
+      LABEL HasDecisionType,
+
+    `__PROJECT_ID__.__DATASET_ID__.candidate_edges` AS CandidateEdge
+      KEY (edge_id)
+      SOURCE KEY (decision_id) REFERENCES DecisionPoint (decision_id)
+      DESTINATION KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
+      LABEL CandidateEdge
+      PROPERTIES (
+        edge_type,
+        rejection_rationale,
+        created_at
+      ),
+
+    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_status_edges` AS HasCandidateStatus
+      KEY (edge_id)
+      SOURCE KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
+      DESTINATION KEY (status_id) REFERENCES CandidateStatus (status_id)
+      LABEL HasCandidateStatus,
+
+    `__PROJECT_ID__.__DATASET_ID__.rich_candidate_reason_edges` AS RejectedBecause
+      KEY (edge_id)
+      SOURCE KEY (candidate_id) REFERENCES CandidateNode (candidate_id)
+      DESTINATION KEY (reason_id) REFERENCES RejectionReason (reason_id)
+      LABEL RejectedBecause
+  );

--- a/examples/decision_lineage_demo/run_agent.py
+++ b/examples/decision_lineage_demo/run_agent.py
@@ -22,7 +22,9 @@ BigQuery before downstream extraction starts.
 
 Records the first session id back into ``.env`` (as ``DEMO_SESSION_ID``)
 so ``render_queries.sh`` can wire it into the per-session GQL block in
-``bq_studio_queries.gql``.
+``bq_studio_queries.gql``. Also writes ``campaign_runs`` so the rich
+demo graph has an exact campaign ↔ session mapping instead of
+inferring it from event timestamps.
 """
 
 from __future__ import annotations
@@ -35,8 +37,12 @@ import time
 from agent import APP_NAME
 from agent import bq_logging_plugin
 from agent import root_agent
+from agent.agent import DATASET_ID
+from agent.agent import DATASET_LOCATION
+from agent.agent import PROJECT_ID
 from campaigns import CAMPAIGN_BRIEFS
 from google.adk.runners import InMemoryRunner
+from google.cloud import bigquery
 from google.genai.types import Content
 from google.genai.types import Part
 
@@ -45,6 +51,17 @@ _ENV_PATH = os.path.join(_HERE, ".env")
 
 USER_ID = os.getenv("DEMO_USER_ID", "u-demo-mediabuyer")
 PER_SESSION_TIMEOUT_S = int(os.getenv("DEMO_SESSION_TIMEOUT_S", "300"))
+
+_CREATE_CAMPAIGN_RUNS_TABLE = """\
+CREATE OR REPLACE TABLE `{project}.{dataset}.campaign_runs` (
+  session_id STRING,
+  campaign STRING,
+  brand STRING,
+  brief STRING,
+  run_order INT64,
+  event_count INT64
+)
+"""
 
 
 async def _run_one(
@@ -103,11 +120,11 @@ async def _run_one(
   return session_id, event_count, error_reason
 
 
-async def _run_all() -> tuple[list[str], list[tuple[str, str]]]:
+async def _run_all() -> tuple[list[dict[str, object]], list[tuple[str, str]]]:
   """Run every campaign brief.
 
   Returns:
-      ``(succeeded_session_ids, failures)`` where ``failures`` is a
+      ``(succeeded_campaign_runs, failures)`` where ``failures`` is a
       list of ``(campaign, reason)`` for diagnosis.
   """
   briefs = CAMPAIGN_BRIEFS
@@ -124,16 +141,25 @@ async def _run_all() -> tuple[list[str], list[tuple[str, str]]]:
       plugins=[bq_logging_plugin],
   )
 
-  succeeded: list[str] = []
+  succeeded: list[dict[str, object]] = []
   failures: list[tuple[str, str]] = []
   for idx, brief in enumerate(briefs, start=1):
     try:
-      session_id, _event_count, error_reason = await asyncio.wait_for(
+      session_id, event_count, error_reason = await asyncio.wait_for(
           _run_one(runner, brief.campaign, brief.brief, idx, len(briefs)),
           timeout=PER_SESSION_TIMEOUT_S,
       )
       if error_reason is None:
-        succeeded.append(session_id)
+        succeeded.append(
+            {
+                "session_id": session_id,
+                "campaign": brief.campaign,
+                "brand": brief.campaign.split()[0],
+                "brief": brief.brief,
+                "run_order": idx,
+                "event_count": event_count,
+            }
+        )
       else:
         failures.append((brief.campaign, error_reason))
     except asyncio.TimeoutError:
@@ -160,11 +186,11 @@ async def _run_all() -> tuple[list[str], list[tuple[str, str]]]:
   return succeeded, failures
 
 
-def _record_first_session_id(session_ids: list[str]) -> None:
+def _record_first_session_id(runs: list[dict[str, object]]) -> None:
   """Append DEMO_SESSION_ID to .env if a first session is available."""
-  if not session_ids:
+  if not runs:
     return
-  first = session_ids[0]
+  first = str(runs[0]["session_id"])
   lines: list[str] = []
   if os.path.exists(_ENV_PATH):
     with open(_ENV_PATH, encoding="utf-8") as f:
@@ -179,12 +205,33 @@ def _record_first_session_id(session_ids: list[str]) -> None:
   print(f"  Wrote DEMO_SESSION_ID={first} to {_ENV_PATH}")
 
 
+def _write_campaign_runs(runs: list[dict[str, object]]) -> None:
+  """Write exact campaign/session mapping for the rich demo graph."""
+  if not runs:
+    return
+
+  client = bigquery.Client(project=PROJECT_ID, location=DATASET_LOCATION)
+  client.query(
+      _CREATE_CAMPAIGN_RUNS_TABLE.format(
+          project=PROJECT_ID,
+          dataset=DATASET_ID,
+      )
+  ).result()
+  table_ref = f"{PROJECT_ID}.{DATASET_ID}.campaign_runs"
+  job_config = bigquery.LoadJobConfig(
+      write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+      source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+  )
+  client.load_table_from_json(runs, table_ref, job_config=job_config).result()
+  print(f"  Wrote {len(runs)} campaign_runs rows to {table_ref}")
+
+
 def main() -> int:
   succeeded, failures = asyncio.run(_run_all())
   print()
   print(f"Sessions: {len(succeeded)} succeeded, {len(failures)} failed.")
-  for sid in succeeded:
-    print(f"  ok  - {sid}")
+  for run in succeeded:
+    print(f"  ok  - {run['session_id']}")
   for campaign, reason in failures:
     print(f"  FAIL- {campaign}: {reason}")
   print()
@@ -202,6 +249,7 @@ def main() -> int:
   if not succeeded:
     print("ERROR: zero sessions produced traces.", file=sys.stderr)
     return 1
+  _write_campaign_runs(succeeded)
   return 0
 
 

--- a/examples/decision_lineage_demo/setup.sh
+++ b/examples/decision_lineage_demo/setup.sh
@@ -36,7 +36,7 @@
 #      cross-link / decision edges, and emits CREATE OR REPLACE
 #      PROPERTY GRAPH.
 #   8. Run build_rich_graph.py — derives demo presentation nodes
-#      (CampaignRun, DecisionType, CandidateStatus, RejectionReason)
+#      (CampaignRun, DecisionCategory, OptionOutcome, DropReason)
 #      and creates rich_agent_context_graph.
 #   9. Render bq_studio_queries.gql with project/dataset/session
 #      values inlined for copy-paste into BigQuery Studio. The

--- a/examples/decision_lineage_demo/setup.sh
+++ b/examples/decision_lineage_demo/setup.sh
@@ -35,7 +35,10 @@
 #      writes BizNode + DecisionPoint + Candidate rows, builds the
 #      cross-link / decision edges, and emits CREATE OR REPLACE
 #      PROPERTY GRAPH.
-#   8. Render bq_studio_queries.gql with project/dataset/session
+#   8. Run build_rich_graph.py — derives demo presentation nodes
+#      (CampaignRun, DecisionType, CandidateStatus, RejectionReason)
+#      and creates rich_agent_context_graph.
+#   9. Render bq_studio_queries.gql with project/dataset/session
 #      values inlined for copy-paste into BigQuery Studio. The
 #      session id is the first session run_agent.py created.
 #
@@ -56,7 +59,7 @@ echo "============================================"
 echo ""
 
 # 1. Tooling
-echo "[1/8] Checking python3 and gcloud..."
+echo "[1/9] Checking python3 and gcloud..."
 if ! command -v python3 &>/dev/null; then
   echo "ERROR: python3 is required." >&2
   exit 1
@@ -81,7 +84,7 @@ fi
 
 # 2. APIs
 echo ""
-echo "[2/8] Enabling BigQuery + Vertex AI APIs..."
+echo "[2/9] Enabling BigQuery + Vertex AI APIs..."
 gcloud services enable bigquery.googleapis.com --project="$PROJECT_ID" 2>/dev/null
 echo "  BigQuery API: enabled"
 gcloud services enable aiplatform.googleapis.com --project="$PROJECT_ID" 2>/dev/null
@@ -89,7 +92,7 @@ echo "  Vertex AI API: enabled"
 
 # 3. Dependencies
 echo ""
-echo "[3/8] Installing Python dependencies into ./.venv..."
+echo "[3/9] Installing Python dependencies into ./.venv..."
 # Use a per-demo venv so PEP 668 (Homebrew Python) doesn't block
 # installs and so the demo doesn't pollute the system interpreter.
 VENV_DIR="$SCRIPT_DIR/.venv"
@@ -116,8 +119,8 @@ echo "  Dependencies installed in $VENV_DIR"
 
 # 4. Dataset + .env
 echo ""
-echo "[4/8] Configuring environment..."
-DATASET_ID="${DATASET_ID:-decision_lineage_demo}"
+echo "[4/9] Configuring environment..."
+DATASET_ID="${DATASET_ID:-decision_lineage_rich_demo}"
 # Vertex AI for the live agent runs needs a regional location, not
 # multi-region "US". Default to us-central1 for both the dataset and
 # the agent. If a user-set location overrides, we use that.
@@ -147,26 +150,31 @@ echo "  Wrote $ENV_FILE"
 
 # 5. Run the live agent (BQ AA Plugin writes spans to agent_events)
 echo ""
-echo "[5/8] Running the media-planner agent against every campaign "
+echo "[5/9] Running the media-planner agent against every campaign "
 echo "      brief — this is real ADK + BQ AA Plugin (3-7 minutes)..."
 cd "$SCRIPT_DIR"
 "$VENV_PY" run_agent.py
 
 # 6. Build graph (AI.GENERATE)
 echo ""
-echo "[6/8] Building the property graph via the SDK extraction "
+echo "[6/9] Building the canonical SDK property graph via extraction "
 echo "      pipeline across every session (AI.GENERATE — this can "
 echo "      take 30-90s)..."
 "$VENV_PY" build_graph.py
 
-# 7. Render BQ Studio queries
+# 7. Build rich demo graph (SQL-only over canonical outputs)
 echo ""
-echo "[7/8] Rendering BigQuery Studio query bundle..."
+echo "[7/9] Building the richer demo presentation graph..."
+"$VENV_PY" build_rich_graph.py
+
+# 8. Render BQ Studio queries
+echo ""
+echo "[8/9] Rendering BigQuery Studio query bundle..."
 "$SCRIPT_DIR/render_queries.sh"
 
-# 8. Done
+# 9. Done
 echo ""
-echo "[8/8] Done."
+echo "[9/9] Done."
 echo ""
 echo "============================================"
 echo "  Setup complete!"
@@ -176,7 +184,7 @@ echo "Next:"
 echo "  1. Open BigQuery Studio in your browser:"
 echo "     https://console.cloud.google.com/bigquery?project=${PROJECT_ID}"
 echo "  2. Navigate to dataset: ${DATASET_ID}"
-echo "     (the property graph 'agent_context_graph' shows in the Explorer pane)"
+echo "     (the rich graph 'rich_agent_context_graph' shows in the Explorer pane)"
 echo "  3. Open ${SCRIPT_DIR}/bq_studio_queries.gql"
 echo "     in a text editor and paste each block into BQ Studio."
 echo ""
@@ -184,6 +192,8 @@ echo "To re-run just the agent (extra sessions):"
 echo "  ./.venv/bin/python3 run_agent.py"
 echo "To re-run just the AI.GENERATE pipeline (e.g. after a flaky run):"
 echo "  ./.venv/bin/python3 build_graph.py"
+echo "To re-run just the rich presentation graph:"
+echo "  ./.venv/bin/python3 build_rich_graph.py"
 echo ""
 echo "Talk track + timing: see DEMO_NARRATION.md"
 echo "Tear down:           ./reset.sh"


### PR DESCRIPTION
## Summary
- add a demo-specific default dataset: decision_lineage_rich_demo
- add build_rich_graph.py plus rich_property_graph.gql.tpl to create rich_agent_context_graph
- expose ads-domain graph labels for the demo surface: AgentStep, MediaEntity, PlanningDecision, DecisionOption, DecisionCategory, OptionOutcome, DropReason
- write exact campaign_runs mapping from run_agent.py; build_rich_graph.py reuses it and only synthesizes fallback rows for cloned/legacy datasets
- add rich_agent_steps as a deduped projection over agent_events so AgentStep / NextStep / CampaignActivity satisfy BigQuery property-graph KEY contracts
- update setup/render/reset plus README, walkthrough, narration, questions, and data-lineage docs to use the richer graph narrative

## Live setup
- created test-project-0728-467323:decision_lineage_rich_demo in us-central1
- cloned the existing demo SDK tables into the new dataset to avoid another live Gemini run
- applied the canonical agent_context_graph DDL and built rich_agent_context_graph
- rebuilt rich_agent_context_graph after the review fixes
- key check: rich_agent_steps 78/78, rich_campaign_span_edges 78/78, rich_campaign_decision_edges 32/32, rich_decision_type_edges 32/32, rich_candidate_status_edges 97/97, rich_candidate_reason_edges 65/65
- GQL spot-check: CampaignRun -> PlanningDecision -> DecisionOption -> OptionOutcome returned 97 reasoning paths

## Verification
- uv run pyink --check examples/decision_lineage_demo/run_agent.py examples/decision_lineage_demo/build_rich_graph.py examples/decision_lineage_demo/agent/agent.py examples/decision_lineage_demo/build_graph.py
- uv run isort --check-only examples/decision_lineage_demo/run_agent.py examples/decision_lineage_demo/build_rich_graph.py examples/decision_lineage_demo/agent/agent.py examples/decision_lineage_demo/build_graph.py
- uv run python -m py_compile examples/decision_lineage_demo/run_agent.py examples/decision_lineage_demo/build_rich_graph.py examples/decision_lineage_demo/agent/agent.py examples/decision_lineage_demo/build_graph.py
- bash -n examples/decision_lineage_demo/setup.sh examples/decision_lineage_demo/reset.sh examples/decision_lineage_demo/render_queries.sh
- git diff --check
- examples/decision_lineage_demo/render_queries.sh
- uv run python examples/decision_lineage_demo/build_rich_graph.py
- BigQuery key-count and GQL spot checks against test-project-0728-467323.decision_lineage_rich_demo