### PR TITLE
feat(views): add A2A_INTERACTION typed view + receiver_session_id COALESCE

### DIFF
--- a/src/bigquery_agent_analytics/views.py
+++ b/src/bigquery_agent_analytics/views.py
@@ -188,6 +188,53 @@ _EVENT_VIEW_DEFS: dict[str, tuple[str, str]] = {
   JSON_VALUE(content, '$.tool') AS tool_name,
   JSON_QUERY(content, '$.result') AS tool_result""",
     ),
+    # A2A_INTERACTION is emitted by the BQ AA Plugin whenever a
+    # supervisor agent invokes a `RemoteA2aAgent` sub-agent. The
+    # ADK plugin populates these fields under
+    # `attributes.a2a_metadata` when `event.custom_metadata`
+    # carries `a2a:request` / `a2a:response`. The SDK side surfaces
+    # the lineage IDs (task_id / context_id) plus the full
+    # request / response payloads as typed top-level columns so
+    # downstream consumers can join without re-extracting JSON.
+    #
+    # `receiver_session_id` is the receiver-side ADK session id
+    # echoed back to the caller via response metadata. The COALESCE
+    # handles both A2A response shapes:
+    #   - Task-shaped responses: the executor populates
+    #     `task.metadata.adk_session_id` and the BQ AA Plugin
+    #     stores the full task object as `a2a:response`. The plugin
+    #     also uses that task object as the row's `content` column,
+    #     so the same value is reachable via either path.
+    #   - `A2AMessage`-shaped responses: when populated, the value
+    #     is at the same nested path; when not populated, the
+    #     COALESCE returns NULL and downstream consumers should
+    #     treat the receiver_session_id as diagnostic only and
+    #     fall back to the context-level join
+    #     (caller.a2a_context_id == receiver.session_id) for the
+    #     primary stitch.
+    "A2A_INTERACTION": (
+        "a2a_interactions",
+        """\
+  JSON_VALUE(
+    attributes, '$.a2a_metadata."a2a:task_id"'
+  ) AS a2a_task_id,
+  JSON_VALUE(
+    attributes, '$.a2a_metadata."a2a:context_id"'
+  ) AS a2a_context_id,
+  JSON_QUERY(
+    attributes, '$.a2a_metadata."a2a:request"'
+  ) AS a2a_request,
+  JSON_QUERY(
+    attributes, '$.a2a_metadata."a2a:response"'
+  ) AS a2a_response,
+  COALESCE(
+    JSON_VALUE(content, '$.metadata.adk_session_id'),
+    JSON_VALUE(
+      attributes,
+      '$.a2a_metadata."a2a:response".metadata.adk_session_id'
+    )
+  ) AS receiver_session_id""",
+    ),
 }
 
 # ------------------------------------------------------------------ #

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,6 +58,7 @@ class TestViewManager:
     assert "HITL_CREDENTIAL_REQUEST_COMPLETED" in types
     assert "HITL_CONFIRMATION_REQUEST_COMPLETED" in types
     assert "HITL_INPUT_REQUEST_COMPLETED" in types
+    assert "A2A_INTERACTION" in types
     assert len(types) == len(_EVENT_VIEW_DEFS)
 
   def test_get_view_name(self, vm):
@@ -195,3 +196,116 @@ class TestViewManager:
       sql = vm.get_view_sql(event_type)
       assert "CREATE OR REPLACE VIEW" in sql
       assert f"event_type = '{event_type}'" in sql
+
+
+class TestA2AInteractionView:
+  """Tests for the A2A_INTERACTION view shape.
+
+  The A2A_INTERACTION view exposes lineage IDs (task / context),
+  the request / response payloads, and a typed
+  ``receiver_session_id`` column derived via COALESCE so both A2A
+  response shapes (task-shaped and ``A2AMessage``-shaped) are
+  covered.
+  """
+
+  def test_view_name(self, vm):
+    assert vm.get_view_name("A2A_INTERACTION") == "adk_a2a_interactions"
+
+  def test_view_sql_columns_present(self, vm):
+    """All five typed columns appear in the rendered SQL."""
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    assert "AS a2a_task_id" in sql
+    assert "AS a2a_context_id" in sql
+    assert "AS a2a_request" in sql
+    assert "AS a2a_response" in sql
+    assert "AS receiver_session_id" in sql
+
+  def test_view_sql_event_filter(self, vm):
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    assert "WHERE event_type = 'A2A_INTERACTION'" in sql
+
+  def test_view_sql_extracts_a2a_metadata_from_attributes(self, vm):
+    """task_id / context_id / request / response come from
+    ``attributes.a2a_metadata.*`` — the JSON column the BQ AA
+    Plugin writes them to.
+    """
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    assert (
+        """JSON_VALUE(
+    attributes, '$.a2a_metadata."a2a:task_id"'
+  )"""
+        in sql
+    )
+    assert (
+        """JSON_VALUE(
+    attributes, '$.a2a_metadata."a2a:context_id"'
+  )"""
+        in sql
+    )
+    assert (
+        """JSON_QUERY(
+    attributes, '$.a2a_metadata."a2a:request"'
+  )"""
+        in sql
+    )
+    assert (
+        """JSON_QUERY(
+    attributes, '$.a2a_metadata."a2a:response"'
+  )"""
+        in sql
+    )
+
+  def test_view_sql_receiver_session_id_covers_task_response_shape(self, vm):
+    """Task-shaped responses carry ``adk_session_id`` at
+    ``content.metadata.adk_session_id`` (the BQ AA Plugin uses the
+    response's task object as the row content). The first COALESCE
+    branch addresses this path.
+    """
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    assert "JSON_VALUE(content, '$.metadata.adk_session_id')" in sql
+
+  def test_view_sql_receiver_session_id_covers_message_response_shape(self, vm):
+    """``A2AMessage``-shaped responses (no task wrapper) keep the
+    response object under
+    ``attributes.a2a_metadata."a2a:response"`` rather than as the
+    row content. The second COALESCE branch addresses this path.
+    """
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    assert (
+        """JSON_VALUE(
+      attributes,
+      '$.a2a_metadata."a2a:response".metadata.adk_session_id'
+    )"""
+        in sql
+    )
+
+  def test_view_sql_receiver_session_id_uses_coalesce(self, vm):
+    """The two response-shape paths must be combined under one
+    ``COALESCE`` so a single typed column always carries the
+    receiver session id when it's present in either location.
+    """
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    receiver_block_start = sql.find("COALESCE")
+    receiver_block_end = sql.find(") AS receiver_session_id")
+    assert (
+        receiver_block_start != -1
+    ), "COALESCE must wrap the receiver_session_id paths"
+    assert (
+        receiver_block_end != -1
+    ), "receiver_session_id alias must close a COALESCE"
+    assert receiver_block_start < receiver_block_end
+
+  def test_view_sql_keeps_standard_headers(self, vm):
+    """A2A_INTERACTION view still surfaces the demo-wide identity
+    headers — ``session_id`` is what downstream auditor projections
+    use as the caller-side join key.
+    """
+    sql = vm.get_view_sql("A2A_INTERACTION")
+    for header in [
+        "timestamp",
+        "event_type",
+        "session_id",
+        "invocation_id",
+        "span_id",
+    ]:
+      assert header in sql


### PR DESCRIPTION
## Why

PR 3 of the [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) implementation plan — the optional SDK view cleanup, [#129b2](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129).

The BQ AA Plugin emits `A2A_INTERACTION` events whenever a supervisor agent invokes a `RemoteA2aAgent` sub-agent, but `src/bigquery_agent_analytics/views.py` `_EVENT_VIEW_DEFS` had no entry for that event type. Consumers had to extract the JSON paths inline — which is exactly what `build_joint_graph.py`'s `remote_agent_invocations` projection does in [PR 2 (#135)](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/135). This PR closes that gap so any consumer can `SELECT a2a_task_id, a2a_context_id, receiver_session_id FROM <P>.<D>.adk_a2a_interactions` instead of writing a `JSON_VALUE(... '$.a2a_metadata."a2a:task_id"')` chain by hand.

## What

- **`src/bigquery_agent_analytics/views.py`** — adds `A2A_INTERACTION` to `_EVENT_VIEW_DEFS` with view suffix `a2a_interactions` and five typed columns:
  - `a2a_task_id` (lineage)
  - `a2a_context_id` (lineage; the primary stitch key)
  - `a2a_request` (full request payload, `JSON_QUERY`)
  - `a2a_response` (full response payload, `JSON_QUERY`)
  - `receiver_session_id` — the receiver-side ADK session id echoed back to the caller via response metadata, derived via `COALESCE` to handle both A2A response shapes:
    - **Task-shaped responses** (`A2ATask` / `TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent`) — `adk_session_id` lives at `content.metadata.adk_session_id`. The plugin uses the response's task object as the row content.
    - **`A2AMessage`-shaped responses** (non-streaming, no task wrapper) — `adk_session_id` is at `attributes.a2a_metadata."a2a:response".metadata.adk_session_id` when populated. May be `NULL` for some `A2AMessage` variants — downstream consumers should treat this column as diagnostic and fall back to the context-level join (`caller.a2a_context_id == receiver.session_id`) for the primary stitch.

- **`tests/test_views.py`** — extends `test_available_event_types` to include `A2A_INTERACTION` and adds a new `TestA2AInteractionView` class with 7 tests covering both response-shape paths in the `COALESCE`, every typed column, the JSON extraction paths, and the COALESCE structure invariant.

## Verification

- `pytest tests/test_views.py`: **26 passed** (was 19 before the new class).
- `pytest tests/test_views.py tests/test_categorical_views.py tests/test_cli.py`: **178 passed** (no regressions).
- `pyink --config pyproject.toml --check`: clean.
- `isort --settings-path pyproject.toml --check-only`: clean.

## Refs

Refs [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129). Builds on PR 1 ([#132](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/132) + [#133](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/133)) and PR 2 ([#135](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/135)). Completes the issue #129 implementation contract.