### PR TITLE
fix(cycle): timestamped outputs, log cleanup, quality threshold

### DIFF
--- a/examples/agent_improvement_cycle/DEMO_NARRATION.md
+++ b/examples/agent_improvement_cycle/DEMO_NARRATION.md
@@ -144,7 +144,7 @@ The agent uses its tools and gives direct, grounded answers. No more "contact HR
 Ten out of ten sessions scored as helpful and grounded — in a single cycle.
 
 And now the operational comparison — the same deterministic metrics we captured as a baseline in Step 3, run on the V2 sessions and shown side by side.
-Latency stayed flat or improved — the V2 prompt routes to tools directly instead of deliberating. Token usage is comparable. 
+Latency consistently drops with V2 — the V1 agent spends time deliberating before refusing, while V2 routes to tools immediately and responds. Token usage increases because V2 calls tools for every question instead of refusing some, but stays well within budget.
 Turn count unchanged. The improved prompt didn't trade quality for cost.
 
 

--- a/examples/agent_improvement_cycle/DEMO_NARRATION.md
+++ b/examples/agent_improvement_cycle/DEMO_NARRATION.md
@@ -197,8 +197,8 @@ Options:
   --agent-config F   Path to agent's config.json
                      (default: config.json)
   --cycles N         Run N improvement cycles (default: 1)
-  --no-auto          Always run all N cycles even if 100%
-                     meaningful (default: stop early)
+  --auto             Enable auto-cycling: run up to N cycles,
+                     stop early when 100% meaningful
   --eval-only        Only run evaluation (Steps 1-3), skip improvement
   --app-name X       Override agent app name for BQ filtering
   --traffic-count N  Number of synthetic questions per cycle (default: 10)
@@ -207,9 +207,9 @@ Options:
 
 You can run again with multiple cycles to see iterative refinement:
 ```shell
-./run_cycle.sh --cycles 3
+./run_cycle.sh --auto --cycles 3
 ```
-By default, the cycle stops early once all synthetic traffic scores 100% meaningful. Each cycle generates fresh traffic, evaluates, improves, and measures. The golden eval set grows with each cycle as new edge cases are discovered.
+By default, the script runs a single cycle and stops. The `--auto` flag enables auto-cycling, which runs up to N cycles and stops early once all synthetic traffic scores 100% meaningful. Each cycle generates fresh traffic, evaluates, improves, and measures. The golden eval set grows with each cycle as new edge cases are discovered.
 
 ---
 

--- a/examples/agent_improvement_cycle/DEMO_NARRATION.md
+++ b/examples/agent_improvement_cycle/DEMO_NARRATION.md
@@ -184,8 +184,8 @@ To reset everything back to V1 and start over:
 ./reset.sh
 ```
 
-This reverts the prompt in the Vertex AI Prompt Registry to V1, restores the original three golden eval cases,
-and clears reports. 
+This reverts the prompt in the Vertex AI Prompt Registry to V1 and restores the original three golden eval cases.
+Previous run reports (under `reports/run_*/`) are preserved.
 
 There are multiple options of how to run the flow:
 ```shell
@@ -198,10 +198,11 @@ Options:
                      (default: config.json)
   --cycles N         Run N improvement cycles (default: 1)
   --auto             Enable auto-cycling: run up to N cycles,
-                     stop early when 100% meaningful
+                     stop early when quality meets threshold
   --eval-only        Only run evaluation (Steps 1-3), skip improvement
   --app-name X       Override agent app name for BQ filtering
   --traffic-count N  Number of synthetic questions per cycle (default: 10)
+  --threshold N      Override quality_threshold (0-100, default: from config)
   -h, --help         Show this help message
 ```
 
@@ -209,7 +210,7 @@ You can run again with multiple cycles to see iterative refinement:
 ```shell
 ./run_cycle.sh --auto --cycles 3
 ```
-By default, the script runs a single cycle and stops. The `--auto` flag enables auto-cycling, which runs up to N cycles and stops early once all synthetic traffic scores 100% meaningful. Each cycle generates fresh traffic, evaluates, improves, and measures. The golden eval set grows with each cycle as new edge cases are discovered.
+By default, the script runs a single cycle and stops. The `--auto` flag enables auto-cycling, which runs up to N cycles and stops early once quality meets `quality_threshold` from `config.json` (default: 0.95 = 95%). The threshold is set below 100% because LLM output is non-deterministic -- at N=100, ~1% variance is noise, not a systematic gap worth another optimizer cycle. Each cycle generates fresh traffic, evaluates, improves, and measures. The golden eval set grows with each cycle as new edge cases are discovered.
 
 ---
 

--- a/examples/agent_improvement_cycle/README.md
+++ b/examples/agent_improvement_cycle/README.md
@@ -217,7 +217,7 @@ All agent-specific settings live in a single declarative config file:
   "eval_cases_path": "eval/eval_cases.json",
   "traffic_generator": "eval/generate_traffic.py",
   "model_id": "gemini-2.5-flash",
-  "max_attempts": 3,
+  "optimizer_max_iterations": 3,
   "prompt_storage": "vertex",
   "vertex_prompt_id": "1234567890",
   "use_vertex_optimizer": true,
@@ -446,12 +446,43 @@ BigQuery from Steps 2 and 5; no additional agent runs are needed. See
 - **Golden eval gate**: Candidate prompts must pass ALL golden cases.
   Rejected if any fail, retried up to 3 times.
 - **Eval case extraction**: Failed synthetic cases are added to the
-  golden set before improvement, raising the bar each cycle.
+  golden set before improvement, raising the bar each cycle. The
+  `max_failure_extract` config controls how many cases are extracted (see
+  [Scaling extraction](#scaling-extraction) below).
 - **Question deduplication**: Extracted cases are deduplicated by both
   ID and question text.
 - **Length check**: Prompts shorter than 50 characters are rejected.
 - **Retry with backoff**: Quality report step retries for BigQuery
   write propagation delays.
+
+### Scaling extraction
+
+At the default traffic volume (N=10), the system typically discovers
+3-5 failures, all of which are extracted into the golden eval set.
+The regression gate (3 original + 3-5 extracted = ~8 cases) is
+manageable for the optimizer to satisfy in one pass.
+
+At higher volumes (`--traffic-count 100`), the system discovers
+30-43 failures. Extracting all of them creates a regression gate of
+40+ cases, which is often too strict for the optimizer to satisfy
+in a single attempt. Many of these failures are redundant — 15
+might be "benefits" questions that all fail the same way.
+
+The `max_failure_extract` config field controls this:
+
+| Value | Behavior |
+|-------|----------|
+| `null` (default) | Extract **all** failures — every unhelpful or partial session becomes a golden eval case. This is the right choice for the small-N demo (N=10) where there are only 3-5 failures. At higher traffic volumes it can overwhelm the optimizer (see below). |
+| `"auto"` | Two-tier category-aware selection. Tier 1: one failure per category (breadth). Tier 2: fill proportionally from heaviest categories. Budget = 2 × number of failing categories. For 6 categories, that's ~12 cases. |
+| Integer (e.g. `10`) | Hard cap with category-aware selection. Same two-tier logic. |
+
+Example config for high-traffic runs:
+
+```json
+{
+  "max_failure_extract": "auto"
+}
+```
 
 ## Quick Start
 
@@ -569,13 +600,14 @@ agent:
 | `eval_cases_path` | required | Path to golden eval set JSON |
 | `traffic_generator` | required | Path to traffic generation script |
 | `model_id` | `gemini-2.5-flash` | Gemini model for agent and judge |
-| `max_attempts` | `3` | Max prompt improvement attempts per cycle |
+| `optimizer_max_iterations` | `3` | Max Vertex AI Prompt Optimizer iterations per improvement step |
 | `prompt_storage` | `python_file` | `vertex` or `python_file` |
 | `vertex_prompt_id` | `""` | Vertex AI prompt ID (auto-filled by setup) |
 | `vertex_project` | from `gcloud` | GCP project for Vertex AI (defaults to env) |
 | `vertex_location` | `us-central1` | Vertex AI region |
 | `use_vertex_optimizer` | `false` | Use Vertex AI Prompt Optimizer |
 | `teacher_model_id` | `null` | Model for teacher agent (null = same as `model_id`) |
+| `max_failure_extract` | `null` | Max failed cases to extract per cycle. `null` = extract **all** failures (best for the small-N demo where N<=20). `"auto"` = two-tier category-aware selection (~2x categories). Integer = hard cap with category-aware selection. See [Scaling extraction](#scaling-extraction). |
 
 ### Environment variables (.env)
 
@@ -599,7 +631,7 @@ Gemini calls; a 3-cycle run uses ~200-300.
 **Golden eval set growth:** The golden eval set grows each cycle as
 failed synthetic cases are extracted into it. Each improvement attempt
 validates the candidate prompt against the full golden set (N agent
-calls + N judge calls per attempt, up to `max_attempts` retries).
+calls + N judge calls per attempt, up to `optimizer_max_iterations` retries).
 After several cycles, the golden set can reach 20+ cases, increasing
 both cost and runtime of the validation step. For long-running
 deployments, consider periodically pruning redundant golden cases.

--- a/examples/agent_improvement_cycle/README.md
+++ b/examples/agent_improvement_cycle/README.md
@@ -148,9 +148,11 @@ The hero moment: quality typically climbs from ~60% to ~100% in a single cycle
 (results vary due to non-deterministic LLM output). With the default
 N=10 traffic, the improvement step typically succeeds on the first
 optimizer attempt. At higher traffic volumes (`--traffic-count 100`),
-the system extracts more failure cases (30-43) into the golden eval
-set, making the regression gate stricter. Use `--auto --cycles 3`
-for higher-N runs to give the optimizer multiple cycles to converge.
+the system discovers more failures but `max_failure_extract: "auto"`
+applies category-aware selection to extract a representative subset
+(~12 cases from ~42 failures in a typical run), keeping the regression
+gate strict but manageable. Use `--auto --cycles 3` for higher-N runs
+to give the optimizer multiple cycles to converge if needed.
 
 ### Why This Matters
 

--- a/examples/agent_improvement_cycle/README.md
+++ b/examples/agent_improvement_cycle/README.md
@@ -142,7 +142,18 @@ running multiple cycles unintentionally can lead to unexpected costs.
 
 To run multiple improvement cycles, use `--auto --cycles N`. The
 `--auto` flag enables auto-cycling, which runs up to N cycles and
-stops early once all synthetic traffic scores 100% meaningful.
+stops early once quality meets the `quality_threshold` setting in
+`config.json` (default: `0.95`, i.e. 95% meaningful).
+
+**Why 95% and not 100%?** LLM output is non-deterministic. At N=100
+traffic, a single stochastic misfire causes a 1% drop. Setting the
+threshold to 100% leads to cycles that fight random variance rather
+than fix systematic gaps. The 95% default means: stop when real
+failures are gone, don't chase noise. If the improvement step finds
+quality already at or above the threshold, it skips the optimizer
+entirely and the cycle moves on. If no new prompt version is produced,
+the measurement step (Step 5) is also skipped -- there is nothing to
+compare.
 
 The hero moment: quality typically climbs from ~60% to ~100% in a single cycle
 (results vary due to non-deterministic LLM output). With the default
@@ -280,6 +291,17 @@ When the cycle identifies failed sessions, it uses the
 4. **Validate**: Test the optimized prompt against the full golden
    eval set before accepting it.
 
+The optimizer also receives the agent's **tool signatures**, auto-extracted
+from the Python functions by `tool_introspection.py` using `inspect` --
+function name, parameter types, and full docstrings. These are appended
+to the prompt as plain text so the optimizer knows what tools exist and
+what arguments they accept. This is how the V2 prompt ends up with
+explicit topic-to-tool mappings: the optimizer saw the tool's signature,
+saw the teacher successfully calling it with specific arguments, and
+generated routing instructions accordingly. If the optimizer's output
+strips the tool references (which it tends to do), they are
+re-appended automatically.
+
 This replaces raw "ask Gemini to rewrite the prompt" with a
 structured optimization pipeline backed by real failure data.
 
@@ -343,10 +365,10 @@ Failed sessions from quality report
   toward tool-grounded answers
 ```
 
-The teacher's answers are saved to `reports/ground_truth_latest.json`
-for inspection. Each entry contains the original question, the bad
-response from the target agent, and the teacher's ground truth
-answer.
+The teacher's answers are saved to
+`reports/run_YYYYMMDD_HHMMSS/ground_truth_latest.json` for inspection.
+Each entry contains the original question, the bad response from the
+target agent, and the teacher's ground truth answer.
 
 #### Why not just use the teacher prompt directly?
 
@@ -532,7 +554,7 @@ git tracking.
 # Single improvement cycle (default — safe for experimentation)
 ./run_cycle.sh
 
-# Auto-cycle: run up to 3 cycles, stop early when 100% meaningful
+# Auto-cycle: run up to 3 cycles, stop early when quality meets threshold (95%)
 ./run_cycle.sh --auto --cycles 3
 
 # Exactly 3 cycles (no early stopping)
@@ -544,24 +566,80 @@ git tracking.
 # Customize traffic volume
 ./run_cycle.sh --auto --cycles 3 --traffic-count 20
 
+# Scaled run (N=100)
+./run_cycle.sh --auto --cycles 5 --traffic-count 100
+
 # Use a different agent's config
 ./run_cycle.sh --agent-config /path/to/other/config.json
 ```
 
-> **Cost note:** Each cycle makes ~50-80 Gemini API calls. Running
-> `./run_cycle.sh` with no flags is always safe (1 cycle). Use `--auto
-> --cycles N` only when you intentionally want multiple iterations.
+The scaled run combines all the flags:
+
+| Flag | What it does |
+|------|--------------|
+| `--auto` | Stop early when quality meets `quality_threshold` (default 95%) |
+| `--cycles 5` | Run up to 5 improvement cycles |
+| `--traffic-count 100` | Generate 100 synthetic questions per cycle (default: 10) |
+
+All output is automatically logged to `reports/run_YYYYMMDD_HHMMSS/run.log`
+(ANSI colour codes stripped for readability). Each run gets its own
+timestamped subdirectory under `reports/`, so previous runs are preserved.
+
+> **Cost note:** Each cycle makes ~50-80 Gemini API calls (more with
+> higher `--traffic-count`). Running `./run_cycle.sh` with no flags is
+> always safe (1 cycle). Use `--auto --cycles N` only when you
+> intentionally want multiple iterations.
+
+#### Standalone quality report
+
+The `quality_report.sh` wrapper can be run independently. Use
+`--env` to point at the right `.env` file (otherwise it loads the
+repo root `.env` which may target a different dataset):
+
+```bash
+# From anywhere — explicit .env
+../../scripts/quality_report.sh \
+  --env .env \
+  --app-name company_info_agent \
+  --time-period all --limit 100
+```
+
+The `--env` flag is also available on `quality_report.py` directly.
 
 ### 4. Inspect results
 
-After a run, check the `reports/` directory:
+Each run creates a timestamped subdirectory under `reports/`:
+
+```
+reports/
+  run_20260430_174920/          # one directory per run
+    run.log                     # full console output (ANSI stripped)
+    synthetic_traffic_cycle_1.json      # generated questions (Step 1)
+    latest_eval_results.json            # session IDs + responses (Step 2)
+    expected_session_ids_cycle_1.json   # copy of eval results for BQ lookup
+    quality_report_cycle_1.json         # LLM judge scores (Step 3)
+    operational_metrics_cycle_1_baseline.json  # latency/tokens/turns (Step 3)
+    ground_truth_latest.json            # teacher agent answers (Step 4)
+    synthetic_traffic_cycle_1_fresh.json       # fresh questions (Step 5)
+    expected_session_ids_cycle_1_fresh.json    # fresh session IDs (Step 5)
+    quality_report_cycle_1_after.json          # post-improvement scores (Step 5)
+    operational_metrics_cycle_1.json           # before/after comparison (Step 5)
+  run_20260430_183045/          # next run — previous runs are preserved
+    ...
+```
+
+Previous runs are never deleted. `reset.sh` only resets the prompt
+and golden eval set, not the reports directory.
 
 ```bash
-# Quality report JSON (consumed by the improver)
-cat reports/quality_report_cycle_1.json | python3 -m json.tool | head -20
+# Browse runs
+ls reports/
 
-# Synthetic traffic that was generated
-cat reports/synthetic_traffic_cycle_1.json | python3 -m json.tool | head -20
+# Quality report JSON (consumed by the improver)
+cat reports/run_*/quality_report_cycle_1.json | python3 -m json.tool | head -20
+
+# Full console log
+less reports/run_20260430_174920/run.log
 
 # See new eval cases extracted from failures
 cat eval/eval_cases.json
@@ -569,14 +647,17 @@ cat eval/eval_cases.json
 
 ### Reset to V1
 
-To start over, reset everything to the initial state (fresh V1
-prompt in Vertex AI, 3 golden eval cases, no reports):
+To start over, reset the prompt and golden eval set to their initial
+state. Previous run reports are preserved.
 
 ```bash
 ./reset.sh
 ```
 
-This deletes the old Vertex AI prompt and creates a fresh one at V1.
+This restores the V1 prompt in Vertex AI, resets `eval_cases.json` to
+the original 3 golden cases, and removes generated synthetic traffic
+files. The `reports/` directory (with timestamped run subdirectories)
+is not deleted.
 
 ## Using with Other Agents
 

--- a/examples/agent_improvement_cycle/README.md
+++ b/examples/agent_improvement_cycle/README.md
@@ -136,12 +136,21 @@ before/after comparison to verify the improved prompt didn't regress
 on cost or performance. No extra agent runs — just math on the session
 data already in BigQuery.
 
-Run multiple cycles with `--cycles N`. By default, the cycle stops
-early once all synthetic traffic scores 100% meaningful. Use
-`--no-auto` to force all N cycles to run regardless.
+By default, the script runs a **single cycle** and stops. This is the
+safe default -- each cycle makes dozens of Gemini API calls, and
+running multiple cycles unintentionally can lead to unexpected costs.
 
-The hero moment: quality typically climbs from ~40% to ~100% in a single cycle
-(results vary due to non-deterministic LLM output).
+To run multiple improvement cycles, use `--auto --cycles N`. The
+`--auto` flag enables auto-cycling, which runs up to N cycles and
+stops early once all synthetic traffic scores 100% meaningful.
+
+The hero moment: quality typically climbs from ~60% to ~100% in a single cycle
+(results vary due to non-deterministic LLM output). With the default
+N=10 traffic, the improvement step typically succeeds on the first
+optimizer attempt. At higher traffic volumes (`--traffic-count 100`),
+the system extracts more failure cases (30-43) into the golden eval
+set, making the regression gate stricter. Use `--auto --cycles 3`
+for higher-N runs to give the optimizer multiple cycles to converge.
 
 ### Why This Matters
 
@@ -487,24 +496,28 @@ git tracking.
 ### 3. Run the demo
 
 ```bash
-# Single improvement cycle
+# Single improvement cycle (default — safe for experimentation)
 ./run_cycle.sh
 
-# Up to 3 cycles, stops early when 100% meaningful (default behavior)
-./run_cycle.sh --cycles 3
+# Auto-cycle: run up to 3 cycles, stop early when 100% meaningful
+./run_cycle.sh --auto --cycles 3
 
-# Force all 3 cycles even if 100% is reached early
-./run_cycle.sh --cycles 3 --no-auto
+# Exactly 3 cycles (no early stopping)
+./run_cycle.sh --cycles 3
 
 # Eval only (no improvement step)
 ./run_cycle.sh --eval-only
 
 # Customize traffic volume
-./run_cycle.sh --cycles 3 --traffic-count 20
+./run_cycle.sh --auto --cycles 3 --traffic-count 20
 
 # Use a different agent's config
 ./run_cycle.sh --agent-config /path/to/other/config.json
 ```
+
+> **Cost note:** Each cycle makes ~50-80 Gemini API calls. Running
+> `./run_cycle.sh` with no flags is always safe (1 cycle). Use `--auto
+> --cycles N` only when you intentionally want multiple iterations.
 
 ### 4. Inspect results
 

--- a/examples/agent_improvement_cycle/agent_improvement/__init__.py
+++ b/examples/agent_improvement_cycle/agent_improvement/__init__.py
@@ -28,8 +28,10 @@ warnings.filterwarnings("ignore")
 # by importing the module early and overriding the filter.
 try:
   import authlib.deprecate
-  warnings.filterwarnings("ignore",
-                          category=authlib.deprecate.AuthlibDeprecationWarning)
+
+  warnings.filterwarnings(
+      "ignore", category=authlib.deprecate.AuthlibDeprecationWarning
+  )
 except ImportError:
   pass
 
@@ -43,12 +45,16 @@ logging.basicConfig(
 # google_adk                   — "Sending out request", "Response received"
 # httpx / httpcore             — "HTTP Request: POST ..."
 for _noisy in (
-    "google.genai", "google_genai",
-    "google.adk", "google_adk",
-    "google.auth", "google_auth",
-    "httpx", "httpcore",
+    "google.genai",
+    "google_genai",
+    "google.adk",
+    "google_adk",
+    "google.auth",
+    "google_auth",
+    "httpx",
+    "httpcore",
 ):
-    logging.getLogger(_noisy).setLevel(logging.ERROR)
+  logging.getLogger(_noisy).setLevel(logging.ERROR)
 
 from agent_improvement.config import ImprovementConfig
 from agent_improvement.config_loader import load_agent_module

--- a/examples/agent_improvement_cycle/agent_improvement/__init__.py
+++ b/examples/agent_improvement_cycle/agent_improvement/__init__.py
@@ -20,6 +20,18 @@ cases pass.
 """
 
 import logging
+import warnings
+
+warnings.filterwarnings("ignore")
+
+# authlib forces simplefilter("always") at import time; neutralise it
+# by importing the module early and overriding the filter.
+try:
+  import authlib.deprecate
+  warnings.filterwarnings("ignore",
+                          category=authlib.deprecate.AuthlibDeprecationWarning)
+except ImportError:
+  pass
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,7 +39,16 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 # Suppress noisy third-party loggers.
-logging.getLogger("google.genai").setLevel(logging.ERROR)
+# google.genai / google_genai  — "AFC is enabled", "will take precedence"
+# google_adk                   — "Sending out request", "Response received"
+# httpx / httpcore             — "HTTP Request: POST ..."
+for _noisy in (
+    "google.genai", "google_genai",
+    "google.adk", "google_adk",
+    "google.auth", "google_auth",
+    "httpx", "httpcore",
+):
+    logging.getLogger(_noisy).setLevel(logging.ERROR)
 
 from agent_improvement.config import ImprovementConfig
 from agent_improvement.config_loader import load_agent_module

--- a/examples/agent_improvement_cycle/agent_improvement/__init__.py
+++ b/examples/agent_improvement_cycle/agent_improvement/__init__.py
@@ -19,6 +19,16 @@ quality and iteratively rewrites its prompt until all golden eval
 cases pass.
 """
 
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+# Suppress noisy third-party loggers.
+logging.getLogger("google.genai").setLevel(logging.ERROR)
+
 from agent_improvement.config import ImprovementConfig
 from agent_improvement.config_loader import load_agent_module
 from agent_improvement.config_loader import load_config

--- a/examples/agent_improvement_cycle/agent_improvement/config.py
+++ b/examples/agent_improvement_cycle/agent_improvement/config.py
@@ -65,7 +65,7 @@ class ImprovementConfig:
   eval_cases_path: str
   model_id: str = "gemini-2.5-flash"
   optimizer_max_iterations: int = 3
-  quality_threshold: float = 1.0
+  quality_threshold: float = 0.95
   judge_prompt: str | None = None
   teacher_model_id: str | None = None
   use_vertex_optimizer: bool = False

--- a/examples/agent_improvement_cycle/agent_improvement/config.py
+++ b/examples/agent_improvement_cycle/agent_improvement/config.py
@@ -40,8 +40,9 @@ class ImprovementConfig:
           (e.g. a ``prompts.py`` file).
       eval_cases_path: Path to the golden eval set JSON file.
       model_id: Gemini model used by the improver and judge LLMs.
-      max_attempts: Maximum number of candidate prompts to try before
-          giving up.
+      optimizer_max_iterations: Maximum number of prompt optimizer
+          iterations per improvement step (Vertex AI Prompt Optimizer
+          retry budget).
       quality_threshold: Fraction of golden cases that must pass
           (1.0 = all cases).
       teacher_model_id: Optional Gemini model for the teacher agent that
@@ -63,9 +64,10 @@ class ImprovementConfig:
   prompt_adapter: PromptAdapter
   eval_cases_path: str
   model_id: str = "gemini-2.5-flash"
-  max_attempts: int = 3
+  optimizer_max_iterations: int = 3
   quality_threshold: float = 1.0
   judge_prompt: str | None = None
   teacher_model_id: str | None = None
   use_vertex_optimizer: bool = False
   vertex_location: str = "us-central1"
+  max_failure_extract: int | str | None = None

--- a/examples/agent_improvement_cycle/agent_improvement/config_loader.py
+++ b/examples/agent_improvement_cycle/agent_improvement/config_loader.py
@@ -162,4 +162,5 @@ def load_config(config_path: str) -> ImprovementConfig:
       max_failure_extract=cfg.get(
           "max_failure_extract", cfg.get("max_extract")
       ),
+      quality_threshold=cfg.get("quality_threshold", 0.95),
   )

--- a/examples/agent_improvement_cycle/agent_improvement/config_loader.py
+++ b/examples/agent_improvement_cycle/agent_improvement/config_loader.py
@@ -146,9 +146,10 @@ def load_config(config_path: str) -> ImprovementConfig:
       prompt_adapter=_build_prompt_adapter(cfg),
       eval_cases_path=cfg["eval_cases_path"],
       model_id=cfg.get("model_id", "gemini-2.5-flash"),
-      max_attempts=cfg.get("max_attempts", 3),
+      optimizer_max_iterations=cfg.get("optimizer_max_iterations", cfg.get("max_attempts", 3)),
       judge_prompt=cfg.get("judge_prompt"),
       teacher_model_id=cfg.get("teacher_model_id"),
       use_vertex_optimizer=cfg.get("use_vertex_optimizer", False),
       vertex_location=cfg.get("vertex_location", "us-central1"),
+      max_failure_extract=cfg.get("max_failure_extract", cfg.get("max_extract")),
   )

--- a/examples/agent_improvement_cycle/agent_improvement/config_loader.py
+++ b/examples/agent_improvement_cycle/agent_improvement/config_loader.py
@@ -31,10 +31,13 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import os
 import sys
 
 from agent_improvement.config import ImprovementConfig
+
+logger = logging.getLogger(__name__)
 from agent_improvement.prompt_adapter import PythonFilePromptAdapter
 from agent_improvement.prompt_adapter import VertexPromptAdapter
 
@@ -69,21 +72,24 @@ def load_agent_module(config_path: str) -> tuple:
 
   cfg = _resolve_paths(cfg, agent_root)
 
-  print(f"\n  Config: {config_path}")
-  print(f"  Agent module: {cfg['agent_module']}")
-  print(f"  Prompt storage: {cfg.get('prompt_storage', 'python_file')}")
+  logger.info("Config: %s", config_path)
+  logger.info("Agent module: %s", cfg["agent_module"])
+  logger.info("Prompt storage: %s", cfg.get("prompt_storage", "python_file"))
   if cfg.get("prompt_storage") == "vertex":
     prompt_id = cfg.get("vertex_prompt_id") or os.environ.get(
         "VERTEX_PROMPT_ID", ""
     )
-    print(f"  Vertex prompt ID: {prompt_id or '(not set)'}")
-    print(
-        f"  Vertex project: {cfg.get('vertex_project') or os.environ.get('PROJECT_ID', '(from gcloud default)')}"
+    logger.info("Vertex prompt ID: %s", prompt_id or "(not set)")
+    logger.info(
+        "Vertex project: %s",
+        cfg.get("vertex_project")
+        or os.environ.get("PROJECT_ID", "(from gcloud default)"),
     )
-    print(f"  Vertex location: {cfg.get('vertex_location', 'us-central1')}")
-  print(f"  Model: {cfg.get('model_id', 'gemini-2.5-flash')}")
-  print(f"  Eval cases: {cfg.get('eval_cases_path', '(not set)')}")
-  print()
+    logger.info(
+        "Vertex location: %s", cfg.get("vertex_location", "us-central1")
+    )
+  logger.info("Model: %s", cfg.get("model_id", "gemini-2.5-flash"))
+  logger.info("Eval cases: %s", cfg.get("eval_cases_path", "(not set)"))
 
   mod = _import_module(cfg["agent_module"], agent_root)
   return mod, cfg
@@ -146,10 +152,14 @@ def load_config(config_path: str) -> ImprovementConfig:
       prompt_adapter=_build_prompt_adapter(cfg),
       eval_cases_path=cfg["eval_cases_path"],
       model_id=cfg.get("model_id", "gemini-2.5-flash"),
-      optimizer_max_iterations=cfg.get("optimizer_max_iterations", cfg.get("max_attempts", 3)),
+      optimizer_max_iterations=cfg.get(
+          "optimizer_max_iterations", cfg.get("max_attempts", 3)
+      ),
       judge_prompt=cfg.get("judge_prompt"),
       teacher_model_id=cfg.get("teacher_model_id"),
       use_vertex_optimizer=cfg.get("use_vertex_optimizer", False),
       vertex_location=cfg.get("vertex_location", "us-central1"),
-      max_failure_extract=cfg.get("max_failure_extract", cfg.get("max_extract")),
+      max_failure_extract=cfg.get(
+          "max_failure_extract", cfg.get("max_extract")
+      ),
   )

--- a/examples/agent_improvement_cycle/agent_improvement/eval_runner.py
+++ b/examples/agent_improvement_cycle/agent_improvement/eval_runner.py
@@ -180,9 +180,13 @@ class EvalRunner:
     agent = self._agent_factory(prompt)
     runner = InMemoryRunner(agent=agent, app_name="eval_agent")
 
+    # Limit concurrent LLM calls to avoid 429 rate-limit errors.
+    semaphore = asyncio.Semaphore(5)
+
     async def _eval_one(case: dict) -> dict:
-      result = await self.run_single_case(runner, case, user_id="eval")
-      result = await self.judge_case(case, result)
+      async with semaphore:
+        result = await self.run_single_case(runner, case, user_id="eval")
+        result = await self.judge_case(case, result)
       tag = "PASS" if result["pass"] else "FAIL"
       tools_called = ", ".join(result.get("tools_called", [])) or "none"
       expected_tool = case.get("expected_tool", "unknown")

--- a/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
+++ b/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
@@ -33,7 +33,8 @@ import re
 import warnings
 
 warnings.filterwarnings("ignore")
-logging.getLogger("google.genai").setLevel(logging.ERROR)
+
+logger = logging.getLogger(__name__)
 
 from agent_improvement.config import ImprovementConfig
 from agent_improvement.eval_runner import EvalRunner
@@ -236,13 +237,12 @@ async def _generate_ground_truth(
       except Exception as e:
         logging.warning(
             "Teacher agent failed for question '%.80s': %s",
-            question, e,
+            question,
+            e,
         )
         return None
 
-  results = await asyncio.gather(
-      *[_get_answer(s) for s in failed_sessions]
-  )
+  results = await asyncio.gather(*[_get_answer(s) for s in failed_sessions])
   return [r for r in results if r and r["ground_truth"].strip()]
 
 
@@ -286,9 +286,9 @@ async def _generate_via_vertex_optimizer(
     )
 
   # Generate ground truth via teacher agent
-  print("  Generating synthetic ground truth via teacher agent...")
+  logger.info("Generating synthetic ground truth via teacher agent...")
   gt_results = await _generate_ground_truth(config, failed)
-  print(f"  Generated {len(gt_results)} ground truth answers.")
+  logger.info("Generated %d ground truth answers.", len(gt_results))
 
   # Save ground truth to reports/ for inspection
   gt_dir = os.path.join(
@@ -298,7 +298,7 @@ async def _generate_via_vertex_optimizer(
   gt_path = os.path.join(gt_dir, "ground_truth_latest.json")
   with open(gt_path, "w") as f:
     json.dump(gt_results, f, indent=2)
-  print(f"  Ground truth saved to {gt_path}")
+  logger.info("Ground truth saved to %s", gt_path)
   print("")
   print("  Agent (bad) vs Teacher (ground truth) comparison:")
   print("  " + "─" * 68)
@@ -348,11 +348,11 @@ async def _generate_via_vertex_optimizer(
   )
   prompt_with_tools = current_prompt + tool_use_directive
 
-  print(
-      f"  Calling Vertex AI Prompt Optimizer with {len(gt_results)} "
-      "ground truth examples..."
+  logger.info(
+      "Calling Vertex AI Prompt Optimizer with %d ground truth examples...",
+      len(gt_results),
   )
-  print("  (The optimizer is a server-side job — typically 2-4 minutes.)")
+  logger.info("(The optimizer is a server-side job — typically 2-4 minutes.)")
 
   from google.genai.types import HttpOptions
   from google.genai.types import HttpRetryOptions
@@ -378,7 +378,7 @@ async def _generate_via_vertex_optimizer(
     while True:
       await asyncio.sleep(15)
       elapsed += 15
-      print(f"  ... still optimizing ({elapsed}s elapsed)", flush=True)
+      logger.info("... still optimizing (%ds elapsed)", elapsed)
 
   progress_task = asyncio.create_task(_progress_indicator())
   try:
@@ -395,7 +395,7 @@ async def _generate_via_vertex_optimizer(
   finally:
     progress_task.cancel()
 
-  print("  Optimizer returned a candidate prompt.")
+  logger.info("Optimizer returned a candidate prompt.")
 
   parsed = result.parsed_response
   if (
@@ -474,9 +474,9 @@ async def test_candidate(candidate_prompt: str) -> str:
       cases_count = len(json.load(_f).get("eval_cases", []))
   except Exception:
     pass
-  print(
-      f"\n  Testing candidate prompt against {cases_count} golden eval "
-      "cases (regression gate)..."
+  logger.info(
+      "Testing candidate prompt against %d golden eval cases (regression gate)...",
+      cases_count,
   )
 
   eval_runner = EvalRunner(
@@ -672,8 +672,9 @@ def extract_failed_cases(
   selected_ids = {c["id"] for c in selected}
 
   # Sort categories by failure count (descending) for proportional fill
-  sorted_cats = sorted(by_category.keys(),
-                       key=lambda k: len(by_category[k]), reverse=True)
+  sorted_cats = sorted(
+      by_category.keys(), key=lambda k: len(by_category[k]), reverse=True
+  )
 
   # Round-robin across categories, heaviest first
   tier2_pool = []
@@ -892,7 +893,7 @@ async def run_improvement(
   print("")
 
   if report["summary"].get("total_sessions", 0) == 0:
-    print("  ERROR: Report has 0 sessions. Cannot improve.")
+    logger.error("Report has 0 sessions. Cannot improve.")
     return {
         "old_version": old_version,
         "new_version": old_version,
@@ -901,7 +902,7 @@ async def run_improvement(
     }
 
   if report["summary"]["meaningful_rate"] >= 95:
-    print("  Quality is already high (>=95%). No improvement needed.")
+    logger.info("Quality is already high (>=95%%). No improvement needed.")
     return {
         "old_version": old_version,
         "new_version": old_version,
@@ -911,18 +912,22 @@ async def run_improvement(
 
   # Extract failed cases into golden set FIRST
   failed_cases = extract_failed_cases(
-      report, tools=config.agent_tools, max_failure_extract=config.max_failure_extract
+      report,
+      tools=config.agent_tools,
+      max_failure_extract=config.max_failure_extract,
   )
   if failed_cases:
     added = add_eval_cases(config.eval_cases_path, failed_cases)
     with open(config.eval_cases_path) as f:
       golden_count = len(json.load(f).get("eval_cases", []))
-    print(
-        f"  Extracted {len(failed_cases)} failed cases, added"
-        f" {added} new to golden set ({golden_count} total)."
+    logger.info(
+        "Extracted %d failed cases, added %d new to golden set (%d total).",
+        len(failed_cases),
+        added,
+        golden_count,
     )
   else:
-    print("  No failed cases to extract.")
+    logger.info("No failed cases to extract.")
 
   # Narrow the report to only the extracted cases so the optimizer
   # generates ground truth for the same subset used in the golden
@@ -930,7 +935,8 @@ async def run_improvement(
   if failed_cases:
     extracted_questions = {c["question"] for c in failed_cases}
     report["sessions"] = [
-        s for s in report["sessions"]
+        s
+        for s in report["sessions"]
         if s.get("question", "") in extracted_questions
     ]
 
@@ -975,10 +981,10 @@ async def run_improvement(
     golden_count = len(json.load(f).get("eval_cases", []))
 
   if new_version > old_version:
-    print(f"\n  v{old_version} -> v{new_version} complete.")
+    logger.info("v%d -> v%d complete.", old_version, new_version)
   else:
-    print(
-        "\n  WARNING: No improvement was written. All candidates"
+    logger.warning(
+        "No improvement was written. All candidates"
         " may have failed regression tests."
     )
 

--- a/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
+++ b/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
@@ -924,6 +924,16 @@ async def run_improvement(
   else:
     print("  No failed cases to extract.")
 
+  # Narrow the report to only the extracted cases so the optimizer
+  # generates ground truth for the same subset used in the golden
+  # eval set, not for every failure in the report.
+  if failed_cases:
+    extracted_questions = {c["question"] for c in failed_cases}
+    report["sessions"] = [
+        s for s in report["sessions"]
+        if s.get("question", "") in extracted_questions
+    ]
+
   # Set shared state for tool functions
   _state["config"] = config
   _state["report"] = report

--- a/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
+++ b/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
@@ -575,14 +575,27 @@ def _classify_question(question: str, tools: list) -> tuple[str, str]:
   return "unknown", "unknown"
 
 
-def extract_failed_cases(report: dict, tools: list | None = None) -> list[dict]:
+def extract_failed_cases(
+    report: dict,
+    tools: list | None = None,
+    max_failure_extract: int | str | None = None,
+) -> list[dict]:
   """Extract failed sessions as new golden eval cases.
 
   Classifies each question against available tools to infer
   category and expected_tool. Questions that don't match any
   tool topic are still extracted with category="unknown".
+
+  Args:
+      report: Quality report dict with sessions.
+      tools: Agent tool functions for classification.
+      max_failure_extract: Controls how many failures to extract.
+          None or "all" extracts everything (default).
+          "auto" uses two-tier selection: one per category
+          first, then fills proportionally up to 2x categories.
+          An integer sets a hard cap with category-aware selection.
   """
-  new_cases = []
+  all_cases = []
   for session in report.get("sessions", []):
     cat = (
         session.get("metrics", {})
@@ -601,7 +614,7 @@ def extract_failed_cases(report: dict, tools: list | None = None) -> list[dict]:
     case_id = re.sub(r"[^a-z0-9]+", "_", question.lower().strip())[:40]
     case_id = f"extracted_{case_id.strip('_')}"
 
-    new_cases.append(
+    all_cases.append(
         {
             "id": case_id,
             "question": question,
@@ -610,7 +623,53 @@ def extract_failed_cases(report: dict, tools: list | None = None) -> list[dict]:
             "notes": f"Extracted from failed synthetic traffic ({cat})",
         }
     )
-  return new_cases
+
+  if not all_cases:
+    return all_cases
+
+  # Apply extraction limit
+  if max_failure_extract is None or max_failure_extract == "all":
+    return all_cases
+
+  # Two-tier category-aware selection
+  if max_failure_extract == "auto":
+    categories = {c["category"] for c in all_cases}
+    budget = 2 * len(categories)
+  else:
+    budget = int(max_failure_extract)
+
+  if len(all_cases) <= budget:
+    return all_cases
+
+  # Tier 1: one case per category (breadth)
+  by_category: dict[str, list[dict]] = {}
+  for case in all_cases:
+    by_category.setdefault(case["category"], []).append(case)
+
+  selected = []
+  for cat_cases in by_category.values():
+    selected.append(cat_cases[0])
+
+  if len(selected) >= budget:
+    return selected[:budget]
+
+  # Tier 2: fill remaining slots proportionally from heaviest categories
+  remaining_budget = budget - len(selected)
+  selected_ids = {c["id"] for c in selected}
+
+  # Sort categories by failure count (descending) for proportional fill
+  sorted_cats = sorted(by_category.keys(),
+                       key=lambda k: len(by_category[k]), reverse=True)
+
+  # Round-robin across categories, heaviest first
+  tier2_pool = []
+  for cat in sorted_cats:
+    for case in by_category[cat]:
+      if case["id"] not in selected_ids:
+        tier2_pool.append(case)
+
+  selected.extend(tier2_pool[:remaining_budget])
+  return selected
 
 
 def add_eval_cases(eval_cases_path: str, new_cases: list[dict]) -> int:
@@ -752,7 +811,7 @@ def create_improver_agent(
   return LoopAgent(
       name="prompt_improver",
       sub_agents=[inner_agent],
-      max_iterations=config.max_attempts,
+      max_iterations=config.optimizer_max_iterations,
   )
 
 
@@ -837,7 +896,9 @@ async def run_improvement(
     }
 
   # Extract failed cases into golden set FIRST
-  failed_cases = extract_failed_cases(report, tools=config.agent_tools)
+  failed_cases = extract_failed_cases(
+      report, tools=config.agent_tools, max_failure_extract=config.max_failure_extract
+  )
   if failed_cases:
     added = add_eval_cases(config.eval_cases_path, failed_cases)
     with open(config.eval_cases_path) as f:

--- a/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
+++ b/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
@@ -290,8 +290,8 @@ async def _generate_via_vertex_optimizer(
   gt_results = await _generate_ground_truth(config, failed)
   logger.info("Generated %d ground truth answers.", len(gt_results))
 
-  # Save ground truth to reports/ for inspection
-  gt_dir = os.path.join(
+  # Save ground truth for inspection
+  gt_dir = _state.get("output_dir") or os.path.join(
       os.path.dirname(config.eval_cases_path), "..", "reports"
   )
   os.makedirs(gt_dir, exist_ok=True)
@@ -840,6 +840,7 @@ async def run_improvement(
     report: dict | None = None,
     report_path: str | None = None,
     from_eval_results: bool = False,
+    output_dir: str | None = None,
 ) -> dict:
   """Run the improvement cycle.
 
@@ -851,6 +852,8 @@ async def run_improvement(
           if ``from_eval_results`` is True).
       from_eval_results: If True, treat ``report_path`` as golden eval
           results and build a synthetic quality report.
+      output_dir: Directory for ground_truth_latest.json. Defaults to
+          ``<demo>/reports/``.
 
   Returns:
       Dict with ``old_version``, ``new_version``, ``golden_cases``,
@@ -901,8 +904,13 @@ async def run_improvement(
         "improvement_result": "no_data",
     }
 
-  if report["summary"]["meaningful_rate"] >= 95:
-    logger.info("Quality is already high (>=95%%). No improvement needed.")
+  threshold_pct = config.quality_threshold * 100
+  if report["summary"]["meaningful_rate"] >= threshold_pct:
+    logger.info(
+        "Quality %.0f%% meets threshold (%.0f%%). No improvement needed.",
+        report["summary"]["meaningful_rate"],
+        threshold_pct,
+    )
     return {
         "old_version": old_version,
         "new_version": old_version,
@@ -943,6 +951,7 @@ async def run_improvement(
   # Set shared state for tool functions
   _state["config"] = config
   _state["report"] = report
+  _state["output_dir"] = output_dir
 
   # Run the LoopAgent
   improver = create_improver_agent(config)

--- a/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
+++ b/examples/agent_improvement_cycle/agent_improvement/improver_agent.py
@@ -189,6 +189,9 @@ async def _generate_ground_truth(
   same tools as the target agent, so its answers are grounded in
   real tool output.
 
+  Limits concurrency to avoid 429 rate-limit errors when many
+  sessions are processed.
+
   Returns a list of dicts with ``question``, ``bad_response``, and
   ``ground_truth`` keys.
   """
@@ -206,30 +209,41 @@ async def _generate_ground_truth(
     teacher_agent = config.agent_factory(teacher_prompt)
   runner = InMemoryRunner(agent=teacher_agent, app_name="teacher_agent")
 
-  async def _get_answer(session: dict) -> dict:
-    question = session.get("question", "")
-    sess = await runner.session_service.create_session(
-        app_name="teacher_agent", user_id="teacher"
-    )
-    msg = Content(role="user", parts=[Part(text=question)])
-    answer = ""
-    async for event in runner.run_async(
-        user_id="teacher", session_id=sess.id, new_message=msg
-    ):
-      if event.content and event.content.parts:
-        for part in event.content.parts:
-          if part.text:
-            answer += part.text
-    return {
-        "question": question,
-        "bad_response": session.get("response", "")[:500],
-        "ground_truth": answer,
-    }
+  # Limit concurrent LLM calls to avoid hitting Vertex AI rate limits.
+  semaphore = asyncio.Semaphore(5)
 
-  results = list(
-      await asyncio.gather(*[_get_answer(s) for s in failed_sessions])
+  async def _get_answer(session: dict) -> dict | None:
+    question = session.get("question", "")
+    async with semaphore:
+      try:
+        sess = await runner.session_service.create_session(
+            app_name="teacher_agent", user_id="teacher"
+        )
+        msg = Content(role="user", parts=[Part(text=question)])
+        answer = ""
+        async for event in runner.run_async(
+            user_id="teacher", session_id=sess.id, new_message=msg
+        ):
+          if event.content and event.content.parts:
+            for part in event.content.parts:
+              if part.text:
+                answer += part.text
+        return {
+            "question": question,
+            "bad_response": session.get("response", "")[:500],
+            "ground_truth": answer,
+        }
+      except Exception as e:
+        logging.warning(
+            "Teacher agent failed for question '%.80s': %s",
+            question, e,
+        )
+        return None
+
+  results = await asyncio.gather(
+      *[_get_answer(s) for s in failed_sessions]
   )
-  return [r for r in results if r["ground_truth"].strip()]
+  return [r for r in results if r and r["ground_truth"].strip()]
 
 
 async def _generate_via_vertex_optimizer(

--- a/examples/agent_improvement_cycle/config.json
+++ b/examples/agent_improvement_cycle/config.json
@@ -11,5 +11,6 @@
   "prompt_storage": "vertex",
   "vertex_prompt_id": "",
   "use_vertex_optimizer": true,
-  "max_failure_extract": "auto"
+  "max_failure_extract": "auto",
+  "quality_threshold": 0.95
 }

--- a/examples/agent_improvement_cycle/config.json
+++ b/examples/agent_improvement_cycle/config.json
@@ -7,8 +7,9 @@
   "eval_cases_path": "eval/eval_cases.json",
   "traffic_generator": "eval/generate_traffic.py",
   "model_id": "gemini-2.5-flash",
-  "max_attempts": 3,
+  "optimizer_max_iterations": 3,
   "prompt_storage": "vertex",
   "vertex_prompt_id": "",
-  "use_vertex_optimizer": true
+  "use_vertex_optimizer": true,
+  "max_failure_extract": "auto"
 }

--- a/examples/agent_improvement_cycle/eval/generate_traffic.py
+++ b/examples/agent_improvement_cycle/eval/generate_traffic.py
@@ -23,8 +23,17 @@ has not been specifically tuned for.
 
 import argparse
 import json
+import logging
 import os
 import sys
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_DEMO_DIR = os.path.dirname(_SCRIPT_DIR)
+sys.path.insert(0, _DEMO_DIR)
+
+import agent_improvement  # noqa: F401 -- configures logging
+
+logger = logging.getLogger(__name__)
 
 from dotenv import load_dotenv
 from google import genai
@@ -32,9 +41,6 @@ import google.auth
 from google.genai.types import GenerateContentConfig
 from google.genai.types import HttpOptions
 from google.genai.types import HttpRetryOptions
-
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-_DEMO_DIR = os.path.dirname(_SCRIPT_DIR)
 
 # Load environment
 _env_path = os.path.join(_DEMO_DIR, ".env")
@@ -142,17 +148,20 @@ def generate_traffic(count: int = 10) -> list[dict]:
 
       if len(cases) < count // 2:
         if attempt < 2:
-          print(
-              f"  Only got {len(cases)} cases (wanted {count}),"
-              f" retrying ({attempt + 1}/3)..."
+          logger.warning(
+              "Only got %d cases (wanted %d), retrying (%d/3)...",
+              len(cases),
+              count,
+              attempt + 1,
           )
           continue
       # Gemini may return more cases than requested; truncate to count.
       return cases[:count]
     except json.JSONDecodeError:
       if attempt < 2:
-        print(
-            f"  Gemini returned malformed JSON, retrying ({attempt + 1}/3)..."
+        logger.warning(
+            "Gemini returned malformed JSON, retrying (%d/3)...",
+            attempt + 1,
         )
       else:
         raise
@@ -182,9 +191,9 @@ def main() -> None:
   )
   os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-  print(f"\n  Generating {args.count} synthetic traffic cases...")
+  logger.info("Generating %d synthetic traffic cases...", args.count)
   cases = generate_traffic(count=args.count)
-  print(f"  Generated {len(cases)} cases.")
+  logger.info("Generated %d cases.", len(cases))
 
   # Wrap in the same format as eval_cases.json so run_eval.py can consume it
   output = {
@@ -198,7 +207,7 @@ def main() -> None:
     json.dump(output, f, indent=2)
     f.write("\n")
 
-  print(f"  Written to {output_path}")
+  logger.info("Written to %s", output_path)
 
 
 if __name__ == "__main__":

--- a/examples/agent_improvement_cycle/eval/generate_traffic.py
+++ b/examples/agent_improvement_cycle/eval/generate_traffic.py
@@ -147,7 +147,8 @@ def generate_traffic(count: int = 10) -> list[dict]:
               f" retrying ({attempt + 1}/3)..."
           )
           continue
-      return cases
+      # Gemini may return more cases than requested; truncate to count.
+      return cases[:count]
     except json.JSONDecodeError:
       if attempt < 2:
         print(

--- a/examples/agent_improvement_cycle/eval/operational_metrics.py
+++ b/examples/agent_improvement_cycle/eval/operational_metrics.py
@@ -33,11 +33,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 import warnings
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+_DEMO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+sys.path.insert(0, _DEMO_DIR)
+
+import agent_improvement  # noqa: F401 -- configures logging
+
+logger = logging.getLogger(__name__)
 
 from dotenv import load_dotenv
 
@@ -66,7 +74,12 @@ METRICS = {
         "unit": "tokens",
         "label": "Total tokens",
     },
-    "turn_count": {"threshold": 10, "unit": "turns", "label": "Turn count", "fmt": "int"},
+    "turn_count": {
+        "threshold": 10,
+        "unit": "turns",
+        "label": "Turn count",
+        "fmt": "int",
+    },
     "error_rate": {
         "threshold": 0.1,
         "unit": "rate",
@@ -220,9 +233,9 @@ def print_comparison(
 
   print("")
   if all_pass:
-    print("  All operational metrics within budget.")
+    logger.info("All operational metrics within budget.")
   else:
-    print("  Some metrics exceeded budget. Review thresholds.")
+    logger.warning("Some metrics exceeded budget. Review thresholds.")
   print("")
   return all_pass
 
@@ -267,7 +280,7 @@ def main():
       print(f"  No session IDs found in {args.sessions}", file=sys.stderr)
       sys.exit(1)
 
-    print(f"  Evaluating {len(ids)} {args.label} sessions...")
+    logger.info("Evaluating %d %s sessions...", len(ids), args.label)
     results = run_metrics(ids)
     print_baseline(results, args.label)
 
@@ -275,7 +288,7 @@ def main():
       output = {"label": args.label, "sessions": len(ids), "metrics": results}
       with open(args.output, "w") as f:
         json.dump(output, f, indent=2, default=str)
-      print(f"  Saved to: {args.output}")
+      logger.info("Saved to: %s", args.output)
     sys.exit(0)
 
   # Comparison mode: before/after
@@ -294,8 +307,12 @@ def main():
     print(f"  No session IDs found in {args.after_sessions}", file=sys.stderr)
     sys.exit(1)
 
-  print(
-      f"  Evaluating {len(before_ids)} {args.before_label} sessions and {len(after_ids)} {args.after_label} sessions..."
+  logger.info(
+      "Evaluating %d %s sessions and %d %s sessions...",
+      len(before_ids),
+      args.before_label,
+      len(after_ids),
+      args.after_label,
   )
 
   before_results = run_metrics(before_ids)
@@ -324,7 +341,7 @@ def main():
     }
     with open(args.output, "w") as f:
       json.dump(output, f, indent=2, default=str)
-    print(f"  Saved to: {args.output}")
+    logger.info("Saved to: %s", args.output)
 
   sys.exit(0 if all_pass else 1)
 

--- a/examples/agent_improvement_cycle/eval/operational_metrics.py
+++ b/examples/agent_improvement_cycle/eval/operational_metrics.py
@@ -133,6 +133,10 @@ def run_metrics(session_ids: list[str]) -> dict:
     avg_observed = (
         sum(observed_values) / len(observed_values) if observed_values else 0
     )
+    if cfg.get("fmt") == "int":
+      avg_observed = int(round(avg_observed))
+    else:
+      avg_observed = round(avg_observed, 1)
 
     results[metric_name] = {
         "label": cfg["label"],
@@ -142,7 +146,7 @@ def run_metrics(session_ids: list[str]) -> dict:
         "passed": report.passed_sessions,
         "failed": report.failed_sessions,
         "pass_rate": report.pass_rate,
-        "avg_observed": round(avg_observed, 1),
+        "avg_observed": avg_observed,
     }
 
   return results
@@ -165,8 +169,7 @@ def print_baseline(metrics: dict, label: str):
     else:
       status = "PASS"
 
-    fmt_val = int(val) if cfg.get("fmt") == "int" and isinstance(val, (int, float)) else val
-    v_str = f"{fmt_val} {unit}" if isinstance(val, (int, float)) else str(val)
+    v_str = f"{val} {unit}" if isinstance(val, (int, float)) else str(val)
     t_str = f"{threshold} {unit}"
     print(f"  {cfg['label']:<18}  {v_str:>14}  {t_str:>14}  {status:>8}")
 
@@ -207,11 +210,8 @@ def print_comparison(
     if status == "WARN":
       all_pass = False
 
-    is_int = cfg.get("fmt") == "int"
-    fmt_b = int(b_val) if is_int and isinstance(b_val, (int, float)) else b_val
-    fmt_a = int(a_val) if is_int and isinstance(a_val, (int, float)) else a_val
-    b_str = f"{fmt_b} {unit}" if isinstance(b_val, (int, float)) else str(b_val)
-    a_str = f"{fmt_a} {unit}" if isinstance(a_val, (int, float)) else str(a_val)
+    b_str = f"{b_val} {unit}" if isinstance(b_val, (int, float)) else str(b_val)
+    a_str = f"{a_val} {unit}" if isinstance(a_val, (int, float)) else str(a_val)
     t_str = f"{threshold} {unit}"
 
     print(

--- a/examples/agent_improvement_cycle/eval/operational_metrics.py
+++ b/examples/agent_improvement_cycle/eval/operational_metrics.py
@@ -38,7 +38,7 @@ import os
 import sys
 import warnings
 
-warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore")
 
 _DEMO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
 sys.path.insert(0, _DEMO_DIR)

--- a/examples/agent_improvement_cycle/eval/operational_metrics.py
+++ b/examples/agent_improvement_cycle/eval/operational_metrics.py
@@ -66,7 +66,7 @@ METRICS = {
         "unit": "tokens",
         "label": "Total tokens",
     },
-    "turn_count": {"threshold": 10, "unit": "turns", "label": "Turn count"},
+    "turn_count": {"threshold": 10, "unit": "turns", "label": "Turn count", "fmt": "int"},
     "error_rate": {
         "threshold": 0.1,
         "unit": "rate",
@@ -165,7 +165,8 @@ def print_baseline(metrics: dict, label: str):
     else:
       status = "PASS"
 
-    v_str = f"{val} {unit}" if isinstance(val, (int, float)) else str(val)
+    fmt_val = int(val) if cfg.get("fmt") == "int" and isinstance(val, (int, float)) else val
+    v_str = f"{fmt_val} {unit}" if isinstance(val, (int, float)) else str(val)
     t_str = f"{threshold} {unit}"
     print(f"  {cfg['label']:<18}  {v_str:>14}  {t_str:>14}  {status:>8}")
 
@@ -206,8 +207,11 @@ def print_comparison(
     if status == "WARN":
       all_pass = False
 
-    b_str = f"{b_val} {unit}" if isinstance(b_val, (int, float)) else str(b_val)
-    a_str = f"{a_val} {unit}" if isinstance(a_val, (int, float)) else str(a_val)
+    is_int = cfg.get("fmt") == "int"
+    fmt_b = int(b_val) if is_int and isinstance(b_val, (int, float)) else b_val
+    fmt_a = int(a_val) if is_int and isinstance(a_val, (int, float)) else a_val
+    b_str = f"{fmt_b} {unit}" if isinstance(b_val, (int, float)) else str(b_val)
+    a_str = f"{fmt_a} {unit}" if isinstance(a_val, (int, float)) else str(a_val)
     t_str = f"{threshold} {unit}"
 
     print(

--- a/examples/agent_improvement_cycle/eval/run_eval.py
+++ b/examples/agent_improvement_cycle/eval/run_eval.py
@@ -31,19 +31,25 @@ warnings.filterwarnings("ignore")
 # authlib forces simplefilter("always") at import time; neutralise early.
 try:
   import authlib.deprecate
-  warnings.filterwarnings("ignore",
-                          category=authlib.deprecate.AuthlibDeprecationWarning)
+
+  warnings.filterwarnings(
+      "ignore", category=authlib.deprecate.AuthlibDeprecationWarning
+  )
 except ImportError:
   pass
 
 # Suppress noisy SDK loggers before any google imports.
 for _name in (
-    "google.genai", "google_genai",
-    "google.auth", "google_auth",
-    "google.adk", "google_adk",
-    "httpx", "httpcore",
+    "google.genai",
+    "google_genai",
+    "google.auth",
+    "google_auth",
+    "google.adk",
+    "google_adk",
+    "httpx",
+    "httpcore",
 ):
-    logging.getLogger(_name).setLevel(logging.ERROR)
+  logging.getLogger(_name).setLevel(logging.ERROR)
 
 import asyncio
 import json

--- a/examples/agent_improvement_cycle/eval/run_eval.py
+++ b/examples/agent_improvement_cycle/eval/run_eval.py
@@ -28,12 +28,13 @@ import warnings
 
 warnings.filterwarnings("ignore")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="authlib")
-logging.getLogger("google.genai").setLevel(logging.ERROR)
 
 import asyncio
 import json
 import os
 import sys
+
+logger = logging.getLogger(__name__)
 
 from google.adk.runners import InMemoryRunner
 from google.genai.types import Content
@@ -101,7 +102,7 @@ async def run_all_cases(
   eval_path = eval_cases_path or cfg["eval_cases_path"]
 
   cases = load_eval_cases(eval_path)
-  print(f"\nRunning {len(cases)} cases...\n")
+  logger.info("Running %d cases...", len(cases))
 
   runner = InMemoryRunner(
       agent=mod.root_agent,
@@ -148,8 +149,8 @@ async def run_all_cases(
   )
   results = list(results)
 
-  print(f"\nCompleted {len(results)}/{len(cases)} cases.")
-  print("Sessions logged to BigQuery via telemetry plugin.")
+  logger.info("Completed %d/%d cases.", len(results), len(cases))
+  print("  Sessions logged to BigQuery via telemetry plugin.")
   return results
 
 
@@ -172,7 +173,7 @@ async def run_golden_eval(
 
   cases = eval_runner.load_eval_cases(eval_path)
   _, version = config.prompt_adapter.read_prompt()
-  print(f"\n  Evaluating {len(cases)} cases with prompt V{version}")
+  logger.info("Evaluating %d cases with prompt V%s", len(cases), version)
   print("  (LLM judge, no BigQuery logging)\n")
 
   prompt, _ = config.prompt_adapter.read_prompt()
@@ -181,7 +182,7 @@ async def run_golden_eval(
   )
 
   rate = round(100 * passed / total) if total else 0
-  print(f"\n  Result: {passed}/{total} passed ({rate}%)")
+  logger.info("Result: %d/%d passed (%d%%)", passed, total, rate)
   if all_passed:
     print("  All cases pass.")
   else:
@@ -239,7 +240,7 @@ def main() -> None:
   os.makedirs(os.path.dirname(results_path), exist_ok=True)
   with open(results_path, "w") as f:
     json.dump(results, f, indent=2)
-  print(f"Results saved to {results_path}")
+  logger.info("Results saved to %s", results_path)
 
   if failed:
     sys.exit(1)

--- a/examples/agent_improvement_cycle/eval/run_eval.py
+++ b/examples/agent_improvement_cycle/eval/run_eval.py
@@ -109,35 +109,39 @@ async def run_all_cases(
       plugins=[mod.bq_logging_plugin],
   )
 
+  # Limit concurrent LLM calls to avoid 429 rate-limit errors and timeouts.
+  semaphore = asyncio.Semaphore(5)
+
   async def _run_one(i: int, case: dict) -> dict:
-    try:
-      result = await asyncio.wait_for(
-          run_single_case(runner, case), timeout=120
-      )
-      resp_text = result["response"].replace("\n", " ").strip()
-      print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
-      print(f"           -> {resp_text}")
-      return result
-    except asyncio.TimeoutError:
-      print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
-      print(f"           -> TIMEOUT (120s)")
-      return {
-          "case_id": case["id"],
-          "question": case["question"],
-          "category": case.get("category", ""),
-          "response": "ERROR: Timeout after 120s",
-          "session_id": "",
-      }
-    except Exception as e:
-      print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
-      print(f"           -> ERROR: {e}")
-      return {
-          "case_id": case["id"],
-          "question": case["question"],
-          "category": case.get("category", ""),
-          "response": f"ERROR: {e}",
-          "session_id": "",
-      }
+    async with semaphore:
+      try:
+        result = await asyncio.wait_for(
+            run_single_case(runner, case), timeout=120
+        )
+        resp_text = result["response"].replace("\n", " ").strip()
+        print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
+        print(f"           -> {resp_text}")
+        return result
+      except asyncio.TimeoutError:
+        print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
+        print(f"           -> TIMEOUT (120s)")
+        return {
+            "case_id": case["id"],
+            "question": case["question"],
+            "category": case.get("category", ""),
+            "response": "ERROR: Timeout after 120s",
+            "session_id": "",
+        }
+      except Exception as e:
+        print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
+        print(f"           -> ERROR: {e}")
+        return {
+            "case_id": case["id"],
+            "question": case["question"],
+            "category": case.get("category", ""),
+            "response": f"ERROR: {e}",
+            "session_id": "",
+        }
 
   results = await asyncio.gather(
       *[_run_one(i, case) for i, case in enumerate(cases, 1)]

--- a/examples/agent_improvement_cycle/eval/run_eval.py
+++ b/examples/agent_improvement_cycle/eval/run_eval.py
@@ -27,7 +27,23 @@ import logging
 import warnings
 
 warnings.filterwarnings("ignore")
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="authlib")
+
+# authlib forces simplefilter("always") at import time; neutralise early.
+try:
+  import authlib.deprecate
+  warnings.filterwarnings("ignore",
+                          category=authlib.deprecate.AuthlibDeprecationWarning)
+except ImportError:
+  pass
+
+# Suppress noisy SDK loggers before any google imports.
+for _name in (
+    "google.genai", "google_genai",
+    "google.auth", "google_auth",
+    "google.adk", "google_adk",
+    "httpx", "httpcore",
+):
+    logging.getLogger(_name).setLevel(logging.ERROR)
 
 import asyncio
 import json
@@ -117,7 +133,7 @@ async def run_all_cases(
     async with semaphore:
       try:
         result = await asyncio.wait_for(
-            run_single_case(runner, case), timeout=120
+            run_single_case(runner, case), timeout=200
         )
         resp_text = result["response"].replace("\n", " ").strip()
         print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
@@ -125,12 +141,12 @@ async def run_all_cases(
         return result
       except asyncio.TimeoutError:
         print(f"  [{i}/{len(cases)}] {case['id']}: {case['question']}")
-        print(f"           -> TIMEOUT (120s)")
+        print(f"           -> TIMEOUT (200s)")
         return {
             "case_id": case["id"],
             "question": case["question"],
             "category": case.get("category", ""),
-            "response": "ERROR: Timeout after 120s",
+            "response": "ERROR: Timeout after 200s",
             "session_id": "",
         }
       except Exception as e:
@@ -220,6 +236,15 @@ def main() -> None:
           " provided, uses the demo's company_info_agent config."
       ),
   )
+  parser.add_argument(
+      "--output-dir",
+      type=str,
+      default=None,
+      help=(
+          "Directory to write latest_eval_results.json into."
+          " Defaults to <demo>/reports/."
+      ),
+  )
   args = parser.parse_args()
 
   if args.golden:
@@ -236,7 +261,8 @@ def main() -> None:
     )
 
   # Write results to a file for reference
-  results_path = os.path.join(_DEMO_DIR, "reports", "latest_eval_results.json")
+  output_dir = args.output_dir or os.path.join(_DEMO_DIR, "reports")
+  results_path = os.path.join(output_dir, "latest_eval_results.json")
   os.makedirs(os.path.dirname(results_path), exist_ok=True)
   with open(results_path, "w") as f:
     json.dump(results, f, indent=2)

--- a/examples/agent_improvement_cycle/reset.sh
+++ b/examples/agent_improvement_cycle/reset.sh
@@ -29,10 +29,6 @@ git checkout -- "$SCRIPT_DIR/agent/prompts.py"
 # Delete old prompt, create fresh V1 in Vertex AI
 python3 "$SCRIPT_DIR/setup_vertex.py"
 
-# Remove generated traffic and reports
-rm -f "$SCRIPT_DIR"/eval/synthetic_traffic_cycle_*.json
-rm -rf "$SCRIPT_DIR"/reports/*
-
 echo ""
 echo "Done. Prompt reset to V1 in Vertex AI, golden eval set reset to 3 cases."
 echo "Run ./run_cycle.sh to start a fresh cycle."

--- a/examples/agent_improvement_cycle/run_cycle.sh
+++ b/examples/agent_improvement_cycle/run_cycle.sh
@@ -26,9 +26,9 @@
 #   Step 5  Measure improvement         (fresh traffic + LLM judge)
 #
 # Usage:
-#   ./run_cycle.sh                                          # Demo agent
+#   ./run_cycle.sh                                          # Single cycle (default)
+#   ./run_cycle.sh --auto --cycles 3                        # Auto-cycle up to 3
 #   ./run_cycle.sh --agent-config /path/to/config.json      # Any agent
-#   ./run_cycle.sh --cycles 3                               # 3 cycles
 #   ./run_cycle.sh --eval-only                              # Steps 1-3 only
 # ============================================================================
 
@@ -57,7 +57,7 @@ CYCLES=1
 EVAL_ONLY=false
 TRAFFIC_COUNT=10
 AGENT_CONFIG=""
-AUTO_CONTINUE=true
+AUTO_CONTINUE=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -83,8 +83,8 @@ while [[ $# -gt 0 ]]; do
       TRAFFIC_COUNT="$2"
       shift 2
       ;;
-    --no-auto)
-      AUTO_CONTINUE=false
+    --auto)
+      AUTO_CONTINUE=true
       shift
       ;;
     -h|--help)
@@ -94,8 +94,8 @@ while [[ $# -gt 0 ]]; do
       echo "  --agent-config F   Path to agent's config.json"
       echo "                     (default: config.json)"
       echo "  --cycles N         Run N improvement cycles (default: 1)"
-      echo "  --no-auto          Always run all N cycles even if 100%"
-      echo "                     meaningful (default: stop early)"
+      echo "  --auto             Enable auto-cycling: run up to N cycles,"
+      echo "                     stop early when 100% meaningful"
       echo "  --eval-only        Only run evaluation (Steps 1-3), skip improvement"
       echo "  --app-name X       Override agent app name for BQ filtering"
       echo "  --traffic-count N  Number of synthetic questions per cycle (default: 10)"

--- a/examples/agent_improvement_cycle/run_cycle.sh
+++ b/examples/agent_improvement_cycle/run_cycle.sh
@@ -36,7 +36,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-REPORTS_DIR="$SCRIPT_DIR/reports"
+
+# Each run gets a unique timestamped directory under reports/
+RUN_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+REPORTS_DIR="$SCRIPT_DIR/reports/run_${RUN_TIMESTAMP}"
+mkdir -p "$REPORTS_DIR"
+
+# Tee all output: terminal gets colour, log file gets plain text.
+RUN_LOG="$REPORTS_DIR/run.log"
+exec > >(tee >(sed 's/\x1b\[[0-9;]*m//g' >> "$RUN_LOG")) 2>&1
 
 # Suppress noisy Python warnings (authlib, etc.) and INFO-level log spam.
 # Belt-and-suspenders: env var for child processes, -W flag for direct calls.
@@ -95,7 +103,8 @@ while [[ $# -gt 0 ]]; do
       echo "                     (default: config.json)"
       echo "  --cycles N         Run N improvement cycles (default: 1)"
       echo "  --auto             Enable auto-cycling: run up to N cycles,"
-      echo "                     stop early when 100% meaningful"
+      echo "                     stop early when quality meets threshold"
+      echo "                     (quality_threshold in config.json, default: 0.95)"
       echo "  --eval-only        Only run evaluation (Steps 1-3), skip improvement"
       echo "  --app-name X       Override agent app name for BQ filtering"
       echo "  --traffic-count N  Number of synthetic questions per cycle (default: 10)"
@@ -133,6 +142,7 @@ VERSION_VAR=$(jq -r '.version_variable // "CURRENT_VERSION"' "$AGENT_CONFIG")
 PROMPT_STORAGE=$(jq -r '.prompt_storage // "python_file"' "$AGENT_CONFIG")
 VERTEX_PROMPT_ID=$(jq -r '.vertex_prompt_id // ""' "$AGENT_CONFIG")
 VERTEX_LOCATION=$(jq -r '.vertex_location // "us-central1"' "$AGENT_CONFIG")
+QUALITY_THRESHOLD=$(jq -r '.quality_threshold // 0.95' "$AGENT_CONFIG")
 
 # Auto-setup: create Vertex AI prompt if not yet configured
 if [[ "$PROMPT_STORAGE" == "vertex" && -z "$VERTEX_PROMPT_ID" ]]; then
@@ -184,18 +194,33 @@ _show_prompt() {
 # Timestamp prefix for log lines
 ts() { date "+%H:%M:%S"; }
 
+# ANSI formatting
+BOLD='\033[1m'
+DIM='\033[2m'
+CYAN='\033[36m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RESET='\033[0m'
+
+# Print a prominent stage banner that stands out from [HH:MM:SS] log lines
+stage() {
+  echo ""
+  echo -e "${BOLD}${CYAN}  ▶ $*${RESET}"
+  echo ""
+}
+
 # Timer: call step_start before a step, step_end after.
 step_start() { STEP_START_TIME=$(date +%s); }
 step_end() {
   local elapsed=$(( $(date +%s) - STEP_START_TIME ))
   local label="${1:-Step}"
   echo ""
-  echo "[$(ts)] Done. ${label} completed in ${elapsed}s."
+  echo -e "  ${GREEN}✔ ${label} completed in ${elapsed}s.${RESET}"
 }
 
 separator() {
   echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo -e "${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
 }
 
 # ---------------------------------------------------------------------------
@@ -204,7 +229,7 @@ separator() {
 
 separator
 echo ""
-echo "  AGENT IMPROVEMENT CYCLE"
+echo -e "  ${BOLD}${CYAN}AGENT IMPROVEMENT CYCLE${RESET}"
 echo ""
 echo "  Cycles:     $CYCLES"
 echo "  Agent:      $APP_NAME"
@@ -214,6 +239,8 @@ if [[ "$PROMPT_STORAGE" == "vertex" && -n "$VERTEX_PROMPT_ID" ]]; then
   echo "  Prompt ID:  $VERTEX_PROMPT_ID"
 fi
 echo "  Traffic:    $TRAFFIC_COUNT questions per cycle"
+THRESHOLD_PCT=$(python3 -c "print(int(float('$QUALITY_THRESHOLD') * 100))")
+echo "  Threshold:  ${THRESHOLD_PCT}% meaningful (skip improvement if met)"
 CYCLE_START_TIME=$(date +%s)
 
 separator
@@ -233,13 +260,11 @@ echo ""
 # ---------------------------------------------------------------------------
 
 separator
-echo ""
-echo "[$(ts)] PRE-FLIGHT: Verifying golden eval set passes with current prompt"
-echo ""
+stage "PRE-FLIGHT: Verifying golden eval set passes with current prompt"
 step_start
 
 set +e
-$PY "$SCRIPT_DIR/eval/run_eval.py" --golden $AGENT_CONFIG_FLAG
+$PY "$SCRIPT_DIR/eval/run_eval.py" --golden $AGENT_CONFIG_FLAG --output-dir "$REPORTS_DIR"
 PREFLIGHT_EXIT=$?
 set -e
 step_end "Pre-flight check"
@@ -273,6 +298,7 @@ with open('$EVAL_RESULTS') as f:
 
   $PY "$SCRIPT_DIR/run_improvement.py" \
     $AGENT_CONFIG_FLAG \
+    --output-dir "$REPORTS_DIR" \
     --from-eval-results "$EVAL_RESULTS"
 
   FIXED_V=$(_read_version)
@@ -286,8 +312,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   TOTAL_STEPS=$( $EVAL_ONLY && echo 3 || echo 5 )
 
   separator
-  echo ""
-  echo "[$(ts)] CYCLE $cycle OF $CYCLES"
+  stage "CYCLE $cycle OF $CYCLES"
 
   # Get current prompt version
   CURRENT_V=$(_read_version)
@@ -296,9 +321,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # STEP 1: Generate synthetic traffic
   # =========================================================================
   separator
-  echo ""
-  echo "[$(ts)] STEP 1/$TOTAL_STEPS: GENERATE SYNTHETIC TRAFFIC"
-  echo ""
+  stage "STEP 1/$TOTAL_STEPS: GENERATE SYNTHETIC TRAFFIC"
   echo "  Goal:    Produce diverse user questions that differ from the golden eval set"
   echo "  Method:  Gemini generates $TRAFFIC_COUNT questions"
   echo ""
@@ -324,9 +347,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # STEP 2: Run synthetic traffic through the agent
   # =========================================================================
   separator
-  echo ""
-  echo "[$(ts)] STEP 2/$TOTAL_STEPS: RUN TRAFFIC THROUGH AGENT"
-  echo ""
+  stage "STEP 2/$TOTAL_STEPS: RUN TRAFFIC THROUGH AGENT"
   echo "  Goal:    Send questions to the agent, log every session to BigQuery"
   echo "  Prompt:  V${CURRENT_V} (current)"
   echo "  Logging: BigQuery via BigQueryAgentAnalyticsPlugin"
@@ -338,7 +359,8 @@ for cycle in $(seq 1 "$CYCLES"); do
   set +e
   $PY "$SCRIPT_DIR/eval/run_eval.py" \
     $AGENT_CONFIG_FLAG \
-    --eval-cases "$TRAFFIC_JSON"
+    --eval-cases "$TRAFFIC_JSON" \
+    --output-dir "$REPORTS_DIR"
   TRAFFIC_EXIT=$?
   set -e
 
@@ -358,9 +380,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # STEP 3: Evaluate session quality
   # =========================================================================
   separator
-  echo ""
-  echo "[$(ts)] STEP 3/$TOTAL_STEPS: EVALUATE SESSION QUALITY"
-  echo ""
+  stage "STEP 3/$TOTAL_STEPS: EVALUATE SESSION QUALITY"
   echo "  Goal:    Score each logged session from BigQuery"
   echo "  Method:  SDK quality_report.py reads sessions, LLM judges each one"
   echo "  Metrics: response_usefulness (meaningful/partial/unhelpful)"
@@ -372,7 +392,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   rm -f "$REPORT_JSON"
 
   # Retry with backoff for BigQuery streaming buffer propagation.
-  echo "[$(ts)] Waiting 15s for BigQuery streaming buffer to flush..."
+  echo -e "  ${DIM}[$(ts)] Waiting 15s for BigQuery streaming buffer to flush...${RESET}"
   echo ""
 #  echo "  While we wait, here are the questions that were sent to the agent:"
 #  jq -r '.eval_cases[] | "    [\(.id)] \(.question)"' "$TRAFFIC_JSON" 2>/dev/null || true
@@ -383,12 +403,13 @@ for cycle in $(seq 1 "$CYCLES"); do
   MAX_RETRIES=6
   for attempt in $(seq 1 "$MAX_RETRIES"); do
     sleep 15
-    echo "[$(ts)] Scoring $ACTUAL_TRAFFIC_COUNT sessions with LLM judge (this may take a few minutes)..."
+    echo -e "  ${DIM}[$(ts)] Scoring $ACTUAL_TRAFFIC_COUNT sessions with LLM judge (this may take a few minutes)...${RESET}"
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$REPORT_JSON" \
       --session-ids-file "$EXPECTED_IDS" \
-      --time-period 24h || { rm -f "$REPORT_JSON"; true; }
+      --time-period 24h \
+      || { rm -f "$REPORT_JSON"; true; }
 
     if [[ -f "$REPORT_JSON" ]]; then
       SESSION_COUNT=$(jq -r '.summary.total_sessions // 0' "$REPORT_JSON" 2>/dev/null || echo "0")
@@ -427,7 +448,7 @@ print(len(missing))
 
   # Print quality summary
   echo ""
-  echo "  BASELINE SCORE (V${CURRENT_V}): $(jq -r '.summary.meaningful_rate' "$REPORT_JSON")% meaningful"
+  echo -e "  ${BOLD}BASELINE SCORE (V${CURRENT_V}): $(jq -r '.summary.meaningful_rate' "$REPORT_JSON")% meaningful${RESET}"
   echo "  ($(jq -r '.summary.meaningful' "$REPORT_JSON") meaningful, $(jq -r '.summary.partial' "$REPORT_JSON") partial, $(jq -r '.summary.unhelpful' "$REPORT_JSON") unhelpful out of $(jq -r '.summary.total_sessions' "$REPORT_JSON"))"
   echo ""
   echo "  Report saved to: $REPORT_JSON"
@@ -456,9 +477,7 @@ print(len(missing))
   fi
 
   separator
-  echo ""
-  echo "[$(ts)] STEP 4/$TOTAL_STEPS: IMPROVE PROMPT"
-  echo ""
+  stage "STEP 4/$TOTAL_STEPS: IMPROVE PROMPT"
   echo "  Goal:    Fix the prompt to address failed sessions"
   echo "  Method:  1. Extract failed cases into golden eval set"
   echo "           2. Generate ground truth via teacher agent"
@@ -473,6 +492,7 @@ print(len(missing))
   set +e
   $PY "$SCRIPT_DIR/run_improvement.py" \
     $AGENT_CONFIG_FLAG \
+    --output-dir "$REPORTS_DIR" \
     "$REPORT_JSON"
   IMPROVE_EXIT=$?
   set -e
@@ -492,13 +512,32 @@ print(len(missing))
 
   step_end "Prompt improvement"
 
+  # Skip measurement if no new version was produced — there's nothing to compare.
+  if [[ "$NEW_V" == "$CURRENT_V" ]]; then
+    echo ""
+    echo "  No new prompt version — skipping measurement step."
+    echo ""
+    echo "  Cycle $cycle complete."
+
+    # Auto-continue: use baseline score to decide
+    if [[ "$AUTO_CONTINUE" == "true" ]]; then
+      B_RATE=$(jq -r '.summary.meaningful_rate // 0' "$REPORT_JSON")
+      B_MEETS=$(python3 -c "print('yes' if float('$B_RATE') >= float('$QUALITY_THRESHOLD') * 100 else 'no')")
+      if [[ "$B_MEETS" == "yes" ]]; then
+        echo "  Quality ${B_RATE}% meets threshold (${THRESHOLD_PCT}%) — stopping auto-continue."
+        break
+      elif [[ $cycle -lt $CYCLES ]]; then
+        echo "  Quality ${B_RATE}% below threshold (${THRESHOLD_PCT}%) — continuing to cycle $((cycle + 1))..."
+      fi
+    fi
+    continue
+  fi
+
   # =========================================================================
   # STEP 5: Measure improvement with fresh traffic
   # =========================================================================
   separator
-  echo ""
-  echo "[$(ts)] STEP 5/$TOTAL_STEPS: MEASURE IMPROVEMENT"
-  echo ""
+  stage "STEP 5/$TOTAL_STEPS: MEASURE IMPROVEMENT"
   echo "  Goal:    Measure quality on fresh, unseen traffic via BigQuery"
   echo "  Method:  1. Generate fresh synthetic traffic (different from Step 1)"
   echo "           2. Run through agent with BigQuery logging"
@@ -518,7 +557,8 @@ print(len(missing))
   set +e
   $PY "$SCRIPT_DIR/eval/run_eval.py" \
     $AGENT_CONFIG_FLAG \
-    --eval-cases "$FRESH_TRAFFIC"
+    --eval-cases "$FRESH_TRAFFIC" \
+    --output-dir "$REPORTS_DIR"
   FRESH_EXIT=$?
   set -e
 
@@ -539,7 +579,7 @@ print(len(missing))
   rm -f "$FRESH_REPORT"
 
   echo ""
-  echo "[$(ts)] Waiting 30s for BigQuery streaming buffer to flush..."
+  echo -e "  ${DIM}[$(ts)] Waiting 30s for BigQuery streaming buffer to flush...${RESET}"
   echo ""
   echo "  While we wait, here is the current golden eval set ($GOLDEN_AFTER cases):"
   jq -r '.eval_cases[] | "    [\(.id)] \(.question) (\(.category // "general"))"' "$EVAL_CASES_PATH" 2>/dev/null || true
@@ -551,12 +591,13 @@ print(len(missing))
   MAX_RETRIES=6
   for attempt in $(seq 1 "$MAX_RETRIES"); do
     sleep 30
-    echo "[$(ts)] Scoring $ACTUAL_FRESH_COUNT fresh sessions with LLM judge (this may take a few minutes)..."
+    echo -e "  ${DIM}[$(ts)] Scoring $ACTUAL_FRESH_COUNT fresh sessions with LLM judge (this may take a few minutes)...${RESET}"
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$FRESH_REPORT" \
       --session-ids-file "$FRESH_EXPECTED_IDS" \
-      --time-period 24h || { rm -f "$FRESH_REPORT"; true; }
+      --time-period 24h \
+      || { rm -f "$FRESH_REPORT"; true; }
 
     # Guard: ensure NO old session IDs from Step 3 appear in the
     # fresh report. A simple != check allows mixed old/new populations.
@@ -643,16 +684,16 @@ print(len(missing))
   echo ""
   echo "  Cycle $cycle complete."
 
-  # Auto-continue: stop early if 100% meaningful
+  # Auto-continue: stop early if quality meets threshold
   if [[ "$AUTO_CONTINUE" == "true" ]]; then
-    A_UNHELPFUL=$(jq -r '.summary.unhelpful // 0' "$FRESH_REPORT")
-    A_PARTIAL=$(jq -r '.summary.partial // 0' "$FRESH_REPORT")
-    if [[ "$A_UNHELPFUL" == "0" && "$A_PARTIAL" == "0" ]]; then
+    A_RATE=$(jq -r '.summary.meaningful_rate // 0' "$FRESH_REPORT")
+    A_MEETS=$(python3 -c "print('yes' if float('$A_RATE') >= float('$QUALITY_THRESHOLD') * 100 else 'no')")
+    if [[ "$A_MEETS" == "yes" ]]; then
       echo ""
-      echo "  All sessions meaningful — stopping auto-continue."
+      echo "  Quality ${A_RATE}% meets threshold (${THRESHOLD_PCT}%) — stopping auto-continue."
       break
     elif [[ $cycle -lt $CYCLES ]]; then
-      echo "  ${A_UNHELPFUL} unhelpful + ${A_PARTIAL} partial remain — continuing to cycle $((cycle + 1))..."
+      echo "  Quality ${A_RATE}% below threshold (${THRESHOLD_PCT}%) — continuing to cycle $((cycle + 1))..."
     fi
   fi
 done
@@ -674,7 +715,7 @@ echo ""
 
 separator
 echo ""
-echo "  DONE  ($CYCLES cycle(s), total wall time: ${TOTAL_MIN}m ${TOTAL_SEC}s)"
+echo -e "  ${BOLD}${GREEN}DONE${RESET}  ($CYCLES cycle(s), total wall time: ${TOTAL_MIN}m ${TOTAL_SEC}s)"
 echo ""
 echo "  Prompt version:   V${FINAL_V}"
 echo "  Golden eval set:  $FINAL_GOLDEN cases"

--- a/examples/agent_improvement_cycle/run_cycle.sh
+++ b/examples/agent_improvement_cycle/run_cycle.sh
@@ -181,13 +181,16 @@ _show_prompt() {
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Timestamp prefix for log lines
+ts() { date "+%H:%M:%S"; }
+
 # Timer: call step_start before a step, step_end after.
 step_start() { STEP_START_TIME=$(date +%s); }
 step_end() {
   local elapsed=$(( $(date +%s) - STEP_START_TIME ))
   local label="${1:-Step}"
   echo ""
-  echo "  Done. ${label} completed in ${elapsed}s."
+  echo "[$(ts)] Done. ${label} completed in ${elapsed}s."
 }
 
 separator() {
@@ -231,7 +234,7 @@ echo ""
 
 separator
 echo ""
-echo "  PRE-FLIGHT: Verifying golden eval set passes with current prompt"
+echo "[$(ts)] PRE-FLIGHT: Verifying golden eval set passes with current prompt"
 echo ""
 step_start
 
@@ -284,7 +287,7 @@ for cycle in $(seq 1 "$CYCLES"); do
 
   separator
   echo ""
-  echo "  CYCLE $cycle OF $CYCLES"
+  echo "[$(ts)] CYCLE $cycle OF $CYCLES"
 
   # Get current prompt version
   CURRENT_V=$(_read_version)
@@ -294,7 +297,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # =========================================================================
   separator
   echo ""
-  echo "  STEP 1/$TOTAL_STEPS: GENERATE SYNTHETIC TRAFFIC"
+  echo "[$(ts)] STEP 1/$TOTAL_STEPS: GENERATE SYNTHETIC TRAFFIC"
   echo ""
   echo "  Goal:    Produce diverse user questions that differ from the golden eval set"
   echo "  Method:  Gemini generates $TRAFFIC_COUNT questions"
@@ -322,7 +325,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # =========================================================================
   separator
   echo ""
-  echo "  STEP 2/$TOTAL_STEPS: RUN TRAFFIC THROUGH AGENT"
+  echo "[$(ts)] STEP 2/$TOTAL_STEPS: RUN TRAFFIC THROUGH AGENT"
   echo ""
   echo "  Goal:    Send questions to the agent, log every session to BigQuery"
   echo "  Prompt:  V${CURRENT_V} (current)"
@@ -356,7 +359,7 @@ for cycle in $(seq 1 "$CYCLES"); do
   # =========================================================================
   separator
   echo ""
-  echo "  STEP 3/$TOTAL_STEPS: EVALUATE SESSION QUALITY"
+  echo "[$(ts)] STEP 3/$TOTAL_STEPS: EVALUATE SESSION QUALITY"
   echo ""
   echo "  Goal:    Score each logged session from BigQuery"
   echo "  Method:  SDK quality_report.py reads sessions, LLM judges each one"
@@ -369,15 +372,18 @@ for cycle in $(seq 1 "$CYCLES"); do
   rm -f "$REPORT_JSON"
 
   # Retry with backoff for BigQuery streaming buffer propagation.
-  echo "  Waiting 15s for BigQuery streaming buffer to flush..."
+  echo "[$(ts)] Waiting 15s for BigQuery streaming buffer to flush..."
   echo ""
 #  echo "  While we wait, here are the questions that were sent to the agent:"
 #  jq -r '.eval_cases[] | "    [\(.id)] \(.question)"' "$TRAFFIC_JSON" 2>/dev/null || true
 #  echo ""
+  # The LLM judge scores each session individually (2 LLM calls per
+  # session: usefulness + grounding). At N=100 this takes 3-5 minutes.
+  # No output is printed until scoring completes — this is normal.
   MAX_RETRIES=6
   for attempt in $(seq 1 "$MAX_RETRIES"); do
     sleep 15
-    echo "  Querying BigQuery and scoring sessions with LLM judge..."
+    echo "[$(ts)] Scoring $ACTUAL_TRAFFIC_COUNT sessions with LLM judge (this may take a few minutes)..."
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$REPORT_JSON" \
@@ -451,7 +457,7 @@ print(len(missing))
 
   separator
   echo ""
-  echo "  STEP 4/$TOTAL_STEPS: IMPROVE PROMPT"
+  echo "[$(ts)] STEP 4/$TOTAL_STEPS: IMPROVE PROMPT"
   echo ""
   echo "  Goal:    Fix the prompt to address failed sessions"
   echo "  Method:  1. Extract failed cases into golden eval set"
@@ -491,7 +497,7 @@ print(len(missing))
   # =========================================================================
   separator
   echo ""
-  echo "  STEP 5/$TOTAL_STEPS: MEASURE IMPROVEMENT"
+  echo "[$(ts)] STEP 5/$TOTAL_STEPS: MEASURE IMPROVEMENT"
   echo ""
   echo "  Goal:    Measure quality on fresh, unseen traffic via BigQuery"
   echo "  Method:  1. Generate fresh synthetic traffic (different from Step 1)"
@@ -533,16 +539,19 @@ print(len(missing))
   rm -f "$FRESH_REPORT"
 
   echo ""
-  echo "  Waiting 30s for BigQuery streaming buffer to flush..."
+  echo "[$(ts)] Waiting 30s for BigQuery streaming buffer to flush..."
   echo ""
   echo "  While we wait, here is the current golden eval set ($GOLDEN_AFTER cases):"
   jq -r '.eval_cases[] | "    [\(.id)] \(.question) (\(.category // "general"))"' "$EVAL_CASES_PATH" 2>/dev/null || true
   echo ""
 
+  # The LLM judge scores each session individually (2 LLM calls per
+  # session: usefulness + grounding). At N=100 this takes 3-5 minutes.
+  # No output is printed until scoring completes — this is normal.
   MAX_RETRIES=6
   for attempt in $(seq 1 "$MAX_RETRIES"); do
     sleep 30
-    echo "  Querying BigQuery and scoring sessions with LLM judge..."
+    echo "[$(ts)] Scoring $ACTUAL_FRESH_COUNT fresh sessions with LLM judge (this may take a few minutes)..."
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$FRESH_REPORT" \

--- a/examples/agent_improvement_cycle/run_cycle.sh
+++ b/examples/agent_improvement_cycle/run_cycle.sh
@@ -245,9 +245,9 @@ if [[ $PREFLIGHT_EXIT -ne 0 ]]; then
   FAILING_V=$(_read_version)
   echo ""
   echo "  ┌─────────────────────────────────────────────────────────────┐"
-  echo "  │  WARNING: Prompt V${FAILING_V} does not pass all golden eval cases.  │"
-  echo "  │  The baseline will be auto-improved before the cycle runs. │"
-  echo "  │  Use ./reset.sh to restore the original V1 prompt.        │"
+  echo "  │  WARNING: Prompt V${FAILING_V} does not pass all golden eval cases.    │"
+  echo "  │  The baseline will be auto-improved before the cycle runs.  │"
+  echo "  │  Use ./reset.sh to restore the original V1 prompt.          │"
   echo "  └─────────────────────────────────────────────────────────────┘"
   echo ""
 

--- a/examples/agent_improvement_cycle/run_cycle.sh
+++ b/examples/agent_improvement_cycle/run_cycle.sh
@@ -330,9 +330,20 @@ for cycle in $(seq 1 "$CYCLES"); do
   echo ""
   step_start
 
+  # Timeouts/errors on individual cases are expected at high traffic
+  # volumes — don't let them abort the whole cycle.
+  set +e
   $PY "$SCRIPT_DIR/eval/run_eval.py" \
     $AGENT_CONFIG_FLAG \
     --eval-cases "$TRAFFIC_JSON"
+  TRAFFIC_EXIT=$?
+  set -e
+
+  if [[ $TRAFFIC_EXIT -ne 0 ]]; then
+    echo ""
+    echo "  Note: $TRAFFIC_EXIT exit code from run_eval.py (some cases may have timed out)."
+    echo "  Continuing — timed-out cases are excluded from quality scoring."
+  fi
 
   # Save expected session IDs from this run for verification in Step 3.
   EXPECTED_IDS="$REPORTS_DIR/expected_session_ids_cycle_${cycle}.json"
@@ -370,7 +381,7 @@ for cycle in $(seq 1 "$CYCLES"); do
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$REPORT_JSON" \
-      --limit "$ACTUAL_TRAFFIC_COUNT" \
+      --session-ids-file "$EXPECTED_IDS" \
       --time-period 24h || { rm -f "$REPORT_JSON"; true; }
 
     if [[ -f "$REPORT_JSON" ]]; then
@@ -498,9 +509,18 @@ print(len(missing))
   ACTUAL_FRESH_COUNT=$(jq '.eval_cases | length' "$FRESH_TRAFFIC")
 
   # 5c: Run fresh traffic through the improved agent (WITH BQ logging)
+  set +e
   $PY "$SCRIPT_DIR/eval/run_eval.py" \
     $AGENT_CONFIG_FLAG \
     --eval-cases "$FRESH_TRAFFIC"
+  FRESH_EXIT=$?
+  set -e
+
+  if [[ $FRESH_EXIT -ne 0 ]]; then
+    echo ""
+    echo "  Note: some fresh traffic cases may have timed out (exit $FRESH_EXIT)."
+    echo "  Continuing — timed-out cases are excluded from quality scoring."
+  fi
 
   # Save expected session IDs for Step 5 verification.
   FRESH_EXPECTED_IDS="$REPORTS_DIR/expected_session_ids_cycle_${cycle}_fresh.json"
@@ -526,7 +546,7 @@ print(len(missing))
     $PY "$REPO_ROOT/scripts/quality_report.py" \
       --app-name "$APP_NAME" \
       --output-json "$FRESH_REPORT" \
-      --limit "$ACTUAL_FRESH_COUNT" \
+      --session-ids-file "$FRESH_EXPECTED_IDS" \
       --time-period 24h || { rm -f "$FRESH_REPORT"; true; }
 
     # Guard: ensure NO old session IDs from Step 3 appear in the

--- a/examples/agent_improvement_cycle/run_improvement.py
+++ b/examples/agent_improvement_cycle/run_improvement.py
@@ -24,12 +24,9 @@ Usage:
     python run_improvement.py --from-eval-results <eval_results.json>
 """
 
-import logging
 import warnings
 
 warnings.filterwarnings("ignore")
-# Suppress noisy genai SDK "non-text parts in the response" warnings.
-logging.getLogger("google.genai").setLevel(logging.ERROR)
 
 import argparse
 import asyncio

--- a/examples/agent_improvement_cycle/run_improvement.py
+++ b/examples/agent_improvement_cycle/run_improvement.py
@@ -64,6 +64,12 @@ def main() -> None:
           " --golden) instead of a BigQuery quality report."
       ),
   )
+  parser.add_argument(
+      "--output-dir",
+      type=str,
+      default=None,
+      help="Directory for ground_truth_latest.json (default: <demo>/reports/)",
+  )
   args = parser.parse_args()
 
   config = load_config(args.agent_config)
@@ -72,6 +78,7 @@ def main() -> None:
           config,
           report_path=args.report_json,
           from_eval_results=args.from_eval_results,
+          output_dir=args.output_dir,
       )
   )
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,10 @@ EVAL_MODEL_ID=gemini-2.5-flash
 ./scripts/quality_report.sh --model gemini-2.5-pro  # use a specific model
 ./scripts/quality_report.sh --samples 20            # show 20 sessions per category
 ./scripts/quality_report.sh --samples all           # show all sessions per category
+./scripts/quality_report.sh --app-name my_agent     # filter to a specific agent app
+./scripts/quality_report.sh --session-ids-file ids.json  # evaluate specific sessions
+./scripts/quality_report.sh --output-json report.json    # write structured JSON output
+./scripts/quality_report.sh --threshold 15          # unhelpful rate warning at 15%
 ```
 
 Or run the Python script directly:
@@ -73,6 +77,21 @@ python scripts/quality_report.py --limit 50 --report
 all the above in a structured markdown format suitable for sharing or archiving.
 
 **Log files** are saved to `scripts/reports/` for each eval run.
+
+### Filtering
+
+By default, the script evaluates the most recent sessions by time. Two
+additional filters are available for targeted evaluation:
+
+- **`--app-name`** filters to sessions from a specific agent. Matches the
+  `root_agent_name` attribute set by `BigQueryAgentAnalyticsPlugin`.
+- **`--session-ids-file`** evaluates only the sessions listed in a JSON file.
+  Accepts either a list of `{"session_id": "..."}` objects (the output of
+  `run_eval.py`) or a plain list of ID strings. When session IDs are provided,
+  the script filters directly by ID instead of relying on time-based queries,
+  which avoids picking up stale sessions from prior runs.
+
+These filters can be combined (e.g. `--app-name my_agent --session-ids-file ids.json`).
 
 ### Metrics
 

--- a/scripts/quality_report.py
+++ b/scripts/quality_report.py
@@ -364,7 +364,8 @@ def resolve_trace_responses(traces):
 # ---------------------------------------------------------------------------
 
 def run_evaluation(
-    time_range=None, limit=100, model=None, persist=False, app_name=None
+    time_range=None, limit=100, model=None, persist=False, app_name=None,
+    session_ids=None,
 ) -> dict:
   from bigquery_agent_analytics import CategoricalEvaluationConfig, TraceFilter
 
@@ -381,17 +382,28 @@ def run_evaluation(
       results_table="quality_eval_results" if persist else None,
   )
 
-  effective_time_range = time_range
-  if effective_time_range and effective_time_range.lower() == "all":
-    effective_time_range = None
-
-  if effective_time_range:
-    trace_filter = TraceFilter.from_cli_args(last=effective_time_range)
+  # When explicit session IDs are provided, filter directly by them
+  # instead of relying on time-based queries that can pick up stale
+  # sessions from prior runs.
+  if session_ids:
+    trace_filter = TraceFilter(
+        session_ids=session_ids,
+        limit=len(session_ids),
+    )
+    if app_name:
+      trace_filter.root_agent_name = app_name
   else:
-    trace_filter = TraceFilter()
-  trace_filter.limit = limit
-  if app_name:
-    trace_filter.root_agent_name = app_name
+    effective_time_range = time_range
+    if effective_time_range and effective_time_range.lower() == "all":
+      effective_time_range = None
+
+    if effective_time_range:
+      trace_filter = TraceFilter.from_cli_args(last=effective_time_range)
+    else:
+      trace_filter = TraceFilter()
+    trace_filter.limit = limit
+    if app_name:
+      trace_filter.root_agent_name = app_name
 
   report = client.evaluate_categorical(config=cat_config, filters=trace_filter)
 
@@ -511,6 +523,20 @@ def run_eval(args):
       args.samples or "default (10/5/3)",
   )
 
+  # Load session IDs from file if provided
+  session_ids = None
+  if args.session_ids_file:
+    import json as _json
+    with open(args.session_ids_file) as _f:
+      _data = _json.load(_f)
+    # Accepts either a list of objects with "session_id" keys
+    # (run_eval.py output) or a plain list of strings.
+    if _data and isinstance(_data[0], dict):
+      session_ids = [r["session_id"] for r in _data if r.get("session_id")]
+    else:
+      session_ids = [s for s in _data if s]
+    logger.info("Filtering to %d session IDs from %s", len(session_ids), args.session_ids_file)
+
   t0 = time.time()
   try:
     result = run_evaluation(
@@ -519,6 +545,7 @@ def run_eval(args):
         model=model,
         persist=args.persist,
         app_name=args.app_name,
+        session_ids=session_ids,
     )
   except Exception:
     logger.exception("Evaluation failed")
@@ -1150,6 +1177,16 @@ Examples:
       type=float,
       default=10.0,
       help="Unhelpful rate warning threshold in %% (default: 10)",
+  )
+  parser.add_argument(
+      "--session-ids-file",
+      type=str,
+      default=None,
+      metavar="PATH",
+      help="JSON file containing session IDs to evaluate. Expects a list of "
+           "objects with 'session_id' fields (e.g. the output of run_eval.py). "
+           "When set, only these sessions are evaluated — --limit and "
+           "--time-period are ignored.",
   )
 
   args = parser.parse_args()

--- a/scripts/quality_report.py
+++ b/scripts/quality_report.py
@@ -41,6 +41,7 @@ Usage:
     python quality_report.py --samples all        # show all sessions
     python quality_report.py --app-name my_agent  # filter to a specific agent
     python quality_report.py --output-json r.json # write structured JSON output
+    python quality_report.py --env path/to/.env   # load a specific .env file
 """
 import warnings
 
@@ -84,12 +85,23 @@ def _configure_logging():
       format="%(asctime)s [%(levelname)s] %(message)s",
       datefmt="%H:%M:%S",
   )
+  for _noisy in (
+      "google.genai", "google_genai",
+      "google.adk", "google_adk",
+      "google.auth", "google_auth",
+      "httpx", "httpcore",
+  ):
+    logging.getLogger(_noisy).setLevel(logging.ERROR)
 
 
-def _load_dotenv():
+def _load_dotenv(env_file=None):
   """Load .env file if present (optional convenience)."""
   try:
     from dotenv import load_dotenv
+
+    if env_file:
+      load_dotenv(env_file, override=True)
+      return
 
     for candidate in [
         os.path.join(_script_dir, ".env"),
@@ -161,8 +173,8 @@ def get_eval_metrics():
   response_usefulness = CategoricalMetricDefinition(
       name="response_usefulness",
       definition=(
-          "Whether the agent's final response provides a genuinely useful, "
-          "substantive answer to the user's question. A response that apologizes, "
+          "Whether the agent final response provides a genuinely useful, "
+          "substantive answer to the user question. A response that apologizes, "
           "says it cannot help, returns no data, provides only generic filler, "
           "or loops without resolving the question is NOT useful."
       ),
@@ -170,7 +182,7 @@ def get_eval_metrics():
           CategoricalMetricCategory(
               name="meaningful",
               definition=(
-                  "The response directly and substantively addresses the user's "
+                  "The response directly and substantively addresses the user "
                   "question with specific, actionable information."
               ),
           ),
@@ -178,9 +190,9 @@ def get_eval_metrics():
               name="unhelpful",
               definition=(
                   "The response technically succeeded (no error) but does NOT "
-                  "meaningfully answer the user's question. Examples: apologies, "
-                  "'I don't have that information', empty data results, generic "
-                  "filler text, or the agent looping without a resolution."
+                  "meaningfully answer the user question. Examples: apologies, "
+                  "saying I do not have that information, empty data results, "
+                  "generic filler text, or the agent looping without a resolution."
               ),
           ),
           CategoricalMetricCategory(
@@ -196,7 +208,7 @@ def get_eval_metrics():
   task_grounding = CategoricalMetricDefinition(
       name="task_grounding",
       definition=(
-          "Whether the agent's response is grounded in actual data retrieved "
+          "Whether the agent response is grounded in actual data retrieved "
           "from its tools, or is fabricated / hallucinated general knowledge."
       ),
       categories=[
@@ -204,13 +216,13 @@ def get_eval_metrics():
               name="grounded",
               definition=(
                   "The response is clearly based on data retrieved from the "
-                  "agent's tools (search results, database lookups, API calls)."
+                  "agent tools (search results, database lookups, API calls)."
               ),
           ),
           CategoricalMetricCategory(
               name="ungrounded",
               definition=(
-                  "The response appears to be fabricated or based on the LLM's "
+                  "The response appears to be fabricated or based on the LLM "
                   "general knowledge rather than actual tool results. The tool "
                   "may have returned empty data and the agent filled in anyway."
               ),
@@ -367,12 +379,14 @@ def run_evaluation(
     time_range=None, limit=100, model=None, persist=False, app_name=None,
     session_ids=None,
 ) -> dict:
-  from bigquery_agent_analytics import CategoricalEvaluationConfig, TraceFilter
+  from bigquery_agent_analytics import (
+      CategoricalEvaluationConfig, TraceFilter,
+  )
 
   model = model or EVAL_MODEL_ID
   client = get_client()
-
   metrics = get_eval_metrics()
+
   cat_config = CategoricalEvaluationConfig(
       metrics=metrics,
       endpoint=model,
@@ -1188,11 +1202,20 @@ Examples:
            "When set, only these sessions are evaluated — --limit and "
            "--time-period are ignored.",
   )
+  parser.add_argument(
+      "--env",
+      type=str,
+      default=None,
+      metavar="PATH",
+      help="Path to .env file to load (overrides default .env discovery). "
+           "Use this to point at a different agent's environment, e.g. "
+           "--env examples/agent_improvement_cycle/.env",
+  )
 
   args = parser.parse_args()
 
   _configure_logging()
-  _load_dotenv()
+  _load_dotenv(env_file=args.env)
   _load_config()
 
   if args.eval:

--- a/scripts/quality_report.sh
+++ b/scripts/quality_report.sh
@@ -10,11 +10,38 @@
 #   ./quality_report.sh --time-period 7d         # evaluate last 7 days
 #   ./quality_report.sh --samples 20             # show 20 sessions per category
 #   ./quality_report.sh --samples all            # show all sessions
+#   ./quality_report.sh --env path/to/.env       # use a specific .env file
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Load .env from repo root if present
-if [ -f "${SCRIPT_DIR}/../.env" ]; then
+# Parse --env flag before other processing
+ENV_FILE=""
+PASSTHROUGH_ARGS=()
+for arg in "$@"; do
+    if [ "$_NEXT_IS_ENV" = "1" ]; then
+        ENV_FILE="$arg"
+        _NEXT_IS_ENV=0
+        continue
+    fi
+    if [ "$arg" = "--env" ]; then
+        _NEXT_IS_ENV=1
+        continue
+    fi
+    PASSTHROUGH_ARGS+=("$arg")
+done
+unset _NEXT_IS_ENV
+set -- "${PASSTHROUGH_ARGS[@]}"
+
+# Load .env: explicit --env wins, then repo root default
+if [ -n "$ENV_FILE" ]; then
+    if [ ! -f "$ENV_FILE" ]; then
+        echo "ERROR: --env file not found: $ENV_FILE"
+        exit 1
+    fi
+    set -a
+    source "$ENV_FILE"
+    set +a
+elif [ -f "${SCRIPT_DIR}/../.env" ]; then
     set -a
     source "${SCRIPT_DIR}/../.env"
     set +a


### PR DESCRIPTION
## Summary

- Route all cycle artifacts (eval results, quality reports, ground truth) to per-run timestamped `reports/run_YYYYMMDD_HHMMSS/` directories instead of scattered locations
- Suppress noisy SDK loggers (google_genai, google_adk, httpx, authlib) and strip ANSI escape codes from run.log for clean IDE viewing
- Add `quality_threshold` to config.json (default 0.95) — previously hardcoded
- Add `--session-ids-file`, `--output-json`, `--env` flags to `quality_report.py/sh` for standalone and scripted usage
- Remove unused client-side batching code from quality_report.py (BQ AI.GENERATE handles parallelism server-side)
- Category-aware failure extraction, throttled concurrent LLM calls to prevent 429s
- Update README with scaled run docs, output directory structure, standalone quality report usage
- Update DEMO_NARRATION to match current flag set and behavior

## Test plan

- [ ] Run `./setup.sh` in a fresh project, verify `.env` and `config.json` are created
- [ ] Run `./run_cycle.sh` (default N=10), verify all artifacts land in `reports/run_*/`
- [ ] Run `./run_cycle.sh --auto --cycles 5 --traffic-count 100`, verify cycle completes and auto-stops at threshold
- [ ] Verify `run.log` has no ANSI escape codes when opened in IDE
- [ ] Run standalone `quality_report.sh --env .env --app-name company_info_agent` and verify it works
- [ ] Run `./reset.sh` and verify prompt reverts to V1, reports are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)