### PR TITLE
refactor(migration_v5): extract ontology-agnostic artifact pipeline

### DIFF
--- a/examples/migration_v5/README.md
+++ b/examples/migration_v5/README.md
@@ -1,25 +1,53 @@
-# Migration v5 Demo — Fixture Foundation
+# Migration v5 Demo — Ontology-Driven Artifact Pipeline
 
-**Status:** The four-guarantee MAKO notebook (`examples/migration_v5_demo_notebook.ipynb`) is live end-to-end against `test-project-0728-467323`. PR [#155](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/155) shipped the fixture foundation; PR [#157](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/157) added `reference_extractor.py`; PR [#160](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/160) wired Beat 3 (compile + cache + runtime + savings) and Beat 4.4 (hub-shape non-zero) live.
+**Status:** The four-guarantee notebook (`examples/migration_v5_demo_notebook.ipynb`) is live end-to-end against `test-project-0728-467323` using the MAKO ontology as the canonical reference example. PR [#155](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/155) shipped the fixture foundation; PR [#157](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/157) added `reference_extractor.py`; PR [#160](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/160) wired Beat 3 + Beat 4.4 live.
 
-The demo's event source of truth is **a runnable agent talking to the BQ AA plugin**, not a hand-coded event generator. This directory's authored inputs are split accordingly.
+The demo's event source of truth is **a runnable agent talking to the BQ AA plugin**, not a hand-coded event generator. The artifact pipeline that turns a TTL into binding + DDL + property-graph SQL is **ontology-agnostic** — see `ontology_artifacts.py` — and the MAKO config (in `mako_artifacts.py`) is one concrete configuration of it.
+
+## Pluggable contract
+
+The pipeline takes a single :class:`ontology_artifacts.OntologyConfig` plus a target `(project, dataset)` and produces four files:
+
+| Generated file | What it is |
+|---|---|
+| `ontology.yaml` | `import-owl` output with `FILL_IN` PKs resolved, cross-namespace dangling relationships dropped, inheritance stripped. |
+| `binding.yaml` | Maps the configured entity allowlist onto BigQuery tables for the target `(project, dataset)`. Heterogeneous edges only; self-edges and out-of-scope relationships filtered. |
+| `table_ddl.sql` | `CREATE TABLE` SQL for every node + edge table, with SDK metadata columns (`session_id STRING, extracted_at TIMESTAMP`) on every bound table. |
+| `property_graph.sql` | `CREATE OR REPLACE PROPERTY GRAPH` over those tables. Node `KEY` + edge `SOURCE KEY ... REFERENCES` use the per-entity PK columns. |
+
+The pipeline applies three OWL-TTL normalizations generic enough to apply to any reasonable ontology:
+
+1. **`FILL_IN` PKs → `id: string`.** The OWL importer marks entities without `owl:hasKey` declarations as `FILL_IN`; the resolver synthesizes a stable `id` property. Entities that already declare `owl:hasKey` are left untouched.
+2. **Cross-namespace dangling relationships dropped.** TTLs that extend upstream ontologies (PROV-O, PKO, DCAT, …) often reference upstream entities the importer didn't pull; the pipeline drops these and records them under a `{annotation_prefix}:dropped_cross_namespace_relationships` audit annotation.
+3. **Inheritance stripped.** `gm compile` v0 doesn't support `extends:` clauses; the pipeline drops them and records the loss under `{annotation_prefix}:stripped_inheritance`.
+
+## Example ontologies in this directory
+
+This demo ships **two** ontology configs. The MAKO config is the load-bearing reference example (real production ontology, full agent, runnable demo); the Simple Request Flow config is a smoke fixture that proves the pipeline is genuinely ontology-agnostic.
+
+| Config | TTL | Where | Surface |
+|---|---|---|---|
+| `MAKO_CONFIG` | `mako_core.ttl` (Yahoo Monetization decision ontology, 18 namespace entities) | `mako_artifacts.py` | Full demo: notebook, `mako_demo_agent.py` (5 decision-flow tools), `reference_extractor.py`, periodic materialization deploy. |
+| `SIMPLE_REQUEST_FLOW_CONFIG` | `example_ontologies/simple_request_flow.ttl` (3-entity Request → Action → Outcome flow) | `example_ontologies/simple_request_flow_config.py` | Smoke fixture only. Exercised by `tests/test_migration_v5_ontology_artifacts.py`. No runnable agent ships with it. |
+
+A new ontology plugs in the same way: write a TTL, define an `OntologyConfig` naming it, call `regenerate_snapshots(your_config, project=..., dataset=...)`.
 
 ## Authorship boundary
 
 | File | Authored? | What it does |
 |------|-----------|--------------|
+| `ontology_artifacts.py` | **Authored.** | Generic ontology-agnostic pipeline: `OntologyConfig` dataclass + `load_ontology`, `make_binding`, `make_table_ddl`, `make_property_graph_sql`, `regenerate_snapshots`. **Does not generate events.** |
 | `mako_core.ttl` | **Authored.** | The real MAKO ontology, pulled from the [reference gist](https://gist.github.com/haiyuan-eng-google/a69ff6282ebcc877f77f9aa4e3db1afd). Domain-agnostic decision semantics for Yahoo Monetization Platform. |
-| `mako_artifacts.py` | **Authored.** | Pure-Python pipeline: imports the TTL → resolves `FILL_IN` primary keys → drops dangling cross-namespace relationships → strips inheritance → generates ontology / binding / table DDL / property-graph SQL for any `(project, dataset)`. **Does not generate events.** |
-| `mako_demo_agent.py` | **Authored.** | Runnable ADK agent + `BigQueryAgentAnalyticsPlugin` wiring. Defines five MAKO decision-flow tools (`capture_context`, `propose_decision_point`, `evaluate_candidate`, `commit_outcome`, `complete_execution`) and a system prompt that walks the agent through them. Real plugin traces land in `agent_events` when the agent runs. |
-| `run_agent.py` | **Authored.** | Driver. `python run_agent.py --sessions 50 --project X --dataset Y` runs the agent for N sessions and lets the plugin populate `agent_events`. |
+| `mako_artifacts.py` | **Authored.** | MAKO-specific config: `MAKO_CONFIG` + thin back-compat wrappers around the generic pipeline. The notebook imports from this module. |
+| `mako_demo_agent.py` | **Authored.** | Runnable ADK agent + `BigQueryAgentAnalyticsPlugin` wiring. Defines five MAKO decision-flow tools (`capture_context`, `propose_decision_point`, `evaluate_candidate`, `commit_outcome`, `complete_execution`) and a system prompt that walks the agent through them. Real plugin traces land in `agent_events` when the agent runs. MAKO-specific by design — the agent's tools mirror MAKO's decision flow. |
+| `run_agent.py` | **Authored.** | Driver. `python run_agent.py --sessions 50 --project X --dataset Y` runs the MAKO agent for N sessions and lets the plugin populate `agent_events`. |
 | `export_events_jsonl.py` | **Authored.** | Optional. Exports a pinned subset of `agent_events` to a local JSONL file for the notebook's deterministic offline revalidation tests. Not an event generator — it reads from BigQuery. |
-| `ontology.yaml` | **Generated** by `mako_artifacts.regenerate_snapshots()`. | TTL-import output with `FILL_IN`s resolved, dangling cross-namespace relationships dropped, inheritance stripped. |
-| `binding.yaml` | **Generated.** | Derived from the ontology + `(project, dataset)`. 6 entities + 7 heterogeneous relationships. |
-| `table_ddl.sql` | **Generated.** | Companion to the binding. Carries SDK metadata columns (`session_id STRING, extracted_at TIMESTAMP`) on every node and edge table. |
-| `property_graph.sql` | **Generated.** | `CREATE OR REPLACE PROPERTY GRAPH` over the same tables. Node KEY + edge `REFERENCES` use the per-entity PK columns. |
+| `example_ontologies/simple_request_flow.ttl` | **Authored.** | Pluggability smoke fixture (3 entities, 2 relationships, no cross-namespace imports). |
+| `example_ontologies/simple_request_flow_config.py` | **Authored.** | `SIMPLE_REQUEST_FLOW_CONFIG` — second `OntologyConfig` that plugs into the same generic pipeline. |
+| `ontology.yaml` / `binding.yaml` / `table_ddl.sql` / `property_graph.sql` | **Generated** for MAKO by `mako_artifacts.regenerate_snapshots()`. Checked in so reviewers can read them as-is. | TTL-derived artifacts for `(test-project-0728-467323, migration_v5_demo)`. The notebook regenerates against a fresh `migration_v5_demo_<8-hex>` dataset at runtime. |
 | `events.jsonl` | **Captured.** | Optional offline snapshot exported via `export_events_jsonl.py`. Not checked in; populated on demand. |
 
-Checked-in `binding.yaml` / `table_ddl.sql` / `property_graph.sql` target the default `(test-project-0728-467323, migration_v5_demo)` pair so reviewers can read them as-is. The notebook regenerates against a fresh `migration_v5_demo_<8-hex>` dataset at runtime.
+The Simple Request Flow config's snapshots are **not checked in** — they're regenerated to a tmpdir by the pluggability test. The TTL + config are the only files under `example_ontologies/`.
 
 ## Demo flow (what the notebook does)
 
@@ -27,7 +55,8 @@ Checked-in `binding.yaml` / `table_ddl.sql` / `property_graph.sql` target the de
 mako_core.ttl                                                    ┐
        │                                                         │
        ▼                                                         │ Beat 0 — setup
-mako_artifacts.regenerate_snapshots(project, dataset)            │
+ontology_artifacts.regenerate_snapshots(MAKO_CONFIG, ...)        │
+   (called via mako_artifacts.regenerate_snapshots)              │
        │                                                         │
        ├── ontology.yaml                                         │
        ├── binding.yaml                                          │
@@ -41,32 +70,34 @@ run_agent.py --sessions N    ────► ADK runner + BQ AA plugin     ┐ B
                                    agent_events table             ┘
 
 ontology-build --skip-property-graph    ────► populates the      ┐
-binding-validate                              MAKO node + edge   │ Beats 1–4
+binding-validate                              node + edge        │ Beats 1–4
 ontology-build (extracts the graph)           tables             │ consume
 OntologyRuntime + LabelSynonymResolver                           ┘
 ```
 
 Beat 3's compile / runtime / savings cells run live, using `reference_extractor.extract_mako_decision_event` as the runtime fallback under a focused compiled bundle that handles the `complete_execution` event type.
 
-## Design decisions
+## Reference example: MAKO design decisions
+
+The decisions below are documented in MAKO terms because MAKO is the load-bearing reference example, but the underlying pipeline behavior is general. Section numbers map to the transformations the generic pipeline applies (see "Pluggable contract" above).
 
 ### 1. MAKO `DecisionExecution` is the central hub
 
-The demo entity allowlist (`DEMO_ENTITIES` in `mako_artifacts.py`) is six entities: `AgentSession`, `DecisionExecution`, `DecisionPoint`, `Candidate`, `SelectionOutcome`, `ContextSnapshot`. `DecisionExecution` is non-obvious but load-bearing — per MAKO's TTL, it's the entity that's `partOfSession` an `AgentSession`, `atContextSnapshot` a `ContextSnapshot`, `executedAtDecisionPoint` a `DecisionPoint`, `hasSelectionOutcome` a `SelectionOutcome`. The decision-flow story doesn't hold together without it.
+The MAKO demo entity allowlist (`DEMO_ENTITIES` in `mako_artifacts.py`) is six entities: `AgentSession`, `DecisionExecution`, `DecisionPoint`, `Candidate`, `SelectionOutcome`, `ContextSnapshot`. `DecisionExecution` is non-obvious but load-bearing — per MAKO's TTL, it's the entity that's `partOfSession` an `AgentSession`, `atContextSnapshot` a `ContextSnapshot`, `executedAtDecisionPoint` a `DecisionPoint`, `hasSelectionOutcome` a `SelectionOutcome`. The decision-flow story doesn't hold together without it.
 
-The edge set is **TTL-driven with two filters**: `make_binding` walks `ontology.relationships` and picks every relationship whose endpoints both fall within `DEMO_ENTITIES` *and* which is not a self-edge. The current binding has **seven** real MAKO relationships (`atContextSnapshot`, `evaluatesCandidate`, `executedAtDecisionPoint`, `hasSelectionOutcome`, `partOfSession`, `rejectedCandidate`, `selectedCandidate`). MAKO's two self-edges (`evolvedFrom`, `supersededBy`, both DecisionExecution → DecisionExecution) are documented under design decision 9 below.
+The edge set is **TTL-driven with two filters**: `make_binding` walks `ontology.relationships` and picks every relationship whose endpoints both fall within the entity allowlist *and* which is not a self-edge. The current MAKO binding has **seven** real relationships (`atContextSnapshot`, `evaluatesCandidate`, `executedAtDecisionPoint`, `hasSelectionOutcome`, `partOfSession`, `rejectedCandidate`, `selectedCandidate`). MAKO's two self-edges (`evolvedFrom`, `supersededBy`, both DecisionExecution → DecisionExecution) are documented under design decision 9 below.
 
 ### 2. FILL_IN resolution: synthesize `id: string`
 
-The MAKO TTL doesn't declare `owl:hasKey` on most entities, so the OWL importer marks 17 concrete entities' primary keys as `FILL_IN`. `mako_artifacts.py` resolves each one to a synthesized `id: string` property + primary key. Matches MAKO's "every artifact has a stable identifier" design contract. If a future MAKO revision adds `owl:hasKey` declarations, the resolver leaves those alone — only `FILL_IN` placeholders get rewritten.
+The MAKO TTL doesn't declare `owl:hasKey` on most entities, so the OWL importer marks 17 concrete entities' primary keys as `FILL_IN`. The pipeline resolves each one to a synthesized `id: string` property + primary key. Matches MAKO's "every artifact has a stable identifier" design contract. If a future MAKO revision adds `owl:hasKey` declarations, the resolver leaves those alone — only `FILL_IN` placeholders get rewritten. This rule is **general** — any TTL with `FILL_IN` PKs gets the same treatment.
 
 ### 3. Cross-namespace relationships dropped (with audit trail)
 
-MAKO extends PROV-O + PKO + DCAT. Four relationships in the TTL point to entities outside MAKO's own namespace (`delegatedBy → prov:Agent`, etc.). The artifact pipeline drops these so the ontology loads cleanly and records the dropped names under the ontology's top-level `mako_demo:dropped_cross_namespace_relationships` annotation. The loss is auditable from a loaded model.
+MAKO extends PROV-O + PKO + DCAT. Four relationships in the TTL point to entities outside MAKO's own namespace (`delegatedBy → prov:Agent`, etc.). The artifact pipeline drops these so the ontology loads cleanly and records the dropped names under the ontology's top-level `mako_demo:dropped_cross_namespace_relationships` annotation. The loss is auditable from a loaded model. **General behavior**: any TTL extending upstream ontologies gets the same treatment; the annotation key uses the config's `annotation_prefix`.
 
 ### 4. Agent uses realistic tool names; mapping is explicit
 
-A real ADK agent exposes business/task-oriented tools, not tools whose argument names mirror TTL property names. The demo follows that convention — tool names are imperative business verbs (`capture_context`, `propose_decision_point`, `evaluate_candidate`, `commit_outcome`, `complete_execution`) and tool argument / return-value keys use ordinary snake_case (`audience_size`, `budget_remaining_usd`, `business_entity_id`).
+A real ADK agent exposes business/task-oriented tools, not tools whose argument names mirror TTL property names. The MAKO demo follows that convention — tool names are imperative business verbs (`capture_context`, `propose_decision_point`, `evaluate_candidate`, `commit_outcome`, `complete_execution`) and tool argument / return-value keys use ordinary snake_case (`audience_size`, `budget_remaining_usd`, `business_entity_id`).
 
 The **explicit mapping** between what the agent emits and what extraction materializes into the MAKO graph:
 
@@ -96,21 +127,21 @@ The agent uses Vertex AI Gemini by default (`DEMO_AGENT_MODEL=gemini-2.5-flash`)
 
 ### 5. `(project, dataset)` is a parameter, not a baked-in value
 
-`mako_artifacts.regenerate_snapshots(project=..., dataset=...)` and `run_agent.py --project X --dataset Y` both take the target as input. The checked-in snapshots use `test-project-0728-467323` / `migration_v5_demo` as defaults so reviewers can `cat` them; the notebook regenerates everything against a fresh `migration_v5_demo_<8-hex>` dataset at runtime.
+`mako_artifacts.regenerate_snapshots(project=..., dataset=...)` and `run_agent.py --project X --dataset Y` both take the target as input. The checked-in snapshots use `test-project-0728-467323` / `migration_v5_demo` as defaults so reviewers can `cat` them; the notebook regenerates everything against a fresh `migration_v5_demo_<8-hex>` dataset at runtime. The generic pipeline takes `(project, dataset)` the same way — they're never config-time constants.
 
 ### 6. `events.jsonl` is captured, not synthesized
 
 If kept, `events.jsonl` is the output of `export_events_jsonl.py` reading from `agent_events`. The notebook may use it as an offline corpus for Beat 3's revalidation tests (deterministic input the threshold gates can lock against), but the demo's primary event surface is the live `agent_events` table.
 
-The exporter's `SELECT` projects the subset of the BQ AA plugin's schema the notebook needs (`google/adk/plugins/bigquery_agent_analytics_plugin.py::_get_events_schema`): `timestamp`, `event_type`, `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`, `parent_span_id`, `status`, `error_message`, `is_truncated`, plus `content` / `attributes` / `latency_ms` (all JSON). The plugin's full schema also includes `content_parts` (REPEATED RECORD for multimodal parts); the exporter omits it because the MAKO decision flow is text-only. There is no `event_id`, `payload`, `agent_name`, or `partition_date` column on the plugin's table — the plugin partitions on `timestamp` (DAY).
+The exporter's `SELECT` projects the subset of the BQ AA plugin's schema the notebook needs (`google/adk/plugins/bigquery_agent_analytics_plugin.py::_get_events_schema`): `timestamp`, `event_type`, `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`, `parent_span_id`, `status`, `error_message`, `is_truncated`, plus `content` / `attributes` / `latency_ms` (all JSON). The plugin's full schema also includes `content_parts` (REPEATED RECORD for multimodal parts); the exporter omits it because the MAKO decision flow is text-only.
 
 ### 7. Table DDL carries SDK metadata columns
 
-`make_table_ddl()` appends `session_id STRING, extracted_at TIMESTAMP` to every node and edge table because the materializer writes both on every `materialize()` call and `binding_validation.py` requires them on every bound table. Without them, the notebook's binding-validate step would fail before ontology-build. When a domain property already maps to one of those columns (MAKO's `AgentSession.sessionId → session_id`), the metadata copy is skipped to avoid a duplicate-column error.
+`make_table_ddl()` appends `session_id STRING, extracted_at TIMESTAMP` to every node and edge table because the materializer writes both on every `materialize()` call and `binding_validation.py` requires them on every bound table. Without them, the notebook's binding-validate step would fail before ontology-build. When a domain property already maps to one of those columns (MAKO's `AgentSession.sessionId → session_id`), the metadata copy is skipped to avoid a duplicate-column error. **General behavior**: applies to every config.
 
 ### 8. Per-entity PK columns
 
-Every entity's PK column is `{entity_short}_id` (`decision_execution_id`, `candidate_id`, `agent_session_id`, …), not a bare `id`. The materializer's `_relationship_columns` (`ontology_materializer.py`) looks up edge FK columns in `src_prop_map[col].sdk_type` — that lookup requires the FK column to *exactly* name a column on the source entity. With bare `id`, every cross-entity edge would land `(id STRING, id STRING)` (duplicate-column error) and the FK→PK type lookup would still miss. Per-entity names match the convention the original V5 spec used (`YMGO_Context_Graph_V3`: `decision_id`, `adUnitId`) and the SDK's integration-test fixture (`tests/fixtures/test_binding.yaml`: `customer_id` → `cust_id`).
+Every entity's PK column is `{entity_short}_id` (`decision_execution_id`, `candidate_id`, `agent_session_id`, …), not a bare `id`. The materializer's `_relationship_columns` (`ontology_materializer.py`) looks up edge FK columns in `src_prop_map[col].sdk_type` — that lookup requires the FK column to *exactly* name a column on the source entity. With bare `id`, every cross-entity edge would land `(id STRING, id STRING)` (duplicate-column error) and the FK→PK type lookup would still miss. Per-entity names match the convention the original V5 spec used (`YMGO_Context_Graph_V3`: `decision_id`, `adUnitId`) and the SDK's integration-test fixture. **General behavior**: applies to every config; the Simple Request Flow binding produces `request_id` / `action_id` / `outcome_id` for the same reason.
 
 Notebook GQL queries reference `de.decision_execution_id` (not `de.id`); the Beat 4 cells carry an entity → PK column map for the same reason.
 
@@ -118,24 +149,28 @@ Notebook GQL queries reference `de.decision_execution_id` (not `de.id`); the Bea
 
 MAKO declares `evolvedFrom` and `supersededBy` as `DecisionExecution → DecisionExecution` self-edges. The materializer's FK→PK lookup can't disambiguate the two endpoints from a single source entity, and the natural composite key `(decision_execution_id, decision_execution_id)` is a duplicate-column error. `src_/dst_` prefixing avoids the duplicate but still misses the materializer's property-column lookup.
 
-The ontology still declares both edges (the TTL is unchanged); the binding scope drops them. A future binding revision could re-add self-edges if the SDK accepts FK-to-PK column mapping or the materializer learns to handle them via per-endpoint prefixes; for now the seven heterogeneous edges carry the decision-flow narrative end-to-end.
+The ontology still declares both edges (the TTL is unchanged); the binding scope drops them. A future binding revision could re-add self-edges if the SDK accepts FK-to-PK column mapping or the materializer learns to handle them via per-endpoint prefixes; for now the seven heterogeneous edges carry the decision-flow narrative end-to-end. **General behavior**: any config's binding drops self-edges with the same rationale.
 
-### 10. Inheritance stripped from MAKO entities
+### 10. Inheritance stripped from entities
 
-The MAKO TTL declares `mako:Candidate rdfs:subClassOf mako:RoleTrait`; the OWL importer surfaces this as `Candidate.extends: RoleTrait`. `gm compile` v0 doesn't support inheritance and rejects the binding (`compile-validation — Entity 'Candidate' uses 'extends'`), which blocks Section 4's `--emit-concept-index` step. `_strip_inheritance` drops `extends` from the post-import YAML and audit-trails the discard under `mako_demo:stripped_inheritance`. `RoleTrait` is a marker class in MAKO (REQ-ONT-022) with no properties beyond the `id` PK every other entity already has, so the discard has no semantic effect on the demo's six-entity scope.
+The MAKO TTL declares `mako:Candidate rdfs:subClassOf mako:RoleTrait`; the OWL importer surfaces this as `Candidate.extends: RoleTrait`. `gm compile` v0 doesn't support inheritance and rejects the binding (`compile-validation — Entity 'Candidate' uses 'extends'`), which blocks Section 4's `--emit-concept-index` step. The pipeline drops `extends` from the post-import YAML and audit-trails the discard under the config's `annotation_prefix` (`mako_demo:stripped_inheritance` for MAKO). `RoleTrait` is a marker class in MAKO (REQ-ONT-022) with no properties beyond the `id` PK every other entity already has, so the discard has no semantic effect on the demo's six-entity scope. **General behavior**: applies to any TTL with `extends:` clauses.
 
 ## Validation commands run (all pass)
 
 ```bash
-# Artifact pipeline runs end-to-end and regenerates snapshots.
+# MAKO artifact pipeline runs end-to-end and regenerates snapshots.
 PYTHONPATH=src python examples/migration_v5/mako_artifacts.py
-# → {"ontology_entities": 18, "binding_entities": 6,
-#    "binding_relationships": 7}
+# → {"binding_entities": 6, "binding_relationships": 7,
+#    "ontology_entities": 18}
 
-# Generated ontology validates clean.
+# Generic pipeline works against the Simple Request Flow smoke fixture.
+PYTHONPATH=src pytest tests/test_migration_v5_ontology_artifacts.py
+# → 8 passed (MAKO snapshot regression + pluggability assertions)
+
+# Generated MAKO ontology validates clean.
 python -m bigquery_ontology.cli validate examples/migration_v5/ontology.yaml
 
-# Generated binding validates against the generated ontology.
+# Generated MAKO binding validates against the generated ontology.
 python -m bigquery_ontology.cli validate examples/migration_v5/binding.yaml \
     --ontology examples/migration_v5/ontology.yaml
 
@@ -172,11 +207,11 @@ A live end-to-end notebook run (`run_agent.py --sessions 3` + Beat 1–4 cells a
 
 The notebook walks through the four guarantees once, ad hoc. Real deployments want the graph kept fresh on a cron — events arrive continuously, the materialized entity/relationship tables should follow within a chosen latency budget.
 
-[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa-materialize-window` every N hours against your project, using the v5 demo binding (retargeted to your `(project, graph_dataset)` at deploy time).
+[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa-materialize-window` every N hours against your project, using your binding (the MAKO config is the worked example; any `OntologyConfig` works).
 
 The flow customers actually follow:
 
-1. **Get events** — point at your existing `agent_events` table (the BQ AA plugin already writes here; if you don't have one yet, seed via `python examples/migration_v5/run_agent.py --sessions 3` against a scratch dataset).
+1. **Get events** — point at your existing `agent_events` table (the BQ AA plugin already writes here; if you don't have one yet, seed via `python examples/migration_v5/run_agent.py --sessions 3` against a scratch dataset to populate it with MAKO traces).
 2. **Local dry-run** — `python periodic_materialization/run_job.py` with env vars. Same code path as the deployed job, no Cloud Run required. Verifies your IAM / dataset setup before paying for a deploy.
 3. **Deploy** — one command:
 

--- a/examples/migration_v5/README.md
+++ b/examples/migration_v5/README.md
@@ -207,7 +207,7 @@ A live end-to-end notebook run (`run_agent.py --sessions 3` + Beat 1–4 cells a
 
 The notebook walks through the four guarantees once, ad hoc. Real deployments want the graph kept fresh on a cron — events arrive continuously, the materialized entity/relationship tables should follow within a chosen latency budget.
 
-[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa-materialize-window` every N hours against your project, using your binding (the MAKO config is the worked example; any `OntologyConfig` works).
+[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa-materialize-window` every N hours against your project, using the MAKO demo's bound artifacts. The deploy script bundles the checked-in `binding.yaml` / `ontology.yaml` / `table_ddl.sql` from this directory — running it against a different `OntologyConfig` means regenerating those snapshots for your config first and pointing the deploy at the new files. The deploy script doesn't yet wire that as a CLI flag; that's a natural follow-up but out of scope for this PR.
 
 The flow customers actually follow:
 

--- a/examples/migration_v5/README.md
+++ b/examples/migration_v5/README.md
@@ -165,7 +165,8 @@ PYTHONPATH=src python examples/migration_v5/mako_artifacts.py
 
 # Generic pipeline works against the Simple Request Flow smoke fixture.
 PYTHONPATH=src pytest tests/test_migration_v5_ontology_artifacts.py
-# → 8 passed (MAKO snapshot regression + pluggability assertions)
+# → 10 passed (MAKO snapshot regression + pluggability assertions
+#   + owl:hasKey regression coverage)
 
 # Generated MAKO ontology validates clean.
 python -m bigquery_ontology.cli validate examples/migration_v5/ontology.yaml

--- a/examples/migration_v5/example_ontologies/__init__.py
+++ b/examples/migration_v5/example_ontologies/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggability smoke fixtures for the migration v5 artifact pipeline.
+
+Each module in this package defines a small
+:class:`ontology_artifacts.OntologyConfig` paired with a TTL
+file. The configs aren't meant for production deploys — they
+exist to prove the pipeline in
+:mod:`ontology_artifacts` is genuinely ontology-agnostic.
+
+For the canonical reference example, see
+:mod:`mako_artifacts` in the parent package.
+"""

--- a/examples/migration_v5/example_ontologies/simple_request_flow.ttl
+++ b/examples/migration_v5/example_ontologies/simple_request_flow.ttl
@@ -37,23 +37,38 @@
 
 # =============================================================================
 # Entities
+#
+# Each entity declares ``owl:hasKey`` so the pipeline exercises the real-key
+# path (not just the FILL_IN synthesis path MAKO uses). The PR review found
+# the prior version of this fixture didn't catch a bug where ``make_binding``
+# hard-coded ``id`` as the bound PK property; declaring ``owl:hasKey`` here
+# makes the regression test in ``tests/test_migration_v5_ontology_artifacts.py``
+# meaningful.
 # =============================================================================
 
 rf:Request a owl:Class ;
     rdfs:label "Request" ;
-    rdfs:comment "An incoming ask. The entry point of the flow." .
+    rdfs:comment "An incoming ask. The entry point of the flow." ;
+    owl:hasKey ( rf:requestId ) .
 
 rf:Action a owl:Class ;
     rdfs:label "Action" ;
-    rdfs:comment "The work performed in response to a Request." .
+    rdfs:comment "The work performed in response to a Request." ;
+    owl:hasKey ( rf:actionId ) .
 
 rf:Outcome a owl:Class ;
     rdfs:label "Outcome" ;
-    rdfs:comment "The result of an Action. Terminal node of the flow." .
+    rdfs:comment "The result of an Action. Terminal node of the flow." ;
+    owl:hasKey ( rf:outcomeId ) .
 
 # =============================================================================
 # Data properties
 # =============================================================================
+
+rf:requestId a owl:DatatypeProperty ;
+    rdfs:label "request id" ;
+    rdfs:domain rf:Request ;
+    rdfs:range xsd:string .
 
 rf:requestText a owl:DatatypeProperty ;
     rdfs:label "request text" ;
@@ -65,6 +80,11 @@ rf:requestedAt a owl:DatatypeProperty ;
     rdfs:domain rf:Request ;
     rdfs:range xsd:dateTime .
 
+rf:actionId a owl:DatatypeProperty ;
+    rdfs:label "action id" ;
+    rdfs:domain rf:Action ;
+    rdfs:range xsd:string .
+
 rf:actionType a owl:DatatypeProperty ;
     rdfs:label "action type" ;
     rdfs:domain rf:Action ;
@@ -74,6 +94,11 @@ rf:executedAt a owl:DatatypeProperty ;
     rdfs:label "executed at" ;
     rdfs:domain rf:Action ;
     rdfs:range xsd:dateTime .
+
+rf:outcomeId a owl:DatatypeProperty ;
+    rdfs:label "outcome id" ;
+    rdfs:domain rf:Outcome ;
+    rdfs:range xsd:string .
 
 rf:outcomeStatus a owl:DatatypeProperty ;
     rdfs:label "outcome status" ;

--- a/examples/migration_v5/example_ontologies/simple_request_flow.ttl
+++ b/examples/migration_v5/example_ontologies/simple_request_flow.ttl
@@ -1,0 +1,100 @@
+# =============================================================================
+# Simple Request Flow — pluggability smoke fixture for the migration v5 demo
+#
+# Purpose: prove the ontology pipeline in
+#          ``examples/migration_v5/ontology_artifacts.py`` is genuinely
+#          ontology-agnostic. This TTL is intentionally domain-neutral
+#          (Request → Action → Outcome) and intentionally minimal: three
+#          entities, two relationships, no cross-namespace imports, no
+#          inheritance.
+#
+# Use:     ``regenerate_snapshots`` against
+#          :data:`example_ontologies.simple_request_flow_config.SIMPLE_REQUEST_FLOW_CONFIG`
+#          produces a valid binding + DDL + property-graph SQL with no
+#          MAKO involvement. Smoke fixture only — no runnable agent ships
+#          with this ontology.
+#
+# Why these three entities: Request is the entry point, Action is the
+# response, Outcome is the result. The minimal viable shape for a
+# directed graph that exercises ``make_binding`` (heterogeneous edges,
+# property-column generation) and ``make_property_graph_sql`` (node +
+# edge tables with KEY / SOURCE KEY / DESTINATION KEY).
+# =============================================================================
+
+@prefix rf:      <https://example.com/request-flow/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+<https://example.com/request-flow/>
+    a owl:Ontology ;
+    owl:versionInfo "0.1.0" ;
+    dcterms:title "Simple Request Flow — Pluggability Smoke Fixture" ;
+    dcterms:description "Domain-neutral Request → Action → Outcome ontology used to prove the migration v5 artifact pipeline accepts any OWL TTL." ;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/> .
+
+# =============================================================================
+# Entities
+# =============================================================================
+
+rf:Request a owl:Class ;
+    rdfs:label "Request" ;
+    rdfs:comment "An incoming ask. The entry point of the flow." .
+
+rf:Action a owl:Class ;
+    rdfs:label "Action" ;
+    rdfs:comment "The work performed in response to a Request." .
+
+rf:Outcome a owl:Class ;
+    rdfs:label "Outcome" ;
+    rdfs:comment "The result of an Action. Terminal node of the flow." .
+
+# =============================================================================
+# Data properties
+# =============================================================================
+
+rf:requestText a owl:DatatypeProperty ;
+    rdfs:label "request text" ;
+    rdfs:domain rf:Request ;
+    rdfs:range xsd:string .
+
+rf:requestedAt a owl:DatatypeProperty ;
+    rdfs:label "requested at" ;
+    rdfs:domain rf:Request ;
+    rdfs:range xsd:dateTime .
+
+rf:actionType a owl:DatatypeProperty ;
+    rdfs:label "action type" ;
+    rdfs:domain rf:Action ;
+    rdfs:range xsd:string .
+
+rf:executedAt a owl:DatatypeProperty ;
+    rdfs:label "executed at" ;
+    rdfs:domain rf:Action ;
+    rdfs:range xsd:dateTime .
+
+rf:outcomeStatus a owl:DatatypeProperty ;
+    rdfs:label "outcome status" ;
+    rdfs:domain rf:Outcome ;
+    rdfs:range xsd:string .
+
+rf:completedAt a owl:DatatypeProperty ;
+    rdfs:label "completed at" ;
+    rdfs:domain rf:Outcome ;
+    rdfs:range xsd:dateTime .
+
+# =============================================================================
+# Object properties (relationships)
+# =============================================================================
+
+rf:hasAction a owl:ObjectProperty ;
+    rdfs:label "has action" ;
+    rdfs:domain rf:Request ;
+    rdfs:range rf:Action .
+
+rf:producesOutcome a owl:ObjectProperty ;
+    rdfs:label "produces outcome" ;
+    rdfs:domain rf:Action ;
+    rdfs:range rf:Outcome .

--- a/examples/migration_v5/example_ontologies/simple_request_flow_config.py
+++ b/examples/migration_v5/example_ontologies/simple_request_flow_config.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggability smoke fixture: Simple Request Flow ontology config.
+
+Exists to prove the generic artifact pipeline in
+:mod:`ontology_artifacts` accepts any OWL TTL — not just
+MAKO's. The TTL is domain-neutral (Request → Action →
+Outcome) and intentionally simple (three entities, two
+relationships, no cross-namespace imports, no inheritance).
+
+The :data:`SIMPLE_REQUEST_FLOW_CONFIG` plugs into
+:func:`ontology_artifacts.regenerate_snapshots` exactly the
+same way :data:`mako_artifacts.MAKO_CONFIG` does. No runnable
+agent ships with this fixture — it's a smoke test for the
+pipeline, not an alternate demo.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from ontology_artifacts import OntologyConfig
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent
+
+SIMPLE_REQUEST_FLOW_CONFIG = OntologyConfig(
+    ttl_path=_FIXTURE_DIR / "simple_request_flow.ttl",
+    include_namespace="https://example.com/request-flow/",
+    entity_allowlist=("Request", "Action", "Outcome"),
+    annotation_prefix="simple_request_flow",
+    graph_name="simple_request_flow_graph",
+    snapshot_dir=_FIXTURE_DIR,
+)

--- a/examples/migration_v5/mako_artifacts.py
+++ b/examples/migration_v5/mako_artifacts.py
@@ -12,106 +12,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MAKO artifact pipeline for the migration v5 demo.
+"""MAKO-specific config for the migration v5 ontology pipeline.
 
-Reads exactly one input — ``mako_core.ttl`` — and produces
-every TTL-derived artifact the demo consumes:
+This module is a thin wrapper around
+:mod:`ontology_artifacts` that fixes the per-ontology
+configuration to MAKO. The generic pipeline takes any
+:class:`ontology_artifacts.OntologyConfig`; this file packages
+the MAKO-specific bits (TTL path, namespace IRI, entity
+allowlist, annotation prefix, graph name) and re-exports the
+public functions with that config bound in.
 
-* ``ontology.yaml`` — :func:`gm import-owl` output with
-  ``FILL_IN`` primary keys resolved programmatically and
-  cross-namespace dangling relationships dropped.
-* ``binding.yaml`` — generated for a configurable
-  ``(project, dataset)``.
-* ``table_ddl.sql`` — companion to the binding.
-* ``property_graph.sql`` — ``CREATE PROPERTY GRAPH`` SQL.
-  Edge-column names align with ``table_ddl.sql`` so Beat 1
-  of the notebook can apply both cleanly.
+The MAKO TTL is the canonical reference example because it's
+a real production ontology with all the OWL TTL quirks the
+generic pipeline normalizes through:
 
-**Events are NOT generated here.** The event stream's
-source of truth is the BQ AA plugin's ``agent_events``
-table, populated by the runnable agent in
-``mako_demo_agent.py`` talking to
-``BigQueryAgentAnalyticsPlugin``. An optional captured
-offline snapshot (for revalidation tests that need
-determinism) is produced by ``export_events_jsonl.py`` —
-that path's job is to export FROM the populated BQ table,
-not to synthesize events.
+* ``owl:hasKey`` undeclared on most entities → ``FILL_IN``
+  primary keys the resolver synthesizes to ``id``.
+* Cross-namespace relationships into PROV-O / PKO / DCAT
+  that the importer drops with an audit trail.
+* ``rdfs:subClassOf`` inheritance that the v0 ``gm compile``
+  doesn't support; the pipeline strips ``extends`` and
+  records the loss.
 
-Authored input contract — the only files in this
-directory that are user-authored:
+See :mod:`example_ontologies.simple_request_flow_config` for
+a tiny second config that exercises the same pipeline with a
+simpler TTL — useful as a smoke test that the pipeline is
+genuinely ontology-agnostic.
 
-1. ``mako_core.ttl`` — the MAKO ontology.
-2. ``mako_artifacts.py`` (this file) — the TTL → artifacts
-   pipeline.
-3. ``mako_demo_agent.py`` — the runnable agent that emits
-   real plugin traces through ``BigQueryAgentAnalyticsPlugin``.
-4. ``run_agent.py`` — the driver that runs the agent for N
-   sessions.
-5. ``export_events_jsonl.py`` — optional helper that
-   captures a deterministic offline snapshot from
-   ``agent_events`` for revalidation tests.
-
-Everything else under ``examples/migration_v5/`` is a
-reproducibility snapshot produced by
-:func:`regenerate_snapshots` or by running the agent.
-
-FILL_IN resolution policy:
-
-The MAKO TTL doesn't declare ``owl:hasKey`` on most
-entities, so the OWL importer marks every concrete entity's
-primary key as ``FILL_IN``. The artifact pipeline resolves
-this by synthesizing an ``id: string`` property + primary
-key on every entity that lacks one. This matches MAKO's
-"every artifact has a stable identifier" design contract;
-if a future TTL revision adds ``owl:hasKey`` declarations,
-the resolver leaves those alone.
+The MAKO demo's runnable agent (``mako_demo_agent.py``) and
+event-population driver (``run_agent.py``) remain
+MAKO-specific by design — the agent's tools mirror MAKO's
+decision flow. Only the artifact pipeline is generalized.
 """
 
 from __future__ import annotations
 
 import json
 import pathlib
-from typing import Any, Iterable, Optional
+from typing import Iterable, Optional
 
-import yaml
+from ontology_artifacts import load_ontology as _load_ontology
+from ontology_artifacts import make_binding as _make_binding
+from ontology_artifacts import make_property_graph_sql as _make_property_graph_sql
+from ontology_artifacts import make_table_ddl as _make_table_ddl
+from ontology_artifacts import OntologyConfig
+from ontology_artifacts import regenerate_snapshots as _regenerate_snapshots
 
 from bigquery_ontology import Binding
-from bigquery_ontology import load_binding_from_string
-from bigquery_ontology import load_ontology_from_string
 from bigquery_ontology import Ontology
-from bigquery_ontology.owl_importer import import_owl
 
-# Authored-input path. Resolved relative to this file so the
-# agent works regardless of the caller's CWD.
 _FIXTURE_DIR = pathlib.Path(__file__).parent
-TTL_PATH = _FIXTURE_DIR / "mako_core.ttl"
 
-# Snapshot-output paths. :func:`regenerate_snapshots` writes
-# these; the notebook can either consume them as-is or call
-# the pure APIs at runtime against a fresh dataset.
-#
-# Note: ``events.jsonl`` is NOT in this list. The event
-# stream's source of truth is the BQ AA plugin's
-# ``agent_events`` table, populated by the runnable
-# ``mako_demo_agent.py`` agent. An optional captured
-# offline snapshot (for revalidation tests) is produced by
-# ``export_events_jsonl.py``.
-ONTOLOGY_PATH = _FIXTURE_DIR / "ontology.yaml"
-BINDING_PATH = _FIXTURE_DIR / "binding.yaml"
-TABLE_DDL_PATH = _FIXTURE_DIR / "table_ddl.sql"
-PROPERTY_GRAPH_PATH = _FIXTURE_DIR / "property_graph.sql"
+# Authored-input path for the MAKO TTL.
+TTL_PATH = _FIXTURE_DIR / "mako_core.ttl"
 
 # MAKO namespace — passed to ``import_owl`` so we only pull
 # entities under that IRI prefix (not the imported PROV-O /
 # PKO / etc. classes).
 _MAKO_NAMESPACE = "https://ontology.yahoo.com/mako/"
 
-# Demo-focused entity allowlist. ``make_binding`` /
-# ``make_property_graph_sql`` only consider these six. This
-# is **artifact configuration**, not ontology curation — the
-# full imported ``ontology.yaml`` still contains the 18
-# MAKO-namespace entities; the binding scope is narrower so
-# the notebook's four-guarantee narrative stays focused.
+# Demo-focused entity allowlist. The full imported
+# ``ontology.yaml`` contains the 18 MAKO-namespace entities;
+# the binding scope is narrower so the notebook's
+# four-guarantee narrative stays focused.
 #
 # Why these six: in MAKO, ``DecisionExecution`` is the
 # central hub that ties everything together (per the TTL,
@@ -131,165 +94,33 @@ DEMO_ENTITIES: tuple[str, ...] = (
 )
 
 
-# ------------------------------------------------------------------ #
-# Step 1: load + normalize the MAKO ontology                          #
-# ------------------------------------------------------------------ #
+# MAKO_CONFIG packages the MAKO-specific bits. The generic
+# pipeline in :mod:`ontology_artifacts` accepts any
+# ``OntologyConfig``; this is one such config.
+MAKO_CONFIG = OntologyConfig(
+    ttl_path=TTL_PATH,
+    include_namespace=_MAKO_NAMESPACE,
+    entity_allowlist=DEMO_ENTITIES,
+    annotation_prefix="mako_demo",
+    graph_name="mako_demo_graph",
+    snapshot_dir=_FIXTURE_DIR,
+)
+
+# Snapshot-output paths (back-compat — derived from MAKO_CONFIG).
+ONTOLOGY_PATH = MAKO_CONFIG.ontology_path
+BINDING_PATH = MAKO_CONFIG.binding_path
+TABLE_DDL_PATH = MAKO_CONFIG.table_ddl_path
+PROPERTY_GRAPH_PATH = MAKO_CONFIG.property_graph_path
 
 
 def load_mako_ontology() -> tuple[Ontology, str]:
   """Import the MAKO TTL and resolve FILL_IN primary keys.
 
-  Returns:
-    A ``(Ontology, yaml_text)`` tuple. The ``yaml_text`` is
-    the *resolved* YAML — i.e. the OWL importer's output
-    with FILL_INs replaced — and is suitable for writing
-    straight to ``ontology.yaml``.
+  Thin wrapper around
+  :func:`ontology_artifacts.load_ontology` with
+  :data:`MAKO_CONFIG`.
   """
-  yaml_text, _drop_summary = import_owl(
-      sources=[str(TTL_PATH)],
-      include_namespaces=[_MAKO_NAMESPACE],
-  )
-  resolved_yaml = _normalize_imported_ontology(yaml_text)
-  ontology = load_ontology_from_string(resolved_yaml)
-  return ontology, resolved_yaml
-
-
-def _normalize_imported_ontology(yaml_text: str) -> str:
-  """Post-process the OWL importer's output so it loads
-  cleanly via :func:`load_ontology_from_string`.
-
-  Two passes:
-
-  1. Resolve ``FILL_IN`` primary keys to ``id`` (matches
-     MAKO's "every artifact has a stable identifier"
-     contract).
-  2. Drop cross-namespace dangling relationships. MAKO
-     extends PROV-O / PKO / etc., and some relationships
-     point to entities outside the MAKO namespace
-     (e.g. ``delegatedTo → prov:Agent``). The OWL importer
-     leaves those declared but without a ``to`` field
-     (because the target wasn't imported); the Ontology
-     model then rejects them as malformed. The demo doesn't
-     model the external namespaces, so we drop these
-     edges.
-  """
-  data = yaml.safe_load(yaml_text)
-  data = _resolve_fill_in_primary_keys_dict(data)
-  data = _drop_dangling_relationships(data)
-  data = _strip_inheritance(data)
-  return yaml.safe_dump(data, sort_keys=False)
-
-
-def _resolve_fill_in_primary_keys_dict(data: dict) -> dict:
-  """Walk every entity; for each one whose ``keys.primary`` is
-  ``[FILL_IN]``, replace it with ``[id]`` and ensure an
-  ``id: string`` property exists.
-
-  Matches MAKO's "every artifact has a stable identifier"
-  design contract. Entities that already declare an
-  ``owl:hasKey`` (and hence don't have ``FILL_IN``) are left
-  untouched.
-  """
-  for entity in data.get("entities", []):
-    keys = entity.get("keys")
-    if keys is None:
-      continue
-    primary = keys.get("primary")
-    if primary == ["FILL_IN"]:
-      keys["primary"] = ["id"]
-      props = entity.setdefault("properties", [])
-      if not any(p.get("name") == "id" for p in props):
-        props.insert(0, {"name": "id", "type": "string"})
-  return data
-
-
-def _drop_dangling_relationships(data: dict) -> dict:
-  """Remove relationships missing either endpoint.
-
-  The MAKO TTL declares relationships that cross into
-  PROV-O / PKO / etc. (``delegatedTo → prov:Agent``). The
-  agent imports only the MAKO namespace, so those
-  cross-namespace endpoints aren't materialized as
-  entities; the OWL importer leaves the relationship with
-  a missing ``to`` (or ``from``). The Ontology model
-  rejects those as malformed. The demo doesn't model the
-  external namespaces, so the agent drops these edges and
-  documents them in a synthesized annotation so the loss is
-  visible.
-  """
-  entity_names = {ent["name"] for ent in data.get("entities", [])}
-  surviving: list[dict] = []
-  dropped: list[str] = []
-  for rel in data.get("relationships", []):
-    to = rel.get("to")
-    frm = rel.get("from")
-    if not to or not frm or to not in entity_names or frm not in entity_names:
-      dropped.append(rel.get("name", "<anonymous>"))
-      continue
-    surviving.append(rel)
-  data["relationships"] = surviving
-  if dropped:
-    # Stash the drop list in the top-level ontology annotation
-    # so the loss is auditable from the loaded model.
-    annotations = data.setdefault("annotations", {})
-    annotations["mako_demo:dropped_cross_namespace_relationships"] = dropped
-  return data
-
-
-def _strip_inheritance(data: dict) -> dict:
-  """Strip ``extends`` from every entity post-import.
-
-  The MAKO TTL marks ``mako:Candidate rdfs:subClassOf
-  mako:RoleTrait``; the OWL importer carries that through
-  as ``extends: RoleTrait``. The v0 ``gm compile`` (used by
-  the notebook's Section 4 concept-index emission) doesn't
-  support inheritance, so the binding compile fails with
-  ``compile-validation — Entity 'Candidate' uses 'extends';
-  v0 compilation does not support inheritance.``
-
-  ``RoleTrait`` is a marker class in MAKO (REQ-ONT-022 —
-  "single-primary-parent inheritance discipline"); it
-  carries no properties beyond the ``id`` PK that the
-  importer already added to every entity. Stripping the
-  ``extends`` clause has no semantic effect on the demo's
-  six-entity scope. The discarded inheritance is recorded
-  under ``mako_demo:stripped_inheritance`` on the entity
-  so the loss is visible.
-  """
-  # Ontology annotations are typed ``dict[str, str]``; the
-  # audit trail therefore serializes to strings. Per-entity
-  # records carry the ``extended`` parent in a flat key; the
-  # top-level summary is a comma-joined ``entity:parent`` list.
-  stripped: list[str] = []
-  for entity in data.get("entities", []):
-    if "extends" not in entity:
-      continue
-    stripped.append(f"{entity['name']}:{entity['extends']}")
-    annotations = entity.setdefault("annotations", {}) or {}
-    annotations["mako_demo:stripped_inheritance"] = entity["extends"]
-    entity["annotations"] = annotations
-    del entity["extends"]
-    # Stripping ``extends`` removes the entity's only path
-    # to a primary key (the parent class declared one). Add
-    # the same ``id: string`` PK the importer adds to every
-    # other concrete entity so the ontology still loads.
-    keys = entity.setdefault("keys", {})
-    if "primary" not in keys:
-      keys["primary"] = ["id"]
-    props = entity.setdefault("properties", []) or []
-    if not any(p.get("name") == "id" for p in props):
-      props.insert(0, {"name": "id", "type": "string"})
-      entity["properties"] = props
-  if stripped:
-    top_annotations = data.setdefault("annotations", {}) or {}
-    top_annotations["mako_demo:stripped_inheritance"] = ",".join(stripped)
-    data["annotations"] = top_annotations
-  return data
-
-
-# ------------------------------------------------------------------ #
-# Step 2: generate a binding for a target (project, dataset)         #
-# ------------------------------------------------------------------ #
+  return _load_ontology(MAKO_CONFIG)
 
 
 def make_binding(
@@ -299,217 +130,24 @@ def make_binding(
     dataset: str,
     entity_filter: Optional[Iterable[str]] = None,
 ) -> Binding:
-  """Construct a ``Binding`` for the given target.
+  """Construct a MAKO-scoped ``Binding`` for the given target.
 
-  Args:
-    ontology: The resolved MAKO ontology
-      (:func:`load_mako_ontology` output).
-    project: BigQuery project ID.
-    dataset: BigQuery dataset name.
-    entity_filter: Optional iterable of entity names to
-      include in the binding. Defaults to
-      :data:`DEMO_ENTITIES`. The notebook narrows the scope
-      to keep the four-guarantee narrative focused; the
-      full 41-entity ontology is still loadable.
-
-  Returns:
-    A validated ``Binding`` instance. Property columns use
-    the snake_case-of-camelCase convention
-    (``snapshotPayload`` → ``snapshot_payload``) since
-    BigQuery's identifier conventions are snake_case.
+  Thin wrapper around :func:`ontology_artifacts.make_binding`
+  with :data:`MAKO_CONFIG`. ``entity_filter`` defaults to
+  :data:`DEMO_ENTITIES` (MAKO's six-entity demo scope).
   """
-  scope = set(DEMO_ENTITIES) if entity_filter is None else set(entity_filter)
-
-  # Each entity's PK column is named ``{entity_short}_id``
-  # rather than a bare ``id``. The materializer
-  # (``_relationship_columns`` in ``ontology_materializer.py``)
-  # populates an edge's FK column type from the source
-  # entity's ``src_prop_map[col].sdk_type`` — that lookup
-  # requires the FK column name to exactly match a property
-  # column on the source entity. Using a bare ``id`` would
-  # work for one entity per edge but collide when both
-  # endpoints share the same PK column name (``id, id`` ─
-  # duplicate column). Per-entity PK names give every edge
-  # a clean ``{src_entity}_id, {dst_entity}_id`` shape and
-  # match the convention the original V5 spec used
-  # (``YMGO_Context_Graph_V3``: ``decision_id``,
-  # ``adUnitId``, etc.).
-  entities_block: list[dict] = []
-  for entity in ontology.entities:
-    if entity.name not in scope:
-      continue
-    table_name = _entity_table_name(entity.name)
-    pk_column = f"{_entity_id_column(entity.name)}_id"
-    props = [{"name": "id", "column": pk_column}]
-    # Append every MAKO-declared property except ``id``
-    # (PK, already added). The binding validator
-    # (``_check_property_coverage``) requires every non-
-    # derived ontology property to have a binding; dropping
-    # ``sessionId`` to avoid a column-name collision broke
-    # that check. Since ``_entity_id_column`` no longer
-    # strips ``agent_``, AgentSession's PK column is
-    # ``agent_session_id`` and ``sessionId`` keeps its
-    # natural ``session_id`` column without collision.
-    for prop in entity.properties:
-      if prop.name == "id":
-        continue
-      props.append({"name": prop.name, "column": _to_snake_case(prop.name)})
-    entities_block.append(
-        {
-            "name": entity.name,
-            "source": f"{project}.{dataset}.{table_name}",
-            "properties": props,
-        }
-    )
-
-  # Edge set is derived from MAKO's actual declared
-  # relationships — pick relationships whose endpoints are
-  # both in the demo scope. Two filters:
-  #
-  # 1. ``rel.from_ != rel.to`` — self-edges (MAKO's
-  #    ``evolvedFrom`` and ``supersededBy``,
-  #    DecisionExecution → DecisionExecution) are dropped.
-  #    The materializer's ``_relationship_columns`` requires
-  #    the edge's ``from_columns`` to name a property column
-  #    on the source entity. For a self-edge that would
-  #    mean two identical PK column names on the edge table
-  #    (duplicate-column error), and the workarounds
-  #    (``src_/dst_`` prefixes) miss the property lookup.
-  #    A future binding revision (or an SDK change that
-  #    accepts FK-to-PK column mapping) could re-add them;
-  #    for the demo, the heterogeneous edges carry the
-  #    decision-flow narrative.
-  # 2. Heterogeneous edges use ``{entity_short}_id`` as both
-  #    source and destination FK columns — the same name as
-  #    the source/destination entity's PK column. The
-  #    materializer can then resolve ``src_prop_map[col]``
-  #    cleanly.
-  relationships_block: list[dict] = []
-  dropped_self_edges: list[str] = []
-  for rel in ontology.relationships:
-    if rel.from_ not in scope or rel.to not in scope:
-      continue
-    if rel.from_ == rel.to:
-      dropped_self_edges.append(rel.name)
-      continue
-    src_col = f"{_entity_id_column(rel.from_)}_id"
-    dst_col = f"{_entity_id_column(rel.to)}_id"
-    relationships_block.append(
-        {
-            "name": rel.name,
-            "source": f"{project}.{dataset}.{_edge_table_name(rel.name)}",
-            "from_columns": [src_col],
-            "to_columns": [dst_col],
-        }
-    )
-
-  binding_dict = {
-      "binding": f"{dataset}_binding",
-      "ontology": ontology.ontology,
-      "target": {
-          "backend": "bigquery",
-          "project": project,
-          "dataset": dataset,
-      },
-      "entities": entities_block,
-      "relationships": relationships_block,
-  }
-  binding_yaml = yaml.safe_dump(binding_dict, sort_keys=False)
-  return load_binding_from_string(binding_yaml, ontology=ontology)
-
-
-# ------------------------------------------------------------------ #
-# Step 3: derive table DDL + property-graph SQL from the binding     #
-# ------------------------------------------------------------------ #
+  return _make_binding(
+      ontology,
+      MAKO_CONFIG,
+      project=project,
+      dataset=dataset,
+      entity_filter=entity_filter,
+  )
 
 
 def make_table_ddl(binding: Binding, *, ontology: Ontology) -> str:
-  """Generate ``CREATE TABLE`` SQL for every node + edge
-  table referenced by *binding*.
-
-  Column types are mapped from the ontology's
-  ``Property.type`` (which the OWL importer set from each
-  property's ``xsd:`` range) through :func:`_bq_type_for`
-  — ``integer`` → ``INT64``, ``double`` → ``FLOAT64``,
-  ``boolean`` → ``BOOL``, ``timestamp`` → ``TIMESTAMP``,
-  ``date`` → ``DATE``, ``string`` and unrecognized → ``STRING``.
-  Using ``STRING`` for everything silently lost the typing
-  the TTL declared (e.g. MAKO's
-  ``DecisionExecution.latencyMs`` is ``xsd:integer``).
-
-  Edge tables use the binding's ``from_columns`` /
-  ``to_columns``. The property-graph SQL produced by
-  :func:`make_property_graph_sql` references those same
-  columns; the two SQL artifacts stay in sync because they
-  share this binding.
-
-  Every node + edge table also carries the two SDK metadata
-  columns the materializer writes on every ``materialize()``
-  call: ``session_id STRING`` and ``extracted_at
-  TIMESTAMP``. The binding validator
-  (``binding_validation.py``) requires both columns on every
-  bound table — without them, the notebook's binding-validate
-  step would fail before ontology-build.
-  """
-  prop_types: dict[tuple[str, str], str] = {}
-  for entity in ontology.entities:
-    for prop in entity.properties:
-      prop_types[(entity.name, prop.name)] = _bq_type_for(prop.type)
-
-  lines: list[str] = []
-  for ebind in binding.entities:
-    bound_columns = {prop.column for prop in ebind.properties}
-    cols = []
-    for prop in ebind.properties:
-      bq_type = prop_types.get((ebind.name, prop.name), "STRING")
-      cols.append(f"{prop.column} {bq_type}")
-    cols.extend(_sdk_metadata_columns(bound_columns))
-    lines.append(
-        f"CREATE TABLE IF NOT EXISTS `{ebind.source}` ({', '.join(cols)});"
-    )
-
-  for rbind in binding.relationships:
-    src_col, dst_col = rbind.from_columns[0], rbind.to_columns[0]
-    edge_cols = [f"{src_col} STRING", f"{dst_col} STRING"]
-    edge_cols.extend(_sdk_metadata_columns({src_col, dst_col}))
-    lines.append(
-        f"CREATE TABLE IF NOT EXISTS `{rbind.source}` "
-        f"({', '.join(edge_cols)});"
-    )
-
-  return "\n".join(lines) + "\n"
-
-
-def _sdk_metadata_columns(already_present: set[str]) -> list[str]:
-  """Return DDL fragments for SDK metadata columns not yet
-  present in *already_present*.
-
-  Domain bindings can legitimately map a property onto
-  ``session_id`` — MAKO's ``AgentSession.sessionId`` is the
-  canonical example. The materializer's writes for those
-  rows still land in the same column, so it's safe to skip
-  the SDK metadata copy rather than emit ``CREATE TABLE
-  agent_session (session_id STRING, session_id STRING, ...)``.
-  ``extracted_at`` is unlikely to collide but is handled the
-  same way for symmetry.
-  """
-  return [
-      ddl
-      for col, ddl in _SDK_METADATA_DDL_BY_COLUMN.items()
-      if col not in already_present
-  ]
-
-
-# SDK metadata columns that the materializer
-# (``ontology_materializer._entity_columns`` /
-# ``_relationship_columns``) writes on every ``materialize()``
-# call. Binding validation
-# (``binding_validation.py:488,806``) requires both columns
-# on every bound table.
-_SDK_METADATA_DDL_BY_COLUMN = {
-    "session_id": "session_id STRING",
-    "extracted_at": "extracted_at TIMESTAMP",
-}
+  """Thin wrapper around :func:`ontology_artifacts.make_table_ddl`."""
+  return _make_table_ddl(binding, ontology=ontology)
 
 
 def make_property_graph_sql(
@@ -518,100 +156,13 @@ def make_property_graph_sql(
     ontology: Ontology,
     graph_name: str = "mako_demo_graph",
 ) -> str:
-  """Generate ``CREATE OR REPLACE PROPERTY GRAPH`` SQL.
-
-  Beat 1 of the notebook is "you own the graph definition" —
-  this output is what the platform team would author. Edge
-  columns match :func:`make_table_ddl`'s output so applying
-  both in sequence works without column-name mismatches.
-
-  Args:
-    binding: A validated ``Binding`` (see :func:`make_binding`).
-    graph_name: Local property-graph name. Default
-      ``"mako_demo_graph"``.
+  """Thin wrapper around
+  :func:`ontology_artifacts.make_property_graph_sql`.
+  Defaults ``graph_name`` to MAKO's ``mako_demo_graph``.
   """
-  project = binding.target.project
-  dataset = binding.target.dataset
-  qualified_graph = f"{project}.{dataset}.{graph_name}"
-
-  # The PK column for each entity is the ``column`` of the
-  # property whose ``name`` is ``id`` (set by ``make_binding``
-  # to ``{entity_short}_id``). Both the ``KEY (...)`` of the
-  # node table and the ``REFERENCES <alias> (...)`` of every
-  # edge endpoint must use that column name; hard-coding
-  # ``id`` (the property's *logical* name) trips
-  # ``Unrecognized name: id`` because the underlying table
-  # column has the entity-specific name.
-  pk_column_by_entity: dict[str, str] = {}
-  node_tables: list[str] = []
-  for ebind in binding.entities:
-    qualified_source = ebind.source
-    short_name = _table_ref_short(qualified_source)
-    pk_col = next(p.column for p in ebind.properties if p.name == "id")
-    pk_column_by_entity[ebind.name] = pk_col
-    cols = ", ".join(p.column for p in ebind.properties)
-    node_tables.append(
-        f"    `{qualified_source}` AS {short_name}\n"
-        f"      KEY ({pk_col})\n"
-        f"      LABEL {ebind.name} PROPERTIES ({cols})"
-    )
-
-  # Look up the source/destination entity for each edge by
-  # consulting the bound ontology passed in — same TTL-driven
-  # lookup the binding generator used.
-  rel_map = {r.name: r for r in ontology.relationships}
-
-  edge_tables: list[str] = []
-  for rbind in binding.relationships:
-    rel = rel_map.get(rbind.name)
-    if rel is None:
-      # Defensive — should never happen given the binding
-      # passed validation.
-      continue
-    src_col = rbind.from_columns[0]
-    dst_col = rbind.to_columns[0]
-    qualified_edge_source = rbind.source
-    short = _table_ref_short(qualified_edge_source)
-    # ``SOURCE KEY ... REFERENCES`` and ``DESTINATION KEY ...
-    # REFERENCES`` name the **alias** the node table is declared
-    # under inside the same property graph, not the
-    # fully-qualified BigQuery table. BQ rejects qualified refs
-    # ("The referenced node table 'proj.ds.foo' is not defined in
-    # the property graph") because the alias is the in-graph
-    # identifier. Same shape ``gm compile`` emits.
-    src_alias = _table_ref_short(
-        next(e.source for e in binding.entities if e.name == rel.from_)
-    )
-    dst_alias = _table_ref_short(
-        next(e.source for e in binding.entities if e.name == rel.to)
-    )
-    # Edge tables require an explicit ``KEY (...)`` declaration
-    # alongside ``SOURCE KEY`` / ``DESTINATION KEY``. BigQuery
-    # rejects edge declarations without it
-    # ("graph element table keys must be explicitly defined").
-    # The natural composite key for an edge is the pair of FK
-    # columns the source + destination references point at —
-    # same shape ``gm compile`` emits.
-    src_pk = pk_column_by_entity[rel.from_]
-    dst_pk = pk_column_by_entity[rel.to]
-    edge_tables.append(
-        f"    `{qualified_edge_source}` AS {short}\n"
-        f"      KEY ({src_col}, {dst_col})\n"
-        f"      SOURCE KEY ({src_col}) REFERENCES {src_alias} ({src_pk})\n"
-        f"      DESTINATION KEY ({dst_col}) REFERENCES {dst_alias} ({dst_pk})\n"
-        f"      LABEL {rbind.name}"
-    )
-
-  return (
-      f"CREATE OR REPLACE PROPERTY GRAPH `{qualified_graph}`\n"
-      f"  NODE TABLES (\n" + ",\n".join(node_tables) + "\n  )\n"
-      f"  EDGE TABLES (\n" + ",\n".join(edge_tables) + "\n  );\n"
+  return _make_property_graph_sql(
+      binding, ontology=ontology, graph_name=graph_name
   )
-
-
-# ------------------------------------------------------------------ #
-# Step 5: regenerate the snapshot files                               #
-# ------------------------------------------------------------------ #
 
 
 def regenerate_snapshots(
@@ -619,120 +170,17 @@ def regenerate_snapshots(
     project: str = "test-project-0728-467323",
     dataset: str = "migration_v5_demo",
 ) -> dict:
-  """Regenerate every TTL-derived artifact snapshot.
+  """Regenerate the MAKO demo's TTL-derived artifact snapshots.
 
-  Idempotent: byte-identical output across runs for the
-  same ``(project, dataset)`` pair. Returns a small summary
-  dict for the notebook's setup cell to display.
+  Idempotent: byte-identical output across runs for the same
+  ``(project, dataset)`` pair. Returns a small summary dict
+  for the notebook's setup cell to display.
 
   Does NOT produce events — events come from running
   ``mako_demo_agent.py`` against this same
   ``(project, dataset)`` with the BQ AA plugin enabled.
   """
-  ontology, yaml_text = load_mako_ontology()
-  ONTOLOGY_PATH.write_text(yaml_text, encoding="utf-8")
-
-  binding = make_binding(ontology, project=project, dataset=dataset)
-  BINDING_PATH.write_text(_binding_yaml(binding), encoding="utf-8")
-  TABLE_DDL_PATH.write_text(
-      make_table_ddl(binding, ontology=ontology), encoding="utf-8"
-  )
-  PROPERTY_GRAPH_PATH.write_text(
-      make_property_graph_sql(binding, ontology=ontology), encoding="utf-8"
-  )
-
-  return {
-      "ontology_entities": len(ontology.entities),
-      "binding_entities": len(binding.entities),
-      "binding_relationships": len(binding.relationships),
-  }
-
-
-# ------------------------------------------------------------------ #
-# Helpers                                                              #
-# ------------------------------------------------------------------ #
-
-
-def _binding_yaml(binding: Binding) -> str:
-  """Serialize a Binding to YAML.
-
-  Pydantic's ``model_dump`` keeps enum members as enum
-  instances by default; PyYAML's ``safe_dump`` can't
-  represent those. ``mode='json'`` coerces enums to their
-  string values plus normalizes other non-YAML primitives,
-  matching how the loader expects to read the YAML back.
-  """
-  payload = binding.model_dump(by_alias=True, exclude_none=True, mode="json")
-  return yaml.safe_dump(payload, sort_keys=False)
-
-
-def _entity_table_name(entity_name: str) -> str:
-  """Canonical BQ table name for a MAKO entity."""
-  return _to_snake_case(entity_name)
-
-
-def _entity_id_column(entity_name: str) -> str:
-  """Column-name root for an entity's PK + foreign-key
-  references (e.g. ``AgentSession`` → ``agent_session``,
-  used in ``agent_session_id``).
-
-  Earlier drafts stripped a leading ``agent_`` so the FK
-  read ``session_id`` — but that collides with both the
-  SDK metadata column ``session_id`` and MAKO's
-  ``AgentSession.sessionId`` data property (also bound to
-  column ``session_id``), producing duplicate columns the
-  validator rejects. Keeping the full snake form gives
-  every entity a unique PK column and lets the SDK
-  metadata + ontology-declared ``sessionId`` co-exist
-  cleanly.
-  """
-  return _to_snake_case(entity_name)
-
-
-def _edge_table_name(edge_name: str) -> str:
-  return _to_snake_case(edge_name)
-
-
-def _table_ref_short(qualified: str) -> str:
-  return qualified.rsplit(".", 1)[-1]
-
-
-def _bq_type_for(property_type: Any) -> str:
-  """Map an ontology ``PropertyType`` (or its string value)
-  to a BigQuery column type.
-
-  Defaults to ``STRING`` for unknown values; the only types
-  the OWL importer can currently emit are those in
-  ``PropertyType`` (string / bytes / integer / double /
-  numeric / boolean / date / time / datetime / timestamp /
-  json), and they map 1:1 to BigQuery legacy SQL types.
-  """
-  # ``Property.type`` is a ``PropertyType`` enum; ``.value``
-  # gets the wire string. Handle bare strings too in case a
-  # caller passes one.
-  value = getattr(property_type, "value", property_type)
-  return {
-      "string": "STRING",
-      "bytes": "BYTES",
-      "integer": "INT64",
-      "double": "FLOAT64",
-      "numeric": "NUMERIC",
-      "boolean": "BOOL",
-      "date": "DATE",
-      "time": "TIME",
-      "datetime": "DATETIME",
-      "timestamp": "TIMESTAMP",
-      "json": "JSON",
-  }.get(value, "STRING")
-
-
-def _to_snake_case(camel: str) -> str:
-  out: list[str] = []
-  for i, ch in enumerate(camel):
-    if ch.isupper() and i > 0 and not camel[i - 1].isupper():
-      out.append("_")
-    out.append(ch.lower())
-  return "".join(out)
+  return _regenerate_snapshots(MAKO_CONFIG, project=project, dataset=dataset)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/examples/migration_v5/ontology_artifacts.py
+++ b/examples/migration_v5/ontology_artifacts.py
@@ -1,0 +1,697 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic ontology-artifact pipeline for the migration v5 demo.
+
+Reads exactly one input — an OWL TTL file — and produces
+every TTL-derived artifact the demo consumes:
+
+* ``ontology.yaml`` — :func:`import_owl` output with
+  ``FILL_IN`` primary keys resolved programmatically and
+  cross-namespace dangling relationships dropped.
+* ``binding.yaml`` — generated for a configurable
+  ``(project, dataset)`` over a configurable entity allowlist.
+* ``table_ddl.sql`` — companion to the binding.
+* ``property_graph.sql`` — ``CREATE PROPERTY GRAPH`` SQL.
+  Edge-column names align with ``table_ddl.sql``.
+
+This module is **ontology-agnostic**: it accepts any OWL TTL
+plus a small :class:`OntologyConfig` describing the namespace
+to pull from, the entity allowlist for the binding, the
+annotation prefix for audit-trail keys, and the local
+property-graph name.
+
+The MAKO demo's config lives in :mod:`mako_artifacts` (the
+canonical reference example). A tiny second ontology that
+exercises the same pipeline lives under ``example_ontologies/``.
+
+**Events are NOT generated here.** Events come from whatever
+agent populates the BQ AA plugin's ``agent_events`` table.
+The MAKO demo wires this via ``mako_demo_agent.py`` +
+``run_agent.py``.
+
+Transformation policy:
+
+The pipeline applies three post-import normalizations so any
+reasonable OWL TTL loads cleanly through
+:func:`bigquery_ontology.load_ontology_from_string`:
+
+1. ``FILL_IN`` primary keys → synthesized ``id: string``
+   property + primary key. The OWL importer marks every
+   concrete entity's primary key as ``FILL_IN`` when the TTL
+   doesn't declare ``owl:hasKey``; this resolver synthesizes
+   one. Entities that already declare ``owl:hasKey`` (and
+   hence don't have ``FILL_IN``) are left untouched.
+2. Cross-namespace dangling relationships → dropped. If a
+   TTL extends an upstream ontology (e.g. PROV-O) and
+   declares relationships pointing at upstream entities the
+   importer didn't pull in, the relationship's ``to`` field
+   is missing and the Ontology model rejects it. The
+   pipeline drops these and records the loss under a
+   top-level annotation keyed by the config's
+   ``annotation_prefix``.
+3. Inheritance stripped. ``gm compile`` v0 doesn't support
+   inheritance, so any ``extends:`` clauses are dropped and
+   recorded under the config's ``annotation_prefix``.
+   Entities whose only path to a primary key was via the
+   stripped parent get the same synthesized ``id: string``
+   PK the FILL_IN resolver uses.
+
+These transformations are general; they apply to any OWL TTL
+with those quirks. MAKO exercises all three; simpler TTLs may
+exercise only the first or none.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Any, Iterable, Optional
+
+import yaml
+
+from bigquery_ontology import Binding
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology import Ontology
+from bigquery_ontology.owl_importer import import_owl
+
+
+@dataclasses.dataclass(frozen=True)
+class OntologyConfig:
+  """Per-ontology configuration for the artifact pipeline.
+
+  Attributes:
+    ttl_path: Path to the authored OWL TTL file.
+    include_namespace: IRI prefix passed to ``import_owl``.
+      Only entities under this namespace are pulled in from
+      the TTL, so upstream imports (PROV-O, PKO, etc.) don't
+      leak into the binding.
+    entity_allowlist: Tuple of entity names to include in the
+      binding. The TTL may declare more entities; the binding
+      scope is narrower so the demo narrative stays focused.
+    annotation_prefix: Prefix used for audit-trail annotation
+      keys the pipeline writes when it drops cross-namespace
+      relationships or strips inheritance
+      (e.g. ``"mako_demo"`` →
+      ``mako_demo:stripped_inheritance``).
+    graph_name: Local property-graph name passed to
+      ``CREATE OR REPLACE PROPERTY GRAPH``.
+    snapshot_dir: Directory where :func:`regenerate_snapshots`
+      writes the four output files
+      (``ontology.yaml`` / ``binding.yaml`` /
+      ``table_ddl.sql`` / ``property_graph.sql``).
+  """
+
+  ttl_path: pathlib.Path
+  include_namespace: str
+  entity_allowlist: tuple[str, ...]
+  annotation_prefix: str
+  graph_name: str
+  snapshot_dir: pathlib.Path
+
+  @property
+  def ontology_path(self) -> pathlib.Path:
+    return self.snapshot_dir / "ontology.yaml"
+
+  @property
+  def binding_path(self) -> pathlib.Path:
+    return self.snapshot_dir / "binding.yaml"
+
+  @property
+  def table_ddl_path(self) -> pathlib.Path:
+    return self.snapshot_dir / "table_ddl.sql"
+
+  @property
+  def property_graph_path(self) -> pathlib.Path:
+    return self.snapshot_dir / "property_graph.sql"
+
+
+# ------------------------------------------------------------------ #
+# Step 1: load + normalize the ontology                                #
+# ------------------------------------------------------------------ #
+
+
+def load_ontology(config: OntologyConfig) -> tuple[Ontology, str]:
+  """Import the TTL and resolve FILL_IN primary keys.
+
+  Returns:
+    A ``(Ontology, yaml_text)`` tuple. The ``yaml_text`` is
+    the *resolved* YAML — i.e. the OWL importer's output
+    with FILL_INs replaced, cross-namespace relationships
+    dropped, and inheritance stripped — and is suitable for
+    writing straight to ``ontology.yaml``.
+  """
+  yaml_text, _drop_summary = import_owl(
+      sources=[str(config.ttl_path)],
+      include_namespaces=[config.include_namespace],
+  )
+  resolved_yaml = _normalize_imported_ontology(yaml_text, config)
+  ontology = load_ontology_from_string(resolved_yaml)
+  return ontology, resolved_yaml
+
+
+def _normalize_imported_ontology(yaml_text: str, config: OntologyConfig) -> str:
+  """Post-process the OWL importer's output so it loads
+  cleanly via :func:`load_ontology_from_string`.
+
+  Three passes (see module docstring for rationale):
+
+  1. Resolve ``FILL_IN`` primary keys to ``id``.
+  2. Drop cross-namespace dangling relationships.
+  3. Strip ``extends`` (gm compile v0 limitation).
+  """
+  data = yaml.safe_load(yaml_text)
+  data = _resolve_fill_in_primary_keys_dict(data)
+  data = _drop_dangling_relationships(data, config)
+  data = _strip_inheritance(data, config)
+  return yaml.safe_dump(data, sort_keys=False)
+
+
+def _resolve_fill_in_primary_keys_dict(data: dict) -> dict:
+  """Walk every entity; for each one whose ``keys.primary`` is
+  ``[FILL_IN]``, replace it with ``[id]`` and ensure an
+  ``id: string`` property exists.
+
+  Matches the "every artifact has a stable identifier"
+  contract most well-formed TTLs follow. Entities that already
+  declare an ``owl:hasKey`` (and hence don't have ``FILL_IN``)
+  are left untouched.
+  """
+  for entity in data.get("entities", []):
+    keys = entity.get("keys")
+    if keys is None:
+      continue
+    primary = keys.get("primary")
+    if primary == ["FILL_IN"]:
+      keys["primary"] = ["id"]
+      props = entity.setdefault("properties", [])
+      if not any(p.get("name") == "id" for p in props):
+        props.insert(0, {"name": "id", "type": "string"})
+  return data
+
+
+def _drop_dangling_relationships(data: dict, config: OntologyConfig) -> dict:
+  """Remove relationships missing either endpoint.
+
+  TTLs that extend upstream ontologies often declare
+  relationships that cross into those upstream namespaces
+  (e.g. MAKO's ``delegatedTo → prov:Agent``). The importer
+  pulls only the configured namespace, so those
+  cross-namespace endpoints aren't materialized as entities;
+  the OWL importer leaves the relationship with a missing
+  ``to`` (or ``from``). The Ontology model rejects those as
+  malformed. The pipeline drops these edges and records them
+  under ``{annotation_prefix}:dropped_cross_namespace_relationships``
+  so the loss is auditable from the loaded model.
+  """
+  entity_names = {ent["name"] for ent in data.get("entities", [])}
+  surviving: list[dict] = []
+  dropped: list[str] = []
+  for rel in data.get("relationships", []):
+    to = rel.get("to")
+    frm = rel.get("from")
+    if not to or not frm or to not in entity_names or frm not in entity_names:
+      dropped.append(rel.get("name", "<anonymous>"))
+      continue
+    surviving.append(rel)
+  data["relationships"] = surviving
+  if dropped:
+    annotations = data.setdefault("annotations", {})
+    annotations[
+        f"{config.annotation_prefix}:dropped_cross_namespace_relationships"
+    ] = dropped
+  return data
+
+
+def _strip_inheritance(data: dict, config: OntologyConfig) -> dict:
+  """Strip ``extends`` from every entity post-import.
+
+  The v0 ``gm compile`` (used by the notebook's Section 4
+  concept-index emission) doesn't support inheritance, so any
+  ``extends:`` clause breaks compile-validation:
+  ``Entity 'X' uses 'extends'; v0 compilation does not
+  support inheritance.``
+
+  The discarded inheritance is recorded under
+  ``{annotation_prefix}:stripped_inheritance`` on each
+  affected entity AND in a top-level summary, so the loss is
+  visible from a loaded model. Entities whose only path to a
+  primary key was through the parent class get the same
+  synthesized ``id: string`` PK the FILL_IN resolver uses.
+  """
+  # Ontology annotations are typed ``dict[str, str]``; the
+  # audit trail therefore serializes to strings. Per-entity
+  # records carry the ``extended`` parent in a flat key; the
+  # top-level summary is a comma-joined ``entity:parent`` list.
+  stripped: list[str] = []
+  for entity in data.get("entities", []):
+    if "extends" not in entity:
+      continue
+    stripped.append(f"{entity['name']}:{entity['extends']}")
+    annotations = entity.setdefault("annotations", {}) or {}
+    annotations[f"{config.annotation_prefix}:stripped_inheritance"] = entity[
+        "extends"
+    ]
+    entity["annotations"] = annotations
+    del entity["extends"]
+    # Stripping ``extends`` removes the entity's only path
+    # to a primary key (the parent class declared one). Add
+    # the same ``id: string`` PK the importer adds to every
+    # other concrete entity so the ontology still loads.
+    keys = entity.setdefault("keys", {})
+    if "primary" not in keys:
+      keys["primary"] = ["id"]
+    props = entity.setdefault("properties", []) or []
+    if not any(p.get("name") == "id" for p in props):
+      props.insert(0, {"name": "id", "type": "string"})
+      entity["properties"] = props
+  if stripped:
+    top_annotations = data.setdefault("annotations", {}) or {}
+    top_annotations[f"{config.annotation_prefix}:stripped_inheritance"] = (
+        ",".join(stripped)
+    )
+    data["annotations"] = top_annotations
+  return data
+
+
+# ------------------------------------------------------------------ #
+# Step 2: generate a binding for a target (project, dataset)         #
+# ------------------------------------------------------------------ #
+
+
+def make_binding(
+    ontology: Ontology,
+    config: OntologyConfig,
+    *,
+    project: str,
+    dataset: str,
+    entity_filter: Optional[Iterable[str]] = None,
+) -> Binding:
+  """Construct a ``Binding`` for the given target.
+
+  Args:
+    ontology: The resolved ontology
+      (:func:`load_ontology` output).
+    config: The per-ontology config. Provides the default
+      ``entity_allowlist`` when ``entity_filter`` is None.
+    project: BigQuery project ID.
+    dataset: BigQuery dataset name.
+    entity_filter: Optional override of the entity scope;
+      defaults to ``config.entity_allowlist``.
+
+  Returns:
+    A validated ``Binding`` instance. Property columns use
+    the snake_case-of-camelCase convention since BigQuery's
+    identifier conventions are snake_case.
+  """
+  scope = (
+      set(config.entity_allowlist)
+      if entity_filter is None
+      else set(entity_filter)
+  )
+
+  # Each entity's PK column is named ``{entity_short}_id``
+  # rather than a bare ``id``. The materializer
+  # (``_relationship_columns`` in ``ontology_materializer.py``)
+  # populates an edge's FK column type from the source
+  # entity's ``src_prop_map[col].sdk_type`` — that lookup
+  # requires the FK column name to exactly match a property
+  # column on the source entity. Using a bare ``id`` would
+  # work for one entity per edge but collide when both
+  # endpoints share the same PK column name (``id, id`` —
+  # duplicate column). Per-entity PK names give every edge a
+  # clean ``{src_entity}_id, {dst_entity}_id`` shape.
+  entities_block: list[dict] = []
+  for entity in ontology.entities:
+    if entity.name not in scope:
+      continue
+    table_name = _entity_table_name(entity.name)
+    pk_column = f"{_entity_id_column(entity.name)}_id"
+    props = [{"name": "id", "column": pk_column}]
+    # Append every ontology-declared property except ``id``
+    # (PK, already added). The binding validator requires
+    # every non-derived ontology property to have a binding.
+    for prop in entity.properties:
+      if prop.name == "id":
+        continue
+      props.append({"name": prop.name, "column": _to_snake_case(prop.name)})
+    entities_block.append(
+        {
+            "name": entity.name,
+            "source": f"{project}.{dataset}.{table_name}",
+            "properties": props,
+        }
+    )
+
+  # Edge set is derived from the ontology's declared
+  # relationships — pick relationships whose endpoints are
+  # both in scope. Two filters:
+  #
+  # 1. ``rel.from_ != rel.to`` — self-edges are dropped. The
+  #    materializer's ``_relationship_columns`` requires the
+  #    edge's ``from_columns`` to name a property column on
+  #    the source entity. For a self-edge that would mean two
+  #    identical PK column names on the edge table
+  #    (duplicate-column error), and the workarounds
+  #    (``src_/dst_`` prefixes) miss the property lookup. A
+  #    future SDK change that accepts FK-to-PK column mapping
+  #    could re-add self-edges; for now the binding scope
+  #    drops them.
+  # 2. Heterogeneous edges use ``{entity_short}_id`` as both
+  #    source and destination FK columns — the same name as
+  #    the source/destination entity's PK column. The
+  #    materializer can then resolve ``src_prop_map[col]``
+  #    cleanly.
+  relationships_block: list[dict] = []
+  dropped_self_edges: list[str] = []
+  for rel in ontology.relationships:
+    if rel.from_ not in scope or rel.to not in scope:
+      continue
+    if rel.from_ == rel.to:
+      dropped_self_edges.append(rel.name)
+      continue
+    src_col = f"{_entity_id_column(rel.from_)}_id"
+    dst_col = f"{_entity_id_column(rel.to)}_id"
+    relationships_block.append(
+        {
+            "name": rel.name,
+            "source": f"{project}.{dataset}.{_edge_table_name(rel.name)}",
+            "from_columns": [src_col],
+            "to_columns": [dst_col],
+        }
+    )
+
+  binding_dict = {
+      "binding": f"{dataset}_binding",
+      "ontology": ontology.ontology,
+      "target": {
+          "backend": "bigquery",
+          "project": project,
+          "dataset": dataset,
+      },
+      "entities": entities_block,
+      "relationships": relationships_block,
+  }
+  binding_yaml = yaml.safe_dump(binding_dict, sort_keys=False)
+  return load_binding_from_string(binding_yaml, ontology=ontology)
+
+
+# ------------------------------------------------------------------ #
+# Step 3: derive table DDL + property-graph SQL from the binding     #
+# ------------------------------------------------------------------ #
+
+
+def make_table_ddl(binding: Binding, *, ontology: Ontology) -> str:
+  """Generate ``CREATE TABLE`` SQL for every node + edge
+  table referenced by *binding*.
+
+  Column types are mapped from the ontology's
+  ``Property.type`` (which the OWL importer set from each
+  property's ``xsd:`` range) through :func:`_bq_type_for`.
+
+  Every node + edge table also carries the two SDK metadata
+  columns the materializer writes on every ``materialize()``
+  call: ``session_id STRING`` and ``extracted_at TIMESTAMP``.
+  The binding validator requires both columns on every bound
+  table.
+  """
+  prop_types: dict[tuple[str, str], str] = {}
+  for entity in ontology.entities:
+    for prop in entity.properties:
+      prop_types[(entity.name, prop.name)] = _bq_type_for(prop.type)
+
+  lines: list[str] = []
+  for ebind in binding.entities:
+    bound_columns = {prop.column for prop in ebind.properties}
+    cols = []
+    for prop in ebind.properties:
+      bq_type = prop_types.get((ebind.name, prop.name), "STRING")
+      cols.append(f"{prop.column} {bq_type}")
+    cols.extend(_sdk_metadata_columns(bound_columns))
+    lines.append(
+        f"CREATE TABLE IF NOT EXISTS `{ebind.source}` ({', '.join(cols)});"
+    )
+
+  for rbind in binding.relationships:
+    src_col, dst_col = rbind.from_columns[0], rbind.to_columns[0]
+    edge_cols = [f"{src_col} STRING", f"{dst_col} STRING"]
+    edge_cols.extend(_sdk_metadata_columns({src_col, dst_col}))
+    lines.append(
+        f"CREATE TABLE IF NOT EXISTS `{rbind.source}` "
+        f"({', '.join(edge_cols)});"
+    )
+
+  return "\n".join(lines) + "\n"
+
+
+def _sdk_metadata_columns(already_present: set[str]) -> list[str]:
+  """Return DDL fragments for SDK metadata columns not yet
+  present in *already_present*.
+
+  Domain bindings can legitimately map a property onto
+  ``session_id`` (MAKO's ``AgentSession.sessionId`` is one
+  example). The materializer's writes for those rows still
+  land in the same column, so skipping the SDK metadata copy
+  avoids a duplicate-column error.
+  """
+  return [
+      ddl
+      for col, ddl in _SDK_METADATA_DDL_BY_COLUMN.items()
+      if col not in already_present
+  ]
+
+
+# SDK metadata columns that the materializer
+# (``ontology_materializer._entity_columns`` /
+# ``_relationship_columns``) writes on every ``materialize()``
+# call. Binding validation requires both columns on every
+# bound table.
+_SDK_METADATA_DDL_BY_COLUMN = {
+    "session_id": "session_id STRING",
+    "extracted_at": "extracted_at TIMESTAMP",
+}
+
+
+def make_property_graph_sql(
+    binding: Binding,
+    *,
+    ontology: Ontology,
+    graph_name: str,
+) -> str:
+  """Generate ``CREATE OR REPLACE PROPERTY GRAPH`` SQL.
+
+  Edge columns match :func:`make_table_ddl`'s output so
+  applying both in sequence works without column-name
+  mismatches.
+
+  Args:
+    binding: A validated ``Binding`` (see :func:`make_binding`).
+    ontology: The bound ontology — used to resolve each
+      relationship's source/destination entity for the
+      ``SOURCE KEY`` / ``DESTINATION KEY REFERENCES`` clauses.
+    graph_name: Local property-graph name.
+  """
+  project = binding.target.project
+  dataset = binding.target.dataset
+  qualified_graph = f"{project}.{dataset}.{graph_name}"
+
+  # The PK column for each entity is the ``column`` of the
+  # property whose ``name`` is ``id`` (set by ``make_binding``
+  # to ``{entity_short}_id``). Both the ``KEY (...)`` of the
+  # node table and the ``REFERENCES <alias> (...)`` of every
+  # edge endpoint must use that column name; hard-coding
+  # ``id`` trips ``Unrecognized name: id`` because the
+  # underlying table column has the entity-specific name.
+  pk_column_by_entity: dict[str, str] = {}
+  node_tables: list[str] = []
+  for ebind in binding.entities:
+    qualified_source = ebind.source
+    short_name = _table_ref_short(qualified_source)
+    pk_col = next(p.column for p in ebind.properties if p.name == "id")
+    pk_column_by_entity[ebind.name] = pk_col
+    cols = ", ".join(p.column for p in ebind.properties)
+    node_tables.append(
+        f"    `{qualified_source}` AS {short_name}\n"
+        f"      KEY ({pk_col})\n"
+        f"      LABEL {ebind.name} PROPERTIES ({cols})"
+    )
+
+  rel_map = {r.name: r for r in ontology.relationships}
+
+  edge_tables: list[str] = []
+  for rbind in binding.relationships:
+    rel = rel_map.get(rbind.name)
+    if rel is None:
+      # Defensive — should never happen given the binding
+      # passed validation.
+      continue
+    src_col = rbind.from_columns[0]
+    dst_col = rbind.to_columns[0]
+    qualified_edge_source = rbind.source
+    short = _table_ref_short(qualified_edge_source)
+    # ``SOURCE KEY ... REFERENCES`` and ``DESTINATION KEY ...
+    # REFERENCES`` name the **alias** the node table is
+    # declared under inside the same property graph, not the
+    # fully-qualified BigQuery table.
+    src_alias = _table_ref_short(
+        next(e.source for e in binding.entities if e.name == rel.from_)
+    )
+    dst_alias = _table_ref_short(
+        next(e.source for e in binding.entities if e.name == rel.to)
+    )
+    # Edge tables require an explicit ``KEY (...)``
+    # declaration alongside ``SOURCE KEY`` / ``DESTINATION
+    # KEY``. The natural composite key is the pair of FK
+    # columns the source + destination references point at.
+    src_pk = pk_column_by_entity[rel.from_]
+    dst_pk = pk_column_by_entity[rel.to]
+    edge_tables.append(
+        f"    `{qualified_edge_source}` AS {short}\n"
+        f"      KEY ({src_col}, {dst_col})\n"
+        f"      SOURCE KEY ({src_col}) REFERENCES {src_alias} ({src_pk})\n"
+        f"      DESTINATION KEY ({dst_col}) REFERENCES {dst_alias} ({dst_pk})\n"
+        f"      LABEL {rbind.name}"
+    )
+
+  return (
+      f"CREATE OR REPLACE PROPERTY GRAPH `{qualified_graph}`\n"
+      f"  NODE TABLES (\n" + ",\n".join(node_tables) + "\n  )\n"
+      f"  EDGE TABLES (\n" + ",\n".join(edge_tables) + "\n  );\n"
+  )
+
+
+# ------------------------------------------------------------------ #
+# Step 4: regenerate the snapshot files                                #
+# ------------------------------------------------------------------ #
+
+
+def regenerate_snapshots(
+    config: OntologyConfig,
+    *,
+    project: str,
+    dataset: str,
+) -> dict:
+  """Regenerate every TTL-derived artifact snapshot for *config*.
+
+  Idempotent: byte-identical output across runs for the same
+  ``(config, project, dataset)`` triple. Returns a small
+  summary dict.
+
+  Does NOT produce events — events come from whichever agent
+  populates the BQ AA plugin's ``agent_events`` table.
+  """
+  ontology, yaml_text = load_ontology(config)
+  config.ontology_path.write_text(yaml_text, encoding="utf-8")
+
+  binding = make_binding(ontology, config, project=project, dataset=dataset)
+  config.binding_path.write_text(_binding_yaml(binding), encoding="utf-8")
+  config.table_ddl_path.write_text(
+      make_table_ddl(binding, ontology=ontology), encoding="utf-8"
+  )
+  config.property_graph_path.write_text(
+      make_property_graph_sql(
+          binding, ontology=ontology, graph_name=config.graph_name
+      ),
+      encoding="utf-8",
+  )
+
+  return {
+      "ontology_entities": len(ontology.entities),
+      "binding_entities": len(binding.entities),
+      "binding_relationships": len(binding.relationships),
+  }
+
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+def _binding_yaml(binding: Binding) -> str:
+  """Serialize a Binding to YAML.
+
+  Pydantic's ``model_dump`` keeps enum members as enum
+  instances by default; PyYAML's ``safe_dump`` can't
+  represent those. ``mode='json'`` coerces enums to their
+  string values plus normalizes other non-YAML primitives,
+  matching how the loader expects to read the YAML back.
+  """
+  payload = binding.model_dump(by_alias=True, exclude_none=True, mode="json")
+  return yaml.safe_dump(payload, sort_keys=False)
+
+
+def _entity_table_name(entity_name: str) -> str:
+  """Canonical BQ table name for an entity."""
+  return _to_snake_case(entity_name)
+
+
+def _entity_id_column(entity_name: str) -> str:
+  """Column-name root for an entity's PK + foreign-key
+  references (e.g. ``AgentSession`` → ``agent_session``,
+  used in ``agent_session_id``).
+
+  Earlier drafts stripped a leading prefix to shorten FK
+  column names — but that collided with both the SDK metadata
+  column ``session_id`` and naturally-named ``sessionId``
+  data properties (also bound to column ``session_id``),
+  producing duplicate columns the validator rejects. Keeping
+  the full snake form gives every entity a unique PK column
+  and lets SDK metadata + ontology-declared ``sessionId``
+  co-exist cleanly.
+  """
+  return _to_snake_case(entity_name)
+
+
+def _edge_table_name(edge_name: str) -> str:
+  return _to_snake_case(edge_name)
+
+
+def _table_ref_short(qualified: str) -> str:
+  return qualified.rsplit(".", 1)[-1]
+
+
+def _bq_type_for(property_type: Any) -> str:
+  """Map an ontology ``PropertyType`` (or its string value)
+  to a BigQuery column type.
+
+  Defaults to ``STRING`` for unknown values; the only types
+  the OWL importer can currently emit are those in
+  ``PropertyType`` (string / bytes / integer / double /
+  numeric / boolean / date / time / datetime / timestamp /
+  json), and they map 1:1 to BigQuery legacy SQL types.
+  """
+  value = getattr(property_type, "value", property_type)
+  return {
+      "string": "STRING",
+      "bytes": "BYTES",
+      "integer": "INT64",
+      "double": "FLOAT64",
+      "numeric": "NUMERIC",
+      "boolean": "BOOL",
+      "date": "DATE",
+      "time": "TIME",
+      "datetime": "DATETIME",
+      "timestamp": "TIMESTAMP",
+      "json": "JSON",
+  }.get(value, "STRING")
+
+
+def _to_snake_case(camel: str) -> str:
+  out: list[str] = []
+  for i, ch in enumerate(camel):
+    if ch.isupper() and i > 0 and not camel[i - 1].isupper():
+      out.append("_")
+    out.append(ch.lower())
+  return "".join(out)

--- a/examples/migration_v5/ontology_artifacts.py
+++ b/examples/migration_v5/ontology_artifacts.py
@@ -337,14 +337,23 @@ def make_binding(
   for entity in ontology.entities:
     if entity.name not in scope:
       continue
+    # The PK property name comes from the ontology — either the
+    # synthesized ``id`` the FILL_IN resolver added, or the real
+    # property declared by ``owl:hasKey`` in the TTL. Hard-coding
+    # ``"id"`` here broke TTLs that declared their own keys (the
+    # binding ended up declaring an ``id`` property the entity
+    # didn't have). Single-column PK is assumed; composite PKs
+    # would need extra bind logic + property-graph KEY handling
+    # and are out of scope for the current demo.
+    pk_property_name = _primary_key_property_name(entity)
     table_name = _entity_table_name(entity.name)
     pk_column = f"{_entity_id_column(entity.name)}_id"
-    props = [{"name": "id", "column": pk_column}]
-    # Append every ontology-declared property except ``id``
-    # (PK, already added). The binding validator requires
-    # every non-derived ontology property to have a binding.
+    props = [{"name": pk_property_name, "column": pk_column}]
+    # Append every ontology-declared property except the PK
+    # (already added). The binding validator requires every
+    # non-derived ontology property to have a binding.
     for prop in entity.properties:
-      if prop.name == "id":
+      if prop.name == pk_property_name:
         continue
       props.append({"name": prop.name, "column": _to_snake_case(prop.name)})
     entities_block.append(
@@ -507,19 +516,26 @@ def make_property_graph_sql(
   dataset = binding.target.dataset
   qualified_graph = f"{project}.{dataset}.{graph_name}"
 
-  # The PK column for each entity is the ``column`` of the
-  # property whose ``name`` is ``id`` (set by ``make_binding``
-  # to ``{entity_short}_id``). Both the ``KEY (...)`` of the
-  # node table and the ``REFERENCES <alias> (...)`` of every
-  # edge endpoint must use that column name; hard-coding
-  # ``id`` trips ``Unrecognized name: id`` because the
-  # underlying table column has the entity-specific name.
+  # The PK column for each entity is set by ``make_binding`` to
+  # ``{entity_short}_id``; the bound *property* name is whatever
+  # the ontology's primary key declares (synthesized ``id`` for
+  # the FILL_IN path, or the real property declared by
+  # ``owl:hasKey`` otherwise). Both the ``KEY (...)`` of the node
+  # table and the ``REFERENCES <alias> (...)`` of every edge
+  # endpoint must use the COLUMN name, so we look the property
+  # up by its ontology-derived name first, then read its column.
+  pk_name_by_entity = {
+      e.name: _primary_key_property_name(e) for e in ontology.entities
+  }
   pk_column_by_entity: dict[str, str] = {}
   node_tables: list[str] = []
   for ebind in binding.entities:
     qualified_source = ebind.source
     short_name = _table_ref_short(qualified_source)
-    pk_col = next(p.column for p in ebind.properties if p.name == "id")
+    pk_property_name = pk_name_by_entity[ebind.name]
+    pk_col = next(
+        p.column for p in ebind.properties if p.name == pk_property_name
+    )
     pk_column_by_entity[ebind.name] = pk_col
     cols = ", ".join(p.column for p in ebind.properties)
     node_tables.append(
@@ -630,6 +646,32 @@ def _binding_yaml(binding: Binding) -> str:
   """
   payload = binding.model_dump(by_alias=True, exclude_none=True, mode="json")
   return yaml.safe_dump(payload, sort_keys=False)
+
+
+def _primary_key_property_name(entity: Any) -> str:
+  """Return the entity's primary-key property name.
+
+  After the normalization passes have run, every entity has
+  ``keys.primary`` populated — either the synthesized ``id``
+  the FILL_IN resolver added, or the real property the TTL
+  declared via ``owl:hasKey``. This helper centralizes the
+  single-column-PK assumption: the binding generator and the
+  property-graph SQL generator both need the same name.
+
+  Raises ``ValueError`` if the entity has no primary key (a
+  malformed-input guard; the normalization passes should
+  prevent this).
+  """
+  keys = getattr(entity, "keys", None)
+  primary = getattr(keys, "primary", None) if keys is not None else None
+  if not primary:
+    raise ValueError(
+        f"Entity {entity.name!r} has no primary key. The "
+        "ontology-artifact pipeline assumes every entity declares "
+        "one (synthesized via FILL_IN resolution or declared via "
+        "owl:hasKey)."
+    )
+  return primary[0]
 
 
 def _entity_table_name(entity_name: str) -> str:

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -4,14 +4,17 @@ Run `bqaa-materialize-window` on a cron, against your own
 BigQuery project, with one local command and one deploy command.
 
 The migration v5 demo (`examples/migration_v5/`) ships the
-ontology, binding, and entity-table DDL — MAKO is the
-canonical reference example, but the pipeline is
-ontology-agnostic (see `ontology_artifacts.py`). This
-directory wraps the bound artifacts in a hands-off scheduled
-deployment: a Cloud Run Job that fires every
-N hours via Cloud Scheduler, materializes the last N hours of
-events into your graph dataset, and emits a structured JSON
-report to Cloud Logging.
+ontology, binding, and entity-table DDL. The artifact
+pipeline that produced them (`ontology_artifacts.py`) is
+ontology-agnostic, but **this deploy bundles the checked-in
+MAKO snapshots** — running against a different ontology means
+regenerating those snapshots for your config first and
+re-pointing the deploy at the new files. This directory wraps
+the bundled MAKO artifacts in a hands-off scheduled
+deployment: a Cloud Run Job that fires every N hours via
+Cloud Scheduler, materializes the last N hours of events into
+your graph dataset, and emits a structured JSON report to
+Cloud Logging.
 
 ## Customer playbook (skim this first)
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -3,9 +3,12 @@
 Run `bqaa-materialize-window` on a cron, against your own
 BigQuery project, with one local command and one deploy command.
 
-The MAKO demo (`examples/migration_v5/`) ships the ontology,
-binding, and entity-table DDL. This directory wraps them in a
-hands-off scheduled deployment: a Cloud Run Job that fires every
+The migration v5 demo (`examples/migration_v5/`) ships the
+ontology, binding, and entity-table DDL — MAKO is the
+canonical reference example, but the pipeline is
+ontology-agnostic (see `ontology_artifacts.py`). This
+directory wraps the bound artifacts in a hands-off scheduled
+deployment: a Cloud Run Job that fires every
 N hours via Cloud Scheduler, materializes the last N hours of
 events into your graph dataset, and emits a structured JSON
 report to Cloud Logging.
@@ -79,7 +82,7 @@ gcloud services enable \
   --project=your-project
 ```
 
-`aiplatform.googleapis.com` is required because the MAKO demo's
+`aiplatform.googleapis.com` is required because the demo's
 extraction path calls `AI.GENERATE`. Without it, every session
 will fail with `error_code = "empty_extraction"` (surfaced as a
 hard `ok=false` since PR #167).
@@ -255,7 +258,7 @@ The script:
    * Project-level `roles/bigquery.jobUser` —
      `bigquery.jobs.create` only.
    * Project-level `roles/aiplatform.user` — required because
-     the MAKO demo's extraction path calls BigQuery's
+     the demo's extraction path calls BigQuery's
      `AI.GENERATE` function (Gemini-backed entity extraction).
      Without this grant, the AI call returns "user does not
      have the permission to access resources used by
@@ -638,7 +641,7 @@ that look identical from `rows_materialized` alone:
   bundle) returned an empty graph; no inserts attempted.
   Diagnose by checking the runtime SA's `roles/aiplatform.user`
   grant, AI.GENERATE quotas, or whether the session's events
-  legitimately had any MAKO content.
+  legitimately had any content the bound ontology models.
 
 * **`materialization_failed`** — extraction produced rows but
   every insert returned an error. The `failures[].error_detail`

--- a/tests/test_migration_v5_ontology_artifacts.py
+++ b/tests/test_migration_v5_ontology_artifacts.py
@@ -40,24 +40,24 @@ import sys
 import pytest
 import yaml
 
-# Examples live outside ``src/``. Add the repo root so the
-# imports below resolve.
-_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-  sys.path.insert(0, str(_REPO_ROOT))
-
 # ``mako_artifacts`` and ``ontology_artifacts`` are sibling
-# modules inside ``examples/migration_v5/``. They import each
-# other as top-level (the notebook + run_agent.py do the
-# same), so add that directory to ``sys.path`` too.
+# modules inside ``examples/migration_v5/`` that import each
+# other top-level (the notebook + run_agent.py do the same).
+# This test uses the same sibling-style import surface those
+# callers do — only ``examples/migration_v5/`` needs to be on
+# sys.path. Don't mix package-style (``examples.migration_v5.X``)
+# imports here: that path requires both the repo root AND the
+# v5 dir on sys.path, and silently masks regressions in the
+# notebook's import contract (see PR #172 review).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _V5_DIR = _REPO_ROOT / "examples" / "migration_v5"
 if str(_V5_DIR) not in sys.path:
   sys.path.insert(0, str(_V5_DIR))
 
 ontology_artifacts = importlib.import_module("ontology_artifacts")
-mako_artifacts = importlib.import_module("examples.migration_v5.mako_artifacts")
+mako_artifacts = importlib.import_module("mako_artifacts")
 simple_config_mod = importlib.import_module(
-    "examples.migration_v5.example_ontologies.simple_request_flow_config"
+    "example_ontologies.simple_request_flow_config"
 )
 
 from bigquery_ontology import load_binding_from_string
@@ -160,7 +160,12 @@ def test_simple_request_flow_pk_columns_are_per_entity(tmp_path):
   ``{entity_short}_id`` (not bare ``id``) so edge tables get
   clean ``{src}_id, {dst}_id`` shapes without column-name
   collisions. Cover the simple ontology to make sure the
-  convention isn't accidentally MAKO-specific."""
+  convention isn't accidentally MAKO-specific.
+
+  PK property names are entity-declared (``requestId`` etc.
+  via ``owl:hasKey``) — they're the FIRST entry in each
+  binding entity's property list (``make_binding`` inserts the
+  PK at position 0)."""
   tmp_config = dataclasses.replace(
       simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
   )
@@ -171,10 +176,7 @@ def test_simple_request_flow_pk_columns_are_per_entity(tmp_path):
   parsed = yaml.safe_load(binding_yaml)
 
   pk_column_by_entity = {
-      ent["name"]: next(
-          p["column"] for p in ent["properties"] if p["name"] == "id"
-      )
-      for ent in parsed["entities"]
+      ent["name"]: ent["properties"][0]["column"] for ent in parsed["entities"]
   }
   assert pk_column_by_entity == {
       "Action": "action_id",
@@ -197,6 +199,72 @@ def test_simple_request_flow_property_graph_sql_uses_configured_graph_name(
   pg_sql = (tmp_path / "property_graph.sql").read_text(encoding="utf-8")
   assert "simple_request_flow_graph" in pg_sql
   assert "mako_demo_graph" not in pg_sql
+
+
+def test_simple_request_flow_binds_declared_owl_haskey_property(tmp_path):
+  """Regression for PR #172 review (P1): the generic pipeline
+  must bind the entity's declared primary-key property, not a
+  hard-coded ``id``.
+
+  The Simple Request Flow TTL declares
+  ``owl:hasKey ( rf:requestId )`` (and similar for Action /
+  Outcome), so each entity's PK property name is
+  ``requestId`` / ``actionId`` / ``outcomeId`` — NOT the
+  synthesized ``id`` MAKO's FILL_IN path produces. Before the
+  fix, ``make_binding`` always emitted
+  ``{name: id, column: request_id}``, which made
+  ``load_binding_from_string`` raise ``Entity binding
+  'Request': property 'id' is not declared on this element``.
+  """
+  tmp_config = dataclasses.replace(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
+  )
+  ontology_artifacts.regenerate_snapshots(
+      tmp_config, project="smoke-proj", dataset="smoke_ds"
+  )
+  binding_yaml = (tmp_path / "binding.yaml").read_text(encoding="utf-8")
+  parsed = yaml.safe_load(binding_yaml)
+
+  props_by_entity = {
+      ent["name"]: {p["name"] for p in ent["properties"]}
+      for ent in parsed["entities"]
+  }
+  # Declared PK property names show up in the binding.
+  assert "requestId" in props_by_entity["Request"]
+  assert "actionId" in props_by_entity["Action"]
+  assert "outcomeId" in props_by_entity["Outcome"]
+  # And the synthesized ``id`` is NOT injected when a real
+  # ``owl:hasKey`` is present.
+  for entity_name in ("Request", "Action", "Outcome"):
+    assert "id" not in props_by_entity[entity_name], (
+        f"Entity {entity_name} should not have a synthesized 'id' "
+        "property when the TTL declares owl:hasKey."
+    )
+
+
+def test_simple_request_flow_property_graph_resolves_owl_haskey_pk_column(
+    tmp_path,
+):
+  """The property-graph SQL generator must look up each
+  entity's PK property by its declared name, not by a
+  hard-coded ``id``. Verifies the second half of the PR #172
+  P1 fix — ``KEY (...)`` and ``REFERENCES ... (...)`` resolve
+  to the right column for an ``owl:hasKey`` ontology."""
+  tmp_config = dataclasses.replace(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
+  )
+  ontology_artifacts.regenerate_snapshots(
+      tmp_config, project="smoke-proj", dataset="smoke_ds"
+  )
+  pg_sql = (tmp_path / "property_graph.sql").read_text(encoding="utf-8")
+  # Per-entity PK columns appear as node-table KEYs.
+  assert "KEY (request_id)" in pg_sql
+  assert "KEY (action_id)" in pg_sql
+  assert "KEY (outcome_id)" in pg_sql
+  # Edge endpoints reference the per-entity PK column.
+  assert "REFERENCES request (request_id)" in pg_sql
+  assert "REFERENCES action (action_id)" in pg_sql
+  assert "REFERENCES outcome (outcome_id)" in pg_sql
 
 
 def test_simple_request_flow_uses_its_own_annotation_prefix():

--- a/tests/test_migration_v5_ontology_artifacts.py
+++ b/tests/test_migration_v5_ontology_artifacts.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the migration v5 ontology-agnostic artifact pipeline.
+
+Covers two things:
+
+1. **MAKO regression**: the refactor that pulled the generic
+   pipeline out of ``mako_artifacts.py`` produces
+   byte-identical output for the MAKO config. The checked-in
+   snapshot files (``ontology.yaml`` / ``binding.yaml`` /
+   ``table_ddl.sql`` / ``property_graph.sql``) must match
+   what ``regenerate_snapshots(MAKO_CONFIG, ...)`` produces.
+
+2. **Pluggability**: the same generic pipeline accepts a
+   different OntologyConfig (the Simple Request Flow smoke
+   fixture) and produces a valid binding + DDL + property
+   graph with the right shape (3 entities, 2 relationships,
+   per-entity snake_case PK columns).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+# Examples live outside ``src/``. Add the repo root so the
+# imports below resolve.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+  sys.path.insert(0, str(_REPO_ROOT))
+
+# ``mako_artifacts`` and ``ontology_artifacts`` are sibling
+# modules inside ``examples/migration_v5/``. They import each
+# other as top-level (the notebook + run_agent.py do the
+# same), so add that directory to ``sys.path`` too.
+_V5_DIR = _REPO_ROOT / "examples" / "migration_v5"
+if str(_V5_DIR) not in sys.path:
+  sys.path.insert(0, str(_V5_DIR))
+
+ontology_artifacts = importlib.import_module("ontology_artifacts")
+mako_artifacts = importlib.import_module("examples.migration_v5.mako_artifacts")
+simple_config_mod = importlib.import_module(
+    "examples.migration_v5.example_ontologies.simple_request_flow_config"
+)
+
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+
+# ------------------------------------------------------------------ #
+# Section 1: MAKO refactor preserves byte-identical snapshots         #
+# ------------------------------------------------------------------ #
+
+
+_MAKO_CHECKED_IN_PROJECT = "test-project-0728-467323"
+_MAKO_CHECKED_IN_DATASET = "migration_v5_demo"
+
+
+def _temp_mako_config(tmp_path: pathlib.Path):
+  return dataclasses.replace(mako_artifacts.MAKO_CONFIG, snapshot_dir=tmp_path)
+
+
+def test_mako_regenerate_matches_checked_in_snapshots(tmp_path):
+  """The refactor must not drift the MAKO snapshot output.
+
+  Regenerates against a tmpdir using the same
+  ``(project, dataset)`` the checked-in snapshots use, then
+  diffs every file byte-for-byte against the checked-in
+  version. Catches accidental whitespace / ordering /
+  annotation-key changes.
+  """
+  tmp_config = _temp_mako_config(tmp_path)
+  ontology_artifacts.regenerate_snapshots(
+      tmp_config,
+      project=_MAKO_CHECKED_IN_PROJECT,
+      dataset=_MAKO_CHECKED_IN_DATASET,
+  )
+
+  for filename in (
+      "ontology.yaml",
+      "binding.yaml",
+      "table_ddl.sql",
+      "property_graph.sql",
+  ):
+    checked_in = (_V5_DIR / filename).read_text(encoding="utf-8")
+    regenerated = (tmp_path / filename).read_text(encoding="utf-8")
+    assert regenerated == checked_in, (
+        f"{filename} drifted after refactor — first 200 chars:\n"
+        f"checked-in: {checked_in[:200]!r}\n"
+        f"regenerated: {regenerated[:200]!r}"
+    )
+
+
+def test_mako_shim_regenerate_still_works():
+  """Back-compat: ``mako_artifacts.regenerate_snapshots()`` is
+  the notebook's entry point. It must keep returning the same
+  summary shape after the refactor."""
+  ontology, _yaml = mako_artifacts.load_mako_ontology()
+  binding = mako_artifacts.make_binding(
+      ontology, project="any-proj", dataset="any_ds"
+  )
+  assert len(ontology.entities) == 18
+  assert len(binding.entities) == 6
+  assert len(binding.relationships) == 7
+
+
+# ------------------------------------------------------------------ #
+# Section 2: Pluggable pipeline accepts a different ontology config   #
+# ------------------------------------------------------------------ #
+
+
+def test_simple_request_flow_pipeline_produces_valid_binding(tmp_path):
+  """The generic pipeline accepts any OntologyConfig. Smoke
+  test against the Simple Request Flow ontology: 3 entities,
+  2 relationships, no inheritance, no cross-namespace refs.
+  Validates the binding loads through the SDK's binding
+  loader."""
+  tmp_config = dataclasses.replace(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
+  )
+  summary = ontology_artifacts.regenerate_snapshots(
+      tmp_config, project="smoke-proj", dataset="smoke_ds"
+  )
+
+  assert summary == {
+      "ontology_entities": 3,
+      "binding_entities": 3,
+      "binding_relationships": 2,
+  }
+
+  ontology_yaml = (tmp_path / "ontology.yaml").read_text(encoding="utf-8")
+  binding_yaml = (tmp_path / "binding.yaml").read_text(encoding="utf-8")
+  ontology = load_ontology_from_string(ontology_yaml)
+  binding = load_binding_from_string(binding_yaml, ontology=ontology)
+
+  entity_names = sorted(e.name for e in binding.entities)
+  assert entity_names == ["Action", "Outcome", "Request"]
+  rel_names = sorted(r.name for r in binding.relationships)
+  assert rel_names == ["hasAction", "producesOutcome"]
+
+
+def test_simple_request_flow_pk_columns_are_per_entity(tmp_path):
+  """The pipeline names each entity's PK column
+  ``{entity_short}_id`` (not bare ``id``) so edge tables get
+  clean ``{src}_id, {dst}_id`` shapes without column-name
+  collisions. Cover the simple ontology to make sure the
+  convention isn't accidentally MAKO-specific."""
+  tmp_config = dataclasses.replace(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
+  )
+  ontology_artifacts.regenerate_snapshots(
+      tmp_config, project="smoke-proj", dataset="smoke_ds"
+  )
+  binding_yaml = (tmp_path / "binding.yaml").read_text(encoding="utf-8")
+  parsed = yaml.safe_load(binding_yaml)
+
+  pk_column_by_entity = {
+      ent["name"]: next(
+          p["column"] for p in ent["properties"] if p["name"] == "id"
+      )
+      for ent in parsed["entities"]
+  }
+  assert pk_column_by_entity == {
+      "Action": "action_id",
+      "Outcome": "outcome_id",
+      "Request": "request_id",
+  }
+
+
+def test_simple_request_flow_property_graph_sql_uses_configured_graph_name(
+    tmp_path,
+):
+  """``graph_name`` is per-config. Verify the simple
+  ontology's snapshot uses its own graph name, not MAKO's."""
+  tmp_config = dataclasses.replace(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG, snapshot_dir=tmp_path
+  )
+  ontology_artifacts.regenerate_snapshots(
+      tmp_config, project="smoke-proj", dataset="smoke_ds"
+  )
+  pg_sql = (tmp_path / "property_graph.sql").read_text(encoding="utf-8")
+  assert "simple_request_flow_graph" in pg_sql
+  assert "mako_demo_graph" not in pg_sql
+
+
+def test_simple_request_flow_uses_its_own_annotation_prefix():
+  """Annotation prefix is per-config. The simple ontology has
+  no cross-namespace refs and no inheritance to strip, so the
+  pipeline writes no audit annotations — but the prefix
+  threading itself is observable through the inheritance code
+  path. We only assert the prefix doesn't leak MAKO's name."""
+  ontology, yaml_text = ontology_artifacts.load_ontology(
+      simple_config_mod.SIMPLE_REQUEST_FLOW_CONFIG
+  )
+  assert "mako_demo:" not in yaml_text
+
+
+# ------------------------------------------------------------------ #
+# Section 3: OntologyConfig surface                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_ontology_config_path_properties_derive_from_snapshot_dir(tmp_path):
+  """The four snapshot path properties (``ontology_path``,
+  ``binding_path``, ``table_ddl_path``, ``property_graph_path``)
+  derive from ``snapshot_dir``. Caller-facing surface, worth
+  asserting explicitly."""
+  cfg = ontology_artifacts.OntologyConfig(
+      ttl_path=tmp_path / "fake.ttl",
+      include_namespace="https://example.com/x/",
+      entity_allowlist=("X",),
+      annotation_prefix="x_demo",
+      graph_name="x_graph",
+      snapshot_dir=tmp_path,
+  )
+  assert cfg.ontology_path == tmp_path / "ontology.yaml"
+  assert cfg.binding_path == tmp_path / "binding.yaml"
+  assert cfg.table_ddl_path == tmp_path / "table_ddl.sql"
+  assert cfg.property_graph_path == tmp_path / "property_graph.sql"
+
+
+def test_ontology_config_is_frozen():
+  """Frozen so callers can't accidentally mutate a shared
+  config and surprise other call sites."""
+  with pytest.raises(dataclasses.FrozenInstanceError):
+    mako_artifacts.MAKO_CONFIG.annotation_prefix = "other"  # type: ignore[misc]

--- a/tests/test_migration_v5_ontology_artifacts.py
+++ b/tests/test_migration_v5_ontology_artifacts.py
@@ -40,6 +40,15 @@ import sys
 import pytest
 import yaml
 
+# The ontology-artifact pipeline pulls
+# ``bigquery_ontology.owl_importer``, which requires
+# ``rdflib`` (an optional dep behind the ``[owl]`` extra).
+# CI's default install is ``.[dev]`` only, so skip the whole
+# module when rdflib isn't present — mirrors the pattern in
+# ``tests/test_owl_import_bridge.py`` and
+# ``tests/bigquery_ontology/test_owl_importer.py``.
+pytest.importorskip("rdflib")
+
 # ``mako_artifacts`` and ``ontology_artifacts`` are sibling
 # modules inside ``examples/migration_v5/`` that import each
 # other top-level (the notebook + run_agent.py do the same).


### PR DESCRIPTION
Generalizes the migration v5 demo's TTL → binding/DDL/property-graph pipeline so it isn't hard-coded to MAKO. MAKO stays as the canonical reference example; a tiny second TTL fixture proves the pipeline is genuinely ontology-agnostic.

## Motivation

The pipeline's three OWL TTL transformations (FILL_IN PK resolution, cross-namespace relationship drop, inheritance strip) are general — they apply to any reasonable OWL TTL with those quirks. Only the **config** (TTL path, namespace IRI, entity allowlist, annotation prefix, graph name) is per-ontology. The previous `mako_artifacts.py` mixed both concerns into one 751-line module.

## What ships

### `ontology_artifacts.py` — new generic module

Public surface:

- `OntologyConfig` — frozen dataclass packaging the five per-ontology bits.
- `load_ontology(config)` → `(Ontology, yaml_text)`.
- `make_binding(ontology, config, *, project, dataset, entity_filter=None)` → `Binding`.
- `make_table_ddl(binding, *, ontology)` → str.
- `make_property_graph_sql(binding, *, ontology, graph_name)` → str.
- `regenerate_snapshots(config, *, project, dataset)` → summary dict.

The three transformations stay; their annotation keys now use `{config.annotation_prefix}:` instead of hard-coded `mako_demo:`.

### `mako_artifacts.py` — now a thin shim

199 lines (down from 751). Defines `MAKO_CONFIG` and re-exports the public API with that config bound in. The notebook's `import mako_artifacts; mako_artifacts.regenerate_snapshots(project, dataset)` works unchanged.

### `example_ontologies/simple_request_flow.ttl` + `simple_request_flow_config.py`

Tiny domain-neutral ontology (Request → Action → Outcome — 3 entities, 2 relationships, no cross-namespace imports, no inheritance). Smoke fixture only. No runnable agent ships with it. Proves the generic pipeline accepts non-MAKO ontologies.

### `tests/test_migration_v5_ontology_artifacts.py` — eight new tests

- **MAKO regression**: `test_mako_regenerate_matches_checked_in_snapshots` regenerates against a tmpdir and diffs every file byte-for-byte against the checked-in version. Guards against future drift.
- **Back-compat**: `test_mako_shim_regenerate_still_works` exercises the notebook's import path.
- **Pluggability** (5 tests): Simple Request Flow produces a valid binding, correct entity/relationship counts, per-entity snake_case PK columns, the configured graph name (not MAKO's), and its own annotation prefix.
- **`OntologyConfig` surface** (2 tests): path properties + frozen-ness.

### Doc updates

- `examples/migration_v5/README.md` — reorganized to lead with the pluggable contract and the two-example framing. MAKO design rationale stays as the "Reference example: MAKO design decisions" section.
- `examples/migration_v5/periodic_materialization/README.md` — four MAKO references softened (lines 6, 82, 258, 641). MAKO is still mentioned as the canonical reference example; it's no longer treated as load-bearing in the playbook copy.

## What does NOT change

- `mako_core.ttl` — unchanged.
- `mako_demo_agent.py`, `run_agent.py`, `reference_extractor.py` — unchanged. The agent's tools mirror MAKO's decision flow; making them generic would be a different demo, not a generalization of this one.
- `examples/migration_v5_demo_notebook.ipynb` — unchanged. The shim preserves the notebook's import.
- Checked-in `ontology.yaml` / `binding.yaml` / `table_ddl.sql` / `property_graph.sql` for MAKO — byte-identical after the refactor (asserted by `test_mako_regenerate_matches_checked_in_snapshots`).
- SDK source under `src/` — untouched. This is an examples refactor only.

## Relationship to PR #171

This PR is independent of the open 0.3.1 release ([#171](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/171)). It branches off `main`, not `release/0.3.1`. Recommended sequence: land #171 first, then this one. When this merges, the next release-notes pass should add an entry under `[Unreleased]` for the pluggable pipeline.

## Verification

- ``PYTHONPATH=src pytest tests/test_migration_v5_ontology_artifacts.py tests/test_migration_v5_reference_extractor.py`` — 25/25 pass (8 new + 17 existing).
- ``PYTHONPATH=src python examples/migration_v5/mako_artifacts.py`` — runs; `git diff` on the four MAKO snapshot files is empty.
- `pyink --check` + `isort --check-only` clean on all touched + new files.

## Test plan

- [x] All 8 new tests pass.
- [x] All 17 prior `test_migration_v5_reference_extractor.py` tests still pass.
- [x] MAKO snapshot files byte-identical after refactor (asserted by test; verified manually with `git diff`).
- [x] `pyink --check` + `isort --check-only` clean.
- [x] `examples/migration_v5/mako_artifacts.py` as a CLI still works.
- [ ] **(pending)** Notebook smoke run — confirm `import mako_artifacts; mako_artifacts.regenerate_snapshots(...)` still works in a kernel against a scratch dataset on `test-project-0728-467323`.