### PR TITLE
feat(extract_graph): orthogonal-flag refactor + diagnostics (#178)

### DIFF
--- a/src/bigquery_agent_analytics/extracted_models.py
+++ b/src/bigquery_agent_analytics/extracted_models.py
@@ -9,7 +9,7 @@ equivalent in the ``bigquery_ontology`` package.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -45,6 +45,76 @@ class ExtractedEdge(BaseModel):
   )
 
 
+DiagnosticCode = Literal[
+    # Per-span — attributable from the structured-extraction pipeline.
+    "structured_fully_handled",
+    "structured_partially_handled",
+    "structured_unhandled",
+    "extractor_exception",
+    # Session-level — what is honestly knowable about the AI fallback
+    # without span-attributed AI output. A future PR can add an
+    # ``ai_handled`` per-span code if span provenance is added to the
+    # ``_extract_via_ai_generate`` return path.
+    "session_ai_fallback_attempted",
+]
+
+
+class ExtractionDiagnostic(BaseModel):
+  """Per-span (or session-level) diagnostic emitted by the extraction
+  pipeline when the caller opts into the diagnostics-emitting path
+  (``extract_graph(..., run_structured=..., on_unhandled_span=...)``).
+
+  Legacy callers using the bool-only surface
+  (``extract_graph(session_ids, use_ai_generate=True/False)``) see an
+  empty ``ExtractedGraph.diagnostics`` list — diagnostics are not
+  emitted on the back-compat path, so existing call sites are
+  byte-identical to today.
+
+  The diagnostic codes are deliberately narrow to what the
+  ``run_structured_extractors`` framework can honestly attribute.
+  ``ai_handled`` per span is intentionally NOT in the list because
+  ``AI.GENERATE`` returns a graph, not a span-attributed result;
+  ``session_ai_fallback_attempted`` is the session-level signal the
+  call site can record from the call site itself.
+  """
+
+  diagnostic_code: DiagnosticCode = Field(
+      description=(
+          "Which diagnostic this is. Per-span codes attribute to a "
+          "specific event; session_ai_fallback_attempted is the "
+          "session-level signal."
+      )
+  )
+  span_id: Optional[str] = Field(
+      default=None,
+      description=("Span ID for per-span codes. None for session-level codes."),
+  )
+  session_id: Optional[str] = Field(
+      default=None,
+      description=(
+          "Session ID for session-level codes (currently just "
+          "session_ai_fallback_attempted)."
+      ),
+  )
+  event_type: Optional[str] = Field(
+      default=None,
+      description=(
+          "Telemetry event_type for the span, when known. "
+          "Populated for per-span codes; None for session-level "
+          "codes."
+      ),
+  )
+  detail: Optional[str] = Field(
+      default=None,
+      description=(
+          "Free-form payload for the diagnostic. For "
+          "extractor_exception, the captured exception text "
+          "(``f'{type(exc).__name__}: {exc}'``). For other codes, "
+          "typically None."
+      ),
+  )
+
+
 class ExtractedGraph(BaseModel):
   """A complete graph instance extracted from agent telemetry."""
 
@@ -54,4 +124,14 @@ class ExtractedGraph(BaseModel):
   )
   edges: list[ExtractedEdge] = Field(
       default_factory=list, description="Extracted edges."
+  )
+  diagnostics: list[ExtractionDiagnostic] = Field(
+      default_factory=list,
+      description=(
+          "Per-span / session diagnostics emitted by the extraction "
+          "pipeline when the caller opts into the diagnostics-"
+          "emitting path. Empty list on the legacy bool surface so "
+          "existing callers see byte-identical ``ExtractedGraph`` "
+          "values."
+      ),
   )

--- a/src/bigquery_agent_analytics/extracted_models.py
+++ b/src/bigquery_agent_analytics/extracted_models.py
@@ -47,6 +47,16 @@ class ExtractedEdge(BaseModel):
 
 DiagnosticCode = Literal[
     # Per-span — attributable from the structured-extraction pipeline.
+    #
+    # ``structured_unhandled`` carries a precise meaning: no
+    # registered extractor was *invoked* for the span (its
+    # ``event_type`` didn't match any key in the extractor
+    # registry). An extractor that matched and returned an empty
+    # ``StructuredExtractionResult()`` — e.g. a recognized event
+    # whose content is missing a required field — is NOT
+    # unhandled; that's a legitimate silent outcome and downstream
+    # compiled-only failure semantics should not flip ``ok=false``
+    # on it.
     "structured_fully_handled",
     "structured_partially_handled",
     "structured_unhandled",
@@ -131,7 +141,10 @@ class ExtractedGraph(BaseModel):
           "Per-span / session diagnostics emitted by the extraction "
           "pipeline when the caller opts into the diagnostics-"
           "emitting path. Empty list on the legacy bool surface so "
-          "existing callers see byte-identical ``ExtractedGraph`` "
-          "values."
+          "the extraction semantics are unchanged. Note: this is an "
+          "additive Pydantic field, so ``model_dump()`` now includes "
+          "``'diagnostics': []`` even for legacy callers — strict-"
+          "shape JSON consumers should add a passthrough for the "
+          "new key."
       ),
   )

--- a/src/bigquery_agent_analytics/extracted_models.py
+++ b/src/bigquery_agent_analytics/extracted_models.py
@@ -77,8 +77,10 @@ class ExtractionDiagnostic(BaseModel):
   Legacy callers using the bool-only surface
   (``extract_graph(session_ids, use_ai_generate=True/False)``) see an
   empty ``ExtractedGraph.diagnostics`` list — diagnostics are not
-  emitted on the back-compat path, so existing call sites are
-  byte-identical to today.
+  emitted on the back-compat path, so the extraction semantics are
+  unchanged. (``model_dump()`` does pick up the ``diagnostics``
+  field as an additive key; see
+  ``ExtractedGraph.diagnostics`` for the compatibility contract.)
 
   The diagnostic codes are deliberately narrow to what the
   ``run_structured_extractors`` framework can honestly attribute.

--- a/src/bigquery_agent_analytics/ontology_graph.py
+++ b/src/bigquery_agent_analytics/ontology_graph.py
@@ -44,7 +44,7 @@ import datetime
 import json
 import logging
 import pathlib
-from typing import Optional
+from typing import Literal, Optional
 
 from google.cloud import bigquery
 
@@ -55,6 +55,7 @@ from .extracted_models import ExtractedEdge
 from .extracted_models import ExtractedGraph
 from .extracted_models import ExtractedNode
 from .extracted_models import ExtractedProperty
+from .extracted_models import ExtractionDiagnostic
 from .ontology_schema_compiler import compile_extraction_prompt
 from .ontology_schema_compiler import compile_output_schema
 from .resolved_spec import resolve_from_graph_spec
@@ -634,31 +635,131 @@ class OntologyGraphManager:
       self,
       session_ids: list[str],
       use_ai_generate: bool = True,
+      *,
+      run_structured: Optional[bool] = None,
+      on_unhandled_span: Optional[
+          Literal["ai_fallback", "fail", "stub"]
+      ] = None,
   ) -> ExtractedGraph:
     """Extract a typed graph from agent telemetry.
 
+    Two surfaces:
+
+    **Legacy bool surface** (back-compat with prior SDK versions).
+    ``extract_graph(session_ids, use_ai_generate=True)`` runs
+    structured extractors (if registered) and then ``AI.GENERATE``,
+    merging both into one graph. ``extract_graph(session_ids, False)``
+    runs neither and returns a stub via ``_extract_payloads``.
+    Diagnostics are NOT emitted on this surface — the returned
+    ``ExtractedGraph.diagnostics`` is an empty list, byte-identical
+    to today.
+
+    **Orthogonal-flag surface** (new in #178). Pass both
+    ``run_structured`` and ``on_unhandled_span`` to opt into the
+    diagnostics-emitting path. The two flags must be set together;
+    setting only one raises ``ValueError`` (the contract is
+    intentionally explicit so an incomplete migration doesn't
+    silently produce the wrong behavior).
+
     Args:
-        session_ids: Sessions to extract from.
-        use_ai_generate: If True, runs AI.GENERATE server-side.
-            If False, fetches raw payloads (stub graph returned).
+      session_ids: Sessions to extract from.
+      use_ai_generate: When ``True`` (the default), ``AI.GENERATE`` is
+        callable as the fallback for unstructured content. When
+        ``False``, no AI calls are issued.
+      run_structured: New keyword-only. ``True`` runs the registered
+        structured extractors; ``False`` skips them. Required when
+        ``on_unhandled_span`` is set.
+      on_unhandled_span: New keyword-only. What to do with spans the
+        structured extractors did not handle.
+
+        * ``"ai_fallback"`` — invoke ``AI.GENERATE`` to handle the
+          gaps. Requires ``use_ai_generate=True``.
+        * ``"fail"`` — surface unhandled spans as
+          ``structured_unhandled`` diagnostics; do not call AI; do
+          not return a stub. The materializer (``materialize_window``)
+          reads these diagnostics and translates them to typed
+          ``empty_extraction`` failures. This is the "compiled-only"
+          mode.
+        * ``"stub"`` — fetch raw payloads via ``_extract_payloads``
+          (the legacy ``use_ai_generate=False`` behavior). Useful
+          when ``run_structured=False`` and AI is also disabled.
+
+        Required when ``run_structured`` is set.
 
     Returns:
-        An ``ExtractedGraph`` with nodes and edges.
+      An ``ExtractedGraph`` with nodes, edges, and (only on the
+      orthogonal-flag surface) per-span / session diagnostics.
+
+    Raises:
+      ValueError: If exactly one of ``run_structured`` /
+        ``on_unhandled_span`` is set; if
+        ``on_unhandled_span='ai_fallback'`` is paired with
+        ``use_ai_generate=False`` (the fallback target is
+        disabled).
     """
-    # Run structured extractors first if any are registered.
+    # Legacy bool surface (back-compat): both new params unset.
+    if run_structured is None and on_unhandled_span is None:
+      return self._extract_graph_impl(
+          session_ids,
+          run_structured=bool(self.extractors and use_ai_generate),
+          use_ai_generate=use_ai_generate,
+          on_unhandled_span="ai_fallback" if use_ai_generate else "stub",
+          emit_diagnostics=False,
+      )
+    # Orthogonal-flag surface: both required, set together.
+    if run_structured is None or on_unhandled_span is None:
+      raise ValueError(
+          "run_structured and on_unhandled_span must be set together "
+          "(or both omitted to use the legacy bool surface); got "
+          f"run_structured={run_structured!r}, "
+          f"on_unhandled_span={on_unhandled_span!r}."
+      )
+    # Coherence: 'ai_fallback' needs AI on.
+    if on_unhandled_span == "ai_fallback" and not use_ai_generate:
+      raise ValueError(
+          "on_unhandled_span='ai_fallback' requires use_ai_generate=True; "
+          "the fallback target is disabled."
+      )
+    return self._extract_graph_impl(
+        session_ids,
+        run_structured=run_structured,
+        use_ai_generate=use_ai_generate,
+        on_unhandled_span=on_unhandled_span,
+        emit_diagnostics=True,
+    )
+
+  def _extract_graph_impl(
+      self,
+      session_ids: list[str],
+      *,
+      run_structured: bool,
+      use_ai_generate: bool,
+      on_unhandled_span: str,
+      emit_diagnostics: bool,
+  ) -> ExtractedGraph:
+    """Shared core for both extract_graph surfaces.
+
+    The public ``extract_graph`` validates inputs + resolves the
+    legacy bool to internal mode flags; this private method runs the
+    actual extraction. Splitting them keeps the legacy and diagnostic
+    paths byte-identical at the merge step — the only difference is
+    whether diagnostics are emitted.
+    """
+    diagnostics: list[ExtractionDiagnostic] = []
     structured_nodes: list[ExtractedNode] = []
     structured_edges: list[ExtractedEdge] = []
     excluded_span_ids: list[str] = []
     partial_span_ids: list[str] = []
     partial_hint = ""
 
-    if self.extractors and use_ai_generate:
+    if run_structured and self.extractors:
       raw_events = self._fetch_raw_events(session_ids)
       if raw_events:
         structured_result = run_structured_extractors(
             raw_events,
             self.extractors,
             self.spec,
+            capture_extractor_exceptions=emit_diagnostics,
         )
         structured_nodes = structured_result.nodes
         structured_edges = structured_result.edges
@@ -676,15 +777,79 @@ class OntologyGraphManager:
               "unstructured content only: " + ", ".join(entity_names) + ".\n"
           )
 
-    if use_ai_generate:
+        if emit_diagnostics:
+          # Per-span codes attributable from the structured pipeline.
+          for span_id in sorted(structured_result.fully_handled_span_ids):
+            diagnostics.append(
+                ExtractionDiagnostic(
+                    diagnostic_code="structured_fully_handled",
+                    span_id=span_id,
+                )
+            )
+          for span_id in sorted(structured_result.partially_handled_span_ids):
+            diagnostics.append(
+                ExtractionDiagnostic(
+                    diagnostic_code="structured_partially_handled",
+                    span_id=span_id,
+                )
+            )
+          for exc in structured_result.exceptions:
+            diagnostics.append(
+                ExtractionDiagnostic(
+                    diagnostic_code="extractor_exception",
+                    span_id=exc.span_id,
+                    event_type=exc.event_type,
+                    detail=exc.detail,
+                )
+            )
+          # structured_unhandled: spans seen in raw_events but not
+          # claimed by any extractor (no matching event_type) and not
+          # already accounted for by an extractor_exception.
+          handled_span_ids = (
+              set(structured_result.fully_handled_span_ids)
+              | set(structured_result.partially_handled_span_ids)
+              | {
+                  exc.span_id
+                  for exc in structured_result.exceptions
+                  if exc.span_id
+              }
+          )
+          for event in raw_events:
+            span_id = event.get("span_id")
+            if not span_id or span_id in handled_span_ids:
+              continue
+            diagnostics.append(
+                ExtractionDiagnostic(
+                    diagnostic_code="structured_unhandled",
+                    span_id=span_id,
+                    event_type=event.get("event_type"),
+                )
+            )
+
+    if on_unhandled_span == "ai_fallback":
       ai_graph = self._extract_via_ai_generate(
           session_ids,
           excluded_span_ids,
           partial_span_ids,
           partial_hint,
       )
-    else:
+      if emit_diagnostics:
+        for sid in session_ids:
+          diagnostics.append(
+              ExtractionDiagnostic(
+                  diagnostic_code="session_ai_fallback_attempted",
+                  session_id=sid,
+              )
+          )
+    elif on_unhandled_span == "stub":
       ai_graph = self._extract_payloads(session_ids)
+    elif on_unhandled_span == "fail":
+      # Compiled-only: no AI, no stub. Unhandled spans are surfaced
+      # via the structured_unhandled diagnostics above; the
+      # materializer translates them to typed failures.
+      ai_graph = ExtractedGraph(name=self.spec.name)
+    else:  # pragma: no cover - dispatcher validated above
+      raise ValueError(f"Unknown on_unhandled_span: {on_unhandled_span!r}")
 
     # Merge: structured nodes/edges + AI-extracted, dedup by node_id.
     if structured_nodes or structured_edges:
@@ -695,13 +860,20 @@ class OntologyGraphManager:
         if node.node_id not in seen_nodes:
           seen_nodes[node.node_id] = node
       all_edges = structured_edges + ai_graph.edges
-      return ExtractedGraph(
+      result = ExtractedGraph(
           name=self.spec.name,
           nodes=list(seen_nodes.values()),
           edges=all_edges,
       )
+    else:
+      result = ai_graph
 
-    return ai_graph
+    # Attach diagnostics only on the new path. Legacy callers see an
+    # empty ``diagnostics`` list — Pydantic default — so the return
+    # value is byte-identical for the back-compat surface.
+    if emit_diagnostics and diagnostics:
+      result = result.model_copy(update={"diagnostics": diagnostics})
+    return result
 
   def _fetch_raw_events(self, session_ids: list[str]) -> list[dict]:
     """Fetch raw events with full content for structured extraction.

--- a/src/bigquery_agent_analytics/ontology_graph.py
+++ b/src/bigquery_agent_analytics/ontology_graph.py
@@ -651,8 +651,11 @@ class OntologyGraphManager:
     merging both into one graph. ``extract_graph(session_ids, False)``
     runs neither and returns a stub via ``_extract_payloads``.
     Diagnostics are NOT emitted on this surface — the returned
-    ``ExtractedGraph.diagnostics`` is an empty list, byte-identical
-    to today.
+    ``ExtractedGraph.diagnostics`` is an empty list and the
+    extraction semantics are unchanged. Note: ``model_dump()`` now
+    includes a ``'diagnostics': []`` key as an additive field
+    (see ``ExtractedGraph.diagnostics`` for the compatibility
+    contract).
 
     **Orthogonal-flag surface** (new in #178). Pass both
     ``run_structured`` and ``on_unhandled_span`` to opt into the
@@ -742,8 +745,9 @@ class OntologyGraphManager:
     The public ``extract_graph`` validates inputs + resolves the
     legacy bool to internal mode flags; this private method runs the
     actual extraction. Splitting them keeps the legacy and diagnostic
-    paths byte-identical at the merge step — the only difference is
-    whether diagnostics are emitted.
+    paths semantically identical at the merge step — the only
+    runtime difference is whether diagnostics are emitted into the
+    returned ``ExtractedGraph``.
     """
     diagnostics: list[ExtractionDiagnostic] = []
     structured_nodes: list[ExtractedNode] = []
@@ -869,9 +873,12 @@ class OntologyGraphManager:
     else:
       result = ai_graph
 
-    # Attach diagnostics only on the new path. Legacy callers see an
-    # empty ``diagnostics`` list — Pydantic default — so the return
-    # value is byte-identical for the back-compat surface.
+    # Attach diagnostics only on the new path. Legacy callers see
+    # an empty ``diagnostics`` list — Pydantic default — so the
+    # extraction semantics are unchanged for the back-compat
+    # surface. (``model_dump()`` does pick up the new field as an
+    # additive key; see ``ExtractedGraph.diagnostics`` description
+    # for the compatibility contract.)
     if emit_diagnostics and diagnostics:
       result = result.model_copy(update={"diagnostics": diagnostics})
     return result

--- a/src/bigquery_agent_analytics/ontology_graph.py
+++ b/src/bigquery_agent_analytics/ontology_graph.py
@@ -802,21 +802,22 @@ class OntologyGraphManager:
                     detail=exc.detail,
                 )
             )
-          # structured_unhandled: spans seen in raw_events but not
-          # claimed by any extractor (no matching event_type) and not
-          # already accounted for by an extractor_exception.
-          handled_span_ids = (
-              set(structured_result.fully_handled_span_ids)
-              | set(structured_result.partially_handled_span_ids)
-              | {
-                  exc.span_id
-                  for exc in structured_result.exceptions
-                  if exc.span_id
-              }
-          )
+          # structured_unhandled: spans seen in raw_events but for
+          # which NO registered extractor was even invoked
+          # (event_type didn't match any key in self.extractors).
+          # An extractor that matched and returned an empty
+          # StructuredExtractionResult (e.g.
+          # reference_extractor._extract_capture_context's
+          # missing-required-field path) is NOT unhandled — the
+          # extractor recognized the event and concluded there was
+          # nothing structured to emit. That's a legitimate silent
+          # outcome and B2's compiled-only failure semantics should
+          # NOT flip ok=false on it. Use the orchestrator's
+          # ``invoked_span_ids`` set to distinguish the two cases.
+          invoked_span_ids = set(structured_result.invoked_span_ids)
           for event in raw_events:
             span_id = event.get("span_id")
-            if not span_id or span_id in handled_span_ids:
+            if not span_id or span_id in invoked_span_ids:
               continue
             diagnostics.append(
                 ExtractionDiagnostic(

--- a/src/bigquery_agent_analytics/structured_extraction.py
+++ b/src/bigquery_agent_analytics/structured_extraction.py
@@ -81,6 +81,17 @@ class StructuredExtractionResult:
         when ``run_structured_extractors`` ran with
         ``capture_extractor_exceptions=True``. Empty list on the
         default (propagating) path.
+    invoked_span_ids: Span IDs for which a registered extractor was
+        invoked (regardless of whether it produced output, returned
+        empty, or raised). Populated by
+        :func:`run_structured_extractors` for diagnostic emission;
+        individual extractor implementations should not set this
+        directly — the orchestrator owns it. The
+        ``structured_unhandled`` diagnostic in ``extract_graph``
+        uses this set to distinguish "no matching extractor" (a real
+        coverage gap) from "extractor matched but emitted nothing"
+        (a legitimate silent outcome, e.g. when a required field is
+        missing from the event content).
   """
 
   nodes: list[ExtractedNode] = field(default_factory=list)
@@ -88,6 +99,7 @@ class StructuredExtractionResult:
   fully_handled_span_ids: set[str] = field(default_factory=set)
   partially_handled_span_ids: set[str] = field(default_factory=set)
   exceptions: list[ExtractorException] = field(default_factory=list)
+  invoked_span_ids: set[str] = field(default_factory=set)
 
 
 # Type alias for extractor callables.
@@ -120,6 +132,7 @@ def merge_extraction_results(
   fully_handled: set[str] = set()
   partially_handled: set[str] = set()
   all_exceptions: list[ExtractorException] = []
+  invoked: set[str] = set()
 
   for result in results:
     for node in result.nodes:
@@ -128,6 +141,7 @@ def merge_extraction_results(
     fully_handled |= result.fully_handled_span_ids
     partially_handled |= result.partially_handled_span_ids
     all_exceptions.extend(result.exceptions)
+    invoked |= result.invoked_span_ids
 
   return StructuredExtractionResult(
       nodes=list(node_map.values()),
@@ -135,6 +149,7 @@ def merge_extraction_results(
       fully_handled_span_ids=fully_handled,
       partially_handled_span_ids=partially_handled,
       exceptions=all_exceptions,
+      invoked_span_ids=invoked,
   )
 
 
@@ -260,6 +275,7 @@ def run_structured_extractors(
   """
   results: list[StructuredExtractionResult] = []
   exceptions: list[ExtractorException] = []
+  invoked: set[str] = set()
 
   for event in events:
     event_type = event.get('event_type')
@@ -268,13 +284,21 @@ def run_structured_extractors(
     extractor = extractors.get(event_type)
     if extractor is None:
       continue
+    # The orchestrator owns ``invoked_span_ids``. Record before the
+    # call so a raising extractor still contributes its span to the
+    # invoked set (the call WAS attempted; the diagnostic stream
+    # surfaces it as ``extractor_exception``, not
+    # ``structured_unhandled``).
+    span_id = event.get('span_id')
+    if span_id:
+      invoked.add(span_id)
     if capture_extractor_exceptions:
       try:
         results.append(extractor(event, spec))
       except Exception as exc:  # noqa: BLE001 — by design when capturing
         exceptions.append(
             ExtractorException(
-                span_id=event.get('span_id'),
+                span_id=span_id,
                 event_type=event_type,
                 detail=f'{type(exc).__name__}: {exc}',
             )
@@ -289,12 +313,15 @@ def run_structured_extractors(
       if results
       else StructuredExtractionResult()
   )
-  if exceptions:
-    merged = StructuredExtractionResult(
-        nodes=merged.nodes,
-        edges=merged.edges,
-        fully_handled_span_ids=merged.fully_handled_span_ids,
-        partially_handled_span_ids=merged.partially_handled_span_ids,
-        exceptions=exceptions,
-    )
-  return merged
+  # Always attach the orchestrator's view of ``invoked_span_ids`` +
+  # propagate any locally-caught exceptions (preserving any
+  # exceptions an extractor result already carried — symmetric to
+  # how nodes / edges / span_ids merge).
+  return StructuredExtractionResult(
+      nodes=merged.nodes,
+      edges=merged.edges,
+      fully_handled_span_ids=merged.fully_handled_span_ids,
+      partially_handled_span_ids=merged.partially_handled_span_ids,
+      exceptions=merged.exceptions + exceptions,
+      invoked_span_ids=merged.invoked_span_ids | invoked,
+  )

--- a/src/bigquery_agent_analytics/structured_extraction.py
+++ b/src/bigquery_agent_analytics/structured_extraction.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from bigquery_agent_analytics.extracted_models import ExtractedEdge
 from bigquery_agent_analytics.extracted_models import ExtractedNode
@@ -44,6 +44,24 @@ from bigquery_agent_analytics.extracted_models import ExtractedProperty
 # ------------------------------------------------------------------ #
 # Data contracts                                                       #
 # ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class ExtractorException:
+  """Captured extractor exception.
+
+  Emitted into :class:`StructuredExtractionResult` when
+  ``run_structured_extractors`` is called with
+  ``capture_extractor_exceptions=True``. The default path
+  propagates extractor exceptions unchanged (see the contract
+  notes on ``runtime_fallback.run_with_fallback`` and
+  ``runtime_registry.WrappedRegistry`` — the diagnostics path
+  is opt-in to preserve those documented contracts).
+  """
+
+  span_id: Optional[str]
+  event_type: str
+  detail: str  # f"{type(exc).__name__}: {exc}"
 
 
 @dataclass
@@ -59,12 +77,17 @@ class StructuredExtractionResult:
     partially_handled_span_ids: Span IDs whose content is only partially
         captured (e.g. free-text fields remain) and should be included in
         the AI transcript with an extraction hint.
+    exceptions: Captured exceptions from individual extractor calls
+        when ``run_structured_extractors`` ran with
+        ``capture_extractor_exceptions=True``. Empty list on the
+        default (propagating) path.
   """
 
   nodes: list[ExtractedNode] = field(default_factory=list)
   edges: list[ExtractedEdge] = field(default_factory=list)
   fully_handled_span_ids: set[str] = field(default_factory=set)
   partially_handled_span_ids: set[str] = field(default_factory=set)
+  exceptions: list[ExtractorException] = field(default_factory=list)
 
 
 # Type alias for extractor callables.
@@ -84,7 +107,7 @@ def merge_extraction_results(
   Nodes are deduplicated by ``node_id`` — when multiple results produce a
   node with the same ID the *last* occurrence wins.  Edges are simply
   concatenated (edge dedup is left to the downstream materialiser).
-  Span-ID sets are unioned.
+  Span-ID sets are unioned. Exception lists are concatenated.
 
   Args:
     results: Individual extraction results to merge.
@@ -96,6 +119,7 @@ def merge_extraction_results(
   all_edges: list[ExtractedEdge] = []
   fully_handled: set[str] = set()
   partially_handled: set[str] = set()
+  all_exceptions: list[ExtractorException] = []
 
   for result in results:
     for node in result.nodes:
@@ -103,12 +127,14 @@ def merge_extraction_results(
     all_edges.extend(result.edges)
     fully_handled |= result.fully_handled_span_ids
     partially_handled |= result.partially_handled_span_ids
+    all_exceptions.extend(result.exceptions)
 
   return StructuredExtractionResult(
       nodes=list(node_map.values()),
       edges=all_edges,
       fully_handled_span_ids=fully_handled,
       partially_handled_span_ids=partially_handled,
+      exceptions=all_exceptions,
   )
 
 
@@ -199,6 +225,8 @@ def run_structured_extractors(
     events: list[dict],
     extractors: dict[str, StructuredExtractor],
     spec: Any,
+    *,
+    capture_extractor_exceptions: bool = False,
 ) -> StructuredExtractionResult:
   """Run registered extractors against a list of telemetry events.
 
@@ -211,11 +239,27 @@ def run_structured_extractors(
         ``event_type`` key to match against the extractor registry.
     extractors: Mapping of ``event_type`` string to extractor callable.
     spec: The active graph spec forwarded to each extractor.
+    capture_extractor_exceptions: When ``False`` (the default and the
+        only behavior prior to issue #178), extractor exceptions
+        propagate to the caller — this is the contract
+        ``runtime_fallback.run_with_fallback`` and
+        ``runtime_registry.WrappedRegistry`` rely on, so changing the
+        default would silently break those propagate-exception
+        contracts. When ``True``, extractor exceptions are caught,
+        recorded in the returned result's ``exceptions`` list, and
+        the loop continues so partial results still surface. Only the
+        new diagnostics-emitting path in
+        :func:`OntologyGraphManager.extract_graph` (with
+        ``run_structured`` and ``on_unhandled_span`` set) opts into
+        the True behavior.
 
   Returns:
-    A single merged ``StructuredExtractionResult``.
+    A single merged ``StructuredExtractionResult``. When
+    ``capture_extractor_exceptions=True``, the result's
+    ``exceptions`` list carries one entry per failed extractor call.
   """
   results: list[StructuredExtractionResult] = []
+  exceptions: list[ExtractorException] = []
 
   for event in events:
     event_type = event.get('event_type')
@@ -224,9 +268,33 @@ def run_structured_extractors(
     extractor = extractors.get(event_type)
     if extractor is None:
       continue
-    results.append(extractor(event, spec))
+    if capture_extractor_exceptions:
+      try:
+        results.append(extractor(event, spec))
+      except Exception as exc:  # noqa: BLE001 — by design when capturing
+        exceptions.append(
+            ExtractorException(
+                span_id=event.get('span_id'),
+                event_type=event_type,
+                detail=f'{type(exc).__name__}: {exc}',
+            )
+        )
+    else:
+      # Default path: exceptions propagate — the contract
+      # ``runtime_fallback`` and ``runtime_registry`` rely on.
+      results.append(extractor(event, spec))
 
-  if not results:
-    return StructuredExtractionResult()
-
-  return merge_extraction_results(results)
+  merged = (
+      merge_extraction_results(results)
+      if results
+      else StructuredExtractionResult()
+  )
+  if exceptions:
+    merged = StructuredExtractionResult(
+        nodes=merged.nodes,
+        edges=merged.edges,
+        fully_handled_span_ids=merged.fully_handled_span_ids,
+        partially_handled_span_ids=merged.partially_handled_span_ids,
+        exceptions=exceptions,
+    )
+  return merged

--- a/tests/test_extract_graph_diagnostics_modes.py
+++ b/tests/test_extract_graph_diagnostics_modes.py
@@ -425,3 +425,138 @@ class TestExtractionDiagnosticModel:
     assert d.session_id is None
     assert d.event_type is None
     assert d.detail is None
+
+  def test_model_dump_includes_diagnostics_field(self):
+    """Documenting the serialization-shape change from PR #189
+    review (P2): ``ExtractedGraph.model_dump()`` now includes
+    ``'diagnostics': []`` even when the caller never opted into
+    the diagnostics-emitting path. Existing JSON consumers that
+    ignore unknown keys (the standard pattern) keep working; only
+    strict-shape consumers need to add a passthrough."""
+    g = ExtractedGraph(name="x")
+    dumped = g.model_dump()
+    assert "diagnostics" in dumped
+    assert dumped["diagnostics"] == []
+
+
+# ---------------------------------------------------------------- #
+# structured_unhandled precise semantics (PR #189 review P2)        #
+# ---------------------------------------------------------------- #
+
+
+class TestStructuredUnhandledPreciseSemantics:
+  """``structured_unhandled`` means "no registered extractor was
+  invoked for this span" — NOT "an extractor matched but produced
+  empty output." The distinction matters because:
+
+  * A recognized event whose content is missing a required field
+    (e.g. ``reference_extractor._extract_capture_context`` when
+    ``context_id`` is absent) returns an empty
+    ``StructuredExtractionResult()``. That's a legitimate silent
+    outcome.
+  * B2's compiled-only failure semantics will translate
+    ``structured_unhandled`` to typed ``empty_extraction`` failures
+    that flip ``ok=false``. Counting the silent-outcome case as
+    "unhandled" would page on-call for events the SDK handled
+    correctly."""
+
+  def _empty_extractor(self, event, spec):
+    """Recognized event-type, empty result — mirrors the
+    reference extractor's missing-required-field path."""
+    return StructuredExtractionResult()
+
+  def test_matched_extractor_returning_empty_is_not_unhandled(self):
+    """An extractor that matches by event_type and returns empty
+    does NOT contribute a ``structured_unhandled`` diagnostic.
+    The orchestrator's ``invoked_span_ids`` set records the
+    invocation; ``structured_unhandled`` filters against that
+    set."""
+    mgr = _build_manager(
+        extractors={"E": self._empty_extractor},
+        raw_events=[
+            {"event_type": "E", "span_id": "s-empty-output"},
+            {"event_type": "UNKNOWN", "span_id": "s-truly-unhandled"},
+        ],
+    )
+    result = mgr.extract_graph(
+        ["sess-1"],
+        use_ai_generate=False,
+        run_structured=True,
+        on_unhandled_span="fail",
+    )
+    unhandled = {
+        d.span_id
+        for d in result.diagnostics
+        if d.diagnostic_code == "structured_unhandled"
+    }
+    assert unhandled == {"s-truly-unhandled"}, (
+        "only the span with no matching extractor counts as "
+        "structured_unhandled; the empty-output path is a "
+        "legitimate silent outcome"
+    )
+
+  def test_invoked_span_ids_records_every_extractor_call(self):
+    """``run_structured_extractors`` populates
+    ``invoked_span_ids`` for every event whose event_type matches
+    an extractor, whether the extractor returns empty, returns
+    full output, or raises (when capturing)."""
+    events = [
+        {"event_type": "OK", "span_id": "s-ok"},
+        {"event_type": "EMPTY", "span_id": "s-empty"},
+        {"event_type": "BOOM", "span_id": "s-boom"},
+        {"event_type": "UNKNOWN", "span_id": "s-no-match"},
+    ]
+    extractors = {
+        "OK": _ok_extractor,
+        "EMPTY": self._empty_extractor,
+        "BOOM": _raising_extractor,
+    }
+    result = run_structured_extractors(
+        events, extractors, _ToySpec(), capture_extractor_exceptions=True
+    )
+    assert result.invoked_span_ids == {"s-ok", "s-empty", "s-boom"}, (
+        "every span whose event_type matched a registered extractor "
+        "must appear in invoked_span_ids; s-no-match must not "
+        "because no extractor was even invoked for it"
+    )
+
+  def test_merge_preserves_invoked_span_ids(self):
+    """``merge_extraction_results`` unions ``invoked_span_ids``
+    just like the other span-id sets so the diagnostic stream
+    reflects the full orchestrator view."""
+    r1 = StructuredExtractionResult(invoked_span_ids={"a", "b"})
+    r2 = StructuredExtractionResult(invoked_span_ids={"b", "c"})
+    from bigquery_agent_analytics.structured_extraction import merge_extraction_results
+
+    merged = merge_extraction_results([r1, r2])
+    assert merged.invoked_span_ids == {"a", "b", "c"}
+
+  def test_merge_preserves_exceptions_from_both_sources(self):
+    """``run_structured_extractors`` concatenates
+    ``merged.exceptions + local_exceptions`` — symmetric to how
+    nodes / edges / span_ids merge. Earlier drafts replaced
+    ``merged.exceptions`` with just the local list, which would
+    silently drop any exceptions an extractor already carried in
+    its return value (PR #189 review informational finding)."""
+    pre_existing_exc = ExtractorException(
+        span_id="s-pre", event_type="EARLIER", detail="from extractor"
+    )
+
+    def _ext_with_baked_in_exc(event, spec):
+      return StructuredExtractionResult(exceptions=[pre_existing_exc])
+
+    events = [
+        {"event_type": "BAKED", "span_id": "s-pre"},
+        {"event_type": "BOOM", "span_id": "s-boom"},
+    ]
+    extractors = {
+        "BAKED": _ext_with_baked_in_exc,
+        "BOOM": _raising_extractor,
+    }
+    result = run_structured_extractors(
+        events, extractors, _ToySpec(), capture_extractor_exceptions=True
+    )
+    # Both exceptions surface — the baked-in one from the
+    # extractor's return value and the orchestrator-caught one.
+    spans = {exc.span_id for exc in result.exceptions}
+    assert spans == {"s-pre", "s-boom"}

--- a/tests/test_extract_graph_diagnostics_modes.py
+++ b/tests/test_extract_graph_diagnostics_modes.py
@@ -1,0 +1,427 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PR B1: ``extract_graph`` orthogonal-flag refactor +
+diagnostics emission (issue #178).
+
+Covers:
+
+* Legacy bool surface (``extract_graph(session_ids, True/False)``) is
+  byte-identical to today and emits no diagnostics.
+* New orthogonal surface (``run_structured`` + ``on_unhandled_span``)
+  emits each of the five diagnostic codes on a code path that
+  produces it.
+* ``capture_extractor_exceptions=False`` (the default on
+  ``run_structured_extractors``) propagates extractor exceptions
+  — the documented contract that ``runtime_fallback`` /
+  ``runtime_registry`` rely on.
+* ``capture_extractor_exceptions=True`` catches exceptions and
+  records them in ``StructuredExtractionResult.exceptions`` so the
+  diagnostics path can emit ``extractor_exception`` codes.
+* Incoherent flag combinations raise ``ValueError`` at the
+  dispatcher boundary, before any BigQuery work.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from bigquery_agent_analytics.extracted_models import ExtractedEdge
+from bigquery_agent_analytics.extracted_models import ExtractedGraph
+from bigquery_agent_analytics.extracted_models import ExtractedNode
+from bigquery_agent_analytics.extracted_models import ExtractionDiagnostic
+from bigquery_agent_analytics.structured_extraction import ExtractorException
+from bigquery_agent_analytics.structured_extraction import run_structured_extractors
+from bigquery_agent_analytics.structured_extraction import StructuredExtractionResult
+
+# ---------------------------------------------------------------- #
+# run_structured_extractors: capture_extractor_exceptions contract  #
+# ---------------------------------------------------------------- #
+
+
+class _ToySpec:
+  name = "toy"
+
+
+def _ok_extractor(event: dict, spec) -> StructuredExtractionResult:
+  span_id = event.get("span_id", "default-span")
+  return StructuredExtractionResult(
+      nodes=[ExtractedNode(node_id="n1", entity_name="E")],
+      fully_handled_span_ids={span_id},
+  )
+
+
+def _raising_extractor(event: dict, spec) -> StructuredExtractionResult:
+  raise RuntimeError("synthetic extractor failure")
+
+
+class TestRunStructuredExtractorsExceptionContract:
+  """The default propagate-exception contract must hold — that's
+  what ``runtime_fallback.run_with_fallback`` and
+  ``runtime_registry.WrappedRegistry`` rely on. The diagnostics path
+  is the only opt-in to exception capture."""
+
+  def test_default_propagates_exception(self):
+    """Existing contract: extractor exceptions propagate. Changing
+    the default would silently break ``runtime_fallback`` /
+    ``runtime_registry``."""
+    events = [
+        {"event_type": "BOOM", "span_id": "s1"},
+    ]
+    extractors = {"BOOM": _raising_extractor}
+    with pytest.raises(RuntimeError, match="synthetic extractor failure"):
+      run_structured_extractors(events, extractors, _ToySpec())
+
+  def test_explicit_false_propagates_exception(self):
+    """The explicit ``capture_extractor_exceptions=False`` path
+    behaves exactly the same as the default."""
+    events = [{"event_type": "BOOM", "span_id": "s1"}]
+    extractors = {"BOOM": _raising_extractor}
+    with pytest.raises(RuntimeError, match="synthetic extractor failure"):
+      run_structured_extractors(
+          events, extractors, _ToySpec(), capture_extractor_exceptions=False
+      )
+
+  def test_capture_records_exception_and_continues(self):
+    """When capturing is on, the exception lands in
+    ``StructuredExtractionResult.exceptions`` (not propagated) and
+    other extractors continue running so partial results still
+    surface."""
+    events = [
+        {"event_type": "OK", "span_id": "s-ok"},
+        {"event_type": "BOOM", "span_id": "s-boom"},
+        {"event_type": "OK", "span_id": "s-ok-2"},
+    ]
+    extractors = {"OK": _ok_extractor, "BOOM": _raising_extractor}
+    result = run_structured_extractors(
+        events, extractors, _ToySpec(), capture_extractor_exceptions=True
+    )
+    # Partial results from the OK extractor still surface.
+    assert len(result.nodes) >= 1
+    assert "s-ok" in result.fully_handled_span_ids
+    assert "s-ok-2" in result.fully_handled_span_ids
+    # The exception is recorded with the right attribution.
+    assert len(result.exceptions) == 1
+    exc = result.exceptions[0]
+    assert exc.span_id == "s-boom"
+    assert exc.event_type == "BOOM"
+    assert "RuntimeError" in exc.detail
+    assert "synthetic extractor failure" in exc.detail
+
+
+# ---------------------------------------------------------------- #
+# extract_graph dispatcher: legacy back-compat                      #
+# ---------------------------------------------------------------- #
+
+
+def _build_manager(
+    *,
+    extractors=None,
+    raw_events=None,
+    ai_graph=None,
+    payloads_graph=None,
+    spec_name="toy",
+):
+  """Build a minimal OntologyGraphManager mock that exercises the
+  ``extract_graph`` dispatch path without touching BigQuery."""
+  from bigquery_agent_analytics.ontology_graph import OntologyGraphManager
+
+  mgr = OntologyGraphManager.__new__(OntologyGraphManager)
+  mgr.extractors = extractors or {}
+  mgr.spec = mock.Mock()
+  mgr.spec.name = spec_name
+  mgr._fetch_raw_events = mock.Mock(return_value=raw_events or [])
+  mgr._extract_via_ai_generate = mock.Mock(
+      return_value=ai_graph
+      if ai_graph is not None
+      else ExtractedGraph(name=spec_name)
+  )
+  mgr._extract_payloads = mock.Mock(
+      return_value=payloads_graph
+      if payloads_graph is not None
+      else ExtractedGraph(name=spec_name)
+  )
+  return mgr
+
+
+class TestLegacyBoolSurface:
+  """``extract_graph(session_ids, True)`` and
+  ``extract_graph(session_ids, False)`` must continue to work
+  positionally and emit no diagnostics — the back-compat contract
+  every existing caller depends on."""
+
+  def test_legacy_true_runs_structured_and_ai(self):
+    structured = ExtractedGraph(
+        name="toy",
+        nodes=[ExtractedNode(node_id="ai-node", entity_name="E")],
+    )
+    mgr = _build_manager(
+        extractors={"E": _ok_extractor},
+        raw_events=[{"event_type": "E", "span_id": "s1"}],
+        ai_graph=structured,
+    )
+    result = mgr.extract_graph(["sess-1"], True)
+    assert mgr._extract_via_ai_generate.called
+    assert mgr._extract_payloads.called is False
+    assert (
+        result.diagnostics == []
+    ), "legacy bool surface must NOT emit diagnostics — back-compat"
+
+  def test_legacy_false_runs_stub_only(self):
+    mgr = _build_manager(
+        extractors={"E": _ok_extractor},
+        payloads_graph=ExtractedGraph(
+            name="toy",
+            nodes=[ExtractedNode(node_id="stub", entity_name="E")],
+        ),
+    )
+    result = mgr.extract_graph(["sess-1"], False)
+    assert mgr._extract_via_ai_generate.called is False
+    assert mgr._extract_payloads.called
+    assert result.diagnostics == []
+    assert result.nodes[0].node_id == "stub"
+
+  def test_legacy_positional_call_still_parses(self):
+    """``extract_graph(session_ids, False)`` is a legitimate
+    positional call shape used by existing callers. Making the new
+    params keyword-only preserves it."""
+    mgr = _build_manager()
+    # If the signature broke, this would TypeError immediately.
+    result = mgr.extract_graph(["s"], False)
+    assert isinstance(result, ExtractedGraph)
+
+
+# ---------------------------------------------------------------- #
+# extract_graph dispatcher: validation                              #
+# ---------------------------------------------------------------- #
+
+
+class TestOrthogonalFlagValidation:
+  """The new params must be set together, and the combo must be
+  coherent. Validation runs at the dispatcher boundary before any
+  BigQuery work."""
+
+  def test_run_structured_alone_raises(self):
+    mgr = _build_manager()
+    with pytest.raises(ValueError, match="must be set together"):
+      mgr.extract_graph(["s"], run_structured=True, on_unhandled_span=None)
+
+  def test_on_unhandled_alone_raises(self):
+    mgr = _build_manager()
+    with pytest.raises(ValueError, match="must be set together"):
+      mgr.extract_graph(
+          ["s"], run_structured=None, on_unhandled_span="ai_fallback"
+      )
+
+  def test_ai_fallback_with_ai_off_raises(self):
+    mgr = _build_manager()
+    with pytest.raises(
+        ValueError,
+        match="ai_fallback.*requires use_ai_generate=True",
+    ):
+      mgr.extract_graph(
+          ["s"],
+          use_ai_generate=False,
+          run_structured=True,
+          on_unhandled_span="ai_fallback",
+      )
+
+  def test_validation_runs_before_any_bigquery_work(self):
+    """``_fetch_raw_events`` / ``_extract_via_ai_generate`` /
+    ``_extract_payloads`` must NOT be called when the dispatcher
+    rejects the inputs."""
+    mgr = _build_manager()
+    with pytest.raises(ValueError):
+      mgr.extract_graph(["s"], run_structured=True, on_unhandled_span=None)
+    assert mgr._fetch_raw_events.called is False
+    assert mgr._extract_via_ai_generate.called is False
+    assert mgr._extract_payloads.called is False
+
+
+# ---------------------------------------------------------------- #
+# extract_graph dispatcher: diagnostics emission                    #
+# ---------------------------------------------------------------- #
+
+
+class TestDiagnosticEmission:
+  """Each diagnostic code is emitted on the code path that produces
+  it. The legacy bool surface emits none of them."""
+
+  def _events_two_handled_one_unhandled(self):
+    return [
+        {"event_type": "E", "span_id": "s-full"},
+        {"event_type": "E", "span_id": "s-partial"},
+        {"event_type": "UNKNOWN", "span_id": "s-unhandled"},
+    ]
+
+  def _extractor_two_codes(self, event, spec):
+    # Emits one fully_handled + one partially_handled to exercise
+    # both diagnostic codes from one extractor invocation set.
+    span_id = event["span_id"]
+    if span_id == "s-full":
+      return StructuredExtractionResult(
+          nodes=[ExtractedNode(node_id="n-full", entity_name="E")],
+          fully_handled_span_ids={span_id},
+      )
+    if span_id == "s-partial":
+      return StructuredExtractionResult(
+          nodes=[ExtractedNode(node_id="n-partial", entity_name="E")],
+          partially_handled_span_ids={span_id},
+      )
+    return StructuredExtractionResult()
+
+  def test_emits_structured_fully_and_partially_handled(self):
+    mgr = _build_manager(
+        extractors={"E": self._extractor_two_codes},
+        raw_events=self._events_two_handled_one_unhandled(),
+    )
+    result = mgr.extract_graph(
+        ["sess-1"],
+        use_ai_generate=True,
+        run_structured=True,
+        on_unhandled_span="ai_fallback",
+    )
+    codes = {(d.diagnostic_code, d.span_id) for d in result.diagnostics}
+    assert ("structured_fully_handled", "s-full") in codes
+    assert ("structured_partially_handled", "s-partial") in codes
+
+  def test_emits_structured_unhandled(self):
+    mgr = _build_manager(
+        extractors={"E": self._extractor_two_codes},
+        raw_events=self._events_two_handled_one_unhandled(),
+    )
+    result = mgr.extract_graph(
+        ["sess-1"],
+        run_structured=True,
+        use_ai_generate=True,
+        on_unhandled_span="ai_fallback",
+    )
+    unhandled = [
+        d
+        for d in result.diagnostics
+        if d.diagnostic_code == "structured_unhandled"
+    ]
+    assert len(unhandled) == 1
+    assert unhandled[0].span_id == "s-unhandled"
+    assert unhandled[0].event_type == "UNKNOWN", (
+        "structured_unhandled must carry the event_type so operators "
+        "can grep Cloud Logging for the offending shape without "
+        "joining the diagnostic back to agent_events"
+    )
+
+  def test_emits_extractor_exception(self):
+    """When ``on_unhandled_span`` is set and the diagnostics path
+    runs, extractor exceptions are caught and recorded — the
+    materializer will translate these to typed
+    ``empty_extraction`` failures (PR B2)."""
+    mgr = _build_manager(
+        extractors={"BOOM": _raising_extractor},
+        raw_events=[{"event_type": "BOOM", "span_id": "s-boom"}],
+    )
+    result = mgr.extract_graph(
+        ["sess-1"],
+        use_ai_generate=False,
+        run_structured=True,
+        on_unhandled_span="fail",
+    )
+    exc_diags = [
+        d
+        for d in result.diagnostics
+        if d.diagnostic_code == "extractor_exception"
+    ]
+    assert len(exc_diags) == 1
+    assert exc_diags[0].span_id == "s-boom"
+    assert exc_diags[0].event_type == "BOOM"
+    assert "RuntimeError" in (exc_diags[0].detail or "")
+
+  def test_emits_session_ai_fallback_attempted(self):
+    """The session-level signal is per-session (not per-span),
+    because AI.GENERATE returns a graph and per-span AI
+    attribution isn't mechanically knowable today."""
+    mgr = _build_manager()
+    result = mgr.extract_graph(
+        ["sess-a", "sess-b"],
+        run_structured=True,
+        use_ai_generate=True,
+        on_unhandled_span="ai_fallback",
+    )
+    sessions = {
+        d.session_id
+        for d in result.diagnostics
+        if d.diagnostic_code == "session_ai_fallback_attempted"
+    }
+    assert sessions == {"sess-a", "sess-b"}
+
+  def test_fail_mode_skips_ai_and_skips_stub(self):
+    """``on_unhandled_span='fail'`` is compiled-only mode: neither
+    AI nor the stub-payload path runs. The materializer reads the
+    structured_unhandled diagnostics to flip ``ok=false``."""
+    mgr = _build_manager(
+        extractors={"E": _ok_extractor},
+        raw_events=[
+            {"event_type": "E", "span_id": "s1"},
+            {"event_type": "UNKNOWN", "span_id": "s-gap"},
+        ],
+    )
+    result = mgr.extract_graph(
+        ["sess-1"],
+        use_ai_generate=False,
+        run_structured=True,
+        on_unhandled_span="fail",
+    )
+    assert mgr._extract_via_ai_generate.called is False
+    assert mgr._extract_payloads.called is False
+    # No session_ai_fallback_attempted diagnostics either — AI
+    # wasn't attempted.
+    assert not any(
+        d.diagnostic_code == "session_ai_fallback_attempted"
+        for d in result.diagnostics
+    )
+    # The unhandled span surfaces in the diagnostic stream.
+    assert any(
+        d.diagnostic_code == "structured_unhandled" and d.span_id == "s-gap"
+        for d in result.diagnostics
+    )
+
+
+# ---------------------------------------------------------------- #
+# Diagnostic model surface                                          #
+# ---------------------------------------------------------------- #
+
+
+class TestExtractionDiagnosticModel:
+  """Pydantic surface — default_factory, optional fields, code enum."""
+
+  def test_default_factory_list_for_diagnostics_field(self):
+    """Following ``nodes`` / ``edges`` pattern — Field(default_factory=list)
+    avoids the mutable-default ambiguity flagged in the v3 review."""
+    g = ExtractedGraph(name="x")
+    assert g.diagnostics == []
+    # Mutation does not leak across instances.
+    g.diagnostics.append(
+        ExtractionDiagnostic(
+            diagnostic_code="structured_unhandled", span_id="s"
+        )
+    )
+    g2 = ExtractedGraph(name="y")
+    assert g2.diagnostics == []
+
+  def test_diagnostic_optional_fields_default_to_none(self):
+    d = ExtractionDiagnostic(diagnostic_code="session_ai_fallback_attempted")
+    assert d.span_id is None
+    assert d.session_id is None
+    assert d.event_type is None
+    assert d.detail is None

--- a/tests/test_extract_graph_diagnostics_modes.py
+++ b/tests/test_extract_graph_diagnostics_modes.py
@@ -17,8 +17,11 @@ diagnostics emission (issue #178).
 
 Covers:
 
-* Legacy bool surface (``extract_graph(session_ids, True/False)``) is
-  byte-identical to today and emits no diagnostics.
+* Legacy bool surface (``extract_graph(session_ids, True/False)``)
+  preserves the existing extraction semantics and emits no
+  diagnostics. ``ExtractedGraph.model_dump()`` does pick up an
+  additive ``'diagnostics': []`` key — see the model surface for
+  the precise compatibility contract.
 * New orthogonal surface (``run_structured`` + ``on_unhandled_span``)
   emits each of the five diagnostic codes on a code path that
   produces it.


### PR DESCRIPTION
PR B1 from the [issue #187 implementation plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187). Closes (part of) [#178](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/178).

SDK-internal refactor that decouples the two extraction concerns ``run_structured_extractors`` and ``AI.GENERATE`` had entangled through the single ``use_ai_generate`` bool, and adds a per-span / session diagnostics channel on the return path. **No deploy / IAM wiring** — B2 does that on top of this foundation.

## What ships

### Two extraction surfaces on ``OntologyGraphManager.extract_graph``

| Surface | Signature | Diagnostics |
|---|---|---|
| **Legacy bool** (back-compat) | ``extract_graph(session_ids, use_ai_generate: bool = True)`` | Empty list |
| **Orthogonal-flag** (new) | ``extract_graph(session_ids, *, run_structured: bool, on_unhandled_span: Literal["ai_fallback", "fail", "stub"])`` | Populated |

- The legacy bool is preserved as the **second positional param**. ``extract_graph(session_ids, False)`` continues to parse positionally and runs the existing stub-payload path. New params are keyword-only with safe defaults.
- ``on_unhandled_span`` is a 3-value ``Literal``:
  - ``"ai_fallback"`` — run AI for unhandled gaps (equivalent to legacy True + diagnostics).
  - ``"fail"`` — compiled-only; surface unhandled spans as typed diagnostics; no AI; no stub.
  - ``"stub"`` — legacy ``use_ai_generate=False`` payload-only path.

### Diagnostics channel

``ExtractedGraph.diagnostics: list[ExtractionDiagnostic] = Field(default_factory=list)``. Five codes:

| Code | Granularity | Trigger |
|---|---|---|
| ``structured_fully_handled`` | per-span | extractor produced output covering the span entirely |
| ``structured_partially_handled`` | per-span | extractor produced partial output; gaps remain |
| ``structured_unhandled`` | per-span | **no registered extractor was invoked** for this span (event_type didn't match any extractor key). Filters against ``invoked_span_ids`` so a matched extractor returning empty (e.g. recognized event with a missing required field) does NOT count as unhandled — that's a legitimate silent outcome. |
| ``extractor_exception`` | per-span | only emitted when ``capture_extractor_exceptions=True``; carries ``detail = f'{type(exc).__name__}: {exc}'`` |
| ``session_ai_fallback_attempted`` | session-level | AI.GENERATE was invoked for the session |

Per-span AI attribution (``ai_handled``) is intentionally **not** a code yet — AI.GENERATE returns a graph, not span-attributed output. Adding it requires extending the AI return path (deferred to a future PR if span provenance lands).

### ``capture_extractor_exceptions`` contract

``run_structured_extractors`` gains a keyword-only ``capture_extractor_exceptions: bool = False``. Default preserves the existing propagate-exception contract — exactly what:

- ``runtime_fallback.run_with_fallback:155`` (*"Exceptions from this extractor propagate; the wrapper does not catch them"*)
- ``runtime_registry.WrappedRegistry:322`` (*"Callback exceptions propagate"*)

rely on. **Only the new diagnostics-emitting path in ``extract_graph`` opts into the True behavior**; legacy callers and the runtime fallback / registry surfaces stay on the propagating default.

When ``True``: each extractor call is wrapped in try/except; exceptions land in ``StructuredExtractionResult.exceptions`` (new field) as ``ExtractorException(span_id, event_type, detail)``; the loop continues so partial results still surface.

### ``invoked_span_ids`` — precise ``structured_unhandled`` semantics

``StructuredExtractionResult.invoked_span_ids: set[str]`` records every span whose ``event_type`` matched a registered extractor — regardless of whether the extractor returned empty, returned full output, or raised. The diagnostic stream uses this set to distinguish "no matching extractor" (real coverage gap → ``structured_unhandled`` → B2 translates to typed ``empty_extraction`` failure) from "extractor matched but emitted nothing" (legitimate silent outcome the diagnostic stream stays quiet on).

### Validation at the dispatcher boundary

- Setting exactly one of ``run_structured`` / ``on_unhandled_span`` raises ``ValueError`` — the contract is "set together or omit together."
- ``on_unhandled_span='ai_fallback'`` paired with ``use_ai_generate=False`` raises ``ValueError`` — the fallback target is disabled.
- Validation runs **before** any ``_fetch_raw_events`` / ``_extract_via_ai_generate`` / ``_extract_payloads`` call (asserted by a test that wires the helpers to a Mock that fails the test if called).

## Compatibility

**Extraction semantics for legacy callers are unchanged.** ``extract_graph(session_ids, True)``, ``extract_graph(session_ids, False)``, and the keyword forms with ``use_ai_generate`` all run the same code paths as today.

**Serialization shape changes — additive.** ``ExtractedGraph.model_dump()`` now includes ``'diagnostics': []`` even on the legacy surface. JSON consumers that ignore unknown keys (the standard pattern) keep working; strict-shape consumers need a passthrough for the new key. Documented in the ``ExtractedGraph.diagnostics`` description and asserted by ``test_model_dump_includes_diagnostics_field``.

**Runtime contracts preserved.** ``run_structured_extractors`` default behavior unchanged. ``runtime_fallback`` and ``runtime_registry`` propagate-exception contracts preserved (they never opt into capture). ``StructuredExtractionResult`` gains ``exceptions`` and ``invoked_span_ids`` fields defaulting to empty containers; existing constructors / accessors work unchanged.

## Tests

**22 new test cases** in ``tests/test_extract_graph_diagnostics_modes.py`` across six test classes:

- ``TestRunStructuredExtractorsExceptionContract`` — default propagates (existing contract preserved); explicit False propagates; True records exception + continues processing other events.
- ``TestLegacyBoolSurface`` — positional True / False both work; no diagnostics emitted on the legacy path.
- ``TestOrthogonalFlagValidation`` — both-or-neither contract; coherent-combination check; validation runs before any BigQuery work.
- ``TestDiagnosticEmission`` — each of the five codes emitted on the path that produces it; ``fail`` mode skips both AI and stub paths; ``structured_unhandled`` carries ``event_type``.
- ``TestExtractionDiagnosticModel`` — ``Field(default_factory=list)`` doesn't leak across instances; optional fields default to None; ``model_dump()`` includes the new key.
- ``TestStructuredUnhandledPreciseSemantics`` — matched extractor returning empty does NOT trigger ``structured_unhandled``; ``invoked_span_ids`` records every extractor call (empty / full / raising); merge unions ``invoked_span_ids``; merge preserves both extractor-baked and locally-caught exceptions.

**Net: 22 new + 436 prior tests across the touched surface pass** (ontology_graph, ontology_orchestrator, materialize_window, extractor_compilation*, migration_v5_reference_extractor). ``pyink --check`` + ``isort --check-only`` clean.

## Verification

```bash
PYTHONPATH=src pytest tests/test_extract_graph_diagnostics_modes.py
# → 22 passed

PYTHONPATH=src pytest tests/test_ontology_graph.py \
                     tests/test_ontology_orchestrator.py \
                     tests/test_materialize_window.py \
                     tests/test_extractor_compilation*.py \
                     tests/test_migration_v5_reference_extractor.py
# → 436 passed (back-compat preserved across every surface)
```

## Where this fits in the implementation plan

PR B1 in the locked sequencing on [#187](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187):

| PR | Issue(s) | Status |
|---|---|---|
| A | #177 (backfill foundation) | ✅ landed (#188) |
| **B1** (this PR) | #178 part 1 (``extract_graph`` refactor + diagnostics) | ▶︎ this PR |
| C1 | #179 (binding-model dict-shape acceptance with list-view shim) | next, parallel |
| B2 | #178 part 2 (materializer translates diagnostics → typed failures; deploy-script IAM conditionality) | after B1 + C1 |
| C2 / D / E / F / G | #179, #180, #181, #184, #185, #186 | per calendar |

## Review history

| Commit | Review finding addressed |
|---|---|
| ``df23bb1`` | Initial implementation. |
| ``8415ceb`` | P2: ``structured_unhandled`` misclassified matched-but-empty extractor returns. Added ``invoked_span_ids`` and rewrote the diagnostic emission to filter against it. P2: ``model_dump()`` shape change documented in field description + new test. Informational: exception-merge symmetry restored. |
| ``15844e4`` | P3: cleaned up three remaining "byte-identical" wording sites; replaced with "extraction semantics are unchanged" + the additive ``model_dump`` field is called out where it matters. |

## Test plan

- [x] All 22 new test cases pass.
- [x] 436 prior tests across the touched surface still pass — back-compat preserved.
- [x] ``pyink --check`` + ``isort --check-only`` clean.
- [x] Legacy ``extract_graph(session_ids, False)`` still parses positionally and runs the stub path.
- [x] ``runtime_fallback`` / ``runtime_registry`` propagate-exception contracts preserved.
- [x] Each of the five diagnostic codes emitted on its triggering path; ``fail`` mode emits ``structured_unhandled`` and skips both AI and stub.
- [x] Matched extractor returning empty (e.g. ``reference_extractor._extract_capture_context`` missing-required-field path) does NOT emit ``structured_unhandled``.
- [x] ``invoked_span_ids`` recorded before extractor execution — raising extractors aren't double-counted as unhandled.
- [x] Exception merge preserves both extractor-baked and orchestrator-caught exceptions.
- [x] ``ExtractedGraph.model_dump()`` includes ``'diagnostics': []`` (documented + tested).
- [ ] **(pending — for B2)** Materializer reads ``ExtractedGraph.diagnostics`` and translates ``structured_unhandled`` / ``extractor_exception`` counts to typed ``empty_extraction`` failures.
- [ ] **(pending — for the reviewer / post-merge)** End-to-end ``--extraction-mode=compiled-only`` smoke against a real ``agent_events`` table with at least one shape the compiled extractor doesn't recognize.