### PR TITLE
docs(decision-lineage): expand leadership slide deck

### DIFF
--- a/examples/decision_lineage_demo/SLIDES.html
+++ b/examples/decision_lineage_demo/SLIDES.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="en-US"><head><title>Decision Lineage with BigQuery Context Graphs</title><meta property="og:title" content="Decision Lineage with BigQuery Context Graphs"><meta name="author" content="BigQuery Agent Analytics SDK"><meta property="article:author" content="BigQuery Agent Analytics SDK"><meta name="description" content="A leadership-pitched deck that mirrors examples/decision_lineage_demo/."><meta property="og:description" content="A leadership-pitched deck that mirrors examples/decision_lineage_demo/."><meta charset="UTF-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"><meta name="apple-mobile-web-app-capable" content="yes"><meta http-equiv="X-UA-Compatible" content="ie=edge"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><style>@media screen{body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{appearance:none;background-color:initial;border:0;color:inherit;cursor:pointer;font-size:inherit;opacity:.8;outline:none;padding:0;transition:opacity .2s linear;-webkit-tap-highlight-color:transparent}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:disabled{cursor:not-allowed;opacity:.15!important}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover{opacity:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:active{opacity:.6}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:not(:disabled){transition:none}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-prev{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNNjggOTAgMjggNTBsNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-next{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJtMzIgOTAgNDAtNDAtNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNNDAgNzBIMjBWNTBtMjAgMEwyMCA3MG00MC00MGgyMHYyMG0tMjAgMCAyMC0yMCIgY2xhc3M9ImEiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen]{background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNMjAgNTBoMjB2MjBtLTIwIDAgMjAtMjBtNDAgMEg2MFYzMG0yMCAwTDYwIDUwIiBjbGFzcz0iYSIvPjwvc3ZnPg==")}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNODcuOCA0Ny41Qzg5IDUwIDg3LjcgNTIgODUgNTJIMzVhOC43IDguNyAwIDAgMS03LjItNC41bC0xNS42LTMxQzExIDE0IDEyLjIgMTIgMTUgMTJoNTBhOC44IDguOCAwIDAgMSA3LjIgNC41ek02MCA1MnYzNm0tMTAgMGgyME00NSA0MmgyMCIvPjwvc3ZnPg==") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-bigger{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODBNNTIgOTBWMTAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-smaller{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4O3J4OjVweDtyeTo1cHg7d2lkdGg6MjVweDtoZWlnaHQ6MjVweH08L3N0eWxlPjwvZGVmcz48cmVjdCB4PSIyMCIgeT0iMjAiIGNsYXNzPSJhIi8+PHJlY3QgeD0iNTUiIHk9IjIwIiBjbGFzcz0iYSIvPjxyZWN0IHg9IjIwIiB5PSI1NSIgY2xhc3M9ImEiLz48cmVjdCB4PSI1NSIgeT0iNTUiIGNsYXNzPSJhIi8+PC9zdmc+") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}}@keyframes __bespoke_marp_transition_reduced_outgoing__{0%{opacity:1}to{opacity:0}}@keyframes __bespoke_marp_transition_reduced_incoming__{0%{mix-blend-mode:plus-lighter;opacity:0}to{mix-blend-mode:plus-lighter;opacity:1}}.bespoke-marp-note,.bespoke-marp-osc,.bespoke-progress-parent{display:none;transition:none}@media screen{::view-transition-group(*){animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-timing-function:ease}::view-transition-new(*),::view-transition-old(*){animation-delay:0s;animation-direction:var(--marp-bespoke-transition-animation-direction,normal);animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-fill-mode:both;animation-name:var(--marp-bespoke-transition-animation-name,var(--marp-bespoke-transition-animation-name-fallback,__bespoke_marp_transition_no_animation__));mix-blend-mode:normal}::view-transition-old(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_outgoing__;animation-timing-function:ease}::view-transition-new(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_incoming__;animation-timing-function:ease}::view-transition-new(root),::view-transition-old(root){animation-timing-function:linear}::view-transition-new(__bespoke_marp_transition_osc__),::view-transition-old(__bespoke_marp_transition_osc__){animation-duration:0s!important;animation-name:__bespoke_marp_transition_osc__!important}::view-transition-new(__bespoke_marp_transition_osc__){opacity:0!important}.bespoke-marp-transition-warming-up::view-transition-group(*),.bespoke-marp-transition-warming-up::view-transition-new(*),.bespoke-marp-transition-warming-up::view-transition-old(*){animation-play-state:paused!important}body,html{height:100%;margin:0}body{background:#000;overflow:hidden}svg.bespoke-marp-slide{content-visibility:hidden;interactivity:inert;opacity:0;pointer-events:none;z-index:-1}svg.bespoke-marp-slide:not(.bespoke-marp-active) *{view-transition-name:none!important}svg.bespoke-marp-slide.bespoke-marp-active{content-visibility:visible;interactivity:auto;opacity:1;pointer-events:auto;z-index:0}svg.bespoke-marp-slide.bespoke-marp-active.bespoke-marp-active-ready *{animation-name:__bespoke_marp__!important}@supports not (content-visibility:hidden){svg.bespoke-marp-slide[data-bespoke-marp-load=hideable]{display:none}svg.bespoke-marp-slide[data-bespoke-marp-load=hideable].bespoke-marp-active{display:block}}}@media screen and (prefers-reduced-motion:reduce){svg.bespoke-marp-slide *{view-transition-name:none!important}}@media screen{[data-bespoke-marp-fragment=inactive]{visibility:hidden}body[data-bespoke-view=""] .bespoke-marp-parent,body[data-bespoke-view=next] .bespoke-marp-parent{inset:0;position:absolute}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc{background:#000000a6;border-radius:7px;bottom:50px;color:#fff;contain:paint;display:block;font-family:Helvetica,Arial,sans-serif;font-size:16px;left:50%;line-height:0;opacity:1;padding:12px;position:absolute;touch-action:manipulation;transform:translateX(-50%);transition:opacity .2s linear;-webkit-user-select:none;user-select:none;view-transition-name:__bespoke_marp_transition_osc__;white-space:nowrap;will-change:transform;z-index:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*){margin-left:6px}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child){margin-left:0}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span{opacity:.8}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page]{display:inline-block;min-width:140px;text-align:center}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev]{height:32px;line-height:32px;width:32px}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive{cursor:none}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc{opacity:0;pointer-events:none}body[data-bespoke-view=""] svg.bespoke-marp-slide,body[data-bespoke-view=next] svg.bespoke-marp-slide{height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent{background:#222;display:flex;height:5px;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent+:where(.bespoke-marp-parent){top:5px}body[data-bespoke-view=""] .bespoke-progress-parent .bespoke-progress-bar{background:#0288d1;flex:0 0 0;transition:flex-basis .2s cubic-bezier(0,1,1,1)}body[data-bespoke-view=next]{background:#0000}body[data-bespoke-view=presenter]{background:#161616}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container{display:grid;font-family:Helvetica,Arial,sans-serif;grid-template:"current dragbar next" minmax(140px,1fr) "current dragbar note" 2fr "info    dragbar note" 3em;grid-template-columns:minmax(3px,var(--bespoke-marp-presenter-split-ratio,66%)) 0 minmax(3px,1fr);height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent){grid-area:current;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide){height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide).bespoke-marp-active{filter:drop-shadow(0 3px 10px rgba(0,0,0,.5))}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container{background:#0288d1;cursor:col-resize;grid-area:dragbar;margin-left:-3px;opacity:0;position:relative;transition:opacity .4s linear .1s;width:6px;z-index:10}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container:hover{opacity:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container.active{opacity:1;transition-delay:0s}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container{background:#222;cursor:pointer;display:none;grid-area:next;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container iframe.bespoke-marp-presenter-next{background:#0000;border:0;display:block;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;interactivity:inert;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container{background:#222;color:#eee;grid-area:note;position:relative;z-index:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper{display:block;inset:0;position:absolute}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons{background:#000000a6;border-radius:4px;bottom:0;display:flex;gap:4px;margin:12px;opacity:0;padding:6px;pointer-events:none;position:absolute;right:0;transition:opacity .2s linear}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons:focus-within,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper:focus-within+.bespoke-marp-presenter-note-buttons,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container:hover .bespoke-marp-presenter-note-buttons{opacity:1;pointer-events:auto}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note{box-sizing:border-box;font-size:calc(1.1em*var(--bespoke-marp-note-font-scale, 1));height:calc(100% - 40px);margin:20px;overflow:auto;padding-right:3px;white-space:pre-wrap;width:calc(100% - 40px);word-wrap:break-word;scrollbar-color:#eeeeee80 #0000;scrollbar-width:thin}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar{width:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-track{background:#0000}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-thumb{background:#eeeeee80;border-radius:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note:empty{pointer-events:none}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:first-child{margin-top:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:last-child{margin-bottom:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container{align-items:center;box-sizing:border-box;color:#eee;display:flex;flex-wrap:nowrap;grid-area:info;justify-content:center;overflow:hidden;padding:0 10px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{box-sizing:border-box;display:block;padding:0 10px;white-space:nowrap;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area{order:2;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page{display:inline-block;min-width:120px;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time{color:#999;order:1;text-align:left}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{color:#999;order:3;text-align:right}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer:hover{cursor:pointer}body[data-bespoke-view=overview]{background:#161616;overflow:auto}body[data-bespoke-view=overview] [data-bespoke-marp-fragment=inactive]{visibility:visible}body[data-bespoke-view=overview] .bespoke-marp-overview-header{backdrop-filter:blur(4px);background:#222222d9;box-shadow:0 3px 10px #00000080;box-sizing:border-box;display:flex;height:48px;inset:0 0 auto;justify-content:flex-end;padding:10px;position:fixed;z-index:1}body[data-bespoke-view=overview] button.bespoke-marp-overview-close{height:28px;line-height:28px;transform:rotate(45deg);width:28px}body[data-bespoke-view=overview] .bespoke-marp-parent{display:grid;gap:40px;grid-template-columns:repeat(auto-fit,minmax(0,240px));justify-content:space-around;padding:30px}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide{--bov-selected:#0000;--bov-focus:#161616;--bov-focus-outline:#0000;background-image:conic-gradient(#161616 0 0),conic-gradient(var(--bov-focus) 0 0),conic-gradient(var(--bov-focus-outline) 0 0),conic-gradient(var(--bov-selected) 0 0);background-position:5px 5px,3px 3px,2px 2px,0 0;background-repeat:no-repeat;background-size:calc(100% - 10px) calc(100% - 10px),calc(100% - 6px) calc(100% - 6px),calc(100% - 4px) calc(100% - 4px),100% 100%;content-visibility:visible;cursor:pointer;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));margin:-6px;padding:6px;interactivity:auto;opacity:1;outline:0;pointer-events:auto;scroll-margin-block:30px;width:100%;z-index:0}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide *,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active *{pointer-events:none;interactivity:inert}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus-outline:#161616}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus:#999}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active{--bov-focus:#eee}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active{--bov-selected:#0288d1}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent{padding-top:78px}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent svg.bespoke-marp-slide{scroll-margin-top:78px}.bespoke-marp-overview{background:#000000a6;inset:0;opacity:0;pointer-events:none;position:fixed;transition:opacity .1s ease;z-index:10}.bespoke-marp-overview iframe{background:#222;border:0;display:block;height:100%;left:0;position:absolute;top:0;width:100%}.bespoke-marp-overview[data-open="1"]{opacity:1;pointer-events:auto}}@media print{.bespoke-marp-overview,.bespoke-marp-presenter-info-container,.bespoke-marp-presenter-next-container,.bespoke-marp-presenter-note-container{display:none}}</style><style>@charset "UTF-8";@import "https://fonts.bunny.net/css?family=Lato:400,900|Roboto+Mono:400,700&display=swap";div#\:\$p > svg > foreignObject > section{width:1280px;height:720px;box-sizing:border-box;overflow:hidden;position:relative;scroll-snap-align:center center;-webkit-text-size-adjust:100%;text-size-adjust:100%}div#\:\$p > svg > foreignObject > section::after{bottom:0;content:attr(data-marpit-pagination);padding:inherit;pointer-events:none;position:absolute;right:0}div#\:\$p > svg > foreignObject > section:not([data-marpit-pagination])::after{display:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:2em;margin-block:0.67em}div#\:\$p > svg > foreignObject > section video::-webkit-media-controls{will-change:transform}@page {size:1280px 720px;margin:0}@media print{html, body{background-color:#fff;margin:0;page-break-inside:avoid;break-inside:avoid-page}div#\:\$p > svg > foreignObject > section{page-break-before:always;break-before:page}div#\:\$p > svg > foreignObject > section, div#\:\$p > svg > foreignObject > section *{-webkit-print-color-adjust:exact!important;animation-delay:0s!important;animation-duration:0s!important;color-adjust:exact!important;print-color-adjust:exact!important;transition:none!important}div#\:\$p > svg[data-marpit-svg]{display:block;height:100vh;width:100vw}}div#\:\$p > svg > foreignObject > :where(section){container-type:size}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"]{direction:ltr}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] > svg{overflow:visible;min-height:1px;min-width:1px}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] > svg a{fill:blue;stroke:blue}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][display="true"]{display:block;text-align:center;margin:1em 0}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][display="true"][width="full"]{display:flex}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][justify="left"]{text-align:left}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][justify="right"]{text-align:right}div#\:\$p > svg > foreignObject > section g[data-mml-node="merror"] > g{fill:red;stroke:red}div#\:\$p > svg > foreignObject > section g[data-mml-node="merror"] > rect[data-background]{fill:yellow;stroke:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > line[data-line], div#\:\$p > svg > foreignObject > section svg[data-table] > g > line[data-line]{stroke-width:70px;fill:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > rect[data-frame], div#\:\$p > svg > foreignObject > section svg[data-table] > g > rect[data-frame]{stroke-width:70px;fill:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > .mjx-dashed, div#\:\$p > svg > foreignObject > section svg[data-table] > g > .mjx-dashed{stroke-dasharray:140}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > .mjx-dotted, div#\:\$p > svg > foreignObject > section svg[data-table] > g > .mjx-dotted{stroke-linecap:round;stroke-dasharray:0,140}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > g > svg{overflow:visible}div#\:\$p > svg > foreignObject > section [jax="SVG"] mjx-tool{display:inline-block;position:relative;width:0;height:0}div#\:\$p > svg > foreignObject > section [jax="SVG"] mjx-tool > mjx-tip{position:absolute;top:0;left:0}div#\:\$p > svg > foreignObject > section mjx-tool > mjx-tip{display:inline-block;padding:.2em;border:1px solid #888;font-size:70%;background-color:#F8F8F8;color:black;box-shadow:2px 2px 5px #AAAAAA}div#\:\$p > svg > foreignObject > section g[data-mml-node="maction"][data-toggle]{cursor:pointer}div#\:\$p > svg > foreignObject > section mjx-status{display:block;position:fixed;left:1em;bottom:1em;min-width:25%;padding:.2em .4em;border:1px solid #888;font-size:90%;background-color:#F8F8F8;color:black}div#\:\$p > svg > foreignObject > section foreignObject[data-mjx-xml]{font-family:initial;line-height:normal;overflow:visible}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] path[data-c], div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] use[data-c]{stroke-width:3}@media print{div#\:\$p > svg > foreignObject > section mjx-container[jax=SVG] path[data-c],div#\:\$p > svg > foreignObject > section mjx-container[jax=SVG] use[data-c]{stroke-width:0}}div#\:\$p > svg > foreignObject > section img[data-marp-twemoji]{background:transparent;height:1em;margin:0 .05em 0 .1em;vertical-align:-.1em;width:1em}/*!
+<!DOCTYPE html><html lang="C"><head><title>Decision Lineage with BigQuery Context Graphs</title><meta property="og:title" content="Decision Lineage with BigQuery Context Graphs"><meta name="author" content="BigQuery Agent Analytics SDK"><meta property="article:author" content="BigQuery Agent Analytics SDK"><meta name="description" content="A leadership-pitched deck that mirrors examples/decision_lineage_demo/."><meta property="og:description" content="A leadership-pitched deck that mirrors examples/decision_lineage_demo/."><meta charset="UTF-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"><meta name="apple-mobile-web-app-capable" content="yes"><meta http-equiv="X-UA-Compatible" content="ie=edge"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><style>@media screen{body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{appearance:none;background-color:initial;border:0;color:inherit;cursor:pointer;font-size:inherit;opacity:.8;outline:none;padding:0;transition:opacity .2s linear;-webkit-tap-highlight-color:transparent}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:disabled{cursor:not-allowed;opacity:.15!important}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover{opacity:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:active{opacity:.6}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:not(:disabled){transition:none}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-prev{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNNjggOTAgMjggNTBsNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-next{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJtMzIgOTAgNDAtNDAtNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNNDAgNzBIMjBWNTBtMjAgMEwyMCA3MG00MC00MGgyMHYyMG0tMjAgMCAyMC0yMCIgY2xhc3M9ImEiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen]{background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNMjAgNTBoMjB2MjBtLTIwIDAgMjAtMjBtNDAgMEg2MFYzMG0yMCAwTDYwIDUwIiBjbGFzcz0iYSIvPjwvc3ZnPg==")}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNODcuOCA0Ny41Qzg5IDUwIDg3LjcgNTIgODUgNTJIMzVhOC43IDguNyAwIDAgMS03LjItNC41bC0xNS42LTMxQzExIDE0IDEyLjIgMTIgMTUgMTJoNTBhOC44IDguOCAwIDAgMSA3LjIgNC41ek02MCA1MnYzNm0tMTAgMGgyME00NSA0MmgyMCIvPjwvc3ZnPg==") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-bigger{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODBNNTIgOTBWMTAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-smaller{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4O3J4OjVweDtyeTo1cHg7d2lkdGg6MjVweDtoZWlnaHQ6MjVweH08L3N0eWxlPjwvZGVmcz48cmVjdCB4PSIyMCIgeT0iMjAiIGNsYXNzPSJhIi8+PHJlY3QgeD0iNTUiIHk9IjIwIiBjbGFzcz0iYSIvPjxyZWN0IHg9IjIwIiB5PSI1NSIgY2xhc3M9ImEiLz48cmVjdCB4PSI1NSIgeT0iNTUiIGNsYXNzPSJhIi8+PC9zdmc+") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}}@keyframes __bespoke_marp_transition_reduced_outgoing__{0%{opacity:1}to{opacity:0}}@keyframes __bespoke_marp_transition_reduced_incoming__{0%{mix-blend-mode:plus-lighter;opacity:0}to{mix-blend-mode:plus-lighter;opacity:1}}.bespoke-marp-note,.bespoke-marp-osc,.bespoke-progress-parent{display:none;transition:none}@media screen{::view-transition-group(*){animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-timing-function:ease}::view-transition-new(*),::view-transition-old(*){animation-delay:0s;animation-direction:var(--marp-bespoke-transition-animation-direction,normal);animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-fill-mode:both;animation-name:var(--marp-bespoke-transition-animation-name,var(--marp-bespoke-transition-animation-name-fallback,__bespoke_marp_transition_no_animation__));mix-blend-mode:normal}::view-transition-old(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_outgoing__;animation-timing-function:ease}::view-transition-new(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_incoming__;animation-timing-function:ease}::view-transition-new(root),::view-transition-old(root){animation-timing-function:linear}::view-transition-new(__bespoke_marp_transition_osc__),::view-transition-old(__bespoke_marp_transition_osc__){animation-duration:0s!important;animation-name:__bespoke_marp_transition_osc__!important}::view-transition-new(__bespoke_marp_transition_osc__){opacity:0!important}.bespoke-marp-transition-warming-up::view-transition-group(*),.bespoke-marp-transition-warming-up::view-transition-new(*),.bespoke-marp-transition-warming-up::view-transition-old(*){animation-play-state:paused!important}body,html{height:100%;margin:0}body{background:#000;overflow:hidden}svg.bespoke-marp-slide{content-visibility:hidden;interactivity:inert;opacity:0;pointer-events:none;z-index:-1}svg.bespoke-marp-slide:not(.bespoke-marp-active) *{view-transition-name:none!important}svg.bespoke-marp-slide.bespoke-marp-active{content-visibility:visible;interactivity:auto;opacity:1;pointer-events:auto;z-index:0}svg.bespoke-marp-slide.bespoke-marp-active.bespoke-marp-active-ready *{animation-name:__bespoke_marp__!important}@supports not (content-visibility:hidden){svg.bespoke-marp-slide[data-bespoke-marp-load=hideable]{display:none}svg.bespoke-marp-slide[data-bespoke-marp-load=hideable].bespoke-marp-active{display:block}}}@media screen and (prefers-reduced-motion:reduce){svg.bespoke-marp-slide *{view-transition-name:none!important}}@media screen{[data-bespoke-marp-fragment=inactive]{visibility:hidden}body[data-bespoke-view=""] .bespoke-marp-parent,body[data-bespoke-view=next] .bespoke-marp-parent{inset:0;position:absolute}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc{background:#000000a6;border-radius:7px;bottom:50px;color:#fff;contain:paint;display:block;font-family:Helvetica,Arial,sans-serif;font-size:16px;left:50%;line-height:0;opacity:1;padding:12px;position:absolute;touch-action:manipulation;transform:translateX(-50%);transition:opacity .2s linear;-webkit-user-select:none;user-select:none;view-transition-name:__bespoke_marp_transition_osc__;white-space:nowrap;will-change:transform;z-index:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*){margin-left:6px}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child){margin-left:0}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span{opacity:.8}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page]{display:inline-block;min-width:140px;text-align:center}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev]{height:32px;line-height:32px;width:32px}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive{cursor:none}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc{opacity:0;pointer-events:none}body[data-bespoke-view=""] svg.bespoke-marp-slide,body[data-bespoke-view=next] svg.bespoke-marp-slide{height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent{background:#222;display:flex;height:5px;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent+:where(.bespoke-marp-parent){top:5px}body[data-bespoke-view=""] .bespoke-progress-parent .bespoke-progress-bar{background:#0288d1;flex:0 0 0;transition:flex-basis .2s cubic-bezier(0,1,1,1)}body[data-bespoke-view=next]{background:#0000}body[data-bespoke-view=presenter]{background:#161616}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container{display:grid;font-family:Helvetica,Arial,sans-serif;grid-template:"current dragbar next" minmax(140px,1fr) "current dragbar note" 2fr "info    dragbar note" 3em;grid-template-columns:minmax(3px,var(--bespoke-marp-presenter-split-ratio,66%)) 0 minmax(3px,1fr);height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent){grid-area:current;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide){height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide).bespoke-marp-active{filter:drop-shadow(0 3px 10px rgba(0,0,0,.5))}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container{background:#0288d1;cursor:col-resize;grid-area:dragbar;margin-left:-3px;opacity:0;position:relative;transition:opacity .4s linear .1s;width:6px;z-index:10}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container:hover{opacity:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container.active{opacity:1;transition-delay:0s}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container{background:#222;cursor:pointer;display:none;grid-area:next;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container iframe.bespoke-marp-presenter-next{background:#0000;border:0;display:block;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;interactivity:inert;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container{background:#222;color:#eee;grid-area:note;position:relative;z-index:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper{display:block;inset:0;position:absolute}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons{background:#000000a6;border-radius:4px;bottom:0;display:flex;gap:4px;margin:12px;opacity:0;padding:6px;pointer-events:none;position:absolute;right:0;transition:opacity .2s linear}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons:focus-within,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper:focus-within+.bespoke-marp-presenter-note-buttons,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container:hover .bespoke-marp-presenter-note-buttons{opacity:1;pointer-events:auto}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note{box-sizing:border-box;font-size:calc(1.1em*var(--bespoke-marp-note-font-scale, 1));height:calc(100% - 40px);margin:20px;overflow:auto;padding-right:3px;white-space:pre-wrap;width:calc(100% - 40px);word-wrap:break-word;scrollbar-color:#eeeeee80 #0000;scrollbar-width:thin}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar{width:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-track{background:#0000}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-thumb{background:#eeeeee80;border-radius:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note:empty{pointer-events:none}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:first-child{margin-top:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:last-child{margin-bottom:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container{align-items:center;box-sizing:border-box;color:#eee;display:flex;flex-wrap:nowrap;grid-area:info;justify-content:center;overflow:hidden;padding:0 10px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{box-sizing:border-box;display:block;padding:0 10px;white-space:nowrap;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area{order:2;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page{display:inline-block;min-width:120px;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time{color:#999;order:1;text-align:left}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{color:#999;order:3;text-align:right}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer:hover{cursor:pointer}body[data-bespoke-view=overview]{background:#161616;overflow:auto}body[data-bespoke-view=overview] [data-bespoke-marp-fragment=inactive]{visibility:visible}body[data-bespoke-view=overview] .bespoke-marp-overview-header{backdrop-filter:blur(4px);background:#222222d9;box-shadow:0 3px 10px #00000080;box-sizing:border-box;display:flex;height:48px;inset:0 0 auto;justify-content:flex-end;padding:10px;position:fixed;z-index:1}body[data-bespoke-view=overview] button.bespoke-marp-overview-close{height:28px;line-height:28px;transform:rotate(45deg);width:28px}body[data-bespoke-view=overview] .bespoke-marp-parent{display:grid;gap:40px;grid-template-columns:repeat(auto-fit,minmax(0,240px));justify-content:space-around;padding:30px}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide{--bov-selected:#0000;--bov-focus:#161616;--bov-focus-outline:#0000;background-image:conic-gradient(#161616 0 0),conic-gradient(var(--bov-focus) 0 0),conic-gradient(var(--bov-focus-outline) 0 0),conic-gradient(var(--bov-selected) 0 0);background-position:5px 5px,3px 3px,2px 2px,0 0;background-repeat:no-repeat;background-size:calc(100% - 10px) calc(100% - 10px),calc(100% - 6px) calc(100% - 6px),calc(100% - 4px) calc(100% - 4px),100% 100%;content-visibility:visible;cursor:pointer;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));margin:-6px;padding:6px;interactivity:auto;opacity:1;outline:0;pointer-events:auto;scroll-margin-block:30px;width:100%;z-index:0}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide *,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active *{pointer-events:none;interactivity:inert}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus-outline:#161616}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus:#999}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active{--bov-focus:#eee}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active{--bov-selected:#0288d1}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent{padding-top:78px}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent svg.bespoke-marp-slide{scroll-margin-top:78px}.bespoke-marp-overview{background:#000000a6;inset:0;opacity:0;pointer-events:none;position:fixed;transition:opacity .1s ease;z-index:10}.bespoke-marp-overview iframe{background:#222;border:0;display:block;height:100%;left:0;position:absolute;top:0;width:100%}.bespoke-marp-overview[data-open="1"]{opacity:1;pointer-events:auto}}@media print{.bespoke-marp-overview,.bespoke-marp-presenter-info-container,.bespoke-marp-presenter-next-container,.bespoke-marp-presenter-note-container{display:none}}</style><style>@charset "UTF-8";@import "https://fonts.bunny.net/css?family=Lato:400,900|Roboto+Mono:400,700&display=swap";div#\:\$p > svg > foreignObject > section{width:1280px;height:720px;box-sizing:border-box;overflow:hidden;position:relative;scroll-snap-align:center center;-webkit-text-size-adjust:100%;text-size-adjust:100%}div#\:\$p > svg > foreignObject > section::after{bottom:0;content:attr(data-marpit-pagination);padding:inherit;pointer-events:none;position:absolute;right:0}div#\:\$p > svg > foreignObject > section:not([data-marpit-pagination])::after{display:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:2em;margin-block:0.67em}div#\:\$p > svg > foreignObject > section video::-webkit-media-controls{will-change:transform}@page {size:1280px 720px;margin:0}@media print{html, body{background-color:#fff;margin:0;page-break-inside:avoid;break-inside:avoid-page}div#\:\$p > svg > foreignObject > section{page-break-before:always;break-before:page}div#\:\$p > svg > foreignObject > section, div#\:\$p > svg > foreignObject > section *{-webkit-print-color-adjust:exact!important;animation-delay:0s!important;animation-duration:0s!important;color-adjust:exact!important;print-color-adjust:exact!important;transition:none!important}div#\:\$p > svg[data-marpit-svg]{display:block;height:100vh;width:100vw}}div#\:\$p > svg > foreignObject > :where(section){container-type:size}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"]{direction:ltr}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] > svg{overflow:visible;min-height:1px;min-width:1px}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] > svg a{fill:blue;stroke:blue}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][display="true"]{display:block;text-align:center;margin:1em 0}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][display="true"][width="full"]{display:flex}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][justify="left"]{text-align:left}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"][justify="right"]{text-align:right}div#\:\$p > svg > foreignObject > section g[data-mml-node="merror"] > g{fill:red;stroke:red}div#\:\$p > svg > foreignObject > section g[data-mml-node="merror"] > rect[data-background]{fill:yellow;stroke:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > line[data-line], div#\:\$p > svg > foreignObject > section svg[data-table] > g > line[data-line]{stroke-width:70px;fill:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > rect[data-frame], div#\:\$p > svg > foreignObject > section svg[data-table] > g > rect[data-frame]{stroke-width:70px;fill:none}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > .mjx-dashed, div#\:\$p > svg > foreignObject > section svg[data-table] > g > .mjx-dashed{stroke-dasharray:140}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > .mjx-dotted, div#\:\$p > svg > foreignObject > section svg[data-table] > g > .mjx-dotted{stroke-linecap:round;stroke-dasharray:0,140}div#\:\$p > svg > foreignObject > section g[data-mml-node="mtable"] > g > svg{overflow:visible}div#\:\$p > svg > foreignObject > section [jax="SVG"] mjx-tool{display:inline-block;position:relative;width:0;height:0}div#\:\$p > svg > foreignObject > section [jax="SVG"] mjx-tool > mjx-tip{position:absolute;top:0;left:0}div#\:\$p > svg > foreignObject > section mjx-tool > mjx-tip{display:inline-block;padding:.2em;border:1px solid #888;font-size:70%;background-color:#F8F8F8;color:black;box-shadow:2px 2px 5px #AAAAAA}div#\:\$p > svg > foreignObject > section g[data-mml-node="maction"][data-toggle]{cursor:pointer}div#\:\$p > svg > foreignObject > section mjx-status{display:block;position:fixed;left:1em;bottom:1em;min-width:25%;padding:.2em .4em;border:1px solid #888;font-size:90%;background-color:#F8F8F8;color:black}div#\:\$p > svg > foreignObject > section foreignObject[data-mjx-xml]{font-family:initial;line-height:normal;overflow:visible}div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] path[data-c], div#\:\$p > svg > foreignObject > section mjx-container[jax="SVG"] use[data-c]{stroke-width:3}@media print{div#\:\$p > svg > foreignObject > section mjx-container[jax=SVG] path[data-c],div#\:\$p > svg > foreignObject > section mjx-container[jax=SVG] use[data-c]{stroke-width:0}}div#\:\$p > svg > foreignObject > section img[data-marp-twemoji]{background:transparent;height:1em;margin:0 .05em 0 .1em;vertical-align:-.1em;width:1em}/*!
  * Marp / Marpit Gaia theme.
  *
  * @theme gaia
@@ -13,7 +13,7 @@
   );--color-foreground:light-dark(#455a64, #fff8e1);--color-dimmed:light-dark(
     #6a7a7d,
     #dad8c8
-  );--color-highlight:light-dark(#0288d1, #81d4fa);background-color:var(--color-background);background-image:linear-gradient(135deg, hsla(0,0%,53%,0), hsla(0,0%,53%,.02) 50%, hsla(0,0%,100%,0) 0, hsla(0,0%,100%,.05));color:var(--color-foreground);color-scheme:light;font-family:Lato,Avenir Next,Avenir,Trebuchet MS,Segoe UI,sans-serif;font-size:35px;height:720px;letter-spacing:1.25px;line-height:1.35;overflow-wrap:break-word;padding:70px;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:35px}div#\:\$p > svg > foreignObject > section:after{bottom:0;font-size:80%;right:0}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:80%}div#\:\$p > svg > foreignObject > section a,div#\:\$p > svg > foreignObject > section mark{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section code{background:var(--color-dimmed);color:var(--color-background)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:var(--color-foreground)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent}div#\:\$p > svg > foreignObject > section blockquote:after,div#\:\$p > svg > foreignObject > section blockquote:before,div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header,div#\:\$p > svg > foreignObject > section section:after{color:var(--color-dimmed)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border-color:var(--color-foreground)}div#\:\$p > svg > foreignObject > section table thead th{background:var(--color-foreground);color:var(--color-background)}div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) td,div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) th{background:var(--color-background-stripe, transparent)}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section:where(.gaia){--color-background:#0288d1;--color-background-stripe:rgba(255,248,225,.1);--color-foreground:#fff8e1;--color-dimmed:#cce2de;--color-highlight:#81d4fa;}div#\:\$p > svg > foreignObject > section:where(.lead){align-items:stretch;flex-flow:column nowrap;place-content:safe center center}div#\:\$p > svg > foreignObject > section:where(.lead) :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h6, marp-h6){text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) p{text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h6, marp-h6),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) ol>li>p,div#\:\$p > svg > foreignObject > section:where(.lead) ul>li>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) table{margin-left:auto;margin-right:auto}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > section{font-family:"Google Sans", "Roboto", -apple-system, "Segoe UI", sans-serif;font-size:27px;line-height:1.35;padding:56px 64px;letter-spacing:0}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size: 27px}div#\:\$p > svg > foreignObject > section.hero{background-color:#174ea6!important;background-image:linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%)!important;color:#ffffff;text-align:left}div#\:\$p > svg > foreignObject > section.hero :is(h1, marp-h1){font-size:66px;line-height:1.1;margin-bottom:16px;color:#ffffff;border:none}div#\:\$p > svg > foreignObject > section.hero :is(h2, marp-h2){font-size:29px;font-weight:400;color:rgba(255,255,255,0.85);border:none;max-width:920px}div#\:\$p > svg > foreignObject > section.hero .footer-note{font-size:18px;color:rgba(255,255,255,0.7);margin-top:48px}div#\:\$p > svg > foreignObject > section.hero div#\:\$p > svg > foreignObject > section section.footer-note{--marpit-root-font-size: 18px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:#1a73e8;border-bottom:2px solid #e8eaed;padding-bottom:8px;font-size:38px}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){color:#202124;font-size:26px;margin-top:0}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){color:#1a73e8;font-size:22px;margin-bottom:4px}div#\:\$p > svg > foreignObject > section.section-divider{background:linear-gradient(90deg, #f8fafd 0%, #ffffff 72%)}div#\:\$p > svg > foreignObject > section.section-divider :is(h1, marp-h1){color:#1a73e8;border:none;font-size:56px}div#\:\$p > svg > foreignObject > section.section-divider .eyebrow{color:#5f6368;text-transform:uppercase;letter-spacing:4px;font-size:16px;margin-bottom:16px}div#\:\$p > svg > foreignObject > section.section-divider div#\:\$p > svg > foreignObject > section section.eyebrow{--marpit-root-font-size: 16px}div#\:\$p > svg > foreignObject > section .kicker{color:#5f6368;text-transform:uppercase;letter-spacing:2px;font-size:15px;font-weight:700;margin-bottom:10px}div#\:\$p > svg > foreignObject > section section.kicker{--marpit-root-font-size: 15px}div#\:\$p > svg > foreignObject > section code{background:#f1f3f4;color:#202124;border-radius:4px;padding:2px 6px;font-size:0.9em}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:#202124;color:#e8eaed;border-radius:8px;padding:18px 22px;font-size:18px;line-height:1.4;box-shadow:0 2px 8px rgba(0,0,0,0.12)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{background:transparent;color:inherit;padding:0}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;margin:12px 0;font-size:22px}div#\:\$p > svg > foreignObject > section th{background:#1a73e8;color:#ffffff;padding:10px 14px;text-align:left}div#\:\$p > svg > foreignObject > section td{border-bottom:1px solid #e8eaed;padding:8px 14px}div#\:\$p > svg > foreignObject > section blockquote{border-left:4px solid #1a73e8;background:#e8f0fe;color:#174ea6;padding:14px 22px;margin:12px 0;font-style:normal;font-size:24px}div#\:\$p > svg > foreignObject > section .pill{display:inline-block;background:#e8f0fe;color:#1a73e8;border-radius:999px;padding:4px 14px;font-size:17px;margin-right:6px;font-weight:600}div#\:\$p > svg > foreignObject > section section.pill{--marpit-root-font-size: 17px}div#\:\$p > svg > foreignObject > section .grid-2{display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start}div#\:\$p > svg > foreignObject > section .grid-3{display:grid;grid-template-columns:repeat(3, 1fr);gap:18px;align-items:stretch}div#\:\$p > svg > foreignObject > section .compact{font-size:23px;line-height:1.28}div#\:\$p > svg > foreignObject > section section.compact{--marpit-root-font-size: 23px}div#\:\$p > svg > foreignObject > section .compact li{margin:4px 0}div#\:\$p > svg > foreignObject > section .card{border:1px solid #dadce0;border-radius:8px;padding:20px 22px;background:#ffffff;box-shadow:0 1px 3px rgba(60,64,67,0.10)}div#\:\$p > svg > foreignObject > section .card :is(h3, marp-h3){margin-top:0}div#\:\$p > svg > foreignObject > section .soft-card{border-radius:8px;padding:18px 22px;background:#f8fafd;border:1px solid #d2e3fc}div#\:\$p > svg > foreignObject > section .pipeline{display:grid;grid-template-columns:1fr 40px 1fr 40px 1fr 40px 1fr;align-items:center;gap:10px;margin-top:22px}div#\:\$p > svg > foreignObject > section .pipeline .step{border-radius:8px;padding:18px 16px;background:#ffffff;border:1px solid #dadce0;min-height:126px}div#\:\$p > svg > foreignObject > section .pipeline .arrow{color:#1a73e8;font-size:34px;text-align:center}div#\:\$p > svg > foreignObject > section .pipeline div#\:\$p > svg > foreignObject > section section.arrow{--marpit-root-font-size: 34px}div#\:\$p > svg > foreignObject > section .step-num{display:inline-flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:50%;background:#1a73e8;color:#ffffff;font-size:16px;font-weight:700;margin-bottom:8px}div#\:\$p > svg > foreignObject > section section.step-num{--marpit-root-font-size: 16px}div#\:\$p > svg > foreignObject > section .metric-row{display:grid;grid-template-columns:repeat(4, 1fr);gap:16px;margin:18px 0}div#\:\$p > svg > foreignObject > section .mini-stat{border-left:5px solid #1a73e8;background:#f8fafd;padding:14px 18px;border-radius:6px}div#\:\$p > svg > foreignObject > section .mini-stat strong{display:block;color:#202124;font-size:32px;line-height:1.1}div#\:\$p > svg > foreignObject > section .mini-stat :is(span, marp-span){color:#5f6368;font-size:15px;text-transform:uppercase;letter-spacing:1px}div#\:\$p > svg > foreignObject > section .stat{font-size:64px;color:#1a73e8;font-weight:700;line-height:1}div#\:\$p > svg > foreignObject > section section.stat{--marpit-root-font-size: 64px}div#\:\$p > svg > foreignObject > section .stat-label{color:#5f6368;font-size:18px;text-transform:uppercase;letter-spacing:2px}div#\:\$p > svg > foreignObject > section section.stat-label{--marpit-root-font-size: 18px}div#\:\$p > svg > foreignObject > section .source-line{color:#5f6368;font-size:14px;margin-top:14px}div#\:\$p > svg > foreignObject > section section.source-line{--marpit-root-font-size: 14px}div#\:\$p > svg > foreignObject > section .small{color:#5f6368;font-size:20px}div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 20px}div#\:\$p > svg > foreignObject > section .accent-blue{color:#1a73e8}div#\:\$p > svg > foreignObject > section .accent-green{color:#188038}div#\:\$p > svg > foreignObject > section .accent-yellow{color:#b06000}div#\:\$p > svg > foreignObject > section .accent-red{color:#d93025}div#\:\$p > svg > foreignObject > section footer{color:#5f6368;font-size:14px}div#\:\$p > svg > foreignObject > section.hero footer{color:rgba(255,255,255,0.70)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
+  );--color-highlight:light-dark(#0288d1, #81d4fa);background-color:var(--color-background);background-image:linear-gradient(135deg, hsla(0,0%,53%,0), hsla(0,0%,53%,.02) 50%, hsla(0,0%,100%,0) 0, hsla(0,0%,100%,.05));color:var(--color-foreground);color-scheme:light;font-family:Lato,Avenir Next,Avenir,Trebuchet MS,Segoe UI,sans-serif;font-size:35px;height:720px;letter-spacing:1.25px;line-height:1.35;overflow-wrap:break-word;padding:70px;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:35px}div#\:\$p > svg > foreignObject > section:after{bottom:0;font-size:80%;right:0}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:80%}div#\:\$p > svg > foreignObject > section a,div#\:\$p > svg > foreignObject > section mark{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section code{background:var(--color-dimmed);color:var(--color-background)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--color-highlight)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:var(--color-foreground)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent}div#\:\$p > svg > foreignObject > section blockquote:after,div#\:\$p > svg > foreignObject > section blockquote:before,div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header,div#\:\$p > svg > foreignObject > section section:after{color:var(--color-dimmed)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border-color:var(--color-foreground)}div#\:\$p > svg > foreignObject > section table thead th{background:var(--color-foreground);color:var(--color-background)}div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) td,div#\:\$p > svg > foreignObject > section table tbody>tr:nth-child(odd) th{background:var(--color-background-stripe, transparent)}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section:where(.gaia){--color-background:#0288d1;--color-background-stripe:rgba(255,248,225,.1);--color-foreground:#fff8e1;--color-dimmed:#cce2de;--color-highlight:#81d4fa;}div#\:\$p > svg > foreignObject > section:where(.lead){align-items:stretch;flex-flow:column nowrap;place-content:safe center center}div#\:\$p > svg > foreignObject > section:where(.lead) :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) :is(h6, marp-h6){text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) p{text-align:center}div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h1, marp-h1),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h2, marp-h2),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h3, marp-h3),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h4, marp-h4),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h5, marp-h5),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>:is(h6, marp-h6),div#\:\$p > svg > foreignObject > section:where(.lead) blockquote>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) ol>li>p,div#\:\$p > svg > foreignObject > section:where(.lead) ul>li>p{text-align:left}div#\:\$p > svg > foreignObject > section:where(.lead) table{margin-left:auto;margin-right:auto}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > section{font-family:"Google Sans", "Roboto", -apple-system, "Segoe UI", sans-serif;font-size:27px;line-height:1.35;padding:56px 64px;letter-spacing:0}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size: 27px}div#\:\$p > svg > foreignObject > section.hero{background-color:#174ea6!important;background-image:linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%)!important;color:#ffffff;text-align:left}div#\:\$p > svg > foreignObject > section.hero :is(h1, marp-h1){font-size:66px;line-height:1.1;margin-bottom:16px;color:#ffffff;border:none}div#\:\$p > svg > foreignObject > section.hero :is(h2, marp-h2){font-size:29px;font-weight:400;color:rgba(255,255,255,0.85);border:none;max-width:920px}div#\:\$p > svg > foreignObject > section.hero .footer-note{font-size:18px;color:rgba(255,255,255,0.7);margin-top:48px}div#\:\$p > svg > foreignObject > section.hero div#\:\$p > svg > foreignObject > section section.footer-note{--marpit-root-font-size: 18px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:#1a73e8;border-bottom:2px solid #e8eaed;padding-bottom:8px;font-size:38px}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){color:#202124;font-size:26px;margin-top:0}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){color:#1a73e8;font-size:22px;margin-bottom:4px}div#\:\$p > svg > foreignObject > section.section-divider{background:linear-gradient(90deg, #f8fafd 0%, #ffffff 72%)}div#\:\$p > svg > foreignObject > section.section-divider :is(h1, marp-h1){color:#1a73e8;border:none;font-size:56px}div#\:\$p > svg > foreignObject > section.section-divider .eyebrow{color:#5f6368;text-transform:uppercase;letter-spacing:4px;font-size:16px;margin-bottom:16px}div#\:\$p > svg > foreignObject > section.section-divider div#\:\$p > svg > foreignObject > section section.eyebrow{--marpit-root-font-size: 16px}div#\:\$p > svg > foreignObject > section .kicker{color:#5f6368;text-transform:uppercase;letter-spacing:2px;font-size:15px;font-weight:700;margin-bottom:10px}div#\:\$p > svg > foreignObject > section section.kicker{--marpit-root-font-size: 15px}div#\:\$p > svg > foreignObject > section code{background:#f1f3f4;color:#202124;border-radius:4px;padding:2px 6px;font-size:0.9em}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:#202124;color:#e8eaed;border-radius:8px;padding:18px 22px;font-size:18px;line-height:1.4;box-shadow:0 2px 8px rgba(0,0,0,0.12)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{background:transparent;color:inherit;padding:0}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;margin:12px 0;font-size:22px}div#\:\$p > svg > foreignObject > section th{background:#1a73e8;color:#ffffff;padding:10px 14px;text-align:left}div#\:\$p > svg > foreignObject > section td{border-bottom:1px solid #e8eaed;padding:8px 14px}div#\:\$p > svg > foreignObject > section blockquote{border-left:4px solid #1a73e8;background:#e8f0fe;color:#174ea6;padding:14px 22px;margin:12px 0;font-style:normal;font-size:24px}div#\:\$p > svg > foreignObject > section .pill{display:inline-block;background:#e8f0fe;color:#1a73e8;border-radius:999px;padding:4px 14px;font-size:17px;margin-right:6px;font-weight:600}div#\:\$p > svg > foreignObject > section section.pill{--marpit-root-font-size: 17px}div#\:\$p > svg > foreignObject > section .grid-2{display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start}div#\:\$p > svg > foreignObject > section .grid-3{display:grid;grid-template-columns:repeat(3, 1fr);gap:18px;align-items:stretch}div#\:\$p > svg > foreignObject > section .compact{font-size:23px;line-height:1.28}div#\:\$p > svg > foreignObject > section section.compact{--marpit-root-font-size: 23px}div#\:\$p > svg > foreignObject > section .compact li{margin:4px 0}div#\:\$p > svg > foreignObject > section .card{border:1px solid #dadce0;border-radius:8px;padding:20px 22px;background:#ffffff;box-shadow:0 1px 3px rgba(60,64,67,0.10)}div#\:\$p > svg > foreignObject > section .card :is(h3, marp-h3){margin-top:0}div#\:\$p > svg > foreignObject > section .soft-card{border-radius:8px;padding:18px 22px;background:#f8fafd;border:1px solid #d2e3fc}div#\:\$p > svg > foreignObject > section .pipeline{display:grid;grid-template-columns:1fr 40px 1fr 40px 1fr 40px 1fr;align-items:center;gap:10px;margin-top:22px}div#\:\$p > svg > foreignObject > section .pipeline .step{border-radius:8px;padding:18px 16px;background:#ffffff;border:1px solid #dadce0;min-height:126px}div#\:\$p > svg > foreignObject > section .pipeline .arrow{color:#1a73e8;font-size:34px;text-align:center}div#\:\$p > svg > foreignObject > section .pipeline div#\:\$p > svg > foreignObject > section section.arrow{--marpit-root-font-size: 34px}div#\:\$p > svg > foreignObject > section .step-num{display:inline-flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:50%;background:#1a73e8;color:#ffffff;font-size:16px;font-weight:700;margin-bottom:8px}div#\:\$p > svg > foreignObject > section section.step-num{--marpit-root-font-size: 16px}div#\:\$p > svg > foreignObject > section .metric-row{display:grid;grid-template-columns:repeat(4, 1fr);gap:16px;margin:18px 0}div#\:\$p > svg > foreignObject > section .mini-stat{border-left:5px solid #1a73e8;background:#f8fafd;padding:14px 18px;border-radius:6px}div#\:\$p > svg > foreignObject > section .mini-stat strong{display:block;color:#202124;font-size:32px;line-height:1.1}div#\:\$p > svg > foreignObject > section .mini-stat :is(span, marp-span){color:#5f6368;font-size:15px;text-transform:uppercase;letter-spacing:1px}div#\:\$p > svg > foreignObject > section .stat{font-size:64px;color:#1a73e8;font-weight:700;line-height:1}div#\:\$p > svg > foreignObject > section section.stat{--marpit-root-font-size: 64px}div#\:\$p > svg > foreignObject > section .stat-label{color:#5f6368;font-size:18px;text-transform:uppercase;letter-spacing:2px}div#\:\$p > svg > foreignObject > section section.stat-label{--marpit-root-font-size: 18px}div#\:\$p > svg > foreignObject > section .source-line{color:#5f6368;font-size:14px;margin-top:14px}div#\:\$p > svg > foreignObject > section section.source-line{--marpit-root-font-size: 14px}div#\:\$p > svg > foreignObject > section .small{color:#5f6368;font-size:20px}div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 20px}div#\:\$p > svg > foreignObject > section .accent-blue{color:#1a73e8}div#\:\$p > svg > foreignObject > section .accent-green{color:#188038}div#\:\$p > svg > foreignObject > section .accent-yellow{color:#b06000}div#\:\$p > svg > foreignObject > section .accent-red{color:#d93025}div#\:\$p > svg > foreignObject > section.dense{font-size:22px;padding:44px 54px}div#\:\$p > svg > foreignObject > section.dense{--marpit-root-font-size: 22px}div#\:\$p > svg > foreignObject > section.dense :is(h1, marp-h1){font-size:34px;margin-bottom:8px}div#\:\$p > svg > foreignObject > section.dense :is(h2, marp-h2){font-size:22px}div#\:\$p > svg > foreignObject > section.dense :is(h3, marp-h3){font-size:18px}div#\:\$p > svg > foreignObject > section.dense table{font-size:17px;margin:8px 0}div#\:\$p > svg > foreignObject > section.dense th, div#\:\$p > svg > foreignObject > section.dense td{padding:5px 8px}div#\:\$p > svg > foreignObject > section.dense :is(pre, marp-pre){font-size:12px;padding:12px 14px}div#\:\$p > svg > foreignObject > section.dense .small{font-size:16px}div#\:\$p > svg > foreignObject > section.dense div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 16px}div#\:\$p > svg > foreignObject > section.dense .compact{font-size:18px}div#\:\$p > svg > foreignObject > section.dense div#\:\$p > svg > foreignObject > section section.compact{--marpit-root-font-size: 18px}div#\:\$p > svg > foreignObject > section.dense footer{display:none}div#\:\$p > svg > foreignObject > section footer{color:#5f6368;font-size:14px}div#\:\$p > svg > foreignObject > section.hero footer{color:rgba(255,255,255,0.70)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
 </style></head><body><div class="bespoke-marp-osc"><button data-bespoke-marp-osc="prev" tabindex="-1" title="Previous slide">Previous slide</button><span data-bespoke-marp-osc="page"></span><button data-bespoke-marp-osc="next" tabindex="-1" title="Next slide">Next slide</button><button data-bespoke-marp-osc="fullscreen" tabindex="-1" title="Toggle fullscreen (f)">Toggle fullscreen</button><button data-bespoke-marp-osc="overview" tabindex="-1" title="Toggle overview view (o)">Toggle overview view</button><button data-bespoke-marp-osc="presenter" tabindex="-1" title="Open presenter view (p)">Open presenter view</button></div><div id=":$p"><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="1" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="hero" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
@@ -254,6 +254,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -261,7 +296,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" class="hero" style="--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:hero;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="hero" style="--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:hero;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -501,6 +536,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -511,13 +581,13 @@ section.hero footer {
 ;color:#202124;background-color:#ffffff;background-image:none;" data-size="16:9">
 <p><span class="pill" style="background:rgba(255,255,255,0.15);color:#fff">EU AI Act · GDPR · DSA</span></p>
 <h1 id="decision-lineage-for-ai-agents">Decision Lineage for AI Agents</h1>
-<h2 id="turn-live-agent-behavior-into-queryable-bigquery-evidence-decisions-options-outcomes-and-rationale">Turn live agent behavior into queryable BigQuery evidence: decisions, options, outcomes, and rationale.</h2>
+<h2 id="from-systems-of-action-to-systems-of-governance--extracted-decisions-options-outcomes-and-rationale-queryable-in-bigquery">From &quot;Systems of Action&quot; to &quot;Systems of Governance&quot; — extracted decisions, options, outcomes, and rationale queryable in BigQuery.</h2>
 <div class="footer-note">
 BigQuery Agent Analytics SDK · examples/decision_lineage_demo · Issue #98
 </div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="2" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="2" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -757,6 +827,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -764,7 +869,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="2" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="section-divider" data-marpit-pagination="2" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -1004,6 +1109,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -1011,26 +1151,8 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="why-this-matters-now">Why this matters now</h1>
-<div class="grid-3">
-<div class="card">
-<h3 id="regulation">Regulation</h3>
-<p>EU AI Act obligations phase in through <strong>2 Aug 2027</strong>; many high-risk and transparency rules start <strong>2 Aug 2026</strong>.</p>
-</div>
-<div class="card">
-<h3 id="trust">Trust</h3>
-<p>Most agent demos produce an answer and ask reviewers to trust a transcript. That does not scale to audit.</p>
-</div>
-<div class="card">
-<h3 id="operations">Operations</h3>
-<p>Product, legal, and engineering need the same answer: <em>what happened, why, and where is the evidence?</em></p>
-</div>
-</div>
-<div class="soft-card">
-<strong>Risk framing:</strong> AI Act fines reach up to <strong>7% of worldwide annual turnover</strong> for prohibited practices, and up to <strong>3%</strong> for many other operator / transparency obligations. The useful response is evidence, not screenshots.
-</div>
-<div class="source-line">Sources: EU AI Act Service Desk implementation timeline; AI Act Article 99 penalty tiers.</div>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Part 1 · Market context</div>
+<h1 id="the-regulatory-landscape-just-changed">The regulatory landscape just changed</h1>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="3" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -1273,6 +1395,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -1280,7 +1437,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="3" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="3" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -1520,6 +1677,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -1527,23 +1719,32 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="what-we-built">What we built</h1>
-<div class="kicker">Working demo, not mock data</div>
-<p>Take a real ADK media-planning agent, attach the <strong>BigQuery Agent Analytics Plugin</strong>, use <code>AI.GENERATE</code> to extract the decisions and options present in the traces, then publish the result as a <strong>BigQuery Property Graph</strong> for GQL in BigQuery Studio.</p>
-<div class="pipeline">
-<div class="step"><span class="step-num">1</span><br /><strong>Live agent</strong><br /><span class="small">Gemini 2.5 Pro campaign planner</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">2</span><br /><strong>Plugin spans</strong><br /><span class="small">162 recorded events in BigQuery</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">3</span><br /><strong>Extraction</strong><br /><span class="small">Entities, decisions, options, rationales</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">4</span><br /><strong>Property graph</strong><br /><span class="small">Query, visualize, audit</span></div>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="why-now--three-regulations-converging">Why now — three regulations converging</h1>
+<div class="grid-3">
+<div class="card">
+<h3 id="eu-ai-act">EU AI Act</h3>
+<p><strong>Regulation (EU) 2024/1689</strong>, in force 1 Aug 2024.<br />
+Most operator obligations apply from <strong>2 Aug 2026</strong>; full rollout by <strong>2 Aug 2027</strong>.</p>
+<div class="small">High-risk-system rules cover transparency, record-keeping, human oversight, post-market monitoring.</div>
 </div>
-<blockquote><strong>Promise:</strong> the graph is derived from real plugin output. The demo does not rely on hand-shaped seed traces.</blockquote>
+<div class="card">
+<h3 id="gdpr">GDPR</h3>
+<p><strong>Article 22</strong> — protections around solely automated decisions with legal or similarly significant effects.</p>
+<div class="small">Access / transparency rights create the "meaningful information about logic" audit expectation.</div>
+</div>
+<div class="card">
+<h3 id="digital-services-act">Digital Services Act</h3>
+<p><strong>Article 26</strong> — online platforms presenting ads must disclose that an item is an ad, who paid for it, and the main targeting parameters.</p>
+<div class="small">The demo's ad-planning lineage gives teams the upstream evidence behind those disclosures.</div>
+</div>
+</div>
+<div class="source-line">
+Sources: <a href="https://ai-act-service-desk.ec.europa.eu/en/ai-act/timeline/timeline-implementation-eu-ai-act">EU AI Act Service Desk timeline</a> · <a href="https://eur-lex.europa.eu/eli/reg/2016/679/oj">GDPR — Reg. 2016/679</a> · <a href="https://eur-lex.europa.eu/eli/reg/2022/2065/oj">DSA — Reg. 2022/2065</a>
+</div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="dense" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -1783,6 +1984,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -1790,7 +2026,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" class="section-divider" data-marpit-pagination="4" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="dense" data-marpit-pagination="4" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:dense;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -2030,6 +2266,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -2037,8 +2308,25 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9"><div class="eyebrow">Section 1 of 4</div>
-<h1 id="the-data-behind-todays-demo">The data behind today's demo</h1>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="the-threat--article-99-penalty-tiers">The threat — Article 99 penalty tiers</h1>
+<p>The AI Act sets fixed-amount maximums <strong>and</strong> turnover thresholds. The fine is the <strong>higher of the two</strong> for non-SMEs.</p>
+<table>
+<thead>
+<tr><th>Article 99 paragraph</th><th>What violates it</th><th>Cap (non-SME)</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Art 99(3)</strong></td><td>Article 5 — prohibited AI practices (e.g. manipulation that exploits vulnerabilities, social scoring, biometric categorisation by protected attributes)</td><td><strong>€35M</strong> or <strong>7%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+<tr><td><strong>Art 99(4)</strong></td><td>Most other AI Act obligations — operators of high-risk systems, transparency, record-keeping, post-market monitoring (Arts 16, 22, 23, 24, 26, 31, 33, 34, 50)</td><td><strong>€15M</strong> or <strong>3%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+<tr><td><strong>Art 99(5)</strong></td><td>Supplying incorrect, incomplete, or misleading information to authorities</td><td><strong>€7.5M</strong> or <strong>1%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+</tbody>
+</table>
+<div class="small" style="margin-top:14px">
+For an ad-tech buyer with <strong>€20B</strong> worldwide annual turnover, the practical maximum under <strong>Art 99(4)</strong> is <strong>€600M per finding</strong> (3%, not the €15M floor). For SMEs and start-ups, Art 99(6) caps at the <em>lower</em> of the two values.
+</div>
+<div class="source-line">
+Source: <a href="https://eur-lex.europa.eu/eli/reg/2024/1689/oj">Reg. 2024/1689 official journal, Article 99</a>
+</div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="5" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -2281,6 +2569,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -2288,7 +2611,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="5" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="5" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -2528,6 +2851,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -2535,66 +2893,38 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="six-campaigns-six-live-agent-runs">Six campaigns, six live agent runs</h1>
-<table>
-<thead>
-<tr>
-<th>Brand</th>
-<th>Campaign</th>
-<th style="text-align:right">Budget</th>
-<th>Audience</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Nike</td>
-<td>Summer Run 2026</td>
-<td style="text-align:right">$360K</td>
-<td>Serious runners 18-35</td>
-</tr>
-<tr>
-<td>Nike</td>
-<td>Winter Trail 2026</td>
-<td style="text-align:right">$500K</td>
-<td>Trail-runners &amp; hikers 25-45</td>
-</tr>
-<tr>
-<td>Adidas</td>
-<td>Track Season 2026</td>
-<td style="text-align:right">$420K</td>
-<td>NCAA &amp; HS sprinters 16-22</td>
-</tr>
-<tr>
-<td>Puma</td>
-<td>Soccer Cup 2026</td>
-<td style="text-align:right">$280K</td>
-<td>Soccer fans 18-30</td>
-</tr>
-<tr>
-<td>Reebok</td>
-<td>CrossFit Open 2026</td>
-<td style="text-align:right">$340K</td>
-<td>Fitness pros 25-40</td>
-</tr>
-<tr>
-<td>Lululemon</td>
-<td>Yoga Flow 2026</td>
-<td style="text-align:right">$250K</td>
-<td>Yoga practitioners 22-45</td>
-</tr>
-</tbody>
-</table>
-<div class="metric-row">
-<div class="mini-stat"><strong>6</strong><span>sessions</span></div>
-<div class="mini-stat"><strong>162</strong><span>plugin spans</span></div>
-<div class="mini-stat"><strong>31</strong><span>extracted decisions</span></div>
-<div class="mini-stat"><strong>92</strong><span>decision options</span></div>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="the-narrative-shift">The narrative shift</h1>
+<div class="grid-2">
+<div class="soft-card">
+<h3 id="yesterday--systems-of-action">Yesterday — Systems of Action</h3>
+<p>AI agents that <strong>do tasks</strong> end-to-end:</p>
+<ul class="compact">
+<li>Pick the audience for a campaign</li>
+<li>Allocate the media budget</li>
+<li>Choose the creative theme</li>
+<li>Set the launch window</li>
+</ul>
+<p>The agent <em>does</em>. We trust the output.</p>
 </div>
-<p>Each row is one ADK invocation against <code>gemini-2.5-pro</code>; each invocation produced <strong>27 plugin-recorded spans</strong> in the verified demo run.</p>
+<div class="card">
+<h3 id="today--systems-of-governance">Today — Systems of Governance</h3>
+<p>The same agents, plus a <strong>queryable evidence layer</strong>:</p>
+<ul class="compact">
+<li>The decisions extracted from the agent trace</li>
+<li>The options and scores the trace exposes</li>
+<li>The rationale attached to dropped options</li>
+<li>Linked to the trace span that produced it</li>
+</ul>
+<p>The agent acts. The graph proves.</p>
+</div>
+</div>
+<blockquote>
+<p>The mandate isn't <em>don't use agents</em> — it's <em>be able to show your work, on demand, in audit format</em>.</p>
+</blockquote>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -2834,6 +3164,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -2841,7 +3206,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="6" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="section-divider" data-marpit-pagination="6" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -3081,6 +3446,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -3088,26 +3488,8 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="three-writers-populate-seven-tables">Three writers populate seven tables</h1>
-<div class="grid-3">
-<div class="card">
-<h3>BQ AA Plugin</h3>
-<strong>Writes</strong> `agent_events`<br />
-<span class="small">Raw trace evidence from the live ADK runner.</span>
-</div>
-<div class="card">
-<h3>SDK AI.GENERATE</h3>
-<strong>Writes</strong> `extracted_biz_nodes`, `decision_points`, `candidates`<br />
-<span class="small">Typed facts extracted from trace text.</span>
-</div>
-<div class="card">
-<h3>SDK SQL DML</h3>
-<strong>Writes</strong> `context_cross_links`, `made_decision_edges`, `candidate_edges`<br />
-<span class="small">Graph edges with stable keys.</span>
-</div>
-</div>
-<blockquote>`AI.GENERATE` runs twice across all sessions: business entities first, then decision options and rationale.</blockquote>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Part 2 · Business value</div>
+<h1 id="what-decision-lineage-gives-you">What &quot;Decision Lineage&quot; gives you</h1>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="7" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -3350,6 +3732,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -3357,7 +3774,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="7" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="7" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -3597,520 +4014,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="the-graph-the-demo-presents">The graph the demo presents</h1>
-<p>The SDK ships the canonical graph. The demo adds <strong>ads-domain labels</strong> so BigQuery Studio reads like the business process:</p>
-<div class="grid-2">
-<div class="card">
-<h3 id="primary-audit-path">Primary audit path</h3>
-<p><code>CampaignRun</code> → <code>PlanningDecision</code> → <code>DecisionOption</code> → <code>OptionOutcome</code></p>
-<p><code>DecisionOption</code> → <code>DropReason</code></p>
-<p><span class="small">A campaign has planning decisions; each decision weighed options; every option has an outcome and dropped options have rationale.</span></p>
-</div>
-<div class="card">
-<h3 id="evidence-path">Evidence path</h3>
-<p><code>CampaignRun</code> → <code>AgentStep</code> → <code>PlanningDecision</code></p>
-<p><code>AgentStep</code> → <code>MediaEntity</code></p>
-<p><code>PlanningDecision</code> → <code>DecisionCategory</code></p>
-<p><span class="small">The business answer stays tied to the span, entity, and category that produced it.</span></p>
-</div>
-</div>
-<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
-</section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
+section.dense {
   font-size: 22px;
-  margin-bottom: 4px;
+  padding: 44px 54px;
 }
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 22px;
-}
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
-}
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
-  font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
-}
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
-}
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
-}
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
+section.dense h1 {
   font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
-  font-size: 16px;
-  font-weight: 700;
   margin-bottom: 8px;
 }
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
-  font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-}
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
-}
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-" lang="en-US" class="section-divider" data-marpit-pagination="8" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
-  font-size: 22px;
-  margin-bottom: 4px;
-}
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
+section.dense h2 {
   font-size: 22px;
 }
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
+section.dense h3 {
+  font-size: 18px;
 }
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
+section.dense table {
   font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
+  margin: 8px 0;
 }
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
 }
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
 }
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
-  font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
+section.dense .small {
   font-size: 16px;
-  font-weight: 700;
-  margin-bottom: 8px;
 }
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
+section.dense .compact {
   font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
 }
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
+section.dense footer {
+  display: none;
 }
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -4118,519 +4056,1177 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9"><div class="eyebrow">Section 2 of 4</div>
-<h1 id="five-regulator-shaped-questions-answered-live">Five regulator-shaped questions, answered live</h1>
-<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
-</section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
-  font-size: 22px;
-  margin-bottom: 4px;
-}
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 22px;
-}
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
-}
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
-  font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
-}
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
-}
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
-}
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
-  font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
-  font-size: 16px;
-  font-weight: 700;
-  margin-bottom: 8px;
-}
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
-  font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-}
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
-}
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-" lang="en-US" data-marpit-pagination="9" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
-  font-size: 22px;
-  margin-bottom: 4px;
-}
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 22px;
-}
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
-}
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
-  font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
-}
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
-}
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
-}
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
-  font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
-  font-size: 16px;
-  font-weight: 700;
-  margin-bottom: 8px;
-}
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
-  font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-}
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
-}
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="q1--right-to-explanation">Q1 — Right to explanation</h1>
-<div class="pill">EU AI Act Art. 86</div> <div class="pill">GDPR Art. 22</div>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="decision-lineage-defined">Decision Lineage, defined</h1>
+<div class="kicker">Working definition</div>
 <blockquote>
-<p><em>&quot;For the Nike Summer Run campaign, what audience did the AI pick, what alternatives did it consider, and why did it reject the others?&quot;</em></p>
+For any agent decision: the ability to retrieve <strong>what was chosen</strong>, <strong>what alternatives were considered</strong>, <strong>what scores or criteria were applied</strong>, <strong>why each alternative was rejected</strong>, and <strong>which trace span produced the decision</strong> — as a single BigQuery query.
 </blockquote>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
-<span class="hljs-keyword">MATCH</span> (cr:CampaignRun)<span class="hljs-operator">-</span>[:CampaignDecision]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(dp:PlanningDecision)
-      <span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
-<span class="hljs-keyword">WHERE</span> cr.session_id <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;&lt;SESSION&gt;&#x27;</span>
-  <span class="hljs-keyword">AND</span> <span class="hljs-built_in">LOWER</span>(dp.decision_type) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%audience%&#x27;</span>
-<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> opt.status, opt.name, opt.score, opt.rejection_rationale
-<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> opt.status <span class="hljs-keyword">DESC</span>, opt.score <span class="hljs-keyword">DESC</span>;
-</code></pre>
-<p><strong>Three rows.</strong> Selected: <em>Serious Runners 18-35</em> @ 0.99. Dropped: <em>Casual Runners 25-45</em> (lower purchase intent), <em>Fitness Enthusiasts 18-35</em> (group too broad). <strong>The extracted rationale stays attached to the option it explains.</strong></p>
+<div class="grid-3" style="margin-top:24px">
+<div class="card"><h3>Trust</h3>The data exists at the moment the regulator asks. No reconstruction.</div>
+<div class="card"><h3>Transparency</h3>Same answer for product, legal, and engineering — one source of truth.</div>
+<div class="card"><h3>Reproducibility</h3>Re-running the audit query a year later returns the same evidence.</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="8" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="what-the-demo-lets-you-prove">What the demo lets you prove</h1>
+<div class="metric-row">
+<div class="mini-stat"><strong>Right to explanation</strong><span>GDPR Art 22 · AI Act Art 86</span></div>
+<div class="mini-stat"><strong>Bias monitoring</strong><span>AI Act Art 10 / 71</span></div>
+<div class="mini-stat"><strong>Human oversight</strong><span>AI Act Art 14</span></div>
+<div class="mini-stat"><strong>Reproducibility</strong><span>AI Act Art 12 / 13</span></div>
+</div>
+<div class="grid-2" style="margin-top:14px">
+<div class="card">
+<h3 id="what-this-is">What this is</h3>
+<ul>
+<li>A queryable record of agent decisions plus alternatives plus reasoning</li>
+<li>The audit substrate regulators ask for under each article above</li>
+<li>Built from real agent traces by an open-source SDK</li>
+</ul>
+</div>
+<div class="card">
+<h3 id="what-this-is-not">What this is not</h3>
+<ul>
+<li>Not a compliance certification — talk to your legal counsel for that</li>
+<li>Not a replacement for a Data Protection Impact Assessment</li>
+<li>Not a model-quality scorecard — it audits what the agent <em>did</em>, not whether it was <em>right</em></li>
+</ul>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="section-divider" data-marpit-pagination="9" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Part 3 · Customer proof</div>
+<h1 id="a-concrete-pattern-from-real-ad-tech-buyers">A concrete pattern from real ad-tech buyers</h1>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -4873,6 +5469,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -4880,7 +5511,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="10" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="10" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -5120,6 +5751,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -5127,21 +5793,33 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="q2--bias--fairness-audit">Q2 — Bias / fairness audit</h1>
-<div class="pill">EU AI Act Art. 10</div> <div class="pill">EU AI Act Art. 71</div>
-<blockquote>
-<p><em>&quot;Across our 2026 ad portfolio, did the AI ever reject a candidate based on age or demographic criteria?&quot;</em></p>
-</blockquote>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
-<span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
-<span class="hljs-keyword">WHERE</span> opt.status <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;DROPPED&#x27;</span>
-  <span class="hljs-keyword">AND</span> (<span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%age %&#x27;</span>
-       <span class="hljs-keyword">OR</span> <span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%demographic%&#x27;</span>
-       <span class="hljs-keyword">OR</span> <span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%youth%&#x27;</span>)
-<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> dp.decision_type, opt.name, opt.rejection_rationale;
-</code></pre>
-<p><strong>Multiple matches.</strong> <em>Youth Track &amp; Field (13-15) — outside specified 16-22 range.</em> <em>Affluent Hikers (35-55) — age-range mismatch.</em> The graph surfaces specific rationales for <strong>human review</strong>: proxy risk, legitimate campaign constraint, or extraction artifact?</p>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="real-world-pattern--programmatic-media-buyer">Real-world pattern — programmatic media-buyer</h1>
+<div class="kicker">Example pattern (anonymised)</div>
+<div class="grid-2">
+<div class="card">
+<h3 id="the-pain">The pain</h3>
+<p>A major brand-side media-buyer running a multi-agent media-planning stack:</p>
+<ul class="compact">
+<li>Internal review board needed evidence for campaign decisions (audience, placement, creative, schedule)</li>
+<li>Compliance team owed regulators a quarterly bias-audit report on demographic targeting</li>
+<li>An adjudicator asked <em>"why was this audience excluded from this campaign?"</em> — answer required digging through Slack threads + run logs</li>
+</ul>
+</div>
+<div class="card">
+<h3 id="the-shape-of-the-fix">The shape of the fix</h3>
+<p>Decision Lineage on BigQuery:</p>
+<ul class="compact">
+<li>Every agent invocation captured by the BQ AA Plugin</li>
+<li>Decisions + alternatives + rationale extracted by <code>AI.GENERATE</code></li>
+<li>Property graph queryable by compliance + product without writing Python</li>
+<li>Same query reused for the quarterly bias-audit and for one-off subpoena responses</li>
+</ul>
+</div>
+</div>
+<div class="small" style="margin-top:18px">
+<em>Replace this slide with your customer's pain point and timeline once a reference customer is named — the demo plugs into any agent the BQ AA Plugin already covers.</em>
+</div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="11" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -5384,6 +6062,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -5391,7 +6104,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="11" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="11" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -5631,6 +6344,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -5638,26 +6386,23 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="q3--human-oversight-trigger">Q3 — Human-oversight trigger</h1>
-<div class="pill">EU AI Act Art. 14</div>
-<blockquote>
-<p><em>&quot;Did the agent ever commit a decision below 0.7 confidence? Those should have triggered human review.&quot;</em></p>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="customer-voice-placeholder">Customer voice (placeholder)</h1>
+<blockquote style="font-size:30px; line-height:1.4">
+"Before this, every audit request was a fire drill across three teams. Now we hand the regulator a five-line GQL query and the answer is the same on every run. The compliance posture moved from <em>defensible</em> to <em>queryable</em>."
 </blockquote>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
-<span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
-<span class="hljs-keyword">WHERE</span> opt.status <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;SELECTED&#x27;</span> <span class="hljs-keyword">AND</span> opt.score <span class="hljs-operator">&lt;</span> <span class="hljs-number">0.7</span>
-<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> dp.session_id, dp.decision_type, opt.name, opt.score
-<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> opt.score <span class="hljs-keyword">ASC</span>;
-</code></pre>
-<div style="text-align:center; margin-top: 24px">
-<div class="stat">0</div>
-<div class="stat-label">rows returned</div>
+<div class="small" style="margin-top:14px">
+— Director, Audience Strategy at a major DSP <span class="accent-blue">[placeholder — swap with a real attributable quote before external use]</span>
 </div>
-<p><strong>The empty result is the audit artifact.</strong> <em>&quot;We ran the human-oversight predicate against the entire portfolio for this period. The trigger never fired.&quot;</em> Tighten the threshold to 0.85 → instant new at-risk list.</p>
+<div class="metric-row" style="margin-top:24px">
+<div class="mini-stat"><strong>~3 weeks</strong><span>Audit response (before)</span></div>
+<div class="mini-stat"><strong>One query</strong><span>Audit response (after)</span></div>
+<div class="mini-stat"><strong>5 articles</strong><span>Regulatory hooks mapped</span></div>
+<div class="mini-stat"><strong>Low cost</strong><span>BQ query over existing graph</span></div>
+</div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -5897,6 +6642,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -5904,7 +6684,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="12" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="section-divider" data-marpit-pagination="12" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -6144,6 +6924,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -6151,22 +6966,8 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="q4--decision-reproducibility">Q4 — Decision reproducibility</h1>
-<div class="pill">EU AI Act Art. 12</div> <div class="pill">EU AI Act Art. 13</div>
-<blockquote>
-<p><em>&quot;Subpoena: produce the full audit trail for the Adidas creative-theme decision.&quot;</em></p>
-</blockquote>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
-<span class="hljs-keyword">MATCH</span> (step:AgentStep)<span class="hljs-operator">-</span>[:DecidedAt]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(dp:PlanningDecision)
-      <span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
-<span class="hljs-keyword">WHERE</span> dp.session_id <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;&lt;SESSION&gt;&#x27;</span>
-  <span class="hljs-keyword">AND</span> <span class="hljs-built_in">LOWER</span>(dp.decision_type) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%creative%&#x27;</span>
-  <span class="hljs-keyword">AND</span> step.event_type <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;LLM_RESPONSE&#x27;</span>
-<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> dp.span_id, opt.status, opt.name, opt.score, opt.rejection_rationale
-<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> opt.status <span class="hljs-keyword">DESC</span>, opt.score <span class="hljs-keyword">DESC</span>;
-</code></pre>
-<p><strong>Three rows.</strong> Selected: <em>&quot;Built for a New Record&quot;</em> @ 0.97. Two dropped with rationale, both pointing back to the same <code>evidence_span_id</code>. That span lives in <code>agent_events</code> with content, timestamp, and latency. <strong>Record-keeping becomes a queryable trail.</strong></p>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Part 4 · Practical demo</div>
+<h1 id="what-an-auditor-actually-sees">What an auditor actually sees</h1>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="13" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -6409,6 +7210,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -6416,7 +7252,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="13" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="13" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -6656,6 +7492,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -6663,54 +7534,28 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="q5--systemic--pattern-audit">Q5 — Systemic / pattern audit</h1>
-<div class="pill">EU AI Act Art. 17</div> <div class="pill">EU AI Act Art. 60</div>
-<blockquote>
-<p><em>&quot;Where in our portfolio does the AI reject candidates least decisively?&quot;</em></p>
-</blockquote>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
-<span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
-<span class="hljs-keyword">WHERE</span> opt.status <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;DROPPED&#x27;</span>
-<span class="hljs-keyword">RETURN</span> dp.decision_type, <span class="hljs-built_in">COUNT</span>(opt) <span class="hljs-keyword">AS</span> rejections, <span class="hljs-built_in">AVG</span>(opt.score) <span class="hljs-keyword">AS</span> avg_dropped_score
-<span class="hljs-keyword">GROUP</span> <span class="hljs-keyword">BY</span> dp.decision_type
-<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> rejections <span class="hljs-keyword">DESC</span> LIMIT <span class="hljs-number">5</span>;
-</code></pre>
-<table>
-<thead>
-<tr>
-<th>decision_type</th>
-<th style="text-align:right">rejections</th>
-<th style="text-align:right">avg_dropped_score</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Creative Theme Selection</td>
-<td style="text-align:right">12</td>
-<td style="text-align:right">0.79</td>
-</tr>
-<tr>
-<td>Audience Selection</td>
-<td style="text-align:right">12</td>
-<td style="text-align:right"><strong>0.66</strong> ← lowest</td>
-</tr>
-<tr>
-<td>Channel Strategy Selection</td>
-<td style="text-align:right">6</td>
-<td style="text-align:right">0.77</td>
-</tr>
-<tr>
-<td>Placement Selection</td>
-<td style="text-align:right">7</td>
-<td style="text-align:right">0.74</td>
-</tr>
-</tbody>
-</table>
-<div class="small"><strong>Audience Selection has the lowest average dropped score.</strong> Reuse the Q2 filter for repeatable bias review.</div>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="the-auditor-persona--five-questions-live">The auditor persona — five questions, live</h1>
+<p>A compliance reviewer, equipped with the BigQuery Conversational Analytics panel, asks five questions of one dataset:</p>
+<div class="grid-2">
+<div>
+<ul class="compact">
+<li><strong>Q1</strong> — <em>"Why did the agent pick this audience?"</em></li>
+<li><strong>Q2</strong> — <em>"Did demographic criteria ever cause a candidate to be dropped?"</em></li>
+<li><strong>Q3</strong> — <em>"Were any decisions committed below 0.7 confidence?"</em></li>
+<li><strong>Q4</strong> — <em>"Show me the full audit trail for the Adidas creative-theme decision."</em></li>
+<li><strong>Q5</strong> — <em>"Which decision categories reject candidates least decisively?"</em></li>
+</ul>
+</div>
+<div>
+<h3 id="why-this-format">Why this format</h3>
+<p>Ground the demo in the <strong>auditor experience</strong>, not the engineering pipeline. The reviewer starts with a business question; the system returns a reproducible evidence path that legal and engineering can inspect together.</p>
+<p>The next slides show the natural-language prompt, the GQL pattern, and the live answer from the demo dataset.</p>
+</div>
+</div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="14" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="14" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -6950,6 +7795,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -6957,7 +7837,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" class="section-divider" data-marpit-pagination="14" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="14" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -7197,6 +8077,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -7204,8 +8119,21 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9"><div class="eyebrow">Section 3 of 4</div>
-<h1 id="what-this-unlocks">What this unlocks</h1>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="q1--right-to-explanation">Q1 — Right to explanation</h1>
+<div class="pill">EU AI Act Art 86</div> <div class="pill">GDPR Art 22</div>
+<blockquote>
+<p><em>&quot;For Nike Summer Run, what audience did the agent pick, and why did it reject the alternatives?&quot;</em></p>
+</blockquote>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
+<span class="hljs-keyword">MATCH</span> (cr:CampaignRun)<span class="hljs-operator">-</span>[:CampaignDecision]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(dp:PlanningDecision)
+      <span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
+<span class="hljs-keyword">WHERE</span> cr.session_id <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;&lt;SESSION&gt;&#x27;</span>
+  <span class="hljs-keyword">AND</span> <span class="hljs-built_in">LOWER</span>(dp.decision_type) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%audience%&#x27;</span>
+<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> opt.status, opt.name, opt.score, opt.rejection_rationale
+<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> opt.status <span class="hljs-keyword">DESC</span>, opt.score <span class="hljs-keyword">DESC</span>;
+</code></pre>
+<p><strong>Three rows.</strong> Selected: <em>Serious Runners 18-35</em> @ 0.99. Dropped: <em>Casual Runners 25-45</em> (lower purchase intent on high-performance footwear), <em>Fitness Enthusiasts 18-35</em> (group too broad for running conversion). <strong>Each rationale extracted by <code>AI.GENERATE</code> from the LLM_RESPONSE trace text.</strong></p>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="15" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -7448,6 +8376,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -7455,7 +8418,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="15" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="15" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -7695,6 +8658,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -7702,25 +8700,26 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="three-takeaways-for-leadership">Three takeaways for leadership</h1>
-<div class="grid-2">
-<div>
-<h3 id="1-audit-posture-as-a-query">1. Audit posture as a query</h3>
-<p>The audit surface for our agent platform is now a <strong>live BigQuery query</strong>, not a slide deck or quarterly review.</p>
-<h3 id="2-the-schema-generalizes">2. The schema generalizes</h3>
-<p>Brand-neutral, channel-neutral, decision-type-neutral. Point an instrumented agent at the same pipeline and the same audit patterns apply.</p>
-</div>
-<div>
-<h3 id="3-composes-with-what-we-run">3. Composes with what we run</h3>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="q2--bias--fairness-audit">Q2 — Bias / fairness audit</h1>
+<div class="pill">EU AI Act Art 10</div> <div class="pill">EU AI Act Art 71</div>
+<blockquote>
+<p><em>&quot;Across our 2026 portfolio, did the agent ever reject a candidate based on age or demographic criteria?&quot;</em></p>
+</blockquote>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
+<span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
+<span class="hljs-keyword">WHERE</span> opt.status <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;DROPPED&#x27;</span>
+  <span class="hljs-keyword">AND</span> (<span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%age %&#x27;</span>
+       <span class="hljs-keyword">OR</span> <span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%demographic%&#x27;</span>
+       <span class="hljs-keyword">OR</span> <span class="hljs-built_in">LOWER</span>(opt.rejection_rationale) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%youth%&#x27;</span>)
+<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> dp.decision_type, opt.name, opt.rejection_rationale;
+</code></pre>
+<p>Multiple matches. Examples (verbatim from the live extraction):</p>
 <ul>
-<li><strong>BQ AA Plugin</strong> — the instrumentation path</li>
-<li><strong>SDK extraction</strong> — one method call: <code>build_context_graph(use_ai_generate=True, include_decisions=True)</code></li>
-<li><strong>BigQuery</strong> — the warehouse you already pay for</li>
+<li><em>&quot;Youth Track &amp; Field (13-15) — outside specified 16-22 range, less focused on in-season purchase&quot;</em></li>
+<li><em>&quot;Affluent Hikers (35-55) — significant age-range mismatch with target demo&quot;</em></li>
 </ul>
-<p>No new graph service. No separate audit datastore.</p>
-</div>
-</div>
+<p><strong>The graph surfaces specific rationales for human review</strong> — proxy or legitimate ad-targeting? The reviewer judges from data, not trust.</p>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="16" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -7963,6 +8962,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -7970,7 +9004,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="16" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="16" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -8210,6 +9244,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -8217,51 +9286,23 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="compliance-anchor-map">Compliance-anchor map</h1>
-<table>
-<thead>
-<tr>
-<th>Question</th>
-<th>EU AI Act</th>
-<th>GDPR</th>
-<th>DSA</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>Q1</strong> Right to explanation</td>
-<td>Art. 86</td>
-<td>Art. 22</td>
-<td>Art. 26</td>
-</tr>
-<tr>
-<td><strong>Q2</strong> Bias / fairness audit</td>
-<td>Art. 10, Art. 71</td>
-<td>Art. 5(1)(d), Art. 22</td>
-<td>Art. 26</td>
-</tr>
-<tr>
-<td><strong>Q3</strong> Human oversight</td>
-<td>Art. 14</td>
-<td>Art. 22</td>
-<td>—</td>
-</tr>
-<tr>
-<td><strong>Q4</strong> Reproducibility</td>
-<td>Art. 12, Art. 13</td>
-<td>Art. 30</td>
-<td>Art. 26</td>
-</tr>
-<tr>
-<td><strong>Q5</strong> Systemic-pattern audit</td>
-<td>Art. 17, Art. 60</td>
-<td>Art. 35</td>
-<td>Art. 26</td>
-</tr>
-</tbody>
-</table>
-<p>Five queries against one graph create reusable <strong>evidence hooks</strong> for three EU regulatory conversations. This is not a compliance certification; it is the data substrate a compliance review needs.</p>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="q3--human-oversight-trigger">Q3 — Human-oversight trigger</h1>
+<div class="pill">EU AI Act Art 14</div>
+<blockquote>
+<p><em>&quot;Did the agent ever commit a decision below 0.7 confidence? That should have triggered human review.&quot;</em></p>
+</blockquote>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
+<span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
+<span class="hljs-keyword">WHERE</span> opt.status <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;SELECTED&#x27;</span> <span class="hljs-keyword">AND</span> opt.score <span class="hljs-operator">&lt;</span> <span class="hljs-number">0.7</span>
+<span class="hljs-keyword">RETURN</span> <span class="hljs-keyword">DISTINCT</span> dp.session_id, dp.decision_type, opt.name, opt.score
+<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> opt.score <span class="hljs-keyword">ASC</span>;
+</code></pre>
+<div style="text-align:center; margin: 22px 0">
+<div class="stat">0</div>
+<div class="stat-label">rows returned</div>
+</div>
+<p><strong>The empty result <em>is</em> the audit artifact.</strong> &quot;We ran the human-oversight predicate against the entire portfolio for this period. The trigger never fired.&quot; Tighten to 0.85 → instant new at-risk list, same query.</p>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="17" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -8504,6 +9545,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -8511,7 +9587,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="17" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="17" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -8751,6 +9827,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -8758,55 +9869,34 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="how-fast-can-we-ship-this">How fast can we ship this?</h1>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="q4--q5--reproducibility-and-pattern-audit">Q4 + Q5 — Reproducibility and pattern audit</h1>
 <div class="grid-2">
-<div>
-<h3 id="setup-on-a-clean-gcp-project">Setup, on a clean GCP project</h3>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-built_in">cd</span> examples/decision_lineage_demo
-./setup.sh
+<div class="card">
+<h3 id="q4--subpoena-reproducibility">Q4 — Subpoena reproducibility</h3>
+<div class="pill">Art 12</div> <div class="pill">Art 13</div>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql"><span class="hljs-keyword">MATCH</span> (step:AgentStep)<span class="hljs-operator">-</span>[:DecidedAt]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(dp:PlanningDecision)
+      <span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
+<span class="hljs-keyword">WHERE</span> dp.session_id<span class="hljs-operator">=</span><span class="hljs-string">&#x27;&lt;S&gt;&#x27;</span>
+  <span class="hljs-keyword">AND</span> <span class="hljs-built_in">LOWER</span>(dp.decision_type) <span class="hljs-keyword">LIKE</span> <span class="hljs-string">&#x27;%creative%&#x27;</span>
+  <span class="hljs-keyword">AND</span> step.event_type<span class="hljs-operator">=</span><span class="hljs-string">&#x27;LLM_RESPONSE&#x27;</span>
+<span class="hljs-keyword">RETURN</span> dp.span_id, opt.status, opt.name, opt.score,
+       opt.rejection_rationale;
 </code></pre>
-<table>
-<thead>
-<tr>
-<th>Phase</th>
-<th>Wall time</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Tooling + APIs + venv</td>
-<td>~30s</td>
-</tr>
-<tr>
-<td>Live agent (6 sessions)</td>
-<td>3-7 min</td>
-</tr>
-<tr>
-<td><code>AI.GENERATE</code> extraction</td>
-<td>30-90s</td>
-</tr>
-<tr>
-<td>Rich-graph projection</td>
-<td>~10s</td>
-</tr>
-<tr>
-<td>Render BQ Studio queries</td>
-<td>&lt;1s</td>
-</tr>
-</tbody>
-</table>
+<p>3 rows. All point to one <code>evidence_span_id</code> → that span lives in <code>agent_events</code> with full content + timestamp + latency.</p>
 </div>
-<div>
-<h3 id="cost-per-setup-run">Cost per setup run</h3>
-<ul>
-<li>6 live <code>gemini-2.5-pro</code> invocations</li>
-<li>2 <code>AI.GENERATE</code> extraction queries</li>
-<li>A few hundred BQ rows + one property graph</li>
-</ul>
-<p><strong>Order-of-cents for the verified demo run.</strong> Queries against the prebuilt graph are lightweight.</p>
-<h3 id="from-zero-to-leadership-demo">From zero to leadership demo</h3>
-<p><strong>Under 10 minutes</strong>, fully reproducible, on any GCP project.</p>
+<div class="card">
+<h3 id="q5--systemic-pattern">Q5 — Systemic pattern</h3>
+<div class="pill">Art 17</div> <div class="pill">Art 60</div>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql"><span class="hljs-keyword">MATCH</span> (dp:PlanningDecision)<span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)
+<span class="hljs-keyword">WHERE</span> opt.status<span class="hljs-operator">=</span><span class="hljs-string">&#x27;DROPPED&#x27;</span>
+<span class="hljs-keyword">RETURN</span> dp.decision_type,
+       <span class="hljs-built_in">COUNT</span>(opt) <span class="hljs-keyword">AS</span> rejections,
+       <span class="hljs-built_in">AVG</span>(opt.score) <span class="hljs-keyword">AS</span> avg_dropped_score
+<span class="hljs-keyword">GROUP</span> <span class="hljs-keyword">BY</span> dp.decision_type
+<span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> rejections <span class="hljs-keyword">DESC</span>;
+</code></pre>
+<p><strong>Audience Selection</strong> rejects with the <strong>lowest avg confidence (0.66)</strong> — the category most worth a fairness loop-back to Q2.</p>
 </div>
 </div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
@@ -9051,6 +10141,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -9058,7 +10183,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" class="section-divider" data-marpit-pagination="18" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="section-divider" data-marpit-pagination="18" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -9298,6 +10423,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -9305,8 +10465,8 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9"><div class="eyebrow">Section 4 of 4</div>
-<h1 id="where-to-go-next">Where to go next</h1>
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Part 5 · Technical architecture</div>
+<h1 id="how-the-evidence-is-built--every-step-concrete">How the evidence is built — every step concrete</h1>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="19" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
@@ -9549,6 +10709,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -9556,7 +10751,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="19" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" data-marpit-pagination="19" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -9796,6 +10991,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -9803,7 +11033,7805 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="end-to-end-pipeline">End-to-end pipeline</h1>
+<div class="pipeline">
+<div class="step">
+<div class="step-num">1</div>
+<strong>ADK agent</strong>
+<div class="small">Gemini 2.5 Pro · 5 tools · system prompt requires 3-candidate enumeration</div>
+</div>
+<div class="arrow">▶</div>
+<div class="step">
+<div class="step-num">2</div>
+<strong>BQ AA Plugin</strong>
+<div class="small"><code>InMemoryRunner(plugins=[bq_logging_plugin])</code> → spans land in <code>agent_events</code></div>
+</div>
+<div class="arrow">▶</div>
+<div class="step">
+<div class="step-num">3</div>
+<strong>SDK extraction</strong>
+<div class="small">Two <code>AI.GENERATE</code> calls — biz nodes (MERGE) + decisions (load job)</div>
+</div>
+<div class="arrow">▶</div>
+<div class="step">
+<div class="step-num">4</div>
+<strong>Property graph</strong>
+<div class="small">Canonical 4-pillar + ads-domain rich layer queried via GQL</div>
+</div>
+</div>
+<div class="grid-2" style="margin-top:24px">
+<div class="card">
+<h3 id="what-runs-locally-one-time-setup-5%E2%80%9310-min">What runs locally (one-time setup, ~5–10 min)</h3>
+<p><code>./setup.sh</code> does steps 1-4 end-to-end on a fresh GCP project: enables APIs, creates the dataset, runs the live agent, extracts decisions, emits the property-graph DDL.</p>
+</div>
+<div class="card">
+<h3 id="what-runs-at-audit-time-seconds">What runs at audit time (seconds)</h3>
+<p>Every regulator question is a single GQL query against the property graph. No re-extraction. No agent rerun. <strong>The graph is the audit substrate.</strong></p>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="20" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="dense" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="dense" data-marpit-pagination="20" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:dense;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-1--the-adk-media-planner-agent">Step 1 — The ADK media-planner agent</h1>
+<div class="grid-2">
+<div>
+<h3 id="agentagentpy"><code>agent/agent.py</code></h3>
+<ul>
+<li><code>google.adk.agents.Agent</code> instance</li>
+<li>Model: <strong>Gemini 2.5 Pro</strong> (regional, Vertex AI)</li>
+<li>5 decision-commit tools (one per category)</li>
+<li>BQ AA Plugin attached to <code>InMemoryRunner</code></li>
+</ul>
+<h3 id="agenttoolspy--five-tools"><code>agent/tools.py</code> — five tools</h3>
+<table>
+<thead>
+<tr>
+<th>Tool</th>
+<th>Decision category</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>select_audience</code></td>
+<td>audience selection</td>
+</tr>
+<tr>
+<td><code>allocate_budget</code></td>
+<td>budget allocation</td>
+</tr>
+<tr>
+<td><code>select_creative</code></td>
+<td>creative theme</td>
+</tr>
+<tr>
+<td><code>define_channel_strategy</code></td>
+<td>channel strategy</td>
+</tr>
+<tr>
+<td><code>schedule_launch</code></td>
+<td>launch scheduling</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div>
+<h3 id="agentpromptspy--system-prompt"><code>agent/prompts.py</code> — system prompt</h3>
+<p>The prompt instructs the agent to, for each structured decision:</p>
+<div class="soft-card compact">
+1. Name <strong>three candidate options</strong><br />
+2. Score each on 0.0–1.0 (two decimals)<br />
+3. Mark exactly one <strong>SELECTED</strong>, the other two <strong>DROPPED</strong><br />
+4. Give an <strong>explicit, specific rejection rationale</strong> for each dropped option<br />
+5. End with <code>Decision: …</code> then call the corresponding tool
+</div>
+<div class="small" style="margin-top:10px">
+The prompt structure is the contract that makes downstream extraction reliable. The LLM_RESPONSE text is what <code>AI.GENERATE</code> later parses.
+</div>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="21" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="21" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-2--the-6-campaigns-%C3%97-27-spans">Step 2 — The 6 campaigns × 27 spans</h1>
+<div class="grid-2">
+<div>
+<h3 id="campaignspy--6-briefs"><code>campaigns.py</code> — 6 briefs</h3>
+<table>
+<thead>
+<tr>
+<th>Brand</th>
+<th>Campaign</th>
+<th style="text-align:right">Budget</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Nike</td>
+<td>Summer Run 2026</td>
+<td style="text-align:right">$360K</td>
+</tr>
+<tr>
+<td>Nike</td>
+<td>Winter Trail 2026</td>
+<td style="text-align:right">$500K</td>
+</tr>
+<tr>
+<td>Adidas</td>
+<td>Track Season 2026</td>
+<td style="text-align:right">$420K</td>
+</tr>
+<tr>
+<td>Puma</td>
+<td>Soccer Cup 2026</td>
+<td style="text-align:right">$280K</td>
+</tr>
+<tr>
+<td>Reebok</td>
+<td>CrossFit Open 2026</td>
+<td style="text-align:right">$340K</td>
+</tr>
+<tr>
+<td>Lululemon</td>
+<td>Yoga Flow 2026</td>
+<td style="text-align:right">$250K</td>
+</tr>
+</tbody>
+</table>
+<h3 id="run_agentpy"><code>run_agent.py</code></h3>
+<p>Iterates briefs; one <code>InMemoryRunner</code> invocation per brief; awaits <code>flush()</code> + <code>shutdown()</code> on the plugin so all spans land before extraction starts; writes <code>campaign_runs</code> mapping (deterministic).</p>
+</div>
+<div>
+<h3 id="per-session--27-plugin-recorded-spans">Per session — 27 plugin-recorded spans</h3>
+<table>
+<thead>
+<tr>
+<th>Event type</th>
+<th style="text-align:right">Count</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>INVOCATION_STARTING</code></td>
+<td style="text-align:right">1</td>
+</tr>
+<tr>
+<td><code>AGENT_STARTING</code></td>
+<td style="text-align:right">1</td>
+</tr>
+<tr>
+<td><code>USER_MESSAGE_RECEIVED</code></td>
+<td style="text-align:right">1</td>
+</tr>
+<tr>
+<td><code>LLM_REQUEST</code> / <code>LLM_RESPONSE</code></td>
+<td style="text-align:right">5 + 5</td>
+</tr>
+<tr>
+<td><code>TOOL_STARTING</code> / <code>TOOL_COMPLETED</code></td>
+<td style="text-align:right">5 + 5</td>
+</tr>
+<tr>
+<td><code>HITL_CONFIRMATION_REQUEST</code> / <code>_COMPLETED</code></td>
+<td style="text-align:right">1 + 1</td>
+</tr>
+<tr>
+<td><code>AGENT_COMPLETED</code></td>
+<td style="text-align:right">1</td>
+</tr>
+<tr>
+<td><code>INVOCATION_COMPLETED</code></td>
+<td style="text-align:right">1</td>
+</tr>
+</tbody>
+</table>
+<p><strong>6 sessions × 27 spans = 162 TechNode rows.</strong> Each span carries <code>span_id</code>, <code>parent_span_id</code>, <code>session_id</code>, <code>event_type</code>, <code>agent</code>, <code>timestamp</code>, JSON <code>content</code>, <code>latency_ms</code>.</p>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="22" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="22" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-3a--aigenerate-extraction-biznodes">Step 3a — <code>AI.GENERATE</code> extraction (BizNodes)</h1>
+<p><code>build_graph.py</code> calls <code>mgr.extract_biz_nodes(session_ids)</code> which runs <strong>one MERGE</strong> statement against <code>agent_events</code>. The MERGE's USING clause invokes <code>AI.GENERATE</code> per row:</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql"><span class="hljs-keyword">MERGE</span> `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.extracted_biz_nodes` <span class="hljs-keyword">AS</span> target
+<span class="hljs-keyword">USING</span> (
+  <span class="hljs-keyword">SELECT</span> base.span_id, base.session_id,
+    JSON_EXTRACT_SCALAR(entity, <span class="hljs-string">&#x27;$.entity_type&#x27;</span>)  <span class="hljs-keyword">AS</span> node_type,
+    JSON_EXTRACT_SCALAR(entity, <span class="hljs-string">&#x27;$.entity_value&#x27;</span>) <span class="hljs-keyword">AS</span> node_value,
+    <span class="hljs-built_in">CAST</span>(JSON_EXTRACT_SCALAR(entity, <span class="hljs-string">&#x27;$.confidence&#x27;</span>) <span class="hljs-keyword">AS</span> FLOAT64) <span class="hljs-keyword">AS</span> confidence
+  <span class="hljs-keyword">FROM</span> `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.agent_events` <span class="hljs-keyword">AS</span> base,
+  <span class="hljs-built_in">UNNEST</span>(JSON_EXTRACT_ARRAY(REGEXP_REPLACE(REGEXP_REPLACE(
+    AI.GENERATE(<span class="hljs-string">&#x27;Extract business entities (Product, Audience, Channel, …) from this payload. Return JSON array of {entity_type, entity_value, confidence}.\n\nPayload:\n&#x27;</span> <span class="hljs-operator">||</span> payload_text,
+                endpoint <span class="hljs-operator">=</span><span class="hljs-operator">&gt;</span> <span class="hljs-string">&#x27;gemini-2.5-flash&#x27;</span>).<span class="hljs-keyword">result</span>,
+    r<span class="hljs-string">&#x27;^```(?:json)?\s*&#x27;</span>,<span class="hljs-string">&#x27;&#x27;</span>), r<span class="hljs-string">&#x27;\s*```$&#x27;</span>,<span class="hljs-string">&#x27;&#x27;</span>))) <span class="hljs-keyword">AS</span> entity
+  <span class="hljs-keyword">WHERE</span> base.session_id <span class="hljs-keyword">IN</span> <span class="hljs-built_in">UNNEST</span>(<span class="hljs-variable">@session_ids</span>)
+    <span class="hljs-keyword">AND</span> base.event_type <span class="hljs-keyword">IN</span> (<span class="hljs-string">&#x27;USER_MESSAGE_RECEIVED&#x27;</span>,<span class="hljs-string">&#x27;LLM_RESPONSE&#x27;</span>,<span class="hljs-string">&#x27;TOOL_COMPLETED&#x27;</span>,<span class="hljs-string">&#x27;AGENT_COMPLETED&#x27;</span>)
+) <span class="hljs-keyword">AS</span> source
+<span class="hljs-keyword">ON</span> target.biz_node_id <span class="hljs-operator">=</span> source.biz_node_id
+<span class="hljs-keyword">WHEN</span> MATCHED <span class="hljs-keyword">THEN</span> <span class="hljs-keyword">UPDATE</span> <span class="hljs-keyword">SET</span> …
+<span class="hljs-keyword">WHEN</span> <span class="hljs-keyword">NOT</span> MATCHED <span class="hljs-keyword">BY</span> TARGET <span class="hljs-keyword">THEN</span> <span class="hljs-keyword">INSERT</span> …
+<span class="hljs-keyword">WHEN</span> <span class="hljs-keyword">NOT</span> MATCHED <span class="hljs-keyword">BY</span> SOURCE <span class="hljs-keyword">AND</span> target.session_id <span class="hljs-keyword">IN</span> <span class="hljs-built_in">UNNEST</span>(<span class="hljs-variable">@session_ids</span>) <span class="hljs-keyword">THEN</span> <span class="hljs-keyword">DELETE</span>
+</code></pre>
+<p><strong>Per-session idempotent in one statement.</strong> No streaming-buffer pitfall. <code>MERGE</code> is the SDK's chosen pattern for the BizNode write path.</p>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="23" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="23" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-3b--aigenerate-extraction-decisions--candidates">Step 3b — <code>AI.GENERATE</code> extraction (Decisions + Candidates)</h1>
+<p><code>mgr.extract_decision_points(session_ids)</code> runs a separate <code>AI.GENERATE</code> query whose prompt asks for structured decision data:</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-text">Identify decision points in this agent payload. A decision point is where
+the agent evaluated multiple candidates and selected or rejected them.
+For each decision, return decision_type, description, and all candidates
+with name, score (0-1), status (SELECTED or DROPPED), and rejection_rationale
+(null if selected, required reason if dropped).
+</code></pre>
+<p>The Python side parses each row's JSON, builds <code>DecisionPoint</code> + <code>Candidate</code> records, then <code>store_decision_points(...)</code>:</p>
+<div class="grid-3" style="margin-top:14px">
+<div class="card">
+<div class="step-num">1</div>
+<strong>Dedupe in Python</strong>
+<div class="small"><code>_dedupe_rows_by_key</code> last-wins on <code>decision_id</code> / <code>candidate_id</code></div>
+</div>
+<div class="card">
+<div class="step-num">2</div>
+<strong>DELETE FROM ... WHERE session_id IN (...)</strong>
+<div class="small">Per-session reseat — guards against re-running</div>
+</div>
+<div class="card">
+<div class="step-num">3</div>
+<strong>load_table_from_json</strong>
+<div class="small">Load job to managed storage; visible to the just-issued DELETE (no streaming-buffer trap)</div>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="24" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="24" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-3c--sql-only-edge-derivation">Step 3c — SQL-only edge derivation</h1>
+<p>After the node tables exist, three pure-SQL <code>INSERT INTO</code> statements build the edges (no <code>AI.GENERATE</code>):</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql"><span class="hljs-comment">-- Evaluated edge (BizNode <img class="emoji" draggable="false" alt="↔" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/2194.svg" data-marp-twemoji=""/> TechNode lineage)</span>
+<span class="hljs-keyword">INSERT INTO</span> context_cross_links (link_id, span_id, biz_node_id, link_type, …)
+<span class="hljs-keyword">SELECT</span> b.biz_node_id, b.span_id, b.biz_node_id, <span class="hljs-string">&#x27;EVALUATED&#x27;</span>, …
+<span class="hljs-keyword">FROM</span> extracted_biz_nodes b <span class="hljs-keyword">WHERE</span> b.session_id <span class="hljs-keyword">IN</span> <span class="hljs-built_in">UNNEST</span>(<span class="hljs-variable">@session_ids</span>);
+
+<span class="hljs-comment">-- MadeDecision edge (TechNode → DecisionPoint)</span>
+<span class="hljs-keyword">INSERT INTO</span> made_decision_edges (edge_id, span_id, decision_id, …)
+<span class="hljs-keyword">SELECT</span> CONCAT(span_id, <span class="hljs-string">&#x27;:MADE_DECISION:&#x27;</span>, decision_id), span_id, decision_id, …
+<span class="hljs-keyword">FROM</span> decision_points <span class="hljs-keyword">WHERE</span> session_id <span class="hljs-keyword">IN</span> <span class="hljs-built_in">UNNEST</span>(<span class="hljs-variable">@session_ids</span>);
+
+<span class="hljs-comment">-- CandidateEdge (DecisionPoint → CandidateNode, with edge_type)</span>
+<span class="hljs-keyword">INSERT INTO</span> candidate_edges (edge_id, decision_id, candidate_id, edge_type, …)
+<span class="hljs-keyword">SELECT</span> …, <span class="hljs-keyword">CASE</span> c.status <span class="hljs-keyword">WHEN</span> <span class="hljs-string">&#x27;SELECTED&#x27;</span> <span class="hljs-keyword">THEN</span> <span class="hljs-string">&#x27;SELECTED_CANDIDATE&#x27;</span>
+                        <span class="hljs-keyword">ELSE</span> <span class="hljs-string">&#x27;DROPPED_CANDIDATE&#x27;</span> <span class="hljs-keyword">END</span>, …
+<span class="hljs-keyword">FROM</span> candidates c <span class="hljs-keyword">WHERE</span> c.session_id <span class="hljs-keyword">IN</span> <span class="hljs-built_in">UNNEST</span>(<span class="hljs-variable">@session_ids</span>);
+</code></pre>
+<p>Three tables, one statement each, all per-session-scoped. The <code>edge_type</code> on <code>candidate_edges</code> is what powers Block 4's <code>WHERE ce.edge_type = 'DROPPED_CANDIDATE'</code> filter.</p>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="25" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="dense" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="dense" data-marpit-pagination="25" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:dense;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-4--the-7-sdk-backing-tables">Step 4 — The 7 SDK backing tables</h1>
+<table>
+<thead>
+<tr>
+<th>Table</th>
+<th>Key</th>
+<th>Written by</th>
+<th>What it holds</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>agent_events</code></td>
+<td><code>span_id</code></td>
+<td>BQ AA Plugin</td>
+<td>Plugin-recorded spans (162 rows = 6 sessions × 27 spans)</td>
+</tr>
+<tr>
+<td><code>extracted_biz_nodes</code></td>
+<td><code>biz_node_id</code></td>
+<td>SDK MERGE</td>
+<td>Business entities from trace text</td>
+</tr>
+<tr>
+<td><code>context_cross_links</code></td>
+<td><code>link_id</code></td>
+<td>SDK DML</td>
+<td>Span <img class="emoji" draggable="false" alt="↔" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/2194.svg" data-marp-twemoji=""/> BizNode references</td>
+</tr>
+<tr>
+<td><code>decision_points</code></td>
+<td><code>decision_id</code></td>
+<td>SDK load job</td>
+<td>Extracted decisions from <code>LLM_RESPONSE</code> text</td>
+</tr>
+<tr>
+<td><code>candidates</code></td>
+<td><code>candidate_id</code></td>
+<td>SDK load job</td>
+<td>Extracted options per decision: selected or dropped</td>
+</tr>
+<tr>
+<td><code>made_decision_edges</code></td>
+<td><code>edge_id</code></td>
+<td>SDK DML</td>
+<td>Span → Decision lineage</td>
+</tr>
+<tr>
+<td><code>candidate_edges</code></td>
+<td><code>edge_id</code></td>
+<td>SDK DML</td>
+<td>Decision → Candidate, with selected / dropped edge type</td>
+</tr>
+</tbody>
+</table>
+<p>Every backing table has <code>row_count == distinct_keys</code> after the SDK fix landed in PR #99 — the property-graph KEY contract holds end-to-end.</p>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="26" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="dense" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="dense" data-marpit-pagination="26" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:dense;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-5--the-rich-graph-projection-layer">Step 5 — The rich-graph projection layer</h1>
+<p><code>build_rich_graph.py</code> adds <strong>demo-only</strong> SQL projections so the BigQuery Studio Explorer reads in business language. <strong>No new AI calls</strong> in this step:</p>
+<table>
+<thead>
+<tr>
+<th>Derived table</th>
+<th>Built from</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>campaign_runs</code></td>
+<td><code>run_agent.py</code> writes directly</td>
+<td>One row per agent invocation, joined to campaign metadata in <code>campaigns.py</code></td>
+</tr>
+<tr>
+<td><code>rich_agent_steps</code></td>
+<td><code>agent_events</code> (DISTINCT)</td>
+<td>Deduped span projection — one row per <code>span_id</code> (TechNode is multi-event per span by design)</td>
+</tr>
+<tr>
+<td><code>rich_decision_types</code></td>
+<td><code>decision_points</code></td>
+<td>Normalised decision categories (<code>audience-selection</code>, <code>budget-allocation</code>, …)</td>
+</tr>
+<tr>
+<td><code>rich_candidate_statuses</code></td>
+<td><code>candidates</code></td>
+<td>Distinct <code>OptionOutcome</code> values (SELECTED, DROPPED)</td>
+</tr>
+<tr>
+<td><code>rich_rejection_reasons</code></td>
+<td><code>candidates</code></td>
+<td>Distinct rejection-rationale strings as first-class nodes</td>
+</tr>
+</tbody>
+</table>
+<p>Plus five edge projections wiring the new labels back to SDK-owned facts. Schema lives in <code>rich_property_graph.gql.tpl</code> and is deterministic across reruns.</p>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="27" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="dense" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="dense" data-marpit-pagination="27" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:dense;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-6--the-8-node-labels-what-each-node-means">Step 6 — The 8 node labels (what each node means)</h1>
+<table>
+<thead>
+<tr><th>Label</th><th>Source table</th><th>KEY</th><th>What it represents</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>CampaignRun</strong></td><td>campaign_runs</td><td>session_id</td><td>One agent invocation against one brief — the unit of audit</td></tr>
+<tr><td><strong>AgentStep</strong></td><td>rich_agent_steps</td><td>span_id</td><td>One step the agent took (LLM call, tool invocation, HITL check)</td></tr>
+<tr><td><strong>MediaEntity</strong></td><td>extracted_biz_nodes</td><td>biz_node_id</td><td>An audience, channel, creative, budget unit, or campaign — extracted from trace text</td></tr>
+<tr><td><strong>PlanningDecision</strong></td><td>decision_points</td><td>decision_id</td><td>A moment the agent committed to a choice between options</td></tr>
+<tr><td><strong>DecisionOption</strong></td><td>candidates</td><td>candidate_id</td><td>One option weighed at a planning decision (selected or dropped)</td></tr>
+<tr><td><strong>DecisionCategory</strong></td><td>rich_decision_types</td><td>decision_type_id</td><td>Normalised decision category (audience selection, budget allocation, …)</td></tr>
+<tr><td><strong>OptionOutcome</strong></td><td>rich_candidate_statuses</td><td>status_id</td><td>SELECTED or DROPPED — the outcome of weighing</td></tr>
+<tr><td><strong>DropReason</strong></td><td>rich_rejection_reasons</td><td>reason_id</td><td>A distinct rejection rationale (deduplicated across the portfolio)</td></tr>
+</tbody>
+</table>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="28" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="28" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-7--the-9-edge-labels-how-the-graph-connects">Step 7 — The 9 edge labels (how the graph connects)</h1>
+<table>
+<thead>
+<tr><th>Edge label</th><th>Source → Destination</th><th>Reads as</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>CampaignActivity</strong></td><td>CampaignRun → AgentStep</td><td>"this run produced this step"</td></tr>
+<tr><td><strong>NextStep</strong></td><td>AgentStep → AgentStep (parent_span_id → span_id)</td><td>"this step caused that step" (causal chain)</td></tr>
+<tr><td><strong>ConsideredEntity</strong></td><td>AgentStep → MediaEntity</td><td>"this step touched this entity"</td></tr>
+<tr><td><strong>DecidedAt</strong></td><td>AgentStep → PlanningDecision</td><td>"this step is where the decision committed"</td></tr>
+<tr><td><strong>CampaignDecision</strong></td><td>CampaignRun → PlanningDecision</td><td>"this run made this decision"</td></tr>
+<tr><td><strong>InCategory</strong></td><td>PlanningDecision → DecisionCategory</td><td>"this decision is an audience-selection / budget-allocation / …"</td></tr>
+<tr><td><strong>WeighedOption</strong></td><td>PlanningDecision → DecisionOption</td><td>"this decision considered this option"</td></tr>
+<tr><td><strong>HasOutcome</strong></td><td>DecisionOption → OptionOutcome</td><td>"this option was selected / dropped"</td></tr>
+<tr><td><strong>RejectedBecause</strong></td><td>DecisionOption → DropReason</td><td>"this option was dropped for this reason"</td></tr>
+</tbody>
+</table>
+<div class="small" style="margin-top:10px">
+Read top to bottom in plain English: <em>"this run produced this step → which decided at this planning decision → which weighed this option → which has this outcome → which was rejected because of this reason."</em> Five edges, one query, full audit trail.
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="29" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="29" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-8--how-a-gql-query-actually-traverses">Step 8 — How a GQL query actually traverses</h1>
+<p>The visualization GQL (the demo's Block 2):</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-sql">GRAPH `<span class="hljs-operator">&lt;</span>P<span class="hljs-operator">&gt;</span>.<span class="hljs-operator">&lt;</span>D<span class="hljs-operator">&gt;</span>.rich_agent_context_graph`
+<span class="hljs-keyword">MATCH</span> p <span class="hljs-operator">=</span> (cr:CampaignRun)<span class="hljs-operator">-</span>[:CampaignDecision]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(dp:PlanningDecision)
+          <span class="hljs-operator">-</span>[:WeighedOption]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(opt:DecisionOption)<span class="hljs-operator">-</span>[:HasOutcome]<span class="hljs-operator">-</span><span class="hljs-operator">&gt;</span>(st:OptionOutcome)
+<span class="hljs-keyword">WHERE</span> cr.session_id <span class="hljs-operator">=</span> <span class="hljs-string">&#x27;&lt;SESSION&gt;&#x27;</span>
+<span class="hljs-keyword">RETURN</span> p;
+</code></pre>
+<p>What BigQuery does, table by table:</p>
+<ol class="compact">
+<li><code>campaign_runs</code> → bind <code>cr</code>, filtered by <code>session_id</code> (1 row).</li>
+<li><code>rich_campaign_decision_edges</code> → join to <code>decision_points</code> on <code>session_id</code> (~5 decisions per session).</li>
+<li><code>candidate_edges</code> → join to <code>candidates</code> on <code>decision_id</code> (~3 options per decision).</li>
+<li><code>rich_candidate_status_edges</code> → join to <code>rich_candidate_statuses</code> on <code>status</code> (1 row per option).</li>
+<li>Return paths bound to <code>p</code>. <strong>BigQuery Studio renders these as one fan-out per decision in the Graph tab.</strong></li>
+</ol>
+<p><strong>5 fan-outs of 3 options each = 15 paths visualized for one session, ~97 paths across all 6 campaigns.</strong> The traversal is deterministic, the rendering is interactive.</p>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="30" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="30" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
+<h1 id="step-9--the-temporal-dimension">Step 9 — The temporal dimension</h1>
+<div class="grid-2">
+<div class="card">
+<h3 id="whats-timestamped">What's timestamped</h3>
+<ul>
+<li><code>agent_events.timestamp</code> — when each plugin-recorded span happened (microsecond precision)</li>
+<li><code>agent_events.latency_ms</code> — <code>{total_ms, time_to_first_token_ms}</code></li>
+<li><code>context_cross_links.created_at</code> — when cross-links were derived</li>
+<li><code>candidate_edges.created_at</code> — when decision edges were derived</li>
+<li><code>decision_points.span_id</code> → traces back to the source span's timestamp</li>
+</ul>
+</div>
+<div class="card">
+<h3 id="what-you-can-ask-over-time">What you can ask over time</h3>
+<ul>
+<li><em>&quot;Across the last 30 days, which decision categories saw rising rejection rates?&quot;</em></li>
+<li><em>&quot;Show me the per-day count of decisions made with confidence &lt; 0.7.&quot;</em> (oversight trend)</li>
+<li><em>&quot;Compare this quarter's rejection-rationale distribution vs last quarter's.&quot;</em> (drift)</li>
+<li><em>&quot;Latency p50/p95 for LLM_RESPONSE spans on the audience-selection decision over the past week.&quot;</em></li>
+</ul>
+<p>Each query is a join of <code>made_decision_edges</code> ⋈ <code>agent_events</code> plus a <code>WHERE timestamp BETWEEN ...</code> filter — no schema changes needed.</p>
+</div>
+</div>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="31" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="section-divider" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" class="section-divider" data-marpit-pagination="31" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:section-divider;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9"><div class="eyebrow">Close</div>
+<h1 id="where-to-start">Where to start</h1>
+<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="32" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+" lang="C" data-marpit-pagination="32" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+section {
+  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
+  font-size: 27px;
+  line-height: 1.35;
+  padding: 56px 64px;
+  letter-spacing: 0;
+}
+section.hero {
+  background-color: #174ea6 !important;
+  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
+  color: #ffffff;
+  text-align: left;
+}
+section.hero h1 {
+  font-size: 66px;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  color: #ffffff;
+  border: none;
+}
+section.hero h2 {
+  font-size: 29px;
+  font-weight: 400;
+  color: rgba(255,255,255,0.85);
+  border: none;
+  max-width: 920px;
+}
+section.hero .footer-note {
+  font-size: 18px;
+  color: rgba(255,255,255,0.7);
+  margin-top: 48px;
+}
+section h1 {
+  color: #1a73e8;
+  border-bottom: 2px solid #e8eaed;
+  padding-bottom: 8px;
+  font-size: 38px;
+}
+section h2 {
+  color: #202124;
+  font-size: 26px;
+  margin-top: 0;
+}
+section h3 {
+  color: #1a73e8;
+  font-size: 22px;
+  margin-bottom: 4px;
+}
+section.section-divider {
+  background:
+    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
+}
+section.section-divider h1 {
+  color: #1a73e8;
+  border: none;
+  font-size: 56px;
+}
+section.section-divider .eyebrow {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+.kicker {
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+code {
+  background: #f1f3f4;
+  color: #202124;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}
+pre {
+  background: #202124;
+  color: #e8eaed;
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 18px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+pre code { background: transparent; color: inherit; padding: 0; }
+table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 22px;
+}
+th {
+  background: #1a73e8;
+  color: #ffffff;
+  padding: 10px 14px;
+  text-align: left;
+}
+td {
+  border-bottom: 1px solid #e8eaed;
+  padding: 8px 14px;
+}
+blockquote {
+  border-left: 4px solid #1a73e8;
+  background: #e8f0fe;
+  color: #174ea6;
+  padding: 14px 22px;
+  margin: 12px 0;
+  font-style: normal;
+  font-size: 24px;
+}
+.pill {
+  display: inline-block;
+  background: #e8f0fe;
+  color: #1a73e8;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 17px;
+  margin-right: 6px;
+  font-weight: 600;
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+.compact {
+  font-size: 23px;
+  line-height: 1.28;
+}
+.compact li {
+  margin: 4px 0;
+}
+.card {
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  padding: 20px 22px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
+}
+.card h3 {
+  margin-top: 0;
+}
+.soft-card {
+  border-radius: 8px;
+  padding: 18px 22px;
+  background: #f8fafd;
+  border: 1px solid #d2e3fc;
+}
+.pipeline {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+}
+.pipeline .step {
+  border-radius: 8px;
+  padding: 18px 16px;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  min-height: 126px;
+}
+.pipeline .arrow {
+  color: #1a73e8;
+  font-size: 34px;
+  text-align: center;
+}
+.step-num {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 18px 0;
+}
+.mini-stat {
+  border-left: 5px solid #1a73e8;
+  background: #f8fafd;
+  padding: 14px 18px;
+  border-radius: 6px;
+}
+.mini-stat strong {
+  display: block;
+  color: #202124;
+  font-size: 32px;
+  line-height: 1.1;
+}
+.mini-stat span {
+  color: #5f6368;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.stat {
+  font-size: 64px;
+  color: #1a73e8;
+  font-weight: 700;
+  line-height: 1;
+}
+.stat-label {
+  color: #5f6368;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.source-line {
+  color: #5f6368;
+  font-size: 14px;
+  margin-top: 14px;
+}
+.small {
+  color: #5f6368;
+  font-size: 20px;
+}
+.accent-blue { color: #1a73e8; }
+.accent-green { color: #188038; }
+.accent-yellow { color: #b06000; }
+.accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
+footer {
+  color: #5f6368;
+  font-size: 14px;
+}
+section.hero footer {
+  color: rgba(255,255,255,0.70);
+}
+;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="33" data-size="16:9">
 <h1 id="open-source--try-it-on-your-project">Open source — try it on your project</h1>
 <div class="grid-2">
 <div>
@@ -9811,21 +18839,25 @@ section.hero footer {
 <p><a href="https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"><code>GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK</code></a></p>
 <h3 id="the-demo-bundle">The demo bundle</h3>
 <p><code>examples/decision_lineage_demo/</code></p>
-<h3 id="what-ships-in-the-bundle">What ships in the bundle</h3>
+<h3 id="one-shot-setup-5%E2%80%9310-min">One-shot setup (5–10 min)</h3>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-built_in">cd</span> examples/decision_lineage_demo
+./setup.sh
+</code></pre>
+<h3 id="what-ships">What ships</h3>
 <ul>
-<li><code>setup.sh</code> / <code>reset.sh</code> — one-shot bootstrap + tear-down</li>
+<li><code>setup.sh</code> / <code>reset.sh</code> — bootstrap + tear-down</li>
 <li><code>agent/</code> + <code>campaigns.py</code> — real ADK agent + 6 briefs</li>
 <li><code>run_agent.py</code> + <code>build_graph.py</code> + <code>build_rich_graph.py</code></li>
-<li><code>bq_studio_queries.gql</code> (rendered) — six GQL blocks</li>
-<li><code>property_graph.gql</code> (rendered) — recreate-from-tables DDL</li>
+<li><code>bq_studio_queries.gql</code> — six paste-and-run GQL blocks</li>
+<li><code>property_graph.gql</code> + <code>rich_property_graph.gql</code> — DDL templates</li>
 </ul>
 </div>
 <div>
-<h3 id="documentation">Documentation</h3>
+<h3 id="documentation-that-ships-with-the-bundle">Documentation that ships with the bundle</h3>
 <ul>
 <li><a href="README.md"><code>README.md</code></a> — orientation</li>
 <li><a href="SETUP_NEW_PROJECT.md"><code>SETUP_NEW_PROJECT.md</code></a> — clean-project reproduction</li>
-<li><a href="DEMO_NARRATION.md"><code>DEMO_NARRATION.md</code></a> — 5-min leadership talk track</li>
+<li><a href="DEMO_NARRATION.md"><code>DEMO_NARRATION.md</code></a> — 5-min talk track</li>
 <li><a href="BQ_STUDIO_WALKTHROUGH.md"><code>BQ_STUDIO_WALKTHROUGH.md</code></a> — click-by-click in BQ Studio</li>
 <li><a href="DEMO_QUESTIONS.md"><code>DEMO_QUESTIONS.md</code></a> — the 5 EU questions with verified GQL</li>
 <li><a href="DATA_LINEAGE.md"><code>DATA_LINEAGE.md</code></a> — how the 7 tables produce the graph</li>
@@ -9837,7 +18869,7 @@ section.hero footer {
 </div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="20" data-paginate="true" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="33" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="hero" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -10077,6 +19109,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
+section.dense {
+  font-size: 22px;
+  padding: 44px 54px;
+}
+section.dense h1 {
+  font-size: 34px;
+  margin-bottom: 8px;
+}
+section.dense h2 {
+  font-size: 22px;
+}
+section.dense h3 {
+  font-size: 18px;
+}
+section.dense table {
+  font-size: 17px;
+  margin: 8px 0;
+}
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
+}
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+section.dense .small {
+  font-size: 16px;
+}
+section.dense .compact {
+  font-size: 18px;
+}
+section.dense footer {
+  display: none;
+}
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -10084,7 +19151,7 @@ footer {
 section.hero footer {
   color: rgba(255,255,255,0.70);
 }
-" lang="en-US" data-marpit-pagination="20" style="--paginate:true;--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
+" lang="C" class="hero" style="--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:hero;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
 section {
   font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
   font-size: 27px;
@@ -10324,538 +19391,41 @@ blockquote {
 .accent-green { color: #188038; }
 .accent-yellow { color: #b06000; }
 .accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-;color:#202124;background-color:#ffffff;background-image:none;" data-marpit-pagination-total="21" data-size="16:9">
-<h1 id="anticipated-questions">Anticipated questions</h1>
-<table>
-<thead>
-<tr>
-<th>Q</th>
-<th>Short answer</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>How long to deploy?</strong></td>
-<td>Plugin integration, SDK call, committed DDL. <strong>Days, not quarters</strong>, for a pilot.</td>
-</tr>
-<tr>
-<td><strong>Other agents we haven't instrumented?</strong></td>
-<td>Same plugin, same plug-in point. Schema doesn't care which agent wrote the spans.</td>
-</tr>
-<tr>
-<td><strong>Cost?</strong></td>
-<td>Two <code>AI.GENERATE</code> calls per build + standard BQ query cost. <strong>Order-of-cents for this verified demo run.</strong></td>
-</tr>
-<tr>
-<td><strong>What if <code>AI.GENERATE</code> misses a decision?</strong></td>
-<td>Build script reports per-session counts. Re-run extraction without re-running the agent. Talk track is count-agnostic by design.</td>
-</tr>
-<tr>
-<td><strong>Does this expose PII?</strong></td>
-<td>Stores trace-derived rationale text. PII handling follows the existing <code>agent_events</code> retention and access policy.</td>
-</tr>
-<tr>
-<td><strong>Who operates this?</strong></td>
-<td>The team that owns the agent platform. Plugin write path + SDK read path both already on-call.</td>
-</tr>
-</tbody>
-</table>
-<footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
-</section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="21" data-background-color="#ffffff" data-color="#202124" data-footer="Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo" data-class="hero" data-theme="gaia" data-style="/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
+section.dense {
   font-size: 22px;
-  margin-bottom: 4px;
+  padding: 44px 54px;
 }
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 22px;
-}
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
-}
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
-  font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
-}
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
-}
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
-}
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
+section.dense h1 {
   font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
-  font-size: 16px;
-  font-weight: 700;
   margin-bottom: 8px;
 }
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
-  font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-}
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
-}
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
-footer {
-  color: #5f6368;
-  font-size: 14px;
-}
-section.hero footer {
-  color: rgba(255,255,255,0.70);
-}
-" lang="en-US" class="hero" style="--background-color:#ffffff;--color:#202124;--footer:Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo;--class:hero;--theme:gaia;--style:/* Google-style typography, presentation rhythm, and executive-ready components. */
-section {
-  font-family: &quot;Google Sans&quot;, &quot;Roboto&quot;, -apple-system, &quot;Segoe UI&quot;, sans-serif;
-  font-size: 27px;
-  line-height: 1.35;
-  padding: 56px 64px;
-  letter-spacing: 0;
-}
-section.hero {
-  background-color: #174ea6 !important;
-  background-image: linear-gradient(135deg, #1a73e8 0%, #174ea6 58%, #202124 100%) !important;
-  color: #ffffff;
-  text-align: left;
-}
-section.hero h1 {
-  font-size: 66px;
-  line-height: 1.1;
-  margin-bottom: 16px;
-  color: #ffffff;
-  border: none;
-}
-section.hero h2 {
-  font-size: 29px;
-  font-weight: 400;
-  color: rgba(255,255,255,0.85);
-  border: none;
-  max-width: 920px;
-}
-section.hero .footer-note {
-  font-size: 18px;
-  color: rgba(255,255,255,0.7);
-  margin-top: 48px;
-}
-section h1 {
-  color: #1a73e8;
-  border-bottom: 2px solid #e8eaed;
-  padding-bottom: 8px;
-  font-size: 38px;
-}
-section h2 {
-  color: #202124;
-  font-size: 26px;
-  margin-top: 0;
-}
-section h3 {
-  color: #1a73e8;
-  font-size: 22px;
-  margin-bottom: 4px;
-}
-section.section-divider {
-  background:
-    linear-gradient(90deg, #f8fafd 0%, #ffffff 72%);
-}
-section.section-divider h1 {
-  color: #1a73e8;
-  border: none;
-  font-size: 56px;
-}
-section.section-divider .eyebrow {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 16px;
-  margin-bottom: 16px;
-}
-.kicker {
-  color: #5f6368;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-code {
-  background: #f1f3f4;
-  color: #202124;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 0.9em;
-}
-pre {
-  background: #202124;
-  color: #e8eaed;
-  border-radius: 8px;
-  padding: 18px 22px;
-  font-size: 18px;
-  line-height: 1.4;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-}
-pre code { background: transparent; color: inherit; padding: 0; }
-table {
-  border-collapse: collapse;
-  margin: 12px 0;
+section.dense h2 {
   font-size: 22px;
 }
-th {
-  background: #1a73e8;
-  color: #ffffff;
-  padding: 10px 14px;
-  text-align: left;
+section.dense h3 {
+  font-size: 18px;
 }
-td {
-  border-bottom: 1px solid #e8eaed;
-  padding: 8px 14px;
-}
-blockquote {
-  border-left: 4px solid #1a73e8;
-  background: #e8f0fe;
-  color: #174ea6;
-  padding: 14px 22px;
-  margin: 12px 0;
-  font-style: normal;
-  font-size: 24px;
-}
-.pill {
-  display: inline-block;
-  background: #e8f0fe;
-  color: #1a73e8;
-  border-radius: 999px;
-  padding: 4px 14px;
+section.dense table {
   font-size: 17px;
-  margin-right: 6px;
-  font-weight: 600;
+  margin: 8px 0;
 }
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
+section.dense th,
+section.dense td {
+  padding: 5px 8px;
 }
-.grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  align-items: stretch;
+section.dense pre {
+  font-size: 12px;
+  padding: 12px 14px;
 }
-.compact {
-  font-size: 23px;
-  line-height: 1.28;
-}
-.compact li {
-  margin: 4px 0;
-}
-.card {
-  border: 1px solid #dadce0;
-  border-radius: 8px;
-  padding: 20px 22px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(60,64,67,0.10);
-}
-.card h3 {
-  margin-top: 0;
-}
-.soft-card {
-  border-radius: 8px;
-  padding: 18px 22px;
-  background: #f8fafd;
-  border: 1px solid #d2e3fc;
-}
-.pipeline {
-  display: grid;
-  grid-template-columns: 1fr 40px 1fr 40px 1fr 40px 1fr;
-  align-items: center;
-  gap: 10px;
-  margin-top: 22px;
-}
-.pipeline .step {
-  border-radius: 8px;
-  padding: 18px 16px;
-  background: #ffffff;
-  border: 1px solid #dadce0;
-  min-height: 126px;
-}
-.pipeline .arrow {
-  color: #1a73e8;
-  font-size: 34px;
-  text-align: center;
-}
-.step-num {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #1a73e8;
-  color: #ffffff;
+section.dense .small {
   font-size: 16px;
-  font-weight: 700;
-  margin-bottom: 8px;
 }
-.metric-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 18px 0;
-}
-.mini-stat {
-  border-left: 5px solid #1a73e8;
-  background: #f8fafd;
-  padding: 14px 18px;
-  border-radius: 6px;
-}
-.mini-stat strong {
-  display: block;
-  color: #202124;
-  font-size: 32px;
-  line-height: 1.1;
-}
-.mini-stat span {
-  color: #5f6368;
-  font-size: 15px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.stat {
-  font-size: 64px;
-  color: #1a73e8;
-  font-weight: 700;
-  line-height: 1;
-}
-.stat-label {
-  color: #5f6368;
+section.dense .compact {
   font-size: 18px;
-  text-transform: uppercase;
-  letter-spacing: 2px;
 }
-.source-line {
-  color: #5f6368;
-  font-size: 14px;
-  margin-top: 14px;
+section.dense footer {
+  display: none;
 }
-.small {
-  color: #5f6368;
-  font-size: 20px;
-}
-.accent-blue { color: #1a73e8; }
-.accent-green { color: #188038; }
-.accent-yellow { color: #b06000; }
-.accent-red { color: #d93025; }
 footer {
   color: #5f6368;
   font-size: 14px;
@@ -10865,7 +19435,7 @@ section.hero footer {
 }
 ;color:#202124;background-color:#ffffff;background-image:none;" data-size="16:9">
 <h1 id="qa">Q&amp;A</h1>
-<h2 id="from-agent-behavior-to-auditable-evidence">From agent behavior to auditable evidence</h2>
+<h2 id="decision-lineage-with-bigquery-context-graphs">Decision Lineage with BigQuery Context Graphs</h2>
 <div class="footer-note">
 Open source · Apache 2.0 · github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
 <br />
@@ -10894,16 +19464,12 @@ After editing this file, regenerate both with:
 
 (or `marp SLIDES.md --html --pptx` if you have Marp installed
 globally via `npm install -g @marp-team/marp-cli`).</p><p>SPEAKER NOTE — 30s
-Open with business pressure, not fear. The point is not &quot;this certifies
-compliance&quot;; the point is &quot;we can now show our work with data.&quot;</p></div><div class="bespoke-marp-note" data-index="1" tabindex="0"><p>Source: https://ai-act-service-desk.ec.europa.eu/en/ai-act/eu-ai-act-implementation-timeline
-Article 99: 7% applies to prohibited practices; 3% applies to many
-non-Article-5 obligations. Keep the wording precise.</p></div><div class="bespoke-marp-note" data-index="4" tabindex="0"><p>Talk track: real diversity — different brand, audience, budget, season.
-If live extraction changes, keep the exact counts in the metric row aligned
-with the latest verified dataset or switch them to approximate language.</p></div><div class="bespoke-marp-note" data-index="6" tabindex="0"><p>Explorer vocabulary in the graph pane:
-CampaignRun, AgentStep, MediaEntity, PlanningDecision, DecisionOption,
-DecisionCategory, OptionOutcome, DropReason; edges CampaignActivity,
-NextStep, DecidedAt, ConsideredEntity, CampaignDecision, WeighedOption,
-HasOutcome, RejectedBecause, InCategory.</p></div><div class="bespoke-marp-note" data-index="20" tabindex="0"><p>Wrap with: &quot;Three things to take with you. (1) Compliance posture as
-a query. (2) The schema generalizes. (3) Composes with what we run.
-Open for questions.&quot;</p></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
+Open with business pressure, not fear. Frame: AI agents are no longer
+just doing tasks (Systems of Action) — regulators now require we can
+prove what they did and why (Systems of Governance). The deck walks
+that line, top to bottom.</p></div><div class="bespoke-marp-note" data-index="32" tabindex="0"><p>SPEAKER NOTE — close
+&quot;Three takeaways: (1) AI Act fines are real and the trigger date is
+near. (2) Decision Lineage is the audit substrate the regulator asks
+for, not a compliance certification. (3) The technical pipeline is
+open-source and runs on infrastructure you already pay for. Thanks.&quot;</p></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
 !function(){"use strict";function e(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var t,n,r=(n||(n=1,t={from:function(e,t){var n,r=1===(e.parent||e).nodeType?e.parent||e:document.querySelector(e.parent||e),o=[].filter.call("string"==typeof e.slides?r.querySelectorAll(e.slides):e.slides||r.children,function(e){return"SCRIPT"!==e.nodeName}),i={},a=function(e,t){return(t=t||{}).index=o.indexOf(e),t.slide=e,t},s=function(e,t){i[e]=(i[e]||[]).filter(function(e){return e!==t})},l=function(e,t){return(i[e]||[]).reduce(function(e,n){return e&&!1!==n(t)},!0)},c=function(e,t){o[e]&&(n&&l("deactivate",a(n,t)),n=o[e],l("activate",a(n,t)))},d=function(e,t){var r=o.indexOf(n)+e;l(e>0?"next":"prev",a(n,t))&&c(r,t)},u={off:s,on:function(e,t){return(i[e]||(i[e]=[])).push(t),s.bind(null,e,t)},fire:l,slide:function(e,t){if(!arguments.length)return o.indexOf(n);l("slide",a(o[e],t))&&c(e,t)},next:d.bind(null,1),prev:d.bind(null,-1),parent:r,slides:o,destroy:function(e){l("destroy",a(n,e)),i={}}};return(t||[]).forEach(function(e){e(u)}),n||c(0),u}}),t),o=e(r);const i=document.body,a=(...e)=>history.replaceState(...e),s="",l="presenter",c="next",d="overview",u=["",l,d,c],f="bespoke-marp-",m=`data-${f}`,g=(e,{protocol:t,host:n,pathname:r,hash:o}=location)=>{const i=e.toString();return`${t}//${n}${r}${i?"?":""}${i}${o}`},p=()=>i.dataset.bespokeView,v=e=>new URLSearchParams(location.search).get(e),h=(e,t={})=>{const n={location,setter:a,...t},r=new URLSearchParams(n.location.search);for(const t of Object.keys(e)){const n=e[t];"string"==typeof n?r.set(t,n):r.delete(t)}try{n.setter({...window.history.state??{}},"",g(r,n.location))}catch(e){console.error(e)}},w=(()=>{const e="bespoke-marp";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch{return!1}})(),y=e=>{try{return localStorage.getItem(e)}catch{return null}},b=(e,t)=>{try{return localStorage.setItem(e,t),!0}catch{return!1}},k=e=>{try{return localStorage.removeItem(e),!0}catch{return!1}},x=(e,t)=>{const n="aria-hidden";t?e.setAttribute(n,"true"):e.removeAttribute(n)},E=e=>{e.parent.classList.add(`${f}parent`),e.slides.forEach(e=>e.classList.add(`${f}slide`)),e.on("activate",t=>{const n=`${f}active`,r=t.slide,o=r.classList,i=!o.contains(n);if(e.slides.forEach(e=>{e.classList.remove(n),x(e,!0)}),o.add(n),x(r,!1),i){const e=`${n}-ready`;o.add(e),document.body.clientHeight,o.remove(e)}})},$=e=>{let t=0,n=0;Object.defineProperty(e,"fragments",{enumerable:!0,value:e.slides.map(e=>[null,...e.querySelectorAll("[data-marpit-fragment]")])});const r=r=>void 0!==e.fragments[t][n+r],o=(r,o)=>{t=r,n=o,e.fragments.forEach((e,t)=>{e.forEach((e,n)=>{if(null==e)return;const i=t<r||t===r&&n<=o;e.setAttribute(`${m}fragment`,(i?"":"in")+"active");const a=`${m}current-fragment`;t===r&&n===o?e.setAttribute(a,"current"):e.removeAttribute(a)})}),e.fragmentIndex=o;const i={slide:e.slides[r],index:r,fragments:e.fragments[r],fragmentIndex:o};e.fire("fragment",i)};e.on("next",({fragment:i=!0})=>{if(i){if(r(1))return o(t,n+1),!1;const i=t+1;e.fragments[i]&&o(i,0)}else{const r=e.fragments[t].length;if(n+1<r)return o(t,r-1),!1;const i=e.fragments[t+1];i&&o(t+1,i.length-1)}}),e.on("prev",({fragment:i=!0})=>{if(r(-1)&&i)return o(t,n-1),!1;const a=t-1;e.fragments[a]&&o(a,e.fragments[a].length-1)}),e.on("slide",({index:t,fragment:n})=>{let r=0;if(void 0!==n){const o=e.fragments[t];if(o){const{length:e}=o;r=-1===n?e-1:Math.min(Math.max(n,0),e-1)}}o(t,r)}),o(0,0)},L=document,S=()=>!(!L.fullscreenEnabled&&!L.webkitFullscreenEnabled),P=()=>!(!L.fullscreenElement&&!L.webkitFullscreenElement),_=e=>{e.fullscreen=()=>{S()&&(async()=>{P()?(L.exitFullscreen||L.webkitExitFullscreen)?.call(L):((e=L.body)=>{(e.requestFullscreen||e.webkitRequestFullscreen)?.call(e)})()})()},document.addEventListener("keydown",t=>{"f"!==t.key&&"F11"!==t.key||t.altKey||t.ctrlKey||t.metaKey||!S()||(e.fullscreen(),t.preventDefault())})},O=`${f}inactive`,T=(e=2e3)=>({parent:t,fire:n})=>{const r=t.classList,o=e=>n(`marp-${e?"":"in"}active`);let i;const a=()=>{i&&clearTimeout(i),i=setTimeout(()=>{r.add(O),o()},e),r.contains(O)&&(r.remove(O),o(!0))};for(const e of["mousedown","mousemove","touchend"])document.addEventListener(e,a);setTimeout(a,0)},I=["AUDIO","BUTTON","INPUT","SELECT","TEXTAREA","VIDEO"],M=e=>{e.parent.addEventListener("keydown",e=>{if(!e.target)return;const t=e.target;(I.includes(t.nodeName)||"true"===t.contentEditable)&&e.stopPropagation()})},A=e=>{window.addEventListener("load",()=>{for(const t of e.slides){const e=t.querySelector("marp-auto-scaling, [data-auto-scaling], [data-marp-fitting]");t.setAttribute(`${m}load`,e?"":"hideable")}})},C=({interval:e=250}={})=>t=>{document.addEventListener("keydown",e=>{if(" "===e.key&&e.shiftKey)t.prev();else if("ArrowLeft"===e.key||"ArrowUp"===e.key||"PageUp"===e.key)t.prev({fragment:!e.shiftKey});else if(" "!==e.key||e.shiftKey)if("ArrowRight"===e.key||"ArrowDown"===e.key||"PageDown"===e.key)t.next({fragment:!e.shiftKey});else if("End"===e.key)t.slide(t.slides.length-1,{fragment:-1});else{if("Home"!==e.key)return;t.slide(0)}else t.next();e.preventDefault()});let n,r,o=0;t.parent.addEventListener("wheel",i=>{let a=!1;const s=(e,t)=>{e&&(a=a||((e,t)=>((e,t)=>{const n="X"===t?"Width":"Height";return e[`client${n}`]<e[`scroll${n}`]})(e,t)&&((e,t)=>{const{overflow:n}=e,r=e[`overflow${t}`];return"auto"===n||"scroll"===n||"auto"===r||"scroll"===r})(getComputedStyle(e),t))(e,t)),e?.parentElement&&s(e.parentElement,t)};if(0!==i.deltaX&&s(i.target,"X"),0!==i.deltaY&&s(i.target,"Y"),a)return;i.preventDefault();const l=Math.sqrt(i.deltaX**2+i.deltaY**2);if(void 0!==i.wheelDelta){if(void 0===i.webkitForce&&Math.abs(i.wheelDelta)<40)return;if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<4)return}else if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<12)return;r&&clearTimeout(r),r=setTimeout(()=>{n=0},e);const c=Date.now()-o<e,d=l<=n;if(n=l,c||d)return;let u;(i.deltaX>0||i.deltaY>0)&&(u="next"),(i.deltaX<0||i.deltaY<0)&&(u="prev"),u&&(t[u](),o=Date.now())})},D=(e=`.${f}osc`)=>{const t=document.querySelector(e);if(!t)return()=>{};const n=(e,n)=>{t.querySelectorAll(`[${m}osc=${JSON.stringify(e)}]`).forEach(n)};if(S()||n("fullscreen",e=>e.style.display="none"),!w){const e=(e,t)=>{e.disabled=!0,e.title=`${t} is disabled due to restricted localStorage.`};n("presenter",t=>e(t,"Presenter view")),n("overview",t=>e(t,"Overview view"))}return e=>{t.addEventListener("click",t=>{if(t.target instanceof HTMLElement){const{bespokeMarpOsc:n}=t.target.dataset;n&&t.target.blur();const r={fragment:!t.shiftKey};"next"===n?e.next(r):"prev"===n?e.prev(r):"fullscreen"===n?e?.fullscreen():"presenter"===n?e.openPresenterView():"overview"===n&&e.toggleOverviewView()}}),e.parent.appendChild(t),e.on("activate",({index:t})=>{n("page",n=>n.textContent=`Page ${t+1} of ${e.slides.length}`)}),e.on("fragment",({index:t,fragments:r,fragmentIndex:o})=>{n("prev",e=>e.disabled=0===t&&0===o),n("next",n=>n.disabled=t===e.slides.length-1&&o===r.length-1)}),e.on("marp-active",()=>x(t,!1)),e.on("marp-inactive",()=>x(t,!0)),S()&&(e=>{for(const t of["","webkit"])L.addEventListener(t+"fullscreenchange",e)})(()=>n("fullscreen",e=>e.classList.toggle("exit",S()&&P())))}},N=e=>{if(e.syncKey&&"string"==typeof e.syncKey)return!0;throw new Error("The current instance of Bespoke.js is incompatible with Marp bespoke sync plugin.")},B=(e={})=>{const t=e.key||window.history.state?.marpBespokeSyncKey||Math.random().toString(36).slice(2),n=`bespoke-marp-sync-${t}`;var r;r={marpBespokeSyncKey:t},h({},{setter:(e,...t)=>a({...e,...r},...t)});const o=()=>{const e=y(n);return e?JSON.parse(e):Object.create(null)},i=e=>{const t=o(),r={...t,...e(t)};return b(n,JSON.stringify(r)),r},s=()=>{window.removeEventListener("pageshow",s),i(e=>({reference:(e.reference||0)+1}))};return e=>{s(),Object.defineProperty(e,"syncKey",{value:t,enumerable:!0});let r=!0;setTimeout(()=>{e.on("fragment",e=>{r&&i(()=>({index:e.index,fragmentIndex:e.fragmentIndex}))})},0),window.addEventListener("storage",t=>{if(t.key===n&&t.oldValue&&t.newValue){const n=JSON.parse(t.oldValue),o=JSON.parse(t.newValue);if(n.index!==o.index||n.fragmentIndex!==o.fragmentIndex)try{r=!1,e.slide(o.index,{fragment:o.fragmentIndex,forSync:!0})}finally{r=!0}}});const a=()=>{const{reference:e}=o();void 0===e||e<=1?k(n):i(()=>({reference:e-1}))};window.addEventListener("pagehide",e=>{e.persisted&&window.addEventListener("pageshow",s),a()}),e.on("destroy",a)}},K=e=>{w&&document.addEventListener("keydown",t=>{("o"!==t.key||t.altKey||t.ctrlKey||t.metaKey)&&"Escape"!==t.key||(t.preventDefault(),e())})};let q=null;const V=({closeOnSelect:e=!0}={})=>t=>{N(t);const n=n=>{const r=(()=>{if(!q||!q.isConnected){q=document.createElement("div"),q.className=`${f}overview`,q.inert=!0;const n=document.createElement("iframe");n.src=(()=>{const n=new URLSearchParams(location.search);return n.set("view","overview"),n.set("sync",t.syncKey),e&&n.set("closeOnSelect","1"),g(n)})(),q.append(n),document.body.append(q)}return q})(),o=n??!r.dataset.open;setTimeout(()=>{if(r.dataset.open=o?"1":"",r.inert=!o,t.skipTransition=o,o){const e=r.querySelector("iframe");try{e?.contentWindow?.focus()}catch{e?.focus()}}else window.focus()},0)};Object.defineProperties(t,{toggleOverviewView:{enumerable:!0,value:n}}),window.addEventListener("message",e=>{e.origin===window.origin&&"closeOverview"===e.data&&n(!1)}),K(n)},j=e=>{const{title:t}=document;document.title="[Overview]"+(t?` - ${t}`:"");const n=!!v("closeOnSelect"),r=()=>{window.parent.postMessage("closeOverview","null"===window.origin?"*":window.origin)};if(e.slides.forEach((t,o)=>{t.tabIndex=0;const i=()=>{e.slide(o,{fragment:-1}),n&&r()};t.addEventListener("click",i),t.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),i())})}),window.addEventListener("keydown",t=>{const n=e.slide(),r=t=>{const r=t=>{const n=e.slides[t].getBoundingClientRect();return[Math.round((n.left+n.right)/2),Math.round((n.top+n.bottom)/2)]};let o=null,i=n;do{const e=r(i);if(o){if(Math.abs(e[0]-o[0])<2)return i}else o=e;i+=t}while(i>=0&&i<e.slides.length);return n};if("ArrowLeft"===t.key)e.slide(Math.max(n-1,0),{fragment:-1});else if("ArrowRight"===t.key)e.slide(Math.min(n+1,e.slides.length-1),{fragment:-1});else if("ArrowUp"===t.key)e.slide(r(-1),{fragment:-1});else if("ArrowDown"===t.key)e.slide(r(1),{fragment:-1});else if("End"===t.key)e.slide(e.slides.length-1,{fragment:-1});else{if("Home"!==t.key)return;e.slide(0,{fragment:-1})}t.preventDefault();const o=e.slide();e.slides[o]?.focus?.(),e.slides[o]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),e.on("slide",({index:t})=>{e.slides[t]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),window.parent!==window){K(r);const e=document.createElement("header");e.className=`${f}overview-header`;const t=document.createElement("button");t.className=`${f}overview-close`,t.type="button",t.title="Close overview",t.textContent=t.title,t.addEventListener("click",r),e.append(t),document.body.prepend(e)}},F=()=>{const e=p();return{[s]:V(),[l]:V({closeOnSelect:!1}),[d]:j}[e]},U=e=>{window.addEventListener("message",t=>{if(t.origin!==window.origin)return;const[n,r]=t.data.split(":");if("navigate"===n){const[t,n]=r.split(",");let o=Number.parseInt(t,10),i=Number.parseInt(n,10)+1;i>=e.fragments[o].length&&(o+=1,i=0),e.slide(o,{fragment:i})}})};var R,X,H,W,J,Y,z,G={exports:{}},Q=(R||(R=1,G.exports=(X=["area","base","br","col","command","embed","hr","img","input","keygen","link","meta","param","source","track","wbr"],H=function(e){return String(e).replace(/[&<>"']/g,function(e){return"&"+W[e]+";"})},W={"&":"amp","<":"lt",">":"gt",'"':"quot","'":"apos"},J="dangerouslySetInnerHTML",Y={className:"class",htmlFor:"for"},z={},function(e,t){var n=[],r="";t=t||{};for(var o=arguments.length;o-- >2;)n.push(arguments[o]);if("function"==typeof e)return t.children=n.reverse(),e(t);if(e){if(r+="<"+e,t)for(var i in t)!1!==t[i]&&null!=t[i]&&i!==J&&(r+=" "+(Y[i]?Y[i]:H(i))+'="'+H(t[i])+'"');r+=">"}if(-1===X.indexOf(e)){if(t[J])r+=t[J].__html;else for(;n.length;){var a=n.pop();if(a)if(a.pop)for(var s=a.length;s--;)n.push(a[s]);else r+=!0===z[a]?a:H(a)}r+=e?"</"+e+">":""}return z[r]=!0,r})),G.exports),Z=e(Q);const ee=({children:e})=>Z(null,null,...e),te=`${f}presenter-`,ne={container:`${te}container`,dragbar:`${te}dragbar-container`,next:`${te}next`,nextContainer:`${te}next-container`,noteContainer:`${te}note-container`,noteWrapper:`${te}note-wrapper`,noteButtons:`${te}note-buttons`,infoContainer:`${te}info-container`,infoPageArea:`${te}info-page-area`,infoPage:`${te}info-page`,infoPagePrev:`${te}info-page-prev`,infoPageNext:`${te}info-page-next`,noteButtonsBigger:`${te}note-bigger`,noteButtonsSmaller:`${te}note-smaller`,infoTime:`${te}info-time`,infoTimer:`${te}info-timer`},re=e=>{const{title:t}=document;document.title="[Presenter view]"+(t?` - ${t}`:"");const n={},r=e=>(n[e]=n[e]||document.querySelector(`.${e}`),n[e]);document.body.appendChild((e=>{const t=document.createElement("div");return t.className=ne.container,t.appendChild(e),t.insertAdjacentHTML("beforeend",Z(ee,null,Z("div",{class:ne.nextContainer},Z("iframe",{class:ne.next,src:"?view=next"})),Z("div",{class:ne.dragbar}),Z("div",{class:ne.noteContainer},Z("div",{class:ne.noteWrapper}),Z("div",{class:ne.noteButtons},Z("button",{class:ne.noteButtonsSmaller,tabindex:"-1",title:"Smaller notes font size"},"Smaller notes font size"),Z("button",{class:ne.noteButtonsBigger,tabindex:"-1",title:"Bigger notes font size"},"Bigger notes font size"))),Z("div",{class:ne.infoContainer},Z("div",{class:ne.infoPageArea},Z("button",{class:ne.infoPagePrev,tabindex:"-1",title:"Previous"},"Previous"),Z("button",{class:ne.infoPage}),Z("button",{class:ne.infoPageNext,tabindex:"-1",title:"Next"},"Next")),Z("time",{class:ne.infoTime,title:"Current time"}),Z("time",{class:ne.infoTimer,title:"Timer"})))),t})(e.parent)),(e=>{let t=!1;r(ne.dragbar).addEventListener("mousedown",()=>{t=!0,r(ne.dragbar).classList.add("active")}),window.addEventListener("mouseup",()=>{t=!1,r(ne.dragbar).classList.remove("active")}),window.addEventListener("mousemove",e=>{if(!t)return;const n=e.clientX/document.documentElement.clientWidth*100;r(ne.container).style.setProperty("--bespoke-marp-presenter-split-ratio",`${Math.max(0,Math.min(100,n))}%`)}),r(ne.nextContainer).addEventListener("click",()=>e.next());const n=r(ne.next),o=(i=n,(e,t)=>i.contentWindow?.postMessage(`navigate:${e},${t}`,"null"===window.origin?"*":window.origin));var i;n.addEventListener("load",()=>{r(ne.nextContainer).classList.add("active"),o(e.slide(),e.fragmentIndex),e.on("fragment",({index:e,fragmentIndex:t})=>o(e,t))});const a=document.querySelectorAll(".bespoke-marp-note");a.forEach(e=>{e.addEventListener("keydown",e=>e.stopPropagation()),r(ne.noteWrapper).appendChild(e)}),e.on("activate",()=>a.forEach(t=>t.classList.toggle("active",t.dataset.index==e.slide())));let s=0;const l=e=>{s=Math.max(-5,s+e),r(ne.noteContainer).style.setProperty("--bespoke-marp-note-font-scale",(1.2**s).toFixed(4))},c=()=>l(1),d=()=>l(-1),u=r(ne.noteButtonsBigger),f=r(ne.noteButtonsSmaller);u.addEventListener("click",()=>{u.blur(),c()}),f.addEventListener("click",()=>{f.blur(),d()}),document.addEventListener("keydown",e=>{"+"===e.key&&c(),"-"===e.key&&d()},!0);const m=r(ne.infoPage);e.on("activate",({index:t})=>{m.textContent=`${t+1} / ${e.slides.length}`}),m.addEventListener("click",()=>{m.blur(),e.toggleOverviewView()});const g=r(ne.infoPagePrev),p=r(ne.infoPageNext);g.addEventListener("click",t=>{g.blur(),e.prev({fragment:!t.shiftKey})}),p.addEventListener("click",t=>{p.blur(),e.next({fragment:!t.shiftKey})}),e.on("fragment",({index:t,fragments:n,fragmentIndex:r})=>{g.disabled=0===t&&0===r,p.disabled=t===e.slides.length-1&&r===n.length-1});let v=new Date;const h=()=>{const e=new Date,t=e=>`${Math.floor(e)}`.padStart(2,"0"),n=e.getTime()-v.getTime(),o=t(n/1e3%60),i=t(n/1e3/60%60),a=t(n/36e5%24);r(ne.infoTime).textContent=e.toLocaleTimeString(),r(ne.infoTimer).textContent=`${a}:${i}:${o}`};h(),setInterval(h,250),r(ne.infoTimer).addEventListener("click",()=>{v=new Date})})(e)},oe=e=>{N(e),Object.defineProperties(e,{openPresenterView:{enumerable:!0,value:ie},presenterUrl:{enumerable:!0,get:ae}}),w&&document.addEventListener("keydown",t=>{"p"!==t.key||t.altKey||t.ctrlKey||t.metaKey||(t.preventDefault(),e.openPresenterView())})};function ie(){const{max:e,floor:t}=Math,n=e(t(.85*window.innerWidth),640),r=e(t(.85*window.innerHeight),360);return window.open(this.presenterUrl,te+this.syncKey,`width=${n},height=${r},menubar=no,toolbar=no`)}function ae(){const e=new URLSearchParams(location.search);return e.set("view","presenter"),e.set("sync",this.syncKey),g(e)}const se=e=>{const t=p();return t===c&&e.appendChild(document.createElement("span")),{[s]:oe,[l]:re,[c]:U}[t]},le=e=>{e.on("activate",t=>{document.querySelectorAll(".bespoke-progress-parent > .bespoke-progress-bar").forEach(n=>{n.style.flexBasis=100*t.index/(e.slides.length-1)+"%"})})},ce=e=>{const t=Number.parseInt(e,10);return Number.isNaN(t)?null:t},de=(e={})=>{const t={history:!0,...e};return e=>{let n=!0;const r=e=>{const t=n;try{return n=!0,e()}finally{n=t}},o=(t={fragment:!0})=>{let n=t.fragment?ce(v("f")||""):null;((t,n)=>{const{min:r,max:o}=Math,{fragments:i,slides:a}=e,s=o(0,r(t,a.length-1)),l=o(0,r(n||0,i[s].length-1));s===e.slide()&&l===e.fragmentIndex||e.slide(s,{fragment:l})})((()=>{if(location.hash){const[t]=location.hash.slice(1).split(":~:");if(/^\d+$/.test(t))return(ce(t)??1)-1;const r=document.getElementById(t)||document.querySelector(`a[name="${CSS.escape(t)}"]`);if(r){const{length:t}=e.slides;for(let o=0;o<t;o+=1)if(e.slides[o].contains(r)){const t=e.fragments?.[o],i=r.closest("[data-marpit-fragment]");if(t&&i){const e=t.indexOf(i);e>=0&&(n=e)}return o}}}return 0})(),n)};e.on("fragment",({index:e,fragmentIndex:r})=>{n||h({f:0===r||r.toString()},{location:{...location,hash:`#${e+1}`},setter:(...e)=>t.history?history.pushState(...e):history.replaceState(...e)})}),setTimeout(()=>{o(),window.addEventListener("hashchange",()=>r(()=>{o({fragment:!1}),h({f:void 0})})),window.addEventListener("popstate",()=>{n||r(()=>o())}),n=!1},0)}},{PI:ue,abs:fe,sqrt:me,atan2:ge}=Math,pe={passive:!0},ve=({slope:e=-.7,swipeThreshold:t=30}={})=>n=>{let r;const o=n.parent,i=e=>{const t=o.getBoundingClientRect();return{x:e.pageX-(t.left+t.right)/2,y:e.pageY-(t.top+t.bottom)/2}};o.addEventListener("touchstart",({touches:e})=>{r=1===e.length?i(e[0]):void 0},pe),o.addEventListener("touchmove",e=>{if(r)if(1===e.touches.length){e.preventDefault();const t=i(e.touches[0]),n=t.x-r.x,o=t.y-r.y;r.delta=me(fe(n)**2+fe(o)**2),r.radian=ge(n,o)}else r=void 0}),o.addEventListener("touchend",o=>{if(r){if(r.delta&&r.delta>=t&&r.radian){const t=(r.radian-e+ue)%(2*ue)-ue;n[t<0?"next":"prev"](),o.stopPropagation()}r=void 0}},pe)},he=new Map;he.clear(),he.set("none",{backward:{both:void 0,incoming:void 0,outgoing:void 0},forward:{both:void 0,incoming:void 0,outgoing:void 0}});const we={both:"",outgoing:"outgoing-",incoming:"incoming-"},ye={forward:"",backward:"-backward"},be=e=>`--marp-bespoke-transition-animation-${e}`,ke=e=>`--marp-transition-${e}`,xe=be("name"),Ee=be("duration"),$e=e=>new Promise(t=>{const n={},r=document.createElement("div"),o=e=>{r.remove(),t(e)};r.addEventListener("animationstart",()=>o(n)),Object.assign(r.style,{animationName:e,animationDuration:"1s",animationFillMode:"both",animationPlayState:"paused",position:"absolute",pointerEvents:"none"}),document.body.appendChild(r);const i=getComputedStyle(r).getPropertyValue(ke("duration"));i&&Number.parseFloat(i)>=0&&(n.defaultDuration=i),((e,t)=>{requestAnimationFrame(()=>{e.style.animationPlayState="running",requestAnimationFrame(()=>t(void 0))})})(r,o)}),Le=async e=>he.has(e)?he.get(e):(e=>{const t={},n=[];for(const[r,o]of Object.entries(we))for(const[i,a]of Object.entries(ye)){const s=`marp-${o}transition${a}-${e}`;n.push($e(s).then(e=>{t[i]=t[i]||{},t[i][r]=e?{...e,name:s}:void 0}))}return Promise.all(n).then(()=>t)})(e).then(t=>(he.set(e,t),t)),Se=e=>Object.values(e).flatMap(Object.values).every(e=>!e),Pe=(e,{type:t,backward:n})=>{const r=e[n?"backward":"forward"],o=(()=>{const e=r[t],n=e=>({[xe]:e.name});if(e)return n(e);if(r.both){const e=n(r.both);return"incoming"===t&&(e[be("direction")]="reverse"),e}})();return!o&&n?Pe(e,{type:t,backward:!1}):o||{[xe]:"__bespoke_marp_transition_no_animation__"}},_e=e=>{if(e)try{const t=JSON.parse(e);if((e=>{if("object"!=typeof e)return!1;const t=e;return"string"==typeof t.name&&(void 0===t.duration||"string"==typeof t.duration)})(t))return t}catch{}},Oe="_tSId",Te="_tA",Ie="bespoke-marp-transition-warming-up",Me=window.matchMedia("(prefers-reduced-motion: reduce)"),Ae="__bespoke_marp_transition_reduced_outgoing__",Ce="__bespoke_marp_transition_reduced_incoming__",De={forward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}},backward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}}},Ne=e=>{if(!document.startViewTransition)return;const t=t=>(void 0!==t&&(e._tD=t),e._tD);let n;t(!1),((...e)=>{CSS.registerProperty({name:ke("duration"),syntax:"<time>",inherits:!0,initialValue:"-1s"});const t=[...new Set(e).values()];return Promise.all(t.map(e=>Le(e))).then()})(...Array.from(document.querySelectorAll("section[data-transition], section[data-transition-back]")).flatMap(e=>[e.dataset.transition,e.dataset.transitionBack].flatMap(e=>{const t=_e(e);return[t?.name,t?.builtinFallback?`__builtin__${t.name}`:void 0]}).filter(e=>!!e))).then(()=>{document.querySelectorAll("style").forEach(e=>{e.innerHTML=e.innerHTML.replace(/--marp-transition-duration:[^;}]*[;}]/g,e=>e.slice(0,-1)+"!important"+e.slice(-1))})});const r=(n,{back:r,cond:o})=>i=>{const a=t();if(a)return!!i[Te]||!("object"!=typeof a||(a.skipTransition(),!i.forSync));if(e.skipTransition)return!0;if(!o(i))return!0;const s=e.slides[e.slide()],l=()=>i.back??r,c="data-transition"+(l()?"-back":""),d=s.querySelector(`section[${c}]`);if(!d)return!0;const u=_e(d.getAttribute(c)??void 0);return!u||((async(e,{builtinFallback:t=!0}={})=>{let n=await Le(e);if(Se(n)){if(!t)return;return n=await Le(`__builtin__${e}`),Se(n)?void 0:n}return n})(u.name,{builtinFallback:u.builtinFallback}).then(e=>{if(!e){t(!0);try{n(i)}finally{t(!1)}return}let r=e;Me.matches&&(console.warn("Use a constant animation to transition because preferring reduced motion by viewer has detected."),r=De);const o=document.getElementById(Oe);o&&o.remove();const a=document.createElement("style");a.id=Oe,document.head.appendChild(a),((e,t)=>{const n=[`:root{${ke("direction")}:${t.backward?-1:1};}`,":root:has(.bespoke-marp-inactive){cursor:none;}"],r=t=>{const n=e[t].both?.defaultDuration||e[t].outgoing?.defaultDuration||e[t].incoming?.defaultDuration;return"forward"===t?n:n||r("forward")},o=t.duration||r(t.backward?"backward":"forward");void 0!==o&&n.push(`::view-transition-group(*){${Ee}:${o};}`);const i=e=>Object.entries(e).map(([e,t])=>`${e}:${t};`).join("");return n.push(`::view-transition-old(root){${i(Pe(e,{...t,type:"outgoing"}))}}`,`::view-transition-new(root){${i(Pe(e,{...t,type:"incoming"}))}}`),n})(r,{backward:l(),duration:u.duration}).forEach(e=>a.sheet?.insertRule(e));const s=document.documentElement.classList;s.add(Ie);let c=!1;const d=()=>{c||(n(i),c=!0,s.remove(Ie))},f=()=>{t(!1),a.remove(),s.remove(Ie)};try{t(!0);const e=document.startViewTransition(d);t(e),e.finished.finally(f)}catch(e){console.error(e),d(),f()}}),!1)};e.on("prev",r(t=>e.prev({...t,[Te]:!0}),{back:!0,cond:e=>e.index>0&&!((e.fragment??1)&&n.fragmentIndex>0)})),e.on("next",r(t=>e.next({...t,[Te]:!0}),{cond:t=>t.index+1<e.slides.length&&!(n.fragmentIndex+1<n.fragments.length)})),setTimeout(()=>{e.on("slide",r(t=>e.slide(t.index,{...t,[Te]:!0}),{cond:t=>{const n=e.slide();return t.index!==n&&(t.back=t.index<n,!0)}}))},0),e.on("fragment",e=>{n=e})};let Be;const Ke=()=>(void 0===Be&&(Be="wakeLock"in navigator&&navigator.wakeLock),Be),qe=async()=>{const e=Ke();if(e)try{return await e.request("screen")}catch(e){console.warn(e)}return null},Ve=async()=>{if(!Ke())return;let e;const t=()=>{e&&"visible"===document.visibilityState&&qe()};for(const e of["visibilitychange","fullscreenchange"])document.addEventListener(e,t);return e=await qe(),e};((e=document.getElementById(":$p"))=>{(()=>{const e=v("view");i.dataset.bespokeView=u.some(t=>t&&t===e)?e:""})();const t=(e=>{const t=v(e);return h({[e]:void 0}),t})("sync")||void 0;o.from(e,((...e)=>{const t=u.findIndex(e=>p()===e);return e.map(([e,n])=>e[t]&&n).filter(e=>e)})([[1,1,1,0],B({key:t})],[[1,1,0,1],se(e)],[[1,1,0,0],M],[[1,1,1,1],E],[[1,0,0,0],T()],[[1,1,1,1],A],[[1,1,1,1],de({history:!1})],[[1,1,0,0],C()],[[1,1,1,0],_],[[1,0,0,0],le],[[1,1,0,0],ve()],[[1,0,0,0],D()],[[1,1,1,0],F()],[[1,0,0,0],Ne],[[1,1,1,1],$],[[1,1,1,0],Ve]))})()}();</script></body></html>

--- a/examples/decision_lineage_demo/SLIDES.html
+++ b/examples/decision_lineage_demo/SLIDES.html
@@ -583,7 +583,7 @@ section.hero footer {
 <h1 id="decision-lineage-for-ai-agents">Decision Lineage for AI Agents</h1>
 <h2 id="from-systems-of-action-to-systems-of-governance--extracted-decisions-options-outcomes-and-rationale-queryable-in-bigquery">From &quot;Systems of Action&quot; to &quot;Systems of Governance&quot; — extracted decisions, options, outcomes, and rationale queryable in BigQuery.</h2>
 <div class="footer-note">
-BigQuery Agent Analytics SDK · examples/decision_lineage_demo · Issue #98
+BigQuery Agent Analytics SDK · examples/decision_lineage_demo
 </div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>
@@ -19439,7 +19439,7 @@ section.hero footer {
 <div class="footer-note">
 Open source · Apache 2.0 · github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
 <br />
-examples/decision_lineage_demo · Issue #98
+examples/decision_lineage_demo
 </div>
 <footer>Decision Lineage with BigQuery Context Graphs · examples/decision_lineage_demo</footer>
 </section>

--- a/examples/decision_lineage_demo/SLIDES.md
+++ b/examples/decision_lineage_demo/SLIDES.md
@@ -328,7 +328,7 @@ globally via `npm install -g @marp-team/marp-cli`).
 ## From "Systems of Action" to "Systems of Governance" — extracted decisions, options, outcomes, and rationale queryable in BigQuery.
 
 <div class="footer-note">
-BigQuery Agent Analytics SDK · examples/decision_lineage_demo · Issue #98
+BigQuery Agent Analytics SDK · examples/decision_lineage_demo
 </div>
 
 <!--
@@ -1163,7 +1163,7 @@ Apache 2.0
 <div class="footer-note">
 Open source · Apache 2.0 · github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
 <br/>
-examples/decision_lineage_demo · Issue #98
+examples/decision_lineage_demo
 </div>
 
 <!--

--- a/examples/decision_lineage_demo/SLIDES.md
+++ b/examples/decision_lineage_demo/SLIDES.md
@@ -249,6 +249,41 @@ style: |
   .accent-green { color: #188038; }
   .accent-yellow { color: #b06000; }
   .accent-red { color: #d93025; }
+  section.dense {
+    font-size: 22px;
+    padding: 44px 54px;
+  }
+  section.dense h1 {
+    font-size: 34px;
+    margin-bottom: 8px;
+  }
+  section.dense h2 {
+    font-size: 22px;
+  }
+  section.dense h3 {
+    font-size: 18px;
+  }
+  section.dense table {
+    font-size: 17px;
+    margin: 8px 0;
+  }
+  section.dense th,
+  section.dense td {
+    padding: 5px 8px;
+  }
+  section.dense pre {
+    font-size: 12px;
+    padding: 12px 14px;
+  }
+  section.dense .small {
+    font-size: 16px;
+  }
+  section.dense .compact {
+    font-size: 18px;
+  }
+  section.dense footer {
+    display: none;
+  }
   footer {
     color: #5f6368;
     font-size: 14px;
@@ -282,6 +317,7 @@ After editing this file, regenerate both with:
 globally via `npm install -g @marp-team/marp-cli`).
 -->
 
+
 <!-- _class: hero -->
 <!-- _paginate: false -->
 
@@ -289,7 +325,7 @@ globally via `npm install -g @marp-team/marp-cli`).
 
 # Decision Lineage for AI Agents
 
-## Turn live agent behavior into queryable BigQuery evidence: decisions, options, outcomes, and rationale.
+## From "Systems of Action" to "Systems of Governance" — extracted decisions, options, outcomes, and rationale queryable in BigQuery.
 
 <div class="footer-note">
 BigQuery Agent Analytics SDK · examples/decision_lineage_demo · Issue #98
@@ -297,194 +333,283 @@ BigQuery Agent Analytics SDK · examples/decision_lineage_demo · Issue #98
 
 <!--
 SPEAKER NOTE — 30s
-Open with business pressure, not fear. The point is not "this certifies
-compliance"; the point is "we can now show our work with data."
+Open with business pressure, not fear. Frame: AI agents are no longer
+just doing tasks (Systems of Action) — regulators now require we can
+prove what they did and why (Systems of Governance). The deck walks
+that line, top to bottom.
 -->
-
----
-
-# Why this matters now
-
-<div class="grid-3">
-
-<div class="card">
-
-### Regulation
-EU AI Act obligations phase in through **2 Aug 2027**; many high-risk and transparency rules start **2 Aug 2026**.
-
-</div>
-
-<div class="card">
-
-### Trust
-Most agent demos produce an answer and ask reviewers to trust a transcript. That does not scale to audit.
-
-</div>
-
-<div class="card">
-
-### Operations
-Product, legal, and engineering need the same answer: *what happened, why, and where is the evidence?*
-
-</div>
-
-</div>
-
-<div class="soft-card">
-<strong>Risk framing:</strong> AI Act fines reach up to <strong>7% of worldwide annual turnover</strong> for prohibited practices, and up to <strong>3%</strong> for many other operator / transparency obligations. The useful response is evidence, not screenshots.
-</div>
-
-<div class="source-line">Sources: EU AI Act Service Desk implementation timeline; AI Act Article 99 penalty tiers.</div>
-
-<!--
-Source: https://ai-act-service-desk.ec.europa.eu/en/ai-act/eu-ai-act-implementation-timeline
-Article 99: 7% applies to prohibited practices; 3% applies to many
-non-Article-5 obligations. Keep the wording precise.
--->
-
----
-
-# What we built
-
-<div class="kicker">Working demo, not mock data</div>
-
-Take a real ADK media-planning agent, attach the **BigQuery Agent Analytics Plugin**, use `AI.GENERATE` to extract the decisions and options present in the traces, then publish the result as a **BigQuery Property Graph** for GQL in BigQuery Studio.
-
-<div class="pipeline">
-
-<div class="step"><span class="step-num">1</span><br/><strong>Live agent</strong><br/><span class="small">Gemini 2.5 Pro campaign planner</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">2</span><br/><strong>Plugin spans</strong><br/><span class="small">162 recorded events in BigQuery</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">3</span><br/><strong>Extraction</strong><br/><span class="small">Entities, decisions, options, rationales</span></div>
-<div class="arrow">→</div>
-<div class="step"><span class="step-num">4</span><br/><strong>Property graph</strong><br/><span class="small">Query, visualize, audit</span></div>
-
-</div>
-
-<blockquote><strong>Promise:</strong> the graph is derived from real plugin output. The demo does not rely on hand-shaped seed traces.</blockquote>
 
 ---
 
 <!-- _class: section-divider -->
+<div class="eyebrow">Part 1 · Market context</div>
 
-<div class="eyebrow">Section 1 of 4</div>
-
-# The data behind today's demo
-
----
-
-# Six campaigns, six live agent runs
-
-| Brand | Campaign | Budget | Audience |
-|---|---|---:|---|
-| Nike | Summer Run 2026 | $360K | Serious runners 18-35 |
-| Nike | Winter Trail 2026 | $500K | Trail-runners & hikers 25-45 |
-| Adidas | Track Season 2026 | $420K | NCAA & HS sprinters 16-22 |
-| Puma | Soccer Cup 2026 | $280K | Soccer fans 18-30 |
-| Reebok | CrossFit Open 2026 | $340K | Fitness pros 25-40 |
-| Lululemon | Yoga Flow 2026 | $250K | Yoga practitioners 22-45 |
-
-<div class="metric-row">
-<div class="mini-stat"><strong>6</strong><span>sessions</span></div>
-<div class="mini-stat"><strong>162</strong><span>plugin spans</span></div>
-<div class="mini-stat"><strong>31</strong><span>extracted decisions</span></div>
-<div class="mini-stat"><strong>92</strong><span>decision options</span></div>
-</div>
-
-Each row is one ADK invocation against `gemini-2.5-pro`; each invocation produced **27 plugin-recorded spans** in the verified demo run.
-
-<!--
-Talk track: real diversity — different brand, audience, budget, season.
-If live extraction changes, keep the exact counts in the metric row aligned
-with the latest verified dataset or switch them to approximate language.
--->
+# The regulatory landscape just changed
 
 ---
 
-# Three writers populate seven tables
+# Why now — three regulations converging
 
 <div class="grid-3">
 
 <div class="card">
-<h3>BQ AA Plugin</h3>
-<strong>Writes</strong> `agent_events`<br/>
-<span class="small">Raw trace evidence from the live ADK runner.</span>
+
+### EU AI Act
+**Regulation (EU) 2024/1689**, in force 1 Aug 2024.
+Most operator obligations apply from **2 Aug 2026**; full rollout by **2 Aug 2027**.
+
+<div class="small">High-risk-system rules cover transparency, record-keeping, human oversight, post-market monitoring.</div>
+
 </div>
 
 <div class="card">
-<h3>SDK AI.GENERATE</h3>
-<strong>Writes</strong> `extracted_biz_nodes`, `decision_points`, `candidates`<br/>
-<span class="small">Typed facts extracted from trace text.</span>
+
+### GDPR
+**Article 22** — protections around solely automated decisions with legal or similarly significant effects.
+
+<div class="small">Access / transparency rights create the "meaningful information about logic" audit expectation.</div>
+
 </div>
 
 <div class="card">
-<h3>SDK SQL DML</h3>
-<strong>Writes</strong> `context_cross_links`, `made_decision_edges`, `candidate_edges`<br/>
-<span class="small">Graph edges with stable keys.</span>
-</div>
+
+### Digital Services Act
+**Article 26** — online platforms presenting ads must disclose that an item is an ad, who paid for it, and the main targeting parameters.
+
+<div class="small">The demo's ad-planning lineage gives teams the upstream evidence behind those disclosures.</div>
 
 </div>
 
-<blockquote>`AI.GENERATE` runs twice across all sessions: business entities first, then decision options and rationale.</blockquote>
+</div>
+
+<div class="source-line">
+Sources: <a href="https://ai-act-service-desk.ec.europa.eu/en/ai-act/timeline/timeline-implementation-eu-ai-act">EU AI Act Service Desk timeline</a> · <a href="https://eur-lex.europa.eu/eli/reg/2016/679/oj">GDPR — Reg. 2016/679</a> · <a href="https://eur-lex.europa.eu/eli/reg/2022/2065/oj">DSA — Reg. 2022/2065</a>
+</div>
 
 ---
 
-# The graph the demo presents
+<!-- _class: dense -->
 
-The SDK ships the canonical graph. The demo adds **ads-domain labels** so BigQuery Studio reads like the business process:
+# The threat — Article 99 penalty tiers
+
+The AI Act sets fixed-amount maximums **and** turnover thresholds. The fine is the **higher of the two** for non-SMEs.
+
+<table>
+<thead>
+<tr><th>Article 99 paragraph</th><th>What violates it</th><th>Cap (non-SME)</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Art 99(3)</strong></td><td>Article 5 — prohibited AI practices (e.g. manipulation that exploits vulnerabilities, social scoring, biometric categorisation by protected attributes)</td><td><strong>€35M</strong> or <strong>7%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+<tr><td><strong>Art 99(4)</strong></td><td>Most other AI Act obligations — operators of high-risk systems, transparency, record-keeping, post-market monitoring (Arts 16, 22, 23, 24, 26, 31, 33, 34, 50)</td><td><strong>€15M</strong> or <strong>3%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+<tr><td><strong>Art 99(5)</strong></td><td>Supplying incorrect, incomplete, or misleading information to authorities</td><td><strong>€7.5M</strong> or <strong>1%</strong> of worldwide annual turnover, <em>whichever is higher</em></td></tr>
+</tbody>
+</table>
+
+<div class="small" style="margin-top:14px">
+For an ad-tech buyer with <strong>€20B</strong> worldwide annual turnover, the practical maximum under <strong>Art 99(4)</strong> is <strong>€600M per finding</strong> (3%, not the €15M floor). For SMEs and start-ups, Art 99(6) caps at the <em>lower</em> of the two values.
+</div>
+
+<div class="source-line">
+Source: <a href="https://eur-lex.europa.eu/eli/reg/2024/1689/oj">Reg. 2024/1689 official journal, Article 99</a>
+</div>
+
+---
+
+# The narrative shift
+
+<div class="grid-2">
+
+<div class="soft-card">
+
+### Yesterday — Systems of Action
+AI agents that <strong>do tasks</strong> end-to-end:
+<ul class="compact">
+<li>Pick the audience for a campaign</li>
+<li>Allocate the media budget</li>
+<li>Choose the creative theme</li>
+<li>Set the launch window</li>
+</ul>
+
+The agent <em>does</em>. We trust the output.
+
+</div>
+
+<div class="card">
+
+### Today — Systems of Governance
+The same agents, plus a <strong>queryable evidence layer</strong>:
+<ul class="compact">
+<li>The decisions extracted from the agent trace</li>
+<li>The options and scores the trace exposes</li>
+<li>The rationale attached to dropped options</li>
+<li>Linked to the trace span that produced it</li>
+</ul>
+
+The agent acts. The graph proves.
+
+</div>
+
+</div>
+
+> The mandate isn't *don't use agents* — it's *be able to show your work, on demand, in audit format*.
+
+---
+
+<!-- _class: section-divider -->
+<div class="eyebrow">Part 2 · Business value</div>
+
+# What "Decision Lineage" gives you
+
+---
+
+# Decision Lineage, defined
+
+<div class="kicker">Working definition</div>
+
+<blockquote>
+For any agent decision: the ability to retrieve <strong>what was chosen</strong>, <strong>what alternatives were considered</strong>, <strong>what scores or criteria were applied</strong>, <strong>why each alternative was rejected</strong>, and <strong>which trace span produced the decision</strong> — as a single BigQuery query.
+</blockquote>
+
+<div class="grid-3" style="margin-top:24px">
+<div class="card"><h3>Trust</h3>The data exists at the moment the regulator asks. No reconstruction.</div>
+<div class="card"><h3>Transparency</h3>Same answer for product, legal, and engineering — one source of truth.</div>
+<div class="card"><h3>Reproducibility</h3>Re-running the audit query a year later returns the same evidence.</div>
+</div>
+
+---
+
+# What the demo lets you prove
+
+<div class="metric-row">
+<div class="mini-stat"><strong>Right to explanation</strong><span>GDPR Art 22 · AI Act Art 86</span></div>
+<div class="mini-stat"><strong>Bias monitoring</strong><span>AI Act Art 10 / 71</span></div>
+<div class="mini-stat"><strong>Human oversight</strong><span>AI Act Art 14</span></div>
+<div class="mini-stat"><strong>Reproducibility</strong><span>AI Act Art 12 / 13</span></div>
+</div>
+
+<div class="grid-2" style="margin-top:14px">
+<div class="card">
+
+### What this is
+- A queryable record of agent decisions plus alternatives plus reasoning
+- The audit substrate regulators ask for under each article above
+- Built from real agent traces by an open-source SDK
+
+</div>
+<div class="card">
+
+### What this is not
+- Not a compliance certification — talk to your legal counsel for that
+- Not a replacement for a Data Protection Impact Assessment
+- Not a model-quality scorecard — it audits what the agent <em>did</em>, not whether it was <em>right</em>
+
+</div>
+</div>
+
+---
+
+<!-- _class: section-divider -->
+<div class="eyebrow">Part 3 · Customer proof</div>
+
+# A concrete pattern from real ad-tech buyers
+
+---
+
+# Real-world pattern — programmatic media-buyer
+
+<div class="kicker">Example pattern (anonymised)</div>
 
 <div class="grid-2">
 
 <div class="card">
 
-### Primary audit path
-`CampaignRun` → `PlanningDecision` → `DecisionOption` → `OptionOutcome`
-
-`DecisionOption` → `DropReason`
-
-<span class="small">A campaign has planning decisions; each decision weighed options; every option has an outcome and dropped options have rationale.</span>
+### The pain
+A major brand-side media-buyer running a multi-agent media-planning stack:
+<ul class="compact">
+<li>Internal review board needed evidence for campaign decisions (audience, placement, creative, schedule)</li>
+<li>Compliance team owed regulators a quarterly bias-audit report on demographic targeting</li>
+<li>An adjudicator asked <em>"why was this audience excluded from this campaign?"</em> — answer required digging through Slack threads + run logs</li>
+</ul>
 
 </div>
 
 <div class="card">
 
-### Evidence path
-`CampaignRun` → `AgentStep` → `PlanningDecision`
-
-`AgentStep` → `MediaEntity`
-
-`PlanningDecision` → `DecisionCategory`
-
-<span class="small">The business answer stays tied to the span, entity, and category that produced it.</span>
-
-</div>
+### The shape of the fix
+Decision Lineage on BigQuery:
+<ul class="compact">
+<li>Every agent invocation captured by the BQ AA Plugin</li>
+<li>Decisions + alternatives + rationale extracted by <code>AI.GENERATE</code></li>
+<li>Property graph queryable by compliance + product without writing Python</li>
+<li>Same query reused for the quarterly bias-audit and for one-off subpoena responses</li>
+</ul>
 
 </div>
 
-<!--
-Explorer vocabulary in the graph pane:
-CampaignRun, AgentStep, MediaEntity, PlanningDecision, DecisionOption,
-DecisionCategory, OptionOutcome, DropReason; edges CampaignActivity,
-NextStep, DecidedAt, ConsideredEntity, CampaignDecision, WeighedOption,
-HasOutcome, RejectedBecause, InCategory.
--->
+</div>
+
+<div class="small" style="margin-top:18px">
+<em>Replace this slide with your customer's pain point and timeline once a reference customer is named — the demo plugs into any agent the BQ AA Plugin already covers.</em>
+</div>
+
+---
+
+# Customer voice (placeholder)
+
+<blockquote style="font-size:30px; line-height:1.4">
+"Before this, every audit request was a fire drill across three teams. Now we hand the regulator a five-line GQL query and the answer is the same on every run. The compliance posture moved from <em>defensible</em> to <em>queryable</em>."
+</blockquote>
+
+<div class="small" style="margin-top:14px">
+— Director, Audience Strategy at a major DSP <span class="accent-blue">[placeholder — swap with a real attributable quote before external use]</span>
+</div>
+
+<div class="metric-row" style="margin-top:24px">
+<div class="mini-stat"><strong>~3 weeks</strong><span>Audit response (before)</span></div>
+<div class="mini-stat"><strong>One query</strong><span>Audit response (after)</span></div>
+<div class="mini-stat"><strong>5 articles</strong><span>Regulatory hooks mapped</span></div>
+<div class="mini-stat"><strong>Low cost</strong><span>BQ query over existing graph</span></div>
+</div>
 
 ---
 
 <!-- _class: section-divider -->
+<div class="eyebrow">Part 4 · Practical demo</div>
 
-<div class="eyebrow">Section 2 of 4</div>
+# What an auditor actually sees
 
-# Five regulator-shaped questions, answered live
+---
+
+# The auditor persona — five questions, live
+
+A compliance reviewer, equipped with the BigQuery Conversational Analytics panel, asks five questions of one dataset:
+
+<div class="grid-2">
+<div>
+<ul class="compact">
+<li><strong>Q1</strong> — <em>"Why did the agent pick this audience?"</em></li>
+<li><strong>Q2</strong> — <em>"Did demographic criteria ever cause a candidate to be dropped?"</em></li>
+<li><strong>Q3</strong> — <em>"Were any decisions committed below 0.7 confidence?"</em></li>
+<li><strong>Q4</strong> — <em>"Show me the full audit trail for the Adidas creative-theme decision."</em></li>
+<li><strong>Q5</strong> — <em>"Which decision categories reject candidates least decisively?"</em></li>
+</ul>
+</div>
+<div>
+
+### Why this format
+Ground the demo in the **auditor experience**, not the engineering pipeline. The reviewer starts with a business question; the system returns a reproducible evidence path that legal and engineering can inspect together.
+
+The next slides show the natural-language prompt, the GQL pattern, and the live answer from the demo dataset.
+</div>
+</div>
 
 ---
 
 # Q1 — Right to explanation
 
-<div class="pill">EU AI Act Art. 86</div> <div class="pill">GDPR Art. 22</div>
+<div class="pill">EU AI Act Art 86</div> <div class="pill">GDPR Art 22</div>
 
-> *"For the Nike Summer Run campaign, what audience did the AI pick, what alternatives did it consider, and why did it reject the others?"*
+> *"For Nike Summer Run, what audience did the agent pick, and why did it reject the alternatives?"*
 
 ```sql
 GRAPH `<P>.<D>.rich_agent_context_graph`
@@ -496,15 +621,15 @@ RETURN DISTINCT opt.status, opt.name, opt.score, opt.rejection_rationale
 ORDER BY opt.status DESC, opt.score DESC;
 ```
 
-**Three rows.** Selected: *Serious Runners 18-35* @ 0.99. Dropped: *Casual Runners 25-45* (lower purchase intent), *Fitness Enthusiasts 18-35* (group too broad). **The extracted rationale stays attached to the option it explains.**
+**Three rows.** Selected: *Serious Runners 18-35* @ 0.99. Dropped: *Casual Runners 25-45* (lower purchase intent on high-performance footwear), *Fitness Enthusiasts 18-35* (group too broad for running conversion). **Each rationale extracted by `AI.GENERATE` from the LLM_RESPONSE trace text.**
 
 ---
 
 # Q2 — Bias / fairness audit
 
-<div class="pill">EU AI Act Art. 10</div> <div class="pill">EU AI Act Art. 71</div>
+<div class="pill">EU AI Act Art 10</div> <div class="pill">EU AI Act Art 71</div>
 
-> *"Across our 2026 ad portfolio, did the AI ever reject a candidate based on age or demographic criteria?"*
+> *"Across our 2026 portfolio, did the agent ever reject a candidate based on age or demographic criteria?"*
 
 ```sql
 GRAPH `<P>.<D>.rich_agent_context_graph`
@@ -516,15 +641,19 @@ WHERE opt.status = 'DROPPED'
 RETURN DISTINCT dp.decision_type, opt.name, opt.rejection_rationale;
 ```
 
-**Multiple matches.** *Youth Track & Field (13-15) — outside specified 16-22 range.* *Affluent Hikers (35-55) — age-range mismatch.* The graph surfaces specific rationales for **human review**: proxy risk, legitimate campaign constraint, or extraction artifact?
+Multiple matches. Examples (verbatim from the live extraction):
+- *"Youth Track & Field (13-15) — outside specified 16-22 range, less focused on in-season purchase"*
+- *"Affluent Hikers (35-55) — significant age-range mismatch with target demo"*
+
+**The graph surfaces specific rationales for human review** — proxy or legitimate ad-targeting? The reviewer judges from data, not trust.
 
 ---
 
 # Q3 — Human-oversight trigger
 
-<div class="pill">EU AI Act Art. 14</div>
+<div class="pill">EU AI Act Art 14</div>
 
-> *"Did the agent ever commit a decision below 0.7 confidence? Those should have triggered human review."*
+> *"Did the agent ever commit a decision below 0.7 confidence? That should have triggered human review."*
 
 ```sql
 GRAPH `<P>.<D>.rich_agent_context_graph`
@@ -534,149 +663,435 @@ RETURN DISTINCT dp.session_id, dp.decision_type, opt.name, opt.score
 ORDER BY opt.score ASC;
 ```
 
-<div style="text-align:center; margin-top: 24px">
+<div style="text-align:center; margin: 22px 0">
 <div class="stat">0</div>
 <div class="stat-label">rows returned</div>
 </div>
 
-**The empty result is the audit artifact.** *"We ran the human-oversight predicate against the entire portfolio for this period. The trigger never fired."* Tighten the threshold to 0.85 → instant new at-risk list.
+**The empty result <em>is</em> the audit artifact.** "We ran the human-oversight predicate against the entire portfolio for this period. The trigger never fired." Tighten to 0.85 → instant new at-risk list, same query.
 
 ---
 
-# Q4 — Decision reproducibility
+# Q4 + Q5 — Reproducibility and pattern audit
 
-<div class="pill">EU AI Act Art. 12</div> <div class="pill">EU AI Act Art. 13</div>
+<div class="grid-2">
 
-> *"Subpoena: produce the full audit trail for the Adidas creative-theme decision."*
+<div class="card">
+
+### Q4 — Subpoena reproducibility
+<div class="pill">Art 12</div> <div class="pill">Art 13</div>
 
 ```sql
-GRAPH `<P>.<D>.rich_agent_context_graph`
 MATCH (step:AgentStep)-[:DecidedAt]->(dp:PlanningDecision)
       -[:WeighedOption]->(opt:DecisionOption)
-WHERE dp.session_id = '<SESSION>'
+WHERE dp.session_id='<S>'
   AND LOWER(dp.decision_type) LIKE '%creative%'
-  AND step.event_type = 'LLM_RESPONSE'
-RETURN DISTINCT dp.span_id, opt.status, opt.name, opt.score, opt.rejection_rationale
-ORDER BY opt.status DESC, opt.score DESC;
+  AND step.event_type='LLM_RESPONSE'
+RETURN dp.span_id, opt.status, opt.name, opt.score,
+       opt.rejection_rationale;
 ```
 
-**Three rows.** Selected: *"Built for a New Record"* @ 0.97. Two dropped with rationale, both pointing back to the same `evidence_span_id`. That span lives in `agent_events` with content, timestamp, and latency. **Record-keeping becomes a queryable trail.**
+3 rows. All point to one `evidence_span_id` → that span lives in `agent_events` with full content + timestamp + latency.
+
+</div>
+
+<div class="card">
+
+### Q5 — Systemic pattern
+<div class="pill">Art 17</div> <div class="pill">Art 60</div>
+
+```sql
+MATCH (dp:PlanningDecision)-[:WeighedOption]->(opt:DecisionOption)
+WHERE opt.status='DROPPED'
+RETURN dp.decision_type,
+       COUNT(opt) AS rejections,
+       AVG(opt.score) AS avg_dropped_score
+GROUP BY dp.decision_type
+ORDER BY rejections DESC;
+```
+
+**Audience Selection** rejects with the **lowest avg confidence (0.66)** — the category most worth a fairness loop-back to Q2.
+
+</div>
+
+</div>
 
 ---
 
-# Q5 — Systemic / pattern audit
+<!-- _class: section-divider -->
+<div class="eyebrow">Part 5 · Technical architecture</div>
 
-<div class="pill">EU AI Act Art. 17</div> <div class="pill">EU AI Act Art. 60</div>
+# How the evidence is built — every step concrete
 
-> *"Where in our portfolio does the AI reject candidates least decisively?"*
+---
+
+# End-to-end pipeline
+
+<div class="pipeline">
+
+<div class="step">
+<div class="step-num">1</div>
+<strong>ADK agent</strong>
+<div class="small">Gemini 2.5 Pro · 5 tools · system prompt requires 3-candidate enumeration</div>
+</div>
+<div class="arrow">▶</div>
+
+<div class="step">
+<div class="step-num">2</div>
+<strong>BQ AA Plugin</strong>
+<div class="small"><code>InMemoryRunner(plugins=[bq_logging_plugin])</code> → spans land in <code>agent_events</code></div>
+</div>
+<div class="arrow">▶</div>
+
+<div class="step">
+<div class="step-num">3</div>
+<strong>SDK extraction</strong>
+<div class="small">Two <code>AI.GENERATE</code> calls — biz nodes (MERGE) + decisions (load job)</div>
+</div>
+<div class="arrow">▶</div>
+
+<div class="step">
+<div class="step-num">4</div>
+<strong>Property graph</strong>
+<div class="small">Canonical 4-pillar + ads-domain rich layer queried via GQL</div>
+</div>
+
+</div>
+
+<div class="grid-2" style="margin-top:24px">
+<div class="card">
+
+### What runs locally (one-time setup, ~5–10 min)
+`./setup.sh` does steps 1-4 end-to-end on a fresh GCP project: enables APIs, creates the dataset, runs the live agent, extracts decisions, emits the property-graph DDL.
+
+</div>
+<div class="card">
+
+### What runs at audit time (seconds)
+Every regulator question is a single GQL query against the property graph. No re-extraction. No agent rerun. **The graph is the audit substrate.**
+
+</div>
+</div>
+
+---
+
+<!-- _class: dense -->
+
+# Step 1 — The ADK media-planner agent
+
+<div class="grid-2">
+
+<div>
+
+### `agent/agent.py`
+- `google.adk.agents.Agent` instance
+- Model: **Gemini 2.5 Pro** (regional, Vertex AI)
+- 5 decision-commit tools (one per category)
+- BQ AA Plugin attached to `InMemoryRunner`
+
+### `agent/tools.py` — five tools
+| Tool | Decision category |
+|---|---|
+| `select_audience` | audience selection |
+| `allocate_budget` | budget allocation |
+| `select_creative` | creative theme |
+| `define_channel_strategy` | channel strategy |
+| `schedule_launch` | launch scheduling |
+
+</div>
+
+<div>
+
+### `agent/prompts.py` — system prompt
+The prompt instructs the agent to, for each structured decision:
+
+<div class="soft-card compact">
+1. Name <strong>three candidate options</strong><br>
+2. Score each on 0.0–1.0 (two decimals)<br>
+3. Mark exactly one <strong>SELECTED</strong>, the other two <strong>DROPPED</strong><br>
+4. Give an <strong>explicit, specific rejection rationale</strong> for each dropped option<br>
+5. End with <code>Decision: …</code> then call the corresponding tool
+</div>
+
+<div class="small" style="margin-top:10px">
+The prompt structure is the contract that makes downstream extraction reliable. The LLM_RESPONSE text is what <code>AI.GENERATE</code> later parses.
+</div>
+
+</div>
+
+</div>
+
+---
+
+# Step 2 — The 6 campaigns × 27 spans
+
+<div class="grid-2">
+
+<div>
+
+### `campaigns.py` — 6 briefs
+| Brand | Campaign | Budget |
+|---|---|---:|
+| Nike | Summer Run 2026 | $360K |
+| Nike | Winter Trail 2026 | $500K |
+| Adidas | Track Season 2026 | $420K |
+| Puma | Soccer Cup 2026 | $280K |
+| Reebok | CrossFit Open 2026 | $340K |
+| Lululemon | Yoga Flow 2026 | $250K |
+
+### `run_agent.py`
+Iterates briefs; one `InMemoryRunner` invocation per brief; awaits `flush()` + `shutdown()` on the plugin so all spans land before extraction starts; writes `campaign_runs` mapping (deterministic).
+
+</div>
+
+<div>
+
+### Per session — 27 plugin-recorded spans
+| Event type | Count |
+|---|---:|
+| `INVOCATION_STARTING` | 1 |
+| `AGENT_STARTING` | 1 |
+| `USER_MESSAGE_RECEIVED` | 1 |
+| `LLM_REQUEST` / `LLM_RESPONSE` | 5 + 5 |
+| `TOOL_STARTING` / `TOOL_COMPLETED` | 5 + 5 |
+| `HITL_CONFIRMATION_REQUEST` / `_COMPLETED` | 1 + 1 |
+| `AGENT_COMPLETED` | 1 |
+| `INVOCATION_COMPLETED` | 1 |
+
+**6 sessions × 27 spans = 162 TechNode rows.** Each span carries `span_id`, `parent_span_id`, `session_id`, `event_type`, `agent`, `timestamp`, JSON `content`, `latency_ms`.
+
+</div>
+
+</div>
+
+---
+
+# Step 3a — `AI.GENERATE` extraction (BizNodes)
+
+`build_graph.py` calls `mgr.extract_biz_nodes(session_ids)` which runs **one MERGE** statement against `agent_events`. The MERGE's USING clause invokes `AI.GENERATE` per row:
+
+```sql
+MERGE `<P>.<D>.extracted_biz_nodes` AS target
+USING (
+  SELECT base.span_id, base.session_id,
+    JSON_EXTRACT_SCALAR(entity, '$.entity_type')  AS node_type,
+    JSON_EXTRACT_SCALAR(entity, '$.entity_value') AS node_value,
+    CAST(JSON_EXTRACT_SCALAR(entity, '$.confidence') AS FLOAT64) AS confidence
+  FROM `<P>.<D>.agent_events` AS base,
+  UNNEST(JSON_EXTRACT_ARRAY(REGEXP_REPLACE(REGEXP_REPLACE(
+    AI.GENERATE('Extract business entities (Product, Audience, Channel, …) from this payload. Return JSON array of {entity_type, entity_value, confidence}.\n\nPayload:\n' || payload_text,
+                endpoint => 'gemini-2.5-flash').result,
+    r'^```(?:json)?\s*',''), r'\s*```$',''))) AS entity
+  WHERE base.session_id IN UNNEST(@session_ids)
+    AND base.event_type IN ('USER_MESSAGE_RECEIVED','LLM_RESPONSE','TOOL_COMPLETED','AGENT_COMPLETED')
+) AS source
+ON target.biz_node_id = source.biz_node_id
+WHEN MATCHED THEN UPDATE SET …
+WHEN NOT MATCHED BY TARGET THEN INSERT …
+WHEN NOT MATCHED BY SOURCE AND target.session_id IN UNNEST(@session_ids) THEN DELETE
+```
+
+**Per-session idempotent in one statement.** No streaming-buffer pitfall. `MERGE` is the SDK's chosen pattern for the BizNode write path.
+
+---
+
+# Step 3b — `AI.GENERATE` extraction (Decisions + Candidates)
+
+`mgr.extract_decision_points(session_ids)` runs a separate `AI.GENERATE` query whose prompt asks for structured decision data:
+
+```text
+Identify decision points in this agent payload. A decision point is where
+the agent evaluated multiple candidates and selected or rejected them.
+For each decision, return decision_type, description, and all candidates
+with name, score (0-1), status (SELECTED or DROPPED), and rejection_rationale
+(null if selected, required reason if dropped).
+```
+
+The Python side parses each row's JSON, builds `DecisionPoint` + `Candidate` records, then `store_decision_points(...)`:
+
+<div class="grid-3" style="margin-top:14px">
+
+<div class="card">
+<div class="step-num">1</div>
+<strong>Dedupe in Python</strong>
+<div class="small"><code>_dedupe_rows_by_key</code> last-wins on <code>decision_id</code> / <code>candidate_id</code></div>
+</div>
+
+<div class="card">
+<div class="step-num">2</div>
+<strong>DELETE FROM ... WHERE session_id IN (...)</strong>
+<div class="small">Per-session reseat — guards against re-running</div>
+</div>
+
+<div class="card">
+<div class="step-num">3</div>
+<strong>load_table_from_json</strong>
+<div class="small">Load job to managed storage; visible to the just-issued DELETE (no streaming-buffer trap)</div>
+</div>
+
+</div>
+
+---
+
+# Step 3c — SQL-only edge derivation
+
+After the node tables exist, three pure-SQL `INSERT INTO` statements build the edges (no `AI.GENERATE`):
+
+```sql
+-- Evaluated edge (BizNode ↔ TechNode lineage)
+INSERT INTO context_cross_links (link_id, span_id, biz_node_id, link_type, …)
+SELECT b.biz_node_id, b.span_id, b.biz_node_id, 'EVALUATED', …
+FROM extracted_biz_nodes b WHERE b.session_id IN UNNEST(@session_ids);
+
+-- MadeDecision edge (TechNode → DecisionPoint)
+INSERT INTO made_decision_edges (edge_id, span_id, decision_id, …)
+SELECT CONCAT(span_id, ':MADE_DECISION:', decision_id), span_id, decision_id, …
+FROM decision_points WHERE session_id IN UNNEST(@session_ids);
+
+-- CandidateEdge (DecisionPoint → CandidateNode, with edge_type)
+INSERT INTO candidate_edges (edge_id, decision_id, candidate_id, edge_type, …)
+SELECT …, CASE c.status WHEN 'SELECTED' THEN 'SELECTED_CANDIDATE'
+                        ELSE 'DROPPED_CANDIDATE' END, …
+FROM candidates c WHERE c.session_id IN UNNEST(@session_ids);
+```
+
+Three tables, one statement each, all per-session-scoped. The `edge_type` on `candidate_edges` is what powers Block 4's `WHERE ce.edge_type = 'DROPPED_CANDIDATE'` filter.
+
+---
+
+<!-- _class: dense -->
+
+# Step 4 — The 7 SDK backing tables
+
+| Table | Key | Written by | What it holds |
+|---|---|---|---|
+| `agent_events` | `span_id` | BQ AA Plugin | Plugin-recorded spans (162 rows = 6 sessions × 27 spans) |
+| `extracted_biz_nodes` | `biz_node_id` | SDK MERGE | Business entities from trace text |
+| `context_cross_links` | `link_id` | SDK DML | Span ↔ BizNode references |
+| `decision_points` | `decision_id` | SDK load job | Extracted decisions from `LLM_RESPONSE` text |
+| `candidates` | `candidate_id` | SDK load job | Extracted options per decision: selected or dropped |
+| `made_decision_edges` | `edge_id` | SDK DML | Span → Decision lineage |
+| `candidate_edges` | `edge_id` | SDK DML | Decision → Candidate, with selected / dropped edge type |
+
+Every backing table has `row_count == distinct_keys` after the SDK fix landed in PR #99 — the property-graph KEY contract holds end-to-end.
+
+---
+
+<!-- _class: dense -->
+
+# Step 5 — The rich-graph projection layer
+
+`build_rich_graph.py` adds **demo-only** SQL projections so the BigQuery Studio Explorer reads in business language. **No new AI calls** in this step:
+
+| Derived table | Built from | Purpose |
+|---|---|---|
+| `campaign_runs` | `run_agent.py` writes directly | One row per agent invocation, joined to campaign metadata in `campaigns.py` |
+| `rich_agent_steps` | `agent_events` (DISTINCT) | Deduped span projection — one row per `span_id` (TechNode is multi-event per span by design) |
+| `rich_decision_types` | `decision_points` | Normalised decision categories (`audience-selection`, `budget-allocation`, …) |
+| `rich_candidate_statuses` | `candidates` | Distinct `OptionOutcome` values (SELECTED, DROPPED) |
+| `rich_rejection_reasons` | `candidates` | Distinct rejection-rationale strings as first-class nodes |
+
+Plus five edge projections wiring the new labels back to SDK-owned facts. Schema lives in `rich_property_graph.gql.tpl` and is deterministic across reruns.
+
+---
+
+<!-- _class: dense -->
+
+# Step 6 — The 8 node labels (what each node means)
+
+<table>
+<thead>
+<tr><th>Label</th><th>Source table</th><th>KEY</th><th>What it represents</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>CampaignRun</strong></td><td>campaign_runs</td><td>session_id</td><td>One agent invocation against one brief — the unit of audit</td></tr>
+<tr><td><strong>AgentStep</strong></td><td>rich_agent_steps</td><td>span_id</td><td>One step the agent took (LLM call, tool invocation, HITL check)</td></tr>
+<tr><td><strong>MediaEntity</strong></td><td>extracted_biz_nodes</td><td>biz_node_id</td><td>An audience, channel, creative, budget unit, or campaign — extracted from trace text</td></tr>
+<tr><td><strong>PlanningDecision</strong></td><td>decision_points</td><td>decision_id</td><td>A moment the agent committed to a choice between options</td></tr>
+<tr><td><strong>DecisionOption</strong></td><td>candidates</td><td>candidate_id</td><td>One option weighed at a planning decision (selected or dropped)</td></tr>
+<tr><td><strong>DecisionCategory</strong></td><td>rich_decision_types</td><td>decision_type_id</td><td>Normalised decision category (audience selection, budget allocation, …)</td></tr>
+<tr><td><strong>OptionOutcome</strong></td><td>rich_candidate_statuses</td><td>status_id</td><td>SELECTED or DROPPED — the outcome of weighing</td></tr>
+<tr><td><strong>DropReason</strong></td><td>rich_rejection_reasons</td><td>reason_id</td><td>A distinct rejection rationale (deduplicated across the portfolio)</td></tr>
+</tbody>
+</table>
+
+---
+
+# Step 7 — The 9 edge labels (how the graph connects)
+
+<table>
+<thead>
+<tr><th>Edge label</th><th>Source → Destination</th><th>Reads as</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>CampaignActivity</strong></td><td>CampaignRun → AgentStep</td><td>"this run produced this step"</td></tr>
+<tr><td><strong>NextStep</strong></td><td>AgentStep → AgentStep (parent_span_id → span_id)</td><td>"this step caused that step" (causal chain)</td></tr>
+<tr><td><strong>ConsideredEntity</strong></td><td>AgentStep → MediaEntity</td><td>"this step touched this entity"</td></tr>
+<tr><td><strong>DecidedAt</strong></td><td>AgentStep → PlanningDecision</td><td>"this step is where the decision committed"</td></tr>
+<tr><td><strong>CampaignDecision</strong></td><td>CampaignRun → PlanningDecision</td><td>"this run made this decision"</td></tr>
+<tr><td><strong>InCategory</strong></td><td>PlanningDecision → DecisionCategory</td><td>"this decision is an audience-selection / budget-allocation / …"</td></tr>
+<tr><td><strong>WeighedOption</strong></td><td>PlanningDecision → DecisionOption</td><td>"this decision considered this option"</td></tr>
+<tr><td><strong>HasOutcome</strong></td><td>DecisionOption → OptionOutcome</td><td>"this option was selected / dropped"</td></tr>
+<tr><td><strong>RejectedBecause</strong></td><td>DecisionOption → DropReason</td><td>"this option was dropped for this reason"</td></tr>
+</tbody>
+</table>
+
+<div class="small" style="margin-top:10px">
+Read top to bottom in plain English: <em>"this run produced this step → which decided at this planning decision → which weighed this option → which has this outcome → which was rejected because of this reason."</em> Five edges, one query, full audit trail.
+</div>
+
+---
+
+# Step 8 — How a GQL query actually traverses
+
+The visualization GQL (the demo's Block 2):
 
 ```sql
 GRAPH `<P>.<D>.rich_agent_context_graph`
-MATCH (dp:PlanningDecision)-[:WeighedOption]->(opt:DecisionOption)
-WHERE opt.status = 'DROPPED'
-RETURN dp.decision_type, COUNT(opt) AS rejections, AVG(opt.score) AS avg_dropped_score
-GROUP BY dp.decision_type
-ORDER BY rejections DESC LIMIT 5;
+MATCH p = (cr:CampaignRun)-[:CampaignDecision]->(dp:PlanningDecision)
+          -[:WeighedOption]->(opt:DecisionOption)-[:HasOutcome]->(st:OptionOutcome)
+WHERE cr.session_id = '<SESSION>'
+RETURN p;
 ```
 
-| decision_type | rejections | avg_dropped_score |
-|---|---:|---:|
-| Creative Theme Selection | 12 | 0.79 |
-| Audience Selection | 12 | **0.66** ← lowest |
-| Channel Strategy Selection | 6 | 0.77 |
-| Placement Selection | 7 | 0.74 |
+What BigQuery does, table by table:
 
-<div class="small"><strong>Audience Selection has the lowest average dropped score.</strong> Reuse the Q2 filter for repeatable bias review.</div>
+<ol class="compact">
+<li><code>campaign_runs</code> → bind <code>cr</code>, filtered by <code>session_id</code> (1 row).</li>
+<li><code>rich_campaign_decision_edges</code> → join to <code>decision_points</code> on <code>session_id</code> (~5 decisions per session).</li>
+<li><code>candidate_edges</code> → join to <code>candidates</code> on <code>decision_id</code> (~3 options per decision).</li>
+<li><code>rich_candidate_status_edges</code> → join to <code>rich_candidate_statuses</code> on <code>status</code> (1 row per option).</li>
+<li>Return paths bound to <code>p</code>. <strong>BigQuery Studio renders these as one fan-out per decision in the Graph tab.</strong></li>
+</ol>
 
----
-
-<!-- _class: section-divider -->
-
-<div class="eyebrow">Section 3 of 4</div>
-
-# What this unlocks
+**5 fan-outs of 3 options each = 15 paths visualized for one session, ~97 paths across all 6 campaigns.** The traversal is deterministic, the rendering is interactive.
 
 ---
 
-# Three takeaways for leadership
+# Step 9 — The temporal dimension
 
 <div class="grid-2">
 
-<div>
+<div class="card">
 
-### 1. Audit posture as a query
-
-The audit surface for our agent platform is now a **live BigQuery query**, not a slide deck or quarterly review.
-
-### 2. The schema generalizes
-
-Brand-neutral, channel-neutral, decision-type-neutral. Point an instrumented agent at the same pipeline and the same audit patterns apply.
-
-</div>
-
-<div>
-
-### 3. Composes with what we run
-
-- **BQ AA Plugin** — the instrumentation path
-- **SDK extraction** — one method call: `build_context_graph(use_ai_generate=True, include_decisions=True)`
-- **BigQuery** — the warehouse you already pay for
-
-No new graph service. No separate audit datastore.
+### What's timestamped
+- `agent_events.timestamp` — when each plugin-recorded span happened (microsecond precision)
+- `agent_events.latency_ms` — `{total_ms, time_to_first_token_ms}`
+- `context_cross_links.created_at` — when cross-links were derived
+- `candidate_edges.created_at` — when decision edges were derived
+- `decision_points.span_id` → traces back to the source span's timestamp
 
 </div>
 
-</div>
+<div class="card">
 
----
+### What you can ask over time
+- *"Across the last 30 days, which decision categories saw rising rejection rates?"*
+- *"Show me the per-day count of decisions made with confidence < 0.7."* (oversight trend)
+- *"Compare this quarter's rejection-rationale distribution vs last quarter's."* (drift)
+- *"Latency p50/p95 for LLM_RESPONSE spans on the audience-selection decision over the past week."*
 
-# Compliance-anchor map
-
-| Question | EU AI Act | GDPR | DSA |
-|---|---|---|---|
-| **Q1** Right to explanation | Art. 86 | Art. 22 | Art. 26 |
-| **Q2** Bias / fairness audit | Art. 10, Art. 71 | Art. 5(1)(d), Art. 22 | Art. 26 |
-| **Q3** Human oversight | Art. 14 | Art. 22 | — |
-| **Q4** Reproducibility | Art. 12, Art. 13 | Art. 30 | Art. 26 |
-| **Q5** Systemic-pattern audit | Art. 17, Art. 60 | Art. 35 | Art. 26 |
-
-Five queries against one graph create reusable **evidence hooks** for three EU regulatory conversations. This is not a compliance certification; it is the data substrate a compliance review needs.
-
----
-
-# How fast can we ship this?
-
-<div class="grid-2">
-
-<div>
-
-### Setup, on a clean GCP project
-```bash
-cd examples/decision_lineage_demo
-./setup.sh
-```
-
-| Phase | Wall time |
-|---|---|
-| Tooling + APIs + venv | ~30s |
-| Live agent (6 sessions) | 3-7 min |
-| `AI.GENERATE` extraction | 30-90s |
-| Rich-graph projection | ~10s |
-| Render BQ Studio queries | <1s |
-
-</div>
-
-<div>
-
-### Cost per setup run
-- 6 live `gemini-2.5-pro` invocations
-- 2 `AI.GENERATE` extraction queries
-- A few hundred BQ rows + one property graph
-
-**Order-of-cents for the verified demo run.** Queries against the prebuilt graph are lightweight.
-
-### From zero to leadership demo
-**Under 10 minutes**, fully reproducible, on any GCP project.
+Each query is a join of `made_decision_edges` ⋈ `agent_events` plus a `WHERE timestamp BETWEEN ...` filter — no schema changes needed.
 
 </div>
 
@@ -685,10 +1100,9 @@ cd examples/decision_lineage_demo
 ---
 
 <!-- _class: section-divider -->
+<div class="eyebrow">Close</div>
 
-<div class="eyebrow">Section 4 of 4</div>
-
-# Where to go next
+# Where to start
 
 ---
 
@@ -704,21 +1118,27 @@ cd examples/decision_lineage_demo
 ### The demo bundle
 `examples/decision_lineage_demo/`
 
-### What ships in the bundle
-- `setup.sh` / `reset.sh` — one-shot bootstrap + tear-down
+### One-shot setup (5–10 min)
+```bash
+cd examples/decision_lineage_demo
+./setup.sh
+```
+
+### What ships
+- `setup.sh` / `reset.sh` — bootstrap + tear-down
 - `agent/` + `campaigns.py` — real ADK agent + 6 briefs
 - `run_agent.py` + `build_graph.py` + `build_rich_graph.py`
-- `bq_studio_queries.gql` (rendered) — six GQL blocks
-- `property_graph.gql` (rendered) — recreate-from-tables DDL
+- `bq_studio_queries.gql` — six paste-and-run GQL blocks
+- `property_graph.gql` + `rich_property_graph.gql` — DDL templates
 
 </div>
 
 <div>
 
-### Documentation
+### Documentation that ships with the bundle
 - [`README.md`](README.md) — orientation
 - [`SETUP_NEW_PROJECT.md`](SETUP_NEW_PROJECT.md) — clean-project reproduction
-- [`DEMO_NARRATION.md`](DEMO_NARRATION.md) — 5-min leadership talk track
+- [`DEMO_NARRATION.md`](DEMO_NARRATION.md) — 5-min talk track
 - [`BQ_STUDIO_WALKTHROUGH.md`](BQ_STUDIO_WALKTHROUGH.md) — click-by-click in BQ Studio
 - [`DEMO_QUESTIONS.md`](DEMO_QUESTIONS.md) — the 5 EU questions with verified GQL
 - [`DATA_LINEAGE.md`](DATA_LINEAGE.md) — how the 7 tables produce the graph
@@ -733,25 +1153,12 @@ Apache 2.0
 
 ---
 
-# Anticipated questions
-
-| Q | Short answer |
-|---|---|
-| **How long to deploy?** | Plugin integration, SDK call, committed DDL. **Days, not quarters**, for a pilot. |
-| **Other agents we haven't instrumented?** | Same plugin, same plug-in point. Schema doesn't care which agent wrote the spans. |
-| **Cost?** | Two `AI.GENERATE` calls per build + standard BQ query cost. **Order-of-cents for this verified demo run.** |
-| **What if `AI.GENERATE` misses a decision?** | Build script reports per-session counts. Re-run extraction without re-running the agent. Talk track is count-agnostic by design. |
-| **Does this expose PII?** | Stores trace-derived rationale text. PII handling follows the existing `agent_events` retention and access policy. |
-| **Who operates this?** | The team that owns the agent platform. Plugin write path + SDK read path both already on-call. |
-
----
-
 <!-- _class: hero -->
 <!-- _paginate: false -->
 
 # Q&A
 
-## From agent behavior to auditable evidence
+## Decision Lineage with BigQuery Context Graphs
 
 <div class="footer-note">
 Open source · Apache 2.0 · github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
@@ -760,7 +1167,9 @@ examples/decision_lineage_demo · Issue #98
 </div>
 
 <!--
-Wrap with: "Three things to take with you. (1) Compliance posture as
-a query. (2) The schema generalizes. (3) Composes with what we run.
-Open for questions."
+SPEAKER NOTE — close
+"Three takeaways: (1) AI Act fines are real and the trigger date is
+near. (2) Decision Lineage is the audit substrate the regulator asks
+for, not a compliance certification. (3) The technical pipeline is
+open-source and runs on infrastructure you already pay for. Thanks."
 -->


### PR DESCRIPTION
## Summary

Follow-up to #103. The original slide-deck PR was squash-merged before
the later "Bei flow" rewrite landed, so this PR carries the current
leadership deck update on top of `main`.

What changed:

- Reframes the deck around:
  1. Market pain
  2. Business solution
  3. Customer proof
  4. Practical demo
  5. Technical architecture
- Adds precise EU AI Act Article 99 penalty tiers and official-source
  links.
- Adds customer-proof slides with clearly marked placeholder copy.
- Expands the technical architecture appendix:
  - ADK agent + prompt contract
  - 6 campaigns x 27 plugin spans
  - `AI.GENERATE` BizNode MERGE
  - decision/candidate extraction write path
  - SQL-only edge derivation
  - 7 SDK backing tables
  - rich-graph projection
  - 8 node labels / 9 edge labels
  - GQL traversal and temporal audit patterns
- Tightens overclaims from "every decision / every reason" to extracted
  decisions/options/rationale.
- Fixes dense-slide layout collisions on the Article 99 and technical
  table slides.
- Regenerates checked-in `SLIDES.html` and `SLIDES.pptx`.

## Test plan

- [x] `marp examples/decision_lineage_demo/SLIDES.md --html -o examples/decision_lineage_demo/SLIDES.html`
- [x] `marp examples/decision_lineage_demo/SLIDES.md --html --pptx -o examples/decision_lineage_demo/SLIDES.pptx`
- [x] `marp examples/decision_lineage_demo/SLIDES.md --html --pdf -o /tmp/pr104_final.pdf`
- [x] PDF has 33 pages; HTML has 33 slide sections.
- [x] Spot-checked rendered pages for title, regulatory landscape,
      Article 99, Step 1, Step 4, Step 5, Step 6, and closing slides.
- [x] `git diff --check`
