### PR TITLE
fix(materialize_window): empty-extraction sessions are not ok (#166 follow-up)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -397,23 +397,38 @@ ff1e956df8b8    2026-05-16 04:38:59    3 / 3 / 0                       true
 
 (Row 1 is the deploy script's `--smoke` execution, which ran
 BEFORE the verification added `roles/aiplatform.user` to the
-deploy. AI.GENERATE failed for every session there, but the
-orchestrator still reported `ok=true` with empty
-`rows_materialized` — see the known issue below.)
+deploy. AI.GENERATE failed for every session there. At the time
+of #166, the orchestrator reported `ok=true` with empty
+`rows_materialized` — the silent-failure mode that PR #167
+fixed. Today, the same situation would produce `ok=false` with
+`failures[0].error_code = "empty_extraction"`.)
 
-### Known issue surfaced by this verification
+### Failure-mode surface (post-#167)
 
-The orchestrator currently reports `sessions_materialized ==
-sessions_discovered` and `ok=true` even when every per-event
-`AI.GENERATE` call failed. The `rows_materialized` dict is
-empty in that case, but `sessions_materialized` doesn't
-reflect the underlying failure. Operators monitoring on
-`jsonPayload.ok` would miss the silent extraction failure.
+The orchestrator distinguishes two zero-row session outcomes
+that look identical from `rows_materialized` alone:
 
-Tracked for SDK follow-up — out of scope for this example PR.
-Workaround: alert on
-`jsonPayload.rows_materialized == {}` in Cloud Logging /
-Monitoring as a second-line check.
+* **`empty_extraction`** — extraction (AI.GENERATE or compiled
+  bundle) returned an empty graph; no inserts attempted.
+  Diagnose by checking the runtime SA's `roles/aiplatform.user`
+  grant, AI.GENERATE quotas, or whether the session's events
+  legitimately had any MAKO content.
+
+* **`materialization_failed`** — extraction produced rows but
+  every insert returned an error. The `failures[].error_detail`
+  names the specific tables (e.g.,
+  `DecisionExecution: rows_attempted=3, insert_status='insert_failed'`),
+  and the aggregate `table_statuses` carries the per-table
+  diagnostic at the top level of the report. Diagnose by
+  checking the SA's dataset write perm on the graph dataset,
+  schema drift the binding-validate pre-flight missed, or
+  streaming-buffer pinning.
+
+In both cases: `ok=false`, CLI exit 1, the cron run shows up
+as a failed execution in Cloud Monitoring. Alert directly on
+`jsonPayload.ok=false` plus `jsonPayload.failures[].error_code`
+for the failure-mode breakdown — no second-line
+`rows_materialized == {}` check needed.
 
 ## Not in scope here
 

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -921,6 +921,81 @@ def run_materialize_window(
             "insert_status": ts.insert_status,
             "idempotent": ts.idempotent,
         }
+      # Zero-rows guard. ``row_counts`` only includes tables
+      # whose insert SUCCEEDED (per ``ontology_materializer.py``
+      # — see the ``inserted_tables`` filter at the build site).
+      # So ``total_rows == 0`` collapses two distinct failure
+      # modes that operators must triage differently:
+      #
+      #   * **empty_extraction** — the graph itself was empty.
+      #     Extraction (AI.GENERATE or compiled bundle) returned
+      #     no rows; nothing to insert. ``table_statuses`` will
+      #     be empty or have ``rows_attempted == 0`` everywhere.
+      #     Common cause: missing ``roles/aiplatform.user`` on
+      #     the runtime SA (surfaced by #166 live deploy), or
+      #     the session's events legitimately had no MAKO
+      #     content.
+      #
+      #   * **materialization_failed** — the graph HAD rows but
+      #     every insert returned an error. ``table_statuses``
+      #     will have entries with ``rows_attempted > 0`` and
+      #     ``insert_status == "insert_failed"``. Common cause:
+      #     dataset write-perm regression, streaming-buffer
+      #     pinning that hits a delete-then-insert idempotency
+      #     boundary, or a schema mismatch the binding-validate
+      #     pre-flight didn't catch.
+      #
+      # Operators chasing the wrong failure mode is the failure
+      # mode this PR was meant to prevent. Classify here.
+      total_rows = sum(int(v) for v in (mat.row_counts or {}).values())
+      if total_rows == 0:
+        any_attempted = any(
+            int(ts.get("rows_attempted", 0)) > 0
+            for ts in table_statuses_dict.values()
+        )
+        any_insert_failed = any(
+            ts.get("insert_status") == "insert_failed"
+            for ts in table_statuses_dict.values()
+        )
+        if any_attempted and any_insert_failed:
+          error_code = "materialization_failed"
+          error_detail = (
+              "session extracted rows but every insert failed: "
+              + "; ".join(
+                  f"{name}: rows_attempted={ts.get('rows_attempted')}, "
+                  f"insert_status={ts.get('insert_status')!r}, "
+                  f"cleanup_status={ts.get('cleanup_status')!r}"
+                  for name, ts in sorted(table_statuses_dict.items())
+              )
+              + ". Common causes: dataset write-permission "
+              "regression on the runtime SA, schema mismatch the "
+              "binding-validate pre-flight didn't catch, or "
+              "streaming-buffer pinning blocking a delete-then-"
+              "insert cycle."
+          )
+        else:
+          error_code = "empty_extraction"
+          error_detail = (
+              "session materialized zero rows across every entity "
+              "table and no inserts were attempted; usually means "
+              "extraction (AI.GENERATE or compiled bundle) returned "
+              "an empty graph. Common causes: missing "
+              "roles/aiplatform.user on the runtime SA, transient "
+              "AI.GENERATE rate limit, or the session's events did "
+              "not contain any extractable ontology content."
+          )
+        session_results.append(
+            SessionResult(
+                session_id=session.session_id,
+                ok=False,
+                completion_timestamp=session.completion_timestamp,
+                rows_materialized=dict(mat.row_counts),
+                table_statuses=table_statuses_dict,
+                error_code=error_code,
+                error_detail=error_detail,
+            )
+        )
+        break
       session_results.append(
           SessionResult(
               session_id=session.session_id,
@@ -1266,18 +1341,30 @@ def _build_result(
   # clean ``deleted``. Operators rely on the report as the
   # "did anything go wrong" signal — any delete failure must
   # bubble up.
+  # Aggregate ``table_statuses`` from EVERY session — including
+  # failed ones. The status surface ("did the delete succeed?
+  # did the insert succeed?") is operator-visible regardless of
+  # session-level success. Dropping failed sessions' statuses
+  # was the gap #167's reviewer flagged: when a session fails
+  # with ``materialization_failed``, the per-table diagnostic
+  # (rows_attempted=N, insert_status=insert_failed) belongs in
+  # the report so operators don't have to dig into log payloads
+  # to see which table broke.
+  #
+  # ``rows_materialized`` still aggregates only successful
+  # sessions — that's the "rows that actually landed" view.
   table_statuses_agg: dict[str, dict[str, Any]] = {}
   for r in session_results:
     if r.ok:
       for table, n in r.rows_materialized.items():
         rows_materialized[table] = rows_materialized.get(table, 0) + n
-      for table, ts in r.table_statuses.items():
-        if table in table_statuses_agg:
-          table_statuses_agg[table] = _merge_table_status(
-              table_statuses_agg[table], ts
-          )
-        else:
-          table_statuses_agg[table] = dict(ts)
+    for table, ts in r.table_statuses.items():
+      if table in table_statuses_agg:
+        table_statuses_agg[table] = _merge_table_status(
+            table_statuses_agg[table], ts
+        )
+      else:
+        table_statuses_agg[table] = dict(ts)
 
   failures = [
       {

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -1897,3 +1897,307 @@ class TestCompletionEventTypeWhitespaceRejected:
           bq_client=client,
           run_started_at=now,
       )
+
+
+# ------------------------------------------------------------------ #
+# Round-7 regressions                                                  #
+# ------------------------------------------------------------------ #
+
+
+def _fake_mat_result(row_counts: dict[str, int]) -> mock.Mock:
+  """Build a fake ``materialize_with_status`` return value with
+  the given row_counts. Per-table statuses are auto-derived
+  to match (clean ``deleted``/``inserted``, idempotent)."""
+  result = mock.Mock()
+  result.row_counts = dict(row_counts)
+  result.table_statuses = {}
+  for table, n in row_counts.items():
+    ts = mock.Mock()
+    ts.table_ref = f"p.d.{table}"
+    ts.rows_attempted = n
+    ts.rows_inserted = n
+    ts.cleanup_status = "deleted"
+    ts.insert_status = "inserted"
+    ts.idempotent = True
+    result.table_statuses[table] = ts
+  return result
+
+
+class TestEmptyExtractionNotOk:
+  """Round-7 contract: a session that completes without raising
+  but produces zero rows across every entity table is NOT a
+  success. The live deploy in PR #166 surfaced the silent
+  failure mode — ``AI.GENERATE`` failed per-event, the SDK
+  swallowed the error, the graph was empty, and the orchestrator
+  reported ``ok=true`` with empty ``rows_materialized``. The fix:
+  treat zero-row extraction as a session failure with
+  ``error_code="empty_extraction"`` and exit non-zero."""
+
+  def test_all_sessions_zero_rows_reports_not_ok(self, fixture_paths):
+    """All discovered sessions extract to empty graphs (e.g.,
+    AI.GENERATE permission missing on the runtime SA). Expected:
+    ``ok=false``, the first session reported as ``empty_extraction``
+    failure, loop breaks (no waste of BQ quota on the rest)."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 16, 12, 0, tzinfo=_dt.timezone.utc)
+    discovered = [
+        _FakeBQRow(
+            session_id="s1",
+            completion_timestamp=_dt.datetime(
+                2026, 5, 16, 11, 0, tzinfo=_dt.timezone.utc
+            ),
+        ),
+        _FakeBQRow(
+            session_id="s2",
+            completion_timestamp=_dt.datetime(
+                2026, 5, 16, 11, 30, tzinfo=_dt.timezone.utc
+            ),
+        ),
+    ]
+    client = _stub_bq_client(discovered)
+
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(return_value=mock.Mock())
+
+    fake_materializer_cls = mock.Mock()
+    fake_materializer = fake_materializer_cls.return_value
+    fake_materializer.materialize_with_status = mock.Mock(
+        return_value=_fake_mat_result({})  # zero rows, no tables
+    )
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert not result.ok, (
+        "empty extraction across every session must surface as "
+        "result.ok=False"
+    )
+    assert result.sessions_discovered == 2
+    assert result.sessions_materialized == 0
+    assert result.sessions_failed == 1, (
+        "loop should break on first empty session — second session "
+        "not processed; reported failures count = 1"
+    )
+    assert result.failures, "failures list must include the empty session"
+    assert result.failures[0]["error_code"] == "empty_extraction"
+    assert "extraction" in result.failures[0]["error_detail"].lower()
+
+  def test_partial_extraction_partial_failure_conservative_checkpoint(
+      self, fixture_paths
+  ):
+    """Session 1 extracts non-empty rows; session 2 returns
+    zero rows. Expected: partial-failure shape — ``ok=false``,
+    session 1 counted as materialized, session 2 in failures
+    with ``empty_extraction``, loop breaks at session 2,
+    checkpoint advances ONLY to session 1's completion
+    timestamp."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 16, 12, 0, tzinfo=_dt.timezone.utc)
+    ts1 = _dt.datetime(2026, 5, 16, 11, 0, tzinfo=_dt.timezone.utc)
+    ts2 = _dt.datetime(2026, 5, 16, 11, 30, tzinfo=_dt.timezone.utc)
+    ts3 = _dt.datetime(2026, 5, 16, 11, 45, tzinfo=_dt.timezone.utc)
+    discovered = [
+        _FakeBQRow(session_id="s1", completion_timestamp=ts1),
+        _FakeBQRow(session_id="s2", completion_timestamp=ts2),
+        _FakeBQRow(session_id="s3", completion_timestamp=ts3),
+    ]
+    client = _stub_bq_client(discovered)
+
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(return_value=mock.Mock())
+
+    fake_materializer_cls = mock.Mock()
+    fake_materializer = fake_materializer_cls.return_value
+    # Session 1: real rows. Session 2: empty extraction. Session
+    # 3: would also have real rows but the loop should break
+    # before reaching it.
+    fake_materializer.materialize_with_status = mock.Mock(
+        side_effect=[
+            _fake_mat_result({"DecisionExecution": 1, "Candidate": 3}),
+            _fake_mat_result({}),
+            _fake_mat_result({"DecisionExecution": 1}),
+        ]
+    )
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert not result.ok
+    assert result.sessions_discovered == 3
+    assert result.sessions_materialized == 1, "only s1 succeeded"
+    assert result.sessions_failed == 1, "s2 failed; s3 never tried"
+    assert result.failures[0]["session_id"] == "s2"
+    assert result.failures[0]["error_code"] == "empty_extraction"
+    # Conservative checkpoint: stop at s1's timestamp, NOT s2's
+    # or s3's. Next run re-tries s2 (idempotent).
+    assert result.checkpoint_written == ts1
+    # Materialize was attempted exactly twice (s1 + s2), never
+    # for s3 — the break-on-failure semantics save BQ quota.
+    assert fake_materializer.materialize_with_status.call_count == 2
+
+  def test_insert_failure_classified_as_materialization_failed(
+      self, fixture_paths
+  ):
+    """The materializer can produce zero rows in
+    ``row_counts`` for two distinct reasons: extraction
+    returned an empty graph (``empty_extraction``) OR
+    extraction produced rows but every insert failed
+    (``materialization_failed``). The two failure modes need
+    different operator response (AI/IAM vs dataset write-perm /
+    schema) — classify them via ``table_statuses``.
+
+    Insert-failure shape: ``rows_attempted > 0`` on some
+    table, ``insert_status == "insert_failed"``, but
+    ``row_counts == {}`` because only successful inserts
+    populate row_counts (see
+    ``ontology_materializer.py``)."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 16, 12, 0, tzinfo=_dt.timezone.utc)
+    discovered = [
+        _FakeBQRow(
+            session_id="s1",
+            completion_timestamp=_dt.datetime(
+                2026, 5, 16, 11, 0, tzinfo=_dt.timezone.utc
+            ),
+        ),
+    ]
+    client = _stub_bq_client(discovered)
+
+    # Hand-build a ``materialize_with_status`` return value
+    # that mimics insert-failure: row_counts empty,
+    # table_statuses show real attempts that all failed.
+    fake_mat = mock.Mock()
+    fake_mat.row_counts = {}  # nothing succeeded → empty
+    fake_mat.table_statuses = {}
+    for table, n_attempted in (("DecisionExecution", 3), ("Candidate", 7)):
+      ts = mock.Mock()
+      ts.table_ref = f"p.d.{table}"
+      ts.rows_attempted = n_attempted
+      ts.rows_inserted = 0
+      ts.cleanup_status = "deleted"
+      ts.insert_status = "insert_failed"
+      ts.idempotent = False
+      fake_mat.table_statuses[table] = ts
+
+    fake_manager = mock.Mock()
+    fake_manager.spec = mock.Mock()
+    fake_manager.extract_graph = mock.Mock(return_value=mock.Mock())
+
+    fake_materializer_cls = mock.Mock()
+    fake_materializer = fake_materializer_cls.return_value
+    fake_materializer.materialize_with_status = mock.Mock(return_value=fake_mat)
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=fake_manager),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+            fake_materializer_cls,
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert not result.ok
+    assert result.failures[0]["error_code"] == "materialization_failed", (
+        f"insert-failed sessions must be classified as "
+        f"materialization_failed, not empty_extraction; got "
+        f"{result.failures[0]['error_code']}"
+    )
+    # The failure detail must name the specific tables that
+    # failed, so operators don't have to dig through log
+    # payloads.
+    detail = result.failures[0]["error_detail"]
+    assert "DecisionExecution" in detail
+    assert "Candidate" in detail
+    assert "insert_failed" in detail
+    # Crucial: failed-session table_statuses must surface in
+    # the aggregate report. Without this, an operator seeing
+    # ``ok=false`` would have no per-table diagnostic at the
+    # top level.
+    assert "DecisionExecution" in result.table_statuses, (
+        f"failed session's table_statuses must appear in the "
+        f"aggregate report; got {sorted(result.table_statuses)}"
+    )
+    assert (
+        result.table_statuses["DecisionExecution"]["insert_status"]
+        == "insert_failed"
+    )
+    assert result.table_statuses["DecisionExecution"]["rows_attempted"] == 3
+
+  def test_empty_window_remains_ok(self, fixture_paths):
+    """``sessions_discovered == 0`` (no terminal events in the
+    scan window) is a legitimate empty-window heartbeat. The
+    empty-extraction guard MUST NOT flip this to ok=false —
+    the new check is per-session and skipped when no sessions
+    were discovered. The orchestrator's existing "empty
+    session_results → ok=true" clause keeps holding."""
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 16, 12, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+      )
+
+    assert result.ok, (
+        "empty window (zero sessions discovered) must remain "
+        "ok=true — the empty-extraction guard is per-session and "
+        "should not fire when no sessions were processed"
+    )
+    assert result.sessions_discovered == 0
+    assert result.sessions_materialized == 0
+    assert result.sessions_failed == 0
+    assert result.failures == []


### PR DESCRIPTION
Closes the silent-failure mode #166's live deploy surfaced. When `AI.GENERATE` failed per-event (e.g., runtime SA missing `roles/aiplatform.user`), the SDK swallowed the error and returned an empty graph for every session. The orchestrator then reported `sessions_materialized == sessions_discovered`, `ok=true`, and an EMPTY `rows_materialized` dict. Operators monitoring on `jsonPayload.ok` saw "all good" while the entity tables stayed empty.

## The fix

After `materialize_with_status` succeeds, check the total rows materialized. If zero, classify the failure mode via `table_statuses` and break the loop (same shape as an exception — advance checkpoint only to the prior successful session):

* **`empty_extraction`** — `table_statuses` empty or all `rows_attempted == 0`. Extraction (AI.GENERATE or compiled bundle) returned an empty graph; nothing was inserted. Operator action: check `roles/aiplatform.user`, AI.GENERATE quotas, or whether the session's events legitimately have any MAKO content.

* **`materialization_failed`** — any `rows_attempted > 0` with `insert_status == "insert_failed"`. Extraction produced rows but every insert returned an error. `error_detail` names the specific tables (e.g., `DecisionExecution: rows_attempted=3, insert_status='insert_failed', cleanup_status='deleted'`). Operator action: dataset write-perm regression on the runtime SA, schema drift the binding-validate pre-flight missed, or streaming-buffer pinning.

Operators chasing the wrong failure mode (AI vs schema) is exactly what the classifier prevents.

## Failed-session table_statuses now surface in the aggregate report

`_build_result` previously aggregated `table_statuses` only from `r.ok` sessions. A `materialization_failed` session's per-table diagnostic was getting dropped from `result.table_statuses` and was only visible buried in `error_detail`. Fixed: aggregate `table_statuses` from EVERY session (the status surface is operator-visible regardless of session success). `rows_materialized` still aggregates only `r.ok` sessions — correct semantics for "rows that actually landed".

## What does NOT change

The empty-window heartbeat path (`sessions_discovered == 0`) is untouched. The empty-extraction guard is per-session and doesn't fire when no sessions were processed. A cron firing into an idle window still reports `ok=true`.

## Test cases (4 total)

| Test | Scenario | Expected |
|---|---|---|
| `test_all_sessions_zero_rows_reports_not_ok` | Every discovered session extracts to empty (e.g., AI permission missing). `row_counts={}`, `table_statuses={}` | `ok=false`, first session reported as `empty_extraction`, loop breaks (sessions_failed=1, not N — no waste of BQ quota), error_code matches |
| `test_partial_extraction_partial_failure_conservative_checkpoint` | Session 1 extracts rows, session 2 empty, session 3 never reached | `ok=false`, `sessions_materialized=1`, `sessions_failed=1`, checkpoint advances ONLY to session 1's timestamp, materializer called exactly twice |
| `test_insert_failure_classified_as_materialization_failed` | Empty `row_counts` but `table_statuses` shows `rows_attempted=3, insert_status='insert_failed'` (insert-failure shape) | `error_code="materialization_failed"` (NOT empty_extraction). `error_detail` names DecisionExecution + Candidate + `insert_failed`. Failed session's `table_statuses` appear in `result.table_statuses` at the top level |
| `test_empty_window_remains_ok` | `sessions_discovered == 0` (idle window) | `ok=true`, `failures == []` — the per-session guard does NOT flip the heartbeat case |

## #166 README cleanup

The "Known issue surfaced by this verification" section in `periodic_materialization/README.md` documented the now-fixed silent-failure mode and recommended a `rows_materialized == {}` workaround. Replaced with a "Failure-mode surface (post-#167)" section that documents both `error_code` values, what each means, and what operator action to take. The primary signal is now `jsonPayload.ok=false` plus `jsonPayload.failures[].error_code` — no second-line check needed.

## Verification

* `pytest tests/test_materialize_window.py` — **72/72 pass** (68 prior + 4 new).
* Full focused suite — **2931 pass**, 15 skipped (15th being the existing live-deploy test from #164, unchanged).
* `pyink --check` + `isort --check-only` clean.
* No existing test broke.

## Operator-visible change

**Before:** `jsonPayload.ok = true` even when every AI.GENERATE call failed silently OR every insert failed. Operators had to alert on `rows_materialized == {}` as a second-line check, and couldn't tell whether the failure was AI/IAM or schema/write-perm without digging into log payloads.

**After:**

* `jsonPayload.ok = false` is the unmistakable red signal.
* `jsonPayload.failures[].error_code` is either `empty_extraction` or `materialization_failed` — direct operator-actionable classification.
* `jsonPayload.failures[].error_detail` names the specific failing tables for the materialization-failed case.
* `jsonPayload.table_statuses[<table>]` carries the per-table diagnostic at the top level even for failed sessions.
* CLI exits 1.

## Out of scope (per reviewer)

* `--check-deploy-inputs` doctor command — separate later PR.
* v5 demo README flow + customer deployment checklist — next PR per reviewer's sequencing.
* Configuration knob to disable the guard for use cases where empty extraction is expected — hold until a real customer asks.

## Test plan

- [x] All 4 new test cases pass.
- [x] All 68 prior `test_materialize_window.py` tests still pass.
- [x] Full focused suite 2931 pass, 15 skipped.
- [x] `pyink --check` + `isort --check-only` clean.
- [x] #166 README updated to reflect the new contract.