### PR TITLE
examples(migration_v5): live Cloud Run deploy verification + IAM fixes (#165 follow-up)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -56,6 +56,15 @@ full prose.
   tables and the state/checkpoint table all live here.
 * `gcloud` authenticated with permissions to deploy Cloud Run
   Jobs, create scheduler triggers, and grant IAM bindings.
+* `python3` on PATH. The deploy script uses Python to apply
+  dataset-level IAM via the BigQuery client's `AccessEntry`
+  API (since `bq add-iam-policy-binding` requires project
+  allowlisting in some environments). If your `python3` doesn't
+  have `google-cloud-bigquery` installed, the script
+  transparently creates a one-shot temp venv with it — no
+  manual install required. If it does (e.g., you ran
+  `pip install -e .` from the repo root), the script reuses
+  that directly.
 
 ## Local dry-run
 
@@ -127,6 +136,14 @@ The script:
 3. **Grants narrow IAM** to the SA:
    * Project-level `roles/bigquery.jobUser` —
      `bigquery.jobs.create` only.
+   * Project-level `roles/aiplatform.user` — required because
+     the MAKO demo's extraction path calls BigQuery's
+     `AI.GENERATE` function (Gemini-backed entity extraction).
+     Without this grant, the AI call returns "user does not
+     have the permission to access resources used by
+     AI.GENERATE" and the orchestrator silently extracts an
+     empty graph for every session. Surfaced by the live
+     verification in PR #166.
    * Dataset-level `roles/bigquery.dataViewer` on
      **events** — read-only access. The events dataset stays
      effectively read-only per the contract above.
@@ -269,6 +286,134 @@ sustained failure (e.g., binding drift), the second retry will
 also fail and the scheduled fire will be reported as failed in
 Cloud Monitoring. Set up an alert on
 `logging.googleapis.com/log_entry_count` with severity `ERROR`.
+
+## Verified Cloud Run deployment evidence
+
+This section documents an end-to-end live verification of the
+deploy path against `test-project-0728-467323` (the
+canonical SDK test project). The verification was the work of
+PR #166 (follow-up to #165) and surfaced four real issues — all
+fixed in `deploy_cloud_run_job.sh` before the evidence below
+was captured. See the PR description for the full discovery
+log.
+
+**Inputs:**
+
+* Events dataset: `migration_v5_idem_43c51d05` (3 demo
+  sessions, 115 events, pre-populated by `run_agent.py` in PR
+  #164).
+* Graph dataset: `migration_v5_graph_verify_500c9f` (auto-
+  created by deploy script).
+* Job name: `bqaa-periodic-verify-500c9f`.
+* Schedule: `0 */6 * * *`.
+* Region: `us-central1`.
+
+**Build + deploy:**
+
+* Cloud Build image:
+  `us-central1-docker.pkg.dev/test-project-0728-467323/cloud-run-source-deploy/bqaa-periodic-verify-500c9f@sha256:d1cd008…`.
+* Built from the vendored `./sdk_src` (PR #165 contract):
+  `Building bigquery-agent-analytics @ file:///workspace/sdk_src` →
+  `Built bigquery-agent-analytics @ file:///workspace/sdk_src`.
+* Build time: ~4 min (Cloud Build + Buildpacks).
+
+**Cloud Scheduler trigger** (`gcloud scheduler jobs describe`):
+
+```yaml
+httpTarget:
+  httpMethod: POST
+  oauthToken:
+    scope: https://www.googleapis.com/auth/cloud-platform
+    serviceAccountEmail: bqaa-periodic-sa@test-project-0728-467323.iam.gserviceaccount.com
+  uri: https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/test-project-0728-467323/jobs/bqaa-periodic-verify-500c9f:run
+schedule: 0 */6 * * *
+state: ENABLED
+```
+
+The OAuth identity matches the runtime SA — same SA serves
+both runtime and scheduler-caller as designed.
+
+**IAM contract** verified post-deploy via the BigQuery client:
+
+```
+Events dataset IAM for SA:
+  role=READER, entity_type=userByEmail, entity_id=bqaa-periodic-sa@…
+  Number of WRITE/OWNER bindings for SA: 0
+
+Graph dataset IAM for SA:
+  role=WRITER, entity_type=userByEmail, entity_id=bqaa-periodic-sa@…
+```
+
+The SA can read events but cannot write — the "events dataset
+read-only" contract holds at the IAM layer.
+
+**Successful execution** (`materialization complete` payload
+from Cloud Logging, after the post-deploy `roles/aiplatform.user`
+grant the verification added to the deploy script):
+
+```json
+{
+  "run_id": "2d52338e16db",
+  "sessions_discovered": 3,
+  "sessions_materialized": 3,
+  "sessions_failed": 0,
+  "rows_materialized": {
+    "DecisionExecution": 3,
+    "DecisionPoint": 3,
+    "Candidate": 11,
+    "SelectionOutcome": 3,
+    "ContextSnapshot": 3,
+    "evaluatesCandidate": 11,
+    "selectedCandidate": 3,
+    "rejectedCandidate": 5,
+    "atContextSnapshot": 3,
+    "executedAtDecisionPoint": 3,
+    "hasSelectionOutcome": 3
+  },
+  "ok": true,
+  "failures": []
+}
+```
+
+All 11 entity/relationship tables populated.
+`cleanup_status=deleted, insert_status=inserted,
+idempotent=true` across the board.
+
+**Scheduler trigger actually fires.** The cron-scheduled fire
+at `2026-05-16T06:00:00Z` produced a third state-table row
+(`run_id 4725ebd79060`) with the same shape — proving the
+end-to-end path from Cloud Scheduler → Cloud Run Job →
+materialization works without manual intervention.
+
+**State table audit log** (`_bqaa_materialization_state` in
+the graph dataset):
+
+```
+run_id          run_started_at         sessions_disc / mat / failed   ok
+ff1e956df8b8    2026-05-16 04:38:59    3 / 3 / 0                       true
+2d52338e16db    2026-05-16 04:48:45    3 / 3 / 0                       true
+4725ebd79060    2026-05-16 06:02:51    3 / 3 / 0                       true
+```
+
+(Row 1 is the deploy script's `--smoke` execution, which ran
+BEFORE the verification added `roles/aiplatform.user` to the
+deploy. AI.GENERATE failed for every session there, but the
+orchestrator still reported `ok=true` with empty
+`rows_materialized` — see the known issue below.)
+
+### Known issue surfaced by this verification
+
+The orchestrator currently reports `sessions_materialized ==
+sessions_discovered` and `ok=true` even when every per-event
+`AI.GENERATE` call failed. The `rows_materialized` dict is
+empty in that case, but `sessions_materialized` doesn't
+reflect the underlying failure. Operators monitoring on
+`jsonPayload.ok` would miss the silent extraction failure.
+
+Tracked for SDK follow-up — out of scope for this example PR.
+Workaround: alert on
+`jsonPayload.rows_materialized == {}` in Cloud Logging /
+Monitoring as a second-line check.
 
 ## Not in scope here
 

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -35,6 +35,9 @@
 # 2. Creates the runtime + scheduler service account
 #    (``bqaa-periodic-sa``) if absent, and grants:
 #      * project-level ``roles/bigquery.jobUser`` (jobs.create).
+#      * project-level ``roles/aiplatform.user`` (the MAKO
+#        demo's extraction path calls ``AI.GENERATE``, which
+#        requires Vertex AI access).
 #      * dataset-level ``roles/bigquery.dataViewer`` on the
 #        events dataset (read-only access — events stay read-
 #        only per the README contract).
@@ -175,6 +178,43 @@ ARTIFACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # ``examples/migration_v5/``, so the repo root is two dirs up.
 REPO_ROOT="$(cd "${ARTIFACTS_DIR}/../.." && pwd)"
 
+# Cleanup state — the staging dir is created later in section
+# 3, the IAM-venv may be created here if needed. Single trap so
+# both get removed on any exit path.
+STAGING=""
+IAM_VENV=""
+_cleanup() {
+  [[ -n "$STAGING" ]] && rm -rf "$STAGING"
+  [[ -n "$IAM_VENV" ]] && rm -rf "$IAM_VENV"
+}
+trap _cleanup EXIT
+
+# ----------------------------------------------------------- #
+# 0. Python preflight for dataset-level IAM grants             #
+# ----------------------------------------------------------- #
+#
+# The dataset-level IAM grants in section 2 use a Python
+# heredoc against ``google.cloud.bigquery`` (legacy
+# ``AccessEntry`` API). The ``bq add-iam-policy-binding``
+# command is gated on project allowlisting in some projects,
+# so we don't rely on it.
+#
+# If the operator's ``python3`` already has
+# ``google-cloud-bigquery`` (e.g., they ran ``pip install -e
+# .`` from the repo root for local dry-run), use it directly.
+# Otherwise create a one-shot temp venv with just that
+# dependency — keeps the deploy a single command from a clean
+# shell. Operator only needs ``gcloud`` + ``python3`` (the
+# universal baseline).
+PY_CMD="python3"
+if ! python3 -c "import google.cloud.bigquery" >/dev/null 2>&1; then
+  echo "==> creating temp venv with google-cloud-bigquery (for dataset IAM)"
+  IAM_VENV="$(mktemp -d -t bqaa-iam-venv-XXXXXXXX)"
+  python3 -m venv "$IAM_VENV" >/dev/null
+  "$IAM_VENV/bin/pip" install --quiet google-cloud-bigquery
+  PY_CMD="$IAM_VENV/bin/python"
+fi
+
 # ----------------------------------------------------------- #
 # 1. Pre-create the graph dataset (idempotent)                 #
 # ----------------------------------------------------------- #
@@ -220,6 +260,37 @@ fi
 SA_NAME="bqaa-periodic-sa"
 SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
 
+# Retry an IAM-binding command on the IAM-propagation race.
+# ``gcloud iam service-accounts create`` returns success once
+# the SA exists in one IAM replica, but
+# ``gcloud projects add-iam-policy-binding`` reads from a
+# different replica that can lag by several seconds. The
+# observed error is ``INVALID_ARGUMENT: Service account ...
+# does not exist``. Polling ``describe`` doesn't help (it hits
+# the same replica that already returned success). The reliable
+# fix is to retry the grant itself.
+_retry_iam() {
+  local attempts=0
+  local max=20
+  while [[ $attempts -lt $max ]]; do
+    if "$@" >/dev/null 2>/tmp/_iam_err.$$; then
+      rm -f /tmp/_iam_err.$$
+      return 0
+    fi
+    if ! grep -qE "(does not exist|Service account)" /tmp/_iam_err.$$; then
+      cat /tmp/_iam_err.$$ >&2
+      rm -f /tmp/_iam_err.$$
+      return 1
+    fi
+    sleep 3
+    attempts=$((attempts + 1))
+  done
+  echo "Error: IAM grant did not succeed after ${max} retries" >&2
+  cat /tmp/_iam_err.$$ >&2
+  rm -f /tmp/_iam_err.$$
+  return 1
+}
+
 if ! gcloud iam service-accounts describe "$SA_EMAIL" \
     --project "$PROJECT" >/dev/null 2>&1; then
   echo "==> creating service account: $SA_EMAIL"
@@ -246,29 +317,80 @@ fi
 # which appends to the dataset's IAM policy rather than
 # replacing it. Idempotent (re-adds are no-ops).
 echo "==> granting project-level roles/bigquery.jobUser to $SA_EMAIL"
-gcloud projects add-iam-policy-binding "$PROJECT" \
+_retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
   --member "serviceAccount:${SA_EMAIL}" \
   --role roles/bigquery.jobUser \
   --condition=None \
-  --quiet >/dev/null
+  --quiet
 
-# ``bq add-iam-policy-binding`` defaults to table-shaped
-# resource identifiers; without ``--dataset`` it parses
-# ``PROJECT:DATASET`` as a malformed table ref and fails. The
-# flag is required for dataset-level grants.
-echo "==> granting dataset-level roles/bigquery.dataViewer on ${EVENTS_DATASET} to $SA_EMAIL"
-bq --project_id="$PROJECT" add-iam-policy-binding \
-  --dataset \
-  --member="serviceAccount:${SA_EMAIL}" \
-  --role="roles/bigquery.dataViewer" \
-  "${PROJECT}:${EVENTS_DATASET}" >/dev/null
+# The MAKO demo's extraction path uses BigQuery's
+# ``AI.GENERATE`` function under the hood (Gemini-backed
+# entity extraction from ``agent_events`` rows). Calling
+# ``AI.GENERATE`` requires Vertex AI access on top of BigQuery
+# perms. Without this grant, the AI call returns "user does
+# not have the permission to access resources used by
+# AI.GENERATE" and the orchestrator silently extracts an empty
+# graph for every session (the SDK currently swallows per-event
+# AI failures and reports ``sessions_materialized`` without
+# checking ``rows_materialized``). The verification round in
+# #166 surfaced this — the deploy looks ``ok=true`` but the
+# entity tables stay empty.
+echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
+_retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role roles/aiplatform.user \
+  --condition=None \
+  --quiet
 
-echo "==> granting dataset-level roles/bigquery.dataEditor on ${GRAPH_DATASET} to $SA_EMAIL"
-bq --project_id="$PROJECT" add-iam-policy-binding \
-  --dataset \
-  --member="serviceAccount:${SA_EMAIL}" \
-  --role="roles/bigquery.dataEditor" \
-  "${PROJECT}:${GRAPH_DATASET}" >/dev/null
+# Dataset-level IAM via the BigQuery Python client (the
+# ``AccessEntry``-based update API — legacy and fully
+# supported, vs ``bq add-iam-policy-binding`` which requires
+# project allowlisting in some environments).
+#
+# ``$PY_CMD`` was set in the preflight section 0: either the
+# operator's existing ``python3`` (if it has
+# ``google-cloud-bigquery`` installed) or a temp venv (if it
+# doesn't). The deploy script doesn't ask the operator to
+# install anything beyond ``gcloud`` + ``python3``.
+#
+# The grant logic is idempotent — it skips the update if the
+# binding is already present, so re-running the deploy is safe.
+_grant_dataset_iam() {
+  local dataset="$1"
+  local role="$2"  # legacy role keyword: READER / WRITER / OWNER
+  local role_display="$3"  # for the echo message
+  echo "==> granting dataset-level ${role_display} on ${dataset} to $SA_EMAIL"
+  "$PY_CMD" - <<EOF || { echo "Error: dataset-level IAM grant failed." >&2; exit 1; }
+import sys
+from google.cloud import bigquery
+client = bigquery.Client(project="${PROJECT}")
+ds = client.get_dataset("${PROJECT}.${dataset}")
+sa = "${SA_EMAIL}"
+role = "${role}"
+existing = [
+    e for e in ds.access_entries
+    if e.entity_type == "userByEmail"
+    and e.entity_id == sa
+    and e.role == role
+]
+if existing:
+    print(f"  already granted ({role})")
+    sys.exit(0)
+entries = list(ds.access_entries) + [
+    bigquery.AccessEntry(
+        role=role, entity_type="userByEmail", entity_id=sa
+    )
+]
+ds.access_entries = entries
+client.update_dataset(ds, ["access_entries"])
+print(f"  granted ({role})")
+EOF
+}
+
+# READER ≡ roles/bigquery.dataViewer.
+_grant_dataset_iam "$EVENTS_DATASET" "READER" "roles/bigquery.dataViewer"
+# WRITER ≡ roles/bigquery.dataEditor.
+_grant_dataset_iam "$GRAPH_DATASET" "WRITER" "roles/bigquery.dataEditor"
 
 # ----------------------------------------------------------- #
 # 3. Build self-contained staging dir                          #
@@ -289,8 +411,10 @@ bq --project_id="$PROJECT" add-iam-policy-binding \
 #     deploy generates its own requirements next to it in the
 #     staging dir.
 
+# ``STAGING`` is declared empty at the top of the script and
+# removed via the unified ``_cleanup`` trap, so we just assign
+# the mktemp result here — no second trap.
 STAGING="$(mktemp -d -t bqaa-cloud-run-job-XXXXXXXX)"
-trap 'rm -rf "$STAGING"' EXIT
 
 echo "==> staging at $STAGING"
 cp "${SCRIPT_DIR}/run_job.py" "$STAGING/"
@@ -320,11 +444,21 @@ google-cloud-bigquery>=3.0.0
 pyyaml>=6.0
 EOF
 
-# Procfile tells Buildpacks how to invoke the entrypoint.
-# Cloud Run Jobs ignore ``web:``; we use a custom ``--command``
-# below, but a Procfile keeps the staging dir self-documenting.
+# Procfile with a ``web:`` entry — required by Buildpacks at
+# build time, and used at runtime as the container's
+# entrypoint (Buildpacks wraps it in a venv-activation
+# script). Without a Procfile, Buildpacks fails with
+# ``provide a main.py or app.py file or set an entrypoint``;
+# with a non-``web`` Procfile, it fails with ``web process
+# not found in Procfile, found processes: [job]``.
+#
+# The ``web:`` label is Buildpacks' default process name; it
+# does NOT imply the container serves HTTP. Cloud Run Jobs
+# just execute the container's default entrypoint, regardless
+# of the Procfile label, and this Procfile's entrypoint is
+# what actually runs at job execution time.
 cat > "$STAGING/Procfile" <<'EOF'
-job: python run_job.py
+web: python run_job.py
 EOF
 
 # ----------------------------------------------------------- #
@@ -348,12 +482,20 @@ fi
 # all values are simple identifiers / numbers).
 ENV_VAR_FLAG="$(IFS=','; echo "${ENV_VARS[*]}")"
 
+# NOTE: no ``--command`` / ``--args``. Buildpacks-baked
+# containers wrap the entrypoint in a script that activates the
+# Python venv (where ``./sdk_src`` is installed). Overriding
+# with ``--command python --args run_job.py`` skips that
+# wrapper — the container then exec's a bare ``python`` that
+# isn't on PATH or can't find the venv packages, and Cloud Run
+# reports "Application failed to start: container exited
+# abnormally" with no Python output. Letting Buildpacks use the
+# Procfile's ``web: python run_job.py`` entrypoint preserves
+# the venv activation.
 gcloud run jobs deploy "$JOB_NAME" \
   --project "$PROJECT" \
   --region "$REGION" \
   --source "$STAGING" \
-  --command python \
-  --args run_job.py \
   --service-account "$SA_EMAIL" \
   --set-env-vars "$ENV_VAR_FLAG" \
   --task-timeout 30m \


### PR DESCRIPTION
Follow-up to #165. Actually deployed the periodic-materialization Cloud Run Job + Cloud Scheduler trigger against `test-project-0728-467323`, captured the evidence, and fixed four real-world issues the live run surfaced.

## The four bugs the live verification caught

| # | Issue | Symptom | Fix |
|---|---|---|---|
| 1 | IAM propagation race | `gcloud iam service-accounts create` returns success, `gcloud projects add-iam-policy-binding` fails with `INVALID_ARGUMENT: Service account ... does not exist` ~1s later | `_retry_iam` helper retries on the "does not exist" error class with 3s backoff, 20 attempts |
| 2 | `bq add-iam-policy-binding` needs project allowlisting | `This feature requires allowlisting` on some projects | Switched dataset-level grants to a Python heredoc using `google-cloud-bigquery`'s `AccessEntry` API. Idempotent + portable |
| 3 | Buildpacks build / runtime entrypoint mismatch | (a) `web process not found in Procfile` with `job:` only. (b) `provide a main.py or app.py file` without a Procfile. (c) `Application failed to start: container exited abnormally` (no Python output) when `--command/--args` skipped Buildpacks' venv-activation wrapper | `web: python run_job.py` Procfile (the label is a Buildpacks convention, doesn't imply HTTP) + no `--command/--args` override |
| 4 | Runtime SA missing `roles/aiplatform.user` | The MAKO demo calls `AI.GENERATE`. Without the grant: `user does not have the permission to access resources used by AI.GENERATE` and the orchestrator silently extracts empty graphs | Added project-level `roles/aiplatform.user` grant to the deploy script |

## What the verification proved

* Deploy script ran clean from `bq mk` through Cloud Scheduler creation.
* Cloud Run Job built from the vendored SDK source (`Building bigquery-agent-analytics @ file:///workspace/sdk_src`).
* Cloud Scheduler created with the correct OAuth-authenticated HTTP target pointing at the Cloud Run Job's `:run` endpoint.
* Runtime SA can read `agent_events` (READER on events dataset, verified via IAM policy inspection).
* Runtime SA can write graph tables (WRITER on graph dataset).
* Runtime SA cannot write to events dataset (zero WRITE/OWNER bindings — read-only contract holds at the IAM layer).
* Cloud Logging structured output works: `severity`, `message`, plus the full `materialization complete` JSON payload.
* Cloud Scheduler trigger fires the cron successfully: a real cron firing at `2026-05-16T06:00:00Z` produced a third state-table row with the same materialization shape — proving end-to-end without manual intervention.
* State table (`_bqaa_materialization_state`) lives in the **graph** dataset, not events. Audit log shows 3 runs: deploy-script's `--smoke` (pre-aiplatform fix), manual re-execute (post-fix, full materialization), and the cron-triggered execution.

## Known issue (out of scope — SDK follow-up)

The orchestrator reports `sessions_materialized == sessions_discovered` and `ok=true` even when every per-event `AI.GENERATE` call failed. The first state-table row from the verification proves this: AI.GENERATE failed for every session yet `ok=true, sessions_materialized=3`. `rows_materialized` is empty in that case, but the top-level `ok` doesn't reflect the silent failure.

Documented as a known issue in the README with a workaround: alert on `jsonPayload.rows_materialized == {}` in Cloud Logging as a second-line check.

## Test plan

- [x] Live deploy + Scheduler trigger against `test-project-0728-467323` end-to-end.
- [x] `--smoke` execution completes ok.
- [x] Real Cloud Scheduler cron firing succeeds (06:02 UTC firing on 2026-05-16).
- [x] IAM policies match documented contract (events READER, graph WRITER, zero events WRITE).
- [x] State-table audit log shows expected rows.
- [x] All GCP resources cleaned up after verification (job, scheduler, graph dataset).
- [x] `bash -n` syntax clean.

## Not in scope

* Terraform / Pulumi.
* SDK-side fix for the silent AI.GENERATE failure (flagged in README, not fixed here).
* Backfill mode.
* Compiled-bundle materialization path.