### PR TITLE
examples(migration_v5): Cloud Run Job + Scheduler periodic materialization

### DIFF
--- a/examples/migration_v5/README.md
+++ b/examples/migration_v5/README.md
@@ -168,6 +168,40 @@ A live end-to-end notebook run (`run_agent.py --sessions 3` + Beat 1–4 cells a
 - **Beat 3.6**: synthetic `ExtractedGraph` triggers all three `FallbackScope` failures (`NODE + FIELD + EDGE`).
 - **Beat 4**: concept index emitted + applied; `LabelSynonymResolver.resolve("DecisionExecution")` returns 1 candidate with a 12-hex `compile_id`; `GRAPH_TABLE` count over the user-authored property graph is non-zero. Hub-shape `(DecisionExecution)-[partOfSession]->(AgentSession)` returns at least one row per current session — the compiled extractor wired in Beat 3.5 synthesizes the envelope-side `AgentSession` + `partOfSession`.
 
+## Run periodic materialization (Cloud Run Job + Cloud Scheduler)
+
+The notebook materializes a graph once, ad hoc. Real deployments want the graph kept fresh on a cron. `examples/migration_v5/periodic_materialization/` packages `bqaa-materialize-window` as a Cloud Run Job + Cloud Scheduler trigger, using the v5 demo binding (re-targeted to the customer's project at runtime).
+
+**Local dry-run** — exercise the path against your own BigQuery without deploying:
+
+```bash
+pip install -r examples/migration_v5/periodic_materialization/requirements.txt
+
+BQAA_PROJECT_ID=your-project \
+BQAA_EVENTS_DATASET_ID=your_events_dataset \
+BQAA_GRAPH_DATASET_ID=your_graph_dataset \
+BQAA_LOOKBACK_HOURS=6 \
+python examples/migration_v5/periodic_materialization/run_job.py
+```
+
+**Deploy** — one command, with `--smoke` to verify the deploy by running the job once and tailing logs:
+
+```bash
+./examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh \
+  --project your-project \
+  --region us-central1 \
+  --events-dataset your_events_dataset \
+  --graph-dataset your_graph_dataset \
+  --schedule "0 */6 * * *" \
+  --smoke
+```
+
+The deploy script bundles `run_job.py` + the demo artifacts (`ontology.yaml`, `binding.yaml`, `table_ddl.sql`) + `requirements.txt` into a staging dir, deploys via `gcloud run jobs deploy --source`, creates a service account, grants `roles/run.invoker`, and wires the Cloud Scheduler HTTP trigger.
+
+The job's JSON report (per run) lands in Cloud Logging as a structured entry. Filter on `resource.labels.job_name` for the materialization audit log. The state table at `<graph_dataset>._bqaa_materialization_state` is a queryable history.
+
+See [`periodic_materialization/README.md`](./periodic_materialization/README.md) for the full operational contract, env-var reference, and troubleshooting notes.
+
 ## What's NOT in this commit
 
 - `docs/README.md` / `CHANGELOG.md` entries — staged for a follow-up PR alongside the user-facing release notes.

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -1,0 +1,314 @@
+# Periodic materialization — Cloud Run Job + Cloud Scheduler
+
+Run `bqaa-materialize-window` on a cron, against your own
+BigQuery project, with one local command and one deploy command.
+
+The MAKO demo (`examples/migration_v5/`) ships the ontology,
+binding, and entity-table DDL. This directory wraps them in a
+hands-off scheduled deployment: a Cloud Run Job that fires every
+N hours via Cloud Scheduler, materializes the last N hours of
+events into your graph dataset, and emits a structured JSON
+report to Cloud Logging.
+
+## Production shape
+
+```
+agent_events            bqaa-materialize-window         graph entity/
+(your events DS)  ────► (Cloud Run Job, every N hrs) ──► relationship tables
+                              │                          (your graph DS)
+                              ▼
+                       _bqaa_materialization_state
+                       (checkpoint / state table,
+                        co-located with the graph DS)
+```
+
+Per run, the orchestrator:
+
+1. Reads the prior checkpoint from `_bqaa_materialization_state`.
+2. Scans events in `[checkpoint - overlap_minutes, run_started_at)`,
+   capped at `lookback_hours` worth of history.
+3. Discovers terminal-event sessions (`event_type =
+   'AGENT_COMPLETED'`) and materializes them one at a time.
+4. Advances the checkpoint to the latest successful session's
+   completion timestamp (never past a failure — partial failure
+   leaves a tight high-water mark for the next run).
+5. Writes the JSON report to stdout for Cloud Logging.
+
+State-table semantics, overlap-windowed late-arrival handling,
+and idempotent retries are all in the SDK's design contract — see
+`src/bigquery_agent_analytics/materialize_window.py` for the
+full prose.
+
+## Prerequisites
+
+* GCP project with the BigQuery, Cloud Run, Cloud Scheduler, and
+  Cloud Build APIs enabled.
+* **Events dataset** (`BQAA_EVENTS_DATASET_ID`) already exists
+  with a populated `agent_events` table. The BQ AA plugin writes
+  to this; if you've never run an agent against BQAA, seed one
+  for this demo via `python examples/migration_v5/run_agent.py
+  --project YOUR_PROJECT --dataset YOUR_EVENTS_DS --sessions 3`.
+  This dataset is **read-only** for the periodic job — the
+  job never writes here.
+* **Graph dataset** (`BQAA_GRAPH_DATASET_ID`) — `run_job.py`
+  creates this on first invocation if missing (idempotent), so
+  you don't have to pre-create it. The entity/relationship
+  tables and the state/checkpoint table all live here.
+* `gcloud` authenticated with permissions to deploy Cloud Run
+  Jobs, create scheduler triggers, and grant IAM bindings.
+
+## Local dry-run
+
+Run the job once on your laptop against a real BigQuery project —
+no Cloud Run required. Useful for shaking out the env-var setup
+before paying for a deploy:
+
+```bash
+# From the repo root, install the SDK in editable mode. The
+# example uses bigquery_agent_analytics.materialize_window
+# (added in PR #162); this isn't in the 0.3.0 PyPI release
+# yet, so install from local until 0.4.0 ships.
+pip install -e .
+
+# Then install the example's ancillary deps:
+pip install -r examples/migration_v5/periodic_materialization/requirements.txt
+
+BQAA_PROJECT_ID=your-project \
+BQAA_EVENTS_DATASET_ID=your_events_dataset \
+BQAA_GRAPH_DATASET_ID=your_graph_dataset \
+BQAA_LOOKBACK_HOURS=6 \
+BQAA_OVERLAP_MINUTES=15 \
+python examples/migration_v5/periodic_materialization/run_job.py
+```
+
+Output is a single JSON line on stdout (the materialize-window
+report) — pipe through `jq` for readability:
+
+```bash
+... python run_job.py | jq .
+```
+
+Exit codes mirror the SDK CLI:
+
+* `0` — every discovered session materialized cleanly.
+* `1` — expected failure: at least one session failed, or
+  binding-validate detected schema drift against live BigQuery.
+* `2` — unexpected internal error (config missing, code bug).
+
+## Deploy to Cloud Run + Cloud Scheduler
+
+One command:
+
+```bash
+./examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh \
+  --project your-project \
+  --region us-central1 \
+  --events-dataset your_events_dataset \
+  --graph-dataset your_graph_dataset \
+  --schedule "0 */6 * * *" \
+  --smoke
+```
+
+`--smoke` (optional) runs the job once after deploy and tails
+the logs, so you find out *now* whether the deploy actually
+works — not when the first scheduled fire happens six hours
+later.
+
+The script:
+
+1. **Pre-creates the graph dataset** (`bq mk`, idempotent) so
+   the runtime SA never needs `bigquery.datasets.create`.
+2. **Creates a service account** (`bqaa-periodic-sa@…`) if
+   absent. This SA serves two roles: **runtime identity** for
+   the Cloud Run Job (does the BigQuery work) and **scheduler
+   caller** for the Cloud Scheduler HTTP trigger. For
+   production, splitting these into separate SAs is reasonable
+   hardening; the script's structure makes that a small edit.
+3. **Grants narrow IAM** to the SA:
+   * Project-level `roles/bigquery.jobUser` —
+     `bigquery.jobs.create` only.
+   * Dataset-level `roles/bigquery.dataViewer` on
+     **events** — read-only access. The events dataset stays
+     effectively read-only per the contract above.
+   * Dataset-level `roles/bigquery.dataEditor` on
+     **graph** — read + write on entity tables, state table,
+     DDL bootstrap.
+4. **Bundles the deploy** into a self-contained staging dir:
+   `run_job.py`, demo artifacts, **the local SDK source**
+   under `sdk_src/`. The deploy-time `requirements.txt`
+   installs the SDK from `./sdk_src` (not PyPI) so the
+   deployed image uses the same code as the local dry-run.
+   This avoids depending on a PyPI release that may not yet
+   contain `materialize_window` (added in PR #162).
+5. **Deploys the Cloud Run Job** via `gcloud run jobs deploy
+   --source <staging>` (Buildpacks autodetects Python) with
+   `--service-account` pointing at the SA. The job's runtime
+   identity is the SA, **not** the Compute Engine default
+   service account — important, since the default SA may lack
+   the dataset-level perms above.
+6. **Grants `roles/run.invoker`** on the job to the same SA
+   (the scheduler-caller side of the cross-product).
+7. **Creates / updates a Cloud Scheduler HTTP job** that POSTs
+   to the Cloud Run Jobs `:run` endpoint with the SA's OAuth
+   identity.
+
+## Inspecting results
+
+**The JSON report (Cloud Logging).** Every run emits a
+single-line JSON to stdout, picked up by Cloud Logging as a
+structured entry. Filter on `resource.labels.job_name=<job>`:
+
+```bash
+gcloud logging read \
+  "resource.type=cloud_run_job AND \
+   resource.labels.job_name=bqaa-periodic-materialization AND \
+   jsonPayload.message=\"materialization complete\"" \
+  --project your-project \
+  --limit 5 \
+  --format='value(jsonPayload)'
+```
+
+Each entry includes:
+
+* `run_id`, `state_key`, `window_start`, `window_end`.
+* `sessions_discovered` / `sessions_materialized` /
+  `sessions_failed`.
+* `rows_materialized` — per-entity row counts.
+* `table_statuses` — per-table cleanup/insert status. A
+  `cleanup_status = "delete_failed"` entry means the BQ
+  streaming buffer pinned a table within the ~90-min window —
+  expected, not a code error.
+* `compiled_outcomes` — C2 (compiled-extractor) telemetry.
+* `failures` — list of failed sessions with error codes.
+* `ok` — overall success boolean.
+
+**The state table.** Co-located with the graph dataset (NOT
+the events dataset — the events dataset stays read-only per
+the contract above). A real BQ table at
+`<project>.<graph_dataset>._bqaa_materialization_state`, one
+append-only row per run. `run_job.py` passes
+`state_table="{project}.{graph_dataset}._bqaa_materialization_state"`
+explicitly to the orchestrator so the default-dataset fallback
+can never point it at the events dataset. Query it for the
+audit log:
+
+```sql
+SELECT
+  run_started_at,
+  scan_start,
+  scan_end,
+  last_completion_at AS checkpoint,
+  sessions_discovered,
+  sessions_materialized,
+  sessions_failed,
+  ok,
+  error_detail
+FROM `your-project.your_graph_dataset._bqaa_materialization_state`
+ORDER BY run_started_at DESC
+LIMIT 20;
+```
+
+The `state_key` column (sha256 of the config) lets you separate
+runs from different ontology/binding/predicate combinations — a
+predicate switch (e.g. swapping `--completion-event-type`) shows
+up as a new key with a fresh bootstrap, not an inherited
+checkpoint.
+
+## Configuration reference
+
+All configuration goes through env vars on the Cloud Run Job.
+The deploy script wires them via `--set-env-vars`; for local
+dry-run, set them in your shell.
+
+| Env var                    | Required | Default | Notes |
+|----------------------------|----------|---------|-------|
+| `BQAA_PROJECT_ID`          | yes      | —       | GCP project. |
+| `BQAA_EVENTS_DATASET_ID`   | yes      | —       | Dataset with `agent_events`. |
+| `BQAA_GRAPH_DATASET_ID`    | yes      | —       | Target dataset for entity/relationship tables + the state table. |
+| `BQAA_LOCATION`            | no       | `US`    | BigQuery location. Must match both datasets. |
+| `BQAA_LOOKBACK_HOURS`      | no       | `6`     | Max history scanned per run. Hard upper bound on scan window. |
+| `BQAA_OVERLAP_MINUTES`     | no       | `15`    | Re-scan window for late-arriving events. Bump (e.g. `60`) if ingestion can lag tens of minutes. |
+| `BQAA_MAX_SESSIONS`        | no       | unlimited | Per-run cost guardrail. |
+
+## Operational notes
+
+**State-table behavior.** Append-only; never truncate it. Each
+run inserts one row. The next run reads
+`MAX(last_completion_at) WHERE state_key = <current_config>` as
+its starting point. A heartbeat row (empty window) carries
+forward the prior checkpoint so the most recent row is self-
+documenting.
+
+**Overlap-windowed re-claim.** `BQAA_OVERLAP_MINUTES` re-scans
+events slightly older than the prior checkpoint. Default 15 min
+is fine for low-latency ingestion; bump higher for slower
+sources. The materializer is idempotent per session (delete-then-
+insert keyed on `session_id`), so re-scanning is safe.
+
+**Partial failures.** If session 3 of 5 raises during
+extraction, the orchestrator stops, advances the checkpoint to
+session 2's completion timestamp, writes a state row with
+`ok=False`, and exits non-zero. The next scheduled run picks up
+from session 2's timestamp and retries session 3 (idempotent
+because session-level delete-then-insert).
+
+**Streaming-buffer pinning.** When inserts land in the streaming
+buffer (default for `insert_rows_json`), BQ pins those rows for
+~30-90 min during which DML `DELETE` returns an error. The
+materializer surfaces this as `cleanup_status = "delete_failed"`
+in `table_statuses` — operator-visible, not silent. The session-
+level delete-then-insert pattern degrades gracefully: if delete
+failed, the insert still happens, producing duplicates that the
+*next* successful delete cleans up.
+
+**Idempotent retries.** Cloud Run Job retry policy: this script
+sets `--max-retries 1`. If a transient BQ error fails a run,
+Cloud Run retries once; the orchestrator's checkpoint plus
+session-level idempotency ensure no double-counting. For
+sustained failure (e.g., binding drift), the second retry will
+also fail and the scheduled fire will be reported as failed in
+Cloud Monitoring. Set up an alert on
+`logging.googleapis.com/log_entry_count` with severity `ERROR`.
+
+## Not in scope here
+
+* **Terraform / Pulumi.** A scripted deploy is easier to read
+  and easier to copy than IaC. IaC can come once the command
+  shape stabilizes.
+* **Compiled-bundle materialization.** This example uses the
+  plain `from_ontology_binding` extraction path (Gemini-backed).
+  For compiled extractors (`--bundles-root`), see
+  `docs/extractor_compilation/` and PR #152.
+* **Backfill mode.** A separate `--backfill --from / --to`
+  CLI mode is on the roadmap (per #161); for now, run the
+  CLI manually with a wider `--lookback-hours` to catch up.
+
+## Troubleshooting
+
+**`required env var BQAA_PROJECT_ID is not set`** — the local
+dry-run path. Set the three required env vars in your shell.
+
+**`binding-validate failed before extraction`** — the schema
+drift contract from #161. Your binding references columns that
+don't exist in the live tables. Either fix the binding, fix the
+tables, or pass `--no-validate-binding` to bypass (not
+recommended in production).
+
+**`Permission denied: bigquery.datasets.create`** — the runtime
+SA lacks dataset-create permission. The deploy script grants
+project-level `roles/bigquery.user` which includes this; if you
+swapped in a custom SA, grant it manually or pre-create the
+graph dataset (`bq mk --location=$LOCATION
+$PROJECT:$GRAPH_DATASET`) and grant the SA dataEditor on it.
+
+**`insert_failed` across every table on the first run** — the
+entity tables don't exist yet. The wrapper bootstraps them via
+`CREATE TABLE IF NOT EXISTS`, but if the runtime SA lacks
+`bigquery.tables.create`, the bootstrap silently no-ops and
+inserts fail. The deploy script grants `roles/bigquery.user` +
+`roles/bigquery.dataEditor` to cover this.
+
+**Scheduler fires but the job doesn't run** — IAM. Confirm the
+scheduler's service account (`bqaa-periodic-sa@…`) has
+`roles/run.invoker` on the job. The deploy script grants this;
+if you renamed the SA or job, regrant manually.

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Deploy the periodic-materialization Cloud Run Job + the Cloud
+# Scheduler trigger that fires it.
+#
+# Usage:
+#
+#   ./deploy_cloud_run_job.sh \
+#     --project PROJECT_ID \
+#     --region REGION \
+#     --events-dataset EVENTS_DS \
+#     --graph-dataset GRAPH_DS \
+#     --schedule "0 */6 * * *" \
+#     [--location BQ_LOCATION] \
+#     [--lookback-hours 6] \
+#     [--overlap-minutes 15] \
+#     [--max-sessions ""] \
+#     [--job-name bqaa-periodic-materialization] \
+#     [--smoke]
+#
+# What this script does (in order):
+#
+# 1. Pre-creates the **graph dataset** (idempotent ``bq mk``)
+#    so the runtime service account doesn't need
+#    ``bigquery.datasets.create`` — narrows the runtime IAM
+#    surface to dataset-level grants.
+#
+# 2. Creates the runtime + scheduler service account
+#    (``bqaa-periodic-sa``) if absent, and grants:
+#      * project-level ``roles/bigquery.jobUser`` (jobs.create).
+#      * dataset-level ``roles/bigquery.dataViewer`` on the
+#        events dataset (read-only access — events stay read-
+#        only per the README contract).
+#      * dataset-level ``roles/bigquery.dataEditor`` on the
+#        graph dataset (read + write — entity tables, state
+#        table, DDL bootstrap).
+#
+# 3. Builds a self-contained staging dir containing:
+#      * ``run_job.py``, ``Procfile``.
+#      * The demo artifacts (``ontology.yaml``, ``binding.yaml``,
+#        ``table_ddl.sql``) next to ``run_job.py`` for the
+#        flat-container layout.
+#      * The local SDK source (``src/bigquery_agent_analytics``
+#        + ``src/bigquery_ontology`` + ``pyproject.toml``)
+#        inside ``sdk_src/``. The deploy-time
+#        ``requirements.txt`` installs from this local path so
+#        the deployed image doesn't depend on a published PyPI
+#        release containing the in-flight orchestrator (#162).
+#
+# 4. Deploys the Cloud Run Job via ``gcloud run jobs deploy
+#    --source <staging>`` with ``--service-account`` pointing
+#    at the runtime SA. Buildpacks autodetects the Python
+#    runtime + ``requirements.txt``. Env vars wired through
+#    ``--set-env-vars``.
+#
+# 5. Enables the Cloud Scheduler API if it isn't already, and
+#    grants the same SA ``roles/run.invoker`` on the job so
+#    the scheduler trigger can actually invoke it.
+#
+# 6. Creates / updates the Cloud Scheduler job pointing at the
+#    Cloud Run Jobs ``:run`` endpoint, authenticated as the SA.
+#
+# 7. If ``--smoke`` is passed, executes the job once via
+#    ``gcloud run jobs execute --wait`` and tails the logs —
+#    so "did it deploy correctly?" is one command away.
+
+set -euo pipefail
+
+# ----------------------------------------------------------- #
+# Arg parsing                                                  #
+# ----------------------------------------------------------- #
+
+PROJECT=""
+REGION=""
+EVENTS_DATASET=""
+GRAPH_DATASET=""
+SCHEDULE=""
+BQ_LOCATION="US"
+LOOKBACK_HOURS="6"
+OVERLAP_MINUTES="15"
+MAX_SESSIONS=""
+JOB_NAME="bqaa-periodic-materialization"
+SMOKE=false
+
+# Print usage. Exit code is the caller's choice: ``usage 0``
+# for ``--help`` (success), ``usage 1`` for parse / required-arg
+# errors. Mixing the two would make ``./deploy_cloud_run_job.sh
+# --help`` look like a failure in CI / wrappers that pivot on
+# exit codes.
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Required:
+  --project PROJECT_ID         GCP project.
+  --region REGION              Cloud Run region (e.g. us-central1).
+  --events-dataset DATASET     BigQuery dataset with agent_events.
+  --graph-dataset DATASET      BigQuery dataset for the graph.
+  --schedule "CRON"            Cloud Scheduler cron (e.g. "0 */6 * * *").
+
+Optional:
+  --location LOCATION          BigQuery location (default: US).
+  --lookback-hours N           Lookback window (default: 6).
+  --overlap-minutes N          Overlap window (default: 15).
+  --max-sessions N             Cap sessions per run (default: unlimited).
+  --job-name NAME              Cloud Run Job name
+                               (default: bqaa-periodic-materialization).
+  --smoke                      After deploy, run the job once + tail logs.
+  -h | --help                  Show this help.
+EOF
+  exit "${1:-1}"
+}
+
+# With ``set -u``, a bare ``$2`` reference raises "unbound
+# variable" — the wrong shape when a user typo like
+# ``--project`` at the very end of the args trailing-edges the
+# parser. ``require_arg`` reads ``$2`` defensively via the
+# ``${2-}`` default-empty expansion, then either fails with a
+# clean usage error or leaves the value on stdout for the
+# caller's assignment. Implemented as an inline check (not via
+# ``$(require_arg ...)``) so the ``exit`` inside ``usage 1``
+# terminates the script — not just a subshell.
+require_arg() {
+  local flag="$1"
+  local value="${2-}"
+  if [[ -z "$value" || "$value" == -* ]]; then
+    echo "Error: $flag requires a value." >&2
+    usage 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)         require_arg "$1" "${2-}"; PROJECT="$2"; shift 2 ;;
+    --region)          require_arg "$1" "${2-}"; REGION="$2"; shift 2 ;;
+    --events-dataset)  require_arg "$1" "${2-}"; EVENTS_DATASET="$2"; shift 2 ;;
+    --graph-dataset)   require_arg "$1" "${2-}"; GRAPH_DATASET="$2"; shift 2 ;;
+    --schedule)        require_arg "$1" "${2-}"; SCHEDULE="$2"; shift 2 ;;
+    --location)        require_arg "$1" "${2-}"; BQ_LOCATION="$2"; shift 2 ;;
+    --lookback-hours)  require_arg "$1" "${2-}"; LOOKBACK_HOURS="$2"; shift 2 ;;
+    --overlap-minutes) require_arg "$1" "${2-}"; OVERLAP_MINUTES="$2"; shift 2 ;;
+    --max-sessions)    require_arg "$1" "${2-}"; MAX_SESSIONS="$2"; shift 2 ;;
+    --job-name)        require_arg "$1" "${2-}"; JOB_NAME="$2"; shift 2 ;;
+    --smoke)           SMOKE=true; shift ;;
+    -h|--help)         usage 0 ;;
+    *)                 echo "Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+# Render ``VAR_NAME`` → ``--var-name`` for the error message.
+# Using ``tr`` instead of Bash 4's ``${var,,}`` so this stays
+# portable on macOS's stock Bash 3.2 — a customer-facing local
+# deploy script should never trip "bad substitution".
+for var in PROJECT REGION EVENTS_DATASET GRAPH_DATASET SCHEDULE; do
+  if [[ -z "${!var}" ]]; then
+    flag=$(printf '%s' "$var" | tr '[:upper:]_' '[:lower:]-')
+    echo "Error: --$flag is required (use --help)." >&2
+    exit 1
+  fi
+done
+
+SCHEDULER_NAME="${JOB_NAME}-cron"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARTIFACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# Repo root — used to locate the SDK source for vendoring.
+# ``periodic_materialization/`` lives under
+# ``examples/migration_v5/``, so the repo root is two dirs up.
+REPO_ROOT="$(cd "${ARTIFACTS_DIR}/../.." && pwd)"
+
+# ----------------------------------------------------------- #
+# 1. Pre-create the graph dataset (idempotent)                 #
+# ----------------------------------------------------------- #
+#
+# Done here, not at job runtime, so the runtime SA doesn't need
+# ``bigquery.datasets.create``. The operator running this script
+# already has the broader perms via their own gcloud auth; the
+# job's SA can then be scoped to the narrower set below.
+
+echo "==> ensuring graph dataset exists: ${PROJECT}:${GRAPH_DATASET}"
+if ! bq --project_id="$PROJECT" show --dataset \
+    "${PROJECT}:${GRAPH_DATASET}" >/dev/null 2>&1; then
+  bq --project_id="$PROJECT" mk \
+    --dataset \
+    --location="$BQ_LOCATION" \
+    "${PROJECT}:${GRAPH_DATASET}"
+else
+  echo "==> graph dataset already exists"
+fi
+
+# ----------------------------------------------------------- #
+# 2. Service account (runtime identity + scheduler caller)     #
+# ----------------------------------------------------------- #
+#
+# A single service account is used for both:
+#   * The Cloud Run Job runtime (``--service-account`` below).
+#     This SA does the actual BigQuery work — reads events,
+#     writes entity rows, writes state-table rows.
+#   * The Cloud Scheduler caller (OAuth identity on the HTTP
+#     trigger). The SA also needs ``roles/run.invoker`` on the
+#     job to invoke itself.
+#
+# Combining the two identities keeps the IAM story simple. For
+# production, splitting them (separate SA for scheduler vs job
+# runtime) is reasonable hardening; the script is structured so
+# swapping in two SAs is a small edit.
+#
+# Grant order matters: create the SA + grant BigQuery perms
+# BEFORE the job deploys, so the job's first invocation has the
+# right identity. The job's ``--service-account`` arg refers to
+# the SA we just set up.
+
+SA_NAME="bqaa-periodic-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+if ! gcloud iam service-accounts describe "$SA_EMAIL" \
+    --project "$PROJECT" >/dev/null 2>&1; then
+  echo "==> creating service account: $SA_EMAIL"
+  gcloud iam service-accounts create "$SA_NAME" \
+    --display-name "BQAA periodic-materialization runtime + scheduler" \
+    --project "$PROJECT"
+else
+  echo "==> service account exists: $SA_EMAIL"
+fi
+
+# IAM grants for the runtime SA — narrowed to dataset-level
+# where possible so the events dataset stays effectively read-
+# only per the README contract.
+#
+#   * Project-level ``roles/bigquery.jobUser``
+#       → ``bigquery.jobs.create`` (run queries / DML).
+#   * Dataset-level ``roles/bigquery.dataViewer`` on events
+#       → read-only access to ``agent_events``.
+#   * Dataset-level ``roles/bigquery.dataEditor`` on graph
+#       → read + write on entity tables, state table, DDL
+#         bootstrap (CREATE TABLE IF NOT EXISTS).
+#
+# The dataset-level grants use ``bq add-iam-policy-binding``,
+# which appends to the dataset's IAM policy rather than
+# replacing it. Idempotent (re-adds are no-ops).
+echo "==> granting project-level roles/bigquery.jobUser to $SA_EMAIL"
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role roles/bigquery.jobUser \
+  --condition=None \
+  --quiet >/dev/null
+
+# ``bq add-iam-policy-binding`` defaults to table-shaped
+# resource identifiers; without ``--dataset`` it parses
+# ``PROJECT:DATASET`` as a malformed table ref and fails. The
+# flag is required for dataset-level grants.
+echo "==> granting dataset-level roles/bigquery.dataViewer on ${EVENTS_DATASET} to $SA_EMAIL"
+bq --project_id="$PROJECT" add-iam-policy-binding \
+  --dataset \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/bigquery.dataViewer" \
+  "${PROJECT}:${EVENTS_DATASET}" >/dev/null
+
+echo "==> granting dataset-level roles/bigquery.dataEditor on ${GRAPH_DATASET} to $SA_EMAIL"
+bq --project_id="$PROJECT" add-iam-policy-binding \
+  --dataset \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/bigquery.dataEditor" \
+  "${PROJECT}:${GRAPH_DATASET}" >/dev/null
+
+# ----------------------------------------------------------- #
+# 3. Build self-contained staging dir                          #
+# ----------------------------------------------------------- #
+#
+# The staging dir vendors:
+#   * ``run_job.py``, ``Procfile``.
+#   * Demo artifacts (``ontology.yaml``, ``binding.yaml``,
+#     ``table_ddl.sql``) next to ``run_job.py``.
+#   * The local SDK source under ``sdk_src/``
+#     (``src/bigquery_agent_analytics`` +
+#     ``src/bigquery_ontology`` + ``pyproject.toml``).
+#   * A deploy-time ``requirements.txt`` that installs the SDK
+#     from ``./sdk_src`` (NOT from PyPI), so the deployed image
+#     uses the same SDK code the local dry-run uses. The
+#     committed ``requirements.txt`` only lists the local-dry-
+#     run ancillary deps (google-cloud-bigquery + pyyaml); the
+#     deploy generates its own requirements next to it in the
+#     staging dir.
+
+STAGING="$(mktemp -d -t bqaa-cloud-run-job-XXXXXXXX)"
+trap 'rm -rf "$STAGING"' EXIT
+
+echo "==> staging at $STAGING"
+cp "${SCRIPT_DIR}/run_job.py" "$STAGING/"
+cp "${ARTIFACTS_DIR}/ontology.yaml" "$STAGING/"
+cp "${ARTIFACTS_DIR}/binding.yaml" "$STAGING/"
+cp "${ARTIFACTS_DIR}/table_ddl.sql" "$STAGING/"
+
+# Vendor the local SDK source.
+mkdir -p "$STAGING/sdk_src/src"
+cp -r "$REPO_ROOT/src/bigquery_agent_analytics" "$STAGING/sdk_src/src/"
+cp -r "$REPO_ROOT/src/bigquery_ontology" "$STAGING/sdk_src/src/"
+cp "$REPO_ROOT/pyproject.toml" "$STAGING/sdk_src/"
+# README.md is referenced by the SDK's ``pyproject.toml``
+# (``readme = "README.md"``); ship a stub to keep hatch happy.
+echo "# bigquery-agent-analytics (vendored for periodic-materialization deploy)" \
+  > "$STAGING/sdk_src/README.md"
+
+# Deploy-time requirements: install SDK from the vendored
+# source, plus the wrapper's ancillary deps. Overrides the
+# committed file in the staging dir.
+cat > "$STAGING/requirements.txt" <<'EOF'
+# Auto-generated by deploy_cloud_run_job.sh. Installs the SDK
+# from the vendored source bundled into the staging dir, so the
+# deployed image uses the same SDK code as the local dry-run.
+./sdk_src
+google-cloud-bigquery>=3.0.0
+pyyaml>=6.0
+EOF
+
+# Procfile tells Buildpacks how to invoke the entrypoint.
+# Cloud Run Jobs ignore ``web:``; we use a custom ``--command``
+# below, but a Procfile keeps the staging dir self-documenting.
+cat > "$STAGING/Procfile" <<'EOF'
+job: python run_job.py
+EOF
+
+# ----------------------------------------------------------- #
+# 4. Deploy the Cloud Run Job                                  #
+# ----------------------------------------------------------- #
+
+echo "==> deploying Cloud Run Job: $JOB_NAME"
+
+ENV_VARS=(
+  "BQAA_PROJECT_ID=${PROJECT}"
+  "BQAA_EVENTS_DATASET_ID=${EVENTS_DATASET}"
+  "BQAA_GRAPH_DATASET_ID=${GRAPH_DATASET}"
+  "BQAA_LOCATION=${BQ_LOCATION}"
+  "BQAA_LOOKBACK_HOURS=${LOOKBACK_HOURS}"
+  "BQAA_OVERLAP_MINUTES=${OVERLAP_MINUTES}"
+)
+if [[ -n "${MAX_SESSIONS}" ]]; then
+  ENV_VARS+=("BQAA_MAX_SESSIONS=${MAX_SESSIONS}")
+fi
+# Comma-join for --set-env-vars (no shell-quoting issues since
+# all values are simple identifiers / numbers).
+ENV_VAR_FLAG="$(IFS=','; echo "${ENV_VARS[*]}")"
+
+gcloud run jobs deploy "$JOB_NAME" \
+  --project "$PROJECT" \
+  --region "$REGION" \
+  --source "$STAGING" \
+  --command python \
+  --args run_job.py \
+  --service-account "$SA_EMAIL" \
+  --set-env-vars "$ENV_VAR_FLAG" \
+  --task-timeout 30m \
+  --max-retries 1
+
+# ----------------------------------------------------------- #
+# 5. Enable Cloud Scheduler API + grant invoker on the job     #
+# ----------------------------------------------------------- #
+
+echo "==> ensuring Cloud Scheduler API is enabled"
+gcloud services enable cloudscheduler.googleapis.com \
+  --project "$PROJECT" \
+  --quiet
+
+# Grant the SA invoker on the specific Cloud Run Job so the
+# scheduler trigger can fire it. (The SA is both the runtime
+# identity AND the scheduler caller; ``roles/run.invoker`` on
+# the job is the cross-product permission for the scheduler
+# side.)
+echo "==> granting roles/run.invoker on $JOB_NAME to $SA_EMAIL"
+gcloud run jobs add-iam-policy-binding "$JOB_NAME" \
+  --project "$PROJECT" \
+  --region "$REGION" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role roles/run.invoker \
+  --quiet >/dev/null
+
+# ----------------------------------------------------------- #
+# 6. Create / update the Cloud Scheduler trigger               #
+# ----------------------------------------------------------- #
+
+JOB_URI="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT}/jobs/${JOB_NAME}:run"
+
+if gcloud scheduler jobs describe "$SCHEDULER_NAME" \
+    --project "$PROJECT" \
+    --location "$REGION" >/dev/null 2>&1; then
+  echo "==> updating Cloud Scheduler job: $SCHEDULER_NAME"
+  gcloud scheduler jobs update http "$SCHEDULER_NAME" \
+    --project "$PROJECT" \
+    --location "$REGION" \
+    --schedule "$SCHEDULE" \
+    --uri "$JOB_URI" \
+    --http-method POST \
+    --oauth-service-account-email "$SA_EMAIL"
+else
+  echo "==> creating Cloud Scheduler job: $SCHEDULER_NAME"
+  gcloud scheduler jobs create http "$SCHEDULER_NAME" \
+    --project "$PROJECT" \
+    --location "$REGION" \
+    --schedule "$SCHEDULE" \
+    --uri "$JOB_URI" \
+    --http-method POST \
+    --oauth-service-account-email "$SA_EMAIL"
+fi
+
+echo
+echo "Cloud Run Job:       projects/${PROJECT}/locations/${REGION}/jobs/${JOB_NAME}"
+echo "Cloud Scheduler:     projects/${PROJECT}/locations/${REGION}/jobs/${SCHEDULER_NAME}"
+echo "Schedule:            ${SCHEDULE}"
+echo "Service account:     ${SA_EMAIL}"
+
+# ----------------------------------------------------------- #
+# 7. Optional smoke run                                        #
+# ----------------------------------------------------------- #
+
+if [[ "$SMOKE" == true ]]; then
+  echo
+  echo "==> running smoke execution (--smoke)"
+  EXECUTION_NAME="$(
+    gcloud run jobs execute "$JOB_NAME" \
+      --project "$PROJECT" \
+      --region "$REGION" \
+      --wait \
+      --format='value(metadata.name)'
+  )"
+  echo "==> execution: $EXECUTION_NAME"
+  echo "==> tailing logs (last 50 lines):"
+  gcloud logging read \
+    "resource.type=cloud_run_job \
+     AND resource.labels.job_name=${JOB_NAME} \
+     AND labels.\"run.googleapis.com/execution_name\"=${EXECUTION_NAME}" \
+    --project "$PROJECT" \
+    --limit 50 \
+    --format='value(textPayload,jsonPayload)' \
+    || true
+fi
+
+echo
+echo "Done."

--- a/examples/migration_v5/periodic_materialization/requirements.txt
+++ b/examples/migration_v5/periodic_materialization/requirements.txt
@@ -1,0 +1,29 @@
+# Dependencies for the periodic-materialization example.
+#
+# This file is for the **local dry-run path** — used by
+# operators running ``run_job.py`` directly on their laptop.
+#
+# The Cloud Run Job deploy uses a DIFFERENT requirements.txt
+# generated dynamically by ``deploy_cloud_run_job.sh``. The
+# deploy script bundles the local SDK source into the staging
+# dir and installs it from there (``./sdk_src``), so the
+# deployed image uses the same SDK code as the local dry-run.
+# This avoids depending on a PyPI release that may not yet
+# contain ``bigquery-agent-analytics.materialize_window``
+# (added in PR #162; not yet in the 0.3.0 release).
+#
+# Local dry-run install path:
+#
+#   # From the repo root, install the SDK in editable mode:
+#   pip install -e .
+#
+#   # Then install this example's ancillary deps:
+#   pip install -r examples/migration_v5/periodic_materialization/requirements.txt
+#
+# Once a PyPI release containing materialize_window ships
+# (>=0.4.0), this file can pin the published version directly
+# (e.g., ``bigquery-agent-analytics>=0.4.0,<0.5.0``) and the
+# ``pip install -e .`` step won't be needed.
+
+google-cloud-bigquery>=3.0.0
+pyyaml>=6.0

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud Run Job entrypoint: periodic graph materialization.
+
+Reads agent events from ``BQAA_EVENTS_DATASET_ID``, materializes
+the MAKO graph into ``BQAA_GRAPH_DATASET_ID``, scoped to the
+last ``BQAA_LOOKBACK_HOURS`` of events. Designed for a Cloud
+Scheduler trigger that fires every N hours; the orchestrator's
+state-table checkpoint plus overlap window handles "exactly once"
+across consecutive runs.
+
+This wrapper does three things the bare ``bqaa-materialize-window``
+CLI doesn't, all needed for a hands-off scheduled deployment:
+
+1. **Retargets the demo binding** to the customer's
+   ``BQAA_PROJECT_ID`` / ``BQAA_GRAPH_DATASET_ID`` at run time.
+   The committed ``binding.yaml`` hard-codes the canonical demo
+   target; rewriting it in-process means the customer only sets
+   env vars, never edits YAML.
+
+2. **Bootstraps entity-table DDL** if absent. ``materialize-
+   window`` requires the bound entity tables to exist before
+   it can insert. ``CREATE TABLE IF NOT EXISTS`` is a no-op on
+   subsequent runs.
+
+3. **Emits the JSON report on stdout** so Cloud Logging picks
+   it up as a structured log entry (Cloud Run forwards stdout
+   to ``run.googleapis.com/stdout``).
+
+Env vars (all set by the deploy script via
+``--set-env-vars``):
+
+* ``BQAA_PROJECT_ID`` (required) — GCP project.
+* ``BQAA_EVENTS_DATASET_ID`` (required) — source dataset with
+  ``agent_events``.
+* ``BQAA_GRAPH_DATASET_ID`` (required) — target dataset for
+  the materialized graph (entity + relationship tables).
+* ``BQAA_LOCATION`` (default ``US``) — BigQuery location;
+  must match both datasets.
+* ``BQAA_LOOKBACK_HOURS`` (default ``6``) — scan window size.
+* ``BQAA_OVERLAP_MINUTES`` (default ``15``) — re-scan window
+  for late-arriving events. Set higher (e.g. ``60``) if your
+  events table sometimes lags ingestion by tens of minutes.
+* ``BQAA_MAX_SESSIONS`` (default unset/unlimited) — cost
+  guardrail.
+
+Exit codes mirror the CLI:
+
+* ``0`` — every discovered session materialized cleanly.
+* ``1`` — expected failure: at least one session failed, or
+  binding-validate detected drift against live BigQuery.
+* ``2`` — unexpected internal error (load failure, missing env
+  var, programming bug).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from typing import Any, Optional
+
+_HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _find_artifact(name: str) -> pathlib.Path:
+  """Locate a demo artifact (``ontology.yaml``, ``binding.yaml``,
+  ``table_ddl.sql``).
+
+  Two layouts are supported:
+
+  * **Repo checkout / local dev** — artifacts live in the parent
+    directory (``examples/migration_v5/<name>``); this script
+    sits in ``examples/migration_v5/periodic_materialization/``.
+  * **Cloud Run Job container** — the deploy script bundles the
+    artifacts next to ``run_job.py`` to keep the deployed source
+    tree flat. Artifacts are at ``<_HERE>/<name>``.
+
+  The container layout takes precedence so a stale parent-dir
+  copy can never shadow the bundled one.
+  """
+  bundled = _HERE / name
+  if bundled.is_file():
+    return bundled
+  repo_local = _HERE.parent / name
+  if repo_local.is_file():
+    return repo_local
+  raise FileNotFoundError(
+      f"required artifact {name!r} not found in {_HERE} or {_HERE.parent}"
+  )
+
+
+# The committed artifacts hard-code this prefix; the wrapper
+# swaps it for the customer's ``{project}.{graph_dataset}``
+# pair at runtime. Single source of truth so both the binding
+# rewrite and the DDL rewrite stay in sync.
+_CANONICAL_PREFIX = "test-project-0728-467323.migration_v5_demo"
+
+
+def _require_env(name: str) -> str:
+  """Read a required env var; raise ``SystemExit(2)`` with a
+  clear message if it's missing or empty. Cloud Run Jobs map
+  exit 2 to "configuration error" in the retry policy."""
+  value = os.environ.get(name)
+  if value is None or not value.strip():
+    print(
+        json.dumps(
+            {
+                "severity": "ERROR",
+                "message": f"required env var {name} is not set",
+                "env_var": name,
+            }
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+  return value.strip()
+
+
+def _optional_env_float(name: str, default: float) -> float:
+  raw = os.environ.get(name)
+  if raw is None or not raw.strip():
+    return default
+  try:
+    return float(raw)
+  except ValueError:
+    print(
+        json.dumps(
+            {
+                "severity": "ERROR",
+                "message": (f"env var {name}={raw!r} is not a valid float"),
+                "env_var": name,
+            }
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _optional_env_int(name: str) -> Optional[int]:
+  """Returns ``None`` if unset (meaning "unlimited" for
+  ``--max-sessions``); raises exit 2 on a non-int value."""
+  raw = os.environ.get(name)
+  if raw is None or not raw.strip():
+    return None
+  try:
+    return int(raw)
+  except ValueError:
+    print(
+        json.dumps(
+            {
+                "severity": "ERROR",
+                "message": (f"env var {name}={raw!r} is not a valid integer"),
+                "env_var": name,
+            }
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _retarget_binding(project_id: str, graph_dataset_id: str) -> pathlib.Path:
+  """Render the committed ``binding.yaml`` against the
+  customer's ``{project}.{graph_dataset}`` and write to a tmp
+  file. Returns the path.
+
+  Why this approach over shipping a Jinja-style template: the
+  committed binding is human-readable, parseable by ``binding-
+  validate``, and exercised end-to-end by the live test fixture.
+  Adding template syntax would diverge those two consumers.
+  """
+  import yaml
+
+  with _find_artifact("binding.yaml").open() as f:
+    binding = yaml.safe_load(f)
+
+  binding["target"]["project"] = project_id
+  binding["target"]["dataset"] = graph_dataset_id
+  for entity in binding.get("entities", []) or []:
+    parts = entity.get("source", "").split(".")
+    if len(parts) == 3:
+      entity["source"] = f"{project_id}.{graph_dataset_id}.{parts[2]}"
+  for rel in binding.get("relationships", []) or []:
+    parts = rel.get("source", "").split(".")
+    if len(parts) == 3:
+      rel["source"] = f"{project_id}.{graph_dataset_id}.{parts[2]}"
+
+  tmp = pathlib.Path(tempfile.mkdtemp()) / "binding.retargeted.yaml"
+  tmp.write_text(yaml.safe_dump(binding))
+  return tmp
+
+
+def _bootstrap_entity_tables(
+    bq_client: Any, project_id: str, graph_dataset_id: str
+) -> int:
+  """Run the committed entity-table DDL against the customer's
+  graph dataset. ``CREATE TABLE IF NOT EXISTS`` makes this
+  idempotent — first run creates, subsequent runs no-op. Returns
+  the count of DDL statements executed.
+
+  This is the load-bearing detail for "the cron job just works"
+  — without these tables, the materializer's per-table INSERT
+  silently fails on every run. Bootstrapping at startup means
+  the customer doesn't need a separate one-time setup step.
+  """
+  ddl_text = (
+      _find_artifact("table_ddl.sql")
+      .read_text()
+      .replace(
+          _CANONICAL_PREFIX,
+          f"{project_id}.{graph_dataset_id}",
+      )
+  )
+  count = 0
+  for stmt in ddl_text.strip().split(";"):
+    stmt = stmt.strip()
+    if stmt:
+      bq_client.query(stmt).result()
+      count += 1
+  return count
+
+
+def _ensure_graph_dataset(
+    bq_client: Any, project_id: str, graph_dataset_id: str, location: str
+) -> bool:
+  """Idempotently ensure the graph dataset exists, probe-first.
+
+  Returns ``True`` if the dataset was created on this call,
+  ``False`` if it already existed.
+
+  Implementation: ``get_dataset`` first (read-only — the
+  runtime SA has ``roles/bigquery.dataEditor`` on the graph
+  dataset, which includes read). On ``NotFound``, fall through
+  to ``create_dataset``. NEVER call ``create_dataset`` against
+  an existing dataset — BigQuery checks IAM before existence,
+  so a ``create`` against an existing dataset would raise
+  ``PermissionDenied`` for an SA without project-level
+  ``datasets.create``, before the would-be ``Conflict`` is
+  produced. The probe-first shape sidesteps that.
+
+  In production (Cloud Run Job),
+  ``deploy_cloud_run_job.sh`` pre-creates the graph dataset
+  before the job ever runs. So the production path is:
+  ``get_dataset`` succeeds → return ``False`` → no
+  ``create_dataset`` call. The runtime SA never needs
+  ``datasets.create``.
+
+  For local dry-run mode the operator uses their own gcloud
+  credentials (typically with project-level
+  ``datasets.create``). The first invocation against a fresh
+  dataset name hits ``NotFound`` and actually creates it; the
+  laptop workflow stays zero-setup.
+
+  If the runtime identity lacks ``datasets.create`` AND the
+  dataset is missing (someone skipped the deploy script's
+  pre-create), the create raises ``PermissionDenied`` and the
+  job exits 2 in the catch-all handler in ``main()`` — the
+  right shape for a misconfigured deploy.
+  """
+  from google.api_core import exceptions as gapi_exceptions
+  from google.cloud import bigquery
+
+  ds_ref = f"{project_id}.{graph_dataset_id}"
+  # Probe with ``get_dataset`` first, NOT ``create_dataset``. The
+  # runtime SA in production has only dataset-level
+  # ``dataEditor`` on this dataset — no project-level
+  # ``datasets.create``. ``create_dataset`` would fail with
+  # ``PermissionDenied`` before BigQuery even checks existence,
+  # so the ``Conflict``-catch idiom doesn't work for that SA.
+  # ``get_dataset`` only needs read access, which the SA has.
+  try:
+    bq_client.get_dataset(ds_ref)
+    return False
+  except gapi_exceptions.NotFound:
+    pass
+
+  # Dataset doesn't exist. The create path is reached only on
+  # local dry-run (operator's gcloud creds, broad perms) or on
+  # the very first deploy where someone skipped the deploy
+  # script's pre-create step. If the runtime SA lacks
+  # ``datasets.create``, the call raises ``PermissionDenied``
+  # and the job exits 2 in the catch-all handler — the right
+  # shape for a misconfigured deploy.
+  ds = bigquery.Dataset(ds_ref)
+  ds.location = location
+  bq_client.create_dataset(ds, exists_ok=False)
+  return True
+
+
+def _emit(severity: str, **fields: Any) -> None:
+  """Structured stdout for Cloud Logging.
+
+  Cloud Logging picks up the ``severity`` key from the JSON
+  payload and uses it for the log entry's severity. Other keys
+  land in ``jsonPayload``. Valid severities: ``DEFAULT``,
+  ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``,
+  ``CRITICAL``, ``ALERT``, ``EMERGENCY``. See
+  https://cloud.google.com/logging/docs/structured-logging.
+  """
+  payload = {"severity": severity, **fields}
+  print(json.dumps(payload, default=str))
+  sys.stdout.flush()
+
+
+def main() -> int:
+  project_id = _require_env("BQAA_PROJECT_ID")
+  events_dataset_id = _require_env("BQAA_EVENTS_DATASET_ID")
+  graph_dataset_id = _require_env("BQAA_GRAPH_DATASET_ID")
+  location = os.environ.get("BQAA_LOCATION", "US")
+  lookback_hours = _optional_env_float("BQAA_LOOKBACK_HOURS", 6.0)
+  overlap_minutes = _optional_env_float("BQAA_OVERLAP_MINUTES", 15.0)
+  max_sessions = _optional_env_int("BQAA_MAX_SESSIONS")
+
+  _emit(
+      "INFO",
+      message="periodic materialization starting",
+      project_id=project_id,
+      events_dataset_id=events_dataset_id,
+      graph_dataset_id=graph_dataset_id,
+      location=location,
+      lookback_hours=lookback_hours,
+      overlap_minutes=overlap_minutes,
+      max_sessions=max_sessions,
+  )
+
+  try:
+    from google.cloud import bigquery
+
+    from bigquery_agent_analytics import materialize_window as mw
+
+    bq_client = bigquery.Client(project=project_id, location=location)
+
+    # 1. Ensure the graph dataset exists. Idempotent — created
+    # on first run, no-op afterwards. Done here (not in the
+    # deploy script) so the local dry-run path also benefits.
+    created = _ensure_graph_dataset(
+        bq_client, project_id, graph_dataset_id, location
+    )
+    _emit(
+        "INFO",
+        message=(
+            "graph dataset created" if created else "graph dataset exists"
+        ),
+        graph_dataset_id=graph_dataset_id,
+        created=created,
+    )
+
+    # 2. Bootstrap entity tables. Idempotent — no-op after first run.
+    ddl_count = _bootstrap_entity_tables(
+        bq_client, project_id, graph_dataset_id
+    )
+    _emit(
+        "INFO",
+        message="entity-table DDL applied",
+        statements=ddl_count,
+    )
+
+    # 3. Retarget binding to the customer's graph dataset.
+    binding_path = _retarget_binding(project_id, graph_dataset_id)
+
+    # 4. Run the orchestrator. Reads events from
+    # ``BQAA_EVENTS_DATASET_ID``; writes entities/relationships
+    # AND the state/checkpoint table into
+    # ``BQAA_GRAPH_DATASET_ID`` per the retargeted binding.
+    # The state-table arg is fully-qualified
+    # (``project.dataset.table``) so it ignores the
+    # orchestrator's default-dataset fallback (which would point
+    # at the read-only events dataset). This keeps the source
+    # dataset truly read-only per the README contract.
+    state_table_ref = (
+        f"{project_id}.{graph_dataset_id}._bqaa_materialization_state"
+    )
+    result = mw.run_materialize_window(
+        project_id=project_id,
+        dataset_id=events_dataset_id,
+        ontology_path=str(_find_artifact("ontology.yaml")),
+        binding_path=str(binding_path),
+        lookback_hours=lookback_hours,
+        overlap_minutes=overlap_minutes,
+        max_sessions=max_sessions,
+        state_table=state_table_ref,
+        location=location,
+        validate_binding=True,
+        bq_client=bq_client,
+        run_started_at=_dt.datetime.now(_dt.timezone.utc),
+    )
+
+    # Structured JSON report for Cloud Logging. Cloud Logging
+    # filters / metrics can pivot on the keys here directly
+    # (e.g., ``jsonPayload.sessions_failed > 0`` for alerts).
+    severity = "INFO" if result.ok else "ERROR"
+    _emit(severity, message="materialization complete", **result.to_json())
+
+    return 0 if result.ok else 1
+
+  except Exception as exc:  # noqa: BLE001 — entrypoint is the boundary
+    # Unexpected internal error (not a session failure or
+    # binding drift — those come back as ``result.ok=False`` and
+    # map to exit 1). Cloud Run Jobs treat exit 2 as
+    # configuration/code error in the retry policy.
+    import traceback
+
+    _emit(
+        "ERROR",
+        message="unexpected error in periodic materialization",
+        error_type=type(exc).__name__,
+        error=str(exc),
+        traceback=traceback.format_exc(limit=10),
+    )
+    return 2
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Operational wrapper around `bqaa-materialize-window` so a customer can keep their MAKO graph fresh on a cron with **one local command and one deploy command**. Follow-up to #162 (orchestrator) + #164 (live test).

## What ships

| File | Purpose |
|---|---|
| `examples/migration_v5/periodic_materialization/run_job.py` | Cloud Run Job entrypoint. Reads env vars, probe-first checks the graph dataset, retargets the demo binding, bootstraps entity-table DDL, calls `run_materialize_window` with a graph-dataset-co-located state table, emits structured JSON (`severity`/`message`/...) on stdout for Cloud Logging. |
| `deploy_cloud_run_job.sh` | Pre-creates the graph dataset, creates + IAM-scopes the runtime SA, vendors local SDK source into the staging dir, deploys via `gcloud run jobs deploy --source` with `--service-account`, wires Cloud Scheduler + invoker IAM. Optional `--smoke` runs the job once + tails logs. |
| `requirements.txt` | Local-dry-run-only deps. The deploy script generates its own staging-dir `requirements.txt` that installs from vendored SDK source (`./sdk_src`). |
| `periodic_materialization/README.md` | Production-shape diagram, local dry-run + deploy commands, inspection recipes (state table + Cloud Logging filter), full config reference, operational notes, troubleshooting. |
| `examples/migration_v5/README.md` (delta) | New "Run periodic materialization" section linking the new directory. |

## Production shape

```
agent_events            bqaa-materialize-window         graph entity/relationship
(events DS,        ────► (Cloud Run Job, every N hrs) ──► tables + _bqaa_materialization_state
 read-only)               │                              (graph DS, read+write)
                          ▼
                   structured JSON on stdout
                   (Cloud Logging)
```

## Local dry-run

Until a PyPI release containing `materialize_window` (added in #162) ships, install the SDK from local source:

```bash
# From the repo root
pip install -e .
pip install -r examples/migration_v5/periodic_materialization/requirements.txt

BQAA_PROJECT_ID=your-project \
BQAA_EVENTS_DATASET_ID=your_events_dataset \
BQAA_GRAPH_DATASET_ID=your_graph_dataset \
BQAA_LOOKBACK_HOURS=6 \
python examples/migration_v5/periodic_materialization/run_job.py
```

## Deploy

```bash
./examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh \
  --project your-project \
  --region us-central1 \
  --events-dataset your_events_dataset \
  --graph-dataset your_graph_dataset \
  --schedule "0 */6 * * *" \
  --smoke
```

## Design choices

- **Demo-owned, not SDK-internal.** The wrapper lives in `examples/` so the SDK stays focused on the orchestrator.
- **Local dry-run is first-class.** Same code path, same env-var shape; customers shake out env-var mistakes before paying for a deploy.
- **State table co-located with the graph dataset.** `run_job.py` passes `state_table="{project}.{graph_dataset}._bqaa_materialization_state"` explicitly, so the events dataset stays effectively read-only.
- **Entity-table DDL bootstrap at job startup (`CREATE TABLE IF NOT EXISTS`).** Idempotent — no separate one-time setup step.
- **Dataset existence check is probe-first.** `_ensure_graph_dataset()` calls `get_dataset` first; on success, returns `False` (the production path). Only on `NotFound` does it call `create_dataset`. Production runtime SA has only dataset-level `dataEditor` (which includes read), so it never needs project-level `datasets.create`. Local dry-run hits the create path on first run with the operator's gcloud creds.
- **Vendored SDK source in the deploy bundle.** Today's PyPI 0.3.0 release predates #162; rather than gate deploy on the next release shipping, the deploy script copies `src/bigquery_agent_analytics` + `src/bigquery_ontology` + `pyproject.toml` into the staging dir and the deploy-time `requirements.txt` installs from `./sdk_src`. The deployed image uses the same SDK code as the local dry-run.
- **Narrow IAM for the runtime SA.** Project-level `roles/bigquery.jobUser` (jobs.create only) + **dataset-level** `roles/bigquery.dataViewer` on events + **dataset-level** `roles/bigquery.dataEditor` on graph. The events dataset is genuinely read-only at the IAM layer. Deploy script grants these via `gcloud projects add-iam-policy-binding` (project) and `bq add-iam-policy-binding --dataset` (dataset).
- **Cloud Run Job runtime identity, not the default SA.** `gcloud run jobs deploy --service-account "$SA_EMAIL"` — the default Compute Engine SA wouldn't have the dataset-scoped grants.
- **Structured logging via `severity`.** All `_emit` calls write `{"severity": "INFO" | "ERROR", ...}` per the Cloud Logging spec — the entry's severity is set from the JSON key, not just buried in the payload.
- **Portable Bash.** No Bash 4-only features (`${var,,}` etc.) — runs on macOS's stock Bash 3.2 without "bad substitution".
- **Defensive arg parsing.** `require_arg` validates `${2-}` before assignment; `--project` at end of args produces a clean error, not `bash: $2: unbound variable`.
- **No Terraform.** Shell + `gcloud` is easier to read and copy than IaC for an example.
- **`--smoke` post-deploy verification.** "Did it deploy correctly?" is one command, not a six-hour wait for the first scheduled fire.

## Verified

**Local dry-run** against `test-project-0728-467323:migration_v5_idem_43c51d05` (3 demo sessions, 115 events) into a fresh `periodic_test_*` graph dataset:

```
{"severity": "INFO", "message": "periodic materialization starting", ...}
{"severity": "INFO", "message": "graph dataset created", "created": true}    # first run, NotFound → create
{"severity": "INFO", "message": "entity-table DDL applied", "statements": 13}
{"severity": "INFO", "message": "materialization complete", "sessions_discovered": 3, "sessions_materialized": 3, "ok": true, ...}
```

Re-run against the same dataset:

```
{"severity": "INFO", "message": "graph dataset exists", "created": false}    # subsequent run, get_dataset hit, no create call
```

Post-run table listing confirms `_bqaa_materialization_state` lives in the **graph** dataset (not events), and all 11 entity/relationship tables show `cleanup_status=deleted, insert_status=inserted, idempotent=true` on a fresh dataset.

**Vendored-SDK install** simulated end-to-end: staged `run_job.py` + artifacts + `sdk_src/` + generated `requirements.txt` into a temp dir, built a fresh venv, ran `pip install ./sdk_src`, confirmed `from bigquery_agent_analytics import materialize_window` works and `run_materialize_window` is importable.

**Arg-parse edge cases:**

```
$ ./deploy_cloud_run_job.sh --help; echo $?           # → 0
$ ./deploy_cloud_run_job.sh; echo $?                  # → 1, "--project is required"
$ ./deploy_cloud_run_job.sh --project; echo $?        # → 1, "--project requires a value"
$ ./deploy_cloud_run_job.sh --project --region us-central1; echo $?  # → 1, "--project requires a value"
$ ./deploy_cloud_run_job.sh --bogus-flag; echo $?     # → 1, "Unknown argument"
```

Scratch datasets cleaned up after verification.

## Not in scope

- Terraform / Pulumi templates.
- Compiled-bundle materialization path (`--bundles-root`).
- Backfill mode (out of scope per #161).
- Full live deploy + Scheduler trigger (deferred — quota-burning; the script's correctness is verified syntactically + via the staging simulation above).

## Test plan

- [x] Local dry-run against real BigQuery completes `ok=true` end-to-end.
- [x] DDL bootstrap idempotent (re-runs no-op on existing tables).
- [x] State table created in **graph** dataset, not events dataset.
- [x] `_ensure_graph_dataset` probe-first: `get_dataset` path for existing, `create_dataset` path for missing.
- [x] Cloud Logging entries use `severity` (uppercase).
- [x] Vendored SDK installs cleanly in a fresh venv; `run_materialize_window` importable.
- [x] `bash -n` syntax check passes on `deploy_cloud_run_job.sh`.
- [x] Arg parsing: `--help` exits 0; missing values / unknown flags exit 1 with clean error message.
- [x] No Bash 4-only features (portable to macOS Bash 3.2).
- [x] Missing-env `run_job.py` path returns exit 2 with structured JSON `severity: ERROR`.
- [ ] **(deferred)** Full deploy + Cloud Scheduler trigger against a real project.