### PR TITLE
feat(cli): add bq-agent-sdk binding-validate + ontology-build --validate-binding flags (#105 PR 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`bq-agent-sdk binding-validate` CLI** — pre-flight validator that
+  checks whether a binding YAML's referenced BigQuery tables
+  physically exist with the columns and types the binding requires,
+  before extraction wastes ``AI.GENERATE`` tokens. Emits a structured
+  JSON report (failures + warnings) and exits 0 / 1 / 2. Supports
+  `--strict` to escalate `KEY_COLUMN_NULLABLE` warnings to hard
+  failures. See [issue #105](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/105)
+  and `docs/ontology/binding-validation.md`.
+- **`bq-agent-sdk ontology-build --validate-binding` and
+  `--validate-binding-strict`** opt-in flags. Run the binding
+  pre-flight before phase 2 (extraction). On any failure, the build
+  short-circuits before any `AI.GENERATE` call fires; default-mode
+  warnings print to stderr but don't block. The two flags are
+  mutually exclusive; both incompatible with the deprecated
+  `--spec-path` form because the validator needs the unresolved
+  `Ontology` + `Binding` pair.
+- **`bq-agent-sdk ontology-build --location`** — BigQuery location
+  (e.g. `US`, `EU`) threaded through to `build_ontology_graph()`.
+  The Python API has supported `location` since 0.2.3; this adds
+  the matching CLI flag.
+- **`validate_binding_against_bigquery(...)` Python API** in
+  `bigquery_agent_analytics.binding_validation`. Same surface the
+  CLI calls: takes `Ontology` + `Binding` + `bq_client`, returns a
+  `BindingValidationReport` with `failures` + `warnings` lists and
+  an `ok` property. Issue [#105](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/105).
+
 ## [0.2.3] - 2026-04-27
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ architecture, rationale, and implementation plans behind key SDK features.
 | [ontology/cli.md](ontology/cli.md) | CLI design for the `gm` tool (validate, compile, import-owl) |
 | [ontology/owl-import.md](ontology/owl-import.md) | OWL import — converting OWL ontologies to YAML format |
 | [ontology/ontology-build.md](ontology/ontology-build.md) | `bq-agent-sdk ontology-build` orchestrator + `--skip-property-graph` reference |
+| [ontology/binding-validation.md](ontology/binding-validation.md) | `bq-agent-sdk binding-validate` pre-flight + `ontology-build --validate-binding[-strict]` reference |
 
 ## Deployment Surfaces
 

--- a/docs/ontology/binding-validation.md
+++ b/docs/ontology/binding-validation.md
@@ -1,0 +1,145 @@
+# Binding Validation — Pre-flight Reference
+
+`bq-agent-sdk binding-validate` checks whether the BigQuery tables a binding YAML points at physically exist with the columns and types the binding requires, **before** the SDK starts extraction. Catches the most common authoring error (binding YAML drifted out of sync with physical tables) before extraction wastes `AI.GENERATE` tokens.
+
+## When to run it
+
+- **Before any `ontology-build`** that points at user-pre-defined tables (Terraform / dbt / hand-authored DDL). Use either:
+  - `bq-agent-sdk binding-validate ...` standalone, or
+  - `bq-agent-sdk ontology-build --validate-binding ...` to gate the build.
+- **In CI** as a pre-flight check that runs on every binding YAML change. Strict mode (`--strict`) is appropriate here — it forces every primary-key column to be REQUIRED.
+- **Locally during binding authoring** to catch typos and column-name drift before the first build.
+
+## Standalone CLI
+
+```bash
+bq-agent-sdk binding-validate \
+  --project-id my-project \
+  --ontology my.ontology.yaml \
+  --binding my-bq-prod.binding.yaml \
+  --location US
+```
+
+Output is a JSON report on stdout, plus advisory warnings printed to stderr. Exit codes:
+
+| Exit | Meaning |
+|---|---|
+| `0` | `report.ok` is True. No failures. Warnings (if any) are advisory. |
+| `1` | `report.ok` is False. At least one failure. |
+| `2` | Unexpected error: missing flags, ontology/binding load failure, etc. |
+
+### Strict mode
+
+```bash
+bq-agent-sdk binding-validate \
+  --project-id my-project \
+  --ontology my.ontology.yaml \
+  --binding my-bq-prod.binding.yaml \
+  --strict
+```
+
+Strict mode escalates `KEY_COLUMN_NULLABLE` warnings into hard failures. Use this in CI when you want every primary-key and endpoint-key column to be REQUIRED. Default mode does **not** require `NOT NULL` on key columns because the SDK's own `OntologyMaterializer.create_tables()` emits NULLABLE keys (`ontology_materializer.py:206`) — a default-mode hard failure here would reject SDK-created tables.
+
+## `ontology-build` integration
+
+Two opt-in flags gate the build on a passing pre-flight:
+
+```bash
+bq-agent-sdk ontology-build \
+  --project-id my-project \
+  --dataset-id my-dataset \
+  --ontology my.ontology.yaml \
+  --binding my-bq-prod.binding.yaml \
+  --session-ids sess-1,sess-2 \
+  --validate-binding         # default mode: warnings advisory; failures short-circuit
+```
+
+Or in strict mode:
+
+```bash
+bq-agent-sdk ontology-build \
+  ... \
+  --validate-binding-strict  # NULLABLE keys escalate to failures
+```
+
+When the validator reports any failure, **the build short-circuits before any `AI.GENERATE` call fires** — no extraction tokens are spent. Default-mode warnings print to stderr but do not block.
+
+The two flags are mutually exclusive. Both are incompatible with the deprecated `--spec-path` form because the validator needs the unresolved `Ontology` + `Binding` pair, not a combined `GraphSpec`.
+
+## Failure-code reference
+
+The validator returns a `BindingValidationReport` with two collections: `failures` (always blocking) and `warnings` (advisory in default mode, escalated under `--strict`). Each entry carries `code`, `binding_element`, `binding_path`, `bq_ref`, `expected`, `observed`, and `detail`.
+
+### Default-mode failure codes (always blocking)
+
+| Code | What it means | Typical fix |
+|---|---|---|
+| `MISSING_TABLE` | The bound `source` table doesn't exist in BigQuery. | Create the table, or fix the binding's `source`. |
+| `MISSING_COLUMN` | A bound column (property, key, or SDK metadata column like `session_id` / `extracted_at`) doesn't exist on the table. | Add the column, or fix the binding's `column` mapping. |
+| `TYPE_MISMATCH` | A bound column exists but its BigQuery type doesn't match the ontology-derived expected type. | Change the BQ column's type, or change the ontology property's type. |
+| `ENDPOINT_TYPE_MISMATCH` | An edge's `from_columns` or `to_columns` entry disagrees with the referenced node's primary-key column type. Two flavors: spec-level (edge vs ontology) and physical (edge vs node's actual storage). | Align the edge endpoint's type with the node's primary-key type. |
+| `UNEXPECTED_REPEATED_MODE` | A scalar property/key column is in REPEATED (ARRAY) mode in BigQuery. | Restructure the table — the SDK can't bind scalar properties to ARRAY columns. |
+| `MISSING_DATASET` | The bound table's dataset doesn't exist. | Create the dataset, or fix the binding's `target.dataset` / fully-qualified `source`. |
+| `INSUFFICIENT_PERMISSIONS` | The calling identity can't read the table. | Grant `bigquery.tables.get` on the dataset, or run as an identity that already has it. |
+
+### Strict-only code (warning by default, failure under `--strict`)
+
+| Code | What it means | Why it's strict-only |
+|---|---|---|
+| `KEY_COLUMN_NULLABLE` | A primary-key or endpoint-key column is in NULLABLE mode. | The SDK's own `CREATE TABLE IF NOT EXISTS` DDL emits NULLABLE key columns. A default-mode hard failure here would reject SDK-created tables. Use `--strict` in CI to enforce REQUIRED keys when you control the DDL. |
+
+## CI usage pattern
+
+```yaml
+# .github/workflows/binding-validation.yml
+- name: Pre-flight binding validation
+  run: |
+    bq-agent-sdk binding-validate \
+      --project-id ${{ secrets.GCP_PROJECT }} \
+      --ontology my.ontology.yaml \
+      --binding my-bq-prod.binding.yaml \
+      --location US \
+      --strict
+```
+
+A failed validation exits 1 and the CI step fails. Combine with the matching `ontology-build --validate-binding-strict` in your deploy step so the same gate runs at build time.
+
+## Python API
+
+The CLI is a thin wrapper around `validate_binding_against_bigquery`. For programmatic use:
+
+```python
+from google.cloud import bigquery
+from bigquery_ontology import load_ontology, load_binding
+from bigquery_agent_analytics.binding_validation import (
+    validate_binding_against_bigquery,
+    FailureCode,
+)
+
+ontology = load_ontology("my.ontology.yaml")
+binding = load_binding("my-bq-prod.binding.yaml", ontology=ontology)
+client = bigquery.Client(project="my-project", location="US")
+
+report = validate_binding_against_bigquery(
+    ontology=ontology,
+    binding=binding,
+    bq_client=client,
+    strict=False,
+)
+
+if not report.ok:
+    for f in report.failures:
+        print(f"{f.code.value} at {f.binding_path} ({f.bq_ref}): {f.detail}")
+    raise SystemExit(1)
+
+for w in report.warnings:
+    print(f"WARN: {w.code.value} at {w.binding_path}")
+```
+
+`report.ok` returns `True` iff `report.failures` is empty — warnings do not flip it. Under `strict=True`, `KEY_COLUMN_NULLABLE` warnings become failures with the same code and `report.warnings` is empty (escalated, not duplicated).
+
+## Related
+
+- `docs/ontology/ontology-build.md` — the orchestrator the validator gates.
+- `docs/ontology/binding.md` — the binding model the validator validates.
+- Issue [#76](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/76) — the planned post-extraction `validate_extracted_graph` validator (different phase, different inputs).

--- a/docs/ontology/binding-validation.md
+++ b/docs/ontology/binding-validation.md
@@ -70,23 +70,32 @@ The two flags are mutually exclusive. Both are incompatible with the deprecated 
 
 The validator returns a `BindingValidationReport` with two collections: `failures` (always blocking) and `warnings` (advisory in default mode, escalated under `--strict`). Each entry carries `code`, `binding_element`, `binding_path`, `bq_ref`, `expected`, `observed`, and `detail`.
 
+The CLI emits failure codes as **lowercase strings** in the JSON report (e.g., `"missing_table"`, not `"MISSING_TABLE"`). Use the lowercase form when filtering with `jq` or other JSON tools. The Python `FailureCode` enum exposes both forms — `FailureCode.MISSING_TABLE.value == "missing_table"`.
+
 ### Default-mode failure codes (always blocking)
 
-| Code | What it means | Typical fix |
-|---|---|---|
-| `MISSING_TABLE` | The bound `source` table doesn't exist in BigQuery. | Create the table, or fix the binding's `source`. |
-| `MISSING_COLUMN` | A bound column (property, key, or SDK metadata column like `session_id` / `extracted_at`) doesn't exist on the table. | Add the column, or fix the binding's `column` mapping. |
-| `TYPE_MISMATCH` | A bound column exists but its BigQuery type doesn't match the ontology-derived expected type. | Change the BQ column's type, or change the ontology property's type. |
-| `ENDPOINT_TYPE_MISMATCH` | An edge's `from_columns` or `to_columns` entry disagrees with the referenced node's primary-key column type. Two flavors: spec-level (edge vs ontology) and physical (edge vs node's actual storage). | Align the edge endpoint's type with the node's primary-key type. |
-| `UNEXPECTED_REPEATED_MODE` | A scalar property/key column is in REPEATED (ARRAY) mode in BigQuery. | Restructure the table — the SDK can't bind scalar properties to ARRAY columns. |
-| `MISSING_DATASET` | The bound table's dataset doesn't exist. | Create the dataset, or fix the binding's `target.dataset` / fully-qualified `source`. |
-| `INSUFFICIENT_PERMISSIONS` | The calling identity can't read the table. | Grant `bigquery.tables.get` on the dataset, or run as an identity that already has it. |
+| Python `FailureCode` | JSON `code` value | What it means | Typical fix |
+|---|---|---|---|
+| `MISSING_TABLE` | `"missing_table"` | The bound `source` table doesn't exist in BigQuery. | Create the table, or fix the binding's `source`. |
+| `MISSING_COLUMN` | `"missing_column"` | A bound column (property, key, or SDK metadata column like `session_id` / `extracted_at`) doesn't exist on the table. | Add the column, or fix the binding's `column` mapping. |
+| `TYPE_MISMATCH` | `"type_mismatch"` | A bound column exists but its BigQuery type doesn't match the ontology-derived expected type. | Change the BQ column's type, or change the ontology property's type. |
+| `ENDPOINT_TYPE_MISMATCH` | `"endpoint_type_mismatch"` | An edge's `from_columns` or `to_columns` entry disagrees with the referenced node's primary-key column type. Two flavors: spec-level (edge vs ontology) and physical (edge vs node's actual storage). | Align the edge endpoint's type with the node's primary-key type. |
+| `UNEXPECTED_REPEATED_MODE` | `"unexpected_repeated_mode"` | A scalar property/key column is in REPEATED (ARRAY) mode in BigQuery. | Restructure the table — the SDK can't bind scalar properties to ARRAY columns. |
+| `MISSING_DATASET` | `"missing_dataset"` | The bound table's dataset doesn't exist. | Create the dataset, or fix the binding's `target.dataset` / fully-qualified `source`. |
+| `INSUFFICIENT_PERMISSIONS` | `"insufficient_permissions"` | The calling identity can't read the table. | Grant `bigquery.tables.get` on the dataset, or run as an identity that already has it. |
 
 ### Strict-only code (warning by default, failure under `--strict`)
 
-| Code | What it means | Why it's strict-only |
-|---|---|---|
-| `KEY_COLUMN_NULLABLE` | A primary-key or endpoint-key column is in NULLABLE mode. | The SDK's own `CREATE TABLE IF NOT EXISTS` DDL emits NULLABLE key columns. A default-mode hard failure here would reject SDK-created tables. Use `--strict` in CI to enforce REQUIRED keys when you control the DDL. |
+| Python `FailureCode` | JSON `code` value | What it means | Why it's strict-only |
+|---|---|---|---|
+| `KEY_COLUMN_NULLABLE` | `"key_column_nullable"` | A primary-key or endpoint-key column is in NULLABLE mode. | The SDK's own `CREATE TABLE IF NOT EXISTS` DDL emits NULLABLE key columns. A default-mode hard failure here would reject SDK-created tables. Use `--strict` in CI to enforce REQUIRED keys when you control the DDL. |
+
+Example `jq` filter for failed builds:
+
+```bash
+bq-agent-sdk binding-validate ... --format=json \
+  | jq '.failures[] | select(.code == "missing_column") | .bq_ref'
+```
 
 ## CI usage pattern
 

--- a/docs/ontology/ontology-build.md
+++ b/docs/ontology/ontology-build.md
@@ -53,7 +53,33 @@ The CLI's `property_graph_status` field has three values:
 
 Without `--skip-property-graph`, the existing exit-1 behavior on graph-create failure is preserved exactly.
 
-## When to use this
+## BigQuery location
+
+`--location` (e.g. `--location=US`, `--location=EU`) is forwarded to the orchestrator's BigQuery client. Required when the bound tables live outside the default location, especially in combination with `--validate-binding[-strict]` (the pre-flight validator queries `INFORMATION_SCHEMA` in the same region).
+
+```
+bq-agent-sdk ontology-build \
+  --project-id my-project \
+  --dataset-id my-dataset \
+  --ontology my.ontology.yaml \
+  --binding my-bq-prod.binding.yaml \
+  --session-ids sess-1 \
+  --location EU \
+  --validate-binding
+```
+
+## Pre-flight binding validation
+
+`--validate-binding` and `--validate-binding-strict` run the binding validator before extraction, short-circuiting the build if the binding YAML drifted from the physical tables. See [binding-validation.md](binding-validation.md) for the full reference.
+
+```
+bq-agent-sdk ontology-build ... --validate-binding         # default mode
+bq-agent-sdk ontology-build ... --validate-binding-strict  # strict mode
+```
+
+The two flags are mutually exclusive and incompatible with the deprecated `--spec-path` form.
+
+## When to use `--skip-property-graph`
 
 - **You already manage `CREATE PROPERTY GRAPH` in Terraform / dbt / a SQL file.** The SDK's `CREATE OR REPLACE PROPERTY GRAPH` would clobber your DDL on every run.
 - **Your property graph definition uses DDL details the SDK compiler doesn't emit.** You hand-authored the graph DDL to express custom labels or other DDL details the SDK's compiler doesn't generate.

--- a/docs/ontology/ontology-build.md
+++ b/docs/ontology/ontology-build.md
@@ -55,7 +55,7 @@ Without `--skip-property-graph`, the existing exit-1 behavior on graph-create fa
 
 ## BigQuery location
 
-`--location` (e.g. `--location=US`, `--location=EU`) is forwarded to the orchestrator's BigQuery client. Required when the bound tables live outside the default location, especially in combination with `--validate-binding[-strict]` (the pre-flight validator queries `INFORMATION_SCHEMA` in the same region).
+`--location` (e.g. `--location=US`, `--location=EU`) is forwarded to the orchestrator's BigQuery client. Required when the bound tables live outside the default location, especially in combination with `--validate-binding[-strict]` (the pre-flight validator uses the BigQuery client with the requested location to fetch each bound table's metadata).
 
 ```
 bq-agent-sdk ontology-build \

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -83,6 +83,67 @@ def _build_client(
   )
 
 
+def _run_binding_preflight(
+    *,
+    ontology_path: str | None,
+    binding_path: str | None,
+    project_id: str,
+    location: str | None,
+    strict: bool,
+) -> None:
+  """Run the binding-vs-BQ pre-flight validator.
+
+  On any failure (default mode) or any failure including escalated
+  warnings (strict mode), prints a structured report to stderr and
+  raises ``typer.Exit(code=1)`` so extraction never starts.
+
+  Advisory warnings in default mode print to stderr but do not flip
+  the exit code — they are informational, not blocking.
+  """
+  if ontology_path is None or binding_path is None:
+    raise typer.BadParameter(
+        "Binding validation requires --ontology PATH and " "--binding PATH."
+    )
+
+  from google.cloud import bigquery
+
+  from bigquery_ontology import load_binding
+  from bigquery_ontology import load_ontology
+
+  from .binding_validation import validate_binding_against_bigquery
+
+  ontology = load_ontology(ontology_path)
+  binding = load_binding(binding_path, ontology=ontology)
+  bq_client = bigquery.Client(project=project_id, location=location)
+
+  report = validate_binding_against_bigquery(
+      ontology=ontology,
+      binding=binding,
+      bq_client=bq_client,
+      strict=strict,
+  )
+
+  for w in report.warnings:
+    typer.echo(
+        f"WARN: {w.code.value} at {w.binding_path} "
+        f"({w.bq_ref}): {w.detail}",
+        err=True,
+    )
+
+  if not report.ok:
+    typer.echo(
+        f"Error: binding validation failed "
+        f"({len(report.failures)} failure(s)).",
+        err=True,
+    )
+    for f in report.failures:
+      typer.echo(
+          f"  {f.code.value} at {f.binding_path} ({f.bq_ref}): " f"{f.detail}",
+          err=True,
+      )
+    raise typer.Exit(code=1)
+
+
 def _load_spec_from_args(
     spec_path: str | None,
     ontology_path: str | None,
@@ -1248,6 +1309,39 @@ def ontology_build(
             "property_graph_status='skipped:user_requested'."
         ),
     ),
+    validate_binding: bool = typer.Option(
+        False,
+        "--validate-binding",
+        help=(
+            "Pre-flight: validate the binding against live BigQuery "
+            "tables before extraction. NULLABLE primary-key columns "
+            "emit advisory warnings (printed to stderr). Other "
+            "failures (missing tables/columns, type mismatches) "
+            "short-circuit the build before any AI.GENERATE call "
+            "fires. Requires --ontology + --binding."
+        ),
+    ),
+    validate_binding_strict: bool = typer.Option(
+        False,
+        "--validate-binding-strict",
+        help=(
+            "Pre-flight: validate the binding in strict mode. Same "
+            "as --validate-binding but escalates KEY_COLUMN_NULLABLE "
+            "warnings into hard failures. Use in CI when you want "
+            "every primary-key column to be REQUIRED. Mutually "
+            "exclusive with --validate-binding."
+        ),
+    ),
+    location: Optional[str] = typer.Option(
+        None,
+        "--location",
+        help=(
+            "BigQuery location (e.g. 'US', 'EU'). Used by the binding "
+            "pre-flight validator and forwarded downstream. Required "
+            "for --validate-binding[-strict] when the bound tables "
+            "live outside the default location."
+        ),
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -1256,7 +1350,26 @@ def ontology_build(
 ) -> None:
   """Run the full ontology graph pipeline end-to-end."""
   try:
+    if validate_binding and validate_binding_strict:
+      raise typer.BadParameter(
+          "Use --validate-binding OR --validate-binding-strict, " "not both."
+      )
+    if (validate_binding or validate_binding_strict) and spec_path:
+      raise typer.BadParameter(
+          "Binding validation requires --ontology + --binding "
+          "(separated form). It is not supported with --spec-path."
+      )
+
     from .ontology_orchestrator import build_ontology_graph
+
+    if validate_binding or validate_binding_strict:
+      _run_binding_preflight(
+          ontology_path=ontology_path,
+          binding_path=binding_path,
+          project_id=project_id,
+          location=location,
+          strict=validate_binding_strict,
+      )
 
     loaded_spec = _load_spec_from_args(
         spec_path, ontology_path, binding_path, env
@@ -1272,6 +1385,7 @@ def ontology_build(
         endpoint=endpoint,
         use_ai_generate=not no_ai_generate,
         skip_property_graph=skip_property_graph,
+        location=location,
     )
 
     output = {
@@ -1302,6 +1416,130 @@ def ontology_build(
           "was not created.",
           err=True,
       )
+      raise typer.Exit(code=1)
+  except typer.Exit:
+    raise
+  except Exception as exc:
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
+# ------------------------------------------------------------------ #
+# binding-validate                                                     #
+# ------------------------------------------------------------------ #
+
+
+@app.command("binding-validate")
+def binding_validate(
+    project_id: str = typer.Option(
+        ..., envvar="BQ_AGENT_PROJECT", help=_PROJECT_HELP
+    ),
+    ontology_path: str = typer.Option(
+        ...,
+        "--ontology",
+        help="Path to ontology YAML file.",
+    ),
+    binding_path: str = typer.Option(
+        ...,
+        "--binding",
+        help="Path to binding YAML file.",
+    ),
+    location: Optional[str] = typer.Option(
+        None,
+        "--location",
+        help="BigQuery location (e.g. 'US', 'EU').",
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help=(
+            "Strict mode: KEY_COLUMN_NULLABLE warnings escalate to "
+            "hard failures. Use in CI when you want every primary-key "
+            "column to be REQUIRED."
+        ),
+    ),
+    fmt: str = typer.Option(
+        "json",
+        "--format",
+        help="Output format: json|text|table.",
+    ),
+) -> None:
+  """Pre-flight validate a binding YAML against live BigQuery tables.
+
+  Catches the most common authoring error (binding YAML drifted out
+  of sync with physical tables) before extraction wastes
+  AI.GENERATE tokens. Loads the ontology + binding, queries
+  BigQuery for each referenced table's actual schema, and reports
+  any drift as structured failures.
+
+  Exit codes:
+      0 — report.ok is True (no failures; warnings allowed in
+          default mode and printed to stderr).
+      1 — report.ok is False (failures present).
+      2 — unexpected error (load failure, missing flag, etc.).
+
+  See bq-agent-sdk binding-validate --help for all flags.
+  """
+  try:
+    from google.cloud import bigquery
+
+    from bigquery_ontology import load_binding
+    from bigquery_ontology import load_ontology
+
+    from .binding_validation import validate_binding_against_bigquery
+
+    ontology = load_ontology(ontology_path)
+    binding = load_binding(binding_path, ontology=ontology)
+    bq_client = bigquery.Client(project=project_id, location=location)
+
+    report = validate_binding_against_bigquery(
+        ontology=ontology,
+        binding=binding,
+        bq_client=bq_client,
+        strict=strict,
+    )
+
+    output = {
+        "ok": report.ok,
+        "strict": strict,
+        "failures": [
+            {
+                "code": f.code.value,
+                "binding_element": f.binding_element,
+                "binding_path": f.binding_path,
+                "bq_ref": f.bq_ref,
+                "expected": f.expected,
+                "observed": f.observed,
+                "detail": f.detail,
+            }
+            for f in report.failures
+        ],
+        "warnings": [
+            {
+                "code": w.code.value,
+                "binding_element": w.binding_element,
+                "binding_path": w.binding_path,
+                "bq_ref": w.bq_ref,
+                "expected": w.expected,
+                "observed": w.observed,
+                "detail": w.detail,
+            }
+            for w in report.warnings
+        ],
+    }
+    typer.echo(format_output(output, fmt))
+
+    # Warnings always print to stderr (one line per warning) so CI
+    # logs surface advisory drift even in JSON-format runs that
+    # consume stdout for the report.
+    for w in report.warnings:
+      typer.echo(
+          f"WARN: {w.code.value} at {w.binding_path} "
+          f"({w.bq_ref}): {w.detail}",
+          err=True,
+      )
+
+    if not report.ok:
       raise typer.Exit(code=1)
   except typer.Exit:
     raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2831,8 +2831,8 @@ class TestBindingValidate:
       self, mock_client_cls, tmp_path
   ):
     """binding-validate --location=EU constructs the BQ client with
-    location='EU' so the validator queries the EU multi-region's
-    INFORMATION_SCHEMA."""
+    location='EU' so the validator uses that client (and its
+    location) to fetch each bound table's metadata."""
     ont, bnd = self._write_specs(tmp_path)
 
     with self._patched_validator_returning(ok=True):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2826,6 +2826,33 @@ class TestBindingValidate:
     )
     assert result.exit_code == 2
 
+  @patch("google.cloud.bigquery.Client")
+  def test_location_threaded_to_bigquery_client(
+      self, mock_client_cls, tmp_path
+  ):
+    """binding-validate --location=EU constructs the BQ client with
+    location='EU' so the validator queries the EU multi-region's
+    INFORMATION_SCHEMA."""
+    ont, bnd = self._write_specs(tmp_path)
+
+    with self._patched_validator_returning(ok=True):
+      result = runner.invoke(
+          app,
+          [
+              "binding-validate",
+              "--project-id=proj",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--location=EU",
+          ],
+      )
+
+    assert result.exit_code == 0
+    # Confirm bigquery.Client was constructed with location="EU".
+    _, kwargs = mock_client_cls.call_args
+    assert kwargs.get("location") == "EU"
+    assert kwargs.get("project") == "proj"
+
 
 # ------------------------------------------------------------------ #
 # ontology-build --validate-binding[-strict]                           #
@@ -3053,3 +3080,103 @@ class TestOntologyBuildValidateBindingFlag:
         ],
     )
     assert result.exit_code == 2
+
+  @patch("google.cloud.bigquery.Client")
+  @patch("bigquery_agent_analytics.ontology_orchestrator.build_ontology_graph")
+  def test_validate_binding_warnings_only_proceeds_to_build(
+      self, mock_build, _mock_client, tmp_path
+  ):
+    """Warning-only validation path: --validate-binding emits the
+    warning to stderr (so it shows up in CI logs) but still allows
+    the build to proceed. Covers _run_binding_preflight()'s default-
+    mode advisory branch — failures short-circuit, warnings don't.
+    """
+    from bigquery_agent_analytics.binding_validation import BindingValidationReport
+    from bigquery_agent_analytics.binding_validation import BindingValidationWarning
+    from bigquery_agent_analytics.binding_validation import FailureCode
+    from bigquery_agent_analytics.ontology_models import ExtractedGraph
+
+    ont, bnd = self._write_specs(tmp_path)
+    mock_build.return_value = {
+        "graph_name": "g",
+        "graph_ref": "proj.ds.g",
+        "graph": ExtractedGraph(name="test"),
+        "tables_created": {},
+        "rows_materialized": {},
+        "property_graph_created": True,
+        "property_graph_status": "created",
+        "spec": MagicMock(),
+    }
+
+    warning = BindingValidationWarning(
+        code=FailureCode.KEY_COLUMN_NULLABLE,
+        binding_element="Decision",
+        binding_path="binding.entities[0].properties[0].column",
+        bq_ref="p.d.decisions.decision_id",
+        detail="primary-key column 'decision_id' is NULLABLE",
+    )
+
+    with patch(
+        "bigquery_agent_analytics.binding_validation"
+        ".validate_binding_against_bigquery",
+        return_value=BindingValidationReport(warnings=(warning,)),
+    ):
+      result = runner.invoke(
+          app,
+          [
+              "ontology-build",
+              "--project-id=proj",
+              "--dataset-id=ds",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--session-ids=sess1",
+              "--validate-binding",
+          ],
+      )
+
+    assert result.exit_code == 0
+    # Build proceeded — the warning did not block extraction.
+    mock_build.assert_called_once()
+    # Warning is visible in CLI output (stderr is mixed into
+    # result.output by default).
+    assert "WARN: key_column_nullable" in result.output
+
+  @patch("google.cloud.bigquery.Client")
+  @patch("bigquery_agent_analytics.ontology_orchestrator.build_ontology_graph")
+  def test_location_threaded_through_orchestrator(
+      self, mock_build, _mock_client, tmp_path
+  ):
+    """ontology-build --location=EU forwards to build_ontology_graph
+    so the orchestrator's BQ client targets the EU multi-region.
+    Catches the regression where the CLI built without forwarding
+    location."""
+    from bigquery_agent_analytics.ontology_models import ExtractedGraph
+
+    ont, bnd = self._write_specs(tmp_path)
+    mock_build.return_value = {
+        "graph_name": "g",
+        "graph_ref": "proj.ds.g",
+        "graph": ExtractedGraph(name="test"),
+        "tables_created": {},
+        "rows_materialized": {},
+        "property_graph_created": True,
+        "property_graph_status": "created",
+        "spec": MagicMock(),
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            "ontology-build",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            f"--ontology={ont}",
+            f"--binding={bnd}",
+            "--session-ids=sess1",
+            "--location=EU",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_build.call_args
+    assert kwargs["location"] == "EU"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2620,3 +2620,436 @@ class TestOntologyBuild:
     )
     assert result.exit_code == 1
     assert "Property Graph creation failed" in result.output
+
+
+# ------------------------------------------------------------------ #
+# binding-validate (issue #105 PR 2b)                                  #
+# ------------------------------------------------------------------ #
+
+
+class TestBindingValidate:
+  """CLI behavior for `bq-agent-sdk binding-validate`."""
+
+  _ONT_YAML = (
+      "ontology: TestGraph\n"
+      "entities:\n"
+      "  - name: Decision\n"
+      "    keys:\n"
+      "      primary: [decision_id]\n"
+      "    properties:\n"
+      "      - name: decision_id\n"
+      "        type: string\n"
+      "relationships: []\n"
+  )
+  _BND_YAML = (
+      "binding: test_bind\n"
+      "ontology: TestGraph\n"
+      "target:\n"
+      "  backend: bigquery\n"
+      "  project: p\n"
+      "  dataset: d\n"
+      "entities:\n"
+      "  - name: Decision\n"
+      "    source: decisions\n"
+      "    properties:\n"
+      "      - name: decision_id\n"
+      "        column: decision_id\n"
+      "relationships: []\n"
+  )
+
+  def _write_specs(self, tmp_path):
+    ont = tmp_path / "ontology.yaml"
+    bnd = tmp_path / "binding.yaml"
+    ont.write_text(self._ONT_YAML, encoding="utf-8")
+    bnd.write_text(self._BND_YAML, encoding="utf-8")
+    return ont, bnd
+
+  def _patched_validator_returning(self, ok=True, failures=(), warnings=()):
+    """Build a context-manager patch chain.
+
+    The CLI imports ``validate_binding_against_bigquery`` at call
+    time from ``bigquery_agent_analytics.binding_validation``. We
+    patch that symbol so the test never touches BQ.
+    """
+    from bigquery_agent_analytics.binding_validation import BindingValidationReport
+
+    return patch(
+        "bigquery_agent_analytics.binding_validation"
+        ".validate_binding_against_bigquery",
+        return_value=BindingValidationReport(
+            failures=tuple(failures), warnings=tuple(warnings)
+        ),
+    )
+
+  @patch("google.cloud.bigquery.Client")
+  def test_clean_validation_exits_zero(self, _mock_client, tmp_path):
+    ont, bnd = self._write_specs(tmp_path)
+
+    with self._patched_validator_returning(ok=True):
+      result = runner.invoke(
+          app,
+          [
+              "binding-validate",
+              "--project-id=proj",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+          ],
+      )
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["ok"] is True
+    assert parsed["failures"] == []
+    assert parsed["warnings"] == []
+    assert parsed["strict"] is False
+
+  @patch("google.cloud.bigquery.Client")
+  def test_failures_exit_one_with_payload(self, _mock_client, tmp_path):
+    from bigquery_agent_analytics.binding_validation import BindingValidationFailure
+    from bigquery_agent_analytics.binding_validation import FailureCode
+
+    ont, bnd = self._write_specs(tmp_path)
+    fail = BindingValidationFailure(
+        code=FailureCode.MISSING_TABLE,
+        binding_element="Decision",
+        binding_path="binding.entities[0].source",
+        bq_ref="p.d.decisions",
+        detail="404 Not found",
+    )
+
+    with self._patched_validator_returning(failures=[fail]):
+      result = runner.invoke(
+          app,
+          [
+              "binding-validate",
+              "--project-id=proj",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+          ],
+      )
+
+    assert result.exit_code == 1
+    parsed = json.loads(result.output)
+    assert parsed["ok"] is False
+    assert len(parsed["failures"]) == 1
+    assert parsed["failures"][0]["code"] == "missing_table"
+    assert parsed["failures"][0]["bq_ref"] == "p.d.decisions"
+    assert parsed["failures"][0]["binding_path"] == (
+        "binding.entities[0].source"
+    )
+
+  @patch("google.cloud.bigquery.Client")
+  def test_warnings_print_to_stderr_but_do_not_flip_exit(
+      self, _mock_client, tmp_path
+  ):
+    """Default mode: warnings go to stderr, exit code stays 0."""
+    from bigquery_agent_analytics.binding_validation import BindingValidationWarning
+    from bigquery_agent_analytics.binding_validation import FailureCode
+
+    ont, bnd = self._write_specs(tmp_path)
+    warn = BindingValidationWarning(
+        code=FailureCode.KEY_COLUMN_NULLABLE,
+        binding_element="Decision",
+        binding_path="binding.entities[0].properties[0].column",
+        bq_ref="p.d.decisions.decision_id",
+        detail="primary-key column 'decision_id' is NULLABLE",
+    )
+
+    with self._patched_validator_returning(warnings=[warn]):
+      result = runner.invoke(
+          app,
+          [
+              "binding-validate",
+              "--project-id=proj",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+          ],
+      )
+
+    assert result.exit_code == 0
+    # The CliRunner mixes stderr into result.output by default, so
+    # the WARN line shows up alongside the JSON payload. Split on
+    # the WARN sentinel before parsing the JSON.
+    json_part = result.output.split("WARN:", 1)[0]
+    parsed = json.loads(json_part)
+    assert parsed["ok"] is True
+    assert len(parsed["warnings"]) == 1
+    # Warning is printed (stderr) so CI logs surface it.
+    assert "WARN: key_column_nullable" in result.output
+
+  @patch("google.cloud.bigquery.Client")
+  def test_strict_flag_threaded_through(self, _mock_client, tmp_path):
+    ont, bnd = self._write_specs(tmp_path)
+
+    with self._patched_validator_returning(ok=True) as mock_validate:
+      result = runner.invoke(
+          app,
+          [
+              "binding-validate",
+              "--project-id=proj",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--strict",
+          ],
+      )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_validate.call_args
+    assert kwargs["strict"] is True
+    parsed = json.loads(result.output)
+    assert parsed["strict"] is True
+
+  def test_missing_required_flags_exit_2(self):
+    """typer enforces required --ontology / --binding."""
+    result = runner.invoke(
+        app,
+        [
+            "binding-validate",
+            "--project-id=proj",
+        ],
+    )
+    assert result.exit_code == 2
+
+  @patch("google.cloud.bigquery.Client")
+  def test_load_failure_exits_two(self, _mock_client, tmp_path):
+    """Missing ontology file → exit 2 (loader raises)."""
+    bnd = tmp_path / "binding.yaml"
+    bnd.write_text(self._BND_YAML, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "binding-validate",
+            "--project-id=proj",
+            "--ontology=/nonexistent/ontology.yaml",
+            f"--binding={bnd}",
+        ],
+    )
+    assert result.exit_code == 2
+
+
+# ------------------------------------------------------------------ #
+# ontology-build --validate-binding[-strict]                           #
+# ------------------------------------------------------------------ #
+
+
+class TestOntologyBuildValidateBindingFlag:
+  """CLI behavior for ontology-build's pre-flight binding validation.
+
+  Verifies that --validate-binding[-strict] short-circuits before
+  any AI.GENERATE call (i.e., before build_ontology_graph is
+  invoked) when the validator reports failures.
+  """
+
+  _SPEC_PATH = os.path.join(
+      os.path.dirname(__file__),
+      "..",
+      "examples",
+      "ymgo_graph_spec.yaml",
+  )
+
+  def _write_specs(self, tmp_path):
+    ont_yaml = (
+        "ontology: TestGraph\n"
+        "entities:\n"
+        "  - name: Decision\n"
+        "    keys:\n"
+        "      primary: [decision_id]\n"
+        "    properties:\n"
+        "      - name: decision_id\n"
+        "        type: string\n"
+        "relationships: []\n"
+    )
+    bnd_yaml = (
+        "binding: test_bind\n"
+        "ontology: TestGraph\n"
+        "target:\n"
+        "  backend: bigquery\n"
+        "  project: p\n"
+        "  dataset: d\n"
+        "entities:\n"
+        "  - name: Decision\n"
+        "    source: decisions\n"
+        "    properties:\n"
+        "      - name: decision_id\n"
+        "        column: decision_id\n"
+        "relationships: []\n"
+    )
+    ont = tmp_path / "ontology.yaml"
+    bnd = tmp_path / "binding.yaml"
+    ont.write_text(ont_yaml, encoding="utf-8")
+    bnd.write_text(bnd_yaml, encoding="utf-8")
+    return ont, bnd
+
+  @patch("google.cloud.bigquery.Client")
+  @patch("bigquery_agent_analytics.ontology_orchestrator.build_ontology_graph")
+  def test_validate_binding_short_circuits_on_failure_before_build(
+      self, mock_build, _mock_client, tmp_path
+  ):
+    """When the validator reports a failure, build_ontology_graph
+    must NOT be called — extraction never starts and AI.GENERATE
+    tokens are not spent."""
+    from bigquery_agent_analytics.binding_validation import BindingValidationFailure
+    from bigquery_agent_analytics.binding_validation import BindingValidationReport
+    from bigquery_agent_analytics.binding_validation import FailureCode
+
+    ont, bnd = self._write_specs(tmp_path)
+
+    with patch(
+        "bigquery_agent_analytics.binding_validation"
+        ".validate_binding_against_bigquery",
+        return_value=BindingValidationReport(
+            failures=(
+                BindingValidationFailure(
+                    code=FailureCode.MISSING_TABLE,
+                    binding_element="Decision",
+                    binding_path="binding.entities[0].source",
+                    bq_ref="p.d.decisions",
+                    detail="404 Not found",
+                ),
+            ),
+        ),
+    ):
+      result = runner.invoke(
+          app,
+          [
+              "ontology-build",
+              "--project-id=proj",
+              "--dataset-id=ds",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--session-ids=sess1",
+              "--validate-binding",
+          ],
+      )
+
+    assert result.exit_code == 1
+    # The orchestrator must not have been invoked — extraction
+    # would have spent AI.GENERATE tokens.
+    mock_build.assert_not_called()
+    assert "binding validation failed" in result.output
+
+  @patch("google.cloud.bigquery.Client")
+  @patch("bigquery_agent_analytics.ontology_orchestrator.build_ontology_graph")
+  def test_validate_binding_strict_short_circuits_on_nullable_keys(
+      self, mock_build, _mock_client, tmp_path
+  ):
+    """--validate-binding-strict: a NULLABLE primary-key column
+    should escalate from advisory warning to hard failure and
+    short-circuit before extraction."""
+    from bigquery_agent_analytics.binding_validation import BindingValidationFailure
+    from bigquery_agent_analytics.binding_validation import BindingValidationReport
+    from bigquery_agent_analytics.binding_validation import FailureCode
+
+    ont, bnd = self._write_specs(tmp_path)
+
+    with patch(
+        "bigquery_agent_analytics.binding_validation"
+        ".validate_binding_against_bigquery",
+        return_value=BindingValidationReport(
+            failures=(
+                BindingValidationFailure(
+                    code=FailureCode.KEY_COLUMN_NULLABLE,
+                    binding_element="Decision",
+                    binding_path="binding.entities[0].properties[0].column",
+                    bq_ref="p.d.decisions.decision_id",
+                    detail="primary-key column is NULLABLE",
+                ),
+            ),
+        ),
+    ) as mock_validate:
+      result = runner.invoke(
+          app,
+          [
+              "ontology-build",
+              "--project-id=proj",
+              "--dataset-id=ds",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--session-ids=sess1",
+              "--validate-binding-strict",
+          ],
+      )
+
+    assert result.exit_code == 1
+    mock_build.assert_not_called()
+    _, kwargs = mock_validate.call_args
+    assert kwargs["strict"] is True
+
+  @patch("google.cloud.bigquery.Client")
+  @patch("bigquery_agent_analytics.ontology_orchestrator.build_ontology_graph")
+  def test_validate_binding_clean_proceeds_to_build(
+      self, mock_build, _mock_client, tmp_path
+  ):
+    """Clean validation lets the build proceed normally."""
+    from bigquery_agent_analytics.binding_validation import BindingValidationReport
+    from bigquery_agent_analytics.ontology_models import ExtractedGraph
+
+    ont, bnd = self._write_specs(tmp_path)
+    mock_build.return_value = {
+        "graph_name": "g",
+        "graph_ref": "proj.ds.g",
+        "graph": ExtractedGraph(name="test"),
+        "tables_created": {},
+        "rows_materialized": {},
+        "property_graph_created": True,
+        "property_graph_status": "created",
+        "spec": MagicMock(),
+    }
+
+    with patch(
+        "bigquery_agent_analytics.binding_validation"
+        ".validate_binding_against_bigquery",
+        return_value=BindingValidationReport(),  # ok=True
+    ):
+      result = runner.invoke(
+          app,
+          [
+              "ontology-build",
+              "--project-id=proj",
+              "--dataset-id=ds",
+              f"--ontology={ont}",
+              f"--binding={bnd}",
+              "--session-ids=sess1",
+              "--validate-binding",
+          ],
+      )
+
+    assert result.exit_code == 0
+    mock_build.assert_called_once()
+
+  def test_validate_binding_with_spec_path_rejected(self, tmp_path):
+    """--validate-binding requires --ontology/--binding (separated
+    form). Combined --spec-path is incompatible because the
+    validator needs the unresolved Ontology+Binding pair."""
+    result = runner.invoke(
+        app,
+        [
+            "ontology-build",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            f"--spec-path={self._SPEC_PATH}",
+            "--session-ids=sess1",
+            "--env=p.d",
+            "--validate-binding",
+        ],
+    )
+    assert result.exit_code == 2
+
+  def test_both_flags_rejected(self, tmp_path):
+    """--validate-binding and --validate-binding-strict are
+    mutually exclusive."""
+    ont, bnd = self._write_specs(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "ontology-build",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            f"--ontology={ont}",
+            f"--binding={bnd}",
+            "--session-ids=sess1",
+            "--validate-binding",
+            "--validate-binding-strict",
+        ],
+    )
+    assert result.exit_code == 2


### PR DESCRIPTION
Implements [#105 PR 2b](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/105) per the [working plan on #96](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/96#issuecomment-4363301699): the user-facing CLI surface and docs. PR 2a (#109, merged) shipped the validator core + unit tests + a live integration test.

## What's new in this PR

### Standalone CLI: `bq-agent-sdk binding-validate`

```bash
bq-agent-sdk binding-validate \
  --project-id my-project \
  --ontology my.ontology.yaml \
  --binding my-bq-prod.binding.yaml \
  --location US \
  [--strict] \
  [--format json|text|table]
```

- Loads ontology + binding, builds a `bigquery.Client`, calls the validator, prints a structured JSON report on stdout.
- Failure-code values are emitted as **lowercase strings** (e.g. `"missing_table"`); the docs reference table shows both the Python `FailureCode` enum name and the JSON value.
- Warnings always print to stderr (one line each) so CI logs surface advisory drift even when stdout is consumed by a JSON-aware tool.
- Exit codes: `0` ok, `1` failure(s), `2` unexpected error (load failure, missing flags).

### `ontology-build` integration flags

```bash
bq-agent-sdk ontology-build ... --validate-binding         # default mode
bq-agent-sdk ontology-build ... --validate-binding-strict  # strict mode
```

- When set, run the validator **before phase 2 (extraction)**. On any failure, the build short-circuits **before any `AI.GENERATE` call fires** — authoring drift never costs tokens.
- Default-mode warnings print to stderr but don't block.
- Mutually exclusive; both incompatible with deprecated `--spec-path` (validator needs the unresolved `Ontology + Binding` pair).
- Helper `_run_binding_preflight()` centralizes the load + validate + print + exit logic.

### Plus: `--location` on `ontology-build`

`build_ontology_graph()` has supported `location` since PR #108. The CLI was building without forwarding it. This PR threads it through.

## Tests

**14 new CLI tests, all pass** (using patched validators — no live BQ; live coverage is in PR 2a's `TestBindingValidationLive`):

- `TestBindingValidate` (7 tests) — clean validation, failure payload, warnings to stderr (default mode does not flip exit), strict flag threading, missing-flag exit-2, load-failure exit-2, `--location` threaded to the BQ client.
- `TestOntologyBuildValidateBindingFlag` (7 tests):
  - `test_validate_binding_short_circuits_on_failure_before_build` — **asserts `build_ontology_graph` is never called** when validation fails. Extraction never starts; no `AI.GENERATE` tokens spent.
  - `test_validate_binding_strict_short_circuits_on_nullable_keys`
  - `test_validate_binding_clean_proceeds_to_build`
  - `test_validate_binding_warnings_only_proceeds_to_build` — **asserts `build_ontology_graph` IS called** when only warnings are present (default-mode advisory branch).
  - `test_validate_binding_with_spec_path_rejected`
  - `test_both_flags_rejected` (mutual exclusion)
  - `test_location_threaded_through_orchestrator` — `--location=EU` reaches `build_ontology_graph`.

**256/256 tests pass** across `test_binding_validation.py`, `test_cli.py`, `test_ontology_orchestrator.py`, `test_ontology_materializer.py`, `test_resolved_spec.py` (6 live tests skip without `RUN_LIVE_BIGQUERY_TESTS=1`).

## Docs

**New: `docs/ontology/binding-validation.md`** — covers:
- When to run (binding authoring / CI gating / ontology-build).
- Standalone CLI examples (default + strict).
- `ontology-build` integration examples.
- Failure-code reference with both Python `FailureCode` enum names and JSON `code` values, plus a sample `jq` filter.
- CI usage pattern (GitHub Actions example).
- Python API example.

**Updated: `docs/ontology/ontology-build.md`** — new "BigQuery location" section covering `--location` and a "Pre-flight binding validation" section linking out to `binding-validation.md`.

**Updated: `docs/README.md`** — links `binding-validation.md` under "Ontology Reference."

**Updated: `CHANGELOG.md`** — `[Unreleased] / Added` entries for the standalone CLI, the two `ontology-build` flags, `--location`, and the Python API.

## What's NOT in this PR

- Live integration test for the CLI subprocess flow. The validator's live coverage is in PR 2a (`TestBindingValidationLive`); the CLI tests here cover wiring + exit codes + flag threading + `AI.GENERATE`-not-called-on-failure comprehensively. A literal `subprocess.run(['bq-agent-sdk', 'binding-validate', ...])` smoke test could land as a follow-up if anyone wants it.
- Refactor to share ontology+binding loading between `_run_binding_preflight` and `_load_spec_from_args`. Both currently load independently; small TOCTOU window. Worth a follow-up helper but not blocking 2b's scope.

## Working plan position

After this lands, **#76 (extracted-graph validator)** is the next prereq for #75 C1 per the [working plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/96#issuecomment-4363301699).

