### PR TITLE
cli: add bqaa-materialize-window for scheduled graph refresh (#161 MVP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ all = [
 [project.scripts]
 bq-agent-sdk = "bigquery_agent_analytics.cli:main"
 bqaa-revalidate-extractors = "bigquery_agent_analytics.extractor_compilation.cli_revalidate:main"
+bqaa-materialize-window = "bigquery_agent_analytics.cli:_materialize_window_entry"
 gm = "bigquery_ontology.cli:main"
 
 [tool.hatch.build.targets.wheel]

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1912,16 +1912,27 @@ def main() -> None:
 
 def _materialize_window_entry() -> None:
   """Entry point for the standalone ``bqaa-materialize-window``
-  console script. Same code path as ``bq-agent-sdk
-  materialize-window``; the standalone name is the customer-
-  facing alias documented in #161, so Cloud Run Job specs can use
-  it directly without the parent subcommand chain.
+  console script.
+
+  Builds a Click command directly from the ``materialize_window``
+  callback so ``--help`` renders as
+  ``Usage: bqaa-materialize-window [OPTIONS]`` — collapsed, no
+  nested subcommand. ``typer.run`` would re-register the function
+  as a subcommand named ``materialize-window``, producing the
+  confusing
+  ``Usage: bqaa-materialize-window materialize-window [OPTIONS]``.
+  The function body is the same one registered on the main ``app``
+  as the ``materialize-window`` subcommand; both call paths share
+  the implementation.
   """
-  # Insert the subcommand name at the front so users invoke
-  # ``bqaa-materialize-window --lookback-hours 6`` directly,
-  # without re-typing the parent command name.
-  sys.argv.insert(1, "materialize-window")
-  app()
+  from typer.main import get_command_from_info
+  from typer.models import CommandInfo
+
+  info = CommandInfo(name=None, callback=materialize_window)
+  click_cmd = get_command_from_info(
+      info, pretty_exceptions_short=True, rich_markup_mode=None
+  )
+  click_cmd()
 
 
 if __name__ == "__main__":

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1836,12 +1836,22 @@ def materialize_window(
     location: Optional[str] = typer.Option(
         None, "--location", help="BigQuery location (e.g. 'US', 'EU')."
     ),
+    validate_binding: bool = typer.Option(
+        True,
+        "--validate-binding/--no-validate-binding",
+        help=(
+            "Pre-flight binding-validate against live BQ tables "
+            "before extraction. The 'fail before AI.GENERATE "
+            "spend' contract from #161. Default on. Skipped on "
+            "--dry-run regardless."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
         help=(
-            "Discover sessions + binding-validate but don't extract "
-            "or materialize. Writes no state-table row."
+            "Discover sessions but don't extract, validate, or "
+            "materialize. Writes no state-table row."
         ),
     ),
     fmt: str = typer.Option(
@@ -1882,6 +1892,7 @@ def materialize_window(
         reference_extractors_module=reference_extractors_module,
         max_sessions=max_sessions,
         location=location,
+        validate_binding=validate_binding,
         dry_run=dry_run,
     )
     typer.echo(format_output(result.to_json(), fmt))
@@ -1896,6 +1907,20 @@ def materialize_window(
 
 def main() -> None:
   """Entry point for ``bq-agent-sdk``."""
+  app()
+
+
+def _materialize_window_entry() -> None:
+  """Entry point for the standalone ``bqaa-materialize-window``
+  console script. Same code path as ``bq-agent-sdk
+  materialize-window``; the standalone name is the customer-
+  facing alias documented in #161, so Cloud Run Job specs can use
+  it directly without the parent subcommand chain.
+  """
+  # Insert the subcommand name at the front so users invoke
+  # ``bqaa-materialize-window --lookback-hours 6`` directly,
+  # without re-typing the parent command name.
+  sys.argv.insert(1, "materialize-window")
   app()
 
 

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1869,9 +1869,14 @@ def materialize_window(
 
   Exit codes:
       0 — every discovered session materialized cleanly.
-      1 — at least one session failed (partial result; checkpoint
-          advanced only to the last successful session).
-      2 — unexpected error (load failure, missing flag, etc.).
+      1 — expected failure. Either at least one session failed
+          (partial result; checkpoint advanced only to the last
+          successful session) OR --validate-binding detected
+          schema drift against live BigQuery before extraction
+          (no sessions materialized; drift recorded in the state
+          table audit trail).
+      2 — unexpected internal error (load failure, missing flag,
+          programming bug).
   """
   try:
     from .materialize_window import run_materialize_window

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1735,6 +1735,165 @@ def views_create(
     raise typer.Exit(code=2)
 
 
+# ------------------------------------------------------------------ #
+# materialize-window (cron-friendly graph refresh)                     #
+# ------------------------------------------------------------------ #
+
+
+@app.command("materialize-window")
+def materialize_window(
+    project_id: str = typer.Option(
+        ..., envvar="BQ_AGENT_PROJECT", help=_PROJECT_HELP
+    ),
+    dataset_id: str = typer.Option(
+        ..., envvar="BQ_AGENT_DATASET", help="BigQuery dataset."
+    ),
+    ontology_path: str = typer.Option(
+        ..., "--ontology", help="Path to ontology YAML file."
+    ),
+    binding_path: str = typer.Option(
+        ..., "--binding", help="Path to binding YAML file."
+    ),
+    events_table: str = typer.Option(
+        "agent_events",
+        "--events-table",
+        help="Source telemetry table name (in --dataset-id).",
+    ),
+    lookback_hours: float = typer.Option(
+        ...,
+        "--lookback-hours",
+        help=(
+            "Hard upper bound on how far back to discover sessions. "
+            "Combined with the state-table checkpoint and --overlap-"
+            "minutes to compute the actual scan window."
+        ),
+    ),
+    overlap_minutes: float = typer.Option(
+        15.0,
+        "--overlap-minutes",
+        help=(
+            "Re-process events newer than (last_checkpoint - "
+            "overlap_minutes). Catches late-arriving rows. Session-"
+            "level idempotency keeps re-runs safe."
+        ),
+    ),
+    completion_event_type: str = typer.Option(
+        "AGENT_COMPLETED",
+        "--completion-event-type",
+        help=(
+            "Treat sessions as done when this event_type appears in "
+            "--events-table. Parameterized so non-BQ-AA-plugin "
+            "emitters aren't locked out."
+        ),
+    ),
+    include_active_sessions: bool = typer.Option(
+        False,
+        "--include-active-sessions",
+        help=(
+            "Drop the completion-event filter and materialize every "
+            "session seen in the window. Partial coverage; useful "
+            "for debugging, not production."
+        ),
+    ),
+    state_table: Optional[str] = typer.Option(
+        None,
+        "--state-table",
+        help=(
+            "Checkpoint table reference. Default: "
+            "{project}.{dataset}._bqaa_materialization_state. Accepts "
+            "table / dataset.table / project.dataset.table."
+        ),
+    ),
+    graph_name: Optional[str] = typer.Option(
+        None,
+        "--graph-name",
+        help="Property-graph name. Default: binding's ontology field.",
+    ),
+    bundles_root: Optional[str] = typer.Option(
+        None,
+        "--bundles-root",
+        envvar="BQAA_BUNDLES_ROOT",
+        help=(
+            "Compiled-bundle directory. When set, the runtime "
+            "registry routes events through compiled bundles with "
+            "validator-gated fallback to --reference-extractors-"
+            "module."
+        ),
+    ),
+    reference_extractors_module: Optional[str] = typer.Option(
+        None,
+        "--reference-extractors-module",
+        help=(
+            "Dotted module path exposing EXTRACTORS dict. Required "
+            "when --bundles-root is set."
+        ),
+    ),
+    max_sessions: Optional[int] = typer.Option(
+        None,
+        "--max-sessions",
+        help="Hard cap on sessions per run (cost guardrail).",
+    ),
+    location: Optional[str] = typer.Option(
+        None, "--location", help="BigQuery location (e.g. 'US', 'EU')."
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Discover sessions + binding-validate but don't extract "
+            "or materialize. Writes no state-table row."
+        ),
+    ),
+    fmt: str = typer.Option(
+        "json",
+        "--format",
+        help="Output format: json|text|table.",
+    ),
+) -> None:
+  """Time-window-driven graph refresh.
+
+  Discover sessions whose terminal event landed in
+  ``[scan_start, scan_end)``, extract each session's full history,
+  and materialize. Append-only state table tracks the high-water
+  mark so subsequent runs pick up where the last left off.
+
+  Exit codes:
+      0 — every discovered session materialized cleanly.
+      1 — at least one session failed (partial result; checkpoint
+          advanced only to the last successful session).
+      2 — unexpected error (load failure, missing flag, etc.).
+  """
+  try:
+    from .materialize_window import run_materialize_window
+
+    result = run_materialize_window(
+        project_id=project_id,
+        dataset_id=dataset_id,
+        ontology_path=ontology_path,
+        binding_path=binding_path,
+        events_table=events_table,
+        lookback_hours=lookback_hours,
+        overlap_minutes=overlap_minutes,
+        completion_event_type=completion_event_type,
+        include_active_sessions=include_active_sessions,
+        state_table=state_table,
+        graph_name=graph_name,
+        bundles_root=bundles_root,
+        reference_extractors_module=reference_extractors_module,
+        max_sessions=max_sessions,
+        location=location,
+        dry_run=dry_run,
+    )
+    typer.echo(format_output(result.to_json(), fmt))
+    if not result.ok:
+      raise typer.Exit(code=1)
+  except typer.Exit:
+    raise
+  except Exception as exc:  # noqa: BLE001
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
 def main() -> None:
   """Entry point for ``bq-agent-sdk``."""
   app()

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1,0 +1,936 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Time-window-driven graph refresh.
+
+The customer-facing entry point for cron-scheduled materialization.
+``ontology-build`` expects an explicit ``--session-ids`` list; this
+module takes a time window and discovers the sessions itself.
+
+Customer model: "materialize the last N hours". Operator wires a
+Cloud Scheduler trigger to a Cloud Run Job that invokes:
+
+    bqaa-materialize-window \\
+        --project-id P --dataset-id D \\
+        --ontology O.yaml --binding B.yaml \\
+        --lookback-hours 6 --completion-event-type AGENT_COMPLETED \\
+        --state-table P.D._bqaa_materialization_state
+
+Design contract (per #161):
+
+* **Pinned ``run_started_at``** at entry; both discovery and state
+  writes see the same snapshot of "now". Prevents the discovery
+  query's row set from drifting across the run.
+* **Append-only state table** keyed on a content-derived
+  ``state_key`` (sha256 of project + dataset + graph_name +
+  events_table + ontology_fingerprint + binding_fingerprint). A
+  config change auto-invalidates the previous checkpoint — the
+  right "this is the same config" signal.
+* **Terminal-event-driven discovery**: query directly for events
+  with ``event_type = @completion_event_type`` in the
+  ``[scan_start, scan_end)`` window. Partition pruning falls out
+  automatically because the predicate is on the partition column.
+* **Per-session loop with checkpoint advance**: on each session
+  success, the checkpoint moves to that session's completion
+  timestamp. Partial failure leaves a tight high-water mark for
+  the next run.
+* **At-least-once with idempotent retries**: session-level
+  delete-then-insert in the materializer means re-processing a
+  session is safe; the ``--overlap-minutes`` window re-claims
+  late-arriving events.
+* **C2 outcome counts** use the runtime-registry names
+  (``compiled_unchanged`` / ``compiled_filtered`` /
+  ``fallback_for_event``) — operators reading the JSON report
+  cross-reference them with the same names in extractor-
+  compilation telemetry.
+
+The CLI is a thin wrapper (``cli.materialize_window``); orchestration
+lives here so it's unit-testable without Typer.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+import hashlib
+import json
+import re
+import secrets
+import traceback
+from typing import Any, Callable, Optional, Sequence
+
+from ._streaming_evaluation import compute_scan_start
+from ._streaming_evaluation import DEFAULT_INITIAL_LOOKBACK_MINUTES
+from ._streaming_evaluation import DEFAULT_OVERLAP_MINUTES
+
+# ------------------------------------------------------------------ #
+# Constants                                                            #
+# ------------------------------------------------------------------ #
+
+
+# Default completion-event predicate. The BQ AA plugin emits
+# ``AGENT_COMPLETED`` as the terminal event for an agent invocation;
+# other plugins / emitters can override via ``--completion-event-type``.
+DEFAULT_COMPLETION_EVENT_TYPE = "AGENT_COMPLETED"
+
+# Default state-table local name (relative to ``--dataset-id``).
+# Picked with a leading underscore so it sorts away from user
+# tables; same convention as other SDK-internal artifacts.
+DEFAULT_STATE_TABLE_NAME = "_bqaa_materialization_state"
+
+# Default property-graph name when the binding's ``ontology`` field
+# is the spec name. ``ontology-build`` falls back to the same name
+# unless ``--graph-name`` overrides it.
+_DEFAULT_GRAPH_NAME_SENTINEL = "<from-spec>"
+
+
+_STATE_TABLE_DDL = """\
+CREATE TABLE IF NOT EXISTS `{table_ref}` (
+  state_key STRING NOT NULL,
+  run_id STRING NOT NULL,
+  run_started_at TIMESTAMP NOT NULL,
+  scan_start TIMESTAMP NOT NULL,
+  scan_end TIMESTAMP NOT NULL,
+  last_completion_at TIMESTAMP,
+  sessions_discovered INT64,
+  sessions_materialized INT64,
+  sessions_failed INT64,
+  ok BOOL NOT NULL,
+  error_detail STRING,
+  report_json STRING
+)
+PARTITION BY DATE(run_started_at)
+CLUSTER BY state_key, run_started_at
+"""
+
+
+# Identifier validation for BQ identifiers we interpolate into SQL.
+# Mirrors ``bq_bundle_mirror._TABLE_ID_PATTERN``. Each segment of
+# ``project.dataset.table`` is constrained to ASCII letters/digits
+# plus ``_`` and ``-`` (project IDs can carry hyphens).
+_BQ_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+# Same shape, but two segments — used for the state table's
+# ``dataset.table`` short form when the user opts not to qualify it.
+_BQ_IDENT_LOOSE = re.compile(r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+){0,2}$")
+
+
+# ------------------------------------------------------------------ #
+# Data shapes                                                          #
+# ------------------------------------------------------------------ #
+
+
+@dataclasses.dataclass(frozen=True)
+class DiscoveredSession:
+  """One session-id returned by the discovery query."""
+
+  session_id: str
+  completion_timestamp: _dt.datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionResult:
+  """Outcome of materializing one session."""
+
+  session_id: str
+  ok: bool
+  completion_timestamp: _dt.datetime
+  rows_materialized: dict[str, int] = dataclasses.field(default_factory=dict)
+  error_code: Optional[str] = None
+  error_detail: Optional[str] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class StateRow:
+  """Row written to the checkpoint state table.
+
+  ``last_completion_at`` is the watermark for the next run's
+  ``compute_scan_start`` lower bound. On partial failure it's the
+  MAX completion timestamp among *successfully* materialized
+  sessions — never advancing past a failure.
+  """
+
+  state_key: str
+  run_id: str
+  run_started_at: _dt.datetime
+  scan_start: _dt.datetime
+  scan_end: _dt.datetime
+  last_completion_at: Optional[_dt.datetime]
+  sessions_discovered: int
+  sessions_materialized: int
+  sessions_failed: int
+  ok: bool
+  error_detail: Optional[str] = None
+  report_json: Optional[str] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class MaterializeWindowResult:
+  """Full JSON-serializable report from one run."""
+
+  run_id: str
+  state_key: str
+  window_start: _dt.datetime
+  window_end: _dt.datetime
+  checkpoint_read: Optional[_dt.datetime]
+  checkpoint_written: Optional[_dt.datetime]
+  sessions_discovered: int
+  sessions_materialized: int
+  sessions_failed: int
+  rows_materialized: dict[str, int]
+  table_statuses: dict[str, dict[str, Any]]
+  compiled_outcomes: dict[str, int]
+  failures: list[dict[str, Any]]
+  ok: bool
+
+  def to_json(self) -> dict[str, Any]:
+    """JSON-serializable dict (timestamps → ISO 8601 UTC strings)."""
+    return {
+        "run_id": self.run_id,
+        "state_key": self.state_key,
+        "window_start": _iso(self.window_start),
+        "window_end": _iso(self.window_end),
+        "checkpoint_read": _iso_optional(self.checkpoint_read),
+        "checkpoint_written": _iso_optional(self.checkpoint_written),
+        "sessions_discovered": self.sessions_discovered,
+        "sessions_materialized": self.sessions_materialized,
+        "sessions_failed": self.sessions_failed,
+        "rows_materialized": dict(self.rows_materialized),
+        "table_statuses": dict(self.table_statuses),
+        "compiled_outcomes": dict(self.compiled_outcomes),
+        "failures": list(self.failures),
+        "ok": self.ok,
+    }
+
+
+# ------------------------------------------------------------------ #
+# Pure helpers                                                         #
+# ------------------------------------------------------------------ #
+
+
+def compute_state_key(
+    *,
+    project_id: str,
+    dataset_id: str,
+    graph_name: str,
+    events_table: str,
+    ontology_fingerprint: str,
+    binding_fingerprint: str,
+) -> str:
+  """Content-derived hex key for the state table.
+
+  Stable across re-runs against the same config. A change to ANY
+  of the inputs (e.g. binding rename, new event source, ontology
+  bump) produces a new key, so the prior checkpoint is *implicitly*
+  invalidated. Operators don't need to manage a versioning column
+  by hand — the SDK's existing fingerprint helpers already
+  canonicalize the model contents, so equivalent YAML (different
+  whitespace, key order) produces the same fingerprint and the
+  same state key.
+  """
+  payload = "\x00".join(
+      [
+          project_id,
+          dataset_id,
+          graph_name,
+          events_table,
+          ontology_fingerprint,
+          binding_fingerprint,
+      ]
+  ).encode("utf-8")
+  return hashlib.sha256(payload).hexdigest()
+
+
+def generate_run_id() -> str:
+  """ULID-ish: 12 hex chars from a fresh random source. Globally
+  unique without requiring callers to pass a clock-driven seed.
+  Sortable-by-time is not a property we need — the state table
+  already partitions on ``run_started_at``."""
+  return secrets.token_hex(6)
+
+
+def validated_table_ref(
+    project_id: str,
+    dataset_id: str,
+    table: str,
+) -> str:
+  """Validate each segment + return the BQ-quoted FQN.
+
+  Backtick-wraps when called from SQL builders. The check is the
+  same per-segment regex used by other CLI surfaces; it rejects
+  whitespace, backticks, semicolons, dots inside a segment, etc.
+  """
+  for label, value in (
+      ("project_id", project_id),
+      ("dataset_id", dataset_id),
+      ("table", table),
+  ):
+    if not isinstance(value, str) or not _BQ_SEGMENT_PATTERN.fullmatch(value):
+      raise ValueError(
+          f"--{label.replace('_', '-')} {value!r} is not a well-formed "
+          f"BigQuery identifier segment (allowed: ASCII letters, digits, "
+          f"'_', '-'; no whitespace, backticks, semicolons, or comment "
+          f"markers)"
+      )
+  return f"{project_id}.{dataset_id}.{table}"
+
+
+def parse_state_table_ref(
+    raw: str, default_project: str, default_dataset: str
+) -> tuple[str, str, str]:
+  """Accept ``table`` / ``dataset.table`` / ``project.dataset.table``;
+  fill from defaults; validate each segment.
+
+  Returns ``(project, dataset, table)`` with the same identifier
+  guarantees ``validated_table_ref`` enforces.
+  """
+  if not isinstance(raw, str) or not _BQ_IDENT_LOOSE.fullmatch(raw):
+    raise ValueError(
+        f"--state-table {raw!r} must be ``[project.[dataset.]]table`` "
+        f"(allowed: ASCII letters/digits/'_'/'-' per segment)"
+    )
+  parts = raw.split(".")
+  if len(parts) == 1:
+    project, dataset, table = default_project, default_dataset, parts[0]
+  elif len(parts) == 2:
+    project, (dataset, table) = default_project, parts
+  else:
+    project, dataset, table = parts
+  validated_table_ref(project, dataset, table)
+  return project, dataset, table
+
+
+def build_discovery_sql(
+    *,
+    events_table_ref: str,
+    completion_event_type: str,
+    max_sessions: Optional[int] = None,
+) -> str:
+  """Discovery query: terminal events in ``[scan_start, scan_end)``.
+
+  Partition pruning falls out because the predicate on
+  ``timestamp`` is the partition column for the BQ AA plugin's
+  table. The ``MAX(timestamp)`` per ``session_id`` is the
+  session's completion watermark (one terminal event per session
+  in normal traffic; we coalesce duplicates).
+
+  Parameters are bound at query time so the SQL string itself is
+  static and safe to interpolate the FQN into.
+  """
+  events_table_ref_quoted = "`" + events_table_ref + "`"
+  limit_clause = (
+      f"\n      LIMIT {int(max_sessions)}" if max_sessions is not None else ""
+  )
+  return (
+      f"SELECT\n"
+      f"  session_id,\n"
+      f"  MAX(timestamp) AS completion_timestamp\n"
+      f"FROM {events_table_ref_quoted}\n"
+      f"WHERE timestamp >= @scan_start\n"
+      f"  AND timestamp < @scan_end\n"
+      f"  AND event_type = @completion_event_type\n"
+      f"  AND session_id IS NOT NULL\n"
+      f"GROUP BY session_id\n"
+      f"ORDER BY completion_timestamp{limit_clause}\n"
+  )
+
+
+def build_state_select_sql(state_table_ref: str) -> str:
+  """Most-recent state row for a given ``state_key``."""
+  state_table_ref_quoted = "`" + state_table_ref + "`"
+  return (
+      f"SELECT\n"
+      f"  state_key,\n"
+      f"  run_id,\n"
+      f"  run_started_at,\n"
+      f"  scan_start,\n"
+      f"  scan_end,\n"
+      f"  last_completion_at,\n"
+      f"  sessions_discovered,\n"
+      f"  sessions_materialized,\n"
+      f"  sessions_failed,\n"
+      f"  ok,\n"
+      f"  error_detail\n"
+      f"FROM {state_table_ref_quoted}\n"
+      f"WHERE state_key = @state_key\n"
+      f"ORDER BY run_started_at DESC\n"
+      f"LIMIT 1\n"
+  )
+
+
+# ------------------------------------------------------------------ #
+# State table I/O (DDL + read + append)                                #
+# ------------------------------------------------------------------ #
+
+
+def ensure_state_table(bq_client: Any, state_table_ref: str) -> None:
+  """Create the state table if it doesn't exist. Idempotent."""
+  bq_client.query(_STATE_TABLE_DDL.format(table_ref=state_table_ref)).result()
+
+
+def read_last_checkpoint(
+    bq_client: Any, state_table_ref: str, state_key: str
+) -> Optional[_dt.datetime]:
+  """Return the ``last_completion_at`` of the most recent row for
+  this state-key, or ``None`` if no row exists yet (bootstrap).
+
+  Note: we read ``last_completion_at`` (the terminal-event
+  high-water mark), not ``run_started_at``. The next-run lower
+  bound advances only as far as we've actually materialized.
+  """
+  from google.cloud import bigquery  # local import: optional dep at module load
+
+  rows = list(
+      bq_client.query(
+          build_state_select_sql(state_table_ref),
+          job_config=bigquery.QueryJobConfig(
+              query_parameters=[
+                  bigquery.ScalarQueryParameter(
+                      "state_key", "STRING", state_key
+                  ),
+              ]
+          ),
+      ).result()
+  )
+  if not rows:
+    return None
+  return rows[0].last_completion_at
+
+
+def append_state_row(
+    bq_client: Any, state_table_ref: str, row: StateRow
+) -> None:
+  """Append a state row. Uses ``insert_rows_json`` (streaming
+  insert) — cheaper than an INSERT job for tiny single-row writes."""
+  payload = {
+      "state_key": row.state_key,
+      "run_id": row.run_id,
+      "run_started_at": _iso(row.run_started_at),
+      "scan_start": _iso(row.scan_start),
+      "scan_end": _iso(row.scan_end),
+      "last_completion_at": _iso_optional(row.last_completion_at),
+      "sessions_discovered": row.sessions_discovered,
+      "sessions_materialized": row.sessions_materialized,
+      "sessions_failed": row.sessions_failed,
+      "ok": row.ok,
+      "error_detail": row.error_detail,
+      "report_json": row.report_json,
+  }
+  errors = bq_client.insert_rows_json(state_table_ref, [payload])
+  if errors:
+    raise RuntimeError(f"insert into {state_table_ref} failed: {errors!r}")
+
+
+# ------------------------------------------------------------------ #
+# Outcome callback (compiled-extractor telemetry)                       #
+# ------------------------------------------------------------------ #
+
+
+def make_outcome_counter() -> tuple[Callable[[str, Any], None], dict[str, int]]:
+  """Returns ``(callback, counts)``.
+
+  Wire ``callback`` into ``OntologyGraphManager.from_bundles_root(
+  ..., on_outcome=callback)`` to count C2 fallback decisions in
+  the JSON report. ``counts`` accumulates ``compiled_unchanged``
+  / ``compiled_filtered`` / ``fallback_for_event`` over the run.
+  Unknown decisions land in a catch-all so a future SDK addition
+  doesn't silently drop telemetry.
+  """
+  counts: dict[str, int] = {
+      "compiled_unchanged": 0,
+      "compiled_filtered": 0,
+      "fallback_for_event": 0,
+  }
+
+  def _callback(event_type: str, outcome: Any) -> None:
+    del event_type  # outcome.decision is the keying field
+    decision = getattr(outcome, "decision", None)
+    if isinstance(decision, str) and decision:
+      counts[decision] = counts.get(decision, 0) + 1
+    else:
+      counts.setdefault("unknown", 0)
+      counts["unknown"] += 1
+
+  return _callback, counts
+
+
+# ------------------------------------------------------------------ #
+# Small datetime helpers                                               #
+# ------------------------------------------------------------------ #
+
+
+def _iso(value: _dt.datetime) -> str:
+  """Coerce to UTC isoformat with a trailing ``Z`` for JSON."""
+  if value.tzinfo is None:
+    value = value.replace(tzinfo=_dt.timezone.utc)
+  return value.astimezone(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _iso_optional(value: Optional[_dt.datetime]) -> Optional[str]:
+  return _iso(value) if value is not None else None
+
+
+# ------------------------------------------------------------------ #
+# Orchestrator                                                         #
+# ------------------------------------------------------------------ #
+
+
+def run_materialize_window(
+    *,
+    project_id: str,
+    dataset_id: str,
+    ontology_path: str,
+    binding_path: str,
+    events_table: str = "agent_events",
+    lookback_hours: float,
+    overlap_minutes: float = DEFAULT_OVERLAP_MINUTES,
+    initial_lookback_minutes: float = DEFAULT_INITIAL_LOOKBACK_MINUTES,
+    completion_event_type: str = DEFAULT_COMPLETION_EVENT_TYPE,
+    include_active_sessions: bool = False,
+    state_table: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    bundles_root: Optional[str] = None,
+    reference_extractors_module: Optional[str] = None,
+    max_sessions: Optional[int] = None,
+    location: Optional[str] = None,
+    dry_run: bool = False,
+    bq_client: Optional[Any] = None,
+    run_started_at: Optional[_dt.datetime] = None,
+) -> MaterializeWindowResult:
+  """The end-to-end run.
+
+  Returns the structured result; caller decides what to do with
+  the exit code (CLI translates ``result.ok`` to 0/1).
+
+  Args:
+    project_id, dataset_id: BigQuery target.
+    ontology_path, binding_path: YAML paths.
+    events_table: Source telemetry table name (relative to
+      ``--dataset-id``).
+    lookback_hours: Window size. The discovery query lower bound
+      is ``max(last_checkpoint - overlap, run_started_at -
+      lookback_hours)``.
+    overlap_minutes: Re-process events newer than
+      ``last_checkpoint - overlap_minutes``. Default 15.
+    initial_lookback_minutes: First-run lookback when no
+      checkpoint exists. Default 30.
+    completion_event_type: ``event_type`` that marks a session
+      as done. Defaults to BQ AA plugin's ``AGENT_COMPLETED``.
+    include_active_sessions: If True, drop the completion-event
+      filter and materialize every session seen in the window
+      (partial coverage; useful for debugging, not production).
+    state_table: Checkpoint table ref. Defaults to
+      ``{project}.{dataset}._bqaa_materialization_state``.
+    graph_name: Property-graph name. Defaults to the binding's
+      ``ontology`` field.
+    bundles_root: Compiled-bundle directory. Optional; if set,
+      C2 wrapper is wired and outcome counts populate.
+    reference_extractors_module: Dotted module path for the
+      reference fallback. Required when ``bundles_root`` is set.
+    max_sessions: Hard cap on sessions per run (cost guardrail).
+      ``None`` = unlimited.
+    location: BigQuery location.
+    dry_run: Discover + binding-validate; don't extract or
+      materialize.
+    bq_client: Optional pre-configured BigQuery client.
+    run_started_at: Test seam. Defaults to UTC ``now``.
+  """
+  from google.cloud import bigquery
+
+  # Pin a single timestamp for the whole run.
+  run_started = (
+      run_started_at
+      if run_started_at is not None
+      else _dt.datetime.now(_dt.timezone.utc)
+  )
+  if run_started.tzinfo is None:
+    run_started = run_started.replace(tzinfo=_dt.timezone.utc)
+  run_id = generate_run_id()
+
+  client = bq_client or bigquery.Client(project=project_id, location=location)
+
+  # Resolve identifiers + qualified refs.
+  events_table_ref = validated_table_ref(project_id, dataset_id, events_table)
+  state_project, state_dataset, state_table_local = parse_state_table_ref(
+      state_table or DEFAULT_STATE_TABLE_NAME,
+      default_project=project_id,
+      default_dataset=dataset_id,
+  )
+  state_table_ref = f"{state_project}.{state_dataset}.{state_table_local}"
+
+  # Load ontology + binding (raw text for the fingerprint helper +
+  # parsed objects for the orchestrator).
+  from bigquery_ontology import Binding
+  from bigquery_ontology import load_binding
+  from bigquery_ontology import load_ontology
+  from bigquery_ontology import Ontology
+  from bigquery_ontology._fingerprint import fingerprint_model
+
+  ontology_obj: Ontology = load_ontology(ontology_path)
+  binding_obj: Binding = load_binding(binding_path, ontology=ontology_obj)
+  ontology_fp = fingerprint_model(ontology_obj)
+  binding_fp = fingerprint_model(binding_obj)
+
+  resolved_graph_name = graph_name or binding_obj.ontology
+
+  state_key = compute_state_key(
+      project_id=project_id,
+      dataset_id=dataset_id,
+      graph_name=resolved_graph_name,
+      events_table=events_table,
+      ontology_fingerprint=ontology_fp,
+      binding_fingerprint=binding_fp,
+  )
+
+  # State table must exist for read/write. Idempotent CREATE.
+  ensure_state_table(client, state_table_ref)
+  last_checkpoint = read_last_checkpoint(client, state_table_ref, state_key)
+
+  scan_start = compute_scan_start(
+      run_started,
+      checkpoint_timestamp=last_checkpoint,
+      overlap=_dt.timedelta(minutes=overlap_minutes),
+      initial_lookback=_dt.timedelta(
+          minutes=initial_lookback_minutes
+          if last_checkpoint is None
+          else lookback_hours * 60.0
+      ),
+  )
+  # ``lookback_hours`` is the hard upper bound on how far back we
+  # ever scan, even when the checkpoint is older. Trim if needed.
+  hard_floor = run_started - _dt.timedelta(hours=lookback_hours)
+  if scan_start < hard_floor:
+    scan_start = hard_floor
+  scan_end = run_started
+
+  # Bind the discovery parameters. ``completion_event_type`` and
+  # ``include_active_sessions`` interact here.
+  if include_active_sessions:
+    # Drop the event-type filter. Any session with at least one
+    # event in the window counts.
+    discovery_sql = (
+        "SELECT session_id, MAX(timestamp) AS completion_timestamp\n"
+        f"FROM `{events_table_ref}`\n"
+        "WHERE timestamp >= @scan_start\n"
+        "  AND timestamp < @scan_end\n"
+        "  AND session_id IS NOT NULL\n"
+        "GROUP BY session_id\n"
+        "ORDER BY completion_timestamp\n"
+        + (f"LIMIT {int(max_sessions)}\n" if max_sessions else "")
+    )
+    discovery_params = [
+        bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+        bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+    ]
+  else:
+    discovery_sql = build_discovery_sql(
+        events_table_ref=events_table_ref,
+        completion_event_type=completion_event_type,
+        max_sessions=max_sessions,
+    )
+    discovery_params = [
+        bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+        bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+        bigquery.ScalarQueryParameter(
+            "completion_event_type", "STRING", completion_event_type
+        ),
+    ]
+
+  discovered = [
+      DiscoveredSession(
+          session_id=row.session_id,
+          completion_timestamp=row.completion_timestamp,
+      )
+      for row in client.query(
+          discovery_sql,
+          job_config=bigquery.QueryJobConfig(query_parameters=discovery_params),
+      ).result()
+  ]
+
+  if dry_run:
+    return _build_result(
+        run_id=run_id,
+        state_key=state_key,
+        scan_start=scan_start,
+        scan_end=scan_end,
+        checkpoint_read=last_checkpoint,
+        checkpoint_written=None,
+        sessions_discovered=len(discovered),
+        session_results=[],
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=True,
+    )
+
+  # Build a runtime manager + outcome counter (only meaningful
+  # when bundles_root is set). For dry-run we already returned.
+  outcomes_cb, outcomes_counts = make_outcome_counter()
+  manager = _build_manager(
+      project_id=project_id,
+      dataset_id=dataset_id,
+      ontology=ontology_obj,
+      binding=binding_obj,
+      location=location,
+      bq_client=client,
+      bundles_root=bundles_root,
+      reference_extractors_module=reference_extractors_module,
+      outcome_callback=outcomes_cb,
+  )
+
+  # Materialize per session so a single-session failure doesn't
+  # cascade. Checkpoint advances after each success; on failure
+  # we stop, record the failure, and exit non-zero.
+  from .ontology_materializer import OntologyMaterializer
+
+  materializer = OntologyMaterializer(
+      spec=manager.spec,
+      project_id=project_id,
+      dataset_id=dataset_id,
+      location=location,
+      bq_client=client,
+  )
+
+  session_results: list[SessionResult] = []
+  for session in discovered:
+    try:
+      graph = manager.extract_graph(
+          session_ids=[session.session_id], use_ai_generate=True
+      )
+      mat = materializer.materialize_with_status(graph, [session.session_id])
+      session_results.append(
+          SessionResult(
+              session_id=session.session_id,
+              ok=True,
+              completion_timestamp=session.completion_timestamp,
+              rows_materialized=dict(mat.row_counts),
+          )
+      )
+    except Exception as exc:  # noqa: BLE001 — orchestrator is the boundary
+      session_results.append(
+          SessionResult(
+              session_id=session.session_id,
+              ok=False,
+              completion_timestamp=session.completion_timestamp,
+              error_code=type(exc).__name__,
+              error_detail=(
+                  f"{type(exc).__name__}: {exc}\n"
+                  + traceback.format_exc(limit=5)
+              ),
+          )
+      )
+      # Conservative stop: don't try to materialize subsequent
+      # sessions. The checkpoint advances only to the highest
+      # successfully-materialized completion timestamp; next run
+      # picks up here.
+      break
+
+  last_success_ts = _max_success_completion(session_results)
+  ok = (
+      all(r.ok for r in session_results)
+      and len(session_results) > 0
+      or (not session_results)
+  )
+  # Note: an empty window is "ok" with no checkpoint write needed,
+  # but we still write a heartbeat row so operators can see the
+  # run happened.
+  checkpoint_written = last_success_ts
+
+  failures = [
+      {
+          "session_id": r.session_id,
+          "error_code": r.error_code,
+          "error_detail": r.error_detail,
+      }
+      for r in session_results
+      if not r.ok
+  ]
+
+  result = _build_result(
+      run_id=run_id,
+      state_key=state_key,
+      scan_start=scan_start,
+      scan_end=scan_end,
+      checkpoint_read=last_checkpoint,
+      checkpoint_written=checkpoint_written,
+      sessions_discovered=len(discovered),
+      session_results=session_results,
+      compiled_outcomes=outcomes_counts,
+      ok=ok and not failures,
+  )
+
+  # Append-only state row.
+  append_state_row(
+      client,
+      state_table_ref,
+      StateRow(
+          state_key=state_key,
+          run_id=run_id,
+          run_started_at=run_started,
+          scan_start=scan_start,
+          scan_end=scan_end,
+          last_completion_at=checkpoint_written,
+          sessions_discovered=len(discovered),
+          sessions_materialized=sum(1 for r in session_results if r.ok),
+          sessions_failed=len(failures),
+          ok=result.ok,
+          error_detail=(failures[0]["error_detail"] if failures else None),
+          report_json=json.dumps(result.to_json()),
+      ),
+  )
+
+  return result
+
+
+# ------------------------------------------------------------------ #
+# Internals                                                            #
+# ------------------------------------------------------------------ #
+
+
+def _build_manager(
+    *,
+    project_id: str,
+    dataset_id: str,
+    ontology: Any,
+    binding: Any,
+    location: Optional[str],
+    bq_client: Any,
+    bundles_root: Optional[str],
+    reference_extractors_module: Optional[str],
+    outcome_callback: Callable[[str, Any], None],
+) -> Any:
+  """Construct the OntologyGraphManager — with compiled bundles
+  wired when ``bundles_root`` is set, otherwise the plain
+  ``from_ontology_binding`` path."""
+  from .ontology_graph import OntologyGraphManager
+
+  if bundles_root is None:
+    return OntologyGraphManager.from_ontology_binding(
+        project_id=project_id,
+        dataset_id=dataset_id,
+        ontology=ontology,
+        binding=binding,
+        location=location,
+        bq_client=bq_client,
+    )
+
+  if reference_extractors_module is None:
+    raise ValueError(
+        "--reference-extractors-module is required when --bundles-root is set"
+    )
+
+  import importlib
+  import pathlib
+
+  ref_module = importlib.import_module(reference_extractors_module)
+  fallback_extractors = getattr(ref_module, "EXTRACTORS", None)
+  if not isinstance(fallback_extractors, dict) or not fallback_extractors:
+    raise ValueError(
+        f"reference module {reference_extractors_module!r} must expose "
+        f"a non-empty EXTRACTORS dict"
+    )
+
+  # Bundle fingerprint must match the inputs the user just loaded.
+  # Compute the expected fingerprint the same way ``compile_extractor``
+  # does — sha256 over (ontology + binding + ...). For the operational
+  # MVP the operator pins one bundle and the SDK verifies on load; we
+  # let ``from_bundles_root``'s discovery enforce this.
+  from .extractor_compilation import discover_bundles
+
+  # Discover the first bundle in the root to extract its fingerprint
+  # without forcing the caller to pass it. If multiple bundles exist
+  # we leave selection to the runtime registry.
+  discovery = discover_bundles(
+      bundles_root=pathlib.Path(bundles_root),
+      expected_fingerprint=None,  # accept whatever is on disk
+  )
+  if not discovery.registry:
+    raise ValueError(
+        f"--bundles-root {bundles_root!r} contained no loadable bundles"
+    )
+  # Pick the first bundle's fingerprint as the "expected" gate. In
+  # production every bundle under one root should share a fingerprint
+  # (one compile produces one bundle); enforce that via the discovery
+  # contract.
+  expected_fingerprint = next(iter(discovery.loaded)).manifest.fingerprint
+
+  return OntologyGraphManager.from_bundles_root(
+      project_id=project_id,
+      dataset_id=dataset_id,
+      ontology=ontology,
+      binding=binding,
+      bundles_root=pathlib.Path(bundles_root),
+      expected_fingerprint=expected_fingerprint,
+      fallback_extractors=fallback_extractors,
+      location=location,
+      bq_client=bq_client,
+      on_outcome=outcome_callback,
+  )
+
+
+def _max_success_completion(
+    session_results: Sequence[SessionResult],
+) -> Optional[_dt.datetime]:
+  """MAX completion-timestamp among successfully materialized
+  sessions. ``None`` if there are no successes."""
+  ts = [r.completion_timestamp for r in session_results if r.ok]
+  return max(ts) if ts else None
+
+
+def _build_result(
+    *,
+    run_id: str,
+    state_key: str,
+    scan_start: _dt.datetime,
+    scan_end: _dt.datetime,
+    checkpoint_read: Optional[_dt.datetime],
+    checkpoint_written: Optional[_dt.datetime],
+    sessions_discovered: int,
+    session_results: Sequence[SessionResult],
+    compiled_outcomes: dict[str, int],
+    ok: bool,
+) -> MaterializeWindowResult:
+  rows_materialized: dict[str, int] = {}
+  for r in session_results:
+    if r.ok:
+      for table, n in r.rows_materialized.items():
+        rows_materialized[table] = rows_materialized.get(table, 0) + n
+
+  failures = [
+      {
+          "session_id": r.session_id,
+          "error_code": r.error_code,
+          "error_detail": r.error_detail,
+      }
+      for r in session_results
+      if not r.ok
+  ]
+
+  return MaterializeWindowResult(
+      run_id=run_id,
+      state_key=state_key,
+      window_start=scan_start,
+      window_end=scan_end,
+      checkpoint_read=checkpoint_read,
+      checkpoint_written=checkpoint_written,
+      sessions_discovered=sessions_discovered,
+      sessions_materialized=sum(1 for r in session_results if r.ok),
+      sessions_failed=len(failures),
+      rows_materialized=rows_materialized,
+      table_statuses={},  # populated in v1 once materializer surfaces them per-session
+      compiled_outcomes=compiled_outcomes,
+      failures=failures,
+      ok=ok,
+  )

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -235,17 +235,32 @@ def compute_state_key(
     events_table: str,
     ontology_fingerprint: str,
     binding_fingerprint: str,
+    discovery_mode: str,
 ) -> str:
   """Content-derived hex key for the state table.
 
   Stable across re-runs against the same config. A change to ANY
   of the inputs (e.g. binding rename, new event source, ontology
-  bump) produces a new key, so the prior checkpoint is *implicitly*
-  invalidated. Operators don't need to manage a versioning column
-  by hand — the SDK's existing fingerprint helpers already
-  canonicalize the model contents, so equivalent YAML (different
-  whitespace, key order) produces the same fingerprint and the
-  same state key.
+  bump, terminal event swap) produces a new key, so the prior
+  checkpoint is *implicitly* invalidated. Operators don't need to
+  manage a versioning column by hand — the SDK's existing
+  fingerprint helpers already canonicalize the model contents, so
+  equivalent YAML (different whitespace, key order) produces the
+  same fingerprint and the same state key.
+
+  ``discovery_mode`` is one of ``terminal:<event_type>`` (normal
+  cron run) or ``active`` (``--include-active-sessions`` debug
+  mode). Including it in the key prevents two regressions:
+
+  * Operator switches from ``AGENT_COMPLETED`` to a custom terminal
+    event — the new predicate's run would otherwise inherit the
+    old predicate's high-water mark and skip historical
+    completions for the new event type.
+  * Debug run with ``--include-active-sessions`` shares state with
+    the production cron — the debug run discovers different
+    sessions (it has no terminal-event filter) and could advance
+    the production checkpoint past sessions production hasn't
+    seen as completed yet.
   """
   payload = "\x00".join(
       [
@@ -255,6 +270,7 @@ def compute_state_key(
           events_table,
           ontology_fingerprint,
           binding_fingerprint,
+          discovery_mode,
       ]
   ).encode("utf-8")
   return hashlib.sha256(payload).hexdigest()
@@ -590,14 +606,29 @@ def run_materialize_window(
   # healthy. Reject the operator typo at the boundary. The
   # ``include_active_sessions`` path drops the event-type filter
   # entirely, so the check is bypassed there.
-  if not include_active_sessions and (
-      not isinstance(completion_event_type, str)
-      or not completion_event_type.strip()
-  ):
-    raise ValueError(
-        f"--completion-event-type must be a non-empty string; "
-        f"got {completion_event_type!r}"
-    )
+  #
+  # Reject impure whitespace too — `` AGENT_COMPLETED `` would
+  # otherwise bind a spaced value into ``event_type =
+  # @completion_event_type`` and produce the same clean no-op
+  # heartbeat. Stripping silently would diverge from what the
+  # operator saw on the command line; explicit rejection forces
+  # them to fix the typo.
+  if not include_active_sessions:
+    if not isinstance(completion_event_type, str):
+      raise ValueError(
+          f"--completion-event-type must be a non-empty string; "
+          f"got {completion_event_type!r}"
+      )
+    if not completion_event_type.strip():
+      raise ValueError(
+          f"--completion-event-type must be a non-empty string; "
+          f"got {completion_event_type!r}"
+      )
+    if completion_event_type != completion_event_type.strip():
+      raise ValueError(
+          f"--completion-event-type must not have leading or trailing "
+          f"whitespace; got {completion_event_type!r}"
+      )
 
   from google.cloud import bigquery
 
@@ -637,6 +668,18 @@ def run_materialize_window(
 
   resolved_graph_name = graph_name or binding_obj.ontology
 
+  # Discovery-mode component of the state key. A switch from
+  # ``terminal:AGENT_COMPLETED`` to a custom event, or a swap to
+  # ``active`` (``--include-active-sessions`` debug mode), produces
+  # a new key so the prior predicate's high-water mark cannot
+  # advance the new predicate past historical completions it
+  # hasn't seen.
+  discovery_mode = (
+      "active"
+      if include_active_sessions
+      else f"terminal:{completion_event_type}"
+  )
+
   state_key = compute_state_key(
       project_id=project_id,
       dataset_id=dataset_id,
@@ -644,6 +687,7 @@ def run_materialize_window(
       events_table=events_table,
       ontology_fingerprint=ontology_fp,
       binding_fingerprint=binding_fp,
+      discovery_mode=discovery_mode,
   )
 
   # State table must exist for read/write. Idempotent CREATE.

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -34,9 +34,14 @@ Design contract (per #161):
   query's row set from drifting across the run.
 * **Append-only state table** keyed on a content-derived
   ``state_key`` (sha256 of project + dataset + graph_name +
-  events_table + ontology_fingerprint + binding_fingerprint). A
-  config change auto-invalidates the previous checkpoint — the
-  right "this is the same config" signal.
+  events_table + ontology_fingerprint + binding_fingerprint +
+  discovery_mode, where ``discovery_mode`` is
+  ``terminal:<event_type>`` for normal cron runs and ``active``
+  for ``--include-active-sessions`` debug runs). A config change
+  — including a swap of ``--completion-event-type`` or a debug
+  mode flip — auto-invalidates the previous checkpoint so the
+  new predicate's run cannot inherit the old predicate's high-
+  water mark.
 * **Terminal-event-driven discovery**: query directly for events
   with ``event_type = @completion_event_type`` in the
   ``[scan_start, scan_end)`` window. Partition pruning falls out

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -355,17 +355,25 @@ def build_discovery_sql(
 
 
 def build_state_select_sql(state_table_ref: str) -> str:
-  """Most-recent state row for a given ``state_key`` whose
-  ``last_completion_at`` is non-NULL.
+  """Highest-watermark state row for a given ``state_key``.
 
-  Empty-window heartbeat rows and all-failed runs both write
-  ``last_completion_at = NULL`` (we never advanced). Reading the
-  newest-by-timestamp row would erase the prior checkpoint and
-  bootstrap from ``--lookback-hours`` on the next run — which can
-  skip the failed session if the lookback is short. Filtering
-  for non-NULL ``last_completion_at`` returns the most recent
-  *successful* checkpoint, which is the watermark to advance
-  from."""
+  Earlier round filtered on non-NULL ``last_completion_at`` and
+  ordered by ``run_started_at DESC``. That was insufficient for
+  two interacting cases:
+
+  * **Carry-forward rows write the prior checkpoint** (not NULL)
+    on failure / empty-window, so the non-NULL filter alone no
+    longer separates "real advance" from "no advance".
+  * **Overlapping runs**: if a later run somehow recorded an
+    *older* ``last_completion_at`` than an earlier run (e.g. an
+    out-of-order rerun against the same state-key), ordering by
+    ``run_started_at`` would shadow the higher watermark.
+
+  Ordering by ``last_completion_at DESC, run_started_at DESC``
+  picks the highest watermark first and breaks ties by recency.
+  The non-NULL filter is retained for defense-in-depth — older
+  state rows pre-carry-forward may still carry NULLs, and we
+  never want one of those to win the ordering."""
   state_table_ref_quoted = "`" + state_table_ref + "`"
   return (
       f"SELECT\n"
@@ -383,7 +391,7 @@ def build_state_select_sql(state_table_ref: str) -> str:
       f"FROM {state_table_ref_quoted}\n"
       f"WHERE state_key = @state_key\n"
       f"  AND last_completion_at IS NOT NULL\n"
-      f"ORDER BY run_started_at DESC\n"
+      f"ORDER BY last_completion_at DESC, run_started_at DESC\n"
       f"LIMIT 1\n"
   )
 
@@ -575,6 +583,20 @@ def run_materialize_window(
   if max_sessions is not None and max_sessions <= 0:
     raise ValueError(
         f"--max-sessions must be unset or > 0; got {max_sessions!r}"
+    )
+  # Empty/whitespace completion-event-type silently turns the run
+  # into a no-op: the discovery query would bind ``event_type =
+  # ""``, match nothing, write a clean heartbeat row, and look
+  # healthy. Reject the operator typo at the boundary. The
+  # ``include_active_sessions`` path drops the event-type filter
+  # entirely, so the check is bypassed there.
+  if not include_active_sessions and (
+      not isinstance(completion_event_type, str)
+      or not completion_event_type.strip()
+  ):
+    raise ValueError(
+        f"--completion-event-type must be a non-empty string; "
+        f"got {completion_event_type!r}"
     )
 
   from google.cloud import bigquery
@@ -884,20 +906,31 @@ def run_materialize_window(
       and len(session_results) > 0
       or (not session_results)
   )
-  # Note: an empty window is "ok" with no checkpoint write needed,
-  # but we still write a heartbeat row so operators can see the
-  # run happened.
-  # Carry forward the prior checkpoint when no session succeeded
-  # this run. The DB-side filter in ``build_state_select_sql``
-  # already skips heartbeat/failure rows on read, but writing the
-  # carry-forward value makes the most recent state row self-
-  # documenting (operators see the watermark without an extra
-  # query). When ``last_success_ts`` is set, it's the advance;
-  # otherwise we replay the prior checkpoint so "no advance this
-  # run, still at X" is the visible answer.
-  checkpoint_written = (
-      last_success_ts if last_success_ts is not None else last_checkpoint
-  )
+  # Note: an empty window is "ok" with no checkpoint advance, but
+  # we still write a heartbeat row so operators can see the run
+  # happened.
+  #
+  # The written checkpoint is the **maximum** of the prior
+  # watermark and this run's last successful completion. Picking
+  # whichever value is higher prevents two regressions:
+  #
+  # * **Overlap rewind.** ``--overlap-minutes`` re-scans events
+  #   slightly older than the last checkpoint to catch late-
+  #   arriving rows. If a session inside that overlap succeeds
+  #   but a *later* session fails, ``last_success_ts`` is the
+  #   re-scanned (older) timestamp; writing that would move the
+  #   high-water mark backwards. Taking ``max`` keeps the prior
+  #   advance.
+  # * **No-advance carry-forward.** When no session succeeded,
+  #   ``last_success_ts`` is ``None`` — the prior checkpoint
+  #   carries forward so the most-recent state row is self-
+  #   documenting ("still at X" rather than NULL).
+  if last_success_ts is None:
+    checkpoint_written = last_checkpoint
+  elif last_checkpoint is None:
+    checkpoint_written = last_success_ts
+  else:
+    checkpoint_written = max(last_checkpoint, last_success_ts)
 
   failures = [
       {

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -65,6 +65,7 @@ import dataclasses
 import datetime as _dt
 import hashlib
 import json
+import pathlib
 import re
 import secrets
 import traceback
@@ -194,6 +195,11 @@ class MaterializeWindowResult:
   compiled_outcomes: dict[str, int]
   failures: list[dict[str, Any]]
   ok: bool
+  # Bundle fingerprint resolved from ``--bundles-root`` (only
+  # set when the compiled-bundle path is wired). Operators
+  # reading ``compiled_outcomes`` cross-reference with this to
+  # confirm which bundle ran.
+  compile_bundle_fingerprint: Optional[str] = None
 
   def to_json(self) -> dict[str, Any]:
     """JSON-serializable dict (timestamps → ISO 8601 UTC strings)."""
@@ -212,6 +218,7 @@ class MaterializeWindowResult:
         "compiled_outcomes": dict(self.compiled_outcomes),
         "failures": list(self.failures),
         "ok": self.ok,
+        "compile_bundle_fingerprint": self.compile_bundle_fingerprint,
     }
 
 
@@ -556,6 +563,20 @@ def run_materialize_window(
     bq_client: Optional pre-configured BigQuery client.
     run_started_at: Test seam. Defaults to UTC ``now``.
   """
+  # Numeric guardrails — reject nonsense at the boundary so the
+  # orchestrator's downstream arithmetic (timedeltas, LIMIT clauses)
+  # never produces a "scan into the future" or an unbounded loop.
+  # A typo like ``--lookback-hours=-6`` would otherwise compute a
+  # negative window and silently scan zero rows.
+  if lookback_hours <= 0:
+    raise ValueError(f"--lookback-hours must be > 0; got {lookback_hours!r}")
+  if overlap_minutes < 0:
+    raise ValueError(f"--overlap-minutes must be >= 0; got {overlap_minutes!r}")
+  if max_sessions is not None and max_sessions <= 0:
+    raise ValueError(
+        f"--max-sessions must be unset or > 0; got {max_sessions!r}"
+    )
+
   from google.cloud import bigquery
 
   # Pin a single timestamp for the whole run.
@@ -594,27 +615,6 @@ def run_materialize_window(
 
   resolved_graph_name = graph_name or binding_obj.ontology
 
-  # Pre-flight binding validation against live BQ — the "fail
-  # before AI.GENERATE spend" contract from #161. Skipped on
-  # ``--dry-run`` (caller already opted out of side effects) and
-  # when explicitly disabled via ``--no-validate-binding``. A
-  # validation failure short-circuits with ValueError; the
-  # materializer is never constructed and no state row is written.
-  if validate_binding and not dry_run:
-    from .binding_validation import validate_binding_against_bigquery
-
-    report = validate_binding_against_bigquery(
-        ontology=ontology_obj, binding=binding_obj, bq_client=client
-    )
-    if not report.ok:
-      failure_msgs = "; ".join(
-          f"{f.code.value}:{f.binding_path}" for f in report.failures[:10]
-      )
-      raise ValueError(
-          f"binding-validate failed before extraction: "
-          f"{len(report.failures)} failures. {failure_msgs}"
-      )
-
   state_key = compute_state_key(
       project_id=project_id,
       dataset_id=dataset_id,
@@ -627,6 +627,77 @@ def run_materialize_window(
   # State table must exist for read/write. Idempotent CREATE.
   ensure_state_table(client, state_table_ref)
   last_checkpoint = read_last_checkpoint(client, state_table_ref, state_key)
+
+  # Pre-flight binding validation against live BQ — the "fail
+  # before AI.GENERATE spend" contract from #161. Skipped on
+  # ``--dry-run`` (caller already opted out of side effects) and
+  # when explicitly disabled via ``--no-validate-binding``.
+  #
+  # On failure we return a structured ``ok=False`` result and
+  # append a state row with the drift details, instead of raising.
+  # The CLI maps ``not result.ok`` to exit 1 (expected non-zero) —
+  # raising would map to exit 2 (unexpected internal error), which
+  # is the wrong signal for an operator: a binding drift is the
+  # expected failure mode this validator was added to catch.
+  if validate_binding and not dry_run:
+    from .binding_validation import validate_binding_against_bigquery
+
+    report = validate_binding_against_bigquery(
+        ontology=ontology_obj, binding=binding_obj, bq_client=client
+    )
+    if not report.ok:
+      failure_msgs = "; ".join(
+          f"{f.code.value}:{f.binding_path}" for f in report.failures[:10]
+      )
+      drift_detail = (
+          f"binding-validate failed before extraction: "
+          f"{len(report.failures)} failures. {failure_msgs}"
+      )
+      drift_failure = {
+          "session_id": None,
+          "error_code": "binding_validate_failed",
+          "error_detail": drift_detail,
+      }
+      drift_result = MaterializeWindowResult(
+          run_id=run_id,
+          state_key=state_key,
+          window_start=run_started,
+          window_end=run_started,
+          checkpoint_read=last_checkpoint,
+          checkpoint_written=last_checkpoint,
+          sessions_discovered=0,
+          sessions_materialized=0,
+          sessions_failed=0,
+          rows_materialized={},
+          table_statuses={},
+          compiled_outcomes={
+              "compiled_unchanged": 0,
+              "compiled_filtered": 0,
+              "fallback_for_event": 0,
+          },
+          failures=[drift_failure],
+          ok=False,
+          compile_bundle_fingerprint=None,
+      )
+      append_state_row(
+          client,
+          state_table_ref,
+          StateRow(
+              state_key=state_key,
+              run_id=run_id,
+              run_started_at=run_started,
+              scan_start=run_started,
+              scan_end=run_started,
+              last_completion_at=last_checkpoint,
+              sessions_discovered=0,
+              sessions_materialized=0,
+              sessions_failed=0,
+              ok=False,
+              error_detail=drift_detail,
+              report_json=json.dumps(drift_result.to_json()),
+          ),
+      )
+      return drift_result
 
   # Bootstrap (no checkpoint) → use ``--lookback-hours`` as the
   # initial scan window. The previous draft used a hard-coded
@@ -694,6 +765,14 @@ def run_materialize_window(
   ]
 
   if dry_run:
+    # Dry-run resolves the fingerprint too so the preview report
+    # reflects which bundle *would* run. Cost: a directory walk;
+    # no BQ side effects.
+    dryrun_fingerprint: Optional[str] = None
+    if bundles_root is not None:
+      dryrun_fingerprint = _pre_scan_bundle_fingerprint(
+          pathlib.Path(bundles_root)
+      )
     return _build_result(
         run_id=run_id,
         state_key=state_key,
@@ -709,11 +788,20 @@ def run_materialize_window(
             "fallback_for_event": 0,
         },
         ok=True,
+        compile_bundle_fingerprint=dryrun_fingerprint,
     )
 
   # Build a runtime manager + outcome counter (only meaningful
   # when bundles_root is set). For dry-run we already returned.
   outcomes_cb, outcomes_counts = make_outcome_counter()
+  # Resolve the bundle fingerprint up here (not inside
+  # ``_build_manager``) so we can record it in the JSON report
+  # even when the manager is mocked out in tests.
+  compile_bundle_fingerprint: Optional[str] = None
+  if bundles_root is not None:
+    compile_bundle_fingerprint = _pre_scan_bundle_fingerprint(
+        pathlib.Path(bundles_root)
+    )
   manager = _build_manager(
       project_id=project_id,
       dataset_id=dataset_id,
@@ -725,6 +813,7 @@ def run_materialize_window(
       reference_extractors_module=reference_extractors_module,
       outcome_callback=outcomes_cb,
       table_id=events_table,
+      expected_fingerprint=compile_bundle_fingerprint,
   )
 
   # Materialize per session so a single-session failure doesn't
@@ -831,6 +920,7 @@ def run_materialize_window(
       session_results=session_results,
       compiled_outcomes=outcomes_counts,
       ok=ok and not failures,
+      compile_bundle_fingerprint=compile_bundle_fingerprint,
   )
 
   # Append-only state row.
@@ -924,6 +1014,7 @@ def _build_manager(
     reference_extractors_module: Optional[str],
     outcome_callback: Callable[[str, Any], None],
     table_id: str,
+    expected_fingerprint: Optional[str] = None,
 ) -> Any:
   """Construct the OntologyGraphManager — with compiled bundles
   wired when ``bundles_root`` is set, otherwise the plain
@@ -965,15 +1056,17 @@ def _build_manager(
         f"a non-empty EXTRACTORS dict"
     )
 
-  # Pre-scan the bundles root for manifest fingerprints. The SDK's
-  # ``discover_bundles`` requires an ``expected_fingerprint`` (any
-  # mismatch is rejected as ``fingerprint_mismatch``) — passing
-  # ``None`` silently rejects every bundle. The CLI must supply
-  # the fingerprint, so we read it from the manifests on disk and
-  # enforce that all bundles in the root share one.
-  expected_fingerprint = _pre_scan_bundle_fingerprint(
-      pathlib.Path(bundles_root)
-  )
+  # The orchestrator pre-scans the bundles root for the manifest
+  # fingerprint and threads it down here. The SDK's
+  # ``discover_bundles`` requires an ``expected_fingerprint``;
+  # passing ``None`` silently rejects every bundle as
+  # ``fingerprint_mismatch``. If the caller didn't pre-resolve
+  # (defensive — orchestrator always does when ``bundles_root`` is
+  # set), fall back to a local scan.
+  if expected_fingerprint is None:
+    expected_fingerprint = _pre_scan_bundle_fingerprint(
+        pathlib.Path(bundles_root)
+    )
 
   from .extractor_compilation import discover_bundles
 
@@ -1018,6 +1111,57 @@ def _max_success_completion(
   return max(ts) if ts else None
 
 
+# Precedence for aggregating per-session ``cleanup_status`` and
+# ``insert_status`` across multiple sessions touching the same
+# bound table. The "worst" status wins, so a single
+# ``delete_failed`` in session A is never masked by a clean
+# ``deleted`` in session B. Operators rely on these surfaces as
+# the "did anything go wrong" signal in the JSON report.
+_CLEANUP_RANK = {"delete_failed": 2, "skipped": 1, "deleted": 0}
+_INSERT_RANK = {"insert_failed": 1, "inserted": 0}
+
+
+def _merge_table_status(
+    existing: dict[str, Any], incoming: dict[str, Any]
+) -> dict[str, Any]:
+  """Combine two per-table status dicts using worst-status wins.
+
+  Row counts (``rows_attempted`` / ``rows_inserted``) sum.
+  ``idempotent`` is AND-ed across sessions — one non-idempotent
+  session contaminates the table's overall idempotency claim.
+  ``table_ref`` is copied from whichever side has a non-empty
+  value (they should agree; if not, the existing one is kept).
+  """
+  cur_cleanup = existing.get("cleanup_status", "deleted")
+  new_cleanup = incoming.get("cleanup_status", "deleted")
+  cleanup = (
+      new_cleanup
+      if _CLEANUP_RANK.get(new_cleanup, -1) > _CLEANUP_RANK.get(cur_cleanup, -1)
+      else cur_cleanup
+  )
+  cur_insert = existing.get("insert_status", "inserted")
+  new_insert = incoming.get("insert_status", "inserted")
+  insert = (
+      new_insert
+      if _INSERT_RANK.get(new_insert, -1) > _INSERT_RANK.get(cur_insert, -1)
+      else cur_insert
+  )
+  return {
+      "table_ref": existing.get("table_ref") or incoming.get("table_ref"),
+      "rows_attempted": (
+          existing.get("rows_attempted", 0) + incoming.get("rows_attempted", 0)
+      ),
+      "rows_inserted": (
+          existing.get("rows_inserted", 0) + incoming.get("rows_inserted", 0)
+      ),
+      "cleanup_status": cleanup,
+      "insert_status": insert,
+      "idempotent": bool(
+          existing.get("idempotent", True) and incoming.get("idempotent", True)
+      ),
+  }
+
+
 def _build_result(
     *,
     run_id: str,
@@ -1030,21 +1174,28 @@ def _build_result(
     session_results: Sequence[SessionResult],
     compiled_outcomes: dict[str, int],
     ok: bool,
+    compile_bundle_fingerprint: Optional[str] = None,
 ) -> MaterializeWindowResult:
   rows_materialized: dict[str, int] = {}
-  # Aggregate per-session table_statuses into the report. The
-  # latest seen status wins for each table; in a single batch
-  # there's typically one status per table per session, so this
-  # is "the most recent successful materialize's view" of each
-  # table. ``cleanup_status = 'delete_failed'`` is the signal
-  # operators read to spot streaming-buffer-pinned tables.
+  # Aggregate per-session table_statuses into the report with
+  # worst-status-wins semantics. A previous draft used "latest
+  # seen status wins", which could hide an earlier
+  # ``cleanup_status = 'delete_failed'`` behind a later session's
+  # clean ``deleted``. Operators rely on the report as the
+  # "did anything go wrong" signal — any delete failure must
+  # bubble up.
   table_statuses_agg: dict[str, dict[str, Any]] = {}
   for r in session_results:
     if r.ok:
       for table, n in r.rows_materialized.items():
         rows_materialized[table] = rows_materialized.get(table, 0) + n
       for table, ts in r.table_statuses.items():
-        table_statuses_agg[table] = ts
+        if table in table_statuses_agg:
+          table_statuses_agg[table] = _merge_table_status(
+              table_statuses_agg[table], ts
+          )
+        else:
+          table_statuses_agg[table] = dict(ts)
 
   failures = [
       {
@@ -1071,4 +1222,5 @@ def _build_result(
       compiled_outcomes=compiled_outcomes,
       failures=failures,
       ok=ok,
+      compile_bundle_fingerprint=compile_bundle_fingerprint,
   )

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -71,7 +71,6 @@ import traceback
 from typing import Any, Callable, Optional, Sequence
 
 from ._streaming_evaluation import compute_scan_start
-from ._streaming_evaluation import DEFAULT_INITIAL_LOOKBACK_MINUTES
 from ._streaming_evaluation import DEFAULT_OVERLAP_MINUTES
 
 # ------------------------------------------------------------------ #
@@ -146,6 +145,9 @@ class SessionResult:
   ok: bool
   completion_timestamp: _dt.datetime
   rows_materialized: dict[str, int] = dataclasses.field(default_factory=dict)
+  table_statuses: dict[str, dict[str, Any]] = dataclasses.field(
+      default_factory=dict
+  )
   error_code: Optional[str] = None
   error_detail: Optional[str] = None
 
@@ -346,7 +348,17 @@ def build_discovery_sql(
 
 
 def build_state_select_sql(state_table_ref: str) -> str:
-  """Most-recent state row for a given ``state_key``."""
+  """Most-recent state row for a given ``state_key`` whose
+  ``last_completion_at`` is non-NULL.
+
+  Empty-window heartbeat rows and all-failed runs both write
+  ``last_completion_at = NULL`` (we never advanced). Reading the
+  newest-by-timestamp row would erase the prior checkpoint and
+  bootstrap from ``--lookback-hours`` on the next run — which can
+  skip the failed session if the lookback is short. Filtering
+  for non-NULL ``last_completion_at`` returns the most recent
+  *successful* checkpoint, which is the watermark to advance
+  from."""
   state_table_ref_quoted = "`" + state_table_ref + "`"
   return (
       f"SELECT\n"
@@ -363,6 +375,7 @@ def build_state_select_sql(state_table_ref: str) -> str:
       f"  error_detail\n"
       f"FROM {state_table_ref_quoted}\n"
       f"WHERE state_key = @state_key\n"
+      f"  AND last_completion_at IS NOT NULL\n"
       f"ORDER BY run_started_at DESC\n"
       f"LIMIT 1\n"
   )
@@ -494,7 +507,6 @@ def run_materialize_window(
     events_table: str = "agent_events",
     lookback_hours: float,
     overlap_minutes: float = DEFAULT_OVERLAP_MINUTES,
-    initial_lookback_minutes: float = DEFAULT_INITIAL_LOOKBACK_MINUTES,
     completion_event_type: str = DEFAULT_COMPLETION_EVENT_TYPE,
     include_active_sessions: bool = False,
     state_table: Optional[str] = None,
@@ -503,6 +515,7 @@ def run_materialize_window(
     reference_extractors_module: Optional[str] = None,
     max_sessions: Optional[int] = None,
     location: Optional[str] = None,
+    validate_binding: bool = True,
     dry_run: bool = False,
     bq_client: Optional[Any] = None,
     run_started_at: Optional[_dt.datetime] = None,
@@ -522,9 +535,7 @@ def run_materialize_window(
       lookback_hours)``.
     overlap_minutes: Re-process events newer than
       ``last_checkpoint - overlap_minutes``. Default 15.
-    initial_lookback_minutes: First-run lookback when no
-      checkpoint exists. Default 30.
-    completion_event_type: ``event_type`` that marks a session
+        completion_event_type: ``event_type`` that marks a session
       as done. Defaults to BQ AA plugin's ``AGENT_COMPLETED``.
     include_active_sessions: If True, drop the completion-event
       filter and materialize every session seen in the window
@@ -583,6 +594,27 @@ def run_materialize_window(
 
   resolved_graph_name = graph_name or binding_obj.ontology
 
+  # Pre-flight binding validation against live BQ — the "fail
+  # before AI.GENERATE spend" contract from #161. Skipped on
+  # ``--dry-run`` (caller already opted out of side effects) and
+  # when explicitly disabled via ``--no-validate-binding``. A
+  # validation failure short-circuits with ValueError; the
+  # materializer is never constructed and no state row is written.
+  if validate_binding and not dry_run:
+    from .binding_validation import validate_binding_against_bigquery
+
+    report = validate_binding_against_bigquery(
+        ontology=ontology_obj, binding=binding_obj, bq_client=client
+    )
+    if not report.ok:
+      failure_msgs = "; ".join(
+          f"{f.code.value}:{f.binding_path}" for f in report.failures[:10]
+      )
+      raise ValueError(
+          f"binding-validate failed before extraction: "
+          f"{len(report.failures)} failures. {failure_msgs}"
+      )
+
   state_key = compute_state_key(
       project_id=project_id,
       dataset_id=dataset_id,
@@ -596,18 +628,22 @@ def run_materialize_window(
   ensure_state_table(client, state_table_ref)
   last_checkpoint = read_last_checkpoint(client, state_table_ref, state_key)
 
+  # Bootstrap (no checkpoint) → use ``--lookback-hours`` as the
+  # initial scan window. The previous draft used a hard-coded
+  # 30min default which made ``--lookback-hours 6`` actually scan
+  # 30 minutes on first run.
+  # Subsequent runs → ``compute_scan_start`` returns
+  # ``last_checkpoint - overlap_minutes`` (the bootstrap window
+  # arg is ignored when ``checkpoint_timestamp`` is set).
   scan_start = compute_scan_start(
       run_started,
       checkpoint_timestamp=last_checkpoint,
       overlap=_dt.timedelta(minutes=overlap_minutes),
-      initial_lookback=_dt.timedelta(
-          minutes=initial_lookback_minutes
-          if last_checkpoint is None
-          else lookback_hours * 60.0
-      ),
+      initial_lookback=_dt.timedelta(hours=lookback_hours),
   )
-  # ``lookback_hours`` is the hard upper bound on how far back we
-  # ever scan, even when the checkpoint is older. Trim if needed.
+  # ``lookback_hours`` is also the hard upper bound on how far
+  # back we ever scan — applies on subsequent runs when the
+  # checkpoint is very stale.
   hard_floor = run_started - _dt.timedelta(hours=lookback_hours)
   if scan_start < hard_floor:
     scan_start = hard_floor
@@ -688,6 +724,7 @@ def run_materialize_window(
       bundles_root=bundles_root,
       reference_extractors_module=reference_extractors_module,
       outcome_callback=outcomes_cb,
+      table_id=events_table,
   )
 
   # Materialize per session so a single-session failure doesn't
@@ -710,12 +747,27 @@ def run_materialize_window(
           session_ids=[session.session_id], use_ai_generate=True
       )
       mat = materializer.materialize_with_status(graph, [session.session_id])
+      # Capture per-session table statuses so the JSON report can
+      # show cleanup_status / insert_status per bound table — the
+      # operational signal that lets customers see streaming-
+      # buffer-pinned delete failures in the right granularity.
+      table_statuses_dict: dict[str, dict[str, Any]] = {}
+      for tbl_name, ts in (mat.table_statuses or {}).items():
+        table_statuses_dict[tbl_name] = {
+            "table_ref": ts.table_ref,
+            "rows_attempted": ts.rows_attempted,
+            "rows_inserted": ts.rows_inserted,
+            "cleanup_status": ts.cleanup_status,
+            "insert_status": ts.insert_status,
+            "idempotent": ts.idempotent,
+        }
       session_results.append(
           SessionResult(
               session_id=session.session_id,
               ok=True,
               completion_timestamp=session.completion_timestamp,
               rows_materialized=dict(mat.row_counts),
+              table_statuses=table_statuses_dict,
           )
       )
     except Exception as exc:  # noqa: BLE001 — orchestrator is the boundary
@@ -746,7 +798,17 @@ def run_materialize_window(
   # Note: an empty window is "ok" with no checkpoint write needed,
   # but we still write a heartbeat row so operators can see the
   # run happened.
-  checkpoint_written = last_success_ts
+  # Carry forward the prior checkpoint when no session succeeded
+  # this run. The DB-side filter in ``build_state_select_sql``
+  # already skips heartbeat/failure rows on read, but writing the
+  # carry-forward value makes the most recent state row self-
+  # documenting (operators see the watermark without an extra
+  # query). When ``last_success_ts`` is set, it's the advance;
+  # otherwise we replay the prior checkpoint so "no advance this
+  # run, still at X" is the visible answer.
+  checkpoint_written = (
+      last_success_ts if last_success_ts is not None else last_checkpoint
+  )
 
   failures = [
       {
@@ -799,6 +861,57 @@ def run_materialize_window(
 # ------------------------------------------------------------------ #
 
 
+def _pre_scan_bundle_fingerprint(bundles_root: pathlib.Path) -> str:
+  """Read ``manifest.json`` from every candidate bundle under
+  *bundles_root* and return the fingerprint shared by all.
+
+  ``discover_bundles`` requires an ``expected_fingerprint`` —
+  passing ``None`` silently rejects every bundle with
+  ``fingerprint_mismatch``. The CLI doesn't ask the operator to
+  type the 64-hex fingerprint by hand, so we read it from the
+  manifests on disk. The contract is "one root, one fingerprint";
+  mixed-fingerprint roots fail fast with a clear error.
+  """
+  import json as _json
+
+  if not bundles_root.is_dir():
+    raise ValueError(f"--bundles-root {str(bundles_root)!r} is not a directory")
+  fingerprints: dict[str, list[str]] = {}
+  for child in sorted(bundles_root.iterdir()):
+    manifest_path = child / "manifest.json"
+    if not manifest_path.is_file():
+      continue
+    try:
+      manifest = _json.loads(manifest_path.read_text())
+    except (OSError, _json.JSONDecodeError) as exc:
+      raise ValueError(
+          f"--bundles-root {str(bundles_root)!r}: unreadable manifest "
+          f"in {child.name}: {type(exc).__name__}: {exc}"
+      )
+    fp = manifest.get("fingerprint")
+    if not isinstance(fp, str) or not fp:
+      raise ValueError(
+          f"--bundles-root {str(bundles_root)!r}: {child.name}/manifest.json "
+          f"has no ``fingerprint`` field"
+      )
+    fingerprints.setdefault(fp, []).append(child.name)
+  if not fingerprints:
+    raise ValueError(
+        f"--bundles-root {str(bundles_root)!r} contains no bundles "
+        f"(no manifest.json files found in immediate subdirectories)"
+    )
+  if len(fingerprints) > 1:
+    summary = "; ".join(
+        f"{fp[:12]}=({', '.join(bundles)})"
+        for fp, bundles in fingerprints.items()
+    )
+    raise ValueError(
+        f"--bundles-root {str(bundles_root)!r} contains bundles with "
+        f"mixed fingerprints; one root, one fingerprint. Got: {summary}"
+    )
+  return next(iter(fingerprints))
+
+
 def _build_manager(
     *,
     project_id: str,
@@ -810,10 +923,19 @@ def _build_manager(
     bundles_root: Optional[str],
     reference_extractors_module: Optional[str],
     outcome_callback: Callable[[str, Any], None],
+    table_id: str,
 ) -> Any:
   """Construct the OntologyGraphManager — with compiled bundles
   wired when ``bundles_root`` is set, otherwise the plain
-  ``from_ontology_binding`` path."""
+  ``from_ontology_binding`` path.
+
+  ``table_id`` is the source telemetry table the manager reads
+  from during extraction. Must match ``--events-table`` — a
+  previous draft hard-coded ``agent_events`` here while discovery
+  read from the configured table, producing the silent split
+  ("discover from X, extract from Y") that #161 reviewer flagged
+  as P1.
+  """
   from .ontology_graph import OntologyGraphManager
 
   if bundles_root is None:
@@ -824,6 +946,7 @@ def _build_manager(
         binding=binding,
         location=location,
         bq_client=bq_client,
+        table_id=table_id,
     )
 
   if reference_extractors_module is None:
@@ -842,29 +965,34 @@ def _build_manager(
         f"a non-empty EXTRACTORS dict"
     )
 
-  # Bundle fingerprint must match the inputs the user just loaded.
-  # Compute the expected fingerprint the same way ``compile_extractor``
-  # does — sha256 over (ontology + binding + ...). For the operational
-  # MVP the operator pins one bundle and the SDK verifies on load; we
-  # let ``from_bundles_root``'s discovery enforce this.
+  # Pre-scan the bundles root for manifest fingerprints. The SDK's
+  # ``discover_bundles`` requires an ``expected_fingerprint`` (any
+  # mismatch is rejected as ``fingerprint_mismatch``) — passing
+  # ``None`` silently rejects every bundle. The CLI must supply
+  # the fingerprint, so we read it from the manifests on disk and
+  # enforce that all bundles in the root share one.
+  expected_fingerprint = _pre_scan_bundle_fingerprint(
+      pathlib.Path(bundles_root)
+  )
+
   from .extractor_compilation import discover_bundles
 
-  # Discover the first bundle in the root to extract its fingerprint
-  # without forcing the caller to pass it. If multiple bundles exist
-  # we leave selection to the runtime registry.
   discovery = discover_bundles(
-      bundles_root=pathlib.Path(bundles_root),
-      expected_fingerprint=None,  # accept whatever is on disk
+      pathlib.Path(bundles_root),
+      expected_fingerprint=expected_fingerprint,
   )
   if not discovery.registry:
-    raise ValueError(
-        f"--bundles-root {bundles_root!r} contained no loadable bundles"
+    # Every candidate bundle must have failed for some other
+    # reason (manifest_missing, smoke_failed, etc.). Surface the
+    # discovery failures so the operator can diagnose.
+    failure_summary = ", ".join(
+        f"{f.bundle_dir.name}={f.code}" for f in discovery.failures
     )
-  # Pick the first bundle's fingerprint as the "expected" gate. In
-  # production every bundle under one root should share a fingerprint
-  # (one compile produces one bundle); enforce that via the discovery
-  # contract.
-  expected_fingerprint = next(iter(discovery.loaded)).manifest.fingerprint
+    raise ValueError(
+        f"--bundles-root {bundles_root!r} matched fingerprint "
+        f"{expected_fingerprint!r} but produced no loadable bundles. "
+        f"Discovery failures: {failure_summary or '(none reported)'}"
+    )
 
   return OntologyGraphManager.from_bundles_root(
       project_id=project_id,
@@ -876,6 +1004,7 @@ def _build_manager(
       fallback_extractors=fallback_extractors,
       location=location,
       bq_client=bq_client,
+      table_id=table_id,
       on_outcome=outcome_callback,
   )
 
@@ -903,10 +1032,19 @@ def _build_result(
     ok: bool,
 ) -> MaterializeWindowResult:
   rows_materialized: dict[str, int] = {}
+  # Aggregate per-session table_statuses into the report. The
+  # latest seen status wins for each table; in a single batch
+  # there's typically one status per table per session, so this
+  # is "the most recent successful materialize's view" of each
+  # table. ``cleanup_status = 'delete_failed'`` is the signal
+  # operators read to spot streaming-buffer-pinned tables.
+  table_statuses_agg: dict[str, dict[str, Any]] = {}
   for r in session_results:
     if r.ok:
       for table, n in r.rows_materialized.items():
         rows_materialized[table] = rows_materialized.get(table, 0) + n
+      for table, ts in r.table_statuses.items():
+        table_statuses_agg[table] = ts
 
   failures = [
       {
@@ -929,7 +1067,7 @@ def _build_result(
       sessions_materialized=sum(1 for r in session_results if r.ok),
       sessions_failed=len(failures),
       rows_materialized=rows_materialized,
-      table_statuses={},  # populated in v1 once materializer surfaces them per-session
+      table_statuses=table_statuses_agg,
       compiled_outcomes=compiled_outcomes,
       failures=failures,
       ok=ok,

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -509,6 +509,7 @@ def test_dry_run_returns_discovered_sessions_without_extracting(
       ontology_path=str(ontology_yaml),
       binding_path=str(binding_yaml),
       lookback_hours=6.0,
+      validate_binding=False,
       dry_run=True,
       bq_client=client,
       run_started_at=now,
@@ -555,6 +556,10 @@ def test_partial_failure_advances_checkpoint_only_to_last_success(
   fake_materializer = fake_materializer_cls.return_value
   fake_mat_result = mock.Mock()
   fake_mat_result.row_counts = {"DecisionExecution": 1}
+  # New: orchestrator iterates ``table_statuses`` after the
+  # ``materialize_with_status`` call. Set to an empty dict so
+  # the iteration doesn't blow up on a Mock object.
+  fake_mat_result.table_statuses = {}
   fake_materializer.materialize_with_status = mock.Mock(
       return_value=fake_mat_result
   )
@@ -572,6 +577,7 @@ def test_partial_failure_advances_checkpoint_only_to_last_success(
         ontology_path=str(ontology_yaml),
         binding_path=str(binding_yaml),
         lookback_hours=6.0,
+        validate_binding=False,
         bq_client=client,
         run_started_at=now,
     )
@@ -610,6 +616,7 @@ def test_empty_window_writes_heartbeat_state_row(fixture_paths):
         ontology_path=str(ontology_yaml),
         binding_path=str(binding_yaml),
         lookback_hours=6.0,
+        validate_binding=False,
         bq_client=client,
         run_started_at=now,
     )
@@ -618,3 +625,322 @@ def test_empty_window_writes_heartbeat_state_row(fixture_paths):
   assert result.sessions_discovered == 0
   assert result.checkpoint_written is None
   assert client.insert_rows_json.call_count == 1
+
+
+# ------------------------------------------------------------------ #
+# Round-2 regressions                                                  #
+# ------------------------------------------------------------------ #
+
+
+class TestStateReadSql:
+
+  def test_filters_null_last_completion_at(self):
+    """Heartbeat (empty window) and all-failed runs write a
+    state row with ``last_completion_at = NULL``. Reading those
+    as "the most recent checkpoint" would erase the prior real
+    checkpoint and bootstrap from --lookback-hours on the next
+    run — which can skip the failed session if lookback is short.
+    The select MUST filter on non-NULL."""
+    sql = mw.build_state_select_sql("p.d._bqaa_materialization_state")
+    assert "last_completion_at IS NOT NULL" in sql
+
+
+class TestPreScanBundleFingerprint:
+
+  def test_single_bundle_returns_its_fingerprint(self, tmp_path):
+    """One bundle in root → that bundle's fingerprint."""
+    bundle = tmp_path / "bundle_abc"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text('{"fingerprint": "abc123def456"}')
+    assert mw._pre_scan_bundle_fingerprint(tmp_path) == "abc123def456"
+
+  def test_multiple_bundles_same_fingerprint_ok(self, tmp_path):
+    """Two bundles, same fingerprint (e.g., re-compile cache
+    hit produced an identical sibling) → returns the shared
+    fingerprint without complaint."""
+    for name in ("a", "b"):
+      b = tmp_path / name
+      b.mkdir()
+      (b / "manifest.json").write_text('{"fingerprint": "shared-fp"}')
+    assert mw._pre_scan_bundle_fingerprint(tmp_path) == "shared-fp"
+
+  def test_mixed_fingerprints_rejected(self, tmp_path):
+    """Two bundles with different fingerprints → fail fast with
+    a summary that lists both. Mixed roots are a deployment bug
+    (operator forgot to clean up); the SDK refuses to guess
+    which is current."""
+    for name, fp in (("old", "fp-old"), ("new", "fp-new")):
+      b = tmp_path / name
+      b.mkdir()
+      (b / "manifest.json").write_text(f'{{"fingerprint": "{fp}"}}')
+    with pytest.raises(ValueError, match="mixed fingerprints"):
+      mw._pre_scan_bundle_fingerprint(tmp_path)
+
+  def test_no_bundles_rejected(self, tmp_path):
+    """Empty root → explicit error, not silent fallback."""
+    with pytest.raises(ValueError, match="contains no bundles"):
+      mw._pre_scan_bundle_fingerprint(tmp_path)
+
+  def test_missing_manifest_field_rejected(self, tmp_path):
+    """Malformed manifest (no ``fingerprint`` key) → clear error
+    so the operator knows which bundle is broken."""
+    bundle = tmp_path / "broken"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text('{"not_fingerprint": "x"}')
+    with pytest.raises(ValueError, match="no ``fingerprint`` field"):
+      mw._pre_scan_bundle_fingerprint(tmp_path)
+
+
+class TestFirstRunLookback:
+
+  def test_first_run_uses_lookback_hours_not_default_30min(self, fixture_paths):
+    """First run (no checkpoint row) must scan ``--lookback-hours``
+    back, not the 30-min ``DEFAULT_INITIAL_LOOKBACK_MINUTES``.
+    Regression: previously the bootstrap path used 30min, so
+    ``--lookback-hours 6`` actually only scanned 30 minutes —
+    a customer requesting 6h coverage got 30min coverage."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,  # we mock the manager; skip
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    expected_window_start = now - _dt.timedelta(hours=6)
+    assert result.window_start == expected_window_start, (
+        f"first-run window_start should be {expected_window_start}; "
+        f"got {result.window_start} (was the 30-min default applied?)"
+    )
+
+
+class TestEventsTableThreading:
+
+  def test_events_table_passed_through_to_manager(self, fixture_paths):
+    """``--events-table custom`` must reach
+    ``OntologyGraphManager.from_ontology_binding(table_id=custom)``.
+    A previous draft discovered from the configured table but
+    extracted from the hard-coded default — silent split."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    captured: dict[str, str] = {}
+
+    def _capture(**kwargs):
+      captured["table_id"] = kwargs.get("table_id")
+      return mock.Mock()
+
+    with (
+        mock.patch.object(mw, "_build_manager", side_effect=_capture),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          events_table="custom_events",
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert captured["table_id"] == "custom_events"
+
+
+class TestCheckpointCarryForward:
+
+  def test_failure_carries_forward_prior_checkpoint(self, fixture_paths):
+    """When this run produces zero successful sessions but a
+    prior checkpoint exists, the state row carries forward the
+    prior watermark. Operators reading the most recent row see
+    "still at X", not NULL."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    prior = _dt.datetime(2026, 5, 15, 12, 0, tzinfo=_dt.timezone.utc)
+    fail_ts = _dt.datetime(2026, 5, 15, 13, 0, tzinfo=_dt.timezone.utc)
+
+    # Client wired so state-read returns the prior checkpoint.
+    client = mock.Mock()
+    state_row = mock.Mock(last_completion_at=prior)
+    discovered = [_FakeBQRow(session_id="s-fail", completion_timestamp=fail_ts)]
+    client.query = mock.Mock(
+        side_effect=[
+            mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
+            mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
+            mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
+        ]
+    )
+    client.insert_rows_json = mock.Mock(return_value=[])
+
+    fake_manager = mock.Mock(spec=["spec", "extract_graph"])
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(
+        side_effect=RuntimeError("simulated")
+    )
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=24.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert not result.ok
+    assert result.checkpoint_read == prior
+    # Carry-forward: prior watermark preserved in the report.
+    # (The DB-side filter ``last_completion_at IS NOT NULL``
+    # would also handle this on read; the carry-forward is the
+    # belt-and-suspenders observability win.)
+    assert result.checkpoint_written == prior
+
+
+class TestTableStatusesSurfaced:
+
+  def test_table_statuses_propagate_into_result(self, fixture_paths):
+    """``materialize_with_status`` returns per-table cleanup /
+    insert status. The orchestrator must surface that into
+    ``result.table_statuses`` so the JSON report shows which
+    tables hit streaming-buffer-pinned delete_failed states."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    ts = _dt.datetime(2026, 5, 15, 13, 0, tzinfo=_dt.timezone.utc)
+    discovered = [_FakeBQRow(session_id="s-1", completion_timestamp=ts)]
+    client = _stub_bq_client(discovered)
+
+    # Fake a TableStatus dataclass-like object.
+    fake_table_status = mock.Mock()
+    fake_table_status.table_ref = "p.d.entity"
+    fake_table_status.rows_attempted = 5
+    fake_table_status.rows_inserted = 5
+    fake_table_status.cleanup_status = "deleted"
+    fake_table_status.insert_status = "inserted"
+    fake_table_status.idempotent = True
+    fake_mat_result = mock.Mock()
+    fake_mat_result.row_counts = {"Entity": 5}
+    fake_mat_result.table_statuses = {"Entity": fake_table_status}
+
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(return_value=mock.Mock())
+
+    fake_materializer_cls = mock.Mock()
+    fake_materializer = fake_materializer_cls.return_value
+    fake_materializer.materialize_with_status = mock.Mock(
+        return_value=fake_mat_result
+    )
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert "Entity" in result.table_statuses
+    assert result.table_statuses["Entity"]["cleanup_status"] == "deleted"
+    assert result.table_statuses["Entity"]["rows_inserted"] == 5
+    assert result.table_statuses["Entity"]["idempotent"] is True
+
+
+class TestValidateBindingShortCircuit:
+
+  def test_failing_validation_raises_before_extraction(self, fixture_paths):
+    """``--validate-binding`` runs before extraction. A failing
+    report short-circuits with a ValueError; the materializer
+    is never constructed. This is the "fail before AI.GENERATE
+    spend" contract from #161."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    fake_failure = mock.Mock(
+        code=mock.Mock(value="missing_column"),
+        binding_path="binding.entities[0].properties[0].column",
+    )
+    fake_report = mock.Mock()
+    fake_report.ok = False
+    fake_report.failures = [fake_failure]
+
+    with (
+        mock.patch(
+            "bigquery_agent_analytics.binding_validation.validate_binding_against_bigquery",
+            return_value=fake_report,
+        ),
+        mock.patch.object(mw, "_build_manager") as mock_build,
+    ):
+      with pytest.raises(ValueError, match="binding-validate failed"):
+        mw.run_materialize_window(
+            project_id="test-proj",
+            dataset_id="test_ds",
+            ontology_path=str(ontology_yaml),
+            binding_path=str(binding_yaml),
+            lookback_hours=6.0,
+            validate_binding=True,
+            bq_client=client,
+            run_started_at=now,
+        )
+      # Manager was never constructed — extraction never started.
+      mock_build.assert_not_called()
+
+  def test_skipped_on_dry_run(self, fixture_paths):
+    """``--dry-run`` already opts out of side effects. Even with
+    ``--validate-binding`` on, dry-run skips the BQ-side check
+    (the binding may legitimately be ahead of the deployed
+    tables during preview)."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    with mock.patch(
+        "bigquery_agent_analytics.binding_validation.validate_binding_against_bigquery"
+    ) as mock_validate:
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=True,
+          dry_run=True,
+          bq_client=client,
+          run_started_at=now,
+      )
+      mock_validate.assert_not_called()

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -1452,3 +1452,242 @@ class TestStandaloneEntryHelp:
     # Usage line should start with the binary name + [OPTIONS],
     # NOT ``materialize-window materialize-window``.
     assert "materialize-window materialize-window" not in result.output
+
+
+# ------------------------------------------------------------------ #
+# Round-4 regressions                                                  #
+# ------------------------------------------------------------------ #
+
+
+class TestCheckpointNeverRegresses:
+  """A later run must never write a ``last_completion_at`` older
+  than the prior watermark. Two ways that could happen:
+
+  * The ``--overlap-minutes`` window pulls in events older than
+    the prior checkpoint. If a session inside the overlap succeeds
+    but a *later* session fails, the loop's last success is the
+    re-scanned (older) timestamp.
+  * An out-of-order rerun re-discovers a stale window.
+
+  In both cases, writing the older value would move the high-water
+  mark backwards and re-process already-materialized rows on the
+  next run (cost burn, not correctness — the materializer is
+  idempotent — but the operator surface lies)."""
+
+  def test_overlap_window_does_not_rewind_high_water_mark(self, fixture_paths):
+    """Prior checkpoint at 14:00. Discovery returns a 13:50
+    success (caught by ``--overlap-minutes``) followed by a 14:05
+    failure. Without the max(), the orchestrator would write
+    13:50 — regressing the watermark."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 30, tzinfo=_dt.timezone.utc)
+    prior = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    older_success = _dt.datetime(2026, 5, 15, 13, 50, tzinfo=_dt.timezone.utc)
+    later_failure = _dt.datetime(2026, 5, 15, 14, 5, tzinfo=_dt.timezone.utc)
+
+    client = mock.Mock()
+    state_row = mock.Mock(last_completion_at=prior)
+    discovered = [
+        _FakeBQRow(session_id="s-old", completion_timestamp=older_success),
+        _FakeBQRow(session_id="s-new", completion_timestamp=later_failure),
+    ]
+    client.query = mock.Mock(
+        side_effect=[
+            mock.Mock(result=mock.Mock(return_value=[])),  # DDL
+            mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
+            mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
+        ]
+    )
+    client.insert_rows_json = mock.Mock(return_value=[])
+
+    # First session succeeds (older timestamp); second raises.
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(
+        side_effect=[mock.Mock(), RuntimeError("simulated")]
+    )
+    fake_materializer_cls = mock.Mock()
+    fake_mat_result = mock.Mock()
+    fake_mat_result.row_counts = {"E": 1}
+    fake_mat_result.table_statuses = {}
+    fake_materializer_cls.return_value.materialize_with_status = mock.Mock(
+        return_value=fake_mat_result
+    )
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=24.0,
+          overlap_minutes=30.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    # Critical: checkpoint did NOT regress to ``older_success``.
+    # It stays at ``prior``, the higher watermark.
+    assert result.checkpoint_written == prior
+    assert result.checkpoint_written >= prior
+
+  def test_advance_when_success_is_newer_than_prior(self, fixture_paths):
+    """Sanity: when this run's last success IS newer than the
+    prior watermark, the checkpoint must still advance. Otherwise
+    the max-guard would freeze the watermark forever."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 30, tzinfo=_dt.timezone.utc)
+    prior = _dt.datetime(2026, 5, 15, 13, 0, tzinfo=_dt.timezone.utc)
+    new_success = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+
+    client = mock.Mock()
+    state_row = mock.Mock(last_completion_at=prior)
+    discovered = [
+        _FakeBQRow(session_id="s-new", completion_timestamp=new_success),
+    ]
+    client.query = mock.Mock(
+        side_effect=[
+            mock.Mock(result=mock.Mock(return_value=[])),
+            mock.Mock(result=mock.Mock(return_value=[state_row])),
+            mock.Mock(result=mock.Mock(return_value=discovered)),
+        ]
+    )
+    client.insert_rows_json = mock.Mock(return_value=[])
+
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(return_value=mock.Mock())
+    fake_materializer_cls = mock.Mock()
+    fake_mat_result = mock.Mock()
+    fake_mat_result.row_counts = {"E": 1}
+    fake_mat_result.table_statuses = {}
+    fake_materializer_cls.return_value.materialize_with_status = mock.Mock(
+        return_value=fake_mat_result
+    )
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert result.checkpoint_written == new_success
+
+
+class TestStateReadSqlOrdersByCompletion:
+  """The state-read query must order by ``last_completion_at DESC,
+  run_started_at DESC`` so an out-of-order run never shadows a
+  higher watermark. Ordering by ``run_started_at`` alone would
+  pick the most recent *run* even if it carried a lower watermark."""
+
+  def test_orders_by_last_completion_then_run_started(self):
+    sql = mw.build_state_select_sql("p.d._bqaa_materialization_state")
+    order_idx = sql.index("ORDER BY")
+    order_clause = sql[order_idx:]
+    assert "last_completion_at DESC" in order_clause
+    assert "run_started_at DESC" in order_clause
+    # Non-NULL filter retained as defense-in-depth.
+    assert "last_completion_at IS NOT NULL" in sql
+
+
+class TestCompletionEventTypeGuardrail:
+  """``--completion-event-type ""`` silently no-ops: every event
+  fails the ``event_type = ""`` predicate, zero sessions are
+  discovered, a clean heartbeat row is written, and the run looks
+  healthy. Reject the typo at the boundary."""
+
+  def test_empty_string_rejected(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError, match="--completion-event-type must be a non-empty string"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type="",
+          validate_binding=False,
+      )
+
+  def test_whitespace_only_rejected(self, fixture_paths):
+    """Whitespace-only is also nonsense — would bind ``event_type
+    = "   "`` and match nothing. Treated identically to empty."""
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError, match="--completion-event-type must be a non-empty string"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type="   ",
+          validate_binding=False,
+      )
+
+  def test_include_active_sessions_bypasses_check(self, fixture_paths):
+    """``--include-active-sessions`` drops the event-type filter
+    entirely (any session with at least one event in the window
+    counts). The completion-event-type guard is irrelevant in
+    that mode — don't false-reject an unused flag."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type="",
+          include_active_sessions=True,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+
+class TestCliHelpExitCodeDocsMentionDrift:
+  """The CLI help text must list binding-validation drift as one
+  of the exit-1 failure modes. A previous draft only mentioned
+  "session failure", which is misleading after the round-3 P2.3
+  change that maps drift to exit 1 (was exit 2)."""
+
+  def test_help_includes_drift_in_exit_1_description(self):
+    """Render the materialize-window subcommand help and assert
+    the exit-code section names drift explicitly."""
+    from typer.testing import CliRunner
+
+    from bigquery_agent_analytics.cli import app
+
+    result = CliRunner().invoke(app, ["materialize-window", "--help"])
+    assert result.exit_code == 0
+    assert "drift" in result.output.lower()

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -1,0 +1,620 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``bigquery_agent_analytics.materialize_window``.
+
+Covers the pure helpers (state-key, SQL builders, identifier
+validation, the outcome counter, the result-shape helper) and the
+orchestrator with mocked BigQuery + manager + materializer so the
+test runs without live infrastructure.
+
+Live BigQuery integration is covered separately (a follow-up).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from unittest import mock
+
+import pytest
+
+from bigquery_agent_analytics import materialize_window as mw
+
+# ------------------------------------------------------------------ #
+# compute_state_key                                                    #
+# ------------------------------------------------------------------ #
+
+
+class TestComputeStateKey:
+
+  def test_deterministic(self):
+    """Same inputs → same key, byte-for-byte."""
+    args = dict(
+        project_id="my-proj",
+        dataset_id="my_ds",
+        graph_name="my_graph",
+        events_table="agent_events",
+        ontology_fingerprint="sha256:abc",
+        binding_fingerprint="sha256:def",
+    )
+    assert mw.compute_state_key(**args) == mw.compute_state_key(**args)
+
+  def test_distinguishes_project(self):
+    """Different ``project_id`` → different key — guards against
+    one project's checkpoint advancing another's by accident."""
+    base = dict(
+        dataset_id="ds",
+        graph_name="g",
+        events_table="t",
+        ontology_fingerprint="o",
+        binding_fingerprint="b",
+    )
+    a = mw.compute_state_key(project_id="proj-a", **base)
+    b = mw.compute_state_key(project_id="proj-b", **base)
+    assert a != b
+
+  def test_distinguishes_binding_fingerprint(self):
+    """Binding edit (e.g., column rename) bumps the fingerprint →
+    new key → fresh bootstrap, prior checkpoint isn't consulted.
+    That's the right behavior: the new binding's row shape may
+    not match what the prior checkpoint's materialize wrote."""
+    base = dict(
+        project_id="p",
+        dataset_id="d",
+        graph_name="g",
+        events_table="t",
+        ontology_fingerprint="o",
+    )
+    a = mw.compute_state_key(binding_fingerprint="b1", **base)
+    b = mw.compute_state_key(binding_fingerprint="b2", **base)
+    assert a != b
+
+  def test_hex_format(self):
+    """sha256 hex — 64 chars, lowercase, no prefix. Reviewers
+    debugging a state table want a key that copies cleanly."""
+    key = mw.compute_state_key(
+        project_id="p",
+        dataset_id="d",
+        graph_name="g",
+        events_table="t",
+        ontology_fingerprint="o",
+        binding_fingerprint="b",
+    )
+    assert len(key) == 64
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+# ------------------------------------------------------------------ #
+# Identifier validation                                                #
+# ------------------------------------------------------------------ #
+
+
+class TestValidatedTableRef:
+
+  def test_clean_inputs(self):
+    assert (
+        mw.validated_table_ref("my-proj", "my_ds", "agent_events")
+        == "my-proj.my_ds.agent_events"
+    )
+
+  @pytest.mark.parametrize(
+      "bad",
+      [
+          ("proj space", "ds", "tbl"),
+          ("proj", "ds;DROP", "tbl"),
+          ("proj", "ds", "tbl`back"),
+          ("proj", "ds", "tbl.dotted"),
+          ("proj", "ds", ""),
+      ],
+  )
+  def test_rejects_unsafe_segments(self, bad):
+    """Whitespace / backticks / semicolons / dots-inside-segment
+    / empty strings all rejected — the FQN is interpolated into
+    SQL with backticks, so the validator is the choke point."""
+    with pytest.raises(ValueError):
+      mw.validated_table_ref(*bad)
+
+
+class TestParseStateTableRef:
+
+  def test_one_segment_fills_defaults(self):
+    assert mw.parse_state_table_ref("state_tbl", "proj", "ds") == (
+        "proj",
+        "ds",
+        "state_tbl",
+    )
+
+  def test_two_segments_fills_project(self):
+    assert mw.parse_state_table_ref("other_ds.state_tbl", "proj", "ds") == (
+        "proj",
+        "other_ds",
+        "state_tbl",
+    )
+
+  def test_three_segments_explicit(self):
+    assert mw.parse_state_table_ref(
+        "other_proj.other_ds.state_tbl", "proj", "ds"
+    ) == ("other_proj", "other_ds", "state_tbl")
+
+  def test_rejects_unsafe(self):
+    with pytest.raises(ValueError):
+      mw.parse_state_table_ref("proj.ds.state tbl", "p", "d")
+
+
+# ------------------------------------------------------------------ #
+# SQL builders                                                         #
+# ------------------------------------------------------------------ #
+
+
+class TestBuildDiscoverySql:
+
+  def test_shape(self):
+    sql = mw.build_discovery_sql(
+        events_table_ref="p.d.agent_events",
+        completion_event_type="AGENT_COMPLETED",
+    )
+    # Partition pruning depends on the predicate being directly
+    # on the partition column. ``timestamp >= @scan_start`` is
+    # what unlocks it; the param binding is at execute time but
+    # the column name has to appear in the WHERE clause literally.
+    assert "timestamp >= @scan_start" in sql
+    assert "timestamp < @scan_end" in sql
+    assert "event_type = @completion_event_type" in sql
+    # FQN is backtick-quoted; the validator gates the segments
+    # before we hit this builder.
+    assert "`p.d.agent_events`" in sql
+    # GROUP BY session_id + ORDER BY completion_timestamp is the
+    # contract the orchestrator depends on for the watermark.
+    assert "GROUP BY session_id" in sql
+    assert "ORDER BY completion_timestamp" in sql
+
+  def test_max_sessions_emits_limit(self):
+    sql = mw.build_discovery_sql(
+        events_table_ref="p.d.agent_events",
+        completion_event_type="AGENT_COMPLETED",
+        max_sessions=42,
+    )
+    assert "LIMIT 42" in sql
+
+  def test_max_sessions_omitted_when_none(self):
+    sql = mw.build_discovery_sql(
+        events_table_ref="p.d.agent_events",
+        completion_event_type="AGENT_COMPLETED",
+    )
+    assert "LIMIT" not in sql
+
+
+# ------------------------------------------------------------------ #
+# Outcome counter                                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestMakeOutcomeCounter:
+
+  def test_counts_known_decisions(self):
+    """All three known C2 decisions accumulate independently.
+    Names mirror ``runtime_fallback.py`` constants so a typo in
+    one place fails this test fast."""
+    cb, counts = mw.make_outcome_counter()
+    cb("TOOL_COMPLETED", mock.Mock(decision="compiled_unchanged"))
+    cb("TOOL_COMPLETED", mock.Mock(decision="compiled_unchanged"))
+    cb("TOOL_COMPLETED", mock.Mock(decision="compiled_filtered"))
+    cb("TOOL_COMPLETED", mock.Mock(decision="fallback_for_event"))
+    assert counts == {
+        "compiled_unchanged": 2,
+        "compiled_filtered": 1,
+        "fallback_for_event": 1,
+    }
+
+  def test_unknown_decision_gets_its_own_bucket(self):
+    """A future SDK addition (new decision name) doesn't silently
+    drop telemetry — it gets its own bucket. ``unknown`` is reserved
+    for outcomes missing the ``decision`` field entirely."""
+    cb, counts = mw.make_outcome_counter()
+    cb("TOOL_COMPLETED", mock.Mock(decision="future_decision"))
+    assert counts["future_decision"] == 1
+    assert "unknown" not in counts
+
+  def test_missing_decision_field_falls_to_unknown(self):
+    """Outcome with no ``decision`` attribute / None value
+    accrues to ``unknown`` so the count is non-silent."""
+    cb, counts = mw.make_outcome_counter()
+    bad = mock.Mock(spec=[])  # no .decision attribute at all
+    cb("TOOL_COMPLETED", bad)
+    assert counts["unknown"] == 1
+
+
+# ------------------------------------------------------------------ #
+# Helpers used by the orchestrator                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestMaxSuccessCompletion:
+
+  def test_returns_max_among_successes(self):
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 10, tzinfo=_dt.timezone.utc
+            ),
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=False,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 11, tzinfo=_dt.timezone.utc
+            ),
+            error_code="X",
+        ),
+        mw.SessionResult(
+            session_id="c",
+            ok=True,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 9, tzinfo=_dt.timezone.utc
+            ),
+        ),
+    ]
+    # ``b`` failed at 11h. The high-water mark must NOT include
+    # it; otherwise the next run skips ``b`` even though it
+    # never landed.
+    assert mw._max_success_completion(results) == _dt.datetime(
+        2026, 5, 15, 10, tzinfo=_dt.timezone.utc
+    )
+
+  def test_returns_none_when_no_successes(self):
+    """Empty window or all-failed → no checkpoint advance."""
+    assert mw._max_success_completion([]) is None
+
+
+class TestBuildResult:
+
+  def test_aggregates_row_counts(self):
+    """rows_materialized sums across sessions — the per-session
+    counts are what materialize_with_status returns."""
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 10, tzinfo=_dt.timezone.utc
+            ),
+            rows_materialized={"DecisionExecution": 2, "AgentSession": 1},
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=True,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 11, tzinfo=_dt.timezone.utc
+            ),
+            rows_materialized={"DecisionExecution": 3, "Candidate": 5},
+        ),
+    ]
+    r = mw._build_result(
+        run_id="r",
+        state_key="k",
+        scan_start=_dt.datetime(2026, 5, 15, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 15, 12, tzinfo=_dt.timezone.utc),
+        checkpoint_read=None,
+        checkpoint_written=_dt.datetime(
+            2026, 5, 15, 11, tzinfo=_dt.timezone.utc
+        ),
+        sessions_discovered=2,
+        session_results=results,
+        compiled_outcomes={
+            "compiled_unchanged": 7,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=True,
+    )
+    assert r.rows_materialized == {
+        "DecisionExecution": 5,
+        "AgentSession": 1,
+        "Candidate": 5,
+    }
+
+  def test_failures_list_only_failed_sessions(self):
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 10, tzinfo=_dt.timezone.utc
+            ),
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=False,
+            completion_timestamp=_dt.datetime(
+                2026, 5, 15, 11, tzinfo=_dt.timezone.utc
+            ),
+            error_code="ValueError",
+            error_detail="boom",
+        ),
+    ]
+    r = mw._build_result(
+        run_id="r",
+        state_key="k",
+        scan_start=_dt.datetime(2026, 5, 15, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 15, 12, tzinfo=_dt.timezone.utc),
+        checkpoint_read=None,
+        checkpoint_written=_dt.datetime(
+            2026, 5, 15, 10, tzinfo=_dt.timezone.utc
+        ),
+        sessions_discovered=2,
+        session_results=results,
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=False,
+    )
+    assert len(r.failures) == 1
+    assert r.failures[0]["session_id"] == "b"
+    assert r.failures[0]["error_code"] == "ValueError"
+
+
+# ------------------------------------------------------------------ #
+# to_json round-trip                                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestToJson:
+
+  def test_iso_timestamps_with_trailing_z(self):
+    """JSON consumers expect ISO 8601 UTC. Trailing ``Z`` is the
+    industry convention; ``+00:00`` is technically valid but
+    irritates many parsers. We pick the strict form."""
+    r = mw.MaterializeWindowResult(
+        run_id="r",
+        state_key="k",
+        window_start=_dt.datetime(2026, 5, 15, 10, tzinfo=_dt.timezone.utc),
+        window_end=_dt.datetime(2026, 5, 15, 16, tzinfo=_dt.timezone.utc),
+        checkpoint_read=None,
+        checkpoint_written=_dt.datetime(
+            2026, 5, 15, 16, tzinfo=_dt.timezone.utc
+        ),
+        sessions_discovered=0,
+        sessions_materialized=0,
+        sessions_failed=0,
+        rows_materialized={},
+        table_statuses={},
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        failures=[],
+        ok=True,
+    )
+    js = r.to_json()
+    assert js["window_start"].endswith("Z")
+    assert js["checkpoint_read"] is None
+    assert js["ok"] is True
+
+
+# ------------------------------------------------------------------ #
+# Orchestrator (full path, with mocks)                                 #
+# ------------------------------------------------------------------ #
+
+
+class _FakeBQRow:
+  """Mimics google.cloud.bigquery.Row attribute access for tests."""
+
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      setattr(self, k, v)
+
+
+@pytest.fixture
+def fixture_paths(tmp_path):
+  """Write a minimal ontology + binding pair to disk so the
+  orchestrator's ``load_ontology`` / ``load_binding`` calls don't
+  go through I/O mock plumbing. The contents are valid enough to
+  parse + fingerprint."""
+  ontology_yaml = tmp_path / "ontology.yaml"
+  ontology_yaml.write_text(
+      "ontology: test_ont\n"
+      "entities:\n"
+      "  - name: Entity\n"
+      "    keys: {primary: [id]}\n"
+      "    properties:\n"
+      "      - name: id\n"
+      "        type: string\n"
+  )
+  binding_yaml = tmp_path / "binding.yaml"
+  binding_yaml.write_text(
+      "binding: test_binding\n"
+      "ontology: test_ont\n"
+      "target:\n"
+      "  backend: bigquery\n"
+      "  project: test-proj\n"
+      "  dataset: test_ds\n"
+      "entities:\n"
+      "  - name: Entity\n"
+      "    source: test-proj.test_ds.entity\n"
+      "    properties:\n"
+      "      - name: id\n"
+      "        column: id\n"
+  )
+  return ontology_yaml, binding_yaml
+
+
+def _stub_bq_client(discovered_rows):
+  """A BigQuery client whose ``.query()`` returns:
+  - the DDL response (anything; we just check it was called)
+  - the state-table read (empty → bootstrap)
+  - the discovery query (returns ``discovered_rows``)
+  ``.insert_rows_json`` returns [] (no errors).
+  """
+  client = mock.Mock()
+
+  # Each .query() call's .result() yields a different row set.
+  # We sequence them via side_effect on the query() Mock.
+  results = [
+      mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
+      mock.Mock(result=mock.Mock(return_value=[])),  # state read
+      mock.Mock(result=mock.Mock(return_value=discovered_rows)),  # discovery
+  ]
+  client.query = mock.Mock(side_effect=results)
+  client.insert_rows_json = mock.Mock(return_value=[])
+  return client
+
+
+def test_dry_run_returns_discovered_sessions_without_extracting(
+    fixture_paths, monkeypatch
+):
+  """``--dry-run`` proves the discovery query runs end-to-end
+  (FQN validated, partition pruning intact) without spending
+  AI.GENERATE tokens. The state row is *not* written on dry-run
+  because the result isn't authoritative."""
+  ontology_yaml, binding_yaml = fixture_paths
+  now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+  discovered = [
+      _FakeBQRow(
+          session_id="sess-1",
+          completion_timestamp=_dt.datetime(
+              2026, 5, 15, 13, tzinfo=_dt.timezone.utc
+          ),
+      ),
+      _FakeBQRow(
+          session_id="sess-2",
+          completion_timestamp=_dt.datetime(
+              2026, 5, 15, 13, 30, tzinfo=_dt.timezone.utc
+          ),
+      ),
+  ]
+  client = _stub_bq_client(discovered)
+
+  # ``bigquery.ScalarQueryParameter`` is imported lazily inside
+  # ``run_materialize_window``; stub at module level so the call
+  # goes through without a real BQ install.
+  result = mw.run_materialize_window(
+      project_id="test-proj",
+      dataset_id="test_ds",
+      ontology_path=str(ontology_yaml),
+      binding_path=str(binding_yaml),
+      lookback_hours=6.0,
+      dry_run=True,
+      bq_client=client,
+      run_started_at=now,
+  )
+  assert result.sessions_discovered == 2
+  assert result.sessions_materialized == 0
+  assert result.sessions_failed == 0
+  assert result.checkpoint_written is None
+  # Dry-run skips the state-row append.
+  assert client.insert_rows_json.call_count == 0
+
+
+def test_partial_failure_advances_checkpoint_only_to_last_success(
+    fixture_paths,
+):
+  """If session 2 of 3 fails, the checkpoint advances to session
+  1's completion timestamp. Next run starts there; session 2 is
+  retried (at-least-once)."""
+  ontology_yaml, binding_yaml = fixture_paths
+  now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+  ts1 = _dt.datetime(2026, 5, 15, 13, 0, tzinfo=_dt.timezone.utc)
+  ts2 = _dt.datetime(2026, 5, 15, 13, 15, tzinfo=_dt.timezone.utc)
+  ts3 = _dt.datetime(2026, 5, 15, 13, 30, tzinfo=_dt.timezone.utc)
+  discovered = [
+      _FakeBQRow(session_id="s1", completion_timestamp=ts1),
+      _FakeBQRow(session_id="s2", completion_timestamp=ts2),
+      _FakeBQRow(session_id="s3", completion_timestamp=ts3),
+  ]
+  client = _stub_bq_client(discovered)
+
+  # Stub the manager + materializer so the test doesn't need real
+  # BQ. Session ``s2`` raises; the orchestrator must catch + halt.
+  fake_manager = mock.Mock()
+  fake_manager.spec = mock.Mock()
+  fake_manager.extract_graph = mock.Mock(
+      side_effect=[
+          mock.Mock(),  # s1 ok
+          RuntimeError("simulated AI.GENERATE failure on s2"),
+          mock.Mock(),  # s3 — should NOT be reached
+      ]
+  )
+
+  fake_materializer_cls = mock.Mock()
+  fake_materializer = fake_materializer_cls.return_value
+  fake_mat_result = mock.Mock()
+  fake_mat_result.row_counts = {"DecisionExecution": 1}
+  fake_materializer.materialize_with_status = mock.Mock(
+      return_value=fake_mat_result
+  )
+
+  with (
+      mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+      mock.patch(
+          "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+          fake_materializer_cls,
+      ),
+  ):
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        bq_client=client,
+        run_started_at=now,
+    )
+
+  assert not result.ok
+  assert result.sessions_materialized == 1  # only s1
+  assert result.sessions_failed == 1  # s2
+  # s3 never reached → not in failures list.
+  assert len(result.failures) == 1
+  assert result.failures[0]["session_id"] == "s2"
+  # Checkpoint advanced to s1's timestamp — NOT s2's, NOT s3's.
+  assert result.checkpoint_written == ts1
+  # State row was appended (it's append-only: we always write,
+  # even on failure).
+  assert client.insert_rows_json.call_count == 1
+
+
+def test_empty_window_writes_heartbeat_state_row(fixture_paths):
+  """Zero discovered sessions → ok=True, no checkpoint
+  advancement, but a state-row write so operators see the run."""
+  ontology_yaml, binding_yaml = fixture_paths
+  now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+  client = _stub_bq_client([])
+
+  # The orchestrator constructs the materializer outside the
+  # per-session loop, so even an empty window touches it.
+  with (
+      mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+      mock.patch(
+          "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+      ),
+  ):
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        bq_client=client,
+        run_started_at=now,
+    )
+
+  assert result.ok
+  assert result.sessions_discovered == 0
+  assert result.checkpoint_written is None
+  assert client.insert_rows_json.call_count == 1

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -47,6 +47,7 @@ class TestComputeStateKey:
         events_table="agent_events",
         ontology_fingerprint="sha256:abc",
         binding_fingerprint="sha256:def",
+        discovery_mode="terminal:AGENT_COMPLETED",
     )
     assert mw.compute_state_key(**args) == mw.compute_state_key(**args)
 
@@ -59,6 +60,7 @@ class TestComputeStateKey:
         events_table="t",
         ontology_fingerprint="o",
         binding_fingerprint="b",
+        discovery_mode="terminal:AGENT_COMPLETED",
     )
     a = mw.compute_state_key(project_id="proj-a", **base)
     b = mw.compute_state_key(project_id="proj-b", **base)
@@ -75,6 +77,7 @@ class TestComputeStateKey:
         graph_name="g",
         events_table="t",
         ontology_fingerprint="o",
+        discovery_mode="terminal:AGENT_COMPLETED",
     )
     a = mw.compute_state_key(binding_fingerprint="b1", **base)
     b = mw.compute_state_key(binding_fingerprint="b2", **base)
@@ -90,6 +93,7 @@ class TestComputeStateKey:
         events_table="t",
         ontology_fingerprint="o",
         binding_fingerprint="b",
+        discovery_mode="terminal:AGENT_COMPLETED",
     )
     assert len(key) == 64
     assert all(c in "0123456789abcdef" for c in key)
@@ -1691,3 +1695,205 @@ class TestCliHelpExitCodeDocsMentionDrift:
     result = CliRunner().invoke(app, ["materialize-window", "--help"])
     assert result.exit_code == 0
     assert "drift" in result.output.lower()
+
+
+# ------------------------------------------------------------------ #
+# Round-5 regressions                                                  #
+# ------------------------------------------------------------------ #
+
+
+class TestStateKeyIncludesDiscoveryMode:
+  """The checkpoint key must vary with the discovery predicate.
+  Two regressions a missing mode component would allow:
+
+  * Operator switches ``--completion-event-type`` from
+    ``AGENT_COMPLETED`` to a custom event. The new predicate
+    inherits the old high-water mark and skips historical
+    completions for the new event type.
+  * Debug ``--include-active-sessions`` run shares state with the
+    production cron. The debug mode has no terminal-event filter
+    and discovers different sessions; it could advance the
+    production checkpoint past sessions production hasn't yet
+    seen as completed."""
+
+  def test_different_terminal_events_produce_different_keys(self):
+    base = dict(
+        project_id="p",
+        dataset_id="d",
+        graph_name="g",
+        events_table="t",
+        ontology_fingerprint="o",
+        binding_fingerprint="b",
+    )
+    a = mw.compute_state_key(discovery_mode="terminal:AGENT_COMPLETED", **base)
+    b = mw.compute_state_key(discovery_mode="terminal:CUSTOM_TERMINAL", **base)
+    assert a != b
+
+  def test_active_mode_differs_from_terminal_mode(self):
+    """``--include-active-sessions`` debug mode must not share a
+    state row with the production terminal-event predicate."""
+    base = dict(
+        project_id="p",
+        dataset_id="d",
+        graph_name="g",
+        events_table="t",
+        ontology_fingerprint="o",
+        binding_fingerprint="b",
+    )
+    terminal = mw.compute_state_key(
+        discovery_mode="terminal:AGENT_COMPLETED", **base
+    )
+    active = mw.compute_state_key(discovery_mode="active", **base)
+    assert terminal != active
+
+
+class TestStateKeyDiscoveryModeWiring:
+  """End-to-end check that the orchestrator derives the right
+  ``discovery_mode`` from its flags. A code review catches the
+  string formula; this test catches a refactor that drops the
+  threading."""
+
+  def test_terminal_predicate_produces_terminal_mode_key(self, fixture_paths):
+    """A normal cron run with ``--completion-event-type X`` →
+    state_key matches a hand-computed
+    ``compute_state_key(discovery_mode="terminal:X", ...)``."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          completion_event_type="MY_TERMINAL",
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    # Same key derived from the same orchestrator inputs, with a
+    # *different* discovery_mode, must differ. The contract under
+    # test is the wiring, not the hash value itself.
+    other = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        completion_event_type="OTHER_TERMINAL",
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=_stub_bq_client([]),
+        run_started_at=now,
+    )
+    assert result.state_key != other.state_key
+
+  def test_active_mode_state_key_differs_from_terminal(self, fixture_paths):
+    """``--include-active-sessions`` produces a different
+    state_key from a terminal-event run with the same other
+    inputs, so debug runs don't share state with prod cron."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      terminal = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=_stub_bq_client([]),
+          run_started_at=now,
+      )
+      active = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          include_active_sessions=True,
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=_stub_bq_client([]),
+          run_started_at=now,
+      )
+
+    assert terminal.state_key != active.state_key
+
+
+class TestCompletionEventTypeWhitespaceRejected:
+  """``--completion-event-type " AGENT_COMPLETED "`` would bind a
+  spaced value into the discovery predicate and produce a clean
+  no-op heartbeat. Reject explicitly rather than stripping
+  silently — silent normalization would diverge from what the
+  operator typed."""
+
+  def test_leading_whitespace_rejected(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError,
+        match="--completion-event-type must not have leading or trailing",
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type=" AGENT_COMPLETED",
+          validate_binding=False,
+      )
+
+  def test_trailing_whitespace_rejected(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError,
+        match="--completion-event-type must not have leading or trailing",
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type="AGENT_COMPLETED ",
+          validate_binding=False,
+      )
+
+  def test_inner_whitespace_accepted(self, fixture_paths):
+    """Inner spaces are legal in BQ STRING values. Only outer
+    whitespace is the operator-typo class; inner spacing is the
+    operator's choice (e.g., a custom event named "user step")."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      # No raise — inner whitespace passes.
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          completion_event_type="user step",
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -882,11 +882,17 @@ class TestTableStatusesSurfaced:
 
 class TestValidateBindingShortCircuit:
 
-  def test_failing_validation_raises_before_extraction(self, fixture_paths):
+  def test_failing_validation_returns_structured_ok_false(self, fixture_paths):
     """``--validate-binding`` runs before extraction. A failing
-    report short-circuits with a ValueError; the materializer
-    is never constructed. This is the "fail before AI.GENERATE
-    spend" contract from #161."""
+    report short-circuits with a structured ``ok=False`` result;
+    the materializer is never constructed and the CLI exits 1
+    (expected failure), not exit 2 (unexpected internal error).
+
+    Operators rely on the exit code shape: a binding drift is the
+    failure mode this validator was added to catch, so it has to
+    surface as a normal "this run did not succeed" — not as
+    "the SDK itself blew up". This is the "fail before AI.GENERATE
+    spend" contract from #161 with the right error-shape mapping."""
     ontology_yaml, binding_yaml = fixture_paths
     now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
     client = _stub_bq_client([])
@@ -906,19 +912,27 @@ class TestValidateBindingShortCircuit:
         ),
         mock.patch.object(mw, "_build_manager") as mock_build,
     ):
-      with pytest.raises(ValueError, match="binding-validate failed"):
-        mw.run_materialize_window(
-            project_id="test-proj",
-            dataset_id="test_ds",
-            ontology_path=str(ontology_yaml),
-            binding_path=str(binding_yaml),
-            lookback_hours=6.0,
-            validate_binding=True,
-            bq_client=client,
-            run_started_at=now,
-        )
-      # Manager was never constructed — extraction never started.
-      mock_build.assert_not_called()
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=True,
+          bq_client=client,
+          run_started_at=now,
+      )
+    # Result is structured ok=False, not an exception.
+    assert result.ok is False
+    assert result.sessions_discovered == 0
+    assert len(result.failures) == 1
+    assert result.failures[0]["error_code"] == "binding_validate_failed"
+    assert "binding-validate failed" in result.failures[0]["error_detail"]
+    # Manager was never constructed — extraction never started.
+    mock_build.assert_not_called()
+    # State row WAS appended — drift is recorded so the next run
+    # sees the failure in the state table audit trail.
+    assert client.insert_rows_json.call_count == 1
 
   def test_skipped_on_dry_run(self, fixture_paths):
     """``--dry-run`` already opts out of side effects. Even with
@@ -944,3 +958,497 @@ class TestValidateBindingShortCircuit:
           run_started_at=now,
       )
       mock_validate.assert_not_called()
+
+
+# ------------------------------------------------------------------ #
+# Round-3 regressions                                                  #
+# ------------------------------------------------------------------ #
+
+
+class TestNumericGuardrails:
+  """Operator-input guardrails. A typo like ``--lookback-hours=-6``
+  produces a negative scan window; without these checks the
+  arithmetic silently scans zero rows. The orchestrator must
+  reject nonsense at the boundary before any BQ side effect."""
+
+  @pytest.fixture
+  def _paths(self, tmp_path):
+    """Cheap fixture — the orchestrator should fail before any I/O,
+    so we don't need a real ontology/binding pair. The numeric
+    check runs at the top of the function, before file load."""
+    return tmp_path / "ontology.yaml", tmp_path / "binding.yaml"
+
+  def test_negative_lookback_hours_rejected(self, _paths):
+    ontology_yaml, binding_yaml = _paths
+    with pytest.raises(ValueError, match="--lookback-hours must be > 0"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=-6.0,
+          validate_binding=False,
+      )
+
+  def test_zero_lookback_hours_rejected(self, _paths):
+    """Zero window is also nonsense — empty range, nothing to
+    do. Reject for the same reason as negative."""
+    ontology_yaml, binding_yaml = _paths
+    with pytest.raises(ValueError, match="--lookback-hours must be > 0"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=0.0,
+          validate_binding=False,
+      )
+
+  def test_negative_overlap_minutes_rejected(self, _paths):
+    """Overlap of zero is fine (no extra rewind). Negative is a
+    typo — would compute a scan_start in the future and skip
+    everything."""
+    ontology_yaml, binding_yaml = _paths
+    with pytest.raises(ValueError, match="--overlap-minutes must be >= 0"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          overlap_minutes=-15.0,
+          validate_binding=False,
+      )
+
+  def test_zero_max_sessions_rejected(self, _paths):
+    """``--max-sessions 0`` would emit ``LIMIT 0`` and discover no
+    sessions on every run — silent zero work. ``None`` is the
+    "unlimited" sentinel; reject 0 and negative explicitly."""
+    ontology_yaml, binding_yaml = _paths
+    with pytest.raises(ValueError, match="--max-sessions must be unset or > 0"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          max_sessions=0,
+          validate_binding=False,
+      )
+
+  def test_negative_max_sessions_rejected(self, _paths):
+    ontology_yaml, binding_yaml = _paths
+    with pytest.raises(ValueError, match="--max-sessions must be unset or > 0"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          max_sessions=-1,
+          validate_binding=False,
+      )
+
+  def test_max_sessions_none_is_unlimited(self, fixture_paths):
+    """``None`` is the unlimited sentinel — no LIMIT clause in the
+    discovery SQL, no rejection. This is the load-bearing case
+    for the default Cloud Run Job spec which doesn't pass
+    ``--max-sessions``."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      # No raise → the None path is accepted.
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          max_sessions=None,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+
+class TestBindingValidateDriftStructured:
+  """P2.3: a binding-validate failure must return a structured
+  ``ok=False`` result, not raise. The CLI maps ``not result.ok``
+  to exit 1 (expected) — raising would map to exit 2 (unexpected
+  internal error) and confuse the operator who's watching for the
+  drift signal this validator was added to surface."""
+
+  def test_drift_returns_ok_false_with_binding_validate_failed_code(
+      self, fixture_paths
+  ):
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    fake_failure = mock.Mock(
+        code=mock.Mock(value="missing_column"),
+        binding_path="binding.entities[0].properties[0].column",
+    )
+    fake_report = mock.Mock()
+    fake_report.ok = False
+    fake_report.failures = [fake_failure]
+
+    with mock.patch(
+        "bigquery_agent_analytics.binding_validation.validate_binding_against_bigquery",
+        return_value=fake_report,
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=True,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert result.ok is False
+    assert result.failures[0]["error_code"] == "binding_validate_failed"
+    assert "missing_column" in result.failures[0]["error_detail"]
+
+  def test_drift_writes_state_row_for_audit_trail(self, fixture_paths):
+    """Append-only state table is the audit log. A drift failure
+    must be written there so the next run + downstream observability
+    queries see it — silent failures are the worst kind."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    fake_report = mock.Mock()
+    fake_report.ok = False
+    fake_report.failures = [
+        mock.Mock(
+            code=mock.Mock(value="missing_table"),
+            binding_path="binding.entities[0]",
+        )
+    ]
+
+    with mock.patch(
+        "bigquery_agent_analytics.binding_validation.validate_binding_against_bigquery",
+        return_value=fake_report,
+    ):
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=True,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    # Exactly one state row written.
+    assert client.insert_rows_json.call_count == 1
+    written_payload = client.insert_rows_json.call_args[0][1][0]
+    assert written_payload["ok"] is False
+    assert "binding-validate failed" in written_payload["error_detail"]
+
+
+class TestWorstStatusAggregation:
+  """P2.4: when two sessions touch the same bound table, the
+  aggregated ``table_statuses`` must NOT mask an earlier
+  ``delete_failed`` with a later clean ``deleted``. Worst-status
+  wins; operators rely on this surface to spot
+  streaming-buffer-pinned tables."""
+
+  def test_delete_failed_in_one_session_propagates_to_aggregate(self):
+    """Session A fails to delete (streaming buffer pinned),
+    session B's delete works clean. Final table_statuses must
+    show ``delete_failed`` — the failure is the operator signal,
+    not the success."""
+    ts_a = _dt.datetime(2026, 5, 15, 10, tzinfo=_dt.timezone.utc)
+    ts_b = _dt.datetime(2026, 5, 15, 11, tzinfo=_dt.timezone.utc)
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=ts_a,
+            rows_materialized={"Entity": 3},
+            table_statuses={
+                "Entity": {
+                    "table_ref": "p.d.entity",
+                    "rows_attempted": 3,
+                    "rows_inserted": 3,
+                    "cleanup_status": "delete_failed",
+                    "insert_status": "inserted",
+                    "idempotent": False,
+                }
+            },
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=True,
+            completion_timestamp=ts_b,
+            rows_materialized={"Entity": 2},
+            table_statuses={
+                "Entity": {
+                    "table_ref": "p.d.entity",
+                    "rows_attempted": 2,
+                    "rows_inserted": 2,
+                    "cleanup_status": "deleted",
+                    "insert_status": "inserted",
+                    "idempotent": True,
+                }
+            },
+        ),
+    ]
+    r = mw._build_result(
+        run_id="r",
+        state_key="k",
+        scan_start=_dt.datetime(2026, 5, 15, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 15, 12, tzinfo=_dt.timezone.utc),
+        checkpoint_read=None,
+        checkpoint_written=ts_b,
+        sessions_discovered=2,
+        session_results=results,
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=True,
+    )
+    # Worst-status wins: delete_failed beats deleted.
+    assert r.table_statuses["Entity"]["cleanup_status"] == "delete_failed"
+    # Rows sum across sessions.
+    assert r.table_statuses["Entity"]["rows_attempted"] == 5
+    assert r.table_statuses["Entity"]["rows_inserted"] == 5
+    # Idempotent flag AND-ed — one non-idempotent session
+    # contaminates the table's overall idempotency claim.
+    assert r.table_statuses["Entity"]["idempotent"] is False
+
+  def test_insert_failed_propagates_to_aggregate(self):
+    """Insert-side parallel: ``insert_failed`` in one session must
+    survive aggregation against ``inserted`` in another."""
+    ts = _dt.datetime(2026, 5, 15, 10, tzinfo=_dt.timezone.utc)
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=ts,
+            rows_materialized={"E": 1},
+            table_statuses={
+                "E": {
+                    "table_ref": "p.d.e",
+                    "rows_attempted": 1,
+                    "rows_inserted": 0,
+                    "cleanup_status": "deleted",
+                    "insert_status": "insert_failed",
+                    "idempotent": False,
+                }
+            },
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=True,
+            completion_timestamp=ts,
+            rows_materialized={"E": 1},
+            table_statuses={
+                "E": {
+                    "table_ref": "p.d.e",
+                    "rows_attempted": 1,
+                    "rows_inserted": 1,
+                    "cleanup_status": "deleted",
+                    "insert_status": "inserted",
+                    "idempotent": True,
+                }
+            },
+        ),
+    ]
+    r = mw._build_result(
+        run_id="r",
+        state_key="k",
+        scan_start=ts,
+        scan_end=ts,
+        checkpoint_read=None,
+        checkpoint_written=ts,
+        sessions_discovered=2,
+        session_results=results,
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=True,
+    )
+    assert r.table_statuses["E"]["insert_status"] == "insert_failed"
+    assert r.table_statuses["E"]["idempotent"] is False
+
+  def test_all_clean_aggregate_remains_clean(self):
+    """Sanity check — when nothing failed, the aggregate is clean
+    too. Otherwise the worst-status logic would be over-
+    pessimistic and the report would always look broken."""
+    ts = _dt.datetime(2026, 5, 15, 10, tzinfo=_dt.timezone.utc)
+    results = [
+        mw.SessionResult(
+            session_id="a",
+            ok=True,
+            completion_timestamp=ts,
+            rows_materialized={"E": 1},
+            table_statuses={
+                "E": {
+                    "table_ref": "p.d.e",
+                    "rows_attempted": 1,
+                    "rows_inserted": 1,
+                    "cleanup_status": "deleted",
+                    "insert_status": "inserted",
+                    "idempotent": True,
+                }
+            },
+        ),
+        mw.SessionResult(
+            session_id="b",
+            ok=True,
+            completion_timestamp=ts,
+            rows_materialized={"E": 1},
+            table_statuses={
+                "E": {
+                    "table_ref": "p.d.e",
+                    "rows_attempted": 1,
+                    "rows_inserted": 1,
+                    "cleanup_status": "deleted",
+                    "insert_status": "inserted",
+                    "idempotent": True,
+                }
+            },
+        ),
+    ]
+    r = mw._build_result(
+        run_id="r",
+        state_key="k",
+        scan_start=ts,
+        scan_end=ts,
+        checkpoint_read=None,
+        checkpoint_written=ts,
+        sessions_discovered=2,
+        session_results=results,
+        compiled_outcomes={
+            "compiled_unchanged": 0,
+            "compiled_filtered": 0,
+            "fallback_for_event": 0,
+        },
+        ok=True,
+    )
+    assert r.table_statuses["E"]["cleanup_status"] == "deleted"
+    assert r.table_statuses["E"]["insert_status"] == "inserted"
+    assert r.table_statuses["E"]["idempotent"] is True
+
+
+class TestCompileBundleFingerprintInReport:
+  """P3.1: when ``--bundles-root`` is set, the JSON report MUST
+  carry the compiled-bundle fingerprint. Operators reading
+  ``compiled_outcomes`` cross-reference with this to answer
+  "which bundle actually ran in this window?" — the same question
+  customers ask when telemetry from two adjacent runs looks
+  different."""
+
+  def test_fingerprint_resolved_and_surfaced(self, fixture_paths, tmp_path):
+    """``--bundles-root`` set → fingerprint flows into both the
+    dataclass field and the ``to_json()`` payload."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+
+    bundles_root = tmp_path / "bundles"
+    bundles_root.mkdir()
+    bundle_dir = bundles_root / "bundle_v1"
+    bundle_dir.mkdir()
+    (bundle_dir / "manifest.json").write_text('{"fingerprint": "fp-abc123def"}')
+
+    client = _stub_bq_client([])
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bundles_root=str(bundles_root),
+          reference_extractors_module="bigquery_agent_analytics",
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert result.compile_bundle_fingerprint == "fp-abc123def"
+    js = result.to_json()
+    assert js["compile_bundle_fingerprint"] == "fp-abc123def"
+
+  def test_fingerprint_none_when_bundles_root_unset(self, fixture_paths):
+    """Plain ``from_ontology_binding`` path (no compiled bundles)
+    → ``compile_bundle_fingerprint`` is ``None``, not a string,
+    not missing from the dict. Consumers can branch on `is None`
+    without a KeyError."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert result.compile_bundle_fingerprint is None
+    js = result.to_json()
+    assert "compile_bundle_fingerprint" in js
+    assert js["compile_bundle_fingerprint"] is None
+
+
+class TestStandaloneEntryHelp:
+  """P2.1: ``bqaa-materialize-window --help`` must render
+  ``Usage: bqaa-materialize-window [OPTIONS]`` — not the confusing
+  ``bqaa-materialize-window materialize-window [OPTIONS]`` that an
+  argv-injection hack would produce. The console-script alias is
+  customer-facing (Cloud Run Job specs use it directly)."""
+
+  def test_help_renders_clean_single_command_usage(self):
+    """Invoke the entry point via Typer's ``CliRunner`` to capture
+    ``--help`` output without spawning a subprocess. The check is
+    on the literal Usage line — that's what shows up first when an
+    operator runs the binary against ``--help``."""
+    import typer
+    from typer.testing import CliRunner
+
+    from bigquery_agent_analytics.cli import materialize_window
+
+    # Same construction the entry point uses.
+    runner = CliRunner()
+    # ``typer.run`` won't return; build the equivalent Typer app
+    # explicitly and invoke ``--help`` against it.
+    app = typer.Typer()
+    app.command()(materialize_window)
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Usage line should start with the binary name + [OPTIONS],
+    # NOT ``materialize-window materialize-window``.
+    assert "materialize-window materialize-window" not in result.output


### PR DESCRIPTION
Closes the operational gap that `ontology-build` has — it requires explicit `--session-ids`, but customers running the SDK in production think in **time windows** ("materialize the last N hours"). This PR ships the cron-friendly entry point.

Tracks #161.

## What ships

- **`src/bigquery_agent_analytics/materialize_window.py`** — orchestrator + pure helpers (state key, SQL builders, identifier validation, outcome counter). Designed for unit testability; the CLI is a thin Typer wrapper, the logic lives here.
- **`bqaa-materialize-window`** standalone console script + `bq-agent-sdk materialize-window` subcommand. Both call paths share the same function body.
- **`tests/test_materialize_window.py`** — **68 unit tests, all passing**, covering every pure helper, the round-2 regressions, the round-3 regressions, the round-4 regressions, and the round-5 regressions.

## Design contract (per #161, with the comment refinements applied)

| Decision | Why |
|---|---|
| **Pinned `run_started_at`** at entry — discovery + state writes share one snapshot of "now". | Prevents the discovery query's row set from drifting across the run. |
| **Append-only state table** keyed on `sha256(project + dataset + graph_name + events_table + ontology_fingerprint + binding_fingerprint + discovery_mode)`, where `discovery_mode` is `terminal:<event_type>` for normal cron runs or `active` for `--include-active-sessions` debug runs. | Stable across re-runs against the same config; a binding rename, ontology bump, terminal-event swap, or debug-mode flip auto-invalidates via the key change. "Same config" is content-derived, not operator-managed — and the discovery predicate is part of "same config". |
| **Terminal-event-driven discovery**: `SELECT ... WHERE event_type = @completion_event_type AND timestamp BETWEEN @scan_start AND @scan_end`. | Partition pruning on the BQ AA plugin's DAY partition falls out because the predicate is literally on the partition column. |
| **Per-session loop with checkpoint advance**. | Partial failure stops the loop; the checkpoint sits at the last fully-materialized completion timestamp. Next run picks up there + `--overlap-minutes`. At-least-once with idempotent retries. |
| **C2 outcome counts** use the runtime-registry names (`compiled_unchanged` / `compiled_filtered` / `fallback_for_event`). | Operators reading the JSON report cross-reference with extractor-compilation telemetry without an alias map. |
| **`--completion-event-type` parameterized** with `AGENT_COMPLETED` as the BQ AA plugin default. | Other plugins / emitters not locked out. |
| **Reuses `_streaming_evaluation.compute_scan_start()`** for the overlap-windowed lower bound. | Same checkpoint semantics the rest of the streaming code already trusts. |

## CLI shape

```
bqaa-materialize-window \
  --project-id my-proj \
  --dataset-id analytics \
  --ontology ontology.yaml \
  --binding binding.yaml \
  --events-table agent_events \
  --lookback-hours 6 \
  --overlap-minutes 15 \
  --completion-event-type AGENT_COMPLETED \
  --state-table _bqaa_materialization_state \
  --max-sessions 100 \
  --bundles-root /var/bqaa/bundles \
  --reference-extractors-module examples.migration_v5.reference_extractor \
  --format json
```

Exit codes:
- `0` — every discovered session materialized cleanly.
- `1` — expected failure: at least one session failed, OR binding-validate detected drift. Checkpoint advanced only to last success; next run retries.
- `2` — unexpected internal error (load failure, missing flag, programming bug).

## State table schema

```sql
CREATE TABLE IF NOT EXISTS `{table_ref}` (
  state_key STRING NOT NULL,
  run_id STRING NOT NULL,
  run_started_at TIMESTAMP NOT NULL,
  scan_start TIMESTAMP NOT NULL,
  scan_end TIMESTAMP NOT NULL,
  last_completion_at TIMESTAMP,
  sessions_discovered INT64,
  sessions_materialized INT64,
  sessions_failed INT64,
  ok BOOL NOT NULL,
  error_detail STRING,
  report_json STRING
)
PARTITION BY DATE(run_started_at)
CLUSTER BY state_key, run_started_at
```

## JSON report

```json
{
  "run_id": "...",
  "state_key": "<64-hex sha256>",
  "window_start": "2026-05-15T08:00:00Z",
  "window_end": "2026-05-15T14:00:00Z",
  "checkpoint_read": "2026-05-15T07:45:00Z",
  "checkpoint_written": "2026-05-15T13:55:00Z",
  "sessions_discovered": 42,
  "sessions_materialized": 42,
  "sessions_failed": 0,
  "rows_materialized": {"DecisionExecution": 42, "...": "..."},
  "table_statuses": {
    "DecisionExecution": {
      "table_ref": "my-proj.analytics.decision_execution",
      "rows_attempted": 42,
      "rows_inserted": 42,
      "cleanup_status": "deleted",
      "insert_status": "inserted",
      "idempotent": true
    }
  },
  "compiled_outcomes": {
    "compiled_unchanged": 168,
    "compiled_filtered": 0,
    "fallback_for_event": 0
  },
  "compile_bundle_fingerprint": "<hex when --bundles-root set, else null>",
  "failures": [],
  "ok": true
}
```

## Round-2 fixes (4 P1s + 2 P2s + P3)

- **P1.1** — `build_state_select_sql` filters `last_completion_at IS NOT NULL`; heartbeat/failure rows don't shadow the prior successful checkpoint. Carry-forward semantics for self-documenting state rows.
- **P1.2** — first-run bootstrap uses `--lookback-hours` (was hardcoded 30min default).
- **P1.3** — `_pre_scan_bundle_fingerprint` walks `manifest.json` files; `discover_bundles(expected_fingerprint=None)` no longer silently rejects every bundle.
- **P1.4** — `_build_manager(table_id=...)` threaded; `--events-table` reaches extraction (was silent split with hard-coded default).
- **P2.1** — `--validate-binding` (default on) calls `validate_binding_against_bigquery` before extraction; skipped on `--dry-run`.
- **P2.2** — `result.table_statuses` populated from `materialize_with_status` (per-table `cleanup_status` / `insert_status` / `idempotent`).
- **P3** — `bqaa-materialize-window` console-script alias in `pyproject.toml`.

## Round-3 fixes (4 P2s + P3)

- **P2.1** — `bqaa-materialize-window --help` renders `Usage: bqaa-materialize-window [OPTIONS]` (was the confusing nested `bqaa-materialize-window materialize-window [OPTIONS]`). The entry point now uses `typer.main.get_command_from_info` to build a bare Click command instead of argv injection through the parent Typer app.
- **P2.2** — numeric guardrails at the boundary: `--lookback-hours <= 0`, `--overlap-minutes < 0`, `--max-sessions <= 0` all rejected with a clear `ValueError` before any BQ side effect.
- **P2.3** — binding-validate drift returns a structured `MaterializeWindowResult(ok=False, failures=[{"error_code": "binding_validate_failed", ...}])` and writes a state row, instead of raising. CLI exit code maps to **1 (expected failure)** rather than 2 (unexpected internal error) — a binding drift is the expected failure mode this validator was added to catch.
- **P2.4** — `table_statuses` aggregation uses worst-status-wins (`delete_failed > skipped > deleted`, `insert_failed > inserted`). Multiple sessions touching the same bound table cannot mask an earlier failure behind a later success.
- **P3.1** — JSON report carries `compile_bundle_fingerprint` (resolved from `manifest.json` when `--bundles-root` is set). Operators reading `compiled_outcomes` cross-reference with this to confirm which bundle actually ran. Dry-run preview reports include it too.

## Round-4 fixes (2 P2s + P3)

- **P2.1** — checkpoint cannot move backwards. ``--overlap-minutes`` re-scans events older than the prior checkpoint; if a session inside the overlap succeeded but a *later* session failed, the orchestrator was writing the older success timestamp and regressing the high-water mark. Now writes ``max(last_checkpoint, last_success_ts)``. State-read SQL also strengthened: ``ORDER BY last_completion_at DESC, run_started_at DESC`` so an out-of-order rerun can't shadow a higher watermark.
- **P2.2** — empty / whitespace `--completion-event-type` rejected at the boundary. Previously bound `event_type = ""` in the discovery query, matched nothing, wrote a clean heartbeat, and looked healthy. `--include-active-sessions` mode bypasses the check (that path drops the event-type filter entirely).
- **P3** — stale docs corrected: CLI exit-code section now mentions binding-validation drift as an exit-1 failure mode (the round-3 P2.3 change routes drift through exit 1, not exit 2). `build_state_select_sql` docstring rewritten to reflect carry-forward semantics rather than the obsolete "always NULL on no-advance" claim.

## Round-5 fixes (P2 + P3)

- **P2** — `compute_state_key` takes a new required `discovery_mode` kwarg (`terminal:<event_type>` for the normal cron path, `active` for `--include-active-sessions` debug runs). Prevents an operator switching `--completion-event-type` from inheriting the old predicate's high-water mark, and prevents a debug `--include-active-sessions` run from sharing state with the production cron and advancing past sessions production hasn't yet seen as completed.
- **P3** — `--completion-event-type` rejects leading/trailing whitespace explicitly (` AGENT_COMPLETED ` would otherwise bind a spaced value into the predicate and produce a clean no-op heartbeat). Inner whitespace remains legal (custom event names like `"user step"` are the operator's call). Rejection rather than silent stripping so the state_key stays consistent across cosmetic differences.

## Tests (68/68 pass)

**Pure helpers** — state-key determinism + cross-config disambiguation + sha256 hex format; identifier validation rejects whitespace / backticks / semicolons / dots-in-segment / empty strings; SQL builders enforce partition-pruning predicate shape + optional `LIMIT N` + `GROUP BY session_id` / `ORDER BY completion_timestamp` contracts.

**Outcome counter** — three known C2 decisions accumulate, unknown future decisions get their own bucket (not silently dropped), missing-`decision` outcomes fall to `"unknown"`.

**Result builder** — row counts aggregate across sessions; failures list contains only failed sessions; worst-status `table_statuses` aggregation (3 cases).

**Orchestrator (with mocks)** — `--dry-run`, partial failure (checkpoint at last success + non-zero exit), empty window heartbeat row, first-run lookback width, `--events-table` threading, checkpoint carry-forward, table-status surfacing, validate-binding short-circuit + structured ok=False, bundle fingerprint flowing into report (set + unset).

**Round-3 additions (14 new tests)**

- `TestNumericGuardrails` — 6 cases for `--lookback-hours` / `--overlap-minutes` / `--max-sessions` boundary input.
- `TestBindingValidateDriftStructured` — 2 cases: structured `ok=False` result + state-row audit trail.
- `TestWorstStatusAggregation` — 3 cases: `delete_failed` propagates, `insert_failed` propagates, all-clean stays clean.
- `TestCompileBundleFingerprintInReport` — 2 cases: fingerprint surfaces when `--bundles-root` is set; `None` when unset.
- `TestStandaloneEntryHelp` — 1 case: Usage line collapses to single command name.

**Round-4 additions (7 new tests)**

- `TestCheckpointNeverRegresses` — 2 cases: overlap re-scan with a later failure does NOT rewind; success newer than prior still advances.
- `TestStateReadSqlOrdersByCompletion` — 1 case: ORDER BY clause leads with `last_completion_at DESC`.
- `TestCompletionEventTypeGuardrail` — 3 cases: empty string rejected; whitespace-only rejected; `--include-active-sessions` bypasses the check.
- `TestCliHelpExitCodeDocsMentionDrift` — 1 case: help output for the materialize-window subcommand mentions drift in the exit-code section.

**Round-5 additions (7 new tests)**

- `TestStateKeyIncludesDiscoveryMode` — 2 cases: different terminal events produce different keys; active vs terminal differ.
- `TestStateKeyDiscoveryModeWiring` — 2 cases: the orchestrator derives `terminal:X` from `--completion-event-type X`; `--include-active-sessions` produces a different state_key.
- `TestCompletionEventTypeWhitespaceRejected` — 3 cases: leading whitespace rejected; trailing whitespace rejected; inner whitespace accepted.

## What's NOT in this PR

Per #161's "out of scope":
- Backfill mode (`--backfill --from / --to / --batch-hours`).
- Multi-tenant state rows beyond one graph/config key (the `state_key` already prevents accidental cross-config advancement).
- Cloud Run deployment templates.
- Complex retry scheduler — exit non-zero, let Cloud Run/Scheduler retry.

Live integration test against a scratch dataset (idempotency proof — re-run same window twice → identical materialized state) is the natural next slice; this PR keeps the diff focused on the CLI surface + the contract.

## Test plan

- [x] `bqaa-materialize-window --help` renders with every flag from #161's table, single-line Usage.
- [x] `pytest tests/test_materialize_window.py` — 68/68 pass.
- [x] `pyink --check` clean, `isort` clean.
- [x] Full test suite — 2927 passed, 14 skipped.
- [ ] **(pending)** Live integration test against a scratch dataset on `test-project-0728-467323` — re-run same window twice, assert identical materialized state.
