### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-18
+
+### Release highlights
+
+Focused follow-up to 0.3.0 that publishes the periodic-materialization
+production path. The `bqaa-materialize-window` CLI merged after the
+0.3.0 cut, so customers `pip install`-ing the SDK couldn't run the
+cron path the migration v5 playbook documents. 0.3.1 closes that gap
+and ships the surrounding deployment artifacts and a behavior fix:
+
+- **`bqaa-materialize-window` CLI on PyPI** ([#162](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/162))
+  — cron-friendly scheduled-graph-refresh command, available as a
+  standalone console script and as a `bq-agent-sdk materialize-window`
+  subcommand.
+- **Empty-extraction silent-failure mode closed** ([#167](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/167))
+  — `ok=true` is now an honest signal; per-session extraction
+  failures classify as `empty_extraction` vs `materialization_failed`
+  and flip `ok=false`. **Operator-visible behavior change** (see
+  Fixed).
+- **Cloud Run Job + Cloud Scheduler example** ([#165](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/165),
+  [#166](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/166))
+  — packaged deployment template under
+  `examples/migration_v5/periodic_materialization/` with
+  one-command deploy + `--smoke` end-to-end verification.
+- **Customer playbook** ([#168](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/168))
+  — the production cron path documented end-to-end: required
+  APIs/IAM, recommended schedules, JSON log shape, Cloud Monitoring
+  alerts, state-table inspection, teardown, troubleshooting.
+
 ### Added
+
+- **`bqaa-materialize-window` console script** (PR
+  [#162](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/162)).
+  New cron-friendly entry point for keeping the materialized graph
+  fresh on a schedule. Shipped as a standalone console script
+  (`bqaa-materialize-window`) and as a `bq-agent-sdk
+  materialize-window` subcommand; both call paths share
+  `src/bigquery_agent_analytics/materialize_window.py`. Terminal-
+  event-driven discovery (`event_type = @completion_event_type`,
+  partition-pruned), pinned `run_started_at` snapshot, append-only
+  state table keyed on a content-derived `state_key` (project +
+  dataset + graph + events_table + ontology fingerprint + binding
+  fingerprint + discovery mode), overlap-windowed re-scan for
+  late-arriving events, per-session loop with idempotent retries
+  and checkpoint advance only on success, worst-status-wins
+  per-table aggregation, structured JSON report with C2 compiled-
+  extractor outcome counters (`compiled_unchanged` /
+  `compiled_filtered` / `fallback_for_event`), binding-validate
+  pre-flight, checkpoint that never regresses across overlap
+  re-scans, numeric/identifier guardrails at the boundary. Exit
+  codes: `0` clean, `1` expected failure (session error or
+  binding drift), `2` unexpected internal error.
+
+- **Migration v5 Cloud Run Job + Cloud Scheduler example** in
+  [`examples/migration_v5/periodic_materialization/`](examples/migration_v5/periodic_materialization/)
+  (PRs
+  [#165](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/165),
+  [#166](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/166)).
+  Packaged Cloud Run Job + Cloud Scheduler deployment that wraps
+  `bqaa-materialize-window` for the migration v5 binding. One-
+  command `deploy_cloud_run_job.sh` creates a runtime service
+  account with narrow IAM (`dataViewer` on the events dataset,
+  `dataEditor` on the graph dataset, `bigquery.jobUser` +
+  `aiplatform.user` at the project, `run.invoker` on the job for
+  the scheduler SA), deploys the job, wires the Cloud Scheduler
+  trigger, and optionally runs `--smoke` to verify end-to-end in
+  one shot. IAM matrix, dataset-role contract (events read-only,
+  graph read/write), and live-deploy evidence captured against the
+  canonical test project.
 
 - **Migration v5 periodic materialization playbook** in
   [`examples/migration_v5/periodic_materialization/README.md`](examples/migration_v5/periodic_materialization/README.md)
@@ -19,6 +87,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Cloud Monitoring alerts, state-table inspection, teardown, and
   troubleshooting. Complements the migration v5 four-guarantee
   notebook by covering the production cron path.
+
+### Fixed
+
+- **`materialize-window` no longer reports `ok=true` on silent
+  extraction failures** (PR
+  [#167](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/167)).
+  Previously, when per-event extraction returned an empty graph
+  (e.g., runtime SA missing `roles/aiplatform.user` so every
+  `AI.GENERATE` call failed and was swallowed), the orchestrator
+  reported `sessions_materialized == sessions_discovered`,
+  `ok=true`, and an empty `rows_materialized` dict. Operators
+  alerting on `jsonPayload.ok` saw "all good" while the entity
+  tables stayed empty. Now, after `materialize_with_status`
+  succeeds, the orchestrator inspects the materialized rows and
+  per-table statuses; sessions producing zero materialized rows
+  break the loop and classify the failure as
+  `empty_extraction` (extraction returned empty — check AI/IAM)
+  or `materialization_failed` (extraction produced rows but every
+  insert failed — check write perms / schema). `ok=false` is the
+  unmistakable red signal, and `failures[].error_code`
+  distinguishes the failure mode without log digging. Per-table
+  statuses now also surface in `result.table_statuses` for
+  failed sessions (previously only `ok` sessions contributed).
+  **Operator-visible behavior change**: alerts on
+  `jsonPayload.ok=false` are sufficient; no second-line
+  `rows_materialized == {}` check needed. The empty-window
+  heartbeat path (`sessions_discovered == 0`) is unchanged — an
+  idle cron firing still reports `ok=true`.
 
 ## [0.3.0] - 2026-05-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigquery-agent-analytics"
-version = "0.3.0"
+version = "0.3.1"
 description = "SDK for analyzing and evaluating agent traces stored in BigQuery."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR for **0.3.1** — focused follow-up to 0.3.0 that publishes the periodic-materialization production path.

## Why 0.3.1 (patch) and not 0.4.0 (minor)

0.3.0 cut on 2026-05-15 (#163). Between that cut and now, six PRs landed on `main`:

| PR | Type | Customer-visible? |
|---|---|---|
| [#162](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/162) | new CLI (`bqaa-materialize-window`) | yes — new console script, not on PyPI yet |
| [#164](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/164) | tests (live BQ idempotency proof) | no |
| [#165](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/165) | examples (Cloud Run Job + Scheduler) | yes — example directory |
| [#166](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/166) | examples (live deploy + IAM fixes) | yes — example directory |
| [#167](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/167) | fix (`materialize_window` empty-extraction) | yes — behavior change |
| [#168](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/168), [#170](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/170) | docs (customer playbook + release-notes index) | yes — playbook |

A strict semver read would call #162 a minor bump (new public API surface). Going with **patch** instead because:

1. The `bqaa-materialize-window` CLI was originally meant to ship in 0.3.0 — it merged the same week and missed the cut by branch timing, not by design. The Unreleased block has been waiting for a 0.3.x cleanup.
2. Everything else in scope is either a bug fix (#167), examples (#165, #166), or docs (#168, #170).
3. There are no breaking changes, no new SDK Python APIs beyond the CLI surface.

If a maintainer would rather cut this as 0.4.0, the diff swap is two characters in `pyproject.toml` and the section header in `CHANGELOG.md`.

## What this PR does

- Bumps `pyproject.toml` version from `0.3.0` to `0.3.1`.
- Renames the existing `## [Unreleased]` section to `## [0.3.1] - 2026-05-18` in `CHANGELOG.md`.
- Adds a **Release highlights** summary scoped to the periodic-materialization production path.
- Adds `### Added` entries for `bqaa-materialize-window` (#162) and the Cloud Run Job + Cloud Scheduler example (#165, #166) — both shipped post-0.3.0 but were never release-noted.
- Adds a `### Fixed` entry for #167 with the **operator-visible behavior change** called out (alerts on `jsonPayload.ok=false` are now sufficient; no `rows_materialized == {}` second-line check needed).
- Keeps the existing playbook entry for #168.
- Re-opens an empty `## [Unreleased]` section above 0.3.1 for post-release work.

No code changes. All entries point to PRs already merged on `main`.

## Verification

- `pyproject.toml` parses: `python3 -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])"` → `0.3.1`.
- `CHANGELOG.md` headers are monotonic + well-formed: `[Unreleased]` → `[0.3.1] - 2026-05-18` → `[0.3.0] - 2026-05-15` → `[0.2.3] - 2026-04-27` → `[0.2.2] - 2026-04-24` → `[0.2.1]`.
- Diff is exactly two files (+97 / -1 lines), no other modifications.

## Post-merge

Once this lands on `main`:

1. Tag `v0.3.1` on the merge commit.
2. Trigger the PyPI publish flow (whichever release pipeline the repo uses — confirm with a maintainer before tagging).
3. Verify `bqaa-materialize-window --help` works after a clean `pip install bigquery-agent-analytics==0.3.1` on a fresh venv.

## Test plan

- [x] `pyproject.toml` parses; version is `0.3.1`.
- [x] `CHANGELOG.md` headers are well-formed, monotonic, and dated.
- [x] Empty `[Unreleased]` placeholder re-opened above 0.3.1.
- [x] No code changes — only `pyproject.toml` and `CHANGELOG.md` touched.
- [ ] CI green on this PR.
- [ ] Post-merge: `pip install bigquery-agent-analytics==0.3.1` → `bqaa-materialize-window --help` renders.