### PR TITLE
fix(a2a-demo): polling NotFound handling + strict smoke-row gate + reset runbook

### DIFF
--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -39,6 +39,8 @@ Then in two terminals:
 ./.venv/bin/python3 build_org_graphs.py
 ```
 
+**For a clean verification run, start with `./reset.sh`** to drop the caller and receiver datasets first. `build_org_graphs.py` discovers all sessions in each table, including the smoke session and any sessions left from prior runs. Resetting up front guarantees the receiver-extraction acceptance gate (≥3 decisions, ≥9 candidates) reflects only the current campaigns. Skip the reset if you're iterating and intentionally want stale rows visible.
+
 After all three commands return zero, you have:
 
 - `<PROJECT>.a2a_caller_demo.agent_events` — caller-side spans, including `A2A_INTERACTION` rows

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -39,7 +39,7 @@ Then in two terminals:
 ./.venv/bin/python3 build_org_graphs.py
 ```
 
-**For a clean verification run, start with `./reset.sh`** to drop the caller and receiver datasets first. `build_org_graphs.py` discovers all sessions in each table, including the smoke session and any sessions left from prior runs. Resetting up front guarantees the receiver-extraction acceptance gate (≥3 decisions, ≥9 candidates) reflects only the current campaigns. Skip the reset if you're iterating and intentionally want stale rows visible.
+**For a clean verification run: `./reset.sh && ./setup.sh`, then run the two-terminal flow above.** `reset.sh` drops the caller and receiver datasets entirely; `setup.sh` recreates them. The plugin creates tables, not datasets, so a bare `./reset.sh` would leave the demo unable to write. Resetting up front guarantees `build_org_graphs.py`'s discover-all-sessions pass and the receiver-extraction acceptance gate (≥3 decisions, ≥9 candidates) reflect only the current campaigns. Skip the reset if you're iterating and intentionally want stale rows visible.
 
 After all three commands return zero, you have:
 

--- a/examples/a2a_joint_lineage_demo/run_caller_agent.py
+++ b/examples/a2a_joint_lineage_demo/run_caller_agent.py
@@ -253,7 +253,10 @@ def _check_acceptance_gates(succeeded: list[dict[str, object]]) -> int:
   print("Running acceptance gates...")
 
   # G1: caller has ≥1 A2A_INTERACTION per campaign session. Caller
-  # plugin already flushed before this point so a single read is fine.
+  # plugin already flushed before this point so a single read is
+  # fine. Catch NotFound — if the caller table is missing the plugin
+  # never wrote anything and we want a clean diagnostic, not a raw
+  # BigQuery exception.
   q_g1 = f"""
     SELECT
       session_id,
@@ -262,7 +265,17 @@ def _check_acceptance_gates(succeeded: list[dict[str, object]]) -> int:
     WHERE session_id IN UNNEST(@sessions)
     GROUP BY session_id
   """
-  rows = list(client.query(q_g1, job_config=job_config).result())
+  try:
+    rows = list(client.query(q_g1, job_config=job_config).result())
+  except gax_exceptions.NotFound:
+    print(
+        f"  G1 FAIL: caller agent_events table `{caller_table}` not "
+        "found after caller flush. Verify the caller BQ AA Plugin "
+        "wrote successfully (check run_caller_agent.py logs for "
+        "flush() / shutdown() warnings).",
+        file=sys.stderr,
+    )
+    return 1
   missing = [r["session_id"] for r in rows if int(r["a2a_calls"]) == 0]
   no_row = set(caller_sessions) - {r["session_id"] for r in rows}
   if missing or no_row:

--- a/examples/a2a_joint_lineage_demo/run_caller_agent.py
+++ b/examples/a2a_joint_lineage_demo/run_caller_agent.py
@@ -54,6 +54,7 @@ from caller_agent.agent import DATASET_LOCATION
 from caller_agent.agent import PROJECT_ID
 from campaigns import CAMPAIGN_BRIEFS
 from google.adk.runners import InMemoryRunner
+from google.api_core import exceptions as gax_exceptions
 from google.cloud import bigquery
 from google.genai.types import Content
 from google.genai.types import Part
@@ -275,10 +276,16 @@ def _check_acceptance_gates(succeeded: list[dict[str, object]]) -> int:
 
   # G2: receiver dataset has ≥1 row. Receiver plugin runs in the
   # other process and flushes asynchronously w.r.t. the caller's HTTP
-  # round-trips, so we poll.
+  # round-trips, so we poll. Treat NotFound as 0 — on a fresh dataset
+  # the receiver table doesn't exist until the plugin's first write
+  # creates it, and we want the poll loop to time out cleanly with
+  # the intended diagnostic instead of stack-tracing.
   def _g2_check():
     q = f"SELECT COUNT(*) AS n FROM `{receiver_table}`"
-    return int(list(client.query(q).result())[0]["n"])
+    try:
+      return int(list(client.query(q).result())[0]["n"])
+    except gax_exceptions.NotFound:
+      return 0
 
   receiver_rows = _poll_until(
       "G2 receiver row poll",
@@ -319,7 +326,10 @@ def _check_acceptance_gates(succeeded: list[dict[str, object]]) -> int:
   """
 
   def _g3_check():
-    rows = list(client.query(q_g3, job_config=job_config).result())
+    try:
+      rows = list(client.query(q_g3, job_config=job_config).result())
+    except gax_exceptions.NotFound:
+      return 0
     return int(rows[0]["matched"]) if rows else 0
 
   matched = _poll_until(

--- a/examples/a2a_joint_lineage_demo/smoke_receiver.py
+++ b/examples/a2a_joint_lineage_demo/smoke_receiver.py
@@ -14,23 +14,29 @@
 
 """Smoke-test the receiver A2A server end-to-end.
 
-Sends one minimal audience-risk-review request to ``RECEIVER_A2A_URL``
-via the A2A client, waits for the response, then polls
-``<RECEIVER_DATASET_ID>.<RECEIVER_TABLE_ID>`` until at least one row
-is visible.
+Captures the receiver row count before the request, sends one
+minimal audience-risk-review request to ``RECEIVER_A2A_URL`` via the
+A2A client, waits for the response, then polls
+``<RECEIVER_DATASET_ID>.<RECEIVER_TABLE_ID>`` until the count
+strictly exceeds the before-count.
 
-The poll matters: ``BigQueryAgentAnalyticsPlugin._log_event`` queues
-spans into an async writer. ``batch_size=1`` triggers a flush per
-event but the BigQuery write is still asynchronous w.r.t. the HTTP
-response, so a naive single-shot count after the response races and
-sometimes returns zero. We retry with backoff so the gate has a real
-chance to observe the row.
+The strict-greater check matters: a previous demo run may have left
+rows in the receiver table, and a plain "count > 0" check would
+silently pass even if the *current* receiver server is running
+without the plugin. The smoke gate's purpose is to confirm the
+*current* request landed, not that the table was ever written to.
 
-If the gate still returns zero after the polling window, the most
-likely cause is that ``run_receiver_server.py`` is using
-``to_a2a()``'s default plugin-free runner instead of the
-explicit-runner path; the receiver agent processes the request but
-the plugin is silent.
+The poll itself matters because
+``BigQueryAgentAnalyticsPlugin._log_event`` queues spans into an
+async writer; ``batch_size=1`` triggers a flush per event but the
+BigQuery write is still asynchronous w.r.t. the HTTP response. We
+retry with backoff so the gate has a real chance to observe the
+new row.
+
+If the gate fails after the polling window, the most likely cause
+is that ``run_receiver_server.py`` is using ``to_a2a()``'s default
+plugin-free runner instead of the explicit-runner path; the
+receiver agent processes the request but the plugin is silent.
 """
 
 from __future__ import annotations
@@ -43,6 +49,7 @@ import time
 import uuid
 
 from dotenv import load_dotenv
+from google.api_core import exceptions as gax_exceptions
 import google.auth
 from google.cloud import bigquery
 import httpx
@@ -110,42 +117,72 @@ async def _send_request() -> tuple[int, dict | None]:
 
 
 def _count_receiver_rows(bq_client: bigquery.Client) -> int:
+  """Return current receiver row count.
+
+  Treats a NotFound (table doesn't exist yet) as zero rows so the
+  poll loop can still time out cleanly with the intended diagnostic
+  instead of stack-tracing on a clean dataset.
+  """
   query = (
       f"SELECT COUNT(*) AS receiver_rows FROM "
       f"`{PROJECT_ID}.{RECEIVER_DATASET_ID}.{RECEIVER_TABLE_ID}`"
   )
-  rows = list(bq_client.query(query).result())
+  try:
+    rows = list(bq_client.query(query).result())
+  except gax_exceptions.NotFound:
+    return 0
   return int(rows[0]["receiver_rows"]) if rows else 0
 
 
-def _poll_for_receiver_rows(
+def _poll_for_new_receiver_rows(
     bq_client: bigquery.Client,
+    before_count: int,
     timeout_s: float,
     interval_s: float,
 ) -> int:
-  """Poll receiver row count until nonzero or timeout. Returns final count."""
+  """Poll until receiver row count strictly exceeds ``before_count``.
+
+  Returns the final observed count. The strict-greater check protects
+  against a stale-rows pass: a previous demo run may have left rows
+  in the receiver table, and a plain ``count > 0`` check would
+  silently pass even if the *current* receiver server is running
+  without the BQ AA Plugin attached. The smoke gate's purpose is to
+  confirm the *current* request landed, not that the table was ever
+  written to.
+  """
   deadline = time.monotonic() + timeout_s
-  count = 0
+  count = before_count
   attempt = 0
   while time.monotonic() < deadline:
     attempt += 1
     count = _count_receiver_rows(bq_client)
-    if count > 0:
+    if count > before_count:
       print(
           f"  Receiver agent_events rows: {count} "
-          f"(observed after {attempt} poll(s))"
+          f"(was {before_count} before the smoke request; observed "
+          f"after {attempt} poll(s))"
       )
       return count
     time.sleep(interval_s)
   print(
-      f"  Receiver agent_events rows: {count} (after {timeout_s:.0f}s "
-      f"poll, {attempt} attempt(s))"
+      f"  Receiver agent_events rows: {count} (was {before_count} "
+      f"before; no new rows after {timeout_s:.0f}s poll, "
+      f"{attempt} attempt(s))"
   )
   return count
 
 
 def main() -> int:
   print(f"Smoking receiver at {RECEIVER_A2A_URL} ...")
+  bq_client = bigquery.Client(project=PROJECT_ID, location=DATASET_LOCATION)
+
+  # Capture the row count before the smoke request so we can require
+  # a strict increase. Without this, a re-run on a dataset that
+  # already has rows from a prior demo would pass even if the
+  # current receiver server is running without the plugin.
+  before_count = _count_receiver_rows(bq_client)
+  print(f"  Receiver agent_events rows before request: {before_count}")
+
   status, body = asyncio.run(_send_request())
   if status >= 400:
     print(
@@ -165,19 +202,21 @@ def main() -> int:
     )
     return 1
 
-  bq_client = bigquery.Client(project=PROJECT_ID, location=DATASET_LOCATION)
-  receiver_rows = _poll_for_receiver_rows(
+  receiver_rows = _poll_for_new_receiver_rows(
       bq_client,
+      before_count=before_count,
       timeout_s=SMOKE_POLL_TIMEOUT_S,
       interval_s=SMOKE_POLL_INTERVAL_S,
   )
   print(f"  Table: `{PROJECT_ID}.{RECEIVER_DATASET_ID}.{RECEIVER_TABLE_ID}`")
-  if receiver_rows == 0:
+  if receiver_rows <= before_count:
     print(
-        "ERROR: receiver agent_events table is still empty after "
-        f"{SMOKE_POLL_TIMEOUT_S}s of polling. The receiver server is "
-        "most likely running with `to_a2a()`'s default plugin-free "
-        "runner. Verify `run_receiver_server.py` constructs "
+        "ERROR: receiver agent_events row count did not increase "
+        f"after the smoke request ({before_count} before -> "
+        f"{receiver_rows} after, polled {SMOKE_POLL_TIMEOUT_S}s). "
+        "The receiver server is most likely running with `to_a2a()`'s "
+        "default plugin-free runner, or the plugin is failing to "
+        "write. Verify `run_receiver_server.py` constructs "
         "`Runner(..., plugins=[receiver_plugin])` and passes it via "
         "`runner=`.",
         file=sys.stderr,


### PR DESCRIPTION
## Why

These fixes were prepared on the PR [#132](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/132) branch but the PR's tracked head was lagging the fork branch — when #132 merged, it merged at `7dcdf91` (the head GitHub still showed) and four commits worth of follow-up review fixes never landed. This PR replays them on top of `main`.

The merged version of `examples/a2a_joint_lineage_demo/` works for the happy path but has three latent failure modes that surface on real-world runs:

1. Polling stack-traces on a clean dataset before the receiver table exists.
2. Smoke gate passes on stale receiver rows from a prior run, masking a missing-plugin receiver server.
3. README's "for a clean verification run, start with `./reset.sh`" leaves the operator with the datasets dropped and no instruction to recreate them — bare reset breaks the demo because the plugin creates *tables*, not datasets.

## What

Two cherry-picked commits from the unmerged tail of #132's fork branch.

### `4cf9a2d` — handle NotFound during poll + require strict row-count increase

- **`smoke_receiver.py`** + **`run_caller_agent.py` G2/G3** wrap their polled BQ queries in `try/except google.api_core.exceptions.NotFound` and treat as 0 rows / 0 matches during the poll window. On a clean dataset the receiver table doesn't exist until the plugin's first write creates it, so the poll loop now times out cleanly with the intended diagnostic instead of stack-tracing.
- **`smoke_receiver.py`** captures `before_count` before sending the smoke request, then polls for `current > before_count` via the new `_poll_for_new_receiver_rows()`. The strict-greater check protects the smoke gate's purpose — confirming the *current* request landed, not that the table was ever written to. A previous demo run leaves rows; without this check, a re-run would silently pass even if the *current* receiver server is running without the BQ AA Plugin attached.
- Error messages include both counts so the operator sees `"X -> Y after Ns"` and can distinguish "table was already populated and the current request didn't land" from "table was empty and stayed empty."

### `3a52828` — correct reset runbook + handle NotFound on caller G1 query

- **`README.md`** now reads:
  > "For a clean verification run: `./reset.sh && ./setup.sh`, then run the two-terminal flow above."

  with an explicit note that `reset.sh` drops datasets entirely and `setup.sh` recreates them. The plugin creates tables, not datasets — bare `./reset.sh` would leave the demo unable to write at all.
- **`run_caller_agent.py` G1** now wraps the caller-table query in `try/except gax_exceptions.NotFound`, mirroring the G2/G3 pattern from the previous commit. Missing caller table now produces:
  > `G1 FAIL: caller agent_events table \`...\` not found after caller flush. Verify the caller BQ AA Plugin wrote successfully (check run_caller_agent.py logs for flush() / shutdown() warnings).`

  instead of a raw BigQuery exception.

## Verification

- `pyink --check` clean across all files.
- `isort --check-only` clean.
- `python3 -m py_compile` clean across all `.py` files.
- `bash -n setup.sh reset.sh` clean.
- `google.api_core.exceptions.NotFound` import resolves.
- `git diff --check origin/main...HEAD` clean.

## Refs

Follow-up to [#132](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/132). Refs [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129).