### PR TITLE
examples(migration_v5): MAKO reference extractor + tests (#107 follow-up)

### DIFF
--- a/examples/migration_v5/reference_extractor.py
+++ b/examples/migration_v5/reference_extractor.py
@@ -1,0 +1,438 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hand-authored reference extractor for the MAKO decision flow.
+
+Consumed by:
+
+* The notebook's Beat 3 cells (3.3 / 3.4 / 3.5 / 3.7) via
+  ``measure_compile(..., reference_extractor=...)``.
+* The revalidation CLI
+  (``bqaa-revalidate-extractors``) via
+  ``--reference-extractors-module
+  examples.migration_v5.reference_extractor``.
+
+Both consumers expect the same module-level surface:
+
+* ``EXTRACTORS`` — ``dict[str, Callable]`` mapping
+  ``event_type`` to an extractor with signature
+  ``(event, spec) -> StructuredExtractionResult``.
+* ``RESOLVED_GRAPH`` — a ``ResolvedGraph`` produced by
+  ``resolve(ontology, binding)``. The harness uses it to
+  validate extractor output before fingerprinting.
+* ``SPEC`` (optional) — forwarded as the second argument
+  of every extractor call. We default to ``None`` since
+  the MAKO extractors don't consume the spec.
+
+Coverage:
+
+The MAKO agent emits ``TOOL_COMPLETED`` events for five
+decision-flow tools. The extractor switches on the tool
+name and produces the per-tool slice of the MAKO graph:
+
+| Tool                       | Node                   | Edges                                                                                                            |
+|----------------------------|------------------------|------------------------------------------------------------------------------------------------------------------|
+| ``capture_context``        | ``ContextSnapshot``    | —                                                                                                                |
+| ``propose_decision_point`` | ``DecisionPoint``      | —                                                                                                                |
+| ``evaluate_candidate``     | ``Candidate``          | ``evaluatesCandidate`` (DecisionPoint → Candidate)                                                              |
+| ``commit_outcome``         | ``SelectionOutcome``   | ``selectedCandidate`` (SelectionOutcome → Candidate)                                                            |
+| ``complete_execution``     | ``DecisionExecution``  | ``executedAtDecisionPoint``, ``atContextSnapshot``, ``hasSelectionOutcome``, plus ``AgentSession`` + ``partOfSession`` |
+
+``AgentSession`` is synthesized from the plugin
+envelope's ``session_id`` because the agent's tools don't
+return a session-shaped payload. The synthesis happens
+inside ``_extract_complete_execution`` so it only fires
+once per session (when the agent finishes a decision
+flow), not on every event.
+
+Node-ID encoding follows the binding's per-entity PK
+columns (see PR #155's mako_artifacts.py): each node_id
+is ``{session_id}:{Entity}:{pk_col}={value}``. Edge FK
+column values fall out of ``parse_key_segment`` against
+those node IDs, which is how
+``ontology_materializer._route_edge`` reads them.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any, Optional
+
+from bigquery_agent_analytics.extracted_models import ExtractedEdge
+from bigquery_agent_analytics.extracted_models import ExtractedNode
+from bigquery_agent_analytics.extracted_models import ExtractedProperty
+from bigquery_agent_analytics.resolved_spec import resolve as _resolve_spec
+from bigquery_agent_analytics.structured_extraction import StructuredExtractionResult
+from bigquery_ontology import load_binding
+from bigquery_ontology import load_ontology
+
+# Resolve paths relative to this file so the module works
+# regardless of CWD (the notebook + the revalidation CLI
+# both import this from different directories).
+_HERE = pathlib.Path(__file__).parent
+_ONTOLOGY_PATH = _HERE / "ontology.yaml"
+_BINDING_PATH = _HERE / "binding.yaml"
+
+
+# ------------------------------------------------------------------ #
+# Per-tool extractors                                                 #
+# ------------------------------------------------------------------ #
+
+
+def _extract_capture_context(
+    session_id: str, span_id: str, result: dict
+) -> StructuredExtractionResult:
+  """``capture_context`` → ``ContextSnapshot`` node."""
+  context_id = result.get("context_id")
+  if not context_id:
+    return StructuredExtractionResult()
+
+  node_id = f"{session_id}:ContextSnapshot:context_snapshot_id={context_id}"
+  properties = [ExtractedProperty(name="context_snapshot_id", value=context_id)]
+  if "snapshot_payload" in result:
+    # ``ContextSnapshot.snapshotPayload`` is declared
+    # ``xsd:string`` in MAKO; the validator rejects a dict
+    # value as ``unsupported_type``. JSON-serialize so the
+    # payload survives as a queryable string column. (The
+    # binding's column is plain ``STRING``, not ``JSON`` —
+    # downstream consumers ``JSON_VALUE`` it.)
+    raw_payload = result["snapshot_payload"]
+    if isinstance(raw_payload, (dict, list)):
+      payload_value = json.dumps(raw_payload, sort_keys=True)
+    else:
+      payload_value = str(raw_payload)
+    properties.append(
+        ExtractedProperty(name="snapshot_payload", value=payload_value)
+    )
+
+  node = ExtractedNode(
+      node_id=node_id,
+      entity_name="ContextSnapshot",
+      labels=["ContextSnapshot"],
+      properties=properties,
+  )
+  return StructuredExtractionResult(
+      nodes=[node],
+      fully_handled_span_ids={span_id} if span_id else set(),
+  )
+
+
+def _extract_propose_decision_point(
+    session_id: str, span_id: str, result: dict
+) -> StructuredExtractionResult:
+  """``propose_decision_point`` → ``DecisionPoint`` node."""
+  decision_point_id = result.get("decision_point_id")
+  if not decision_point_id:
+    return StructuredExtractionResult()
+
+  node_id = f"{session_id}:DecisionPoint:decision_point_id={decision_point_id}"
+  properties = [
+      ExtractedProperty(name="decision_point_id", value=decision_point_id),
+  ]
+  if "reversibility" in result:
+    properties.append(
+        ExtractedProperty(name="reversibility", value=result["reversibility"])
+    )
+
+  node = ExtractedNode(
+      node_id=node_id,
+      entity_name="DecisionPoint",
+      labels=["DecisionPoint"],
+      properties=properties,
+  )
+  return StructuredExtractionResult(
+      nodes=[node],
+      fully_handled_span_ids={span_id} if span_id else set(),
+  )
+
+
+def _extract_evaluate_candidate(
+    session_id: str, span_id: str, result: dict
+) -> StructuredExtractionResult:
+  """``evaluate_candidate`` → ``Candidate`` node +
+  ``evaluatesCandidate`` edge (DecisionPoint → Candidate)."""
+  candidate_id = result.get("candidate_id")
+  decision_point_id = result.get("decision_point_id")
+  if not candidate_id or not decision_point_id:
+    return StructuredExtractionResult()
+
+  candidate_node_id = f"{session_id}:Candidate:candidate_id={candidate_id}"
+  decision_point_node_id = (
+      f"{session_id}:DecisionPoint:decision_point_id={decision_point_id}"
+  )
+
+  node = ExtractedNode(
+      node_id=candidate_node_id,
+      entity_name="Candidate",
+      labels=["Candidate"],
+      properties=[ExtractedProperty(name="candidate_id", value=candidate_id)],
+  )
+  edge = ExtractedEdge(
+      edge_id=f"evaluatesCandidate:{decision_point_id}:{candidate_id}",
+      relationship_name="evaluatesCandidate",
+      from_node_id=decision_point_node_id,
+      to_node_id=candidate_node_id,
+  )
+  return StructuredExtractionResult(
+      nodes=[node],
+      edges=[edge],
+      fully_handled_span_ids={span_id} if span_id else set(),
+  )
+
+
+def _extract_commit_outcome(
+    session_id: str, span_id: str, result: dict
+) -> StructuredExtractionResult:
+  """``commit_outcome`` → ``SelectionOutcome`` node +
+  ``selectedCandidate`` edge (SelectionOutcome → Candidate).
+
+  Rationale field on the tool result is **trace-only** —
+  MAKO doesn't declare ``rationale`` on
+  ``SelectionOutcome``, so the span is marked
+  ``partially_handled`` (the free-text rationale stays in
+  the AI transcript)."""
+  outcome_id = result.get("outcome_id")
+  selected_candidate_id = result.get("selected_candidate_id")
+  if not outcome_id or not selected_candidate_id:
+    return StructuredExtractionResult()
+
+  outcome_node_id = (
+      f"{session_id}:SelectionOutcome:selection_outcome_id={outcome_id}"
+  )
+  candidate_node_id = (
+      f"{session_id}:Candidate:candidate_id={selected_candidate_id}"
+  )
+
+  node = ExtractedNode(
+      node_id=outcome_node_id,
+      entity_name="SelectionOutcome",
+      labels=["SelectionOutcome"],
+      properties=[
+          ExtractedProperty(name="selection_outcome_id", value=outcome_id)
+      ],
+  )
+  edge = ExtractedEdge(
+      edge_id=f"selectedCandidate:{outcome_id}:{selected_candidate_id}",
+      relationship_name="selectedCandidate",
+      from_node_id=outcome_node_id,
+      to_node_id=candidate_node_id,
+  )
+
+  partial = {span_id} if span_id and "rationale" in result else set()
+  full = {span_id} if span_id and "rationale" not in result else set()
+  return StructuredExtractionResult(
+      nodes=[node],
+      edges=[edge],
+      fully_handled_span_ids=full,
+      partially_handled_span_ids=partial,
+  )
+
+
+def _extract_complete_execution(
+    session_id: str, span_id: str, result: dict
+) -> StructuredExtractionResult:
+  """``complete_execution`` → ``DecisionExecution`` node +
+  every edge that hangs off the central hub.
+
+  This is also where the envelope-side ``AgentSession`` is
+  synthesized. The agent's tools never return a session
+  payload, but the plugin envelope carries ``session_id``
+  on every event. Emitting ``AgentSession`` + the
+  ``partOfSession`` edge from this extractor keeps the
+  whole hub-shape graph in one place — Beat 4.4's hub-
+  shape traversal `(DecisionExecution)-[partOfSession]->
+  (AgentSession)` is what consumes them.
+  """
+  execution_id = result.get("execution_id")
+  decision_point_id = result.get("decision_point_id")
+  context_id = result.get("context_id")
+  outcome_id = result.get("outcome_id")
+  if not (execution_id and decision_point_id and context_id and outcome_id):
+    return StructuredExtractionResult()
+
+  execution_node_id = (
+      f"{session_id}:DecisionExecution:decision_execution_id={execution_id}"
+  )
+  decision_point_node_id = (
+      f"{session_id}:DecisionPoint:decision_point_id={decision_point_id}"
+  )
+  context_node_id = (
+      f"{session_id}:ContextSnapshot:context_snapshot_id={context_id}"
+  )
+  outcome_node_id = (
+      f"{session_id}:SelectionOutcome:selection_outcome_id={outcome_id}"
+  )
+  agent_session_node_id = (
+      f"{session_id}:AgentSession:agent_session_id={session_id}"
+  )
+
+  execution_properties = [
+      ExtractedProperty(name="decision_execution_id", value=execution_id),
+  ]
+  if "business_entity_id" in result:
+    execution_properties.append(
+        ExtractedProperty(
+            name="business_entity_id", value=result["business_entity_id"]
+        )
+    )
+  if "latency_ms" in result:
+    execution_properties.append(
+        ExtractedProperty(name="latency_ms", value=result["latency_ms"])
+    )
+
+  execution_node = ExtractedNode(
+      node_id=execution_node_id,
+      entity_name="DecisionExecution",
+      labels=["DecisionExecution"],
+      properties=execution_properties,
+  )
+
+  # AgentSession synthesis: one node per session,
+  # primary-key column ``agent_session_id`` (per binding).
+  # ``AgentSession.sessionId`` is the MAKO-declared data
+  # property — value is the same envelope session_id.
+  agent_session_node = ExtractedNode(
+      node_id=agent_session_node_id,
+      entity_name="AgentSession",
+      labels=["AgentSession"],
+      properties=[
+          ExtractedProperty(name="agent_session_id", value=session_id),
+          ExtractedProperty(name="session_id", value=session_id),
+      ],
+  )
+
+  edges = [
+      ExtractedEdge(
+          edge_id=f"executedAtDecisionPoint:{execution_id}:{decision_point_id}",
+          relationship_name="executedAtDecisionPoint",
+          from_node_id=execution_node_id,
+          to_node_id=decision_point_node_id,
+      ),
+      ExtractedEdge(
+          edge_id=f"atContextSnapshot:{execution_id}:{context_id}",
+          relationship_name="atContextSnapshot",
+          from_node_id=execution_node_id,
+          to_node_id=context_node_id,
+      ),
+      ExtractedEdge(
+          edge_id=f"hasSelectionOutcome:{execution_id}:{outcome_id}",
+          relationship_name="hasSelectionOutcome",
+          from_node_id=execution_node_id,
+          to_node_id=outcome_node_id,
+      ),
+      ExtractedEdge(
+          edge_id=f"partOfSession:{execution_id}:{session_id}",
+          relationship_name="partOfSession",
+          from_node_id=execution_node_id,
+          to_node_id=agent_session_node_id,
+      ),
+  ]
+
+  return StructuredExtractionResult(
+      nodes=[execution_node, agent_session_node],
+      edges=edges,
+      fully_handled_span_ids={span_id} if span_id else set(),
+  )
+
+
+# ------------------------------------------------------------------ #
+# Top-level extractor (event_type-keyed dispatch)                    #
+# ------------------------------------------------------------------ #
+
+
+_TOOL_HANDLERS = {
+    "capture_context": _extract_capture_context,
+    "propose_decision_point": _extract_propose_decision_point,
+    "evaluate_candidate": _extract_evaluate_candidate,
+    "commit_outcome": _extract_commit_outcome,
+    "complete_execution": _extract_complete_execution,
+}
+
+
+def extract_mako_decision_event(
+    event: dict, spec: Any
+) -> StructuredExtractionResult:
+  """Reference extractor for MAKO ``TOOL_COMPLETED`` events.
+
+  The MAKO agent emits five tool-call types; this function
+  dispatches on ``content.tool`` and delegates to the
+  per-tool helper. Non-tool events (LLM_REQUEST,
+  USER_MESSAGE_RECEIVED, etc.) return an empty result —
+  the AI fallback handles them.
+
+  Args:
+    event: Plugin event row (dict-shaped, matches
+      ``_get_events_schema`` from
+      ``bigquery_agent_analytics_plugin``). Required keys:
+      ``content`` (dict), ``session_id`` (str),
+      ``span_id`` (str).
+    spec: Unused. Forwarded by the
+      ``StructuredExtractor`` contract.
+
+  Returns:
+    A ``StructuredExtractionResult`` — empty when the
+    event isn't a MAKO tool-call or required fields are
+    missing.
+  """
+  del spec  # Reference extractors take spec but MAKO doesn't use it.
+
+  content = event.get("content")
+  if not isinstance(content, dict):
+    return StructuredExtractionResult()
+  tool_name = content.get("tool")
+  if tool_name not in _TOOL_HANDLERS:
+    return StructuredExtractionResult()
+  result = content.get("result")
+  if not isinstance(result, dict):
+    return StructuredExtractionResult()
+
+  session_id = event.get("session_id") or ""
+  span_id = event.get("span_id") or ""
+  return _TOOL_HANDLERS[tool_name](session_id, span_id, result)
+
+
+# ------------------------------------------------------------------ #
+# Module-level surface for the revalidation CLI + harness            #
+# ------------------------------------------------------------------ #
+
+
+def _load_resolved_graph():
+  """Lazy load to keep import-time work minimal — the
+  revalidation CLI imports this module from arbitrary CWDs
+  and only some callers actually use the ``RESOLVED_GRAPH``
+  attribute."""
+  ontology = load_ontology(str(_ONTOLOGY_PATH))
+  binding = load_binding(str(_BINDING_PATH), ontology=ontology)
+  return _resolve_spec(ontology, binding)
+
+
+# The revalidation CLI keys this dict on the
+# ``event_type`` column. MAKO's structured payloads all
+# land in ``TOOL_COMPLETED`` events (one per tool call;
+# the agent emits five per decision flow). Other event
+# types (``LLM_RESPONSE`` reasoning text,
+# ``USER_MESSAGE_RECEIVED`` raw prompt, etc.) are left to
+# the AI fallback.
+EXTRACTORS = {
+    "TOOL_COMPLETED": extract_mako_decision_event,
+}
+
+RESOLVED_GRAPH = _load_resolved_graph()
+
+# ``SPEC`` is the second arg the harness/CLI passes to
+# every extractor call. The MAKO extractor doesn't use it
+# (the graph shape is locked in by ``RESOLVED_GRAPH``);
+# ``None`` matches the harness's keyword default.
+SPEC: Optional[Any] = None

--- a/examples/migration_v5/reference_extractor.py
+++ b/examples/migration_v5/reference_extractor.py
@@ -87,6 +87,37 @@ _BINDING_PATH = _HERE / "binding.yaml"
 
 
 # ------------------------------------------------------------------ #
+# Session-scoping                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _scoped_id(session_id: str, raw_id: str) -> str:
+  """Session-scope a raw tool ID so two sessions producing
+  the same tool output don't collide on the node table's
+  PK column.
+
+  The MAKO demo agent generates IDs via content-derived
+  sha1 prefixes (``ctx-<10hex>`` etc.). Sessions whose
+  ``capture_context`` calls happen to receive the same
+  ``(audience_size, budget_remaining_usd)`` pair produce
+  identical ``ctx-...`` IDs. Without scoping, both
+  sessions would write rows whose PK column carries the
+  same value — BigQuery doesn't enforce PK uniqueness, but
+  ``CREATE PROPERTY GRAPH`` declares ``KEY (...)`` and the
+  graph traversal semantics assume uniqueness.
+
+  The scoping is applied to **PK column values** (the
+  data the materializer writes to BigQuery), to the
+  **node_id** key segment (so ``parse_key_segment`` →
+  edge FK lookup sees the scoped value), and to **edge
+  IDs**. ``AgentSession`` is the one exception: its
+  identity is already the envelope ``session_id``, so
+  scoping ``session_id`` by itself is redundant.
+  """
+  return f"{session_id}:{raw_id}"
+
+
+# ------------------------------------------------------------------ #
 # Per-tool extractors                                                 #
 # ------------------------------------------------------------------ #
 
@@ -95,9 +126,10 @@ def _extract_capture_context(
     session_id: str, span_id: str, result: dict
 ) -> StructuredExtractionResult:
   """``capture_context`` → ``ContextSnapshot`` node."""
-  context_id = result.get("context_id")
-  if not context_id:
+  raw_context_id = result.get("context_id")
+  if not raw_context_id:
     return StructuredExtractionResult()
+  context_id = _scoped_id(session_id, raw_context_id)
 
   node_id = f"{session_id}:ContextSnapshot:context_snapshot_id={context_id}"
   properties = [ExtractedProperty(name="context_snapshot_id", value=context_id)]
@@ -133,9 +165,10 @@ def _extract_propose_decision_point(
     session_id: str, span_id: str, result: dict
 ) -> StructuredExtractionResult:
   """``propose_decision_point`` → ``DecisionPoint`` node."""
-  decision_point_id = result.get("decision_point_id")
-  if not decision_point_id:
+  raw_decision_point_id = result.get("decision_point_id")
+  if not raw_decision_point_id:
     return StructuredExtractionResult()
+  decision_point_id = _scoped_id(session_id, raw_decision_point_id)
 
   node_id = f"{session_id}:DecisionPoint:decision_point_id={decision_point_id}"
   properties = [
@@ -163,10 +196,12 @@ def _extract_evaluate_candidate(
 ) -> StructuredExtractionResult:
   """``evaluate_candidate`` → ``Candidate`` node +
   ``evaluatesCandidate`` edge (DecisionPoint → Candidate)."""
-  candidate_id = result.get("candidate_id")
-  decision_point_id = result.get("decision_point_id")
-  if not candidate_id or not decision_point_id:
+  raw_candidate_id = result.get("candidate_id")
+  raw_decision_point_id = result.get("decision_point_id")
+  if not raw_candidate_id or not raw_decision_point_id:
     return StructuredExtractionResult()
+  candidate_id = _scoped_id(session_id, raw_candidate_id)
+  decision_point_id = _scoped_id(session_id, raw_decision_point_id)
 
   candidate_node_id = f"{session_id}:Candidate:candidate_id={candidate_id}"
   decision_point_node_id = (
@@ -180,7 +215,14 @@ def _extract_evaluate_candidate(
       properties=[ExtractedProperty(name="candidate_id", value=candidate_id)],
   )
   edge = ExtractedEdge(
-      edge_id=f"evaluatesCandidate:{decision_point_id}:{candidate_id}",
+      # Edge IDs are session-scoped too: the materializer
+      # uses ``edge_id`` for delete-then-insert dedup. Two
+      # sessions producing the same ``(dp_id, cand_id)``
+      # pair would otherwise collide.
+      edge_id=(
+          f"{session_id}:evaluatesCandidate:"
+          f"{raw_decision_point_id}:{raw_candidate_id}"
+      ),
       relationship_name="evaluatesCandidate",
       from_node_id=decision_point_node_id,
       to_node_id=candidate_node_id,
@@ -203,10 +245,12 @@ def _extract_commit_outcome(
   ``SelectionOutcome``, so the span is marked
   ``partially_handled`` (the free-text rationale stays in
   the AI transcript)."""
-  outcome_id = result.get("outcome_id")
-  selected_candidate_id = result.get("selected_candidate_id")
-  if not outcome_id or not selected_candidate_id:
+  raw_outcome_id = result.get("outcome_id")
+  raw_selected_candidate_id = result.get("selected_candidate_id")
+  if not raw_outcome_id or not raw_selected_candidate_id:
     return StructuredExtractionResult()
+  outcome_id = _scoped_id(session_id, raw_outcome_id)
+  selected_candidate_id = _scoped_id(session_id, raw_selected_candidate_id)
 
   outcome_node_id = (
       f"{session_id}:SelectionOutcome:selection_outcome_id={outcome_id}"
@@ -224,7 +268,10 @@ def _extract_commit_outcome(
       ],
   )
   edge = ExtractedEdge(
-      edge_id=f"selectedCandidate:{outcome_id}:{selected_candidate_id}",
+      edge_id=(
+          f"{session_id}:selectedCandidate:"
+          f"{raw_outcome_id}:{raw_selected_candidate_id}"
+      ),
       relationship_name="selectedCandidate",
       from_node_id=outcome_node_id,
       to_node_id=candidate_node_id,
@@ -241,7 +288,10 @@ def _extract_commit_outcome(
 
 
 def _extract_complete_execution(
-    session_id: str, span_id: str, result: dict
+    session_id: str,
+    span_id: str,
+    trace_id: str,
+    result: dict,
 ) -> StructuredExtractionResult:
   """``complete_execution`` → ``DecisionExecution`` node +
   every edge that hangs off the central hub.
@@ -254,13 +304,29 @@ def _extract_complete_execution(
   whole hub-shape graph in one place — Beat 4.4's hub-
   shape traversal `(DecisionExecution)-[partOfSession]->
   (AgentSession)` is what consumes them.
+
+  ``DecisionExecution.spanId`` / ``DecisionExecution.traceId``
+  are MAKO-declared provenance properties; the values come
+  from the plugin envelope of the ``complete_execution``
+  event (it's the last tool call in the flow, so its
+  span/trace IDs are a stable handle for the whole
+  decision execution).
   """
-  execution_id = result.get("execution_id")
-  decision_point_id = result.get("decision_point_id")
-  context_id = result.get("context_id")
-  outcome_id = result.get("outcome_id")
-  if not (execution_id and decision_point_id and context_id and outcome_id):
+  raw_execution_id = result.get("execution_id")
+  raw_decision_point_id = result.get("decision_point_id")
+  raw_context_id = result.get("context_id")
+  raw_outcome_id = result.get("outcome_id")
+  if not (
+      raw_execution_id
+      and raw_decision_point_id
+      and raw_context_id
+      and raw_outcome_id
+  ):
     return StructuredExtractionResult()
+  execution_id = _scoped_id(session_id, raw_execution_id)
+  decision_point_id = _scoped_id(session_id, raw_decision_point_id)
+  context_id = _scoped_id(session_id, raw_context_id)
+  outcome_id = _scoped_id(session_id, raw_outcome_id)
 
   execution_node_id = (
       f"{session_id}:DecisionExecution:decision_execution_id={execution_id}"
@@ -291,6 +357,18 @@ def _extract_complete_execution(
     execution_properties.append(
         ExtractedProperty(name="latency_ms", value=result["latency_ms"])
     )
+  # Envelope-side provenance: span/trace IDs link the
+  # materialized DecisionExecution row back to the plugin
+  # trace. Only emit when present — sparse-event sources
+  # (offline replay, synthetic fixtures) may not carry them.
+  if span_id:
+    execution_properties.append(
+        ExtractedProperty(name="span_id", value=span_id)
+    )
+  if trace_id:
+    execution_properties.append(
+        ExtractedProperty(name="trace_id", value=trace_id)
+    )
 
   execution_node = ExtractedNode(
       node_id=execution_node_id,
@@ -315,25 +393,36 @@ def _extract_complete_execution(
 
   edges = [
       ExtractedEdge(
-          edge_id=f"executedAtDecisionPoint:{execution_id}:{decision_point_id}",
+          edge_id=(
+              f"{session_id}:executedAtDecisionPoint:"
+              f"{raw_execution_id}:{raw_decision_point_id}"
+          ),
           relationship_name="executedAtDecisionPoint",
           from_node_id=execution_node_id,
           to_node_id=decision_point_node_id,
       ),
       ExtractedEdge(
-          edge_id=f"atContextSnapshot:{execution_id}:{context_id}",
+          edge_id=(
+              f"{session_id}:atContextSnapshot:"
+              f"{raw_execution_id}:{raw_context_id}"
+          ),
           relationship_name="atContextSnapshot",
           from_node_id=execution_node_id,
           to_node_id=context_node_id,
       ),
       ExtractedEdge(
-          edge_id=f"hasSelectionOutcome:{execution_id}:{outcome_id}",
+          edge_id=(
+              f"{session_id}:hasSelectionOutcome:"
+              f"{raw_execution_id}:{raw_outcome_id}"
+          ),
           relationship_name="hasSelectionOutcome",
           from_node_id=execution_node_id,
           to_node_id=outcome_node_id,
       ),
       ExtractedEdge(
-          edge_id=f"partOfSession:{execution_id}:{session_id}",
+          # ``session_id`` is already the AgentSession's PK,
+          # so just including it once here is enough.
+          edge_id=f"{session_id}:partOfSession:{raw_execution_id}",
           relationship_name="partOfSession",
           from_node_id=execution_node_id,
           to_node_id=agent_session_node_id,
@@ -352,13 +441,17 @@ def _extract_complete_execution(
 # ------------------------------------------------------------------ #
 
 
+# ``complete_execution`` is dispatched separately (see the
+# ``extract_mako_decision_event`` body) because it also
+# consumes the envelope ``trace_id``. The handler table
+# carries only the unified-arity tools.
 _TOOL_HANDLERS = {
     "capture_context": _extract_capture_context,
     "propose_decision_point": _extract_propose_decision_point,
     "evaluate_candidate": _extract_evaluate_candidate,
     "commit_outcome": _extract_commit_outcome,
-    "complete_execution": _extract_complete_execution,
 }
+_KNOWN_TOOLS = set(_TOOL_HANDLERS) | {"complete_execution"}
 
 
 def extract_mako_decision_event(
@@ -392,7 +485,7 @@ def extract_mako_decision_event(
   if not isinstance(content, dict):
     return StructuredExtractionResult()
   tool_name = content.get("tool")
-  if tool_name not in _TOOL_HANDLERS:
+  if tool_name not in _KNOWN_TOOLS:
     return StructuredExtractionResult()
   result = content.get("result")
   if not isinstance(result, dict):
@@ -400,6 +493,17 @@ def extract_mako_decision_event(
 
   session_id = event.get("session_id") or ""
   span_id = event.get("span_id") or ""
+  # ``complete_execution`` carries the envelope-side
+  # provenance fields (span_id + trace_id) onto the
+  # materialized ``DecisionExecution`` row. Other tools
+  # don't need ``trace_id`` so the dispatch table holds
+  # the unified-arity ``(session, span, result)``
+  # handlers; the complete-execution branch is special-
+  # cased here rather than complicating every handler's
+  # signature.
+  if tool_name == "complete_execution":
+    trace_id = event.get("trace_id") or ""
+    return _extract_complete_execution(session_id, span_id, trace_id, result)
   return _TOOL_HANDLERS[tool_name](session_id, span_id, result)
 
 

--- a/tests/test_migration_v5_reference_extractor.py
+++ b/tests/test_migration_v5_reference_extractor.py
@@ -172,9 +172,11 @@ def test_capture_context_emits_context_snapshot():
   assert len(result.edges) == 0
   node = result.nodes[0]
   assert node.entity_name == "ContextSnapshot"
-  assert node.node_id == ("sess-A:ContextSnapshot:context_snapshot_id=ctx-42")
+  assert (
+      node.node_id == "sess-A:ContextSnapshot:context_snapshot_id=sess-A:ctx-42"
+  )
   prop_by_name = {p.name: p.value for p in node.properties}
-  assert prop_by_name["context_snapshot_id"] == "ctx-42"
+  assert prop_by_name["context_snapshot_id"] == "sess-A:ctx-42"
   # ``snapshot_payload`` must be a JSON-serialized STRING
   # (ontology declares xsd:string; validator rejects raw
   # dict values as ``unsupported_type``).
@@ -190,8 +192,9 @@ def test_propose_decision_point_emits_decision_point():
   result = reference_extractor.extract_mako_decision_event(event, None)
   assert len(result.nodes) == 1
   assert result.nodes[0].entity_name == "DecisionPoint"
-  assert result.nodes[0].node_id == (
-      "sess-A:DecisionPoint:decision_point_id=dp-42"
+  assert (
+      result.nodes[0].node_id
+      == "sess-A:DecisionPoint:decision_point_id=sess-A:dp-42"
   )
 
 
@@ -209,8 +212,10 @@ def test_evaluate_candidate_emits_node_and_edge():
   assert len(result.edges) == 1
   edge = result.edges[0]
   assert edge.relationship_name == "evaluatesCandidate"
-  assert edge.from_node_id == "sess-A:DecisionPoint:decision_point_id=dp-7"
-  assert edge.to_node_id == "sess-A:Candidate:candidate_id=cand-7"
+  assert (
+      edge.from_node_id == "sess-A:DecisionPoint:decision_point_id=sess-A:dp-7"
+  )
+  assert edge.to_node_id == "sess-A:Candidate:candidate_id=sess-A:cand-7"
 
 
 def test_commit_outcome_marks_span_partial_when_rationale_present():
@@ -278,8 +283,9 @@ def test_complete_execution_synthesizes_agent_session_and_hub_edges():
   part_of_session = next(
       e for e in result.edges if e.relationship_name == "partOfSession"
   )
-  assert part_of_session.from_node_id == (
-      "my-session:DecisionExecution:decision_execution_id=exec-1"
+  assert (
+      part_of_session.from_node_id
+      == "my-session:DecisionExecution:decision_execution_id=my-session:exec-1"
   )
   assert part_of_session.to_node_id == (
       "my-session:AgentSession:agent_session_id=my-session"
@@ -382,3 +388,101 @@ def test_two_sessions_dedupe_agent_session_nodes():
       "sess-A:AgentSession:agent_session_id=sess-A",
       "sess-B:AgentSession:agent_session_id=sess-B",
   }
+
+
+def test_two_sessions_have_unique_node_pk_values_and_edge_ids():
+  """Cross-session collision regression: two sessions whose
+  agent tools happen to emit identical raw IDs (same args
+  → same content-hashed IDs) must produce **distinct** PK
+  column values on the materialized rows AND distinct
+  ``edge_id`` values. Without session-scoping the
+  extracted graph would silently merge two sessions'
+  decision flows."""
+  events = _decision_flow("sess-A") + _decision_flow("sess-B")
+  results = [
+      reference_extractor.extract_mako_decision_event(ev, None) for ev in events
+  ]
+  merged = merge_extraction_results(results)
+
+  # Every node's PK property value must be unique across
+  # the whole graph (excluding AgentSession, whose PK is
+  # the session_id itself — already unique per session).
+  pk_property_names = {
+      "ContextSnapshot": "context_snapshot_id",
+      "DecisionPoint": "decision_point_id",
+      "Candidate": "candidate_id",
+      "SelectionOutcome": "selection_outcome_id",
+      "DecisionExecution": "decision_execution_id",
+      "AgentSession": "agent_session_id",
+  }
+  pk_values: list[tuple[str, str]] = []
+  for node in merged.nodes:
+    pk_name = pk_property_names[node.entity_name]
+    pk_value = next(p.value for p in node.properties if p.name == pk_name)
+    pk_values.append((node.entity_name, pk_value))
+  # Build set of all (entity, pk_value) pairs; duplicates
+  # within the same entity name are the bug.
+  seen: dict[str, set[str]] = {}
+  for entity, value in pk_values:
+    seen.setdefault(entity, set())
+    assert (
+        value not in seen[entity]
+    ), f"duplicate PK value {value!r} for entity {entity!r}"
+    seen[entity].add(value)
+
+  # Every edge_id must be unique.
+  edge_ids = [e.edge_id for e in merged.edges]
+  assert len(edge_ids) == len(set(edge_ids)), (
+      f"duplicate edge_id in merged graph: "
+      f"{[eid for eid in edge_ids if edge_ids.count(eid) > 1]}"
+  )
+
+
+def test_complete_execution_carries_envelope_span_and_trace():
+  """``DecisionExecution.spanId`` / ``traceId`` are MAKO-
+  declared provenance properties pulled from the plugin
+  envelope of the ``complete_execution`` event."""
+  event = _tool_event(
+      "complete_execution",
+      {
+          "execution_id": "exec-1",
+          "decision_point_id": "dp-1",
+          "context_id": "ctx-1",
+          "outcome_id": "out-1",
+      },
+      session_id="sess-1",
+      span_id="span-prov-1",
+  )
+  event["trace_id"] = "trace-prov-1"
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  exec_node = next(
+      n for n in result.nodes if n.entity_name == "DecisionExecution"
+  )
+  prop_by_name = {p.name: p.value for p in exec_node.properties}
+  assert prop_by_name["span_id"] == "span-prov-1"
+  assert prop_by_name["trace_id"] == "trace-prov-1"
+
+
+def test_complete_execution_omits_span_trace_when_missing():
+  """Provenance props are optional — sparse-event sources
+  (offline replay, synthetic fixtures) may omit them and
+  shouldn't trip the validator with empty-string
+  ``span_id`` / ``trace_id`` properties."""
+  event = _tool_event(
+      "complete_execution",
+      {
+          "execution_id": "exec-1",
+          "decision_point_id": "dp-1",
+          "context_id": "ctx-1",
+          "outcome_id": "out-1",
+      },
+      span_id="",
+  )
+  # No trace_id key at all
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  exec_node = next(
+      n for n in result.nodes if n.entity_name == "DecisionExecution"
+  )
+  prop_names = {p.name for p in exec_node.properties}
+  assert "span_id" not in prop_names
+  assert "trace_id" not in prop_names

--- a/tests/test_migration_v5_reference_extractor.py
+++ b/tests/test_migration_v5_reference_extractor.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``examples/migration_v5/reference_extractor.py``.
+
+Covers:
+
+* Per-tool extractor behavior (one event → expected nodes + edges).
+* Module-level surface contract (``EXTRACTORS``, ``RESOLVED_GRAPH``,
+  ``SPEC``) the revalidation CLI expects.
+* End-to-end: a full 5-event decision flow merges into a graph
+  that passes ``validate_extracted_graph`` against the MAKO
+  ``RESOLVED_GRAPH``.
+* AgentSession synthesis from the plugin envelope ``session_id``
+  (Beat 4.4's ``partOfSession`` hub edge depends on this).
+* Empty-result fast paths (non-tool events, missing keys,
+  non-dict content).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+import sys
+
+import pytest
+
+# The reference extractor lives under ``examples/``, which isn't
+# on ``sys.path`` by default. Add the repo root so
+# ``import examples.migration_v5.reference_extractor`` works.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+  sys.path.insert(0, str(_REPO_ROOT))
+
+reference_extractor = importlib.import_module(
+    "examples.migration_v5.reference_extractor"
+)
+
+from bigquery_agent_analytics.extracted_models import ExtractedGraph
+from bigquery_agent_analytics.graph_validation import FallbackScope
+from bigquery_agent_analytics.graph_validation import validate_extracted_graph
+from bigquery_agent_analytics.structured_extraction import merge_extraction_results
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+def _tool_event(
+    tool: str,
+    result: dict,
+    *,
+    session_id: str = "sess-A",
+    span_id: str = "span-1",
+) -> dict:
+  """Build a synthetic ``TOOL_COMPLETED`` event with the
+  same shape the BQ AA plugin produces. The fields outside
+  ``content`` are deliberately sparse — the extractor only
+  reads ``content`` + envelope-side ``session_id`` /
+  ``span_id``."""
+  return {
+      "event_type": "TOOL_COMPLETED",
+      "session_id": session_id,
+      "span_id": span_id,
+      "content": {"tool": tool, "result": result},
+  }
+
+
+def _decision_flow(session_id: str = "sess-A") -> list[dict]:
+  """The canonical five-event flow the agent produces per
+  decision."""
+  return [
+      _tool_event(
+          "capture_context",
+          {
+              "context_id": "ctx-1",
+              "snapshot_payload": {
+                  "audience_size": 1000,
+                  "budget_remaining_usd": 500,
+              },
+          },
+          session_id=session_id,
+          span_id="s1",
+      ),
+      _tool_event(
+          "propose_decision_point",
+          {"decision_point_id": "dp-1", "reversibility": "compensable"},
+          session_id=session_id,
+          span_id="s2",
+      ),
+      _tool_event(
+          "evaluate_candidate",
+          {"candidate_id": "cand-1", "decision_point_id": "dp-1"},
+          session_id=session_id,
+          span_id="s3",
+      ),
+      _tool_event(
+          "commit_outcome",
+          {
+              "outcome_id": "out-1",
+              "decision_point_id": "dp-1",
+              "selected_candidate_id": "cand-1",
+              "rationale": "best fit",
+          },
+          session_id=session_id,
+          span_id="s4",
+      ),
+      _tool_event(
+          "complete_execution",
+          {
+              "execution_id": "exec-1",
+              "decision_point_id": "dp-1",
+              "context_id": "ctx-1",
+              "outcome_id": "out-1",
+              "business_entity_id": "campaign-x",
+              "latency_ms": 42,
+          },
+          session_id=session_id,
+          span_id="s5",
+      ),
+  ]
+
+
+# ------------------------------------------------------------------ #
+# Module surface contract                                              #
+# ------------------------------------------------------------------ #
+
+
+def test_module_surface_exports():
+  """Revalidation CLI requires
+  ``EXTRACTORS`` (non-empty dict[str, callable]) +
+  ``RESOLVED_GRAPH``. ``SPEC`` is optional."""
+  assert isinstance(reference_extractor.EXTRACTORS, dict)
+  assert reference_extractor.EXTRACTORS
+  for event_type, fn in reference_extractor.EXTRACTORS.items():
+    assert isinstance(event_type, str) and event_type
+    assert callable(fn)
+  assert reference_extractor.RESOLVED_GRAPH is not None
+
+
+def test_extractors_keyed_on_tool_completed():
+  """Only ``TOOL_COMPLETED`` events carry MAKO tool
+  outputs; the dict must be keyed on that event_type so the
+  revalidation CLI dispatches correctly."""
+  assert "TOOL_COMPLETED" in reference_extractor.EXTRACTORS
+
+
+# ------------------------------------------------------------------ #
+# Per-tool extractors                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_capture_context_emits_context_snapshot():
+  event = _tool_event(
+      "capture_context",
+      {"context_id": "ctx-42", "snapshot_payload": {"audience_size": 99}},
+  )
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert len(result.nodes) == 1
+  assert len(result.edges) == 0
+  node = result.nodes[0]
+  assert node.entity_name == "ContextSnapshot"
+  assert node.node_id == ("sess-A:ContextSnapshot:context_snapshot_id=ctx-42")
+  prop_by_name = {p.name: p.value for p in node.properties}
+  assert prop_by_name["context_snapshot_id"] == "ctx-42"
+  # ``snapshot_payload`` must be a JSON-serialized STRING
+  # (ontology declares xsd:string; validator rejects raw
+  # dict values as ``unsupported_type``).
+  assert isinstance(prop_by_name["snapshot_payload"], str)
+  assert json.loads(prop_by_name["snapshot_payload"]) == {"audience_size": 99}
+
+
+def test_propose_decision_point_emits_decision_point():
+  event = _tool_event(
+      "propose_decision_point",
+      {"decision_point_id": "dp-42", "reversibility": "compensable"},
+  )
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert len(result.nodes) == 1
+  assert result.nodes[0].entity_name == "DecisionPoint"
+  assert result.nodes[0].node_id == (
+      "sess-A:DecisionPoint:decision_point_id=dp-42"
+  )
+
+
+def test_evaluate_candidate_emits_node_and_edge():
+  """``evaluate_candidate`` produces both a ``Candidate``
+  node and the ``evaluatesCandidate`` edge that points
+  back at the originating ``DecisionPoint``."""
+  event = _tool_event(
+      "evaluate_candidate",
+      {"candidate_id": "cand-7", "decision_point_id": "dp-7"},
+  )
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert len(result.nodes) == 1
+  assert result.nodes[0].entity_name == "Candidate"
+  assert len(result.edges) == 1
+  edge = result.edges[0]
+  assert edge.relationship_name == "evaluatesCandidate"
+  assert edge.from_node_id == "sess-A:DecisionPoint:decision_point_id=dp-7"
+  assert edge.to_node_id == "sess-A:Candidate:candidate_id=cand-7"
+
+
+def test_commit_outcome_marks_span_partial_when_rationale_present():
+  """The ``rationale`` field is trace-only — MAKO doesn't
+  declare it on ``SelectionOutcome``, so the span stays in
+  the AI transcript even after structured extraction."""
+  with_rationale = _tool_event(
+      "commit_outcome",
+      {
+          "outcome_id": "out-1",
+          "decision_point_id": "dp-1",
+          "selected_candidate_id": "cand-1",
+          "rationale": "best fit",
+      },
+      span_id="s-with",
+  )
+  result = reference_extractor.extract_mako_decision_event(with_rationale, None)
+  assert "s-with" in result.partially_handled_span_ids
+  assert "s-with" not in result.fully_handled_span_ids
+
+  without = _tool_event(
+      "commit_outcome",
+      {
+          "outcome_id": "out-1",
+          "decision_point_id": "dp-1",
+          "selected_candidate_id": "cand-1",
+      },
+      span_id="s-without",
+  )
+  result_no = reference_extractor.extract_mako_decision_event(without, None)
+  assert "s-without" in result_no.fully_handled_span_ids
+  assert "s-without" not in result_no.partially_handled_span_ids
+
+
+def test_complete_execution_synthesizes_agent_session_and_hub_edges():
+  """The central hub: one node + four edges + the
+  envelope-side ``AgentSession`` synthesis that Beat 4.4's
+  hub-shape traversal needs."""
+  event = _tool_event(
+      "complete_execution",
+      {
+          "execution_id": "exec-1",
+          "decision_point_id": "dp-1",
+          "context_id": "ctx-1",
+          "outcome_id": "out-1",
+          "business_entity_id": "campaign-x",
+          "latency_ms": 42,
+      },
+      session_id="my-session",
+  )
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  nodes_by_entity = {n.entity_name: n for n in result.nodes}
+  assert set(nodes_by_entity) == {"DecisionExecution", "AgentSession"}
+  assert nodes_by_entity["AgentSession"].node_id == (
+      "my-session:AgentSession:agent_session_id=my-session"
+  )
+
+  edges_by_rel = {e.relationship_name for e in result.edges}
+  assert edges_by_rel == {
+      "executedAtDecisionPoint",
+      "atContextSnapshot",
+      "hasSelectionOutcome",
+      "partOfSession",
+  }
+  part_of_session = next(
+      e for e in result.edges if e.relationship_name == "partOfSession"
+  )
+  assert part_of_session.from_node_id == (
+      "my-session:DecisionExecution:decision_execution_id=exec-1"
+  )
+  assert part_of_session.to_node_id == (
+      "my-session:AgentSession:agent_session_id=my-session"
+  )
+
+
+# ------------------------------------------------------------------ #
+# Empty / non-matching fast paths                                       #
+# ------------------------------------------------------------------ #
+
+
+def test_non_tool_event_returns_empty():
+  """Reasoning / message events fall through to the AI
+  fallback — the extractor must not produce noise."""
+  event = {
+      "event_type": "LLM_RESPONSE",
+      "session_id": "sess-A",
+      "span_id": "span-x",
+      "content": {"text": "I will pick candidate A."},
+  }
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert not result.nodes and not result.edges
+
+
+def test_unknown_tool_returns_empty():
+  event = _tool_event("not_a_mako_tool", {"some": "data"})
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert not result.nodes and not result.edges
+
+
+def test_missing_required_field_returns_empty():
+  """Each per-tool extractor needs specific keys in
+  ``result``. Without them, no partial graph is emitted."""
+  event = _tool_event(
+      "complete_execution",
+      {"execution_id": "exec-1"},  # missing dp/ctx/outcome
+  )
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert not result.nodes and not result.edges
+
+
+def test_non_dict_content_returns_empty():
+  event = {
+      "event_type": "TOOL_COMPLETED",
+      "session_id": "sess-A",
+      "span_id": "span-1",
+      "content": "not-a-dict",
+  }
+  result = reference_extractor.extract_mako_decision_event(event, None)
+  assert not result.nodes and not result.edges
+
+
+# ------------------------------------------------------------------ #
+# End-to-end: full decision flow validates against the ontology        #
+# ------------------------------------------------------------------ #
+
+
+def test_full_decision_flow_validator_clean():
+  """A merged 5-tool flow produces 6 nodes + 6 edges that
+  pass the MAKO validator. This is the contract the
+  notebook's Beat 3 cells (3.3 / 3.5 / 3.7) gate on."""
+  results = [
+      reference_extractor.extract_mako_decision_event(ev, None)
+      for ev in _decision_flow()
+  ]
+  merged = merge_extraction_results(results)
+  assert len(merged.nodes) == 6
+  assert len(merged.edges) == 6
+
+  graph = ExtractedGraph(name="mako", nodes=merged.nodes, edges=merged.edges)
+  report = validate_extracted_graph(reference_extractor.RESOLVED_GRAPH, graph)
+  assert report.ok, [(f.scope.value, f.code, f.path) for f in report.failures]
+
+
+def test_full_decision_flow_emits_part_of_session_edge():
+  """Beat 4.4's hub-shape traversal expects at least one
+  ``partOfSession`` row. The reference extractor must
+  synthesize it from the envelope side."""
+  results = [
+      reference_extractor.extract_mako_decision_event(ev, None)
+      for ev in _decision_flow()
+  ]
+  merged = merge_extraction_results(results)
+  rels = {e.relationship_name for e in merged.edges}
+  assert "partOfSession" in rels
+
+
+def test_two_sessions_dedupe_agent_session_nodes():
+  """If two distinct sessions both complete a decision,
+  the merged graph carries two distinct ``AgentSession``
+  nodes (one per session) — not one collapsed node nor
+  duplicate rows."""
+  events = _decision_flow("sess-A") + _decision_flow("sess-B")
+  results = [
+      reference_extractor.extract_mako_decision_event(ev, None) for ev in events
+  ]
+  merged = merge_extraction_results(results)
+  agent_sessions = [n for n in merged.nodes if n.entity_name == "AgentSession"]
+  assert {n.node_id for n in agent_sessions} == {
+      "sess-A:AgentSession:agent_session_id=sess-A",
+      "sess-B:AgentSession:agent_session_id=sess-B",
+  }


### PR DESCRIPTION
**Status:** PR #155 (the fixture foundation + notebook scaffold) is merged. This PR rebased onto current `main`, so the diff is now just two files: `examples/migration_v5/reference_extractor.py` (542 lines) + `tests/test_migration_v5_reference_extractor.py` (488 lines).

Current HEAD: `6411328`.

## Goal

Close the remaining Beat 3 + Beat 4.4 gaps in the MAKO notebook (#107) by shipping a hand-authored reference extractor + tests, then (in a follow-up commit on this branch) wiring it into the notebook's compile/parity/fingerprint/runtime/savings cells.

Per the reviewer's recommendation, this first cut ships the module + focused tests only. Once validator-clean output + `partOfSession` synthesis are signed off, the notebook cells flip live.

## What this PR ships

### `examples/migration_v5/reference_extractor.py`

Module surface the revalidation CLI + harness require:

```python
EXTRACTORS:     dict[str, Callable[[dict, Any], StructuredExtractionResult]]
RESOLVED_GRAPH: ResolvedGraph  # from resolve(ontology, binding)
SPEC:           Optional[Any]  # None (MAKO extractors don't use spec)
```

`EXTRACTORS["TOOL_COMPLETED"] = extract_mako_decision_event`. Only `TOOL_COMPLETED` events carry MAKO tool payloads; other event types fall through to the AI fallback.

`extract_mako_decision_event` dispatches on `content.tool`:

| Tool | Emits |
|---|---|
| `capture_context` | `ContextSnapshot` node. `snapshot_payload` (dict) is JSON-serialized to a string — MAKO declares `ContextSnapshot.snapshotPayload` as `xsd:string`; a raw dict would fail validation. |
| `propose_decision_point` | `DecisionPoint` node with `reversibility`. |
| `evaluate_candidate` | `Candidate` node + `evaluatesCandidate` edge (DecisionPoint → Candidate). |
| `commit_outcome` | `SelectionOutcome` node + `selectedCandidate` edge. Spans with a `rationale` field are `partially_handled` (rationale is trace-only, not MAKO-declared). |
| `complete_execution` | `DecisionExecution` node + 4 hub edges (`executedAtDecisionPoint`, `atContextSnapshot`, `hasSelectionOutcome`, `partOfSession`) **plus** the envelope-side `AgentSession` node — synthesized from the plugin's `session_id` because the agent's tools never return a session-shaped payload. This is the synthesis Beat 4.4's hub-shape traversal needs. |

#### Cross-session safety (round-2 fix)

The MAKO agent generates IDs via content-derived sha1 prefixes (`ctx-<10hex>` / `dp-<10hex>` / etc.); two sessions whose tool calls receive the same arguments produce identical raw IDs. Without session-scoping, BigQuery would carry duplicate PK column values across sessions and the property graph's `KEY (...)` uniqueness assumption would silently break. The new `_scoped_id(session_id, raw_id)` helper produces `"{session_id}:{raw_id}"` and is applied to every entity PK *value* (the data the materializer writes), every `node_id` key segment (so `parse_key_segment` → FK lookup sees the scoped value), and every `edge_id`. `AgentSession` is unchanged because its identity is already `session_id`.

#### DecisionExecution provenance (round-2 fix)

`DecisionExecution.spanId` / `traceId` are MAKO-declared and bound in `binding.yaml` (columns `span_id` / `trace_id`). `_extract_complete_execution` now pulls them from the event envelope and emits them as properties when present. Sparse sources (offline replay, synthetic fixtures) that omit the envelope fields skip the properties rather than emitting empty strings.

### `tests/test_migration_v5_reference_extractor.py` — 17 tests, all passing

```
$ PYTHONPATH=src python -m pytest tests/test_migration_v5_reference_extractor.py
============================== 17 passed in 4.29s ==============================
```

Coverage:

- **Module surface contract** — `EXTRACTORS` non-empty dict[str, callable], `RESOLVED_GRAPH` present, keyed on `TOOL_COMPLETED`.
- **Per-tool behavior** — each of the 5 tools emits the expected node(s) + edges with the right node_id encoding.
- **`commit_outcome` span handling** — `partially_handled` set when rationale present, `fully_handled` otherwise.
- **`complete_execution` hub synthesis** — emits `DecisionExecution` + `AgentSession`, all 4 hub edges including `partOfSession`.
- **Empty / fast paths** — non-tool events, unknown tools, missing required fields, non-dict content all return empty.
- **End-to-end validator-clean** — full 5-event flow → 6 nodes + 6 edges; `validate_extracted_graph(RESOLVED_GRAPH, graph).ok` is True.
- **`partOfSession` present** — closes Beat 4.4's hub-shape gap.
- **Multi-session AgentSession dedup** — two sessions produce two distinct `AgentSession` nodes.
- **Cross-session uniqueness** — `test_two_sessions_have_unique_node_pk_values_and_edge_ids` runs two flows that share raw tool IDs and asserts every node's PK *value* is unique within its entity AND every `edge_id` is unique. This is the regression test for the collision risk above.
- **Envelope span/trace** — `test_complete_execution_carries_envelope_span_and_trace` asserts `DecisionExecution.span_id` / `trace_id` properties land.
- **Sparse-source graceful** — `test_complete_execution_omits_span_trace_when_missing` asserts a missing envelope `trace_id` produces a node without a `trace_id` property rather than an empty-string one.

## What this PR is NOT (yet)

The notebook cells are *not* updated in this PR. That's the next step:

- **Cell 3.3** — call `compile_extractor` / `measure_compile` against real MAKO sample events with this module as the reference.
- **Cell 3.4** — recompile and assert same fingerprint / cache hit.
- **Cell 3.5** — run `ontology-build` with compiled bundle / runtime wiring.
- **Cell 3.7** — savings table: baseline vs compiled/fallback.
- **Cell 4.4** — hub-shape GQL traversal returns non-zero `partOfSession` rows.

Lands in a follow-up commit on this same branch once this module is signed off.

## Acceptance criteria status

- [x] `validate_extracted_graph` passes on reference output.
- [x] `partOfSession` edge present in extractor output (envelope-side `AgentSession` synthesis).
- [x] Multi-session uniqueness: distinct PK values + distinct edge IDs.
- [x] `DecisionExecution.span_id` / `trace_id` provenance properties wired.
- [ ] **(pending notebook wiring)** `measure_compile(...).parity_ok == True` against this reference + the compiled MAKO extractor.
- [ ] **(pending)** Recompile proves stable fingerprint / cache.
- [ ] **(pending)** Hub-shape GQL returns at least one `partOfSession` row in the executed notebook.
- [ ] **(pending)** Live notebook output includes the savings delta table.
- [ ] **(pending)** No PR-#156 placeholders remain in Beat 3.

## Test plan

- [x] `pytest tests/test_migration_v5_reference_extractor.py` — **17/17 pass**.
- [x] Module imports cleanly + exposes correct surface for the revalidation CLI.
- [x] Two-session synthetic flow validates clean + produces 12 nodes / 12 edges with unique PK values + unique edge IDs.
- [ ] **(pending)** Notebook cells wired + executed against `test-project-0728-467323` with the new extractor.