### PR TITLE
feat(a2a-demo): one-command E2E runner + presenter docs + Gemini 3.x defaults

### DIFF
--- a/examples/a2a_joint_lineage_demo/.gitignore
+++ b/examples/a2a_joint_lineage_demo/.gitignore
@@ -2,6 +2,7 @@
 .env
 __pycache__/
 *.pyc
+receiver_server.log
 # Rendered GQL — keep .tpl source, ignore the generated output that
 # render_queries.sh produces with project-specific values inlined.
 joint_property_graph.gql

--- a/examples/a2a_joint_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
+++ b/examples/a2a_joint_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
@@ -1,0 +1,177 @@
+# BigQuery Studio Walkthrough — A2A Joint Lineage
+
+This walkthrough shows a real ADK caller agent delegating to a real
+receiver agent over A2A, with both sides logged by the BQ AA Plugin and
+stitched into one auditor-facing property graph.
+
+Pair this with [`DEMO_NARRATION.md`](DEMO_NARRATION.md) for the
+presenter talk track.
+
+## Before You Start
+
+Run setup once:
+
+```bash
+cd examples/a2a_joint_lineage_demo
+./setup.sh
+```
+
+For a presentation run, use the one-command runner:
+
+```bash
+./run_e2e_demo.sh
+```
+
+The runner starts the receiver A2A server, smoke-tests that receiver
+plugin writes land in BigQuery, runs the caller campaigns, builds both
+per-org SDK context graphs, builds the auditor joint graph, and renders
+`bq_studio_queries.gql`.
+
+## Step 0 — Open BigQuery Studio
+
+1. Open `https://console.cloud.google.com/bigquery?project=<PROJECT_ID>`.
+2. In **Explorer**, expand these datasets:
+   - `a2a_caller_demo`
+   - `a2a_receiver_demo`
+   - `a2a_auditor_demo`
+3. In `a2a_auditor_demo`, confirm the property graph
+   `a2a_joint_context_graph` is present.
+
+What to say:
+
+> There are two independent plugin trace tables. The caller and receiver
+> never share memory. The auditor dataset is the redacted stitch layer
+> that turns those traces into one queryable graph.
+
+## Step 1 — Show The Raw BQ AA Data
+
+Open a new query and run:
+
+```sql
+SELECT
+  'caller' AS side,
+  event_type,
+  COUNT(*) AS rows
+FROM `<PROJECT_ID>.a2a_caller_demo.agent_events`
+GROUP BY event_type
+UNION ALL
+SELECT
+  'receiver' AS side,
+  event_type,
+  COUNT(*) AS rows
+FROM `<PROJECT_ID>.a2a_receiver_demo.agent_events`
+GROUP BY event_type
+ORDER BY side, rows DESC;
+```
+
+Point out:
+
+- Caller rows include `A2A_INTERACTION`.
+- Receiver rows are ordinary ADK spans: request, LLM, response, and
+  completion events.
+- This is real plugin output, not seeded rows.
+
+## Step 2 — Confirm The A2A Stitch
+
+Paste **Block 1** from `bq_studio_queries.gql`.
+
+Expected:
+
+- `a2a_calls > 0`
+- `stitched_edges = a2a_calls`
+- `unstitched_calls = 0`
+
+What to say:
+
+> The caller-side A2A event carries a context id. The receiver uses that
+> same value as its session id. That equality is the stitch key:
+> caller context id equals receiver session id.
+
+## Step 3 — Visualize The Cross-Agent Path
+
+Paste **Block 2** from `bq_studio_queries.gql`.
+
+After it runs:
+
+1. Click the **Graph** tab in BigQuery Studio.
+2. Show the path:
+   `CallerCampaignRun -> RemoteAgentInvocation -> ReceiverAgentRun`.
+3. Click a `RemoteAgentInvocation` node and show `a2a_context_id`.
+4. Click a `ReceiverAgentRun` node and show `receiver_session_id`.
+
+What to say:
+
+> This is the cross-agent handoff as a graph edge. The caller made a
+> remote delegation, and the receiver session that handled it is now
+> visible without exposing raw request or response payloads.
+
+## Step 4 — Show Decisions And Rejections
+
+Paste **Block 3** from `bq_studio_queries.gql`.
+
+This walks:
+
+```text
+RemoteAgentInvocation
+  -> ReceiverAgentRun
+  -> ReceiverPlanningDecision
+  -> ReceiverDecisionOption
+```
+
+Point out:
+
+- Each row is a dropped receiver option.
+- `rejection_rationale` is the auditor-facing explanation.
+- The reason came from receiver trace text via the SDK context-graph
+  extraction path.
+
+## Step 5 — Right-To-Explanation Drilldown
+
+Paste **Block 4** from `bq_studio_queries.gql`.
+
+`run_caller_agent.py` records `DEMO_CALLER_SESSION_ID` into `.env`, and
+`build_joint_graph.py` renders that value into the query file.
+
+Show:
+
+- One campaign.
+- The remote receiver decision.
+- All selected and dropped options.
+- The rationale on dropped options.
+
+What to say:
+
+> This is the practical audit question: for one campaign, what did the
+> remote governance agent consider, what did it select, what did it drop,
+> and why?
+
+## Step 6 — Redaction Proof
+
+Paste **Block 5** from `bq_studio_queries.gql`.
+
+Expected result: zero rows.
+
+What to say:
+
+> The auditor graph exposes lineage ids, decision labels, scores,
+> outcomes, and rationale. It does not expose raw A2A request, raw A2A
+> response, or full trace content in the auditor projection tables.
+
+## What This Demo Proves
+
+- Real ADK agents can be instrumented with the BQ AA Plugin.
+- A caller and receiver can write separate trace tables.
+- The SDK can materialize context graphs independently for both sides.
+- A redacted auditor layer can stitch the two sides with graph semantics.
+- BigQuery Studio can visualize the handoff and answer audit questions
+  with GQL.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `run_e2e_demo.sh` says receiver did not become ready | Port already in use or Vertex/auth failure during server startup | Check `receiver_server.log`; change `RECEIVER_A2A_URL` or fix auth |
+| Smoke gate fails | Receiver server is not writing BQ AA Plugin rows | Confirm `run_receiver_server.py` uses `Runner(..., plugins=[receiver_plugin])` |
+| `unstitched_calls > 0` | Receiver session service did not honor caller context ids | Use the demo's `InMemorySessionService` path; see `A2A_JOINT_LINEAGE.md` |
+| Receiver-scope gate fails | Receiver response was too loose for extraction | Inspect receiver `LLM_RESPONSE` rows and tighten `receiver_agent/prompts.py` |
+| Block 5 returns rows | Auditor projections leaked raw payload columns | Fix `build_joint_graph.py` projection SQL |

--- a/examples/a2a_joint_lineage_demo/DEMO_NARRATION.md
+++ b/examples/a2a_joint_lineage_demo/DEMO_NARRATION.md
@@ -1,0 +1,149 @@
+# Demo Narration — A2A Joint Lineage
+
+Target length: 5 minutes.
+
+Audience: users evaluating whether BQ AA SDK can turn real multi-agent
+runtime traces into audit-ready context graphs.
+
+## Setup Line
+
+> We are looking at two real ADK agents. A media-planning supervisor
+> delegates audience-risk review to a remote governance agent over A2A.
+> Both agents are instrumented with the BQ AA Plugin, both write trace
+> rows to BigQuery, and the SDK materializes context graphs from those
+> traces.
+
+## Beat 1 — The Raw Evidence
+
+Show the caller and receiver `agent_events` event-type counts.
+
+> This is the raw evidence layer. The caller has normal ADK spans plus
+> `A2A_INTERACTION` rows. The receiver has its own independent ADK spans.
+> There is no shared process state here. The only bridge is the A2A
+> context id that the caller sends and the receiver uses as its session
+> id.
+
+User takeaway:
+
+> The system starts from actual runtime telemetry, not hand-authored
+> audit records.
+
+## Beat 2 — Two Local Graphs
+
+Point at:
+
+- `a2a_caller_demo.agent_context_graph`
+- `a2a_receiver_demo.agent_context_graph`
+- receiver `decision_points`
+- receiver `candidates`
+
+> The SDK builds a context graph for each side independently. That keeps
+> ownership clean: the caller graph describes the supervisor run, and the
+> receiver graph describes what the governance agent decided.
+
+User takeaway:
+
+> Each agent can retain its own context graph without handing raw traces
+> to another team.
+
+## Beat 3 — The Auditor Stitch
+
+Run Block 1 from `bq_studio_queries.gql`.
+
+> Now the auditor layer performs one narrow stitch. It joins caller
+> `a2a_context_id` to receiver `session_id`. The health check proves every
+> remote call has a matching receiver session.
+
+When `unstitched_calls = 0`:
+
+> That zero matters. It means the auditor graph covers every remote
+> delegation in the current campaign run.
+
+User takeaway:
+
+> A2A delegation becomes queryable lineage.
+
+## Beat 4 — The Graph Picture
+
+Run Block 2 and open the BigQuery Studio Graph tab.
+
+> The graph now reads naturally: a campaign run delegated through a
+> remote A2A invocation, and that invocation was handled by a receiver
+> agent run.
+
+Click nodes and show properties.
+
+> The properties are identifiers and run metadata. They are enough to
+> trace the handoff, but they do not expose the raw A2A request or raw
+> receiver response in the auditor surface.
+
+User takeaway:
+
+> The graph is useful for inspection without being a raw data dump.
+
+## Beat 5 — The Decision Trail
+
+Run Block 3.
+
+> This is where the trace becomes an audit answer. The receiver made a
+> planning decision, weighed options, selected one, and dropped others.
+> For dropped options, the graph carries a rejection rationale.
+
+Point at a concrete row.
+
+> A reviewer can ask, "why did the remote agent reject this audience?"
+> and get the rationale from the extracted receiver trace.
+
+User takeaway:
+
+> The SDK context graph turns unstructured runtime behavior into a
+> queryable decision trail.
+
+## Beat 6 — One Campaign Explanation
+
+Run Block 4.
+
+> This is the right-to-explanation drilldown for one caller campaign. We
+> can show all options the remote governance agent considered, which one
+> it selected, which ones it dropped, the score, and the rationale.
+
+User takeaway:
+
+> The same graph supports both portfolio-level review and case-level
+> explanation.
+
+## Beat 7 — Redaction Proof
+
+Run Block 5.
+
+> Finally, the auditor projection deliberately excludes raw A2A request,
+> raw A2A response, and full content columns. The result is zero rows,
+> which is the proof that this curated surface is not exposing raw
+> payload columns.
+
+User takeaway:
+
+> The demo separates trace collection from the auditor-facing surface.
+
+## Close
+
+> This is the end-to-end pattern: real agents, BQ AA Plugin telemetry,
+> per-agent context graphs, and one redacted joint graph for audit. The
+> key is that the graph is built from runtime evidence, so the demo is
+> not just a dashboard. It is a lineage surface over what the agents
+> actually did.
+
+## Questions To Invite
+
+- Can we run this against our own ADK agents?
+- Can the caller and receiver live in different projects?
+- Can we add stricter redaction with IAM?
+- Can we carry task-level A2A ids onto receiver spans?
+- Can the context graph align decisions to an ontology?
+
+The current answer:
+
+> Yes for real ADK agents and BigQuery-backed context graphs today. The
+> cross-project IAM/redaction, receiver task-id propagation, and ontology
+> alignment are follow-up tracks already split out from the implementation
+> issue.

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -45,7 +45,7 @@ For debugging, the same flow can be run manually in two terminals:
 
 The auditor-side projections built by `build_joint_graph.py` are scoped to the current campaign run regardless (the chain `caller_campaign_runs → remote_agent_invocations → receiver_runs → receiver decisions/options` filters out anything not matched to a current caller session). Stale rows from prior runs still accumulate in the **source** layers — `<CALLER_DATASET>.agent_events`, `<RECEIVER_DATASET>.agent_events`, and the per-org `decision_points` / `candidates` tables `build_org_graphs.py` writes — and remain visible in the BQ Studio Explorer for those datasets. Skip the reset if you're iterating and want that source-side history kept; reset if you want a guaranteed-clean per-org and acceptance-gate baseline.
 
-After all five commands return zero, you have:
+After `run_e2e_demo.sh` succeeds (or after the manual two-terminal flow returns zero on every step), you have:
 
 - `<PROJECT>.a2a_caller_demo.agent_events` — caller-side spans, including `A2A_INTERACTION` rows
 - `<PROJECT>.a2a_caller_demo.campaign_runs` — campaign ↔ caller-session map

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -2,10 +2,11 @@
 
 Two BQ AA Plugin instances. Two `agent_events` tables. One A2A delegation in the middle. The caller's media-planning supervisor delegates audience-risk review to the receiver's governance agent over A2A; both sides write traces to BigQuery; the SDK materializes a context graph for each side independently; an auditor projection stitches them into a single joint property graph that an external reviewer queries through BigQuery Studio.
 
-This bundle implements the plan in [issue #129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) and ships in two PRs:
+This bundle implements the plan in [issue #129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) and ships in three slices:
 
 - **PR 1** (merged) — caller / receiver agents, receiver server with custom-runner plugin attach, smoke gate, caller driver, dual `ContextGraphManager` materialization.
-- **PR 2** (this slice) — auditor projections (`build_joint_graph.py`), Phase 1 joint property graph (`joint_property_graph.gql.tpl`), 5 paste-and-run BigQuery Studio blocks (`bq_studio_queries.gql.tpl`), `render_queries.sh`, and the narrative docs.
+- **PR 2** (merged) — auditor projections (`build_joint_graph.py`), Phase 1 joint property graph (`joint_property_graph.gql.tpl`), 5 paste-and-run BigQuery Studio blocks (`bq_studio_queries.gql.tpl`), `render_queries.sh`, and the narrative docs.
+- **PR 3** (merged) — SDK `A2A_INTERACTION` typed view (`adk_a2a_interactions`) for downstream consumers that want the A2A metadata without writing JSON extraction by hand.
 
 ## Running it
 
@@ -13,7 +14,19 @@ This bundle implements the plan in [issue #129](https://github.com/GoogleCloudPl
 ./setup.sh
 ```
 
-Then in two terminals:
+For the user-facing E2E demo, run:
+
+```bash
+./run_e2e_demo.sh
+```
+
+That script starts the receiver A2A server in the background, verifies
+that receiver plugin rows land in BigQuery, runs the caller campaigns,
+builds the caller and receiver SDK context graphs, builds the auditor
+joint graph, renders `bq_studio_queries.gql`, and stops the receiver
+server on exit.
+
+For debugging, the same flow can be run manually in two terminals:
 
 ```bash
 # Terminal A — long-lived receiver server
@@ -46,6 +59,12 @@ After all five commands return zero, you have:
 
 Open BigQuery Studio in the project, navigate to `a2a_auditor_demo`, and paste blocks from `bq_studio_queries.gql` (rendered by `render_queries.sh`). See [`A2A_JOINT_LINEAGE.md`](A2A_JOINT_LINEAGE.md) for the per-block walkthrough.
 
+For a presentation-ready path, use:
+
+- [`BQ_STUDIO_WALKTHROUGH.md`](BQ_STUDIO_WALKTHROUGH.md) — click-by-click BigQuery Studio guide
+- [`DEMO_NARRATION.md`](DEMO_NARRATION.md) — 5-minute talk track for users
+- [`DATA_LINEAGE.md`](DATA_LINEAGE.md) — table-by-table source map
+
 ## Stitch contract
 
 The auditor stitches caller and receiver at **context/session level**:
@@ -62,6 +81,7 @@ Per-span `a2a_task_id` propagation onto receiver spans is **deferred to a follow
 
 ## Known limitations
 
+- **Gemini 3.x preview models:** the agent defaults to `gemini-3.1-pro-preview` (Vertex AI) and the BQ AI.GENERATE endpoint defaults to `gemini-3-flash`. Both are preview models. Vertex AI preview access on the demo project is required. If endpoint resolution fails for `AI.GENERATE`, override `DEMO_AI_ENDPOINT` with the full path: `projects/<PROJECT_NUMBER>/locations/global/publishers/google/models/gemini-3-flash`. To fall back to stable models, override `DEMO_AGENT_MODEL=gemini-2.5-pro` and `DEMO_AI_ENDPOINT=gemini-2.5-flash`.
 - **Receiver task-level spans:** context-level stitch works now; per-span `a2a_task_id` is a separate follow-up that needs ADK runtime plumbing plus a plugin change.
 - **`adk_session_id` response echo:** the response-metadata path may or may not populate for `A2AMessage`-shaped responses; the stitch above does not depend on it. Treat the `receiver_session_id_from_response` column as diagnostic only.
 - **Cross-org security:** this is a one-project demo. Caller, receiver, and auditor datasets sit in the same project and the auditor redaction is enforced by curated projection tables, not IAM. Production cross-org redaction is a separate working group.
@@ -76,7 +96,10 @@ examples/a2a_joint_lineage_demo/
 ├── README.md                       ← this file
 ├── A2A_JOINT_LINEAGE.md            ← stitch contract + walkthrough
 ├── DATA_LINEAGE.md                 ← table-by-table source map
+├── BQ_STUDIO_WALKTHROUGH.md        ← click-by-click BigQuery Studio guide
+├── DEMO_NARRATION.md               ← 5-minute presenter talk track
 ├── setup.sh                        ← bootstrap (datasets, .env, deps)
+├── run_e2e_demo.sh                 ← one-command live demo runner
 ├── reset.sh                        ← drop caller + receiver + auditor datasets
 ├── render_queries.sh               ← render *.gql.tpl with .env values
 ├── .gitignore

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -81,7 +81,17 @@ Per-span `a2a_task_id` propagation onto receiver spans is **deferred to a follow
 
 ## Known limitations
 
-- **Gemini 3.x preview models:** the agent defaults to `gemini-3.1-pro-preview` (Vertex AI) and the BQ AI.GENERATE endpoint defaults to `gemini-3-flash`. Both are preview models. Vertex AI preview access on the demo project is required. If endpoint resolution fails for `AI.GENERATE`, override `DEMO_AI_ENDPOINT` with the full path: `projects/<PROJECT_NUMBER>/locations/global/publishers/google/models/gemini-3-flash`. To fall back to stable models, override `DEMO_AGENT_MODEL=gemini-2.5-pro` and `DEMO_AI_ENDPOINT=gemini-2.5-flash`.
+- **Gemini 3.x preview models — `global`-only, full-URL only.** Verified live against Vertex AI + BigQuery `AI.GENERATE` in May 2026:
+  - The agent defaults to `gemini-3.1-pro-preview` at **`global`** (`DEMO_AGENT_LOCATION=global`). The model is **not** published at `us-central1` or any other regional location — a regional lookup returns 404.
+  - The BQ AI.GENERATE endpoint defaults to the full HTTPS URL `https://aiplatform.googleapis.com/v1/projects/<PROJECT_ID>/locations/global/publishers/google/models/gemini-3-flash-preview`. The model ID is `gemini-3-flash-preview` (not `gemini-3-flash`); the BQML simple-name resolver does **not** recognize either short form during the Gemini 3 preview, so the full URL is required. `setup.sh` resolves `<PROJECT_ID>` at .env-write time.
+  - Both are preview models — confirm Vertex AI preview access on the demo project before running.
+  - **To fall back to stable models** on a project without preview access, override all three:
+    ```bash
+    DEMO_AGENT_LOCATION=us-central1
+    DEMO_AGENT_MODEL=gemini-2.5-pro
+    DEMO_AI_ENDPOINT=gemini-2.5-flash
+    ```
+    The `gemini-2.5-*` simple names work directly with BQML's resolver.
 - **Receiver task-level spans:** context-level stitch works now; per-span `a2a_task_id` is a separate follow-up that needs ADK runtime plumbing plus a plugin change.
 - **`adk_session_id` response echo:** the response-metadata path may or may not populate for `A2AMessage`-shaped responses; the stitch above does not depend on it. Treat the `receiver_session_id_from_response` column as diagnostic only.
 - **Cross-org security:** this is a one-project demo. Caller, receiver, and auditor datasets sit in the same project and the auditor redaction is enforced by curated projection tables, not IAM. Production cross-org redaction is a separate working group.

--- a/examples/a2a_joint_lineage_demo/build_org_graphs.py
+++ b/examples/a2a_joint_lineage_demo/build_org_graphs.py
@@ -55,12 +55,21 @@ CALLER_DATASET_ID = os.getenv("CALLER_DATASET_ID", "a2a_caller_demo")
 CALLER_TABLE_ID = os.getenv("CALLER_TABLE_ID", "agent_events")
 RECEIVER_DATASET_ID = os.getenv("RECEIVER_DATASET_ID", "a2a_receiver_demo")
 RECEIVER_TABLE_ID = os.getenv("RECEIVER_TABLE_ID", "agent_events")
-# Default to gemini-3-flash for AI.GENERATE. During the Gemini 3.0
-# preview window, BigQuery may require the full Vertex AI endpoint
-# string instead of the simple name; override DEMO_AI_ENDPOINT with
-#   projects/<NUM>/locations/global/publishers/google/models/gemini-3-flash
-# (or fall back to gemini-2.5-flash) if endpoint resolution fails.
-DEMO_AI_ENDPOINT = os.getenv("DEMO_AI_ENDPOINT", "gemini-3-flash")
+# BigQuery AI.GENERATE endpoint default — verified live in May 2026:
+# the Gemini 3 preview is reachable ONLY via the full HTTPS endpoint
+# URL at locations/global. The simple-name resolver in BQML does not
+# recognize "gemini-3-flash" or "gemini-3-flash-preview" today; both
+# return 404. The model ID is gemini-3-flash-preview (NOT
+# gemini-3-flash). The endpoint URL is per-project, so the default is
+# computed from PROJECT_ID at module load. setup.sh writes the same
+# resolved URL into .env so the explicit env var also works in the
+# normal demo flow. To fall back to a stable model that does work as
+# a simple name, override DEMO_AI_ENDPOINT=gemini-2.5-flash.
+DEMO_AI_ENDPOINT = os.getenv(
+    "DEMO_AI_ENDPOINT",
+    f"https://aiplatform.googleapis.com/v1/projects/{PROJECT_ID}"
+    f"/locations/global/publishers/google/models/gemini-3-flash-preview",
+)
 
 # Receiver-extraction acceptance gate. The receiver prompt forces
 # three options per call; for the default 3-campaign demo the

--- a/examples/a2a_joint_lineage_demo/build_org_graphs.py
+++ b/examples/a2a_joint_lineage_demo/build_org_graphs.py
@@ -55,7 +55,12 @@ CALLER_DATASET_ID = os.getenv("CALLER_DATASET_ID", "a2a_caller_demo")
 CALLER_TABLE_ID = os.getenv("CALLER_TABLE_ID", "agent_events")
 RECEIVER_DATASET_ID = os.getenv("RECEIVER_DATASET_ID", "a2a_receiver_demo")
 RECEIVER_TABLE_ID = os.getenv("RECEIVER_TABLE_ID", "agent_events")
-DEMO_AI_ENDPOINT = os.getenv("DEMO_AI_ENDPOINT", "gemini-2.5-flash")
+# Default to gemini-3-flash for AI.GENERATE. During the Gemini 3.0
+# preview window, BigQuery may require the full Vertex AI endpoint
+# string instead of the simple name; override DEMO_AI_ENDPOINT with
+#   projects/<NUM>/locations/global/publishers/google/models/gemini-3-flash
+# (or fall back to gemini-2.5-flash) if endpoint resolution fails.
+DEMO_AI_ENDPOINT = os.getenv("DEMO_AI_ENDPOINT", "gemini-3-flash")
 
 # Receiver-extraction acceptance gate. The receiver prompt forces
 # three options per call; for the default 3-campaign demo the

--- a/examples/a2a_joint_lineage_demo/caller_agent/agent.py
+++ b/examples/a2a_joint_lineage_demo/caller_agent/agent.py
@@ -56,10 +56,13 @@ CALLER_DATASET_ID = os.getenv("CALLER_DATASET_ID", "a2a_caller_demo")
 CALLER_TABLE_ID = os.getenv("CALLER_TABLE_ID", "agent_events")
 # Default to Gemini 3.1 Pro preview. gemini-3-pro-preview was
 # discontinued in March 2026; gemini-3.1-pro-preview is the current
-# supported 3.x ID on Vertex AI. Override DEMO_AGENT_MODEL to fall
-# back to gemini-2.5-pro on projects without preview access.
+# supported 3.x ID on Vertex AI. Verified live: this model is only
+# published at locations/global — a regional lookup returns 404. The
+# `global` default for AGENT_LOCATION below is required when this
+# default is in use. To fall back to gemini-2.5-pro on projects
+# without preview access, also override DEMO_AGENT_LOCATION=us-central1.
 MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-3.1-pro-preview")
-AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "us-central1")
+AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "global")
 RECEIVER_A2A_URL = os.getenv("RECEIVER_A2A_URL", "http://127.0.0.1:8000")
 # Standard A2A protocol exposes the agent card at this well-known
 # path; ``adk-python``'s ``to_a2a()`` helper serves it from

--- a/examples/a2a_joint_lineage_demo/caller_agent/agent.py
+++ b/examples/a2a_joint_lineage_demo/caller_agent/agent.py
@@ -54,7 +54,11 @@ PROJECT_ID = os.getenv("PROJECT_ID") or _auth_project
 DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
 CALLER_DATASET_ID = os.getenv("CALLER_DATASET_ID", "a2a_caller_demo")
 CALLER_TABLE_ID = os.getenv("CALLER_TABLE_ID", "agent_events")
-MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-2.5-pro")
+# Default to Gemini 3.1 Pro preview. gemini-3-pro-preview was
+# discontinued in March 2026; gemini-3.1-pro-preview is the current
+# supported 3.x ID on Vertex AI. Override DEMO_AGENT_MODEL to fall
+# back to gemini-2.5-pro on projects without preview access.
+MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-3.1-pro-preview")
 AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "us-central1")
 RECEIVER_A2A_URL = os.getenv("RECEIVER_A2A_URL", "http://127.0.0.1:8000")
 # Standard A2A protocol exposes the agent card at this well-known

--- a/examples/a2a_joint_lineage_demo/receiver_agent/agent.py
+++ b/examples/a2a_joint_lineage_demo/receiver_agent/agent.py
@@ -56,10 +56,13 @@ RECEIVER_DATASET_ID = os.getenv("RECEIVER_DATASET_ID", "a2a_receiver_demo")
 RECEIVER_TABLE_ID = os.getenv("RECEIVER_TABLE_ID", "agent_events")
 # Default to Gemini 3.1 Pro preview. gemini-3-pro-preview was
 # discontinued in March 2026; gemini-3.1-pro-preview is the current
-# supported 3.x ID on Vertex AI. Override DEMO_AGENT_MODEL to fall
-# back to gemini-2.5-pro on projects without preview access.
+# supported 3.x ID on Vertex AI. Verified live: this model is only
+# published at locations/global — a regional lookup returns 404. The
+# `global` default for AGENT_LOCATION below is required when this
+# default is in use. To fall back to gemini-2.5-pro on projects
+# without preview access, also override DEMO_AGENT_LOCATION=us-central1.
 MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-3.1-pro-preview")
-AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "us-central1")
+AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "global")
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID or ""
 os.environ["GOOGLE_CLOUD_LOCATION"] = AGENT_LOCATION

--- a/examples/a2a_joint_lineage_demo/receiver_agent/agent.py
+++ b/examples/a2a_joint_lineage_demo/receiver_agent/agent.py
@@ -54,7 +54,11 @@ PROJECT_ID = os.getenv("PROJECT_ID") or _auth_project
 DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
 RECEIVER_DATASET_ID = os.getenv("RECEIVER_DATASET_ID", "a2a_receiver_demo")
 RECEIVER_TABLE_ID = os.getenv("RECEIVER_TABLE_ID", "agent_events")
-MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-2.5-pro")
+# Default to Gemini 3.1 Pro preview. gemini-3-pro-preview was
+# discontinued in March 2026; gemini-3.1-pro-preview is the current
+# supported 3.x ID on Vertex AI. Override DEMO_AGENT_MODEL to fall
+# back to gemini-2.5-pro on projects without preview access.
+MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-3.1-pro-preview")
 AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "us-central1")
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID or ""

--- a/examples/a2a_joint_lineage_demo/run_e2e_demo.sh
+++ b/examples/a2a_joint_lineage_demo/run_e2e_demo.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One-command runner for the A2A Joint Lineage demo.
+#
+# Prerequisite:
+#   ./setup.sh
+#
+# This script starts the receiver A2A server in the background, runs the
+# receiver smoke gate, runs the caller campaigns, builds both per-org SDK
+# context graphs, builds the auditor joint graph, then stops the receiver.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+VENV_PY="$SCRIPT_DIR/.venv/bin/python3"
+SERVER_LOG="$SCRIPT_DIR/receiver_server.log"
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" &>/dev/null; then
+    echo ""
+    echo "Stopping receiver server (pid $SERVER_PID)..."
+    kill "$SERVER_PID" &>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "$ENV_FILE" || ! -x "$VENV_PY" ]]; then
+  echo "ERROR: run ./setup.sh first so .env and ./.venv exist." >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+
+PROJECT_ID="${PROJECT_ID:?missing PROJECT_ID in .env}"
+RECEIVER_A2A_URL="${RECEIVER_A2A_URL:-http://127.0.0.1:8000}"
+RECEIVER_START_TIMEOUT_S="${DEMO_RECEIVER_START_TIMEOUT_S:-60}"
+RECEIVER_AGENT_CARD="${RECEIVER_A2A_URL%/}/.well-known/agent-card.json"
+
+echo ""
+echo "============================================"
+echo "  A2A Joint Lineage Demo — E2E Runner"
+echo "============================================"
+echo ""
+echo "Project:      $PROJECT_ID"
+echo "Receiver URL: $RECEIVER_A2A_URL"
+echo "Server log:   $SERVER_LOG"
+echo ""
+
+echo "[1/5] Starting receiver A2A server..."
+: > "$SERVER_LOG"
+"$VENV_PY" "$SCRIPT_DIR/run_receiver_server.py" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+echo "  Waiting for receiver agent card..."
+deadline=$((SECONDS + RECEIVER_START_TIMEOUT_S))
+until "$VENV_PY" -c \
+  'import sys, urllib.request; urllib.request.urlopen(sys.argv[1], timeout=2).read()' \
+  "$RECEIVER_AGENT_CARD" &>/dev/null; do
+  if ! kill -0 "$SERVER_PID" &>/dev/null; then
+    echo "ERROR: receiver server exited before becoming ready." >&2
+    echo "Last 80 log lines:" >&2
+    tail -80 "$SERVER_LOG" >&2 || true
+    exit 1
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "ERROR: receiver did not become ready within ${RECEIVER_START_TIMEOUT_S}s." >&2
+    echo "Last 80 log lines:" >&2
+    tail -80 "$SERVER_LOG" >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+echo "  Receiver ready: $RECEIVER_AGENT_CARD"
+
+echo ""
+echo "[2/5] Smoke-testing receiver plugin writes..."
+"$VENV_PY" "$SCRIPT_DIR/smoke_receiver.py"
+
+echo ""
+echo "[3/5] Running caller campaigns through the remote A2A receiver..."
+"$VENV_PY" "$SCRIPT_DIR/run_caller_agent.py"
+
+echo ""
+echo "[4/5] Building caller and receiver SDK context graphs..."
+"$VENV_PY" "$SCRIPT_DIR/build_org_graphs.py"
+
+echo ""
+echo "[5/5] Building auditor projections and joint property graph..."
+"$VENV_PY" "$SCRIPT_DIR/build_joint_graph.py"
+
+echo ""
+echo "============================================"
+echo "  E2E demo ready"
+echo "============================================"
+echo ""
+echo "Open BigQuery Studio:"
+echo "  https://console.cloud.google.com/bigquery?project=$PROJECT_ID"
+echo ""
+echo "Use:"
+echo "  $SCRIPT_DIR/BQ_STUDIO_WALKTHROUGH.md"
+echo "  $SCRIPT_DIR/bq_studio_queries.gql"
+echo "  $SCRIPT_DIR/DEMO_NARRATION.md"
+echo ""

--- a/examples/a2a_joint_lineage_demo/setup.sh
+++ b/examples/a2a_joint_lineage_demo/setup.sh
@@ -117,22 +117,37 @@ CALLER_TABLE_ID="${CALLER_TABLE_ID:-agent_events}"
 RECEIVER_DATASET_ID="${RECEIVER_DATASET_ID:-a2a_receiver_demo}"
 RECEIVER_TABLE_ID="${RECEIVER_TABLE_ID:-agent_events}"
 AUDITOR_DATASET_ID="${AUDITOR_DATASET_ID:-a2a_auditor_demo}"
-DEMO_AGENT_LOCATION="${DEMO_AGENT_LOCATION:-us-central1}"
-# Model defaults updated to Gemini 3.x:
-#   - gemini-3.1-pro-preview is the supported 3.x preview ID for the
-#     ADK agent on Vertex AI (gemini-3-pro-preview was discontinued in
-#     March 2026; use gemini-3.1-pro-preview going forward).
-#   - gemini-3-flash is the BigQuery AI.GENERATE endpoint name. During
-#     the Gemini 3.0 preview window, BigQuery may also accept the full
-#     endpoint string `projects/<NUM>/locations/global/publishers/google/models/gemini-3-flash`
-#     if the simple name resolution hasn't landed in your project.
-#     Override DEMO_AI_ENDPOINT to that full path if you see endpoint-
-#     resolution errors during preview.
-# Both are preview models — confirm Vertex AI preview access on the
-# project before running the demo, or override these env vars to fall
-# back to gemini-2.5-pro / gemini-2.5-flash.
+# Gemini 3.x model defaults — verified against live Vertex AI +
+# BigQuery AI.GENERATE in May 2026:
+#
+#   - DEMO_AGENT_LOCATION must be `global` for Gemini 3.x preview
+#     models. They are not published at us-central1 (or any other
+#     regional location); a regional lookup returns 404. To fall
+#     back to gemini-2.5-pro, also override
+#     DEMO_AGENT_LOCATION=us-central1.
+#
+#   - DEMO_AGENT_MODEL: gemini-3.1-pro-preview is the supported 3.x
+#     preview ID. gemini-3-pro-preview was discontinued in March
+#     2026; gemini-3.1-pro-preview is the current ID.
+#
+#   - DEMO_AI_ENDPOINT for BigQuery AI.GENERATE must be the full
+#     HTTPS endpoint URL. During the Gemini 3 preview the BQML
+#     simple-name resolver does NOT recognize "gemini-3-flash" or
+#     "gemini-3-flash-preview"; only the full URL works, and only
+#     the locations/global publisher path is registered. The model
+#     ID is gemini-3-flash-preview (NOT gemini-3-flash). The full
+#     URL must be substituted with the demo's PROJECT_ID at .env-
+#     write time below; a literal default would not be reachable
+#     across projects.
+#
+#   - To fall back to stable models on a project without Gemini 3
+#     preview access, override:
+#       DEMO_AGENT_LOCATION=us-central1
+#       DEMO_AGENT_MODEL=gemini-2.5-pro
+#       DEMO_AI_ENDPOINT=gemini-2.5-flash
+DEMO_AGENT_LOCATION="${DEMO_AGENT_LOCATION:-global}"
 DEMO_AGENT_MODEL="${DEMO_AGENT_MODEL:-gemini-3.1-pro-preview}"
-DEMO_AI_ENDPOINT="${DEMO_AI_ENDPOINT:-gemini-3-flash}"
+DEMO_AI_ENDPOINT="${DEMO_AI_ENDPOINT:-https://aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/global/publishers/google/models/gemini-3-flash-preview}"
 RECEIVER_A2A_URL="${RECEIVER_A2A_URL:-http://127.0.0.1:8000}"
 
 for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID"; do

--- a/examples/a2a_joint_lineage_demo/setup.sh
+++ b/examples/a2a_joint_lineage_demo/setup.sh
@@ -118,8 +118,21 @@ RECEIVER_DATASET_ID="${RECEIVER_DATASET_ID:-a2a_receiver_demo}"
 RECEIVER_TABLE_ID="${RECEIVER_TABLE_ID:-agent_events}"
 AUDITOR_DATASET_ID="${AUDITOR_DATASET_ID:-a2a_auditor_demo}"
 DEMO_AGENT_LOCATION="${DEMO_AGENT_LOCATION:-us-central1}"
-DEMO_AGENT_MODEL="${DEMO_AGENT_MODEL:-gemini-2.5-pro}"
-DEMO_AI_ENDPOINT="${DEMO_AI_ENDPOINT:-gemini-2.5-flash}"
+# Model defaults updated to Gemini 3.x:
+#   - gemini-3.1-pro-preview is the supported 3.x preview ID for the
+#     ADK agent on Vertex AI (gemini-3-pro-preview was discontinued in
+#     March 2026; use gemini-3.1-pro-preview going forward).
+#   - gemini-3-flash is the BigQuery AI.GENERATE endpoint name. During
+#     the Gemini 3.0 preview window, BigQuery may also accept the full
+#     endpoint string `projects/<NUM>/locations/global/publishers/google/models/gemini-3-flash`
+#     if the simple name resolution hasn't landed in your project.
+#     Override DEMO_AI_ENDPOINT to that full path if you see endpoint-
+#     resolution errors during preview.
+# Both are preview models — confirm Vertex AI preview access on the
+# project before running the demo, or override these env vars to fall
+# back to gemini-2.5-pro / gemini-2.5-flash.
+DEMO_AGENT_MODEL="${DEMO_AGENT_MODEL:-gemini-3.1-pro-preview}"
+DEMO_AI_ENDPOINT="${DEMO_AI_ENDPOINT:-gemini-3-flash}"
 RECEIVER_A2A_URL="${RECEIVER_A2A_URL:-http://127.0.0.1:8000}"
 
 for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID"; do
@@ -176,6 +189,9 @@ echo ""
 echo "============================================"
 echo "  Setup complete! Next: run the demo."
 echo "============================================"
+echo ""
+echo "Presentation run (starts/stops the receiver server for you):"
+echo "  cd $SCRIPT_DIR && ./run_e2e_demo.sh"
 echo ""
 echo "Two terminals:"
 echo ""


### PR DESCRIPTION
## Why

User-facing demo packaging on top of the merged [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) work ([#132](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/132) / [#133](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/133) / [#135](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/135) / [#136](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/136)). The implementation contract is complete and stable; this PR makes the demo presentable: a one-command runner so a user evaluating the SDK can `./setup.sh && ./run_e2e_demo.sh`, plus a click-by-click BQ Studio guide and a 5-minute presenter talk track.

While the demo was being packaged, also bumps the model defaults to current **Gemini 3.x** preview models. **All defaults are confirmed against live Vertex AI + BigQuery `AI.GENERATE` in May 2026** — see the live verification matrix below.

## What

### One-command runner

- **`run_e2e_demo.sh`** — starts the receiver A2A server in the background (log → `receiver_server.log`, gitignored), polls the well-known agent-card endpoint until ready (default 60s, override via `DEMO_RECEIVER_START_TIMEOUT_S`), runs the receiver smoke gate, the caller campaigns, both per-org SDK context graph builds, and the auditor joint graph. EXIT trap kills the background server cleanly. Tails the last 80 log lines on receiver-startup failure for fast diagnosis.

### Presenter materials

- **`BQ_STUDIO_WALKTHROUGH.md`** — 6-step click-by-click guide for the BigQuery Studio side, with a troubleshooting table that mirrors the failure-mode table in `A2A_JOINT_LINEAGE.md`.
- **`DEMO_NARRATION.md`** — 5-minute presenter talk track in 7 beats: raw evidence → two local graphs → auditor stitch → graph picture → decision trail → one-campaign explanation → redaction proof. Each beat carries a setup line and a user takeaway.
- **`README.md`** — adds the `run_e2e_demo.sh` path, marks all three #129 PRs merged, links the new docs, updates the file map.
- **`setup.sh`** — next-step echo now points at `run_e2e_demo.sh` as the presentation path, with the two-terminal manual flow kept for debugging.
- **`.gitignore`** — `receiver_server.log` added.

### Gemini 3.x model defaults (live-verified)

| Env var | Default | Notes |
|---|---|---|
| `DEMO_AGENT_LOCATION` | `global` | Gemini 3.x preview models are published **only** at the `global` publisher path. Regional lookups return 404. |
| `DEMO_AGENT_MODEL` | `gemini-3.1-pro-preview` | `gemini-3-pro-preview` was discontinued March 2026; the current supported 3.x ID is `gemini-3.1-pro-preview`. |
| `DEMO_AI_ENDPOINT` | `https://aiplatform.googleapis.com/v1/projects/<PROJECT_ID>/locations/global/publishers/google/models/gemini-3-flash-preview` | The model ID is `gemini-3-flash-preview` (**not** `gemini-3-flash`). The BQML simple-name resolver does **not** recognize either short form during the Gemini 3 preview — only the full HTTPS URL works. `setup.sh` interpolates `<PROJECT_ID>` at `.env`-write time; `build_org_graphs.py` resolves the same URL at module load. |

### Live verification matrix (project `test-project-0728-467323`, May 2026)

| Probe | Result |
|---|---|
| Agent: `gemini-3.1-pro-preview` at `us-central1` | **404 NOT FOUND** |
| Agent: `gemini-3.1-pro-preview` at `global` | **OK** |
| Agent: `gemini-3-pro-preview` at `global` | 404 (discontinued, confirms docs) |
| `AI.GENERATE(... endpoint => 'gemini-3-flash')` | **404** |
| `AI.GENERATE(... endpoint => 'gemini-3-flash-preview')` (simple name) | **404** |
| `AI.GENERATE(... endpoint => 'projects/.../locations/global/...')` (bare) | **404** |
| `AI.GENERATE(... endpoint => 'https://aiplatform.googleapis.com/v1/projects/.../gemini-3-flash-preview')` | **OK — returned `"confirmed"`** |

A smoke `AI.GENERATE` call against the resolved default URL returned the expected response live.

### Fallback override for projects without preview access

```bash
DEMO_AGENT_LOCATION=us-central1
DEMO_AGENT_MODEL=gemini-2.5-pro
DEMO_AI_ENDPOINT=gemini-2.5-flash
```

The `gemini-2.5-*` simple names work directly with the BQML resolver, and the agent is published at `us-central1`. Documented in `README.md` "Known limitations."

## Verification

- `pyink --check` clean across all `.py` files in the demo.
- `isort --check-only` clean.
- `python3 -m py_compile` clean.
- `bash -n` clean on `setup.sh`, `reset.sh`, `render_queries.sh`, `run_e2e_demo.sh`.
- `run_e2e_demo.sh` chmod +x.
- **Live AI.GENERATE smoke against the new default endpoint URL returned `"confirmed"`** (see matrix above).
- Full end-to-end `./run_e2e_demo.sh` not run live — would burn the project's Vertex AI quota for the 3-campaign demo.

## Out of scope

- Updating the older `examples/decision_lineage_demo/` to Gemini 3.x — not in this PR's scope.
- Per-span `a2a_task_id` propagation, cross-org IAM/redaction, cross-ontology alignment — already filed as [#138](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/138) / [#139](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/139) / [#140](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/140) when [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) closed.

## Refs

Builds on the merged [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) work.