### PR TITLE
feat: deterministic source generator for compiled extractors (#75 PR 4b.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``ResolvedExtractorPlan`` dataclasses + ``render_extractor_source(plan)
   -> str``. The renderer is the deterministic boundary the LLM
   step in PR 4b.2.2 will plug into; **no LLM call lives here**.
-  Generated source matches ``extract_bka_decision_event``'s
-  runtime behavior on the BKA fixture's sample events, exercised
-  end-to-end by 25 unit tests covering plan validation, the AST
-  gate, the subprocess smoke runner, and plan-shape variations
-  (no property fields, no span handling, single-step paths,
-  deep traversal paths).
+  Generated source carries a top-of-function ``event_type``
+  guard that returns an empty result when the incoming event
+  doesn't match the plan's declared type, layered with the
+  orchestrator's manifest-driven dispatch so a plan/manifest
+  mismatch can't silently attach an extractor to the wrong
+  event type. Output otherwise matches
+  ``extract_bka_decision_event``'s runtime behavior on the BKA
+  fixture's sample events. Exercised end-to-end by 39 unit
+  tests covering plan validation, the AST gate, the subprocess
+  smoke runner, plan-shape variations (no property fields, no
+  span handling, single-step paths, deep traversal paths,
+  non-dict intermediates at every depth-3 traversal site), and
+  wrong-event-type rejection.
 - **`bq-agent-sdk binding-validate` CLI** — pre-flight validator that
   checks whether a binding YAML's referenced BigQuery tables
   physically exist with the columns and types the binding requires,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Deterministic source generator for compiled structured
+  extractors** in
+  `bigquery_agent_analytics.extractor_compilation.template_renderer`
+  and
+  [`docs/extractor_compilation_template_renderer.md`](docs/extractor_compilation_template_renderer.md).
+  Issue [#75](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/75)
+  PR 4b.2.1 — turns a pre-resolved
+  ``ResolvedExtractorPlan`` into a Python source string that 4b.1's
+  ``compile_extractor`` runs through every gate (AST allowlist,
+  smoke runner, #76 validator). Public surface:
+  ``FieldMapping`` / ``SpanHandlingRule`` /
+  ``ResolvedExtractorPlan`` dataclasses + ``render_extractor_source(plan)
+  -> str``. The renderer is the deterministic boundary the LLM
+  step in PR 4b.2.2 will plug into; **no LLM call lives here**.
+  Generated source matches ``extract_bka_decision_event``'s
+  runtime behavior on the BKA fixture's sample events, exercised
+  end-to-end by 25 unit tests covering plan validation, the AST
+  gate, the subprocess smoke runner, and plan-shape variations
+  (no property fields, no span handling, single-step paths,
+  deep traversal paths).
 - **`bq-agent-sdk binding-validate` CLI** — pre-flight validator that
   checks whether a binding YAML's referenced BigQuery tables
   physically exist with the columns and types the binding requires,

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ architecture, rationale, and implementation plans behind key SDK features.
 | [ontology/validation.md](ontology/validation.md) | `validate_extracted_graph(spec, graph)` post-extraction validator with NODE/FIELD/EDGE-scope failure classification |
 | [extractor_compilation_runtime_target.md](extractor_compilation_runtime_target.md) | Phase 1 runtime-target decision for compiled structured extractors (issue #75 P0.2): client-side Python via the existing `run_structured_extractors()` hook |
 | [extractor_compilation_scaffolding.md](extractor_compilation_scaffolding.md) | Compile-time scaffolding for compiled structured extractors (issue #75 PR 4b.1): fingerprint, manifest, AST allowlist, smoke-test runner, end-to-end `compile_extractor`. LLM-driven template fill is PR 4b.2; runtime loading is C2. |
+| [extractor_compilation_template_renderer.md](extractor_compilation_template_renderer.md) | Deterministic source generator for compiled structured extractors (issue #75 PR 4b.2.1): `render_extractor_source(plan)` turns a `ResolvedExtractorPlan` into Python source compatible with 4b.1's `compile_extractor`. LLM step that *resolves* raw rules into a plan is PR 4b.2.2. |
 
 ## Deployment Surfaces
 

--- a/docs/extractor_compilation_template_renderer.md
+++ b/docs/extractor_compilation_template_renderer.md
@@ -93,11 +93,11 @@ Per the runtime-target RFC and the PR 4b.2.1 sizing call:
 - **Edge extractors** — only nodes for now. `ExtractedEdge` import is in the call-target allowlist but the renderer doesn't emit edge construction; that's a future plan-shape extension.
 - **Composite property values** (lists, dicts) — ontology v0 explicitly defers these.
 
-## Tests (25 cases in `tests/test_extractor_compilation_template.py`)
+## Tests (39 cases in `tests/test_extractor_compilation_template.py`)
 
-- **`TestPlanValidation`** (12 cases): valid BKA plan renders; parametrized rejection of bad function names (path-traversal, leading digit, whitespace, empty, Python keywords, allowlist shadowing); empty `event_type` / `target_entity_name` / `key_field.source_path`; duplicate `property_name` (within `property_fields` and against the key).
-- **`TestGeneratedSourceClearsGates`** (4 cases): BKA source passes `validate_source`; BKA source compiles end-to-end via `compile_extractor` (subprocess smoke + #76 validator); rendered output matches `extract_bka_decision_event` on every sample event; render is deterministic (byte-identical for identical plans).
-- **`TestPlanShapeVariations`** (4 cases): plan with no `property_fields`; plan with no `span_handling`; plan with single-step paths (key directly on event root); plan with deep traversal path (length 3).
+- **`TestPlanValidation`** (27 cases): valid BKA plan renders; parametrized rejection of bad function names (path-traversal, leading digit, whitespace, empty, Python keywords, allowlist shadowing); empty / non-string `event_type` / `target_entity_name` / `key_field`; duplicate `property_name` (within `property_fields` and against the key); `target_entity_name` containing a quote rejected; non-identifier-shaped property names rejected (parametrized); non-string top-level fields and path segments rejected (parametrized).
+- **`TestGeneratedSourceClearsGates`** (5 cases): BKA source passes `validate_source`; BKA source compiles end-to-end via `compile_extractor` (subprocess smoke + #76 validator); rendered output matches `extract_bka_decision_event` on every sample event; **wrong-event-type input returns empty** (top-of-function guard); render is deterministic (byte-identical for identical plans).
+- **`TestPlanShapeVariations`** (7 cases): plan with no `property_fields`; plan with no `span_handling`; plan with single-step paths; plan with deep traversal path (length 3, including missing-intermediate negative case); deep optional property / `session_id_path` / `partial_when_path` with non-dict intermediate at depth 1.
 
 ## Related
 

--- a/docs/extractor_compilation_template_renderer.md
+++ b/docs/extractor_compilation_template_renderer.md
@@ -73,7 +73,7 @@ source = render_extractor_source(plan)
 
 The output:
 
-- Imports only the four extracted-models / structured-extraction symbols from 4b.1's per-module symbol allowlist.
+- Imports only the three symbols it actually uses (`ExtractedNode`, `ExtractedProperty`, `StructuredExtractionResult`) from 4b.1's per-module symbol allowlist. `ExtractedEdge` isn't imported since the renderer doesn't emit edges yet.
 - Calls only allowlisted Names (`isinstance`, `len`, `set`, `ExtractedNode`, etc.) and allowlisted method names (`get`, `items`, `keys`, `values`, `append`).
 - Has no shadowing of allowlisted call targets, no decorators, no non-constant defaults, no halt/escape constructs (`while`, `raise`, `try`, `with`, `match`).
 - Returns well-formed `StructuredExtractionResult` instances — `nodes` is a `list[ExtractedNode]`, `edges` is `list[ExtractedEdge]`, span sets are `set[str]`. Passes the smoke runner's well-formed-result check.

--- a/docs/extractor_compilation_template_renderer.md
+++ b/docs/extractor_compilation_template_renderer.md
@@ -1,0 +1,106 @@
+# Compiled Structured Extractors — Template Renderer (PR 4b.2.1)
+
+**Status:** Implemented (PR 4b.2.1 of issue #75 Phase C)
+**Parent epic:** [issue #75](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/75)
+**Builds on:** [`extractor_compilation_scaffolding.md`](extractor_compilation_scaffolding.md) (PR 4b.1)
+**Working plan:** [issue #96, comment 4363301699](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/96#issuecomment-4363301699), Milestone C1 / PR 4b.2.1
+
+---
+
+## What this is
+
+The deterministic source generator the LLM-driven template fill (PR 4b.2.2) will plug into. Turns a pre-resolved `ResolvedExtractorPlan` into a Python source string that 4b.1's `compile_extractor` can run through every gate (AST allowlist, smoke runner, #76 validator).
+
+**No LLM call lives here.** PR 4b.2.2 owns the LLM step that *resolves* a raw extraction-rule + event-schema pair into a `ResolvedExtractorPlan`; this module is the deterministic boundary the LLM output has to cross before any source generation happens.
+
+## Public API
+
+```python
+from bigquery_agent_analytics.extractor_compilation import (
+    FieldMapping,
+    ResolvedExtractorPlan,
+    SpanHandlingRule,
+    render_extractor_source,
+)
+
+plan = ResolvedExtractorPlan(
+    event_type="bka_decision",
+    target_entity_name="mako_DecisionPoint",
+    function_name="extract_bka_decision_event_compiled",
+    key_field=FieldMapping(
+        property_name="decision_id",
+        source_path=("content", "decision_id"),
+    ),
+    property_fields=(
+        FieldMapping("outcome", ("content", "outcome")),
+        FieldMapping("confidence", ("content", "confidence")),
+        FieldMapping(
+            "alternatives_considered", ("content", "alternatives_considered")
+        ),
+    ),
+    span_handling=SpanHandlingRule(
+        span_id_path=("span_id",),
+        partial_when_path=("content", "reasoning_text"),
+    ),
+)
+
+source = render_extractor_source(plan)
+# Hand `source` to compile_extractor(source=..., ...) — it clears
+# every 4b.1 gate by construction.
+```
+
+`render_extractor_source(plan)` raises `ValueError` for malformed plans (empty strings, duplicate property names, invalid `function_name`, `function_name` shadowing an allowlisted call target). All checks are at the renderer boundary so callers see a clear plan-level error rather than an opaque AST-gate failure later.
+
+## Plan model
+
+`ResolvedExtractorPlan` is deliberately boring. Every field-level decision is already made by the caller; the renderer is pure source-generation. Fields:
+
+| Field | Description |
+|---|---|
+| `event_type` | The event type the bundle covers. Recorded in the docstring; the manifest's `event_types` is set independently by `compile_extractor`. |
+| `target_entity_name` | The ontology entity the extractor produces (e.g., `mako_DecisionPoint`). Becomes the `ExtractedNode.entity_name`. |
+| `function_name` | Name of the generated callable. Must be a Python identifier, not a keyword, not a name in 4b.1's call-target allowlist. |
+| `key_field` | The required key — extractor declines (returns empty result) when this path is missing or `None`. |
+| `property_fields` | Optional fields appended to the result's properties list when present. Each `property_name` must be unique (and distinct from the key's). |
+| `session_id_path` | Where to find the session id in the event. Default `("session_id",)`. |
+| `span_handling` | Optional. When set, the rendered extractor populates the result's `fully_handled_span_ids` / `partially_handled_span_ids` sets. When unset, both stay empty. |
+
+`FieldMapping(property_name, source_path)`: `source_path` is a tuple of dict keys. Length 1 means the field is at the event root (`event["x"]`); length ≥2 means nested (`event["content"]["x"]`). Missing or wrong-shape intermediates resolve to "field absent" rather than raising.
+
+`SpanHandlingRule(span_id_path, partial_when_path)`: `partial_when_path` is optional. When set, the span is marked **partially** handled if the path's value is truthy (matches the BKA pattern of "free-text reasoning still needs the AI extractor"). When unset, the span is always **fully** handled.
+
+## Generated-source contract
+
+The output:
+
+- Imports only the four extracted-models / structured-extraction symbols from 4b.1's per-module symbol allowlist.
+- Calls only allowlisted Names (`isinstance`, `len`, `set`, `ExtractedNode`, etc.) and allowlisted method names (`get`, `items`, `keys`, `values`, `append`).
+- Has no shadowing of allowlisted call targets, no decorators, no non-constant defaults, no halt/escape constructs (`while`, `raise`, `try`, `with`, `match`).
+- Returns well-formed `StructuredExtractionResult` instances — `nodes` is a `list[ExtractedNode]`, `edges` is `list[ExtractedEdge]`, span sets are `set[str]`. Passes the smoke runner's well-formed-result check.
+- Is **deterministic**: identical plans render byte-identical source. Useful so the compile fingerprint stays stable across consecutive renders of the same plan.
+
+## Equivalence with the BKA fixture
+
+The BKA-equivalent plan (above) renders source whose runtime output is structurally identical to `extract_bka_decision_event` on the same sample events. The end-to-end test compiles the rendered source through `compile_extractor`, re-loads the bundle, and asserts equivalence on every BKA sample.
+
+## Out of scope
+
+Per the runtime-target RFC and the PR 4b.2.1 sizing call:
+
+- **LLM prompt/schema** for resolving raw extraction rules → `ResolvedExtractorPlan` — PR 4b.2.2.
+- **Retry-on-AST/smoke/validator failure** — PR 4b.2.2.
+- **Diagnostics** showing which gate failed and what was changed on retry — PR 4b.2.2.
+- **Edge extractors** — only nodes for now. `ExtractedEdge` import is in the call-target allowlist but the renderer doesn't emit edge construction; that's a future plan-shape extension.
+- **Composite property values** (lists, dicts) — ontology v0 explicitly defers these.
+
+## Tests (25 cases in `tests/test_extractor_compilation_template.py`)
+
+- **`TestPlanValidation`** (12 cases): valid BKA plan renders; parametrized rejection of bad function names (path-traversal, leading digit, whitespace, empty, Python keywords, allowlist shadowing); empty `event_type` / `target_entity_name` / `key_field.source_path`; duplicate `property_name` (within `property_fields` and against the key).
+- **`TestGeneratedSourceClearsGates`** (4 cases): BKA source passes `validate_source`; BKA source compiles end-to-end via `compile_extractor` (subprocess smoke + #76 validator); rendered output matches `extract_bka_decision_event` on every sample event; render is deterministic (byte-identical for identical plans).
+- **`TestPlanShapeVariations`** (4 cases): plan with no `property_fields`; plan with no `span_handling`; plan with single-step paths (key directly on event root); plan with deep traversal path (length 3).
+
+## Related
+
+- [`extractor_compilation_scaffolding.md`](extractor_compilation_scaffolding.md) — 4b.1 scaffolding (the gates the rendered source must clear).
+- [`extractor_compilation_runtime_target.md`](extractor_compilation_runtime_target.md) — Phase 1 runtime-target decision.
+- `tests/fixtures_extractor_compilation/bka_decision_template.py` — the hand-authored fixture this PR's renderer must match.

--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -592,9 +592,13 @@ try:
   from .extractor_compilation import compile_extractor
   from .extractor_compilation import CompileResult
   from .extractor_compilation import compute_fingerprint
+  from .extractor_compilation import FieldMapping
   from .extractor_compilation import Manifest
+  from .extractor_compilation import render_extractor_source
+  from .extractor_compilation import ResolvedExtractorPlan
   from .extractor_compilation import run_smoke_test
   from .extractor_compilation import SmokeTestReport
+  from .extractor_compilation import SpanHandlingRule
   from .extractor_compilation import validate_source
 
   __all__.extend(
@@ -602,10 +606,14 @@ try:
           "AstFailure",
           "AstReport",
           "CompileResult",
+          "FieldMapping",
           "Manifest",
+          "ResolvedExtractorPlan",
           "SmokeTestReport",
+          "SpanHandlingRule",
           "compile_extractor",
           "compute_fingerprint",
+          "render_extractor_source",
           "run_smoke_test",
           "validate_source",
       ]

--- a/src/bigquery_agent_analytics/extractor_compilation/__init__.py
+++ b/src/bigquery_agent_analytics/extractor_compilation/__init__.py
@@ -52,18 +52,26 @@ from .smoke_test import load_callable_from_source
 from .smoke_test import run_smoke_test
 from .smoke_test import run_smoke_test_in_subprocess
 from .smoke_test import SmokeTestReport
+from .template_renderer import FieldMapping
+from .template_renderer import render_extractor_source
+from .template_renderer import ResolvedExtractorPlan
+from .template_renderer import SpanHandlingRule
 
 __all__ = [
     "AstFailure",
     "AstReport",
     "CompileResult",
+    "FieldMapping",
     "Manifest",
+    "ResolvedExtractorPlan",
     "SmokeTestReport",
+    "SpanHandlingRule",
     "compile_extractor",
     "compute_fingerprint",
     "default_bundle_dir",
     "load_callable_from_source",
     "now_iso_utc",
+    "render_extractor_source",
     "run_smoke_test",
     "run_smoke_test_in_subprocess",
     "validate_source",

--- a/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
+++ b/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
@@ -27,10 +27,13 @@ source generation happens.
 Design constraints:
 
 * Output passes 4b.1's :func:`validate_source` allowlist —
-  imports only the four extracted-models / structured-extraction
-  symbols, calls only allowlisted Names and method names, no
-  shadowing of allowlisted call targets, no halt/escape
-  constructs, no decorators, no non-constant defaults.
+  imports only the three symbols actually used (``ExtractedNode``,
+  ``ExtractedProperty``, ``StructuredExtractionResult``); calls
+  only allowlisted Names and method names; no shadowing of
+  allowlisted call targets, no halt/escape constructs, no
+  decorators, no non-constant defaults. ``ExtractedEdge`` isn't
+  imported since the renderer doesn't emit edges yet — adding
+  edge support is a future plan-shape extension.
 * Output, when run on sample events, emits well-formed
   :class:`StructuredExtractionResult` instances (lists for
   ``nodes`` / ``edges``, sets for the span-id fields) so the
@@ -204,7 +207,17 @@ def render_extractor_source(plan: ResolvedExtractorPlan) -> str:
 
 
 def _validate_plan(plan: ResolvedExtractorPlan) -> None:
-  """Reject malformed plans before any source is generated."""
+  """Reject malformed plans before any source is generated.
+
+  Type hints on the dataclasses don't enforce types at runtime —
+  ``ResolvedExtractorPlan(event_type=1)`` is accepted by Python
+  even though the renderer expects a string. The validator
+  catches every shape that would produce broken Python source or
+  an opaque downstream failure (Pydantic ``ExtractedNode``
+  construction, AST-gate rejection, etc.) and raises
+  ``ValueError`` at the renderer boundary so callers see one
+  consistent error shape.
+  """
   if not _is_python_identifier(plan.function_name):
     raise ValueError(
         f"function_name={plan.function_name!r} must be a plain Python "
@@ -216,24 +229,21 @@ def _validate_plan(plan: ResolvedExtractorPlan) -> None:
         f"function_name={plan.function_name!r} would shadow an "
         f"allowlisted call target; pick a different name"
     )
-  if not plan.event_type:
-    raise ValueError("event_type must be a non-empty string")
-  if not plan.target_entity_name:
-    raise ValueError("target_entity_name must be a non-empty string")
+  _require_nonempty_str(plan.event_type, "event_type")
+  _require_safe_identifier(plan.target_entity_name, "target_entity_name")
   if not plan.key_field.source_path:
     raise ValueError("key_field.source_path must be non-empty")
-  if not plan.key_field.property_name:
-    raise ValueError("key_field.property_name must be non-empty")
+  _require_safe_identifier(
+      plan.key_field.property_name, "key_field.property_name"
+  )
+  _require_string_path(plan.key_field.source_path, "key_field.source_path")
   seen_properties: set[str] = {plan.key_field.property_name}
-  for fm in plan.property_fields:
-    if not fm.property_name:
-      raise ValueError(
-          "property_fields entries must have non-empty property_name"
-      )
+  for index, fm in enumerate(plan.property_fields):
+    field_label = f"property_fields[{index}]"
+    _require_safe_identifier(fm.property_name, f"{field_label}.property_name")
     if not fm.source_path:
-      raise ValueError(
-          f"property_fields[{fm.property_name!r}].source_path must be non-empty"
-      )
+      raise ValueError(f"{field_label}.source_path must be non-empty")
+    _require_string_path(fm.source_path, f"{field_label}.source_path")
     if fm.property_name in seen_properties:
       raise ValueError(
           f"duplicate property_name {fm.property_name!r} in plan; the key "
@@ -242,9 +252,59 @@ def _validate_plan(plan: ResolvedExtractorPlan) -> None:
     seen_properties.add(fm.property_name)
   if not plan.session_id_path:
     raise ValueError("session_id_path must be non-empty")
+  _require_string_path(plan.session_id_path, "session_id_path")
   if plan.span_handling is not None:
     if not plan.span_handling.span_id_path:
       raise ValueError("span_handling.span_id_path must be non-empty")
+    _require_string_path(
+        plan.span_handling.span_id_path, "span_handling.span_id_path"
+    )
+    if plan.span_handling.partial_when_path is not None:
+      if not plan.span_handling.partial_when_path:
+        raise ValueError(
+            "span_handling.partial_when_path must be non-empty when set"
+        )
+      _require_string_path(
+          plan.span_handling.partial_when_path,
+          "span_handling.partial_when_path",
+      )
+
+
+def _require_nonempty_str(value, label: str) -> None:
+  if not isinstance(value, str):
+    raise ValueError(
+        f"{label} must be a string; got {type(value).__name__}={value!r}"
+    )
+  if not value:
+    raise ValueError(f"{label} must be a non-empty string")
+
+
+def _require_safe_identifier(value, label: str) -> None:
+  """Validate that *value* is a non-empty string AND a Python
+  identifier-shape (letters/digits/underscore, no leading digit).
+  Used for fields that get embedded directly into generated
+  Python source as raw characters (e.g., ``target_entity_name``
+  in the ``node_id`` f-string) — restricting them to identifier
+  shape means the source is well-formed regardless of input.
+  """
+  _require_nonempty_str(value, label)
+  if not value.isidentifier():
+    raise ValueError(
+        f"{label}={value!r} must be a Python-identifier-shaped string "
+        f"(letters/digits/underscore, no leading digit, no spaces or "
+        f"special characters); the renderer embeds it directly into "
+        f"generated Python source"
+    )
+
+
+def _require_string_path(value, label: str) -> None:
+  """Each path segment must be a non-empty string. Path segments
+  go through ``repr()`` when emitted into ``.get(...)`` calls, so
+  identifier shape isn't required — but mixed-type paths
+  (``("a", 1)``) or empty segments would render confusing source.
+  """
+  for i, segment in enumerate(value):
+    _require_nonempty_str(segment, f"{label}[{i}]")
 
 
 def _is_python_identifier(value: str) -> bool:
@@ -287,7 +347,10 @@ def _render_session_and_span_id(plan: ResolvedExtractorPlan) -> list[str]:
   lines: list[str] = []
   lines.extend(
       _render_optional_path_get(
-          plan.session_id_path, target_var="session_id", default_repr="''"
+          plan.session_id_path,
+          target_var="session_id",
+          var_prefix="_sid",
+          default_repr="''",
       )
   )
   if plan.span_handling is not None:
@@ -295,6 +358,7 @@ def _render_session_and_span_id(plan: ResolvedExtractorPlan) -> list[str]:
         _render_optional_path_get(
             plan.span_handling.span_id_path,
             target_var="span_id",
+            var_prefix="_spn",
             default_repr="''",
         )
     )
@@ -304,32 +368,46 @@ def _render_session_and_span_id(plan: ResolvedExtractorPlan) -> list[str]:
 
 
 def _render_optional_path_get(
-    path: tuple[str, ...], *, target_var: str, default_repr: str
+    path: tuple[str, ...],
+    *,
+    target_var: str,
+    var_prefix: str,
+    default_repr: str,
 ) -> list[str]:
   """Emit ``target_var = event[path]`` style traversal that falls
   back to ``default_repr`` when any intermediate isn't a dict or
-  the leaf is missing."""
-  lines: list[str] = []
+  the leaf is missing.
+
+  Each ``.get(...)`` is emitted *inside* the previous step's
+  ``isinstance(..., dict)`` guard — so a string / list / None
+  intermediate can never crash the next ``.get(...)`` call. The
+  previous flat pattern checked all isinstances *after* the
+  ``.get()`` chain had already run, which was the P1.1 bug.
+
+  Pattern (for path ``("a", "b", "c")``)::
+
+      target = default          # safe baseline
+      v0 = event.get('a')       # fails fast for missing keys
+      if isinstance(v0, dict):
+        v1 = v0.get('b')
+        if isinstance(v1, dict):
+          target = v1.get('c', default)
+  """
   if len(path) == 1:
-    lines.append(f"  {target_var} = event.get({path[0]!r}, {default_repr})")
-    return lines
-  # Multi-step: probe each intermediate, fall back if anything's
-  # not a dict.
+    return [f"  {target_var} = event.get({path[0]!r}, {default_repr})"]
+
+  lines: list[str] = [f"  {target_var} = {default_repr}"]
   last_dict = "event"
-  guard_var = f"_g_{target_var}"
-  for i, step in enumerate(path[:-1]):
-    var = f"{guard_var}_{i}"
-    lines.append(f"  {var} = {last_dict}.get({step!r})")
+  indent = "  "
+  for depth in range(len(path) - 1):
+    var = f"{var_prefix}_{depth}"
+    lines.append(f"{indent}{var} = {last_dict}.get({path[depth]!r})")
+    lines.append(f"{indent}if isinstance({var}, dict):")
     last_dict = var
-  guards = " and ".join(
-      f"isinstance({guard_var}_{i}, dict)" for i in range(len(path) - 1)
-  )
-  lines.append(f"  if {guards}:")
+    indent = indent + "  "
   lines.append(
-      f"    {target_var} = {last_dict}.get({path[-1]!r}, {default_repr})"
+      f"{indent}{target_var} = {last_dict}.get({path[-1]!r}, {default_repr})"
   )
-  lines.append("  else:")
-  lines.append(f"    {target_var} = {default_repr}")
   return lines
 
 
@@ -349,51 +427,53 @@ def _render_node_id_and_properties(
   lines.append(
       f"  properties = [ExtractedProperty(name={key_property!r}, value=key_value)]"
   )
-  for fm in plan.property_fields:
-    lines.extend(_render_optional_property(fm))
+  for index, fm in enumerate(plan.property_fields):
+    lines.extend(_render_optional_property(fm, index))
   return lines
 
 
-def _render_optional_property(fm: FieldMapping) -> list[str]:
+def _render_optional_property(fm: FieldMapping, index: int) -> list[str]:
   """Emit the conditional append for one optional property field.
 
-  Pattern (for path of length >= 1):
+  Each ``.get(...)`` lives inside the previous step's
+  ``isinstance(..., dict)`` guard so a non-dict intermediate
+  doesn't raise. *index* is the property's position in
+  ``plan.property_fields``; helper variable names derive from the
+  index (``_op0_0``, ``_op0_1``, ...) instead of from
+  ``fm.property_name`` so a property name that isn't a Python
+  identifier can't pollute the generated source.
 
-    _p0 = event.get('content')   # for path ('content', 'outcome')
-    if isinstance(_p0, dict) and 'outcome' in _p0:
-      properties.append(ExtractedProperty(name='outcome', value=_p0['outcome']))
+  Pattern (for path ``("content", "outcome")``)::
 
-  For length 1 the receiver is ``event`` directly.
+      _op0_0 = event.get('content')
+      if isinstance(_op0_0, dict):
+        if 'outcome' in _op0_0:
+          properties.append(ExtractedProperty(
+              name='outcome', value=_op0_0['outcome']))
   """
-  lines: list[str] = []
   path = fm.source_path
-  unique = fm.property_name
   if len(path) == 1:
-    receiver = "event"
     leaf_key = path[0]
-    lines.append(
-        f"  if isinstance({receiver}, dict) and {leaf_key!r} in {receiver}:"
-    )
-    lines.append(
+    return [
+        f"  if {leaf_key!r} in event:",
         f"    properties.append(ExtractedProperty("
-        f"name={fm.property_name!r}, value={receiver}[{leaf_key!r}]))"
-    )
-    return lines
+        f"name={fm.property_name!r}, value=event[{leaf_key!r}]))",
+    ]
 
-  # Multi-step: probe each intermediate, then check membership.
+  lines: list[str] = []
   last_dict = "event"
-  guard_var = f"_op_{unique}"
-  for i, step in enumerate(path[:-1]):
-    var = f"{guard_var}_{i}"
-    lines.append(f"  {var} = {last_dict}.get({step!r})")
+  indent = "  "
+  var_prefix = f"_op{index}"
+  for depth in range(len(path) - 1):
+    var = f"{var_prefix}_{depth}"
+    lines.append(f"{indent}{var} = {last_dict}.get({path[depth]!r})")
+    lines.append(f"{indent}if isinstance({var}, dict):")
     last_dict = var
-  guards = " and ".join(
-      f"isinstance({guard_var}_{i}, dict)" for i in range(len(path) - 1)
-  )
+    indent = indent + "  "
   leaf_key = path[-1]
-  lines.append(f"  if {guards} and {leaf_key!r} in {last_dict}:")
+  lines.append(f"{indent}if {leaf_key!r} in {last_dict}:")
   lines.append(
-      f"    properties.append(ExtractedProperty("
+      f"{indent}  properties.append(ExtractedProperty("
       f"name={fm.property_name!r}, value={last_dict}[{leaf_key!r}]))"
   )
   return lines
@@ -435,6 +515,7 @@ def _render_span_handling(plan: ResolvedExtractorPlan) -> list[str]:
       _render_optional_path_get(
           rule.partial_when_path,
           target_var="_partial_v",
+          var_prefix="_pw",
           default_repr="None",
       )
   )

--- a/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
+++ b/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
@@ -179,6 +179,15 @@ def render_extractor_source(plan: ResolvedExtractorPlan) -> str:
       f'  """Generated extractor for event_type='
       f'{plan.event_type!r} (entity={plan.target_entity_name!r})."""'
   )
+  # Top-of-function event_type guard: the orchestrator (C2) routes
+  # events by ``event.get("event_type")`` against the manifest's
+  # declared types, but a plan/manifest mismatch could silently
+  # attach an extractor to the wrong event type. Layering the
+  # check inside the generated body means the extractor itself
+  # enforces its declared coverage — even if invoked directly on
+  # a stray event.
+  body_lines.append(f"  if event.get('event_type') != {plan.event_type!r}:")
+  body_lines.append("    return StructuredExtractionResult()")
   body_lines.extend(_render_key_traversal(plan))
   body_lines.append("")
   body_lines.extend(_render_session_and_span_id(plan))

--- a/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
+++ b/src/bigquery_agent_analytics/extractor_compilation/template_renderer.py
@@ -1,0 +1,447 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic source generator for compiled structured extractors.
+
+PR 4b.2.1: turns a pre-resolved :class:`ResolvedExtractorPlan` into
+a Python source string that 4b.1's
+:func:`bigquery_agent_analytics.extractor_compilation.compile_extractor`
+can run through every gate (AST allowlist, smoke runner, #76
+validator). **No LLM call lives here.** PR 4b.2.2 owns the LLM
+step that *resolves* a raw extraction-rule + event-schema pair
+into a :class:`ResolvedExtractorPlan`; this module is the
+deterministic boundary the LLM output has to cross before any
+source generation happens.
+
+Design constraints:
+
+* Output passes 4b.1's :func:`validate_source` allowlist —
+  imports only the four extracted-models / structured-extraction
+  symbols, calls only allowlisted Names and method names, no
+  shadowing of allowlisted call targets, no halt/escape
+  constructs, no decorators, no non-constant defaults.
+* Output, when run on sample events, emits well-formed
+  :class:`StructuredExtractionResult` instances (lists for
+  ``nodes`` / ``edges``, sets for the span-id fields) so the
+  smoke runner's well-formed-result check accepts them.
+* Output is **deterministic**: identical plans produce
+  byte-identical source. Useful so the compile fingerprint stays
+  stable across consecutive renders.
+
+The plan model is intentionally narrow. Every field-level
+decision is already resolved before the renderer runs — there is
+no "look at the event_schema to figure out the path." That keeps
+the renderer's contract small and makes the LLM step in 4b.2.2 a
+pure mapping problem (raw rule + schema → ResolvedExtractorPlan).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import keyword
+from typing import Optional
+
+# Names that ``compile_extractor`` and the AST allowlist agree
+# can be safely imported / called inside generated source. Keeping
+# this list aligned with ``_ALLOWED_CALL_TARGETS`` in
+# ``ast_validator.py`` is what makes generated source pass
+# validation at all.
+_GENERATED_HEADER = (
+    '"""Compiled structured extractor (rendered by '
+    "bigquery_agent_analytics.extractor_compilation.template_renderer)."
+    '"""\n'
+    "\n"
+    "from __future__ import annotations\n"
+    "\n"
+    "from bigquery_agent_analytics.extracted_models import ExtractedNode\n"
+    "from bigquery_agent_analytics.extracted_models import ExtractedProperty\n"
+    "from bigquery_agent_analytics.structured_extraction import (\n"
+    "    StructuredExtractionResult,\n"
+    ")\n"
+)
+
+# 4b.1's call-target allowlist. Imported names must not shadow
+# any of these; the renderer's identifier validator enforces the
+# rule for ``function_name``. Mirrors ``_ALLOWED_CALL_TARGETS``
+# in ``ast_validator.py``.
+_ALLOWLIST_CALL_TARGETS = frozenset(
+    {
+        "ExtractedNode",
+        "ExtractedEdge",
+        "ExtractedProperty",
+        "StructuredExtractionResult",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "bytes",
+        "set",
+        "frozenset",
+        "dict",
+        "list",
+        "tuple",
+        "isinstance",
+        "len",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class FieldMapping:
+  """Maps an ontology property name to a path in the event payload.
+
+  ``source_path`` is a sequence of dict keys: ``("content",
+  "decision_id")`` means ``event["content"]["decision_id"]``.
+  Each intermediate value must be a ``dict`` for the lookup to
+  succeed; the renderer emits ``isinstance`` guards at every
+  level so missing or wrong-shape intermediates produce ``None``
+  (which the caller treats as "field absent") rather than raising.
+  """
+
+  property_name: str
+  source_path: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class SpanHandlingRule:
+  """How to populate the result's ``fully_handled_span_ids`` and
+  ``partially_handled_span_ids`` sets.
+
+  ``span_id_path`` is where to find the span id in the event
+  (default ``("span_id",)``).
+
+  ``partial_when_path`` is optional. When set, the span is marked
+  *partially* handled when the value at that path is truthy —
+  matches the BKA pattern of "free-text reasoning still needs the
+  AI extractor." When unset, the span is always *fully* handled
+  whenever it's present.
+  """
+
+  span_id_path: tuple[str, ...] = ("span_id",)
+  partial_when_path: Optional[tuple[str, ...]] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ResolvedExtractorPlan:
+  """A pre-resolved plan for one compiled extractor.
+
+  The plan is deliberately boring — every field-level decision is
+  already made by the caller. PR 4b.2.2 will populate this from a
+  raw extraction rule + event schema via an LLM step; PR 4b.2.1
+  exists so that source-generation can be reviewed independently
+  of any probabilistic mapping.
+  """
+
+  event_type: str
+  target_entity_name: str
+  function_name: str
+  key_field: FieldMapping
+  property_fields: tuple[FieldMapping, ...] = ()
+  session_id_path: tuple[str, ...] = ("session_id",)
+  span_handling: Optional[SpanHandlingRule] = None
+
+
+def render_extractor_source(plan: ResolvedExtractorPlan) -> str:
+  """Render a Python source string for one compiled extractor.
+
+  The returned source is a complete module that defines a single
+  ``StructuredExtractor`` callable named ``plan.function_name``.
+  When fed to ``compile_extractor(source=..., ...)`` it must
+  clear every gate; the tests in
+  ``tests/test_extractor_compilation_template.py`` lock that
+  behavior in.
+
+  Raises:
+    ValueError: if any plan field violates the renderer's
+      contract (empty strings, duplicate property names, invalid
+      function name, etc.). Failures are caught here rather than
+      delegated to ``compile_extractor`` so callers see a clear
+      plan-level error.
+  """
+  _validate_plan(plan)
+
+  body_lines: list[str] = []
+  body_lines.append(
+      f'  """Generated extractor for event_type='
+      f'{plan.event_type!r} (entity={plan.target_entity_name!r})."""'
+  )
+  body_lines.extend(_render_key_traversal(plan))
+  body_lines.append("")
+  body_lines.extend(_render_session_and_span_id(plan))
+  body_lines.append("")
+  body_lines.extend(_render_node_id_and_properties(plan))
+  body_lines.append("")
+  body_lines.extend(_render_node_construction(plan))
+  body_lines.append("")
+  body_lines.extend(_render_span_handling(plan))
+  body_lines.append("")
+  body_lines.append("  return StructuredExtractionResult(")
+  body_lines.append("      nodes=[node],")
+  body_lines.append("      edges=[],")
+  body_lines.append("      fully_handled_span_ids=fully_handled,")
+  body_lines.append("      partially_handled_span_ids=partially_handled,")
+  body_lines.append("  )")
+
+  source = (
+      _GENERATED_HEADER
+      + "\n"
+      + f"def {plan.function_name}(event, spec):\n"
+      + "\n".join(body_lines)
+      + "\n"
+  )
+  return source
+
+
+def _validate_plan(plan: ResolvedExtractorPlan) -> None:
+  """Reject malformed plans before any source is generated."""
+  if not _is_python_identifier(plan.function_name):
+    raise ValueError(
+        f"function_name={plan.function_name!r} must be a plain Python "
+        f"identifier (letters/digits/underscore, not starting with a "
+        f"digit, not a Python keyword)"
+    )
+  if plan.function_name in _ALLOWLIST_CALL_TARGETS:
+    raise ValueError(
+        f"function_name={plan.function_name!r} would shadow an "
+        f"allowlisted call target; pick a different name"
+    )
+  if not plan.event_type:
+    raise ValueError("event_type must be a non-empty string")
+  if not plan.target_entity_name:
+    raise ValueError("target_entity_name must be a non-empty string")
+  if not plan.key_field.source_path:
+    raise ValueError("key_field.source_path must be non-empty")
+  if not plan.key_field.property_name:
+    raise ValueError("key_field.property_name must be non-empty")
+  seen_properties: set[str] = {plan.key_field.property_name}
+  for fm in plan.property_fields:
+    if not fm.property_name:
+      raise ValueError(
+          "property_fields entries must have non-empty property_name"
+      )
+    if not fm.source_path:
+      raise ValueError(
+          f"property_fields[{fm.property_name!r}].source_path must be non-empty"
+      )
+    if fm.property_name in seen_properties:
+      raise ValueError(
+          f"duplicate property_name {fm.property_name!r} in plan; the key "
+          f"field plus property_fields must be a set of distinct names"
+      )
+    seen_properties.add(fm.property_name)
+  if not plan.session_id_path:
+    raise ValueError("session_id_path must be non-empty")
+  if plan.span_handling is not None:
+    if not plan.span_handling.span_id_path:
+      raise ValueError("span_handling.span_id_path must be non-empty")
+
+
+def _is_python_identifier(value: str) -> bool:
+  return (
+      isinstance(value, str)
+      and value.isidentifier()
+      and not keyword.iskeyword(value)
+  )
+
+
+def _render_key_traversal(plan: ResolvedExtractorPlan) -> list[str]:
+  """Emit the traversal that pulls the key value from
+  ``plan.key_field.source_path``. Returns an empty result if any
+  intermediate is not a dict, or if the leaf is ``None`` — the
+  same "extractor declines this event" contract the BKA fixture
+  uses."""
+  lines: list[str] = []
+  path = plan.key_field.source_path
+  if len(path) == 1:
+    lines.append(f"  key_value = event.get({path[0]!r})")
+  else:
+    last_dict = "event"
+    for i, step in enumerate(path[:-1]):
+      var = f"_p{i}"
+      lines.append(f"  {var} = {last_dict}.get({step!r})")
+      lines.append(f"  if not isinstance({var}, dict):")
+      lines.append("    return StructuredExtractionResult()")
+      last_dict = var
+    lines.append(f"  key_value = {last_dict}.get({path[-1]!r})")
+  lines.append("  if key_value is None:")
+  lines.append("    return StructuredExtractionResult()")
+  return lines
+
+
+def _render_session_and_span_id(plan: ResolvedExtractorPlan) -> list[str]:
+  """``session_id`` and (optionally) ``span_id`` come from the
+  event root via simple ``.get(..., '')`` calls — missing values
+  fall back to ``''`` so the generated node_id and span sets are
+  always well-shaped."""
+  lines: list[str] = []
+  lines.extend(
+      _render_optional_path_get(
+          plan.session_id_path, target_var="session_id", default_repr="''"
+      )
+  )
+  if plan.span_handling is not None:
+    lines.extend(
+        _render_optional_path_get(
+            plan.span_handling.span_id_path,
+            target_var="span_id",
+            default_repr="''",
+        )
+    )
+  else:
+    lines.append("  span_id = ''")
+  return lines
+
+
+def _render_optional_path_get(
+    path: tuple[str, ...], *, target_var: str, default_repr: str
+) -> list[str]:
+  """Emit ``target_var = event[path]`` style traversal that falls
+  back to ``default_repr`` when any intermediate isn't a dict or
+  the leaf is missing."""
+  lines: list[str] = []
+  if len(path) == 1:
+    lines.append(f"  {target_var} = event.get({path[0]!r}, {default_repr})")
+    return lines
+  # Multi-step: probe each intermediate, fall back if anything's
+  # not a dict.
+  last_dict = "event"
+  guard_var = f"_g_{target_var}"
+  for i, step in enumerate(path[:-1]):
+    var = f"{guard_var}_{i}"
+    lines.append(f"  {var} = {last_dict}.get({step!r})")
+    last_dict = var
+  guards = " and ".join(
+      f"isinstance({guard_var}_{i}, dict)" for i in range(len(path) - 1)
+  )
+  lines.append(f"  if {guards}:")
+  lines.append(
+      f"    {target_var} = {last_dict}.get({path[-1]!r}, {default_repr})"
+  )
+  lines.append("  else:")
+  lines.append(f"    {target_var} = {default_repr}")
+  return lines
+
+
+def _render_node_id_and_properties(
+    plan: ResolvedExtractorPlan,
+) -> list[str]:
+  """Emit ``node_id`` and ``properties`` list construction. Each
+  optional property field is added under an ``in``-check guard so
+  missing fields stay absent from the materialized row."""
+  lines: list[str] = []
+  key_property = plan.key_field.property_name
+  lines.append(
+      f"  node_id = "
+      f"f'{{session_id}}:{plan.target_entity_name}:"
+      f"{key_property}={{key_value}}'"
+  )
+  lines.append(
+      f"  properties = [ExtractedProperty(name={key_property!r}, value=key_value)]"
+  )
+  for fm in plan.property_fields:
+    lines.extend(_render_optional_property(fm))
+  return lines
+
+
+def _render_optional_property(fm: FieldMapping) -> list[str]:
+  """Emit the conditional append for one optional property field.
+
+  Pattern (for path of length >= 1):
+
+    _p0 = event.get('content')   # for path ('content', 'outcome')
+    if isinstance(_p0, dict) and 'outcome' in _p0:
+      properties.append(ExtractedProperty(name='outcome', value=_p0['outcome']))
+
+  For length 1 the receiver is ``event`` directly.
+  """
+  lines: list[str] = []
+  path = fm.source_path
+  unique = fm.property_name
+  if len(path) == 1:
+    receiver = "event"
+    leaf_key = path[0]
+    lines.append(
+        f"  if isinstance({receiver}, dict) and {leaf_key!r} in {receiver}:"
+    )
+    lines.append(
+        f"    properties.append(ExtractedProperty("
+        f"name={fm.property_name!r}, value={receiver}[{leaf_key!r}]))"
+    )
+    return lines
+
+  # Multi-step: probe each intermediate, then check membership.
+  last_dict = "event"
+  guard_var = f"_op_{unique}"
+  for i, step in enumerate(path[:-1]):
+    var = f"{guard_var}_{i}"
+    lines.append(f"  {var} = {last_dict}.get({step!r})")
+    last_dict = var
+  guards = " and ".join(
+      f"isinstance({guard_var}_{i}, dict)" for i in range(len(path) - 1)
+  )
+  leaf_key = path[-1]
+  lines.append(f"  if {guards} and {leaf_key!r} in {last_dict}:")
+  lines.append(
+      f"    properties.append(ExtractedProperty("
+      f"name={fm.property_name!r}, value={last_dict}[{leaf_key!r}]))"
+  )
+  return lines
+
+
+def _render_node_construction(plan: ResolvedExtractorPlan) -> list[str]:
+  return [
+      "  node = ExtractedNode(",
+      f"      node_id=node_id,",
+      f"      entity_name={plan.target_entity_name!r},",
+      f"      labels=[{plan.target_entity_name!r}],",
+      "      properties=properties,",
+      "  )",
+  ]
+
+
+def _render_span_handling(plan: ResolvedExtractorPlan) -> list[str]:
+  """Emit ``fully_handled`` / ``partially_handled`` set
+  construction. When ``span_handling`` is ``None`` the span sets
+  are always empty (the extractor doesn't claim any span
+  handling); otherwise the partial-when path determines partial vs
+  full."""
+  if plan.span_handling is None:
+    return [
+        "  fully_handled = set()",
+        "  partially_handled = set()",
+    ]
+  rule = plan.span_handling
+  if rule.partial_when_path is None:
+    return [
+        "  fully_handled = {span_id} if span_id else set()",
+        "  partially_handled = set()",
+    ]
+  # Partial-when path: pull the value via the same safe-traversal
+  # helper used for ``span_id`` itself, then treat as partial iff
+  # truthy. The helper returns ``None`` when any intermediate
+  # isn't a dict, so we don't need a separate raise/missing path.
+  lines: list[str] = list(
+      _render_optional_path_get(
+          rule.partial_when_path,
+          target_var="_partial_v",
+          default_repr="None",
+      )
+  )
+  lines.append("  if _partial_v:")
+  lines.append("    fully_handled = set()")
+  lines.append("    partially_handled = {span_id} if span_id else set()")
+  lines.append("  else:")
+  lines.append("    fully_handled = {span_id} if span_id else set()")
+  lines.append("    partially_handled = set()")
+  return lines

--- a/tests/test_extractor_compilation_template.py
+++ b/tests/test_extractor_compilation_template.py
@@ -320,6 +320,96 @@ class TestPlanValidation:
     with pytest.raises(ValueError, match="duplicate property_name"):
       render_extractor_source(plan)
 
+  def test_target_entity_name_with_quote_rejected(self):
+    """``target_entity_name`` is embedded directly in an f-string
+    in the generated source. A value containing a quote would
+    produce broken Python. The identifier-shape check rejects it
+    before any source is generated."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="Foo's",
+        function_name="f",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+    )
+    with pytest.raises(ValueError, match="target_entity_name"):
+      render_extractor_source(plan)
+
+  @pytest.mark.parametrize(
+      "bad_name",
+      [
+          "bad-name",
+          "with space",
+          "1leading",
+          "weird;chars",
+      ],
+  )
+  def test_property_name_with_non_identifier_chars_rejected(self, bad_name):
+    """Property names with characters that aren't identifier-safe
+    used to render variable names like ``_op_bad-name_0`` (broken
+    Python). The renderer now derives variable names from the
+    property index, but the validator still rejects non-identifier
+    property names so the manifest contract stays predictable."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+        property_fields=(FieldMapping(bad_name, ("p",)),),
+    )
+    with pytest.raises(ValueError, match="property_name"):
+      render_extractor_source(plan)
+
+  @pytest.mark.parametrize(
+      "field, value",
+      [
+          ("event_type", 1),
+          ("event_type", None),
+          ("target_entity_name", 42),
+          ("function_name", b"bytes"),
+      ],
+  )
+  def test_non_string_top_level_fields_rejected(self, field, value):
+    """``ResolvedExtractorPlan`` doesn't enforce types at runtime
+    (no Pydantic). The renderer catches non-string values up front
+    so they don't render as broken Python that fails later in
+    ``compile_extractor`` or at runtime."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    base = dict(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ("k",)),
+    )
+    base[field] = value
+    plan = ResolvedExtractorPlan(**base)
+    with pytest.raises(ValueError):
+      render_extractor_source(plan)
+
+  def test_non_string_path_segment_rejected(self):
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ("ok", 1, "x")),
+    )
+    with pytest.raises(ValueError, match="key_field.source_path"):
+      render_extractor_source(plan)
+
   def test_property_name_collides_with_key_rejected(self):
     """The key property is also in the rendered properties list,
     so a property_field with the same name would emit two
@@ -534,6 +624,117 @@ class TestPlanShapeVariations:
     assert len(result.nodes) == 1
     properties = {p.name: p.value for p in result.nodes[0].properties}
     assert properties == {"decision_id": "d1", "outcome": "approved"}
+
+  def test_deep_optional_property_path_with_non_dict_intermediate(
+      self, tmp_path: pathlib.Path
+  ):
+    """The renderer's docs promise wrong-shape intermediates
+    resolve to "field absent" rather than crashing. Verify with
+    a length-3 *optional property* path where the first
+    intermediate is a string."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="deep",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_deep_opt",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+        property_fields=(FieldMapping("outcome", ("a", "b", "outcome")),),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "deep_opt.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="deep_opt_"),
+        function_name=plan.function_name,
+    )
+
+    # event["a"] is a string, not a dict — must NOT raise.
+    result = extractor(
+        {"decision_id": "d1", "a": "notadict"},
+        None,
+    )
+    assert len(result.nodes) == 1
+    properties = {p.name for p in result.nodes[0].properties}
+    assert properties == {"decision_id"}, "outcome should be absent"
+
+  def test_deep_session_id_path_with_non_dict_intermediate(
+      self, tmp_path: pathlib.Path
+  ):
+    """Same protection on ``session_id_path``: a non-dict
+    intermediate falls back to the empty-string default rather
+    than crashing."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="deep",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_deep_session",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+        session_id_path=("a", "b", "c"),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "deep_session.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="deep_sess_"),
+        function_name=plan.function_name,
+    )
+
+    result = extractor(
+        {"decision_id": "d1", "a": "notadict"},
+        None,
+    )
+    assert len(result.nodes) == 1
+    # session_id falls back to '' so the node_id starts with the
+    # empty session prefix.
+    assert result.nodes[0].node_id == ":mako_DecisionPoint:decision_id=d1"
+
+  def test_deep_partial_when_path_with_non_dict_intermediate(
+      self, tmp_path: pathlib.Path
+  ):
+    """Same protection on ``partial_when_path``: a non-dict
+    intermediate resolves to None (i.e., span fully handled)
+    rather than crashing."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+    from bigquery_agent_analytics.extractor_compilation import SpanHandlingRule
+
+    plan = ResolvedExtractorPlan(
+        event_type="deep",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_deep_partial",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+        span_handling=SpanHandlingRule(
+            span_id_path=("span_id",),
+            partial_when_path=("a", "b", "c"),
+        ),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "deep_partial.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="deep_partial_"),
+        function_name=plan.function_name,
+    )
+
+    result = extractor(
+        {"decision_id": "d1", "span_id": "s1", "a": "notadict"},
+        None,
+    )
+    assert result.fully_handled_span_ids == {"s1"}
+    assert result.partially_handled_span_ids == set()
 
   def test_plan_with_deep_traversal_path(self, tmp_path: pathlib.Path):
     """Length-3 paths emit nested ``isinstance(..., dict)`` guards

--- a/tests/test_extractor_compilation_template.py
+++ b/tests/test_extractor_compilation_template.py
@@ -503,6 +503,64 @@ class TestGeneratedSourceClearsGates:
           auto
       ), f"rendered vs hand-written diverge on event {event!r}"
 
+  def test_wrong_event_type_returns_empty(self, tmp_path: pathlib.Path):
+    """Generated extractors carry a top-of-function event_type
+    guard so a plan/manifest mismatch can't silently attach one
+    extractor to another extractor's events. Without the guard,
+    an extractor for ``"bka_decision"`` would still emit a node
+    for ``{"event_type": "wrong", "decision_id": "1"}`` if the
+    key path happened to match.
+    """
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    plan = _bka_plan()
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "bka_guard.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="bka_guard_"),
+        function_name=plan.function_name,
+    )
+
+    # Right event_type: produces output.
+    matching = extractor(
+        {
+            "event_type": "bka_decision",
+            "session_id": "s1",
+            "span_id": "sp1",
+            "content": {"decision_id": "d1"},
+        },
+        None,
+    )
+    assert len(matching.nodes) == 1
+
+    # Wrong event_type: declines, even though the key path resolves.
+    wrong = extractor(
+        {
+            "event_type": "tool_completed",
+            "session_id": "s1",
+            "span_id": "sp1",
+            "content": {"decision_id": "d1"},
+        },
+        None,
+    )
+    assert wrong.nodes == []
+    assert wrong.fully_handled_span_ids == set()
+    assert wrong.partially_handled_span_ids == set()
+
+    # Missing event_type: declines.
+    missing = extractor(
+        {
+            "session_id": "s1",
+            "span_id": "sp1",
+            "content": {"decision_id": "d1"},
+        },
+        None,
+    )
+    assert missing.nodes == []
+
   def test_render_is_deterministic(self):
     """Identical plans produce byte-identical source. Important
     so the compile fingerprint stays stable across consecutive
@@ -655,7 +713,7 @@ class TestPlanShapeVariations:
 
     # event["a"] is a string, not a dict — must NOT raise.
     result = extractor(
-        {"decision_id": "d1", "a": "notadict"},
+        {"event_type": "deep", "decision_id": "d1", "a": "notadict"},
         None,
     )
     assert len(result.nodes) == 1
@@ -690,7 +748,7 @@ class TestPlanShapeVariations:
     )
 
     result = extractor(
-        {"decision_id": "d1", "a": "notadict"},
+        {"event_type": "deep", "decision_id": "d1", "a": "notadict"},
         None,
     )
     assert len(result.nodes) == 1
@@ -730,7 +788,12 @@ class TestPlanShapeVariations:
     )
 
     result = extractor(
-        {"decision_id": "d1", "span_id": "s1", "a": "notadict"},
+        {
+            "event_type": "deep",
+            "decision_id": "d1",
+            "span_id": "s1",
+            "a": "notadict",
+        },
         None,
     )
     assert result.fully_handled_span_ids == {"s1"}

--- a/tests/test_extractor_compilation_template.py
+++ b/tests/test_extractor_compilation_template.py
@@ -1,0 +1,584 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the deterministic source generator (issue #75 PR 4b.2.1).
+
+Coverage:
+- Plan validation (function_name, event_type, target_entity_name,
+  key_field, property_fields, session_id_path, span_handling).
+- Generated source clears 4b.1's ``validate_source`` AST gate.
+- Generated source compiles end-to-end via ``compile_extractor``
+  (including subprocess smoke + #76 validator).
+- BKA-equivalent plan produces output matching
+  ``extract_bka_decision_event`` on the same sample events.
+- Determinism: identical plans render byte-identical source.
+- Plan-shape variations: optional span_handling, no
+  property_fields, deep traversal paths, single-step paths.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import uuid
+
+import pytest
+
+# ------------------------------------------------------------------ #
+# Shared fixtures                                                     #
+# ------------------------------------------------------------------ #
+
+
+_BKA_ONTOLOGY_YAML = (
+    "ontology: BkaTest\n"
+    "entities:\n"
+    "  - name: mako_DecisionPoint\n"
+    "    keys:\n"
+    "      primary: [decision_id]\n"
+    "    properties:\n"
+    "      - name: decision_id\n"
+    "        type: string\n"
+    "      - name: outcome\n"
+    "        type: string\n"
+    "      - name: confidence\n"
+    "        type: double\n"
+    "      - name: alternatives_considered\n"
+    "        type: string\n"
+    "relationships: []\n"
+)
+_BKA_BINDING_YAML = (
+    "binding: bka_test\n"
+    "ontology: BkaTest\n"
+    "target:\n"
+    "  backend: bigquery\n"
+    "  project: p\n"
+    "  dataset: d\n"
+    "entities:\n"
+    "  - name: mako_DecisionPoint\n"
+    "    source: decision_points\n"
+    "    properties:\n"
+    "      - name: decision_id\n"
+    "        column: decision_id\n"
+    "      - name: outcome\n"
+    "        column: outcome\n"
+    "      - name: confidence\n"
+    "        column: confidence\n"
+    "      - name: alternatives_considered\n"
+    "        column: alternatives_considered\n"
+    "relationships: []\n"
+)
+
+
+def _bka_resolved_spec():
+  from bigquery_agent_analytics.resolved_spec import resolve
+  from bigquery_ontology import load_binding
+  from bigquery_ontology import load_ontology
+
+  tmp = pathlib.Path(tempfile.mkdtemp(prefix="bka_template_test_"))
+  (tmp / "ont.yaml").write_text(_BKA_ONTOLOGY_YAML, encoding="utf-8")
+  (tmp / "bnd.yaml").write_text(_BKA_BINDING_YAML, encoding="utf-8")
+  ontology = load_ontology(str(tmp / "ont.yaml"))
+  binding = load_binding(str(tmp / "bnd.yaml"), ontology=ontology)
+  return resolve(ontology, binding)
+
+
+def _sample_bka_events():
+  return [
+      {
+          "event_type": "bka_decision",
+          "session_id": "sess1",
+          "span_id": "span1",
+          "content": {
+              "decision_id": "d1",
+              "outcome": "approved",
+              "confidence": 0.92,
+              "reasoning_text": "rationale",
+          },
+      },
+      {
+          "event_type": "bka_decision",
+          "session_id": "sess1",
+          "span_id": "span2",
+          "content": {
+              "decision_id": "d2",
+              "outcome": "rejected",
+              "confidence": 0.4,
+          },
+      },
+      {
+          # Event without decision_id — extractor declines.
+          "event_type": "bka_decision",
+          "session_id": "sess1",
+          "span_id": "span3",
+          "content": {"unrelated": "noise"},
+      },
+      {
+          # Event with non-dict content — extractor declines.
+          "event_type": "bka_decision",
+          "session_id": "sess1",
+          "span_id": "span4",
+          "content": None,
+      },
+  ]
+
+
+def _bka_plan(*, function_name: str = "extract_bka_decision_event_compiled"):
+  from bigquery_agent_analytics.extractor_compilation import FieldMapping
+  from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+  from bigquery_agent_analytics.extractor_compilation import SpanHandlingRule
+
+  return ResolvedExtractorPlan(
+      event_type="bka_decision",
+      target_entity_name="mako_DecisionPoint",
+      function_name=function_name,
+      key_field=FieldMapping(
+          property_name="decision_id",
+          source_path=("content", "decision_id"),
+      ),
+      property_fields=(
+          FieldMapping("outcome", ("content", "outcome")),
+          FieldMapping("confidence", ("content", "confidence")),
+          FieldMapping(
+              "alternatives_considered", ("content", "alternatives_considered")
+          ),
+      ),
+      span_handling=SpanHandlingRule(
+          span_id_path=("span_id",),
+          partial_when_path=("content", "reasoning_text"),
+      ),
+  )
+
+
+def _fingerprint_inputs():
+  return {
+      "ontology_text": _BKA_ONTOLOGY_YAML,
+      "binding_text": _BKA_BINDING_YAML,
+      "event_schema": {
+          "bka_decision": {
+              "content": {
+                  "decision_id": "string",
+                  "outcome": "string",
+                  "confidence": "double",
+                  "reasoning_text": "string",
+              }
+          }
+      },
+      "event_allowlist": ("bka_decision",),
+      "transcript_builder_version": "v0.1",
+      "content_serialization_rules": {"strip_ansi": True},
+      "extraction_rules": {
+          "bka_decision": {
+              "entity": "mako_DecisionPoint",
+              "key_field": "decision_id",
+          }
+      },
+  }
+
+
+def _unique_module_name(prefix: str = "rendered_") -> str:
+  return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _result_signature(result):
+  """Same structural compare used in
+  ``test_extractor_compilation.test_compiled_output_matches_handwritten_extractor``.
+  """
+  nodes = tuple(
+      (
+          n.node_id,
+          n.entity_name,
+          tuple(n.labels),
+          tuple((p.name, p.value) for p in n.properties),
+      )
+      for n in result.nodes
+  )
+  edges = tuple(
+      (
+          e.edge_id,
+          e.relationship_name,
+          e.from_node_id,
+          e.to_node_id,
+          tuple((p.name, p.value) for p in e.properties),
+      )
+      for e in result.edges
+  )
+  return (
+      nodes,
+      edges,
+      frozenset(result.fully_handled_span_ids),
+      frozenset(result.partially_handled_span_ids),
+  )
+
+
+# ------------------------------------------------------------------ #
+# Plan validation                                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestPlanValidation:
+
+  def test_valid_bka_plan_renders(self):
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    src = render_extractor_source(_bka_plan())
+    assert "def extract_bka_decision_event_compiled" in src
+
+  @pytest.mark.parametrize("name", ["", "1leading", "with space", "../escape"])
+  def test_invalid_function_name_rejected(self, name):
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    plan = _bka_plan(function_name=name)
+    with pytest.raises(ValueError, match="function_name"):
+      render_extractor_source(plan)
+
+  @pytest.mark.parametrize("kw", ["class", "def", "for", "return"])
+  def test_python_keyword_function_name_rejected(self, kw):
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    plan = _bka_plan(function_name=kw)
+    with pytest.raises(ValueError, match="function_name"):
+      render_extractor_source(plan)
+
+  @pytest.mark.parametrize("name", ["len", "isinstance", "ExtractedNode"])
+  def test_function_name_shadowing_call_target_rejected(self, name):
+    """function_name in ``_ALLOWED_CALL_TARGETS`` would shadow the
+    builtin in the generated module. Catch up front."""
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    plan = _bka_plan(function_name=name)
+    with pytest.raises(ValueError, match="shadow"):
+      render_extractor_source(plan)
+
+  def test_empty_event_type_rejected(self):
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ("k",)),
+    )
+    with pytest.raises(ValueError, match="event_type"):
+      render_extractor_source(plan)
+
+  def test_empty_target_entity_rejected(self):
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="",
+        function_name="f",
+        key_field=FieldMapping("k", ("k",)),
+    )
+    with pytest.raises(ValueError, match="target_entity_name"):
+      render_extractor_source(plan)
+
+  def test_empty_key_path_rejected(self):
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ()),
+    )
+    with pytest.raises(ValueError, match="source_path"):
+      render_extractor_source(plan)
+
+  def test_duplicate_property_name_rejected(self):
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ("k",)),
+        property_fields=(
+            FieldMapping("dup", ("a",)),
+            FieldMapping("dup", ("b",)),
+        ),
+    )
+    with pytest.raises(ValueError, match="duplicate property_name"):
+      render_extractor_source(plan)
+
+  def test_property_name_collides_with_key_rejected(self):
+    """The key property is also in the rendered properties list,
+    so a property_field with the same name would emit two
+    ExtractedProperty entries with the same ``name`` — confusing
+    at materialize time. Reject up front."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="x",
+        target_entity_name="E",
+        function_name="f",
+        key_field=FieldMapping("k", ("k",)),
+        property_fields=(FieldMapping("k", ("alt",)),),
+    )
+    with pytest.raises(ValueError, match="duplicate property_name"):
+      render_extractor_source(plan)
+
+
+# ------------------------------------------------------------------ #
+# Generated source clears 4b.1's gates                                #
+# ------------------------------------------------------------------ #
+
+
+class TestGeneratedSourceClearsGates:
+
+  def test_bka_source_passes_ast_validator(self):
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import validate_source
+
+    src = render_extractor_source(_bka_plan())
+    report = validate_source(src)
+    assert (
+        report.ok is True
+    ), f"failures: {[(f.code, f.detail) for f in report.failures]}"
+
+  def test_bka_source_compiles_end_to_end(self, tmp_path: pathlib.Path):
+    """Full pipeline: render → ``compile_extractor`` → bundle on
+    disk. Default isolation=True so this exercises the subprocess
+    smoke gate too."""
+    from bigquery_agent_analytics.extractor_compilation import compile_extractor
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    plan = _bka_plan()
+    src = render_extractor_source(plan)
+    spec = _bka_resolved_spec()
+
+    result = compile_extractor(
+        source=src,
+        module_name=_unique_module_name(),
+        function_name=plan.function_name,
+        event_types=("bka_decision",),
+        sample_events=_sample_bka_events(),
+        spec=None,
+        resolved_graph=spec,
+        parent_bundle_dir=tmp_path,
+        fingerprint_inputs=_fingerprint_inputs(),
+        template_version="v0.1",
+        compiler_package_version="0.0.0",
+    )
+    assert (
+        result.ok is True
+    ), f"compile failed: ast={result.ast_report.failures} smoke={result.smoke_report and (result.smoke_report.exceptions, result.smoke_report.validation_failures)}"
+
+  def test_bka_source_matches_handwritten_extractor(
+      self, tmp_path: pathlib.Path
+  ):
+    """The whole point: rendered BKA source produces output
+    structurally identical to ``extract_bka_decision_event`` on
+    the same sample events."""
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.structured_extraction import extract_bka_decision_event
+
+    plan = _bka_plan()
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "bka_rendered.py"
+    source_path.write_text(src, encoding="utf-8")
+
+    compiled = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(),
+        function_name=plan.function_name,
+    )
+
+    for event in _sample_bka_events():
+      hand = extract_bka_decision_event(event, None)
+      auto = compiled(event, None)
+      assert _result_signature(hand) == _result_signature(
+          auto
+      ), f"rendered vs hand-written diverge on event {event!r}"
+
+  def test_render_is_deterministic(self):
+    """Identical plans produce byte-identical source. Important
+    so the compile fingerprint stays stable across consecutive
+    renders of the same plan."""
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+
+    a = render_extractor_source(_bka_plan())
+    b = render_extractor_source(_bka_plan())
+    assert a == b
+
+
+# ------------------------------------------------------------------ #
+# Plan-shape variations                                               #
+# ------------------------------------------------------------------ #
+
+
+class TestPlanShapeVariations:
+
+  def test_plan_without_property_fields(self, tmp_path: pathlib.Path):
+    """A minimal plan (key only, no optional properties) renders,
+    compiles, and emits a node with only the key."""
+    from bigquery_agent_analytics.extractor_compilation import compile_extractor
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+    from bigquery_agent_analytics.extractor_compilation import SpanHandlingRule
+
+    plan = ResolvedExtractorPlan(
+        event_type="bka_decision",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_bka_minimal",
+        key_field=FieldMapping("decision_id", ("content", "decision_id")),
+        span_handling=SpanHandlingRule(),
+    )
+    src = render_extractor_source(plan)
+    result = compile_extractor(
+        source=src,
+        module_name=_unique_module_name(prefix="minimal_"),
+        function_name=plan.function_name,
+        event_types=("bka_decision",),
+        sample_events=_sample_bka_events(),
+        spec=None,
+        resolved_graph=_bka_resolved_spec(),
+        parent_bundle_dir=tmp_path,
+        fingerprint_inputs=_fingerprint_inputs(),
+        template_version="v0.1",
+        compiler_package_version="0.0.0",
+    )
+    assert result.ok is True
+
+  def test_plan_without_span_handling(self, tmp_path: pathlib.Path):
+    """When ``span_handling`` is None, the rendered extractor
+    leaves both span sets empty."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="bka_decision",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_no_span",
+        key_field=FieldMapping("decision_id", ("content", "decision_id")),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "no_span.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="nospan_"),
+        function_name=plan.function_name,
+    )
+
+    result = extractor(
+        {
+            "event_type": "bka_decision",
+            "session_id": "s1",
+            "span_id": "sp1",
+            "content": {"decision_id": "d1"},
+        },
+        None,
+    )
+    assert result.fully_handled_span_ids == set()
+    assert result.partially_handled_span_ids == set()
+
+  def test_plan_with_single_step_paths(self, tmp_path: pathlib.Path):
+    """Length-1 paths (key directly on event root) render
+    without any traversal guards and still compile."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="flat",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_flat",
+        key_field=FieldMapping("decision_id", ("decision_id",)),
+        property_fields=(FieldMapping("outcome", ("outcome",)),),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "flat.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="flat_"),
+        function_name=plan.function_name,
+    )
+
+    result = extractor(
+        {
+            "event_type": "flat",
+            "session_id": "s1",
+            "decision_id": "d1",
+            "outcome": "approved",
+        },
+        None,
+    )
+    assert len(result.nodes) == 1
+    properties = {p.name: p.value for p in result.nodes[0].properties}
+    assert properties == {"decision_id": "d1", "outcome": "approved"}
+
+  def test_plan_with_deep_traversal_path(self, tmp_path: pathlib.Path):
+    """Length-3 paths emit nested ``isinstance(..., dict)`` guards
+    at every intermediate level."""
+    from bigquery_agent_analytics.extractor_compilation import FieldMapping
+    from bigquery_agent_analytics.extractor_compilation import load_callable_from_source
+    from bigquery_agent_analytics.extractor_compilation import render_extractor_source
+    from bigquery_agent_analytics.extractor_compilation import ResolvedExtractorPlan
+
+    plan = ResolvedExtractorPlan(
+        event_type="deep",
+        target_entity_name="mako_DecisionPoint",
+        function_name="extract_deep",
+        key_field=FieldMapping(
+            "decision_id", ("content", "metadata", "decision_id")
+        ),
+    )
+    src = render_extractor_source(plan)
+    source_path = tmp_path / "deep.py"
+    source_path.write_text(src, encoding="utf-8")
+    extractor = load_callable_from_source(
+        source_path,
+        module_name=_unique_module_name(prefix="deep_"),
+        function_name=plan.function_name,
+    )
+
+    # Found: deep path resolves cleanly.
+    found = extractor(
+        {
+            "event_type": "deep",
+            "session_id": "s1",
+            "content": {"metadata": {"decision_id": "d1"}},
+        },
+        None,
+    )
+    assert len(found.nodes) == 1
+    assert found.nodes[0].node_id == "s1:mako_DecisionPoint:decision_id=d1"
+
+    # Missing intermediate: extractor declines.
+    missing = extractor(
+        {
+            "event_type": "deep",
+            "session_id": "s1",
+            "content": {"metadata": "not_a_dict"},
+        },
+        None,
+    )
+    assert missing.nodes == []


### PR DESCRIPTION
Implements **PR 4b.2.1** in the [#96 working plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/96#issuecomment-4363301699) per the user-sharpened slice — the deterministic source generator the LLM-driven template fill (PR 4b.2.2) will plug into. Builds on PR 4b.1's compile scaffolding (`compile_extractor`, AST allowlist, subprocess smoke runner, #76 validator gate).

**No LLM call in this PR.** PR 4b.2.2 owns the LLM step that *resolves* a raw extraction-rule + event-schema pair into a `ResolvedExtractorPlan`; this module is the deterministic boundary the LLM output has to cross before any source generation happens.

## What's in this PR

New module `bigquery_agent_analytics.extractor_compilation.template_renderer` with:

- **`FieldMapping(property_name, source_path)`** — maps an ontology property to a path in the event payload. `source_path` is a tuple of dict keys; missing or wrong-shape intermediates resolve to "field absent" rather than raising (stepwise `isinstance(..., dict)` guards inside each `.get(...)`).
- **`SpanHandlingRule(span_id_path, partial_when_path)`** — optional. Matches the BKA pattern: `partial_when_path` truthy → span is marked partially handled; otherwise fully handled.
- **`ResolvedExtractorPlan`** — deliberately boring dataclass: `event_type`, `target_entity_name`, `function_name`, `key_field`, optional `property_fields`, `session_id_path`, optional `span_handling`. Every field-level decision is already made before the renderer runs.
- **`render_extractor_source(plan: ResolvedExtractorPlan) -> str`** — pure source generation. Strict plan validation up front: every string field is a non-empty string; `target_entity_name` and property names are Python-identifier-shaped (so they're safe to embed directly into generated source); path segments are non-empty strings; duplicate property names rejected; `function_name` is a Python identifier, not a keyword, not in the call-target allowlist.

## Generated-source contract

- Imports only the three symbols actually used (`ExtractedNode`, `ExtractedProperty`, `StructuredExtractionResult`). `ExtractedEdge` isn't imported since the renderer doesn't emit edges yet.
- Calls only allowlisted Names + allowlisted method names (`get`, `items`, `keys`, `values`, `append`).
- No shadowing of allowlisted call targets, no decorators, no non-constant defaults, no halt/escape constructs.
- **Top-of-function `event_type` guard** rejects events whose type doesn't match the plan's declared coverage — layered defense with C2's manifest-driven dispatch so a plan/manifest mismatch can't silently attach an extractor to the wrong event type.
- Returns well-formed `StructuredExtractionResult` (lists for nodes/edges, sets for span ids).
- **Deterministic**: identical plans render byte-identical source.

## BKA equivalence

The BKA-equivalent plan renders source whose runtime output is structurally identical to `extract_bka_decision_event` on the fixture's sample events (which all carry `event_type="bka_decision"`). End-to-end test compiles through `compile_extractor` (subprocess smoke + #76 validator), re-loads the bundle, and asserts equivalence on every BKA sample.

## Out of scope

Per the PR 4b.2.1 sizing call:

- LLM prompt/schema for resolving raw rules → `ResolvedExtractorPlan` — PR 4b.2.2.
- Retry-on-AST/smoke/validator failure — PR 4b.2.2.
- Diagnostics on retry — PR 4b.2.2.
- Edge extractors — only nodes for now.
- Composite property values — ontology v0 explicitly defers these.

## Tests (39 in `tests/test_extractor_compilation_template.py`)

- **`TestPlanValidation`** (27 cases) — valid BKA plan renders; parametrized rejection of bad function names; empty / non-string `event_type` / `target_entity_name` / `key_field`; duplicate `property_name`; `target_entity_name` with a quote rejected; non-identifier-shaped property names rejected (parametrized); non-string top-level fields and path segments rejected (parametrized).
- **`TestGeneratedSourceClearsGates`** (5 cases) — BKA source passes `validate_source`; compiles end-to-end via `compile_extractor`; rendered output matches `extract_bka_decision_event`; **wrong-event-type input returns empty**; render is deterministic.
- **`TestPlanShapeVariations`** (7 cases) — plan with no `property_fields`; plan with no `span_handling`; single-step paths; deep traversal path (length 3) with missing-intermediate negative case; deep optional property / `session_id_path` / `partial_when_path` with non-dict intermediate.

## Verification at `7310f04`

- Focused suite: `tests/test_extractor_compilation_template.py` 39 passed.
- Full repo suite: **2394 passed, 9 skipped**.
- Autoformat clean.
- `git diff --check upstream/main...HEAD` clean.

## Working plan position

```
✅ #104 — --skip-property-graph (merged in #108)
✅ #105 PR 2a — validator core (merged in #109)
✅ #105 PR 2b — CLI + docs (merged in #112)
✅ #76  — extracted-graph validator (merged in #113)
✅ #75 PR 4a — runtime-target RFC (merged in #115)
✅ #75 PR 4b.1 — compile scaffolding (merged in #117)
🔄 #75 PR 4b.2.1 — deterministic source generator (this PR)
   #75 PR 4b.2.2 — LLM-driven plan resolution + retry
   #75 PR 4c — compile extract_bka_decision_event + measurement report
   #75 C2 (gated) — orchestrator integration, runtime discovery, fallback wiring
```