### PR TITLE
feat(a2a-demo): add audit-analyst agent that closes the BQAA loop

### DIFF
--- a/examples/a2a_joint_lineage_demo/A2A_JOINT_LINEAGE.md
+++ b/examples/a2a_joint_lineage_demo/A2A_JOINT_LINEAGE.md
@@ -127,6 +127,28 @@ Lists every column named `a2a_request` / `a2a_response` / `content` across the a
 
 If this returns rows, an upstream change has leaked payload columns into the auditor projection tables — fix the projection SQL in `build_joint_graph.py` before merging.
 
+## Closing the loop — the analyst agent
+
+`run_analyst_agent.py` is the demo's last hop. It instantiates an ADK agent (`analyst_agent/agent.py`) whose system prompt frames it as an audit analyst with four bounded BigQuery tools — one per headline audit question:
+
+| Tool | Maps to | When the agent picks it |
+|---|---|---|
+| `stitch_health()` | Block 1 | "Is the audit graph healthy? Are all calls accounted for?" |
+| `list_campaigns()` | (discovery) | "What campaigns are in scope?" or session-id lookup when the user names a campaign |
+| `audit_campaign(caller_session_id)` | Block 4 | "Walk me through the audit path for campaign X" |
+| `find_governance_rejections(decision_type=None, max_score=None)` | Block 3 (filtered) | Portfolio-level scans for dropped options |
+
+Each tool runs a parameterized BigQuery query against the auditor projections and the `a2a_joint_context_graph`. Results are dict-shaped and bounded (default 25 campaigns, 30 rejection rows) so the LLM doesn't blow its context window. Raw `a2a_request` / `a2a_response` payloads are never returned — the redaction contract from the projection layer carries through to the agent surface.
+
+The analyst's own ADK session — its tool-call sequence, its LLM responses, its final summary — lands in `<ANALYST_DATASET>.agent_events` via a third BQ AA Plugin instance. Operators can run `ContextGraphManager.build_context_graph` against that dataset for audit-of-the-audit lineage if they need it; that's left as a follow-on.
+
+The default `run_analyst_agent.py` invocation fires four canned questions (one per tool) so a fresh demo exercises the whole tool surface. Positional arguments override the canned set for ad-hoc questions:
+
+```bash
+./.venv/bin/python3 run_analyst_agent.py \
+  "Across all campaigns, which dropped options scored below 0.3?"
+```
+
 ## Failure modes and what each gate catches
 
 | Symptom | Likely cause | Where it surfaces |

--- a/examples/a2a_joint_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
+++ b/examples/a2a_joint_lineage_demo/BQ_STUDIO_WALKTHROUGH.md
@@ -24,8 +24,9 @@ For a presentation run, use the one-command runner:
 
 The runner starts the receiver A2A server, smoke-tests that receiver
 plugin writes land in BigQuery, runs the caller campaigns, builds both
-per-org SDK context graphs, builds the auditor joint graph, and renders
-`bq_studio_queries.gql`.
+per-org SDK context graphs, builds the auditor joint graph, renders
+`bq_studio_queries.gql`, and runs the analyst agent against the canned
+audit question set (closing the loop).
 
 ## Step 0 — Open BigQuery Studio
 

--- a/examples/a2a_joint_lineage_demo/DEMO_NARRATION.md
+++ b/examples/a2a_joint_lineage_demo/DEMO_NARRATION.md
@@ -125,13 +125,46 @@ User takeaway:
 
 > The demo separates trace collection from the auditor-facing surface.
 
+## Beat 8 — Closing The Loop With An Analyst Agent
+
+Run `./.venv/bin/python3 run_analyst_agent.py` (the one-command runner does this as step 6).
+
+> So far the human has been reading the graph. This last step closes
+> the loop: a third agent — the audit analyst — reads the joint graph
+> back through four bounded BigQuery tools and answers natural-language
+> audit questions. Its own reasoning trace lands in the analyst
+> `agent_events` table, so the audit-of-the-audit lineage is itself a
+> first-class BQ AA dataset.
+
+Show the four canned answers the agent produces:
+
+- "Is the joint audit graph healthy?" → tool: `stitch_health()`
+- "What campaigns are in scope?" → tool: `list_campaigns()`
+- "Walk me through the first campaign's audit path." → tool: `audit_campaign(...)`
+- "What are the lowest-scored dropped options?" → tool: `find_governance_rejections(...)`
+
+Then drop into ad-hoc mode:
+
+```bash
+./.venv/bin/python3 run_analyst_agent.py \
+  "Why was anything dropped for the Adidas track campaign?"
+```
+
+User takeaway:
+
+> The same data model used to record the trace is used to ask
+> questions about the trace. An agent → BQAA → context graph → agent
+> loop, not just agent → BQAA → human SQL.
+
 ## Close
 
 > This is the end-to-end pattern: real agents, BQ AA Plugin telemetry,
-> per-agent context graphs, and one redacted joint graph for audit. The
-> key is that the graph is built from runtime evidence, so the demo is
-> not just a dashboard. It is a lineage surface over what the agents
-> actually did.
+> per-agent context graphs, one redacted joint graph for audit, and an
+> analyst agent that reads that graph back in natural language. The
+> key is that every step — including the analyst's reasoning — is
+> built from runtime evidence in the same data model. It is a lineage
+> surface over what the agents actually did, queryable both by humans
+> (BigQuery Studio) and by other agents (the analyst's BQ tools).
 
 ## Questions To Invite
 

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -24,8 +24,9 @@ For the user-facing E2E demo, run:
 That script starts the receiver A2A server in the background, verifies
 that receiver plugin rows land in BigQuery, runs the caller campaigns,
 builds the caller and receiver SDK context graphs, builds the auditor
-joint graph, renders `bq_studio_queries.gql`, and stops the receiver
-server on exit.
+joint graph, renders `bq_studio_queries.gql`, **runs the analyst agent
+against the canned audit question set (closes the loop)**, and stops
+the receiver server on exit.
 
 For debugging, the same flow can be run manually in two terminals:
 
@@ -47,7 +48,7 @@ For debugging, the same flow can be run manually in two terminals:
 
 `run_analyst_agent.py` runs four canned questions by default (one per analyst tool); pass any free-text question(s) as positional args to ask ad-hoc.
 
-**For a clean verification run: `./reset.sh && ./setup.sh`, then run the two-terminal flow above.** `reset.sh` drops the caller, receiver, and auditor datasets entirely; `setup.sh` recreates them. The plugin creates tables, not datasets, so a bare `./reset.sh` would leave the demo unable to write. Resetting up front guarantees `build_org_graphs.py`'s discover-all-sessions pass reflects only the current campaigns.
+**For a clean verification run: `./reset.sh && ./setup.sh`, then run the two-terminal flow above.** `reset.sh` drops the caller, receiver, auditor, and analyst datasets entirely; `setup.sh` recreates them. The plugin creates tables, not datasets, so a bare `./reset.sh` would leave the demo unable to write. Resetting up front guarantees `build_org_graphs.py`'s discover-all-sessions pass reflects only the current campaigns.
 
 The auditor-side projections built by `build_joint_graph.py` are scoped to the current campaign run regardless (the chain `caller_campaign_runs → remote_agent_invocations → receiver_runs → receiver decisions/options` filters out anything not matched to a current caller session). Stale rows from prior runs still accumulate in the **source** layers — `<CALLER_DATASET>.agent_events`, `<RECEIVER_DATASET>.agent_events`, and the per-org `decision_points` / `candidates` tables `build_org_graphs.py` writes — and remain visible in the BQ Studio Explorer for those datasets. Skip the reset if you're iterating and want that source-side history kept; reset if you want a guaranteed-clean per-org and acceptance-gate baseline.
 
@@ -117,7 +118,7 @@ examples/a2a_joint_lineage_demo/
 ├── DEMO_NARRATION.md               ← 5-minute presenter talk track
 ├── setup.sh                        ← bootstrap (datasets, .env, deps)
 ├── run_e2e_demo.sh                 ← one-command live demo runner
-├── reset.sh                        ← drop caller + receiver + auditor datasets
+├── reset.sh                        ← drop caller + receiver + auditor + analyst datasets
 ├── render_queries.sh               ← render *.gql.tpl with .env values
 ├── .gitignore
 ├── campaigns.py                    ← three campaign briefs

--- a/examples/a2a_joint_lineage_demo/README.md
+++ b/examples/a2a_joint_lineage_demo/README.md
@@ -1,12 +1,13 @@
 # A2A Joint Lineage Demo
 
-Two BQ AA Plugin instances. Two `agent_events` tables. One A2A delegation in the middle. The caller's media-planning supervisor delegates audience-risk review to the receiver's governance agent over A2A; both sides write traces to BigQuery; the SDK materializes a context graph for each side independently; an auditor projection stitches them into a single joint property graph that an external reviewer queries through BigQuery Studio.
+Two BQ AA Plugin instances. Two `agent_events` tables. One A2A delegation in the middle. The caller's media-planning supervisor delegates audience-risk review to the receiver's governance agent over A2A; both sides write traces to BigQuery; the SDK materializes a context graph for each side independently; an auditor projection stitches them into a single joint property graph; **a third agent — the audit-analyst — closes the loop by reading that joint graph back through bounded BigQuery tools and answering natural-language audit questions**. The analyst's own reasoning trace also lands in BigQuery via the BQ AA Plugin, giving you audit-of-the-audit lineage in the same data model.
 
 This bundle implements the plan in [issue #129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129) and ships in three slices:
 
 - **PR 1** (merged) — caller / receiver agents, receiver server with custom-runner plugin attach, smoke gate, caller driver, dual `ContextGraphManager` materialization.
 - **PR 2** (merged) — auditor projections (`build_joint_graph.py`), Phase 1 joint property graph (`joint_property_graph.gql.tpl`), 5 paste-and-run BigQuery Studio blocks (`bq_studio_queries.gql.tpl`), `render_queries.sh`, and the narrative docs.
 - **PR 3** (merged) — SDK `A2A_INTERACTION` typed view (`adk_a2a_interactions`) for downstream consumers that want the A2A metadata without writing JSON extraction by hand.
+- **Analyst loop** — `analyst_agent/` package + `run_analyst_agent.py`. Closes the demo loop: an ADK agent with four bounded BigQuery tools (`stitch_health`, `list_campaigns`, `audit_campaign`, `find_governance_rejections`) answers natural-language audit questions against the joint graph. The analyst's own traces land in `<ANALYST_DATASET>.agent_events`.
 
 ## Running it
 
@@ -37,9 +38,14 @@ For debugging, the same flow can be run manually in two terminals:
 ./.venv/bin/python3 run_caller_agent.py
 ./.venv/bin/python3 build_org_graphs.py
 ./.venv/bin/python3 build_joint_graph.py
+./.venv/bin/python3 run_analyst_agent.py     # canned questions
+# or:
+./.venv/bin/python3 run_analyst_agent.py "Why was X rejected for campaign Y?"
 ```
 
-`build_joint_graph.py` already runs `./render_queries.sh` itself, so `bq_studio_queries.gql` is on disk after the last command. Re-run `./render_queries.sh` only if you edit `.env` (e.g. swap `DEMO_CALLER_SESSION_ID` to inspect a different campaign) or change the `*.gql.tpl` templates.
+`build_joint_graph.py` already runs `./render_queries.sh` itself, so `bq_studio_queries.gql` is on disk after that command. Re-run `./render_queries.sh` only if you edit `.env` (e.g. swap `DEMO_CALLER_SESSION_ID` to inspect a different campaign) or change the `*.gql.tpl` templates.
+
+`run_analyst_agent.py` runs four canned questions by default (one per analyst tool); pass any free-text question(s) as positional args to ask ad-hoc.
 
 **For a clean verification run: `./reset.sh && ./setup.sh`, then run the two-terminal flow above.** `reset.sh` drops the caller, receiver, and auditor datasets entirely; `setup.sh` recreates them. The plugin creates tables, not datasets, so a bare `./reset.sh` would leave the demo unable to write. Resetting up front guarantees `build_org_graphs.py`'s discover-all-sessions pass reflects only the current campaigns.
 
@@ -56,6 +62,7 @@ After `run_e2e_demo.sh` succeeds (or after the manual two-terminal flow returns 
 - `<PROJECT>.a2a_receiver_demo.agent_context_graph` — receiver property graph
 - `<PROJECT>.a2a_auditor_demo.{caller_campaign_runs,remote_agent_invocations,receiver_runs,receiver_planning_decisions,receiver_decision_options,joint_a2a_edges}` — auditor projections (redacted)
 - `<PROJECT>.a2a_auditor_demo.a2a_joint_context_graph` — joint property graph spanning both orgs
+- `<PROJECT>.a2a_analyst_demo.agent_events` — analyst-agent traces (one ADK session per question, including the tool-call lineage that produced each answer)
 
 Open BigQuery Studio in the project, navigate to `a2a_auditor_demo`, and paste blocks from `bq_studio_queries.gql` (rendered by `render_queries.sh`). See [`A2A_JOINT_LINEAGE.md`](A2A_JOINT_LINEAGE.md) for the per-block walkthrough.
 
@@ -123,11 +130,17 @@ examples/a2a_joint_lineage_demo/
 │   ├── __init__.py
 │   ├── agent.py
 │   └── prompts.py
+├── analyst_agent/                  ← audit-analyst that closes the loop
+│   ├── __init__.py
+│   ├── agent.py
+│   ├── prompts.py
+│   └── tools.py                    ← 4 bounded BQ tools over the joint graph
 ├── run_receiver_server.py          ← custom Runner(..., plugins=[...]) + to_a2a()
 ├── smoke_receiver.py               ← receiver-row gate
 ├── run_caller_agent.py             ← caller campaigns + 3 acceptance gates
 ├── build_org_graphs.py             ← dual ContextGraphManager.build_context_graph
 ├── build_joint_graph.py            ← auditor projections + joint property graph
+├── run_analyst_agent.py            ← natural-language audit Q&A loop
 ├── joint_property_graph.gql.tpl    ← Phase 1 5-node / 4-edge graph DDL
 └── bq_studio_queries.gql.tpl       ← 5 paste-and-run BQ Studio blocks
 ```

--- a/examples/a2a_joint_lineage_demo/analyst_agent/__init__.py
+++ b/examples/a2a_joint_lineage_demo/analyst_agent/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit-analyst agent that queries the joint A2A context graph."""
+
+from .agent import APP_NAME
+from .agent import bq_logging_plugin
+from .agent import root_agent
+
+__all__ = ["APP_NAME", "bq_logging_plugin", "root_agent"]

--- a/examples/a2a_joint_lineage_demo/analyst_agent/agent.py
+++ b/examples/a2a_joint_lineage_demo/analyst_agent/agent.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit-analyst agent.
+
+Closes the demo loop: the caller and receiver agents produce trace
+rows in their `agent_events` tables; the SDK materializes per-org
+context graphs; `build_joint_graph.py` stitches a redacted joint
+property graph in the auditor dataset; this agent then queries that
+joint graph back, answering natural-language audit questions.
+
+The analyst's own traces (its tool calls and reasoning) are logged
+to `<ANALYST_DATASET>.agent_events` via the BQ AA Plugin. Operators
+can build a separate per-analyst context graph from those rows if
+they want audit-of-the-audit lineage.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from google.adk.agents import Agent
+from google.adk.models import Gemini
+from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin
+from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryLoggerConfig
+import google.auth
+from google.genai import types
+
+from .prompts import SYSTEM_PROMPT
+from .tools import ANALYST_TOOLS
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEMO_DIR = os.path.dirname(_HERE)
+_env_path = os.path.join(_DEMO_DIR, ".env")
+if os.path.exists(_env_path):
+  load_dotenv(dotenv_path=_env_path)
+
+_, _auth_project = google.auth.default()
+PROJECT_ID = os.getenv("PROJECT_ID") or _auth_project
+DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
+ANALYST_DATASET_ID = os.getenv("ANALYST_DATASET_ID", "a2a_analyst_demo")
+ANALYST_TABLE_ID = os.getenv("ANALYST_TABLE_ID", "agent_events")
+MODEL_ID = os.getenv("DEMO_AGENT_MODEL", "gemini-3.1-pro-preview")
+# Gemini 3.x preview models are only published at locations/global;
+# AGENT_LOCATION below is required when the default MODEL_ID is in
+# use. The fallback override to gemini-2.5-pro is documented in
+# the demo README and uses DEMO_AGENT_LOCATION=us-central1.
+AGENT_LOCATION = os.getenv("DEMO_AGENT_LOCATION", "global")
+
+os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID or ""
+os.environ["GOOGLE_CLOUD_LOCATION"] = AGENT_LOCATION
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+
+APP_NAME = "a2a_joint_lineage_analyst"
+
+
+root_agent = Agent(
+    name="audit_analyst",
+    model=Gemini(
+        model=MODEL_ID,
+        retry_options=types.HttpRetryOptions(attempts=3),
+    ),
+    description=(
+        "Audit-analyst agent that answers natural-language questions "
+        "about the joint A2A context graph by calling four bounded "
+        "BigQuery query tools."
+    ),
+    instruction=SYSTEM_PROMPT,
+    tools=ANALYST_TOOLS,
+)
+
+
+_bq_config = BigQueryLoggerConfig(
+    enabled=True,
+    max_content_length=500 * 1024,
+    batch_size=1,
+    shutdown_timeout=15.0,
+)
+bq_logging_plugin = BigQueryAgentAnalyticsPlugin(
+    project_id=PROJECT_ID,
+    dataset_id=ANALYST_DATASET_ID,
+    table_id=ANALYST_TABLE_ID,
+    location=DATASET_LOCATION,
+    config=_bq_config,
+)

--- a/examples/a2a_joint_lineage_demo/analyst_agent/prompts.py
+++ b/examples/a2a_joint_lineage_demo/analyst_agent/prompts.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""System prompt for the audit-analyst agent.
+
+The analyst takes natural-language audit questions and answers them
+by calling tools that query the redacted joint property graph and
+auditor projection tables. The closed loop is: caller and receiver
+agents produce traces → SDK materializes per-org context graphs →
+auditor projection stitches them → analyst agent answers questions
+*about* that graph in natural language.
+"""
+
+SYSTEM_PROMPT = """\
+You are an audit-analyst agent. Your job is to answer
+natural-language audit questions about an A2A delegation between two
+agents — a media-planning supervisor (the "caller") and a remote
+governance reviewer (the "receiver") — by querying the redacted
+joint property graph and auditor projection tables.
+
+You have four tools, each wrapping one well-known audit pattern:
+
+  1. `stitch_health()` — Returns counts of A2A calls, calls with a
+     valid context id, calls with the optional receiver-session
+     echo, and how many calls have a matching receiver session
+     (stitched_edges). The expected healthy state is
+     stitched_edges == a2a_calls and unstitched_calls == 0. Use
+     this when the user asks about "demo health", "are all calls
+     accounted for", "is the join working".
+
+  2. `list_campaigns()` — Returns every caller CampaignRun with
+     caller_session_id, campaign name, brand, and event count.
+     Use this when the user asks "what campaigns are in scope" or
+     to look up a session id for a campaign name.
+
+  3. `audit_campaign(caller_session_id)` — Returns the full
+     right-to-explanation path for ONE caller campaign:
+     campaign, the remote A2A context id, the receiver's planning
+     decision type, every option the receiver weighed (selected
+     and dropped), each option's score, and the rejection rationale
+     for dropped options. Use this for case-specific audit
+     questions like "what did the remote agent decide for X?",
+     "why was Y rejected for campaign Z?".
+
+  4. `find_governance_rejections(decision_type=None, max_score=None)` —
+     Returns every option the remote agent DROPPED across all
+     campaigns, with the rejection rationale. Optional filters:
+     `decision_type` for substring match on the decision label,
+     `max_score` to only return options scoring at or below a
+     threshold. Use this for portfolio-level questions like "show
+     me every audience dropped because of PII concerns" or
+     "what's the lowest-scored dropped option across the demo".
+
+Pick the smallest tool that answers the user's question. Prefer
+`audit_campaign` over `find_governance_rejections` if the user
+names a specific campaign. Prefer `list_campaigns` first if the
+user names a campaign by brand/title without a session id and you
+need to resolve it.
+
+When you respond:
+  - Cite the concrete identifiers (caller_session_id,
+    a2a_context_id, decision_type) the tool returned.
+  - Quote dropped-option rationale text verbatim — that's the
+    audit evidence the reviewer needs.
+  - If the tool returns zero rows for a specific session id or
+    filter, say so directly. Do not invent data.
+  - Keep the answer short. Two or three sentences plus a small
+    table or bulleted list is plenty.
+
+Privacy reminder: every tool result already strips raw A2A request
+and response payloads. Do not ask the user to provide raw payloads,
+and do not infer payload contents from the rationale strings.
+"""

--- a/examples/a2a_joint_lineage_demo/analyst_agent/tools.py
+++ b/examples/a2a_joint_lineage_demo/analyst_agent/tools.py
@@ -58,6 +58,11 @@ AUDITOR_DATASET_ID = os.getenv("AUDITOR_DATASET_ID", "a2a_auditor_demo")
 # scan; the defaults stay tight to keep the demo readable.
 _LIST_LIMIT = int(os.getenv("ANALYST_LIST_LIMIT", "25"))
 _REJECTIONS_LIMIT = int(os.getenv("ANALYST_REJECTIONS_LIMIT", "30"))
+# audit_campaign() walks N options × M decisions for one campaign;
+# at the receiver-prompt contract (3 candidates × 1 decision per
+# call) this is ~3 rows per A2A call. A misconfigured receiver
+# can produce many more, hence the cap.
+_AUDIT_LIMIT = int(os.getenv("ANALYST_AUDIT_LIMIT", "50"))
 
 _GRAPH = f"`{PROJECT_ID}.{AUDITOR_DATASET_ID}.a2a_joint_context_graph`"
 
@@ -211,6 +216,7 @@ def audit_campaign(caller_session_id: str) -> dict[str, Any]:
       option.status AS status,
       option.rejection_rationale AS rationale
     ORDER BY option.status DESC, option.score DESC
+    LIMIT {_AUDIT_LIMIT}
   """
   job_config = bigquery.QueryJobConfig(
       query_parameters=[
@@ -284,8 +290,11 @@ def find_governance_rejections(
           ANALYST_REJECTIONS_LIMIT, default 30).
         - filters (dict): echo of the applied filter values.
         - rejections (list[dict]): each entry has
-          a2a_context_id, decision_type, option_name, score, and
-          rationale.
+          caller_session_id, campaign, brand, a2a_context_id,
+          decision_type, option_name, score, and rationale. Campaign
+          identity is included so the analyst can attribute each
+          rejection back to a specific caller campaign in
+          portfolio-level questions.
   """
   filters = {"decision_type": decision_type, "max_score": max_score}
   where = ["option.status = 'DROPPED'"]
@@ -304,13 +313,23 @@ def find_governance_rejections(
     )
 
   where_clause = " AND ".join(where)
+  # Walk back to CallerCampaignRun so the analyst can attribute each
+  # rejection to a specific campaign (caller_session_id + campaign
+  # + brand). The earlier shape started from RemoteAgentInvocation,
+  # which made portfolio-level answers ambiguous about which
+  # campaign each rejection belonged to.
   q = f"""
     GRAPH {_GRAPH}
-    MATCH (remote:RemoteAgentInvocation)-[:HandledBy]->(receiver:ReceiverAgentRun)
+    MATCH (campaign:CallerCampaignRun)
+          -[:DelegatedVia]->(remote:RemoteAgentInvocation)
+          -[:HandledBy]->(receiver:ReceiverAgentRun)
           -[:ReceiverMadeDecision]->(decision:ReceiverPlanningDecision)
           -[:ReceiverWeighedOption]->(option:ReceiverDecisionOption)
     WHERE {where_clause}
     RETURN
+      campaign.caller_session_id AS caller_session_id,
+      campaign.campaign AS campaign,
+      campaign.brand AS brand,
       remote.a2a_context_id AS a2a_context_id,
       decision.decision_type AS decision_type,
       option.name AS option_name,
@@ -334,6 +353,9 @@ def find_governance_rejections(
     }
   rejections = [
       {
+          "caller_session_id": str(r["caller_session_id"]),
+          "campaign": str(r["campaign"]),
+          "brand": str(r["brand"]) if r["brand"] is not None else None,
           "a2a_context_id": (
               str(r["a2a_context_id"]) if r["a2a_context_id"] else None
           ),

--- a/examples/a2a_joint_lineage_demo/analyst_agent/tools.py
+++ b/examples/a2a_joint_lineage_demo/analyst_agent/tools.py
@@ -1,0 +1,361 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools the analyst agent uses to query the joint A2A context graph.
+
+Each tool wraps one of the four headline audit questions the demo
+already supports via BigQuery Studio (`bq_studio_queries.gql.tpl`
+Blocks 1-4). The analyst agent reasons in natural language and
+picks a tool; the tool runs a parameterized query against the
+auditor projection tables and joint property graph, returns a
+small structured result, and never exposes raw A2A request /
+response payloads.
+
+`<P>.<AUDITOR>.a2a_joint_context_graph` is the graph. Its node and
+edge tables are populated by `build_joint_graph.py` from the
+caller and receiver `agent_events` tables earlier in the runbook.
+
+All tools accept no credentials directly; they use ADC via
+`google.cloud.bigquery.Client`. The dataset references come from
+module-level constants resolved from `.env`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+from google.api_core import exceptions as gax_exceptions
+import google.auth
+from google.cloud import bigquery
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEMO_DIR = os.path.dirname(_HERE)
+_env_path = os.path.join(_DEMO_DIR, ".env")
+if os.path.exists(_env_path):
+  load_dotenv(dotenv_path=_env_path)
+
+_, _auth_project = google.auth.default()
+PROJECT_ID = os.getenv("PROJECT_ID") or _auth_project
+DATASET_LOCATION = os.getenv("DATASET_LOCATION", "us-central1")
+AUDITOR_DATASET_ID = os.getenv("AUDITOR_DATASET_ID", "a2a_auditor_demo")
+
+# Row caps protect the LLM context window against pathological
+# audit datasets (e.g. thousands of dropped options). Operators can
+# override either through env vars when they truly want a wider
+# scan; the defaults stay tight to keep the demo readable.
+_LIST_LIMIT = int(os.getenv("ANALYST_LIST_LIMIT", "25"))
+_REJECTIONS_LIMIT = int(os.getenv("ANALYST_REJECTIONS_LIMIT", "30"))
+
+_GRAPH = f"`{PROJECT_ID}.{AUDITOR_DATASET_ID}.a2a_joint_context_graph`"
+
+
+def _client() -> bigquery.Client:
+  return bigquery.Client(project=PROJECT_ID, location=DATASET_LOCATION)
+
+
+def stitch_health() -> dict[str, Any]:
+  """Audit-stack health gate (Block 1 in the BQ Studio walkthrough).
+
+  Returns:
+      Dict with five keys:
+        - a2a_calls (int): number of remote A2A delegations the
+          caller recorded in the current campaign run.
+        - calls_with_context_id (int): subset that carry an
+          a2a_context_id (should equal a2a_calls).
+        - calls_with_receiver_echo (int): subset whose response
+          carried a diagnostic adk_session_id echo.
+        - stitched_edges (int): number of (remote_invocation,
+          receiver_session) pairs the auditor join found.
+        - unstitched_calls (int): a2a_calls - stitched_edges; the
+          failure signal.
+  """
+  client = _client()
+  q = f"""
+    WITH ri AS (
+      SELECT
+        COUNT(*)                                                  AS a2a_calls,
+        COUNTIF(a2a_context_id IS NOT NULL)                       AS calls_with_context_id,
+        COUNTIF(receiver_session_id_from_response IS NOT NULL)    AS calls_with_receiver_echo
+      FROM `{PROJECT_ID}.{AUDITOR_DATASET_ID}.remote_agent_invocations`
+    ),
+    edges AS (
+      SELECT COUNT(*) AS stitched_edges
+      FROM `{PROJECT_ID}.{AUDITOR_DATASET_ID}.joint_a2a_edges`
+    )
+    SELECT
+      ri.a2a_calls,
+      ri.calls_with_context_id,
+      ri.calls_with_receiver_echo,
+      edges.stitched_edges,
+      ri.a2a_calls - edges.stitched_edges AS unstitched_calls
+    FROM ri, edges
+  """
+  try:
+    row = list(client.query(q).result())[0]
+  except gax_exceptions.NotFound:
+    return {
+        "error": (
+            "Auditor projections not found. Run build_joint_graph.py first."
+        ),
+    }
+  return {
+      "a2a_calls": int(row["a2a_calls"]),
+      "calls_with_context_id": int(row["calls_with_context_id"]),
+      "calls_with_receiver_echo": int(row["calls_with_receiver_echo"]),
+      "stitched_edges": int(row["stitched_edges"]),
+      "unstitched_calls": int(row["unstitched_calls"]),
+  }
+
+
+def list_campaigns() -> dict[str, Any]:
+  """Lists every caller CampaignRun visible to the auditor graph.
+
+  Returns:
+      Dict with two keys:
+        - count (int): number of rows.
+        - campaigns (list[dict]): one entry per campaign with
+          caller_session_id, campaign, brand, run_order, and
+          event_count.
+  """
+  client = _client()
+  q = f"""
+    SELECT
+      caller_session_id,
+      campaign,
+      brand,
+      run_order,
+      event_count
+    FROM `{PROJECT_ID}.{AUDITOR_DATASET_ID}.caller_campaign_runs`
+    ORDER BY run_order
+    LIMIT {_LIST_LIMIT}
+  """
+  try:
+    rows = list(client.query(q).result())
+  except gax_exceptions.NotFound:
+    return {
+        "count": 0,
+        "campaigns": [],
+        "error": (
+            "caller_campaign_runs not found. Run build_joint_graph.py first."
+        ),
+    }
+  campaigns = [
+      {
+          "caller_session_id": str(r["caller_session_id"]),
+          "campaign": str(r["campaign"]),
+          "brand": str(r["brand"]),
+          "run_order": int(r["run_order"]),
+          "event_count": int(r["event_count"]),
+      }
+      for r in rows
+  ]
+  return {"count": len(campaigns), "campaigns": campaigns}
+
+
+def audit_campaign(caller_session_id: str) -> dict[str, Any]:
+  """Right-to-explanation audit path for one caller campaign.
+
+  Walks the graph:
+
+      CallerCampaignRun -[:DelegatedVia]-> RemoteAgentInvocation
+        -[:HandledBy]-> ReceiverAgentRun
+        -[:ReceiverMadeDecision]-> ReceiverPlanningDecision
+        -[:ReceiverWeighedOption]-> ReceiverDecisionOption
+
+  Both selected and dropped options appear because
+  `rejection_rationale` is a property on every
+  `ReceiverDecisionOption` (NULL for SELECTED, non-NULL for DROPPED).
+
+  Args:
+      caller_session_id: The caller session id for the campaign
+          under audit. Use `list_campaigns()` to look this up if
+          the user provided only a campaign or brand name.
+
+  Returns:
+      Dict with:
+        - caller_session_id (str): echo of input.
+        - count (int): number of option rows returned.
+        - options (list[dict]): each entry has campaign,
+          a2a_context_id, decision_type, option_name, score,
+          status (SELECTED | DROPPED), and rationale (the dropped
+          option's rejection reason, or null for selected options).
+  """
+  client = _client()
+  q = f"""
+    GRAPH {_GRAPH}
+    MATCH (campaign:CallerCampaignRun)
+          -[:DelegatedVia]->(remote:RemoteAgentInvocation)
+          -[:HandledBy]->(receiver:ReceiverAgentRun)
+          -[:ReceiverMadeDecision]->(decision:ReceiverPlanningDecision)
+          -[:ReceiverWeighedOption]->(option:ReceiverDecisionOption)
+    WHERE campaign.caller_session_id = @caller_session
+    RETURN
+      campaign.campaign AS campaign,
+      remote.a2a_context_id AS a2a_context_id,
+      decision.decision_type AS decision_type,
+      option.name AS option_name,
+      option.score AS score,
+      option.status AS status,
+      option.rejection_rationale AS rationale
+    ORDER BY option.status DESC, option.score DESC
+  """
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "caller_session", "STRING", caller_session_id
+          ),
+      ],
+  )
+  try:
+    rows = list(client.query(q, job_config=job_config).result())
+  except gax_exceptions.NotFound:
+    return {
+        "caller_session_id": caller_session_id,
+        "count": 0,
+        "options": [],
+        "error": (
+            "Joint property graph not found. Run build_joint_graph.py first."
+        ),
+    }
+  if not rows:
+    return {
+        "caller_session_id": caller_session_id,
+        "count": 0,
+        "options": [],
+        "note": (
+            "No options found for that caller_session_id. Use "
+            "list_campaigns() to confirm the session id exists."
+        ),
+    }
+  options = [
+      {
+          "campaign": str(r["campaign"]),
+          "a2a_context_id": (
+              str(r["a2a_context_id"]) if r["a2a_context_id"] else None
+          ),
+          "decision_type": str(r["decision_type"]),
+          "option_name": str(r["option_name"]),
+          "score": float(r["score"]) if r["score"] is not None else None,
+          "status": str(r["status"]),
+          "rationale": (
+              str(r["rationale"]) if r["rationale"] is not None else None
+          ),
+      }
+      for r in rows
+  ]
+  return {
+      "caller_session_id": caller_session_id,
+      "count": len(options),
+      "options": options,
+  }
+
+
+def find_governance_rejections(
+    decision_type: Optional[str] = None,
+    max_score: Optional[float] = None,
+) -> dict[str, Any]:
+  """Portfolio-level scan of every DROPPED option in the joint graph.
+
+  Args:
+      decision_type: Optional case-insensitive substring filter on
+          the decision label (e.g. ``"audience"`` to match
+          ``"Audience risk review"``). Pass ``None`` to include
+          all decision types.
+      max_score: Optional upper bound on option score. Pass
+          ``None`` to include all dropped options regardless of
+          score.
+
+  Returns:
+      Dict with:
+        - count (int): rows returned (capped by
+          ANALYST_REJECTIONS_LIMIT, default 30).
+        - filters (dict): echo of the applied filter values.
+        - rejections (list[dict]): each entry has
+          a2a_context_id, decision_type, option_name, score, and
+          rationale.
+  """
+  filters = {"decision_type": decision_type, "max_score": max_score}
+  where = ["option.status = 'DROPPED'"]
+  params: list[bigquery.ScalarQueryParameter] = []
+  if decision_type is not None:
+    where.append(
+        "LOWER(decision.decision_type) LIKE CONCAT('%', LOWER(@dtype), '%')"
+    )
+    params.append(
+        bigquery.ScalarQueryParameter("dtype", "STRING", decision_type)
+    )
+  if max_score is not None:
+    where.append("option.score <= @max_score")
+    params.append(
+        bigquery.ScalarQueryParameter("max_score", "FLOAT64", float(max_score))
+    )
+
+  where_clause = " AND ".join(where)
+  q = f"""
+    GRAPH {_GRAPH}
+    MATCH (remote:RemoteAgentInvocation)-[:HandledBy]->(receiver:ReceiverAgentRun)
+          -[:ReceiverMadeDecision]->(decision:ReceiverPlanningDecision)
+          -[:ReceiverWeighedOption]->(option:ReceiverDecisionOption)
+    WHERE {where_clause}
+    RETURN
+      remote.a2a_context_id AS a2a_context_id,
+      decision.decision_type AS decision_type,
+      option.name AS option_name,
+      option.score AS score,
+      option.rejection_rationale AS rationale
+    ORDER BY option.score ASC
+    LIMIT {_REJECTIONS_LIMIT}
+  """
+  job_config = bigquery.QueryJobConfig(query_parameters=params)
+  client = _client()
+  try:
+    rows = list(client.query(q, job_config=job_config).result())
+  except gax_exceptions.NotFound:
+    return {
+        "count": 0,
+        "filters": filters,
+        "rejections": [],
+        "error": (
+            "Joint property graph not found. Run build_joint_graph.py first."
+        ),
+    }
+  rejections = [
+      {
+          "a2a_context_id": (
+              str(r["a2a_context_id"]) if r["a2a_context_id"] else None
+          ),
+          "decision_type": str(r["decision_type"]),
+          "option_name": str(r["option_name"]),
+          "score": float(r["score"]) if r["score"] is not None else None,
+          "rationale": (
+              str(r["rationale"]) if r["rationale"] is not None else None
+          ),
+      }
+      for r in rows
+  ]
+  return {
+      "count": len(rejections),
+      "filters": filters,
+      "rejections": rejections,
+  }
+
+
+ANALYST_TOOLS = [
+    stitch_health,
+    list_campaigns,
+    audit_campaign,
+    find_governance_rejections,
+]

--- a/examples/a2a_joint_lineage_demo/reset.sh
+++ b/examples/a2a_joint_lineage_demo/reset.sh
@@ -15,8 +15,8 @@
 
 # Tear down A2A Joint Lineage demo state.
 #
-# Drops the caller, receiver, and auditor datasets created by
-# setup.sh. Leaves the .venv intact (delete it manually if you
+# Drops the caller, receiver, auditor, and analyst datasets created
+# by setup.sh. Leaves the .venv intact (delete it manually if you
 # want a fresh install).
 
 set -euo pipefail
@@ -38,9 +38,10 @@ fi
 CALLER_DATASET_ID="${CALLER_DATASET_ID:-a2a_caller_demo}"
 RECEIVER_DATASET_ID="${RECEIVER_DATASET_ID:-a2a_receiver_demo}"
 AUDITOR_DATASET_ID="${AUDITOR_DATASET_ID:-a2a_auditor_demo}"
+ANALYST_DATASET_ID="${ANALYST_DATASET_ID:-a2a_analyst_demo}"
 
 echo "Tearing down A2A Joint Lineage demo state in project $PROJECT_ID..."
-for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID"; do
+for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID" "$ANALYST_DATASET_ID"; do
   if bq show "${PROJECT_ID}:${ds}" &>/dev/null 2>&1; then
     echo "  Removing dataset ${ds}..."
     bq rm -r -f --dataset "${PROJECT_ID}:${ds}" 2>/dev/null || true

--- a/examples/a2a_joint_lineage_demo/run_analyst_agent.py
+++ b/examples/a2a_joint_lineage_demo/run_analyst_agent.py
@@ -49,6 +49,7 @@ import asyncio
 import os
 import sys
 import time
+from typing import Optional
 
 from analyst_agent import APP_NAME
 from analyst_agent import bq_logging_plugin
@@ -90,8 +91,16 @@ _DEFAULT_QUESTIONS = [
 ]
 
 
-def _final_text(events: list) -> str:
-  """Pull the analyst agent's last user-visible text response."""
+def _final_text(events: list) -> Optional[str]:
+  """Pull the analyst agent's last user-visible text response.
+
+  Returns ``None`` when the agent produced no terminal text response
+  (e.g. all events were tool calls/results with no follow-up
+  summary). Callers should treat that case as a failure rather than
+  silently exiting success: ``run_e2e_demo.sh`` exits 0 if the
+  driver returns 0, and we don't want a question that produced
+  zero answer text to slip past the e2e gate.
+  """
   for event in reversed(events):
     content = getattr(event, "content", None)
     if not content:
@@ -107,7 +116,7 @@ def _final_text(events: list) -> str:
     ]
     if text_parts:
       return "\n".join(text_parts).strip()
-  return "(analyst produced no final text response)"
+  return None
 
 
 async def _ask_one(
@@ -145,6 +154,14 @@ async def _ask_one(
     return session_id, len(events), exception_msg
 
   answer = _final_text(events)
+  if answer is None:
+    msg = "analyst produced no final text response"
+    print(
+        f"          ! {msg} ({elapsed:.1f}s, {len(events)} events)",
+        file=sys.stderr,
+    )
+    return session_id, len(events), msg
+
   print(f"          A ({elapsed:.1f}s, {len(events)} events):")
   for line in answer.splitlines():
     print(f"            {line}")

--- a/examples/a2a_joint_lineage_demo/run_analyst_agent.py
+++ b/examples/a2a_joint_lineage_demo/run_analyst_agent.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the audit-analyst agent against the joint context graph.
+
+This is the loop-closing step of the demo:
+
+  1. ``run_caller_agent.py`` ran the supervisor agent through the
+     campaign briefs; its A2A delegations landed in the caller
+     ``agent_events``.
+  2. ``run_receiver_server.py`` served the governance reviewer;
+     receiver spans landed in the receiver ``agent_events``.
+  3. ``build_org_graphs.py`` materialized per-org context graphs.
+  4. ``build_joint_graph.py`` stitched the auditor projections and
+     created ``a2a_joint_context_graph``.
+  5. **This script** asks the analyst agent a natural-language
+     question; the agent picks one of four tools (stitch_health,
+     list_campaigns, audit_campaign, find_governance_rejections),
+     runs a parameterized query, and answers in plain English.
+
+The analyst's own reasoning trace lands in
+``<ANALYST_DATASET>.agent_events`` via the BQ AA Plugin, so
+operators can build audit-of-the-audit lineage from it later.
+
+Usage::
+
+    ./.venv/bin/python3 run_analyst_agent.py                # canned question
+    ./.venv/bin/python3 run_analyst_agent.py "Is the audit graph healthy?"
+
+Multiple questions can be passed positionally; each runs as its own
+ADK session so the analyst's traces stay scoped per-question.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+
+from analyst_agent import APP_NAME
+from analyst_agent import bq_logging_plugin
+from analyst_agent import root_agent
+from google.adk.runners import InMemoryRunner
+from google.genai.types import Content
+from google.genai.types import Part
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+USER_ID = os.getenv("DEMO_USER_ID", "u-a2a-demo-analyst")
+PER_QUESTION_TIMEOUT_S = int(os.getenv("DEMO_ANALYST_TIMEOUT_S", "300"))
+
+# Default canned questions cover one read against each of the four
+# analyst tools (stitch_health, list_campaigns, audit_campaign,
+# find_governance_rejections) so a no-argument run exercises every
+# tool surface end-to-end.
+_DEFAULT_QUESTIONS = [
+    (
+        "Is the joint audit graph healthy? How many remote A2A calls"
+        " did we record, and were they all stitched to a receiver"
+        " session?"
+    ),
+    (
+        "What campaigns are in scope for this audit run? List each"
+        " campaign and its caller_session_id."
+    ),
+    (
+        "For the first campaign you find, walk me through the remote"
+        " governance agent's full audit path — every option it"
+        " considered, which one it selected, and the rationale for"
+        " each dropped option."
+    ),
+    (
+        "Across the whole portfolio, what are the lowest-scored"
+        " options the governance agent dropped? Quote the rejection"
+        " rationale verbatim."
+    ),
+]
+
+
+def _final_text(events: list) -> str:
+  """Pull the analyst agent's last user-visible text response."""
+  for event in reversed(events):
+    content = getattr(event, "content", None)
+    if not content:
+      continue
+    parts = getattr(content, "parts", None)
+    if not parts:
+      continue
+    role = getattr(content, "role", None)
+    if role == "user":
+      continue
+    text_parts = [
+        getattr(p, "text", None) for p in parts if getattr(p, "text", None)
+    ]
+    if text_parts:
+      return "\n".join(text_parts).strip()
+  return "(analyst produced no final text response)"
+
+
+async def _ask_one(
+    runner: InMemoryRunner, question: str, idx: int, total: int
+) -> tuple[str, int, str | None]:
+  """Run one question through the analyst end-to-end."""
+  session = await runner.session_service.create_session(
+      app_name=runner.app_name,
+      user_id=USER_ID,
+  )
+  session_id = session.id
+  print(f"\n  [{idx}/{total}] analyst_session={session_id}")
+  print(f"          Q: {question}")
+
+  message = Content(role="user", parts=[Part(text=question)])
+  start = time.monotonic()
+  events: list = []
+  exception_msg: str | None = None
+  try:
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=session_id,
+        new_message=message,
+    ):
+      events.append(event)
+  except Exception as exc:  # pylint: disable=broad-except
+    exception_msg = f"{type(exc).__name__}: {exc}"
+    print(
+        f"          ! analyst errored after {len(events)} events: {exc}",
+        file=sys.stderr,
+    )
+
+  elapsed = time.monotonic() - start
+  if exception_msg is not None:
+    return session_id, len(events), exception_msg
+
+  answer = _final_text(events)
+  print(f"          A ({elapsed:.1f}s, {len(events)} events):")
+  for line in answer.splitlines():
+    print(f"            {line}")
+  return session_id, len(events), None
+
+
+async def _ask_all(questions: list[str]) -> int:
+  print(f"Running {len(questions)} analyst question(s)...")
+  runner = InMemoryRunner(
+      agent=root_agent,
+      app_name=APP_NAME,
+      plugins=[bq_logging_plugin],
+  )
+
+  failures = 0
+  for idx, q in enumerate(questions, start=1):
+    try:
+      _, _, error_msg = await asyncio.wait_for(
+          _ask_one(runner, q, idx, len(questions)),
+          timeout=PER_QUESTION_TIMEOUT_S,
+      )
+    except asyncio.TimeoutError:
+      error_msg = f"timeout after {PER_QUESTION_TIMEOUT_S}s"
+      print(f"  [{idx}/{len(questions)}] TIMEOUT", file=sys.stderr)
+    if error_msg:
+      failures += 1
+
+  print("\nFlushing analyst BQ AA Plugin...")
+  try:
+    await bq_logging_plugin.flush()
+  except Exception as exc:  # pylint: disable=broad-except
+    print(f"  flush() warning: {exc}", file=sys.stderr)
+  try:
+    await bq_logging_plugin.shutdown()
+  except Exception as exc:  # pylint: disable=broad-except
+    print(f"  shutdown() warning: {exc}", file=sys.stderr)
+
+  return failures
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+      description=(
+          "Ask the analyst agent natural-language audit questions"
+          " about the joint A2A context graph."
+      ),
+  )
+  parser.add_argument(
+      "questions",
+      nargs="*",
+      help=(
+          "One or more questions. Each question runs as its own ADK"
+          " session. If omitted, four canned questions exercise"
+          " every analyst tool."
+      ),
+  )
+  args = parser.parse_args()
+
+  questions = args.questions if args.questions else _DEFAULT_QUESTIONS
+
+  failures = asyncio.run(_ask_all(questions))
+  if failures:
+    print(
+        f"\nERROR: {failures} of {len(questions)} questions failed.",
+        file=sys.stderr,
+    )
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/examples/a2a_joint_lineage_demo/run_e2e_demo.sh
+++ b/examples/a2a_joint_lineage_demo/run_e2e_demo.sh
@@ -20,7 +20,8 @@
 #
 # This script starts the receiver A2A server in the background, runs the
 # receiver smoke gate, runs the caller campaigns, builds both per-org SDK
-# context graphs, builds the auditor joint graph, then stops the receiver.
+# context graphs, builds the auditor joint graph, runs the analyst agent
+# against that graph (closing the loop), then stops the receiver.
 
 set -euo pipefail
 
@@ -63,7 +64,7 @@ echo "Receiver URL: $RECEIVER_A2A_URL"
 echo "Server log:   $SERVER_LOG"
 echo ""
 
-echo "[1/5] Starting receiver A2A server..."
+echo "[1/6] Starting receiver A2A server..."
 : > "$SERVER_LOG"
 "$VENV_PY" "$SCRIPT_DIR/run_receiver_server.py" > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
@@ -90,20 +91,24 @@ done
 echo "  Receiver ready: $RECEIVER_AGENT_CARD"
 
 echo ""
-echo "[2/5] Smoke-testing receiver plugin writes..."
+echo "[2/6] Smoke-testing receiver plugin writes..."
 "$VENV_PY" "$SCRIPT_DIR/smoke_receiver.py"
 
 echo ""
-echo "[3/5] Running caller campaigns through the remote A2A receiver..."
+echo "[3/6] Running caller campaigns through the remote A2A receiver..."
 "$VENV_PY" "$SCRIPT_DIR/run_caller_agent.py"
 
 echo ""
-echo "[4/5] Building caller and receiver SDK context graphs..."
+echo "[4/6] Building caller and receiver SDK context graphs..."
 "$VENV_PY" "$SCRIPT_DIR/build_org_graphs.py"
 
 echo ""
-echo "[5/5] Building auditor projections and joint property graph..."
+echo "[5/6] Building auditor projections and joint property graph..."
 "$VENV_PY" "$SCRIPT_DIR/build_joint_graph.py"
+
+echo ""
+echo "[6/6] Asking the analyst agent canned audit questions..."
+"$VENV_PY" "$SCRIPT_DIR/run_analyst_agent.py"
 
 echo ""
 echo "============================================"
@@ -117,4 +122,7 @@ echo "Use:"
 echo "  $SCRIPT_DIR/BQ_STUDIO_WALKTHROUGH.md"
 echo "  $SCRIPT_DIR/bq_studio_queries.gql"
 echo "  $SCRIPT_DIR/DEMO_NARRATION.md"
+echo ""
+echo "Ask the analyst agent ad-hoc questions:"
+echo "  $SCRIPT_DIR/.venv/bin/python3 run_analyst_agent.py \"<your question>\""
 echo ""

--- a/examples/a2a_joint_lineage_demo/setup.sh
+++ b/examples/a2a_joint_lineage_demo/setup.sh
@@ -19,7 +19,7 @@
 #   1. Verify python3 + gcloud + .venv tooling.
 #   2. Enable BigQuery + Vertex AI APIs.
 #   3. Install dependencies into ./.venv.
-#   4. Create caller, receiver, and auditor datasets if missing.
+#   4. Create caller, receiver, auditor, and analyst datasets if missing.
 #   5. Write a .env file the agents and runners read.
 #
 # After setup, the demo runs in two terminals:
@@ -27,11 +27,12 @@
 #   Terminal A  (long-lived receiver server)
 #     ./.venv/bin/python3 run_receiver_server.py
 #
-#   Terminal B  (smoke + caller campaigns + dual graph + auditor graph)
+#   Terminal B  (smoke + caller campaigns + dual graph + auditor graph + analyst)
 #     ./.venv/bin/python3 smoke_receiver.py
 #     ./.venv/bin/python3 run_caller_agent.py
 #     ./.venv/bin/python3 build_org_graphs.py
 #     ./.venv/bin/python3 build_joint_graph.py
+#     ./.venv/bin/python3 run_analyst_agent.py
 #
 # Required IAM roles for the authenticated principal:
 #   - roles/bigquery.dataEditor
@@ -117,6 +118,8 @@ CALLER_TABLE_ID="${CALLER_TABLE_ID:-agent_events}"
 RECEIVER_DATASET_ID="${RECEIVER_DATASET_ID:-a2a_receiver_demo}"
 RECEIVER_TABLE_ID="${RECEIVER_TABLE_ID:-agent_events}"
 AUDITOR_DATASET_ID="${AUDITOR_DATASET_ID:-a2a_auditor_demo}"
+ANALYST_DATASET_ID="${ANALYST_DATASET_ID:-a2a_analyst_demo}"
+ANALYST_TABLE_ID="${ANALYST_TABLE_ID:-agent_events}"
 # Gemini 3.x model defaults — verified against live Vertex AI +
 # BigQuery AI.GENERATE in May 2026:
 #
@@ -150,7 +153,7 @@ DEMO_AGENT_MODEL="${DEMO_AGENT_MODEL:-gemini-3.1-pro-preview}"
 DEMO_AI_ENDPOINT="${DEMO_AI_ENDPOINT:-https://aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/global/publishers/google/models/gemini-3-flash-preview}"
 RECEIVER_A2A_URL="${RECEIVER_A2A_URL:-http://127.0.0.1:8000}"
 
-for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID"; do
+for ds in "$CALLER_DATASET_ID" "$RECEIVER_DATASET_ID" "$AUDITOR_DATASET_ID" "$ANALYST_DATASET_ID"; do
   if bq show "${PROJECT_ID}:${ds}" &>/dev/null; then
     echo "  Dataset ${ds} already exists."
     continue
@@ -189,6 +192,9 @@ RECEIVER_TABLE_ID=$RECEIVER_TABLE_ID
 
 AUDITOR_DATASET_ID=$AUDITOR_DATASET_ID
 
+ANALYST_DATASET_ID=$ANALYST_DATASET_ID
+ANALYST_TABLE_ID=$ANALYST_TABLE_ID
+
 DEMO_AGENT_LOCATION=$DEMO_AGENT_LOCATION
 DEMO_AGENT_MODEL=$DEMO_AGENT_MODEL
 DEMO_AI_ENDPOINT=$DEMO_AI_ENDPOINT
@@ -219,6 +225,7 @@ echo "    ./.venv/bin/python3 smoke_receiver.py"
 echo "    ./.venv/bin/python3 run_caller_agent.py"
 echo "    ./.venv/bin/python3 build_org_graphs.py"
 echo "    ./.venv/bin/python3 build_joint_graph.py   # runs ./render_queries.sh itself"
+echo "    ./.venv/bin/python3 run_analyst_agent.py   # closes the loop"
 echo ""
 echo "  (Re-run ./render_queries.sh only after editing .env or *.gql.tpl.)"
 echo ""


### PR DESCRIPTION
## Why

Today's [`examples/a2a_joint_lineage_demo/`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/a2a_joint_lineage_demo) flow is **agent → BQAA → context graph → human SQL**. The user runs the caller and receiver agents, the SDK materializes per-org graphs, `build_joint_graph.py` stitches the auditor projections, and then it's on the operator to open BigQuery Studio and paste GQL from `bq_studio_queries.gql`.

This PR adds the missing fourth hop — **agent → BQAA → context graph → agent** — by adding a third ADK agent (the *audit analyst*) that reads the joint property graph back through bounded BigQuery tools and answers natural-language audit questions. Its own reasoning trace also lands in BQ via the BQ AA Plugin, so audit-of-the-audit lineage uses the same data model.

## What

### `analyst_agent/` — ADK Agent + 4 bounded BQ tools

| Tool | Wraps | Picked when |
|---|---|---|
| `stitch_health()` | `bq_studio_queries.gql` Block 1 | "Is the audit graph healthy? Are all calls accounted for?" |
| `list_campaigns()` | (new discovery query) | "What campaigns are in scope?" / session-id lookup by brand or title |
| `audit_campaign(caller_session_id)` | Block 4 | "Walk me through the audit path for campaign X" |
| `find_governance_rejections(decision_type=None, max_score=None)` | Block 3 (filtered) | Portfolio-level scans for dropped options |

Tools are parameterized BigQuery queries with row caps (`ANALYST_LIST_LIMIT` default 25, `ANALYST_REJECTIONS_LIMIT` default 30) so the LLM context window can't get blown by pathological audit datasets. Raw `a2a_request` / `a2a_response` payloads are never returned — the redaction contract from the projection layer carries through to the agent surface.

### `run_analyst_agent.py` — CLI driver

```bash
./.venv/bin/python3 run_analyst_agent.py                # 4 canned questions
./.venv/bin/python3 run_analyst_agent.py "Why was X rejected for campaign Y?"
```

No args = four canned questions, one per tool, so a fresh demo exercises every tool surface. Positional args become free-text questions; each runs as its own ADK session.

### Plumbing

- **`setup.sh` / `reset.sh`** — new `ANALYST_DATASET_ID` env var (default `a2a_analyst_demo`), plus a fourth dataset to create/drop. The dataset houses the analyst's own ADK traces.
- **`run_e2e_demo.sh`** — new `[6/6]` step runs the analyst against the canned question set after the joint graph is built, then prints an ad-hoc invocation hint.

### Documentation

- **`README.md`** — describes the closed loop, lists the analyst file map, shows both canned + ad-hoc invocation patterns.
- **`A2A_JOINT_LINEAGE.md`** — new *Closing the loop — the analyst agent* section with the tool→question mapping table and the rationale for landing analyst traces in their own dataset (audit-of-the-audit).
- **`DEMO_NARRATION.md`** — new Beat 8 in the 5-minute talk track, with show-and-tell cues for each canned answer + the ad-hoc mode pivot.

## Verification

- `pyink --check`, `isort --check-only`, `python3 -m py_compile`, `bash -n` — all clean.
- **Live tool smoke** against `test-project-0728-467323`: each of the four tool entrypoints returned its `NotFound`-handling branch with the expected human-readable error (the project doesn't have the demo materialized — that's exactly what we wanted to verify). No exceptions raised.
- E2E not run live — would burn Vertex AI quota and require the auditor dataset to be materialized first.

## Out of scope

- Building a per-analyst context graph from `<ANALYST_DATASET>.agent_events`. The traces are there for follow-up `ContextGraphManager.build_context_graph` work but the demo doesn't materialize it.
- Cross-org IAM and redaction enforcement on the analyst dataset. Today's demo is one-project, four datasets; production hardening is tracked separately ([#139](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/139)).
- Adding the analyst agent's tools to the SDK's view layer. They live in the demo bundle for now; promoting them to first-class SDK helpers is a follow-up if the pattern proves valuable.

## Refs

Builds on the four merged PRs from [#129](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/129): [#132](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/132), [#133](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/133), [#135](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/135), [#136](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/136), plus the E2E packaging PR [#141](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/141).