### PR TITLE
feat(materialize_window): --backfill --from/--to --state-key-suffix (#177)

### DIFF
--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -55,6 +55,18 @@ Env vars (all set by the deploy script via
   events table sometimes lags ingestion by tens of minutes.
 * ``BQAA_MAX_SESSIONS`` (default unset/unlimited) — cost
   guardrail.
+* ``BQAA_BACKFILL`` (default ``false``) — set ``true`` to run a
+  one-shot backfill of a fixed historical window instead of the
+  steady-state cron. When set, ``BQAA_FROM`` and ``BQAA_TO`` are
+  required. Steady-state cron jobs leave this unset.
+* ``BQAA_FROM`` (required when ``BQAA_BACKFILL=true``) — UTC ISO
+  8601 lower bound, inclusive (e.g. ``2026-05-01T00:00:00Z``).
+* ``BQAA_TO`` (required when ``BQAA_BACKFILL=true``) — UTC ISO
+  8601 upper bound, exclusive (e.g. ``2026-05-08T00:00:00Z``).
+* ``BQAA_STATE_KEY_SUFFIX`` (default unset) — optional suffix
+  folded into the state-key SHA so a backfill / re-extraction
+  run writes its state rows in a distinct namespace from the
+  steady-state cron. Recommended whenever ``BQAA_BACKFILL=true``.
 
 Exit codes mirror the CLI:
 
@@ -326,6 +338,16 @@ def main() -> int:
   overlap_minutes = _optional_env_float("BQAA_OVERLAP_MINUTES", 15.0)
   max_sessions = _optional_env_int("BQAA_MAX_SESSIONS")
 
+  # Backfill plumbing. ``BQAA_BACKFILL`` is a string env var; the
+  # canonical truthy values are ``"true"`` / ``"1"`` (case-insensitive).
+  # Everything else (including unset and the empty string) is false
+  # so a defaulted env var doesn't accidentally flip the mode.
+  backfill_raw = os.environ.get("BQAA_BACKFILL", "").strip().lower()
+  backfill = backfill_raw in ("true", "1", "yes")
+  from_time_raw = os.environ.get("BQAA_FROM") or None
+  to_time_raw = os.environ.get("BQAA_TO") or None
+  state_key_suffix = os.environ.get("BQAA_STATE_KEY_SUFFIX") or None
+
   _emit(
       "INFO",
       message="periodic materialization starting",
@@ -336,6 +358,10 @@ def main() -> int:
       lookback_hours=lookback_hours,
       overlap_minutes=overlap_minutes,
       max_sessions=max_sessions,
+      backfill=backfill,
+      from_time=from_time_raw,
+      to_time=to_time_raw,
+      state_key_suffix=state_key_suffix,
   )
 
   try:
@@ -385,6 +411,12 @@ def main() -> int:
     state_table_ref = (
         f"{project_id}.{graph_dataset_id}._bqaa_materialization_state"
     )
+    # Parse backfill window bounds at the boundary. Empty / unset
+    # env vars become ``None``; the materializer's own validator
+    # then enforces "both required when backfill=True".
+    parsed_from = mw._parse_backfill_timestamp("BQAA_FROM", from_time_raw)
+    parsed_to = mw._parse_backfill_timestamp("BQAA_TO", to_time_raw)
+
     result = mw.run_materialize_window(
         project_id=project_id,
         dataset_id=events_dataset_id,
@@ -398,6 +430,10 @@ def main() -> int:
         validate_binding=True,
         bq_client=bq_client,
         run_started_at=_dt.datetime.now(_dt.timezone.utc),
+        backfill=backfill,
+        from_time=parsed_from,
+        to_time=parsed_to,
+        state_key_suffix=state_key_suffix,
     )
 
     # Structured JSON report for Cloud Logging. Cloud Logging

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1854,6 +1854,45 @@ def materialize_window(
             "materialize. Writes no state-table row."
         ),
     ),
+    backfill: bool = typer.Option(
+        False,
+        "--backfill",
+        help=(
+            "Backfill mode: re-materialize a fixed historical window "
+            "given by --from / --to without reading or advancing the "
+            "steady-state checkpoint. Recommended companion: "
+            "--state-key-suffix to keep the backfill's state rows in "
+            "a separate namespace from the steady-state cron."
+        ),
+    ),
+    from_time: Optional[str] = typer.Option(
+        None,
+        "--from",
+        help=(
+            "Backfill window lower bound, inclusive. UTC ISO 8601 "
+            "(e.g. 2026-05-01T00:00:00Z). Required when --backfill."
+        ),
+    ),
+    to_time: Optional[str] = typer.Option(
+        None,
+        "--to",
+        help=(
+            "Backfill window upper bound, exclusive. UTC ISO 8601 "
+            "(e.g. 2026-05-08T00:00:00Z). Required when --backfill."
+        ),
+    ),
+    state_key_suffix: Optional[str] = typer.Option(
+        None,
+        "--state-key-suffix",
+        help=(
+            "Optional suffix folded into the state-key SHA. Use to "
+            "isolate backfill / re-extraction runs from the steady-"
+            "state cron so their state rows never advance the live "
+            "checkpoint. Treat as a stable name (e.g. "
+            "'backfill-may-w1') — changing it produces a new "
+            "state_key and a fresh checkpoint stream."
+        ),
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -1879,7 +1918,16 @@ def materialize_window(
           programming bug).
   """
   try:
+    from .materialize_window import _parse_backfill_timestamp
     from .materialize_window import run_materialize_window
+
+    # Parse --from / --to at the CLI boundary. Empty strings are
+    # treated as "unset" so an env-var pass-through that passes
+    # the empty default through doesn't accidentally flip the
+    # backfill validator. The materializer's own validator then
+    # enforces the required-when-backfill contract.
+    parsed_from = _parse_backfill_timestamp("--from", from_time)
+    parsed_to = _parse_backfill_timestamp("--to", to_time)
 
     result = run_materialize_window(
         project_id=project_id,
@@ -1899,6 +1947,10 @@ def materialize_window(
         location=location,
         validate_binding=validate_binding,
         dry_run=dry_run,
+        backfill=backfill,
+        from_time=parsed_from,
+        to_time=parsed_to,
+        state_key_suffix=state_key_suffix,
     )
     typer.echo(format_output(result.to_json(), fmt))
     if not result.ok:

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1860,9 +1860,11 @@ def materialize_window(
         help=(
             "Backfill mode: re-materialize a fixed historical window "
             "given by --from / --to without reading or advancing the "
-            "steady-state checkpoint. Recommended companion: "
-            "--state-key-suffix to keep the backfill's state rows in "
-            "a separate namespace from the steady-state cron."
+            "steady-state checkpoint. REQUIRES --state-key-suffix so "
+            "the backfill's state rows occupy a distinct state_key "
+            "namespace from the steady-state cron — without a suffix "
+            "the backfill row would later be read as the cron's "
+            "checkpoint and silently rewind the high-water mark."
         ),
     ),
     from_time: Optional[str] = typer.Option(

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -714,18 +714,31 @@ def run_materialize_window(
         f"--max-sessions must be unset or > 0; got {max_sessions!r}"
     )
 
+  # Normalize ``state_key_suffix`` at the boundary so a whitespace-
+  # only value ("   ") doesn't slip past the missing-suffix check
+  # and become an opaque component of the state-key hash. The CLI's
+  # ``--state-key-suffix`` and the env-var pass-through in
+  # ``run_job.py`` both deliver raw operator input here; the strip
+  # happens once, applies to both surfaces, and propagates into
+  # ``compute_state_key`` cleanly. Net behavior for a callable
+  # passing a non-trivial suffix is unchanged.
+  if state_key_suffix is not None:
+    stripped = state_key_suffix.strip()
+    state_key_suffix = stripped if stripped else None
+
   # Backfill mode validation. Both bounds are required, the window
   # must be non-empty (from < to), AND ``state_key_suffix`` must be
-  # set. The suffix is what carves the backfill out of the steady-
-  # state ``state_key`` namespace; ``read_last_checkpoint`` filters
-  # only by ``state_key``, so a backfill that shares the steady-
-  # state key would write a row that the next cron run reads as its
-  # checkpoint. ``mode='backfill'`` on the row is an audit signal,
-  # not a filter — it does not protect the checkpoint stream.
-  # Reject the missing-suffix configuration loudly at the boundary;
-  # this is the contract the CLI's ``--backfill`` help text
-  # promises ("without reading or advancing the steady-state
-  # checkpoint"). PR #188 review.
+  # set (post-normalization above). The suffix is what carves the
+  # backfill out of the steady-state ``state_key`` namespace;
+  # ``read_last_checkpoint`` filters only by ``state_key``, so a
+  # backfill that shares the steady-state key would write a row
+  # that the next cron run reads as its checkpoint.
+  # ``mode='backfill'`` on the row is an audit signal, not a
+  # filter — it does not protect the checkpoint stream. Reject the
+  # missing-suffix configuration loudly at the boundary; this is
+  # the contract the CLI's ``--backfill`` help text promises
+  # ("without reading or advancing the steady-state checkpoint").
+  # PR #188 review.
   if backfill:
     if from_time is None or to_time is None:
       raise ValueError(

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -113,11 +113,25 @@ CREATE TABLE IF NOT EXISTS `{table_ref}` (
   sessions_failed INT64,
   ok BOOL NOT NULL,
   error_detail STRING,
-  report_json STRING
+  report_json STRING,
+  mode STRING
 )
 PARTITION BY DATE(run_started_at)
 CLUSTER BY state_key, run_started_at
 """
+
+# ``mode`` was added to the schema in the ``--backfill`` follow-up
+# (issue #177). Older state tables were created without it; running
+# ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS`` on every
+# ``ensure_state_table`` call is idempotent in BigQuery and brings
+# pre-existing tables up to the current schema without a destructive
+# migration. Reads default missing rows to ``mode='steady'``.
+_STATE_TABLE_MODE_MIGRATIONS = (
+    "ALTER TABLE `{table_ref}` ADD COLUMN IF NOT EXISTS mode STRING",
+)
+
+STATE_MODE_STEADY = "steady"
+STATE_MODE_BACKFILL = "backfill"
 
 
 # Identifier validation for BQ identifiers we interpolate into SQL.
@@ -166,6 +180,15 @@ class StateRow:
   ``compute_scan_start`` lower bound. On partial failure it's the
   MAX completion timestamp among *successfully* materialized
   sessions — never advancing past a failure.
+
+  ``mode`` identifies the orchestrator mode that wrote the row:
+  :data:`STATE_MODE_STEADY` for normal cron-driven advances,
+  :data:`STATE_MODE_BACKFILL` for ``--backfill --from/--to`` runs.
+  Backfill rows are written under a distinct ``state_key`` (via the
+  ``--state-key-suffix`` plumbing) so they never advance the
+  steady-state checkpoint; the ``mode`` column is the audit-trail
+  signal that distinguishes the two streams when an operator joins
+  them in a single query.
   """
 
   state_key: str
@@ -180,6 +203,7 @@ class StateRow:
   ok: bool
   error_detail: Optional[str] = None
   report_json: Optional[str] = None
+  mode: str = STATE_MODE_STEADY
 
 
 @dataclasses.dataclass(frozen=True)
@@ -241,6 +265,7 @@ def compute_state_key(
     ontology_fingerprint: str,
     binding_fingerprint: str,
     discovery_mode: str,
+    state_key_suffix: Optional[str] = None,
 ) -> str:
   """Content-derived hex key for the state table.
 
@@ -266,18 +291,27 @@ def compute_state_key(
     sessions (it has no terminal-event filter) and could advance
     the production checkpoint past sessions production hasn't
     seen as completed yet.
+
+  ``state_key_suffix`` (optional) is folded into the same hash. It
+  exists so backfill or ad-hoc re-extraction runs can carve out a
+  separate state-key namespace from the steady-state cron — the
+  backfill writes its own ``_bqaa_materialization_state`` rows
+  without polluting the steady checkpoint stream. When unset, the
+  hash is byte-identical to the prior (suffix-less) computation,
+  so existing state keys do not drift.
   """
-  payload = "\x00".join(
-      [
-          project_id,
-          dataset_id,
-          graph_name,
-          events_table,
-          ontology_fingerprint,
-          binding_fingerprint,
-          discovery_mode,
-      ]
-  ).encode("utf-8")
+  components = [
+      project_id,
+      dataset_id,
+      graph_name,
+      events_table,
+      ontology_fingerprint,
+      binding_fingerprint,
+      discovery_mode,
+  ]
+  if state_key_suffix:
+    components.append(f"suffix:{state_key_suffix}")
+  payload = "\x00".join(components).encode("utf-8")
   return hashlib.sha256(payload).hexdigest()
 
 
@@ -423,8 +457,19 @@ def build_state_select_sql(state_table_ref: str) -> str:
 
 
 def ensure_state_table(bq_client: Any, state_table_ref: str) -> None:
-  """Create the state table if it doesn't exist. Idempotent."""
+  """Create the state table if it doesn't exist + apply additive
+  schema migrations. Idempotent.
+
+  Newer SDK versions add columns to the state table (currently:
+  ``mode``). The ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``
+  statements below run every time and bring pre-existing tables up
+  to the current schema without a destructive migration. Reads of
+  the migrated column on rows written by older SDK versions return
+  ``NULL``; callers default missing values to ``STATE_MODE_STEADY``.
+  """
   bq_client.query(_STATE_TABLE_DDL.format(table_ref=state_table_ref)).result()
+  for migration in _STATE_TABLE_MODE_MIGRATIONS:
+    bq_client.query(migration.format(table_ref=state_table_ref)).result()
 
 
 def read_last_checkpoint(
@@ -474,6 +519,7 @@ def append_state_row(
       "ok": row.ok,
       "error_detail": row.error_detail,
       "report_json": row.report_json,
+      "mode": row.mode,
   }
   errors = bq_client.insert_rows_json(state_table_ref, [payload])
   if errors:
@@ -529,6 +575,47 @@ def _iso_optional(value: Optional[_dt.datetime]) -> Optional[str]:
   return _iso(value) if value is not None else None
 
 
+def _parse_backfill_timestamp(
+    flag_name: str, value: Optional[str]
+) -> Optional[_dt.datetime]:
+  """Parse a backfill window bound from the CLI / env-var surface.
+
+  Accepts ``None`` or empty string as "unset" (the materializer's
+  own validator then enforces the required-when-backfill contract).
+  Empty-string handling matters for env-var pass-through: a
+  defaulted-but-unset env var in ``run_job.py`` arrives as ``""``,
+  not ``None``.
+
+  Accepts UTC ISO 8601 with either ``Z`` or ``+00:00`` suffix and
+  normalizes to a tz-aware UTC datetime. ``Z`` is handled
+  explicitly so the parser works on Python 3.10 (3.11+ added
+  native ``Z`` support to ``fromisoformat``).
+
+  Raises ``ValueError`` with the flag name embedded in the
+  message so the operator can fix the typo without digging.
+  """
+  if value is None or value == "":
+    return None
+  normalized = value.strip()
+  if not normalized:
+    return None
+  # Python 3.10 ``datetime.fromisoformat`` doesn't recognize ``Z``;
+  # rewrite to ``+00:00`` so the parse succeeds across all
+  # supported versions.
+  if normalized.endswith("Z"):
+    normalized = normalized[:-1] + "+00:00"
+  try:
+    parsed = _dt.datetime.fromisoformat(normalized)
+  except ValueError as exc:
+    raise ValueError(
+        f"{flag_name} must be a UTC ISO 8601 timestamp "
+        f"(e.g. 2026-05-01T00:00:00Z); got {value!r}"
+    ) from exc
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+  return parsed.astimezone(_dt.timezone.utc)
+
+
 # ------------------------------------------------------------------ #
 # Orchestrator                                                         #
 # ------------------------------------------------------------------ #
@@ -555,6 +642,10 @@ def run_materialize_window(
     dry_run: bool = False,
     bq_client: Optional[Any] = None,
     run_started_at: Optional[_dt.datetime] = None,
+    backfill: bool = False,
+    from_time: Optional[_dt.datetime] = None,
+    to_time: Optional[_dt.datetime] = None,
+    state_key_suffix: Optional[str] = None,
 ) -> MaterializeWindowResult:
   """The end-to-end run.
 
@@ -568,7 +659,9 @@ def run_materialize_window(
       ``--dataset-id``).
     lookback_hours: Window size. The discovery query lower bound
       is ``max(last_checkpoint - overlap, run_started_at -
-      lookback_hours)``.
+      lookback_hours)``. **Ignored when ``backfill=True``**: the
+      backfill window comes from ``from_time`` / ``to_time``
+      directly and is not bounded by the lookback cap.
     overlap_minutes: Re-process events newer than
       ``last_checkpoint - overlap_minutes``. Default 15.
         completion_event_type: ``event_type`` that marks a session
@@ -591,6 +684,22 @@ def run_materialize_window(
       materialize.
     bq_client: Optional pre-configured BigQuery client.
     run_started_at: Test seam. Defaults to UTC ``now``.
+    backfill: If True, runs in backfill mode. ``from_time`` and
+      ``to_time`` are required and used as the absolute scan
+      window; the steady-state checkpoint is neither read nor
+      advanced. State rows written by the run carry
+      ``mode=STATE_MODE_BACKFILL``. Pairs with
+      ``state_key_suffix`` to carve out a distinct state-key
+      stream so backfill runs cannot pollute the steady-state
+      checkpoint.
+    from_time, to_time: UTC datetimes defining the backfill scan
+      window ``[from_time, to_time)``. Required when
+      ``backfill=True``; ignored otherwise.
+    state_key_suffix: Optional string folded into
+      :func:`compute_state_key`. Recommended for any non-
+      steady-state run (backfill, ad-hoc re-extraction) so the
+      run's state rows occupy a distinct ``state_key`` namespace
+      and do not advance the steady-state checkpoint.
   """
   # Numeric guardrails — reject nonsense at the boundary so the
   # orchestrator's downstream arithmetic (timedeltas, LIMIT clauses)
@@ -605,6 +714,41 @@ def run_materialize_window(
     raise ValueError(
         f"--max-sessions must be unset or > 0; got {max_sessions!r}"
     )
+
+  # Backfill mode validation. Both bounds are required; window must
+  # be non-empty (from < to). Backfill without ``state_key_suffix``
+  # is allowed but discouraged — the run still gets its own state
+  # row via the ``mode='backfill'`` audit column, but the suffix is
+  # the mechanism that prevents the backfill from sharing the
+  # steady-state's ``state_key`` namespace. Operators backfilling
+  # against the same config more than once should always pass a
+  # suffix (the CLI doc'string says so).
+  if backfill:
+    if from_time is None or to_time is None:
+      raise ValueError(
+          "--backfill requires both --from and --to (UTC ISO 8601). "
+          f"Got from_time={from_time!r}, to_time={to_time!r}."
+      )
+    # Normalize tz-naive boundaries to UTC so comparisons + state
+    # writes don't depend on the caller's locale.
+    if from_time.tzinfo is None:
+      from_time = from_time.replace(tzinfo=_dt.timezone.utc)
+    if to_time.tzinfo is None:
+      to_time = to_time.replace(tzinfo=_dt.timezone.utc)
+    if from_time >= to_time:
+      raise ValueError(
+          f"--backfill requires --from < --to; got {from_time!r} >= {to_time!r}."
+      )
+  else:
+    # ``from_time`` / ``to_time`` are meaningless outside backfill.
+    # Reject the misconfiguration loudly rather than silently
+    # ignoring it — an operator who passed them without ``--backfill``
+    # probably intended backfill mode.
+    if from_time is not None or to_time is not None:
+      raise ValueError(
+          "--from and --to are only valid with --backfill. "
+          f"Got from_time={from_time!r}, to_time={to_time!r}, backfill=False."
+      )
   # Empty/whitespace completion-event-type silently turns the run
   # into a no-op: the discovery query would bind ``event_type =
   # ""``, match nothing, write a clean heartbeat row, and look
@@ -693,10 +837,23 @@ def run_materialize_window(
       ontology_fingerprint=ontology_fp,
       binding_fingerprint=binding_fp,
       discovery_mode=discovery_mode,
+      state_key_suffix=state_key_suffix,
   )
+
+  # Tag every state-row write with the orchestrator mode. The
+  # ``state_key_suffix`` keeps the storage namespaces apart; ``mode``
+  # is the audit-trail signal so an operator joining the two streams
+  # in a single query can tell them apart at a glance.
+  current_state_mode = STATE_MODE_BACKFILL if backfill else STATE_MODE_STEADY
 
   # State table must exist for read/write. Idempotent CREATE.
   ensure_state_table(client, state_table_ref)
+  # In backfill mode the steady-state checkpoint is irrelevant to
+  # the scan window (``from_time`` / ``to_time`` are absolute).
+  # Reading it is still cheap and surfaces in the JSON report as
+  # ``checkpoint_read`` for audit clarity, but a fresh ``state_key``
+  # (when ``state_key_suffix`` is set) means the read returns
+  # ``None`` and the bootstrap path triggers — that's expected.
   last_checkpoint = read_last_checkpoint(client, state_table_ref, state_key)
 
   # Pre-flight binding validation against live BQ — the "fail
@@ -766,30 +923,44 @@ def run_materialize_window(
               ok=False,
               error_detail=drift_detail,
               report_json=json.dumps(drift_result.to_json()),
+              mode=current_state_mode,
           ),
       )
       return drift_result
 
-  # Bootstrap (no checkpoint) → use ``--lookback-hours`` as the
-  # initial scan window. The previous draft used a hard-coded
-  # 30min default which made ``--lookback-hours 6`` actually scan
-  # 30 minutes on first run.
-  # Subsequent runs → ``compute_scan_start`` returns
-  # ``last_checkpoint - overlap_minutes`` (the bootstrap window
-  # arg is ignored when ``checkpoint_timestamp`` is set).
-  scan_start = compute_scan_start(
-      run_started,
-      checkpoint_timestamp=last_checkpoint,
-      overlap=_dt.timedelta(minutes=overlap_minutes),
-      initial_lookback=_dt.timedelta(hours=lookback_hours),
-  )
-  # ``lookback_hours`` is also the hard upper bound on how far
-  # back we ever scan — applies on subsequent runs when the
-  # checkpoint is very stale.
-  hard_floor = run_started - _dt.timedelta(hours=lookback_hours)
-  if scan_start < hard_floor:
-    scan_start = hard_floor
-  scan_end = run_started
+  if backfill:
+    # Backfill mode: ``from_time`` / ``to_time`` are the absolute
+    # scan window. The lookback cap intentionally does NOT apply —
+    # an operator backfilling six weeks of history must not have
+    # the window silently clipped to ``lookback_hours``. The
+    # numeric guardrail (``lookback_hours > 0``) still ran at the
+    # boundary above; the value is unused here.
+    assert from_time is not None and to_time is not None  # validated above
+    scan_start = from_time
+    scan_end = to_time
+  else:
+    # Steady-state mode: original behavior.
+    #
+    # Bootstrap (no checkpoint) → use ``--lookback-hours`` as the
+    # initial scan window. The previous draft used a hard-coded
+    # 30min default which made ``--lookback-hours 6`` actually
+    # scan 30 minutes on first run.
+    # Subsequent runs → ``compute_scan_start`` returns
+    # ``last_checkpoint - overlap_minutes`` (the bootstrap window
+    # arg is ignored when ``checkpoint_timestamp`` is set).
+    scan_start = compute_scan_start(
+        run_started,
+        checkpoint_timestamp=last_checkpoint,
+        overlap=_dt.timedelta(minutes=overlap_minutes),
+        initial_lookback=_dt.timedelta(hours=lookback_hours),
+    )
+    # ``lookback_hours`` is also the hard upper bound on how far
+    # back we ever scan — applies on subsequent runs when the
+    # checkpoint is very stale.
+    hard_floor = run_started - _dt.timedelta(hours=lookback_hours)
+    if scan_start < hard_floor:
+      scan_start = hard_floor
+    scan_end = run_started
 
   # Bind the discovery parameters. ``completion_event_type`` and
   # ``include_active_sessions`` interact here.
@@ -1097,6 +1268,7 @@ def run_materialize_window(
           ok=result.ok,
           error_detail=(failures[0]["error_detail"] if failures else None),
           report_json=json.dumps(result.to_json()),
+          mode=current_state_mode,
       ),
   )
 

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -684,14 +684,13 @@ def run_materialize_window(
       materialize.
     bq_client: Optional pre-configured BigQuery client.
     run_started_at: Test seam. Defaults to UTC ``now``.
-    backfill: If True, runs in backfill mode. ``from_time`` and
-      ``to_time`` are required and used as the absolute scan
-      window; the steady-state checkpoint is neither read nor
-      advanced. State rows written by the run carry
-      ``mode=STATE_MODE_BACKFILL``. Pairs with
-      ``state_key_suffix`` to carve out a distinct state-key
-      stream so backfill runs cannot pollute the steady-state
-      checkpoint.
+    backfill: If True, runs in backfill mode. ``from_time``,
+      ``to_time``, and ``state_key_suffix`` are all required.
+      The window ``[from_time, to_time)`` is the absolute scan
+      range; the steady-state checkpoint is neither read nor
+      advanced (the run uses a distinct ``state_key`` carved
+      out by the suffix). State rows written by the run carry
+      ``mode=STATE_MODE_BACKFILL`` as an audit signal.
     from_time, to_time: UTC datetimes defining the backfill scan
       window ``[from_time, to_time)``. Required when
       ``backfill=True``; ignored otherwise.
@@ -715,19 +714,32 @@ def run_materialize_window(
         f"--max-sessions must be unset or > 0; got {max_sessions!r}"
     )
 
-  # Backfill mode validation. Both bounds are required; window must
-  # be non-empty (from < to). Backfill without ``state_key_suffix``
-  # is allowed but discouraged — the run still gets its own state
-  # row via the ``mode='backfill'`` audit column, but the suffix is
-  # the mechanism that prevents the backfill from sharing the
-  # steady-state's ``state_key`` namespace. Operators backfilling
-  # against the same config more than once should always pass a
-  # suffix (the CLI doc'string says so).
+  # Backfill mode validation. Both bounds are required, the window
+  # must be non-empty (from < to), AND ``state_key_suffix`` must be
+  # set. The suffix is what carves the backfill out of the steady-
+  # state ``state_key`` namespace; ``read_last_checkpoint`` filters
+  # only by ``state_key``, so a backfill that shares the steady-
+  # state key would write a row that the next cron run reads as its
+  # checkpoint. ``mode='backfill'`` on the row is an audit signal,
+  # not a filter — it does not protect the checkpoint stream.
+  # Reject the missing-suffix configuration loudly at the boundary;
+  # this is the contract the CLI's ``--backfill`` help text
+  # promises ("without reading or advancing the steady-state
+  # checkpoint"). PR #188 review.
   if backfill:
     if from_time is None or to_time is None:
       raise ValueError(
           "--backfill requires both --from and --to (UTC ISO 8601). "
           f"Got from_time={from_time!r}, to_time={to_time!r}."
+      )
+    if not state_key_suffix:
+      raise ValueError(
+          "--backfill requires --state-key-suffix so the backfill's "
+          "state rows occupy a distinct state_key namespace from the "
+          "steady-state cron. Without a suffix a successful backfill "
+          "row would later be read by the steady-state checkpoint "
+          "and silently rewind the cron's high-water mark. "
+          "Recommended: a short stable name like 'backfill-may-w1'."
       )
     # Normalize tz-naive boundaries to UTC so comparisons + state
     # writes don't depend on the caller's locale.

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2349,6 +2349,28 @@ class TestBackfillValidation:
           state_key_suffix="",
           bq_client=bq_client,
       )
+    # Whitespace-only suffix is treated as unset too. Without the
+    # boundary strip, ``"   "`` is truthy in Python and would slip
+    # past the missing-suffix check, then become an opaque
+    # whitespace token in the state-key hash — an unreadable
+    # namespace that's nearly impossible to debug. The boundary
+    # normalization in ``run_materialize_window`` makes the
+    # behavior here identical to the empty-string case.
+    with pytest.raises(
+        ValueError, match="--backfill requires --state-key-suffix"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=True,
+          from_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+          to_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
+          state_key_suffix="   ",
+          bq_client=bq_client,
+      )
 
   def test_from_to_without_backfill_rejected(self, fixture_paths):
     ontology_yaml, binding_yaml = fixture_paths

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2287,8 +2287,67 @@ class TestBackfillValidation:
           binding_path=str(binding_yaml),
           lookback_hours=6.0,
           backfill=True,
+          # Pass a suffix so this test reaches the from<to check
+          # instead of being short-circuited by the
+          # suffix-required check.
+          state_key_suffix="reversed-window",
           from_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
           to_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+      )
+
+  def test_backfill_requires_state_key_suffix(self, fixture_paths):
+    """Regression for PR #188 review (P1): backfill without
+    ``--state-key-suffix`` would write a state row under the
+    steady-state ``state_key`` and silently rewind the next
+    steady-state cron's high-water mark. ``read_last_checkpoint``
+    filters only by ``state_key``, so ``mode='backfill'`` on the
+    row is an audit signal that does NOT protect the checkpoint
+    stream — the suffix is what carves out a distinct namespace.
+
+    Asserted before any BigQuery client interaction: the
+    validation runs at the boundary so the failure mode is loud,
+    fast, and cheap. The fake client's ``query`` raises on call
+    so the test fails if anything tries to hit BigQuery before
+    the suffix check fires."""
+    ontology_yaml, binding_yaml = fixture_paths
+    bq_client = mock.Mock()
+    bq_client.query = mock.Mock(
+        side_effect=AssertionError(
+            "BigQuery work must NOT start before the suffix check fires"
+        )
+    )
+    with pytest.raises(
+        ValueError, match="--backfill requires --state-key-suffix"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=True,
+          from_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+          to_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
+          state_key_suffix=None,
+          bq_client=bq_client,
+      )
+    # Empty string is treated as unset too, matching the env-var
+    # pass-through semantics in ``_parse_backfill_timestamp`` and
+    # the env-var reader in ``run_job.py``.
+    with pytest.raises(
+        ValueError, match="--backfill requires --state-key-suffix"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=True,
+          from_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+          to_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
+          state_key_suffix="",
+          bq_client=bq_client,
       )
 
   def test_from_to_without_backfill_rejected(self, fixture_paths):

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -460,7 +460,9 @@ def fixture_paths(tmp_path):
 
 def _stub_bq_client(discovered_rows):
   """A BigQuery client whose ``.query()`` returns:
-  - the DDL response (anything; we just check it was called)
+  - the CREATE TABLE response (anything; we just check it was called)
+  - one response per additive schema-migration ALTER
+    (currently: ``ADD COLUMN IF NOT EXISTS mode STRING``)
   - the state-table read (empty → bootstrap)
   - the discovery query (returns ``discovered_rows``)
   ``.insert_rows_json`` returns [] (no errors).
@@ -468,9 +470,13 @@ def _stub_bq_client(discovered_rows):
   client = mock.Mock()
 
   # Each .query() call's .result() yields a different row set.
-  # We sequence them via side_effect on the query() Mock.
+  # We sequence them via side_effect on the query() Mock. Keep the
+  # ALTER-TABLE response count in sync with
+  # ``_STATE_TABLE_MODE_MIGRATIONS`` in
+  # ``src/bigquery_agent_analytics/materialize_window.py``.
   results = [
       mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
+      mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
       mock.Mock(result=mock.Mock(return_value=[])),  # state read
       mock.Mock(result=mock.Mock(return_value=discovered_rows)),  # discovery
   ]
@@ -788,6 +794,7 @@ class TestCheckpointCarryForward:
     client.query = mock.Mock(
         side_effect=[
             mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
+            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
             mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
             mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
         ]
@@ -1498,6 +1505,7 @@ class TestCheckpointNeverRegresses:
     client.query = mock.Mock(
         side_effect=[
             mock.Mock(result=mock.Mock(return_value=[])),  # DDL
+            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
             mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
             mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
         ]
@@ -1558,7 +1566,8 @@ class TestCheckpointNeverRegresses:
     ]
     client.query = mock.Mock(
         side_effect=[
-            mock.Mock(result=mock.Mock(return_value=[])),
+            mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
+            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
             mock.Mock(result=mock.Mock(return_value=[state_row])),
             mock.Mock(result=mock.Mock(return_value=discovered)),
         ]
@@ -2201,3 +2210,233 @@ class TestEmptyExtractionNotOk:
     assert result.sessions_materialized == 0
     assert result.sessions_failed == 0
     assert result.failures == []
+
+
+# ====================================================================== #
+# Backfill mode + state-key suffix + ``mode`` column (PR A, issue #177)   #
+# ====================================================================== #
+
+
+class TestStateKeySuffixIsolation:
+  """``state_key_suffix`` folds into the SHA so backfill / re-extraction
+  runs occupy a distinct state-key namespace from the steady-state cron.
+  Without the suffix the hash is byte-identical to the prior (suffix-less)
+  computation, so existing checkpoints don't drift after the SDK upgrade.
+  """
+
+  _BASE = dict(
+      project_id="proj",
+      dataset_id="ds",
+      graph_name="g",
+      events_table="agent_events",
+      ontology_fingerprint="ofp",
+      binding_fingerprint="bfp",
+      discovery_mode="terminal:AGENT_COMPLETED",
+  )
+
+  def test_suffix_unset_is_byte_identical_to_legacy_hash(self):
+    legacy = mw.compute_state_key(**self._BASE)
+    with_none = mw.compute_state_key(state_key_suffix=None, **self._BASE)
+    with_empty = mw.compute_state_key(state_key_suffix="", **self._BASE)
+    assert legacy == with_none, "suffix=None must not drift the hash"
+    assert legacy == with_empty, (
+        "suffix='' must not drift the hash either — env-var pass-through "
+        "delivers empty strings for unset values; flipping the hash on "
+        "those would silently invalidate every existing checkpoint"
+    )
+
+  def test_different_suffixes_produce_different_state_keys(self):
+    week1 = mw.compute_state_key(
+        state_key_suffix="backfill-may-w1", **self._BASE
+    )
+    week2 = mw.compute_state_key(
+        state_key_suffix="backfill-may-w2", **self._BASE
+    )
+    steady = mw.compute_state_key(**self._BASE)
+    assert week1 != week2
+    assert week1 != steady
+    assert week2 != steady
+
+
+class TestBackfillValidation:
+  """The orchestrator rejects misconfigurations at the boundary so an
+  operator typo doesn't silently degrade to a no-op or, worse, pollute
+  the steady-state checkpoint stream."""
+
+  def test_backfill_requires_both_from_and_to(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(ValueError, match="--backfill requires both --from"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=True,
+          from_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+          to_time=None,
+      )
+
+  def test_backfill_requires_from_less_than_to(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(ValueError, match="requires --from < --to"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=True,
+          from_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
+          to_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+      )
+
+  def test_from_to_without_backfill_rejected(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError, match="--from and --to are only valid with --backfill"
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          backfill=False,
+          from_time=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+          to_time=_dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc),
+      )
+
+
+class TestBackfillTimestampParser:
+  """``_parse_backfill_timestamp`` handles the formats env-var
+  pass-through actually delivers."""
+
+  def test_accepts_z_suffix_iso8601(self):
+    parsed = mw._parse_backfill_timestamp("--from", "2026-05-01T00:00:00Z")
+    assert parsed == _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+
+  def test_accepts_explicit_utc_offset(self):
+    parsed = mw._parse_backfill_timestamp("--from", "2026-05-01T00:00:00+00:00")
+    assert parsed == _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+
+  def test_none_and_empty_string_are_unset(self):
+    assert mw._parse_backfill_timestamp("--from", None) is None
+    assert mw._parse_backfill_timestamp("--from", "") is None
+    assert mw._parse_backfill_timestamp("--from", "   ") is None
+
+  def test_invalid_input_raises_with_flag_name(self):
+    with pytest.raises(ValueError, match="--from must be a UTC ISO 8601"):
+      mw._parse_backfill_timestamp("--from", "not-a-date")
+
+
+class TestBackfillScanWindow:
+  """The backfill scan window is the operator-supplied [from, to)
+  range, not the lookback-derived window. The lookback cap does NOT
+  clip the backfill — an operator backfilling six weeks of history
+  must not have their window silently truncated to ``lookback_hours``."""
+
+  def test_backfill_window_uses_from_to_directly(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    # ``run_started_at`` is fixed in 2026-05-20; the backfill window
+    # is one full week earlier (May 1 → May 8). A lookback-derived
+    # window would scan May 19 → May 20; backfill must scan the
+    # explicit range instead.
+    now = _dt.datetime(2026, 5, 20, 12, tzinfo=_dt.timezone.utc)
+    from_ts = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    to_ts = _dt.datetime(2026, 5, 8, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+    with (
+        mock.patch.object(mw, "_build_manager", return_value=mock.Mock()),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      result = mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=24.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+          backfill=True,
+          from_time=from_ts,
+          to_time=to_ts,
+          state_key_suffix="backfill-may-w1",
+      )
+    assert result.window_start == from_ts, (
+        "backfill scan_start must be the supplied --from, not "
+        "lookback-derived from run_started_at"
+    )
+    assert (
+        result.window_end == to_ts
+    ), "backfill scan_end must be the supplied --to, not run_started_at"
+
+
+class TestStateRowModeColumn:
+  """``mode`` round-trips through ``append_state_row`` and identifies
+  whether a state row was written by a steady-state or backfill run.
+  Default is ``'steady'`` so pre-existing callers continue to write
+  the expected value."""
+
+  def test_state_row_defaults_to_steady_mode(self):
+    row = mw.StateRow(
+        state_key="sk",
+        run_id="rid",
+        run_started_at=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_start=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        last_completion_at=None,
+        sessions_discovered=0,
+        sessions_materialized=0,
+        sessions_failed=0,
+        ok=True,
+    )
+    assert row.mode == mw.STATE_MODE_STEADY
+
+  def test_append_state_row_includes_mode_in_payload(self):
+    client = mock.Mock()
+    client.insert_rows_json = mock.Mock(return_value=[])
+    row = mw.StateRow(
+        state_key="sk",
+        run_id="rid",
+        run_started_at=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_start=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        last_completion_at=None,
+        sessions_discovered=0,
+        sessions_materialized=0,
+        sessions_failed=0,
+        ok=True,
+        mode=mw.STATE_MODE_BACKFILL,
+    )
+    mw.append_state_row(client, "p.d.t", row)
+    call_args = client.insert_rows_json.call_args
+    payload = call_args[0][1][0]
+    assert payload["mode"] == "backfill"
+
+
+class TestEnsureStateTableMigration:
+  """``ensure_state_table`` runs the schema-evolution ALTERs every call.
+  ``ADD COLUMN IF NOT EXISTS`` is idempotent in BigQuery; the test
+  asserts the calls are issued, not their side effect."""
+
+  def test_ensure_state_table_runs_create_and_alter(self):
+    client = mock.Mock()
+    client.query = mock.Mock(
+        return_value=mock.Mock(result=mock.Mock(return_value=[]))
+    )
+    mw.ensure_state_table(client, "p.d._bqaa_materialization_state")
+    queries = [args[0][0] for args in client.query.call_args_list]
+    create = next(q for q in queries if q.startswith("CREATE TABLE"))
+    assert (
+        "mode STRING" in create
+    ), "fresh tables must include the mode column in the initial DDL"
+    alters = [q for q in queries if q.startswith("ALTER TABLE")]
+    assert any("ADD COLUMN IF NOT EXISTS mode STRING" in q for q in alters), (
+        "ensure_state_table must run ADD COLUMN IF NOT EXISTS for the "
+        "mode column on every call so pre-migration tables get patched "
+        "without a destructive migration"
+    )


### PR DESCRIPTION
PR A from the [issue #187 implementation plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187). Closes (part of) [#177](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/177).

Adds first-class backfill mode and state-key isolation to ``bqaa-materialize-window`` so re-materialization of a historical window can run without polluting the steady-state cron's checkpoint.

## What ships

### CLI surface

Four new flags on ``bqaa-materialize-window`` (with matching env-var pass-through in ``examples/migration_v5/periodic_materialization/run_job.py``):

| Flag | Env var | Behavior |
|---|---|---|
| ``--backfill`` | ``BQAA_BACKFILL`` | Run a fixed historical window without reading or advancing the steady-state checkpoint. |
| ``--from <ISO 8601>`` | ``BQAA_FROM`` | Backfill window lower bound, inclusive. Required when ``--backfill``. |
| ``--to <ISO 8601>`` | ``BQAA_TO`` | Backfill window upper bound, exclusive. Required when ``--backfill``. |
| ``--state-key-suffix`` | ``BQAA_STATE_KEY_SUFFIX`` | Suffix folded into the state-key SHA. **Required** when ``--backfill`` (see below). |

### Backfill semantics

- Skips ``compute_scan_start``; ``scan_start = from_time``, ``scan_end = to_time``. The lookback cap intentionally does NOT clip the window — an operator backfilling six weeks of history must not have the scan silently truncated.
- All state rows written during a backfill run carry ``mode='backfill'``. Steady-state runs continue to write ``mode='steady'`` (the new default).
- Validation runs at the boundary, before any BigQuery I/O:
  - ``--backfill`` requires both ``--from`` and ``--to``.
  - The window must be non-empty (``--from < --to``).
  - **``--backfill`` requires ``--state-key-suffix``.** Without a suffix, the backfill's state row would later be read by the steady-state cron's ``read_last_checkpoint`` (which filters only by ``state_key``) and silently rewind the high-water mark. ``mode='backfill'`` on the row is an audit signal that does NOT protect the checkpoint stream; the suffix is what carves out a distinct namespace.
  - ``--from`` / ``--to`` outside ``--backfill`` is rejected loudly rather than silently ignored.
  - ``--state-key-suffix`` is normalized at the boundary: ``None`` / ``""`` / whitespace-only all collapse to "unset" before the validation and the hash, so a stray space-only env-var doesn't slip past as an opaque whitespace token.

### State-key isolation

``compute_state_key`` gains an optional ``state_key_suffix`` parameter. When unset (or empty / whitespace), the hash is **byte-identical** to the prior (suffix-less) computation — explicitly asserted by ``test_suffix_unset_is_byte_identical_to_legacy_hash``. No existing state key drifts after the SDK upgrade.

### State-table schema migration

- ``_STATE_TABLE_DDL`` gains a ``mode STRING`` column for fresh tables.
- ``ensure_state_table`` runs ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS mode STRING`` on every call — idempotent in BigQuery, brings pre-existing tables up to the current schema without a destructive migration. Rows written by older SDK versions return ``NULL`` for the column; callers default missing values to ``STATE_MODE_STEADY``.
- ``StateRow`` dataclass + ``append_state_row`` payload extend symmetrically.

### Backfill timestamp parser

New helper ``_parse_backfill_timestamp(flag_name, value)`` handles the formats env-var pass-through actually delivers: ``None`` / empty string / whitespace → ``None`` (treats unset env vars as unset); ``Z`` suffix normalized to ``+00:00`` for Python 3.10 compatibility; invalid input raises ``ValueError`` with the flag name embedded so the operator can fix the typo without digging.

## Compatibility

- Existing callers that don't pass ``backfill`` / ``from_time`` / ``to_time`` / ``state_key_suffix`` see byte-identical behavior. The state-key SHA, the scan window, and the state-row write are all unchanged for steady-state cron callers.
- Existing state tables read clean — the new ``mode`` column returns ``NULL`` for rows written by older SDK versions; no code path treats ``NULL`` as a hard error.
- No breaking signature changes on ``run_materialize_window`` or ``compute_state_key`` — all new parameters are keyword-only with safe defaults.

## Tests

**86 tests pass (72 existing + 14 new across six test classes):**

- **``TestStateKeySuffixIsolation``** — suffix=None and suffix='' produce byte-identical hashes to the legacy compute (the back-compat contract); different suffixes produce different state keys.
- **``TestBackfillValidation``** — ``--backfill`` requires both bounds; ``--from >= --to`` rejected; ``--from`` / ``--to`` without ``--backfill`` rejected; ``--backfill`` requires ``--state-key-suffix`` (regression for the first review pass); ``None``, ``""``, and ``"   "`` whitespace-only suffix all caught at the boundary before BigQuery I/O (regression for the second review pass).
- **``TestBackfillTimestampParser``** — Z suffix accepted; explicit UTC offset accepted; None / empty / whitespace → None; invalid input raises ``ValueError`` with flag name.
- **``TestBackfillScanWindow``** — backfill scan_start / scan_end use ``--from`` / ``--to`` directly, ignoring the lookback cap (verified against a fixed ``run_started_at`` where the lookback window and the backfill window do not overlap).
- **``TestStateRowModeColumn``** — ``StateRow.mode`` defaults to ``'steady'``; ``append_state_row`` payload includes ``mode``.
- **``TestEnsureStateTableMigration``** — fresh-table DDL includes ``mode STRING``; ``ADD COLUMN IF NOT EXISTS`` runs on every call.

Existing mock-sequence helpers (``_stub_bq_client`` and three custom mock sequences) updated to queue one extra response for the ALTER TABLE call. ``pyink --check`` + ``isort --check-only`` clean.

## Verification

```bash
PYTHONPATH=src pytest tests/test_materialize_window.py
# → 86 passed

PYTHONPATH=src python -m bigquery_agent_analytics.cli materialize-window --help
# → --backfill / --from / --to / --state-key-suffix all listed
```

## Where this fits in the implementation plan

PR A in the sequencing committed on [#187](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187):

| PR | Issue(s) | Status |
|---|---|---|
| **A** (this PR) | #177 (backfill + state-key suffix + ``mode`` foundation) | ▶︎ this PR |
| B1 | #178 (``extract_graph`` orthogonal-flag refactor + diagnostics) | next |
| C1 | #179 (binding-model dict-shape acceptance with list-view shim) | next |
| B2 / C2 / D | #178 / #179 / #180 (customer-visible wiring + orphan watchdog) | following week |
| E / F / G | #181, #184 / #185 / #186 | per calendar |

PR A is intentionally SDK-internal-with-deploy-wiring so #178 / #179 can land in parallel against the same ``mode`` column without re-scoping the state-table evolution.

## Review history

| Commit | Review finding addressed |
|---|---|
| ``ad0f678`` | Initial implementation. |
| ``f050dad`` | P1: ``--backfill`` without ``--state-key-suffix`` could rewind the steady-state checkpoint. Now rejected at the boundary. |
| ``52dbc3f`` | P2: whitespace-only suffix (``"   "``) slipped past as an opaque hash token. Now normalized to ``None`` at the boundary. |

## Test plan

- [x] All 14 new test cases pass (including both review-cycle regressions).
- [x] All 72 prior ``test_materialize_window.py`` tests still pass.
- [x] ``pyink --check`` + ``isort --check-only`` clean.
- [x] CLI ``--help`` lists the four new flags; ``--backfill`` flags ``--state-key-suffix`` as REQUIRED.
- [x] State-key SHA is byte-identical when suffix is unset (asserted by ``test_suffix_unset_is_byte_identical_to_legacy_hash``).
- [x] Whitespace-only suffix rejected at the boundary, before any BigQuery I/O.
- [ ] **(pending — for the reviewer / post-merge)** Live BigQuery round-trip against a real ``_bqaa_materialization_state`` table: confirm ``ADD COLUMN IF NOT EXISTS`` is idempotent against an already-migrated table, and that backfill rows + steady rows coexist without state-stream collision.