### PR TITLE
feat(binding): explicit FK→PK mapping with list-view shim (#179)

### DIFF
--- a/src/bigquery_agent_analytics/resolved_spec.py
+++ b/src/bigquery_agent_analytics/resolved_spec.py
@@ -71,7 +71,25 @@ class ResolvedRelationship:
   """One relationship in the resolved runtime view.
 
   ``from_columns`` / ``to_columns`` are the binding's endpoint join
-  columns. ``from_session_column`` / ``to_session_column`` are the
+  columns as a list-view (just the edge column names). They remain
+  ``tuple[str, ...]`` so the many downstream surfaces that read them
+  as names (the SQL compiler, the validators, the scaffolders, the
+  TTL importer, the materializer's column-set assembly) keep working
+  unchanged after #179's binding-model evolution.
+
+  ``from_column_mapping`` / ``to_column_mapping`` (new in #179) carry
+  the canonical ``(edge_column, target_property)`` form. They're the
+  source of truth when a caller needs to know which property on the
+  endpoint entity each edge column references — required for
+  self-edge support where the same entity sits at both ends and the
+  bare list of column names is ambiguous about which side a column
+  belongs to. ``None`` (the default) means the legacy shape was used
+  and the caller should fall back to "Nth edge column maps to the
+  endpoint's Nth PK property in declaration order." Surfaces that
+  predate #179 and don't yet consume the mapping fall back to that
+  legacy convention silently.
+
+  ``from_session_column`` / ``to_session_column`` are the
   SDK-specific lineage session overrides (None if not configured).
   ``properties`` are in ontology declaration order.
 
@@ -94,6 +112,8 @@ class ResolvedRelationship:
   metadata_columns: tuple[str, ...] = ("session_id", "extracted_at")
   ontology_key_primary: Optional[tuple[str, ...]] = None
   ontology_key_additional: Optional[tuple[str, ...]] = None
+  from_column_mapping: Optional[tuple[tuple[str, str], ...]] = None
+  to_column_mapping: Optional[tuple[tuple[str, str], ...]] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -380,20 +400,46 @@ def resolve(
       if ont_rel.keys.additional:
         ont_key_additional = tuple(ont_rel.keys.additional)
 
+    # Canonical FK→PK mapping (issue #179): resolves both legacy
+    # ``list[str]`` and the new ``list[dict[str, str]]`` shape into a
+    # tuple of ``(edge_column, target_property)`` pairs. The
+    # list-view ``from_columns`` / ``to_columns`` below is derived
+    # from the mapping so downstream surfaces that only need names
+    # don't have to change.
+    from bigquery_ontology.binding_loader import edge_column_names  # local: avoid cycle
+    from bigquery_ontology.binding_loader import normalize_relationship_columns
+
+    from_mapping = normalize_relationship_columns(
+        list(rb.from_columns),
+        ont_rel.from_,
+        ont_entity_map,
+        side="from",
+        relationship_name=rb.name,
+    )
+    to_mapping = normalize_relationship_columns(
+        list(rb.to_columns),
+        ont_rel.to,
+        ont_entity_map,
+        side="to",
+        relationship_name=rb.name,
+    )
+
     resolved_rels.append(
         ResolvedRelationship(
             name=ont_rel.name,
             source=_qualify_source(rb.source, project, dataset),
             from_entity=ont_rel.from_,
             to_entity=ont_rel.to,
-            from_columns=tuple(rb.from_columns),
-            to_columns=tuple(rb.to_columns),
+            from_columns=edge_column_names(list(rb.from_columns)),
+            to_columns=edge_column_names(list(rb.to_columns)),
             properties=tuple(properties),
             description=ont_rel.description or "",
             from_session_column=from_session,
             to_session_column=to_session,
             ontology_key_primary=ont_key_primary,
             ontology_key_additional=ont_key_additional,
+            from_column_mapping=from_mapping,
+            to_column_mapping=to_mapping,
         )
     )
 

--- a/src/bigquery_agent_analytics/resolved_spec.py
+++ b/src/bigquery_agent_analytics/resolved_spec.py
@@ -79,15 +79,20 @@ class ResolvedRelationship:
 
   ``from_column_mapping`` / ``to_column_mapping`` (new in #179) carry
   the canonical ``(edge_column, target_property)`` form. They're the
-  source of truth when a caller needs to know which property on the
-  endpoint entity each edge column references — required for
+  source of truth when a caller needs to know which PK property on
+  the endpoint entity each edge column references — required for
   self-edge support where the same entity sits at both ends and the
   bare list of column names is ambiguous about which side a column
-  belongs to. ``None`` (the default) means the legacy shape was used
-  and the caller should fall back to "Nth edge column maps to the
-  endpoint's Nth PK property in declaration order." Surfaces that
-  predate #179 and don't yet consume the mapping fall back to that
-  legacy convention silently.
+  belongs to. ``resolve()`` populates these fields for BOTH the
+  legacy ``list[str]`` shape (the str entry resolves to the
+  endpoint's Nth effective PK property by position) AND the explicit
+  ``list[dict[str, str]]`` shape (the dict's value is used directly,
+  after the loader validates it names a real effective PK property).
+  ``None`` (the default) means the ``ResolvedRelationship`` was
+  manually constructed without going through ``resolve()`` or
+  predates this field — newer callers should not rely on the
+  list-view alone in that case and instead derive the mapping
+  themselves from the endpoint's effective PK.
 
   ``from_session_column`` / ``to_session_column`` are the
   SDK-specific lineage session overrides (None if not configured).

--- a/src/bigquery_agent_analytics/runtime_spec.py
+++ b/src/bigquery_agent_analytics/runtime_spec.py
@@ -49,6 +49,7 @@ from bigquery_agent_analytics.ontology_models import GraphSpec
 from bigquery_agent_analytics.ontology_models import KeySpec
 from bigquery_agent_analytics.ontology_models import PropertySpec
 from bigquery_agent_analytics.ontology_models import RelationshipSpec
+from bigquery_ontology.binding_loader import require_legacy_column_shape
 from bigquery_ontology.binding_models import Backend
 from bigquery_ontology.binding_models import BigQueryTarget
 from bigquery_ontology.binding_models import Binding
@@ -329,8 +330,29 @@ def graph_spec_from_ontology_binding(
             to_entity=ont_rel.to,
             binding=BindingSpec(
                 source=_resolve_source(rb.source, target),
-                from_columns=list(rb.from_columns),
-                to_columns=list(rb.to_columns),
+                # ``graph_spec_from_ontology_binding`` is a legacy
+                # converter that targets ``BindingSpec.from_columns:
+                # list[str]``. Like ``compile_graph``, it predates
+                # #179's canonical mapping and would pydantic-error
+                # at this BindingSpec construction site when handed
+                # a dict-shape binding. Guard at the boundary with
+                # a precise error pointing at the migration path.
+                from_columns=list(
+                    require_legacy_column_shape(
+                        list(rb.from_columns),
+                        consumer_name='graph_spec_from_ontology_binding',
+                        side='from',
+                        relationship_name=rb.name,
+                    )
+                ),
+                to_columns=list(
+                    require_legacy_column_shape(
+                        list(rb.to_columns),
+                        consumer_name='graph_spec_from_ontology_binding',
+                        side='to',
+                        relationship_name=rb.name,
+                    )
+                ),
                 from_session_column=from_session_col,
                 to_session_column=to_session_col,
             ),

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -332,7 +332,14 @@ def _check_relationship_endpoint_arity(
     rel: Relationship,
     entity_map: dict[str, Entity],
 ) -> None:
-  """``from_columns`` / ``to_columns`` arity must match the endpoint keys."""
+  """``from_columns`` / ``to_columns`` arity must match the endpoint keys.
+
+  Works against both legacy ``list[str]`` and the new
+  ``list[dict[str, str]]`` shape — each list entry counts as one
+  column regardless of which shape it takes. The semantic check that
+  every ``target_property`` names a real property on the endpoint is
+  in :func:`_check_relationship_target_properties`.
+  """
   from_pk = _primary_key_len(rel.from_, entity_map)
   to_pk = _primary_key_len(rel.to, entity_map)
   if len(rb.from_columns) != from_pk:
@@ -347,6 +354,119 @@ def _check_relationship_endpoint_arity(
         f"{len(rb.to_columns)} column(s) but endpoint entity "
         f"{rel.to!r} has {to_pk}-column primary key."
     )
+
+
+def normalize_relationship_columns(
+    column_entries: list,
+    endpoint_entity_name: str,
+    entity_map: dict[str, Entity],
+    *,
+    side: str,
+    relationship_name: str,
+) -> tuple[tuple[str, str], ...]:
+  """Resolve a ``RelationshipBinding`` column list to canonical form.
+
+  Returns a tuple of ``(edge_column, target_property)`` pairs in the
+  declared order. The two input shapes resolve as follows:
+
+  * ``str`` (legacy) — ``target_property`` defaults to the endpoint
+    entity's Nth primary-key property (1-to-1 by position).
+  * ``dict[str, str]`` (explicit) — the dict's single key is the
+    edge column and its value is the target property name.
+
+  This is the bridge between the pydantic shape (which accepts both)
+  and the canonical form ``ResolvedRelationship.from_column_mapping``
+  / ``to_column_mapping`` carry. The shape check in
+  :class:`RelationshipBinding._validate_column_entries` already
+  guarantees each entry is a non-empty string or a single-key
+  ``str → str`` dict; this function does the semantic check that
+  ``target_property`` names a real property on ``endpoint_entity``.
+
+  Args:
+    column_entries: ``rb.from_columns`` or ``rb.to_columns``.
+    endpoint_entity_name: ``rel.from_`` or ``rel.to``.
+    entity_map: Map of entity name → :class:`Entity` for property
+        lookup.
+    side: ``"from"`` or ``"to"`` — used in error messages.
+    relationship_name: ``rb.name`` — used in error messages.
+
+  Returns:
+    A tuple of ``(edge_column, target_property)`` pairs.
+
+  Raises:
+    ValueError: If ``target_property`` doesn't name a declared
+      property on the endpoint entity, or if a legacy ``str``-shape
+      entry's position exceeds the endpoint's PK arity.
+  """
+  endpoint = entity_map.get(endpoint_entity_name)
+  if endpoint is None or endpoint.keys is None or not endpoint.keys.primary:
+    raise ValueError(
+        f"Relationship binding {relationship_name!r}: endpoint entity "
+        f"{endpoint_entity_name!r} has no primary key declared in the "
+        "ontology."
+    )
+  endpoint_pk_properties = list(endpoint.keys.primary)
+  endpoint_property_names = {p.name for p in (endpoint.properties or [])}
+  # The PK property itself is always implicitly part of the entity even
+  # when it's declared as a key without a separate properties entry.
+  endpoint_property_names |= set(endpoint_pk_properties)
+
+  canonical: list[tuple[str, str]] = []
+  for idx, entry in enumerate(column_entries):
+    if isinstance(entry, str):
+      # Legacy shape: target_property = endpoint's Nth PK property.
+      if idx >= len(endpoint_pk_properties):
+        # Caught earlier by the arity check, but defend in depth so
+        # this helper is safe to call in isolation.
+        raise ValueError(
+            f"Relationship binding {relationship_name!r}: {side}_columns "
+            f"entry [{idx}] is a legacy string entry but endpoint "
+            f"{endpoint_entity_name!r} has only "
+            f"{len(endpoint_pk_properties)} primary-key column(s)."
+        )
+      target_property = endpoint_pk_properties[idx]
+      canonical.append((entry, target_property))
+      continue
+    if isinstance(entry, dict):
+      # The pydantic validator already guaranteed single-key str→str.
+      edge_column, target_property = next(iter(entry.items()))
+      if target_property not in endpoint_property_names:
+        raise ValueError(
+            f"Relationship binding {relationship_name!r}: {side}_columns "
+            f"entry [{idx}] maps {edge_column!r} → "
+            f"{target_property!r}, but endpoint entity "
+            f"{endpoint_entity_name!r} has no property named "
+            f"{target_property!r}."
+        )
+      canonical.append((edge_column, target_property))
+      continue
+    # Unreachable: the pydantic validator rejected anything else.
+    raise ValueError(  # pragma: no cover
+        f"Relationship binding {relationship_name!r}: {side}_columns "
+        f"entry [{idx}] has unexpected type {type(entry).__name__}."
+    )
+  return tuple(canonical)
+
+
+def edge_column_names(
+    column_entries: list,
+) -> tuple[str, ...]:
+  """Extract just the edge column names from a mixed ``ColumnRef`` list.
+
+  Used by downstream surfaces that only need the list-view of edge
+  column names (the legacy ``ResolvedRelationship.from_columns`` /
+  ``to_columns`` shim). The canonical
+  ``(edge_column, target_property)`` form is produced by
+  :func:`normalize_relationship_columns`.
+  """
+  out: list[str] = []
+  for entry in column_entries:
+    if isinstance(entry, str):
+      out.append(entry)
+    elif isinstance(entry, dict):
+      # Pydantic validator guarantees a single key.
+      out.append(next(iter(entry.keys())))
+  return tuple(out)
 
 
 def _primary_key_len(entity_name: str, entity_map: dict[str, Entity]) -> int:

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -471,6 +471,39 @@ def normalize_relationship_columns(
         f"Relationship binding {relationship_name!r}: {side}_columns "
         f"entry [{idx}] has unexpected type {type(entry).__name__}."
     )
+
+  # Coverage invariant: the canonical mapping's target-property
+  # sequence must be a permutation of the endpoint's effective PK
+  # properties (each PK property covered exactly once). Arity has
+  # already been enforced upstream (``_check_relationship_endpoint_arity``)
+  # so ``len(targets) == len(endpoint_pk_properties)``; if every
+  # target is also in the PK set (which the per-entry check above
+  # guarantees) and the targets are unique, the three conditions
+  # together imply the permutation invariant.
+  #
+  # Without this check a composite PK ``[k1, k2]`` could be bound as
+  # two entries that both target ``k1``, leaving ``k2`` uncovered —
+  # C2's materializer would then consume a canonical endpoint
+  # mapping that cannot uniquely identify the target row.
+  target_sequence = [target for _, target in canonical]
+  if len(set(target_sequence)) != len(target_sequence):
+    # Find the first duplicate for a precise error.
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for target in target_sequence:
+      if target in seen and target not in duplicates:
+        duplicates.append(target)
+      seen.add(target)
+    raise ValueError(
+        f"Relationship binding {relationship_name!r}: {side}_columns "
+        f"covers some endpoint PK properties more than once "
+        f"({duplicates!r}) which necessarily leaves at least one PK "
+        "property uncovered. The canonical mapping must be a "
+        "permutation of the endpoint's effective primary-key "
+        f"properties {sorted(endpoint_pk_property_set)!r} — each PK "
+        "property mapped exactly once. C2's materializer needs this "
+        "invariant so the edge uniquely identifies the target row."
+    )
   return tuple(canonical)
 
 

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -517,6 +517,16 @@ def edge_column_names(
   ``to_columns`` shim). The canonical
   ``(edge_column, target_property)`` form is produced by
   :func:`normalize_relationship_columns`.
+
+  Important: returns column names in **declared binding order**, not
+  in endpoint-PK declaration order. Consumers that pair these
+  columns positionally with the endpoint's PK columns (DDL emitters,
+  property-graph compilers) must NOT use this function for permuted
+  dict-shape bindings; they should go through
+  :func:`require_legacy_column_shape` to assert the legacy
+  list-of-strings shape (which is implicitly PK-ordered) until they
+  are wired to consume :func:`normalize_relationship_columns`
+  output directly.
   """
   out: list[str] = []
   for entry in column_entries:
@@ -526,6 +536,63 @@ def edge_column_names(
       # Pydantic validator guarantees a single key.
       out.append(next(iter(entry.keys())))
   return tuple(out)
+
+
+def require_legacy_column_shape(
+    column_entries: list,
+    *,
+    consumer_name: str,
+    side: str,
+    relationship_name: str,
+) -> tuple[str, ...]:
+  """Assert ``column_entries`` uses the legacy ``list[str]`` shape.
+
+  Returns the list-view as ``tuple[str, ...]`` when every entry is a
+  bare string. Raises ``ValueError`` with a precise, actionable
+  error if any entry is a dict.
+
+  Background: PR C1 (issue #179) introduced an explicit
+  ``{edge_column: target_property}`` dict-shape entry on
+  ``RelationshipBinding.from_columns`` / ``to_columns`` so C2 can
+  bind self-edges (same entity on both ends) by giving each side a
+  distinct edge column name. The dict shape parses cleanly through
+  :class:`RelationshipBinding` and resolves into the canonical
+  ``ResolvedRelationship.from_column_mapping`` /
+  ``to_column_mapping`` via :func:`normalize_relationship_columns`,
+  but a handful of public surfaces — the property-graph DDL
+  compiler in ``graph_ddl_compiler.compile_graph``, the legacy
+  ``runtime_spec.graph_spec_from_ontology_binding`` converter —
+  still read ``rb.from_columns`` / ``rb.to_columns`` as
+  ``list[str]`` and would silently mispair edge columns against
+  endpoint PK columns (or simply crash at the next ``''.join``)
+  when handed a dict.
+
+  Routing those consumers through this helper makes the boundary
+  explicit: legacy bindings flow through unchanged; new dict-shape
+  bindings get a clear "this consumer needs the canonical mapping"
+  error pointing at the offending entry and the migration path
+  (route through ``resolve()`` and consume
+  ``ResolvedRelationship.from_column_mapping``). C2 lifts the
+  restriction on a consumer-by-consumer basis as it wires the
+  canonical mapping through them.
+  """
+  for idx, entry in enumerate(column_entries):
+    if isinstance(entry, dict):
+      raise ValueError(
+          f"{consumer_name}: relationship binding "
+          f"{relationship_name!r} {side}_columns[{idx}] uses the "
+          f"explicit FK→PK mapping shape ({entry!r}) introduced in "
+          "#179, but this consumer is not yet wired through the "
+          "canonical mapping. Either revert this entry to the legacy "
+          "``[edge_column_name, ...]`` list-of-strings shape, or "
+          "route your code through ``resolve()`` and consume "
+          "``ResolvedRelationship.from_column_mapping`` / "
+          "``to_column_mapping`` directly. C2 (issue #179 follow-up) "
+          "will lift this restriction."
+      )
+  # All entries are str at this point — the pydantic validator
+  # already rejected anything else.
+  return tuple(column_entries)
 
 
 def _primary_key_len(entity_name: str, entity_map: dict[str, Entity]) -> int:

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -372,7 +372,12 @@ def normalize_relationship_columns(
   * ``str`` (legacy) — ``target_property`` defaults to the endpoint
     entity's Nth primary-key property (1-to-1 by position).
   * ``dict[str, str]`` (explicit) — the dict's single key is the
-    edge column and its value is the target property name.
+    edge column and its value is the target property name. The
+    target property MUST be one of the endpoint's effective
+    primary-key properties — this is FK→PK mapping, not FK→any-
+    column, because a non-PK target would let a relationship edge
+    point at a row that isn't uniquely identified by its endpoint
+    columns.
 
   This is the bridge between the pydantic shape (which accepts both)
   and the canonical form ``ResolvedRelationship.from_column_mapping``
@@ -380,13 +385,16 @@ def normalize_relationship_columns(
   :class:`RelationshipBinding._validate_column_entries` already
   guarantees each entry is a non-empty string or a single-key
   ``str → str`` dict; this function does the semantic check that
-  ``target_property`` names a real property on ``endpoint_entity``.
+  ``target_property`` names a real PK property on
+  ``endpoint_entity_name``, honoring inherited keys.
 
   Args:
     column_entries: ``rb.from_columns`` or ``rb.to_columns``.
     endpoint_entity_name: ``rel.from_`` or ``rel.to``.
     entity_map: Map of entity name → :class:`Entity` for property
-        lookup.
+        lookup. Inheritance is followed via :func:`_effective_keys`
+        and :func:`_effective_properties` so an endpoint that
+        inherits its PK from a parent entity resolves correctly.
     side: ``"from"`` or ``"to"`` — used in error messages.
     relationship_name: ``rb.name`` — used in error messages.
 
@@ -395,21 +403,34 @@ def normalize_relationship_columns(
 
   Raises:
     ValueError: If ``target_property`` doesn't name a declared
-      property on the endpoint entity, or if a legacy ``str``-shape
-      entry's position exceeds the endpoint's PK arity.
+      primary-key property on the endpoint entity (including
+      inherited PKs), or if a legacy ``str``-shape entry's position
+      exceeds the endpoint's PK arity.
   """
   endpoint = entity_map.get(endpoint_entity_name)
-  if endpoint is None or endpoint.keys is None or not endpoint.keys.primary:
+  if endpoint is None:
     raise ValueError(
         f"Relationship binding {relationship_name!r}: endpoint entity "
-        f"{endpoint_entity_name!r} has no primary key declared in the "
-        "ontology."
+        f"{endpoint_entity_name!r} not found in the ontology."
     )
-  endpoint_pk_properties = list(endpoint.keys.primary)
-  endpoint_property_names = {p.name for p in (endpoint.properties or [])}
-  # The PK property itself is always implicitly part of the entity even
-  # when it's declared as a key without a separate properties entry.
-  endpoint_property_names |= set(endpoint_pk_properties)
+  # Use the inheritance-aware helpers so an endpoint that inherits
+  # its PK from a parent entity resolves correctly. Mirrors what the
+  # arity check already does via ``_primary_key_len``; not doing it
+  # here would silently regress every ontology that uses an
+  # ``extends`` chain on the endpoint side of a relationship.
+  effective_keys = _effective_keys(endpoint, entity_map)
+  if effective_keys is None or not effective_keys.primary:
+    raise ValueError(
+        f"Relationship binding {relationship_name!r}: endpoint entity "
+        f"{endpoint_entity_name!r} has no effective primary key declared "
+        "in the ontology (including inherited keys)."
+    )
+  endpoint_pk_properties = list(effective_keys.primary)
+  # FK→PK: explicit mappings must target a PK property. Allowing any
+  # property would let C2's materializer fix consume a canonical
+  # mapping that points an edge endpoint at a non-key column, which
+  # doesn't uniquely identify the target row.
+  endpoint_pk_property_set = set(endpoint_pk_properties)
 
   canonical: list[tuple[str, str]] = []
   for idx, entry in enumerate(column_entries):
@@ -430,13 +451,17 @@ def normalize_relationship_columns(
     if isinstance(entry, dict):
       # The pydantic validator already guaranteed single-key str→str.
       edge_column, target_property = next(iter(entry.items()))
-      if target_property not in endpoint_property_names:
+      if target_property not in endpoint_pk_property_set:
         raise ValueError(
             f"Relationship binding {relationship_name!r}: {side}_columns "
             f"entry [{idx}] maps {edge_column!r} → "
             f"{target_property!r}, but endpoint entity "
-            f"{endpoint_entity_name!r} has no property named "
-            f"{target_property!r}."
+            f"{endpoint_entity_name!r} has no primary-key property "
+            f"named {target_property!r}. Effective PK properties: "
+            f"{sorted(endpoint_pk_property_set)!r}. This is FK→PK "
+            "mapping; the target must be a primary-key property "
+            "(including inherited PKs) so the edge uniquely "
+            "identifies the target row."
         )
       canonical.append((edge_column, target_property))
       continue

--- a/src/bigquery_ontology/binding_loader.py
+++ b/src/bigquery_ontology/binding_loader.py
@@ -336,9 +336,10 @@ def _check_relationship_endpoint_arity(
 
   Works against both legacy ``list[str]`` and the new
   ``list[dict[str, str]]`` shape — each list entry counts as one
-  column regardless of which shape it takes. The semantic check that
-  every ``target_property`` names a real property on the endpoint is
-  in :func:`_check_relationship_target_properties`.
+  column regardless of which shape it takes. The semantic check
+  that every ``target_property`` names an effective primary-key
+  property on the endpoint is in
+  :func:`normalize_relationship_columns`.
   """
   from_pk = _primary_key_len(rel.from_, entity_map)
   to_pk = _primary_key_len(rel.to, entity_map)

--- a/src/bigquery_ontology/binding_models.py
+++ b/src/bigquery_ontology/binding_models.py
@@ -34,10 +34,12 @@ SDK's Spanner support.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any, Union
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
 
 
 class Backend(str, Enum):
@@ -110,6 +112,32 @@ class EntityBinding(BaseModel):
   properties: list[PropertyBinding]
 
 
+# An entry in ``RelationshipBinding.from_columns`` / ``to_columns``.
+# Two equivalent shapes are accepted:
+#
+# 1. ``str`` (legacy) — the edge-table column name. The target
+#    property defaults to the endpoint entity's primary-key property
+#    in declaration order: the Nth string entry maps to the endpoint's
+#    Nth PK property. This is what every existing binding YAML uses.
+#
+# 2. ``dict[str, str]`` (explicit FK→PK mapping, new in #179) — a
+#    single-key dict ``{edge_column: target_property}``. Lets a
+#    relationship that needs distinct edge column names (e.g. a
+#    self-edge like ``evolvedFrom`` where ``from_entity == to_entity``
+#    so the legacy shape would collide on a single ``decision_execution_id``
+#    column) declare both endpoints explicitly:
+#
+#       from_columns: [{src_decision_execution_id: id}]
+#       to_columns:   [{dst_decision_execution_id: id}]
+#
+# Both shapes resolve to a canonical (edge_column, target_property)
+# tuple stream in the binding loader. The validator below enforces
+# the structural shape only (single-key + str→str). The loader
+# enforces the semantic check that target_property names a real
+# property on the endpoint entity.
+ColumnRef = Union[str, dict[str, str]]
+
+
 class RelationshipBinding(BaseModel):
   """Realizes one ontology relationship against a physical edge table.
 
@@ -121,19 +149,73 @@ class RelationshipBinding(BaseModel):
 
   ``from_columns`` and ``to_columns`` are the columns in ``source`` that
   carry the source and target endpoint keys — a list because primary
-  keys may be composite. Their arity must equal the corresponding
-  endpoint entity's primary-key arity, which only the loader can check
-  against the ontology; the ``min_length=1`` guard here just rejects
-  the structurally-invalid empty list.
+  keys may be composite. Each entry is either a bare column-name
+  string (legacy; target property defaults to the endpoint's PK in
+  declaration order) or a single-key ``{edge_column: target_property}``
+  dict (explicit FK→PK mapping; required for self-edges and any case
+  where the edge column name differs from the endpoint's PK property).
+  Arity must equal the corresponding endpoint entity's primary-key
+  arity, which only the loader can check against the ontology; the
+  ``min_length=1`` guard here just rejects the structurally-invalid
+  empty list.
   """
 
   model_config = ConfigDict(extra="forbid")
 
   name: str
   source: str
-  from_columns: list[str] = Field(min_length=1)
-  to_columns: list[str] = Field(min_length=1)
+  from_columns: list[ColumnRef] = Field(min_length=1)
+  to_columns: list[ColumnRef] = Field(min_length=1)
   properties: list[PropertyBinding] = Field(default_factory=list)
+
+  @field_validator("from_columns", "to_columns")
+  @classmethod
+  def _validate_column_entries(cls, value: list[Any]) -> list[ColumnRef]:
+    """Reject malformed dict entries at the shape boundary.
+
+    Each entry must be either a bare string or a single-key dict
+    mapping str → str. A multi-key dict, an empty dict, or a dict
+    with non-string keys / values would slip past pydantic's
+    structural type-check and surface as a confusing failure later
+    in the loader; rejecting here gives the operator a precise
+    error message anchored to the offending entry.
+    """
+    for idx, entry in enumerate(value):
+      if isinstance(entry, str):
+        if not entry:
+          raise ValueError(
+              f"column entry [{idx}] is an empty string; "
+              "edge column names must be non-empty"
+          )
+        continue
+      if isinstance(entry, dict):
+        if len(entry) != 1:
+          raise ValueError(
+              f"column entry [{idx}] must be a single-key dict "
+              "mapping ``edge_column`` (str) → ``target_property`` "
+              f"(str); got dict with {len(entry)} key(s): {entry!r}. "
+              "Composite endpoints are expressed by listing multiple "
+              "single-key dicts in order."
+          )
+        edge_col, target_prop = next(iter(entry.items()))
+        if not isinstance(edge_col, str) or not edge_col:
+          raise ValueError(
+              f"column entry [{idx}] dict key must be a non-empty str "
+              f"naming the edge column; got {type(edge_col).__name__} "
+              f"{edge_col!r}"
+          )
+        if not isinstance(target_prop, str) or not target_prop:
+          raise ValueError(
+              f"column entry [{idx}] dict value must be a non-empty str "
+              f"naming the target property; got {type(target_prop).__name__} "
+              f"{target_prop!r}"
+          )
+        continue
+      raise ValueError(
+          f"column entry [{idx}] must be a string or a single-key dict; "
+          f"got {type(entry).__name__}: {entry!r}"
+      )
+    return value
 
 
 class Binding(BaseModel):

--- a/src/bigquery_ontology/binding_models.py
+++ b/src/bigquery_ontology/binding_models.py
@@ -133,8 +133,11 @@ class EntityBinding(BaseModel):
 # Both shapes resolve to a canonical (edge_column, target_property)
 # tuple stream in the binding loader. The validator below enforces
 # the structural shape only (single-key + str→str). The loader
-# enforces the semantic check that target_property names a real
-# property on the endpoint entity.
+# enforces the semantic check that target_property names an
+# *effective primary-key property* on the endpoint entity
+# (honoring inherited PKs). This is FK→PK mapping, not FK→any-
+# column: only a PK target uniquely identifies the row the edge
+# endpoint points at.
 ColumnRef = Union[str, dict[str, str]]
 
 

--- a/src/bigquery_ontology/graph_ddl_compiler.py
+++ b/src/bigquery_ontology/graph_ddl_compiler.py
@@ -242,16 +242,40 @@ def _resolve_edge_table(
       owner=f"relationship {rel.name!r}",
   )
 
+  # ``compile_graph`` is one of the consumers C1 didn't wire through
+  # the canonical FK→PK mapping yet (issue #179): it pairs edge
+  # columns positionally with the endpoint's PK columns when
+  # emitting ``SOURCE KEY (...) REFERENCES from_node (...)``. The
+  # dict-shape binding introduced in #179 would silently mispair
+  # (or, more commonly, crash at the next ``str.join``). Until C2
+  # wires the canonical mapping through here, require legacy
+  # list-of-strings on both sides — the error names the offending
+  # entry and the migration path.
+  from .binding_loader import require_legacy_column_shape
+
+  from_columns_legacy = require_legacy_column_shape(
+      list(rb.from_columns),
+      consumer_name="compile_graph",
+      side="from",
+      relationship_name=rb.name,
+  )
+  to_columns_legacy = require_legacy_column_shape(
+      list(rb.to_columns),
+      consumer_name="compile_graph",
+      side="to",
+      relationship_name=rb.name,
+  )
+
   return ResolvedEdgeTable(
       # Same rationale as ResolvedNodeTable.alias: use the relationship name
       # so the DDL reads by logical name rather than physical table
       # basename.
       alias=rel.name,
       source=rb.source,
-      from_columns=tuple(rb.from_columns),
+      from_columns=from_columns_legacy,
       from_node_alias=from_node.alias,
       from_node_key_columns=from_node.key_columns,
-      to_columns=tuple(rb.to_columns),
+      to_columns=to_columns_legacy,
       to_node_alias=to_node.alias,
       to_node_key_columns=to_node.key_columns,
       key_columns=_resolve_edge_key_columns(rel, rb, column_by_property),
@@ -298,7 +322,24 @@ def _resolve_edge_key_columns(
   enforced by the ontology loader, so at most one of the first two
   branches can fire.
   """
-  from_to_columns = tuple(rb.from_columns) + tuple(rb.to_columns)
+  # See the comment in ``_resolve_edge_table`` for the rationale:
+  # ``compile_graph`` doesn't yet consume the canonical FK→PK
+  # mapping, so we still rely on the legacy list-of-strings shape
+  # here. The same helper enforces that contract with an
+  # actionable error for dict-shape bindings.
+  from .binding_loader import require_legacy_column_shape
+
+  from_to_columns = require_legacy_column_shape(
+      list(rb.from_columns),
+      consumer_name="compile_graph._resolve_edge_key_columns",
+      side="from",
+      relationship_name=rb.name,
+  ) + require_legacy_column_shape(
+      list(rb.to_columns),
+      consumer_name="compile_graph._resolve_edge_key_columns",
+      side="to",
+      relationship_name=rb.name,
+  )
   if rel.keys is None:
     return from_to_columns
   if rel.keys.primary:

--- a/tests/test_binding_explicit_fk_mapping.py
+++ b/tests/test_binding_explicit_fk_mapping.py
@@ -766,3 +766,84 @@ class TestCompositePKCoverageInvariant:
     resolved = resolve(ontology=ont, binding=binding)
     rel = resolved.relationships[0]
     assert rel.to_column_mapping == (("b_k1", "k1"), ("b_k2", "k2"))
+
+
+# ------------------------------------------------------------------ #
+# Raw-binding consumer guards (PR #191 review P1)                      #
+# ------------------------------------------------------------------ #
+
+
+class TestRawBindingConsumerGuards:
+  """C1 introduced the dict-shape ``ColumnRef`` at the binding-model
+  boundary, but a couple of consumers (``compile_graph``,
+  ``graph_spec_from_ontology_binding``) read ``rb.from_columns`` /
+  ``rb.to_columns`` directly as ``list[str]`` and would silently
+  mispair (or crash) on a dict-shape binding. C2 will wire them
+  through the canonical mapping; until then, those boundaries raise
+  with a precise error pointing at the migration path. This test
+  class pins the contract."""
+
+  def _dict_shape_binding(self):
+    binding_yaml = _binding_with_columns("[{src_id: id}]", "[{dst_id: id}]")
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    return ont, binding
+
+  def test_compile_graph_rejects_dict_shape(self):
+    """``compile_graph`` pairs edge columns positionally with the
+    endpoint's PK columns when emitting ``SOURCE KEY ...
+    REFERENCES from_node (...)``. Until C2 wires the canonical
+    mapping through, a dict-shape binding must raise — not crash
+    at ``str.join`` or mispair silently."""
+    from bigquery_ontology.graph_ddl_compiler import compile_graph
+
+    ont, binding = self._dict_shape_binding()
+    with pytest.raises(
+        ValueError,
+        match=r"compile_graph: relationship binding 'linksTo' from_columns",
+    ):
+      compile_graph(ont, binding)
+
+  def test_graph_spec_from_ontology_binding_rejects_dict_shape(self):
+    """The legacy ``GraphSpec`` converter targets
+    ``BindingSpec.from_columns: list[str]``; a dict-shape entry
+    would pydantic-error there. Catch at the boundary with the
+    same actionable error as ``compile_graph``."""
+    from bigquery_agent_analytics.runtime_spec import graph_spec_from_ontology_binding
+
+    ont, binding = self._dict_shape_binding()
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"graph_spec_from_ontology_binding: relationship "
+            r"binding 'linksTo' from_columns"
+        ),
+    ):
+      graph_spec_from_ontology_binding(ont, binding)
+
+  def test_consumer_guard_error_names_migration_path(self):
+    """The error message tells the operator how to fix this: route
+    through ``resolve()`` and read
+    ``ResolvedRelationship.from_column_mapping``."""
+    from bigquery_ontology.graph_ddl_compiler import compile_graph
+
+    ont, binding = self._dict_shape_binding()
+    with pytest.raises(ValueError) as excinfo:
+      compile_graph(ont, binding)
+    msg = str(excinfo.value)
+    assert "resolve()" in msg
+    assert "from_column_mapping" in msg
+
+  def test_legacy_shape_passes_through_both_consumers(self):
+    """The whole point of the guard is to keep legacy bindings
+    working unchanged — sanity-check that ``list[str]`` bindings
+    still flow through both consumers."""
+    from bigquery_agent_analytics.runtime_spec import graph_spec_from_ontology_binding
+    from bigquery_ontology.graph_ddl_compiler import compile_graph
+
+    binding_yaml = _binding_with_columns("[src_id]", "[dst_id]")
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    # Both consumers run cleanly.
+    compile_graph(ont, binding)
+    graph_spec_from_ontology_binding(ont, binding)

--- a/tests/test_binding_explicit_fk_mapping.py
+++ b/tests/test_binding_explicit_fk_mapping.py
@@ -1,0 +1,409 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PR C1: explicit FK→PK mapping in ``RelationshipBinding``
+(issue #179).
+
+Covers:
+
+* The pydantic shape boundary (``RelationshipBinding`` accepts both
+  the legacy ``list[str]`` and the new ``list[dict[str, str]]``
+  shapes; malformed entries are rejected with a precise error).
+* The loader's canonical normalization
+  (``normalize_relationship_columns`` resolves both shapes to a
+  tuple of ``(edge_column, target_property)`` pairs; legacy entries
+  default to the endpoint's Nth PK property).
+* The list-view shim (``ResolvedRelationship.from_columns`` /
+  ``to_columns`` remain ``tuple[str, ...]`` so downstream surfaces
+  that only need column names keep working unchanged).
+* Byte-identical SQL emission for the existing migration v5 binding
+  (the canonical form is only consumed by callers that opt in;
+  legacy callers see no SQL drift).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+import yaml
+
+from bigquery_ontology import load_binding_from_string
+from bigquery_ontology import load_ontology_from_string
+from bigquery_ontology.binding_loader import edge_column_names
+from bigquery_ontology.binding_loader import normalize_relationship_columns
+from bigquery_ontology.binding_models import RelationshipBinding
+
+# Local ontology used by most of these tests. Two entities with a
+# single-column PK each, one relationship between them.
+_TOY_ONTOLOGY = textwrap.dedent(
+    """
+    ontology: toy
+    entities:
+      - name: Source
+        keys:
+          primary: [id]
+        properties:
+          - {name: id, type: string}
+      - name: Target
+        keys:
+          primary: [id]
+        properties:
+          - {name: id, type: string}
+    relationships:
+      - name: linksTo
+        from: Source
+        to: Target
+    """
+).strip()
+
+
+def _binding_with_columns(from_columns_yaml: str, to_columns_yaml: str) -> str:
+  """Build a binding YAML fragment with the given column shapes
+  embedded into a complete document the loader will accept."""
+  return textwrap.dedent(
+      f"""
+      binding: toy_bq
+      ontology: toy
+      target:
+        backend: bigquery
+        project: p
+        dataset: d
+      entities:
+        - name: Source
+          source: p.d.source
+          properties:
+            - {{name: id, column: id}}
+        - name: Target
+          source: p.d.target
+          properties:
+            - {{name: id, column: id}}
+      relationships:
+        - name: linksTo
+          source: p.d.linksto
+          from_columns: {from_columns_yaml}
+          to_columns: {to_columns_yaml}
+      """
+  ).strip()
+
+
+# ------------------------------------------------------------------ #
+# Pydantic shape boundary                                              #
+# ------------------------------------------------------------------ #
+
+
+class TestRelationshipBindingColumnShapes:
+  """``RelationshipBinding.from_columns`` / ``to_columns`` accept
+  both shapes. The pydantic validator enforces the structural
+  contract; the semantic check (target_property exists on the
+  endpoint) is in the loader."""
+
+  def test_legacy_list_of_strings_parses(self):
+    rb = RelationshipBinding(
+        name="r",
+        source="p.d.t",
+        from_columns=["src_id"],
+        to_columns=["dst_id"],
+    )
+    assert rb.from_columns == ["src_id"]
+    assert rb.to_columns == ["dst_id"]
+
+  def test_explicit_mapping_dict_parses(self):
+    rb = RelationshipBinding(
+        name="r",
+        source="p.d.t",
+        from_columns=[{"src_decision_execution_id": "id"}],
+        to_columns=[{"dst_decision_execution_id": "id"}],
+    )
+    assert rb.from_columns == [{"src_decision_execution_id": "id"}]
+    assert rb.to_columns == [{"dst_decision_execution_id": "id"}]
+
+  def test_mixed_str_and_dict_entries_parses(self):
+    """Composite endpoint where some columns use the legacy
+    shape (default to endpoint's Nth PK) and others use the
+    explicit shape."""
+    rb = RelationshipBinding(
+        name="r",
+        source="p.d.t",
+        from_columns=["src_col_a", {"src_col_b": "prop_b"}],
+        to_columns=["dst_col_a", {"dst_col_b": "prop_b"}],
+    )
+    assert rb.from_columns == ["src_col_a", {"src_col_b": "prop_b"}]
+
+  def test_empty_dict_rejected(self):
+    with pytest.raises(
+        ValueError, match=r"column entry \[0\] must be a single-key dict"
+    ):
+      RelationshipBinding(
+          name="r",
+          source="p.d.t",
+          from_columns=[{}],
+          to_columns=["dst_id"],
+      )
+
+  def test_multi_key_dict_rejected(self):
+    with pytest.raises(ValueError, match=r"got dict with 2 key\(s\)"):
+      RelationshipBinding(
+          name="r",
+          source="p.d.t",
+          from_columns=[{"a": "p1", "b": "p2"}],
+          to_columns=["dst_id"],
+      )
+
+  def test_empty_string_entry_rejected(self):
+    with pytest.raises(
+        ValueError, match=r"column entry \[0\] is an empty string"
+    ):
+      RelationshipBinding(
+          name="r",
+          source="p.d.t",
+          from_columns=[""],
+          to_columns=["dst_id"],
+      )
+
+  def test_non_string_dict_value_rejected(self):
+    """A dict value of the wrong type is rejected. Pydantic's
+    structural ``dict[str, str]`` check fires before my custom
+    validator, so the error message is Pydantic's generic
+    "Input should be a valid string" rather than my custom
+    text — that's fine; the rejection still happens at the
+    boundary with a clear message naming the offending entry."""
+    with pytest.raises(Exception, match=r"should be a valid string"):
+      RelationshipBinding(
+          name="r",
+          source="p.d.t",
+          from_columns=[{"src_id": 42}],
+          to_columns=["dst_id"],
+      )
+
+  def test_error_message_points_at_offending_entry(self):
+    """The validator surfaces the index of the offending entry so
+    operators can fix the typo without binary-searching the list."""
+    with pytest.raises(ValueError) as excinfo:
+      RelationshipBinding(
+          name="r",
+          source="p.d.t",
+          from_columns=["src_a", "src_b", {}],
+          to_columns=["dst_id"],
+      )
+    assert "[2]" in str(
+        excinfo.value
+    ), "the error should name index 2 (the empty dict), not 0 or 1"
+
+
+# ------------------------------------------------------------------ #
+# Loader's canonical normalization                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestNormalizeRelationshipColumns:
+  """``normalize_relationship_columns`` is the bridge between the
+  pydantic shape (both forms accepted) and the canonical
+  ``(edge_column, target_property)`` form ``ResolvedRelationship``
+  carries. Tested directly so the contract is documented at the
+  helper level too."""
+
+  def _entity_map(self):
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    return {e.name: e for e in ont.entities}
+
+  def test_legacy_str_entries_default_to_endpoint_pk(self):
+    """Legacy ``list[str]`` resolves each entry to the endpoint's
+    Nth PK property — the implicit convention every existing
+    binding YAML relies on."""
+    mapping = normalize_relationship_columns(
+        ["src_id"],
+        endpoint_entity_name="Source",
+        entity_map=self._entity_map(),
+        side="from",
+        relationship_name="linksTo",
+    )
+    assert mapping == (("src_id", "id"),)
+
+  def test_explicit_dict_entries_pass_through(self):
+    mapping = normalize_relationship_columns(
+        [{"src_decision_execution_id": "id"}],
+        endpoint_entity_name="Source",
+        entity_map=self._entity_map(),
+        side="from",
+        relationship_name="linksTo",
+    )
+    assert mapping == (("src_decision_execution_id", "id"),)
+
+  def test_target_property_must_exist_on_endpoint(self):
+    """Semantic check: if a dict entry references a property the
+    endpoint entity doesn't declare, raise with the bad name."""
+    with pytest.raises(
+        ValueError, match=r"no property named 'not_a_real_property'"
+    ):
+      normalize_relationship_columns(
+          [{"src_x": "not_a_real_property"}],
+          endpoint_entity_name="Source",
+          entity_map=self._entity_map(),
+          side="from",
+          relationship_name="linksTo",
+      )
+
+  def test_edge_column_names_helper(self):
+    """``edge_column_names`` extracts just the list-view of edge
+    column names — used by surfaces that don't care about the
+    target property."""
+    assert edge_column_names(["a", "b"]) == ("a", "b")
+    assert edge_column_names([{"a": "p1"}, {"b": "p2"}]) == ("a", "b")
+    assert edge_column_names(["a", {"b": "p2"}]) == ("a", "b")
+
+
+# ------------------------------------------------------------------ #
+# End-to-end via load_binding_from_string                              #
+# ------------------------------------------------------------------ #
+
+
+class TestEndToEndBindingLoad:
+  """Full loader path: YAML → Binding → arity check → SDK
+  ``ResolvedRelationship`` with the canonical mapping populated."""
+
+  def test_legacy_binding_loads_with_default_mapping(self):
+    binding_yaml = _binding_with_columns("[src_id]", "[dst_id]")
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    rb = binding.relationships[0]
+    # Pydantic surface preserves the original list.
+    assert rb.from_columns == ["src_id"]
+    assert rb.to_columns == ["dst_id"]
+
+  def test_dict_binding_loads(self):
+    """The new shape parses cleanly when target_property names a
+    real endpoint property."""
+    binding_yaml = _binding_with_columns("[{src_id: id}]", "[{dst_id: id}]")
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    rb = binding.relationships[0]
+    assert rb.from_columns == [{"src_id": "id"}]
+    assert rb.to_columns == [{"dst_id": "id"}]
+
+  def test_dict_binding_with_bad_target_property_rejected_at_resolve(self):
+    """Semantic mistake (target_property doesn't exist on the
+    endpoint) surfaces when the SDK's ``resolve()`` builds the
+    canonical mapping. The pydantic + binding-loader shape pass
+    is intentionally permissive here so the failure mode reads
+    consistently with other ``ResolvedRelationship`` build errors."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _binding_with_columns(
+        "[{src_id: not_a_real_property}]", "[{dst_id: id}]"
+    )
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    with pytest.raises(
+        ValueError, match=r"no property named 'not_a_real_property'"
+    ):
+      resolve(ontology=ont, binding=binding)
+
+
+# ------------------------------------------------------------------ #
+# ResolvedRelationship list-view shim + canonical mapping              #
+# ------------------------------------------------------------------ #
+
+
+class TestResolvedRelationshipShape:
+  """``ResolvedRelationship`` keeps ``from_columns`` / ``to_columns``
+  as the list view (downstream compat) AND carries the canonical
+  mapping under ``from_column_mapping`` / ``to_column_mapping`` for
+  callers that need the target property."""
+
+  def _resolve_with(self, from_yaml: str, to_yaml: str):
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _binding_with_columns(from_yaml, to_yaml)
+    ont = load_ontology_from_string(_TOY_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    return resolve(ontology=ont, binding=binding)
+
+  def test_legacy_binding_populates_both_views(self):
+    g = self._resolve_with("[src_id]", "[dst_id]")
+    rel = g.relationships[0]
+    # List view — what downstream callers (DDL compiler, validators,
+    # scaffolders) keep reading. Same shape as before C1.
+    assert rel.from_columns == ("src_id",)
+    assert rel.to_columns == ("dst_id",)
+    # Canonical mapping — populated even for the legacy shape so
+    # newer callers (e.g. C2's self-edge materializer fix) don't
+    # need a fallback branch for legacy bindings.
+    assert rel.from_column_mapping == (("src_id", "id"),)
+    assert rel.to_column_mapping == (("dst_id", "id"),)
+
+  def test_explicit_dict_binding_populates_both_views(self):
+    g = self._resolve_with(
+        "[{src_decision_execution_id: id}]",
+        "[{dst_decision_execution_id: id}]",
+    )
+    rel = g.relationships[0]
+    assert rel.from_columns == ("src_decision_execution_id",)
+    assert rel.to_columns == ("dst_decision_execution_id",)
+    assert rel.from_column_mapping == (("src_decision_execution_id", "id"),)
+    assert rel.to_column_mapping == (("dst_decision_execution_id", "id"),)
+
+  def test_list_view_matches_canonical_first_components(self):
+    """For any binding, the list-view ``from_columns`` is the
+    first component of each canonical mapping pair. The shim is
+    derived, not duplicated."""
+    g = self._resolve_with("[src_id]", "[dst_id]")
+    rel = g.relationships[0]
+    assert rel.from_columns == tuple(c for c, _ in rel.from_column_mapping)
+    assert rel.to_columns == tuple(c for c, _ in rel.to_column_mapping)
+
+
+# ------------------------------------------------------------------ #
+# Byte-identical SQL for existing bindings (migration v5)              #
+# ------------------------------------------------------------------ #
+
+
+class TestExistingMigrationV5BindingByteIdenticalSQL:
+  """The migration v5 binding uses the legacy ``list[str]`` shape
+  exclusively. C1 must produce byte-identical resolved relationships
+  for it — the field shape grew but the values that flow into
+  downstream SQL compilers stay the same."""
+
+  def test_migration_v5_legacy_binding_round_trips(self):
+    """Load the committed migration v5 binding (legacy shape) and
+    confirm every relationship's list-view ``from_columns`` /
+    ``to_columns`` are unchanged, byte-for-byte."""
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    ont_path = repo_root / "examples" / "migration_v5" / "ontology.yaml"
+    binding_path = repo_root / "examples" / "migration_v5" / "binding.yaml"
+    if not ont_path.exists() or not binding_path.exists():
+      pytest.skip("migration_v5 snapshots not checked in")
+    ont = load_ontology_from_string(ont_path.read_text())
+    binding = load_binding_from_string(binding_path.read_text(), ontology=ont)
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    resolved = resolve(ontology=ont, binding=binding)
+    # Each relationship's list-view columns equal the original
+    # binding YAML values exactly.
+    binding_rels = {r.name: r for r in binding.relationships}
+    for rel in resolved.relationships:
+      rb = binding_rels[rel.name]
+      assert rel.from_columns == tuple(
+          rb.from_columns
+      ), f"list-view drift on {rel.name}.from_columns"
+      assert rel.to_columns == tuple(
+          rb.to_columns
+      ), f"list-view drift on {rel.name}.to_columns"
+      # Canonical mapping is populated even for the legacy shape.
+      assert rel.from_column_mapping is not None
+      assert rel.to_column_mapping is not None
+      assert len(rel.from_column_mapping) == len(rb.from_columns)
+      assert len(rel.to_column_mapping) == len(rb.to_columns)

--- a/tests/test_binding_explicit_fk_mapping.py
+++ b/tests/test_binding_explicit_fk_mapping.py
@@ -245,7 +245,8 @@ class TestNormalizeRelationshipColumns:
     """Semantic check: if a dict entry references a property the
     endpoint entity doesn't declare, raise with the bad name."""
     with pytest.raises(
-        ValueError, match=r"no property named 'not_a_real_property'"
+        ValueError,
+        match=r"no primary-key property named 'not_a_real_property'",
     ):
       normalize_relationship_columns(
           [{"src_x": "not_a_real_property"}],
@@ -306,7 +307,8 @@ class TestEndToEndBindingLoad:
     ont = load_ontology_from_string(_TOY_ONTOLOGY)
     binding = load_binding_from_string(binding_yaml, ontology=ont)
     with pytest.raises(
-        ValueError, match=r"no property named 'not_a_real_property'"
+        ValueError,
+        match=r"no primary-key property named 'not_a_real_property'",
     ):
       resolve(ontology=ont, binding=binding)
 
@@ -407,3 +409,214 @@ class TestExistingMigrationV5BindingByteIdenticalSQL:
       assert rel.to_column_mapping is not None
       assert len(rel.from_column_mapping) == len(rb.from_columns)
       assert len(rel.to_column_mapping) == len(rb.to_columns)
+
+
+# ------------------------------------------------------------------ #
+# PR #191 review fixes — inherited PK + PK-only target restriction    #
+# ------------------------------------------------------------------ #
+
+
+_INHERITANCE_ONTOLOGY = textwrap.dedent(
+    """
+    ontology: inherits
+    entities:
+      - name: Party
+        keys:
+          primary: [party_id]
+        properties:
+          - {name: party_id, type: string}
+          - {name: display_name, type: string}
+      - name: Person
+        extends: Party
+        properties:
+          - {name: email, type: string}
+      - name: Account
+        keys:
+          primary: [account_id]
+        properties:
+          - {name: account_id, type: string}
+    relationships:
+      - name: ownsAccount
+        from: Person
+        to: Account
+    """
+).strip()
+
+
+_INHERITANCE_BINDING = textwrap.dedent(
+    """
+    binding: inherits_bq
+    ontology: inherits
+    target:
+      backend: bigquery
+      project: p
+      dataset: d
+    entities:
+      - name: Person
+        source: p.d.person
+        properties:
+          - {name: party_id, column: party_id}
+          - {name: display_name, column: display_name}
+          - {name: email, column: email}
+      - name: Account
+        source: p.d.account
+        properties:
+          - {name: account_id, column: account_id}
+    relationships:
+      - name: ownsAccount
+        source: p.d.owns_account
+        from_columns: [src_party_id]
+        to_columns: [dst_account_id]
+    """
+).strip()
+
+
+class TestInheritedKeyRegression:
+  """Regression for PR #191 review (P1): a relationship whose
+  endpoint inherits its PK from a parent (e.g. ``Person extends
+  Party`` where ``Party`` owns ``keys.primary: [party_id]``) must
+  resolve cleanly. Previously ``normalize_relationship_columns``
+  read ``endpoint.keys`` directly and bailed with "no primary key
+  declared" for inherited keys; mirroring the arity check's
+  ``_effective_keys`` call fixes it.
+  """
+
+  def test_relationship_endpoint_with_inherited_pk_resolves(self):
+    """Person inherits ``party_id`` from Party. The legacy
+    ``list[str]`` shape must resolve to the inherited PK as the
+    default target property."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    ont = load_ontology_from_string(_INHERITANCE_ONTOLOGY)
+    binding = load_binding_from_string(_INHERITANCE_BINDING, ontology=ont)
+    resolved = resolve(ontology=ont, binding=binding)
+    rel = resolved.relationships[0]
+    # Legacy str entry on the from side resolves to the inherited
+    # PK property name.
+    assert rel.from_column_mapping == (("src_party_id", "party_id"),)
+    # Account is not inherited; its PK resolves normally.
+    assert rel.to_column_mapping == (("dst_account_id", "account_id"),)
+
+  def test_inherited_pk_accepted_as_explicit_target(self):
+    """Explicit dict entries can target inherited PKs too."""
+    binding_yaml = textwrap.dedent(
+        """
+        binding: inherits_bq
+        ontology: inherits
+        target:
+          backend: bigquery
+          project: p
+          dataset: d
+        entities:
+          - name: Person
+            source: p.d.person
+            properties:
+              - {name: party_id, column: party_id}
+              - {name: display_name, column: display_name}
+              - {name: email, column: email}
+          - name: Account
+            source: p.d.account
+            properties:
+              - {name: account_id, column: account_id}
+        relationships:
+          - name: ownsAccount
+            source: p.d.owns_account
+            from_columns: [{src_party_id: party_id}]
+            to_columns:   [{dst_account_id: account_id}]
+        """
+    ).strip()
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    ont = load_ontology_from_string(_INHERITANCE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    resolved = resolve(ontology=ont, binding=binding)
+    rel = resolved.relationships[0]
+    assert rel.from_column_mapping == (("src_party_id", "party_id"),)
+
+
+class TestExplicitMappingPKOnly:
+  """Regression for PR #191 review (P2): explicit
+  ``target_property`` must be one of the endpoint's effective
+  primary-key properties. The PR is explicitly FK→PK; allowing
+  any-declared-property would let C2's materializer fix consume a
+  canonical mapping that points an edge endpoint at a non-key
+  column, which doesn't uniquely identify the target row."""
+
+  def test_explicit_mapping_to_non_pk_property_rejected(self):
+    """``display_name`` is a real declared property on Party (and
+    thus on Person via inheritance), but it is NOT a PK property.
+    A binding that targets it must be rejected at the
+    normalization step before C2 ever sees it."""
+    binding_yaml = textwrap.dedent(
+        """
+        binding: inherits_bq
+        ontology: inherits
+        target:
+          backend: bigquery
+          project: p
+          dataset: d
+        entities:
+          - name: Person
+            source: p.d.person
+            properties:
+              - {name: party_id, column: party_id}
+              - {name: display_name, column: display_name}
+              - {name: email, column: email}
+          - name: Account
+            source: p.d.account
+            properties:
+              - {name: account_id, column: account_id}
+        relationships:
+          - name: ownsAccount
+            source: p.d.owns_account
+            from_columns: [{src_display_name: display_name}]
+            to_columns:   [{dst_account_id: account_id}]
+        """
+    ).strip()
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    ont = load_ontology_from_string(_INHERITANCE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    with pytest.raises(
+        ValueError, match=r"has no primary-key property named 'display_name'"
+    ):
+      resolve(ontology=ont, binding=binding)
+
+  def test_non_pk_target_error_lists_effective_pk_properties(self):
+    """The error message names the effective PK property set so the
+    operator can fix the typo without inspecting the ontology by
+    hand."""
+    binding_yaml = textwrap.dedent(
+        """
+        binding: inherits_bq
+        ontology: inherits
+        target:
+          backend: bigquery
+          project: p
+          dataset: d
+        entities:
+          - name: Person
+            source: p.d.person
+            properties:
+              - {name: party_id, column: party_id}
+              - {name: display_name, column: display_name}
+              - {name: email, column: email}
+          - name: Account
+            source: p.d.account
+            properties:
+              - {name: account_id, column: account_id}
+        relationships:
+          - name: ownsAccount
+            source: p.d.owns_account
+            from_columns: [{src_email: email}]
+            to_columns:   [{dst_account_id: account_id}]
+        """
+    ).strip()
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    ont = load_ontology_from_string(_INHERITANCE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    with pytest.raises(ValueError) as excinfo:
+      resolve(ontology=ont, binding=binding)
+    # Error names the available PK set (inherited from Party).
+    assert "['party_id']" in str(excinfo.value)

--- a/tests/test_binding_explicit_fk_mapping.py
+++ b/tests/test_binding_explicit_fk_mapping.py
@@ -287,8 +287,8 @@ class TestEndToEndBindingLoad:
     assert rb.to_columns == ["dst_id"]
 
   def test_dict_binding_loads(self):
-    """The new shape parses cleanly when target_property names a
-    real endpoint property."""
+    """The new shape parses cleanly when target_property names an
+    effective primary-key property on the endpoint."""
     binding_yaml = _binding_with_columns("[{src_id: id}]", "[{dst_id: id}]")
     ont = load_ontology_from_string(_TOY_ONTOLOGY)
     binding = load_binding_from_string(binding_yaml, ontology=ont)
@@ -623,3 +623,146 @@ class TestExplicitMappingPKOnly:
       resolve(ontology=ont, binding=binding)
     # Error names the available PK set (inherited from Party).
     assert "['party_id']" in str(excinfo.value)
+
+
+# ------------------------------------------------------------------ #
+# Composite-PK coverage invariant (PR #191 review P2)                  #
+# ------------------------------------------------------------------ #
+
+
+_COMPOSITE_ONTOLOGY = textwrap.dedent(
+    """
+    ontology: composite
+    entities:
+      - name: ABody
+        keys:
+          primary: [a_id]
+        properties:
+          - {name: a_id, type: string}
+      - name: BPair
+        keys:
+          primary: [k1, k2]
+        properties:
+          - {name: k1, type: string}
+          - {name: k2, type: string}
+    relationships:
+      - name: refs
+        from: ABody
+        to: BPair
+    """
+).strip()
+
+
+def _composite_binding(to_columns_yaml: str) -> str:
+  return textwrap.dedent(
+      f"""
+      binding: composite_bq
+      ontology: composite
+      target:
+        backend: bigquery
+        project: p
+        dataset: d
+      entities:
+        - name: ABody
+          source: p.d.a
+          properties:
+            - {{name: a_id, column: a_id}}
+        - name: BPair
+          source: p.d.b
+          properties:
+            - {{name: k1, column: k1}}
+            - {{name: k2, column: k2}}
+      relationships:
+        - name: refs
+          source: p.d.refs
+          from_columns: [a_id]
+          to_columns: {to_columns_yaml}
+      """
+  ).strip()
+
+
+class TestCompositePKCoverageInvariant:
+  """Regression for PR #191 review (P2): the canonical mapping must
+  be a permutation of the endpoint's effective PK properties — each
+  PK property covered exactly once. Arity already matches by the
+  time the per-entry PK check runs; without an additional "no
+  duplicate target" check, a composite PK ``[k1, k2]`` could be
+  bound as two entries that both target ``k1``, silently dropping
+  ``k2``. C2 would then consume a canonical endpoint mapping that
+  cannot uniquely identify the target row.
+  """
+
+  def test_legitimate_composite_pk_permutation_resolves(self):
+    """The intended use of the explicit shape for composite PKs:
+    each PK property mapped exactly once, in either declaration
+    order or any permutation."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _composite_binding("[{b_k1: k1}, {b_k2: k2}]")
+    ont = load_ontology_from_string(_COMPOSITE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    resolved = resolve(ontology=ont, binding=binding)
+    rel = resolved.relationships[0]
+    assert rel.to_column_mapping == (("b_k1", "k1"), ("b_k2", "k2"))
+
+  def test_reversed_composite_pk_permutation_resolves(self):
+    """Permutation, not strict declaration order — the explicit
+    shape lets the binding author choose whichever edge column
+    name they want for each PK."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _composite_binding("[{b_k2: k2}, {b_k1: k1}]")
+    ont = load_ontology_from_string(_COMPOSITE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    resolved = resolve(ontology=ont, binding=binding)
+    rel = resolved.relationships[0]
+    assert rel.to_column_mapping == (("b_k2", "k2"), ("b_k1", "k1"))
+
+  def test_duplicate_target_property_rejected(self):
+    """The original bug: both entries target the same PK
+    property. With arity matching, that necessarily leaves one
+    PK property uncovered."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _composite_binding("[{b_k1_left: k1}, {b_k1_right: k1}]")
+    ont = load_ontology_from_string(_COMPOSITE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    with pytest.raises(
+        ValueError,
+        match=(r"covers some endpoint PK properties more than once " r".*'k1'"),
+    ):
+      resolve(ontology=ont, binding=binding)
+
+  def test_duplicate_target_error_names_offending_property(self):
+    """The error message names the duplicated PK property and the
+    full effective PK set so the operator can fix the typo
+    without inspecting the ontology by hand."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _composite_binding("[{b_k2_left: k2}, {b_k2_right: k2}]")
+    ont = load_ontology_from_string(_COMPOSITE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    with pytest.raises(ValueError) as excinfo:
+      resolve(ontology=ont, binding=binding)
+    msg = str(excinfo.value)
+    assert "'k2'" in msg, "duplicated PK property must appear in the error"
+    assert "'k1'" in msg, (
+        "effective PK set must appear in the error so the operator can "
+        "see what was supposed to be covered"
+    )
+
+  def test_legacy_str_shape_unaffected_by_permutation_check(self):
+    """The duplicate-target check is for the explicit dict shape.
+    The legacy ``list[str]`` shape resolves entries to the
+    endpoint's Nth PK property by position — it's structurally
+    impossible to produce a duplicate target through that path
+    when the arity check already matched. Sanity-check that
+    composite-PK legacy bindings still resolve cleanly."""
+    from bigquery_agent_analytics.resolved_spec import resolve
+
+    binding_yaml = _composite_binding("[b_k1, b_k2]")
+    ont = load_ontology_from_string(_COMPOSITE_ONTOLOGY)
+    binding = load_binding_from_string(binding_yaml, ontology=ont)
+    resolved = resolve(ontology=ont, binding=binding)
+    rel = resolved.relationships[0]
+    assert rel.to_column_mapping == (("b_k1", "k1"), ("b_k2", "k2"))

--- a/tests/test_binding_explicit_fk_mapping.py
+++ b/tests/test_binding_explicit_fk_mapping.py
@@ -242,8 +242,11 @@ class TestNormalizeRelationshipColumns:
     assert mapping == (("src_decision_execution_id", "id"),)
 
   def test_target_property_must_exist_on_endpoint(self):
-    """Semantic check: if a dict entry references a property the
-    endpoint entity doesn't declare, raise with the bad name."""
+    """Semantic check: if a dict entry references a property that
+    isn't an effective primary-key property on the endpoint,
+    raise with the bad name. ``not_a_real_property`` isn't
+    declared at all on ``Source``; the inheritance fixture below
+    covers the more nuanced "declared but not a PK" case."""
     with pytest.raises(
         ValueError,
         match=r"no primary-key property named 'not_a_real_property'",
@@ -543,7 +546,7 @@ class TestExplicitMappingPKOnly:
   column, which doesn't uniquely identify the target row."""
 
   def test_explicit_mapping_to_non_pk_property_rejected(self):
-    """``display_name`` is a real declared property on Party (and
+    """``display_name`` is a real declared (non-PK) property on Party (and
     thus on Person via inheritance), but it is NOT a PK property.
     A binding that targets it must be rejected at the
     normalization step before C2 ever sees it."""


### PR DESCRIPTION
PR C1 from the [issue #187 implementation plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187). Closes (part of) [#179](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/179).

SDK-internal binding-model evolution that accepts an explicit ``edge_column → target_property`` mapping in ``RelationshipBinding.from_columns`` / ``to_columns``, while preserving byte-identical behavior for every existing binding that uses the legacy ``list[str]`` shape. **No materializer / DDL changes** — C2 consumes the canonical mapping in a follow-up PR to land the actual self-edge support that ``evolvedFrom`` / ``supersededBy`` need.

## What ships

### Two binding shapes on ``RelationshipBinding``

| Shape | YAML | Semantics |
|---|---|---|
| Legacy ``list[str]`` | ``from_columns: [decision_execution_id]`` | Nth entry maps to the endpoint entity's Nth effective PK property in declaration order |
| Explicit ``list[dict[str, str]]`` | ``from_columns: [{src_decision_execution_id: id}]`` | Each entry explicitly maps an edge column to a named **primary-key** property on the endpoint entity (FK→PK, not FK→any-column). Composite PKs require the mapping to be a permutation of the endpoint's effective PK properties — each PK property covered exactly once. |

Mixed lists are accepted (some entries str, others dict). Pydantic ``field_validator`` enforces the structural contract:

- Each entry is either a non-empty string or a single-key ``str → str`` dict.
- Multi-key dicts, empty dicts, empty strings, and non-string values are all rejected with a precise error message naming the offending entry's index.

### Canonical normalization in the loader

New helper ``binding_loader.normalize_relationship_columns(...)`` resolves any ``RelationshipBinding`` column list to a canonical tuple of ``(edge_column, target_property)`` pairs:

- Legacy ``str`` entries resolve to ``(entry, endpoint_effective_pk[i])`` — uses ``_effective_keys`` so inherited PKs (e.g. ``Person extends Party``) resolve correctly.
- Explicit ``dict`` entries pass through after the semantic check that ``target_property`` is one of the endpoint's **effective primary-key properties** AND the post-canonicalization invariant that the target-property sequence is a permutation of the endpoint's PK properties (each PK property covered exactly once).

Companion helper ``binding_loader.edge_column_names(...)`` extracts the list-view of edge column names (binding-declaration order) for surfaces that don't need positional PK pairing.

### Raw-binding consumer guards

``binding_loader.require_legacy_column_shape(...)`` is the boundary helper for consumers that read ``RelationshipBinding.from_columns`` / ``to_columns`` directly and would silently mispair (or crash) under the new dict shape. It returns the legacy ``tuple[str, ...]`` view when every entry is a string and raises with an actionable error pointing at the migration path otherwise.

Applied at:

- ``graph_ddl_compiler.compile_graph`` — both the ``ResolvedEdgeTable`` construction site and the ``_resolve_edge_key_columns`` ``KEY`` clause builder.
- ``runtime_spec.graph_spec_from_ontology_binding`` — the legacy GraphSpec converter that targets ``BindingSpec.from_columns: list[str]``.

C2 (issue #179 follow-up) will wire the canonical mapping through each consumer on a case-by-case basis and lift the restriction. The guards make the consumer-side limitation explicit at the boundary so a dict-shape binding can't silently misalign edge columns against endpoint PK columns through positional pairing.

### ``ResolvedRelationship`` list-view shim + canonical accessor

``ResolvedRelationship.from_columns`` / ``to_columns`` remain ``tuple[str, ...]`` carrying just the edge column names. New optional fields ``from_column_mapping`` / ``to_column_mapping`` carry the canonical ``(edge_column, target_property)`` form. ``resolve()`` populates them for **both** shapes — legacy str entries get the default PK mapping; explicit dict entries get their declared mapping (after PK + permutation validation). ``None`` only means a ``ResolvedRelationship`` was manually constructed without going through ``resolve()``.

## Compatibility

- Every existing binding YAML in the repo parses unchanged.
- ``ResolvedRelationship.from_columns`` / ``to_columns`` field shape is byte-identical (``tuple[str, ...]``).
- The migration v5 binding round-trips through ``resolve(...)`` with byte-identical list-view values (asserted by ``test_migration_v5_legacy_binding_round_trips``).
- ``compile_graph`` and ``graph_spec_from_ontology_binding`` continue to work for legacy bindings; dict-shape bindings are rejected at the boundary with an actionable error pointing at the migration path.
- Arity check at the loader is unchanged — both shapes count as one entry per list position.
- **Inherited PKs honored:** ontologies that put a PK on a parent entity (``Person extends Party`` with ``Party.keys.primary == [party_id]``) resolve correctly.
- No public function signature change beyond the new optional ``from_column_mapping`` / ``to_column_mapping`` fields with ``None`` defaults.

## Tests

**32 new test cases** in ``tests/test_binding_explicit_fk_mapping.py`` across nine test classes:

- ``TestRelationshipBindingColumnShapes`` — both shapes parse; mixed entries work; multi-key, empty, and non-string-value shapes rejected at the pydantic boundary; error messages point at the offending entry's index.
- ``TestNormalizeRelationshipColumns`` — legacy str entries default to the endpoint's Nth PK property; explicit dicts pass through; bad ``target_property`` names rejected.
- ``TestEndToEndBindingLoad`` — full YAML → ``load_binding`` path works for both shapes; semantic bad-target rejected at ``resolve()``.
- ``TestResolvedRelationshipShape`` — list-view ``from_columns`` matches the first component of each canonical mapping pair; both shapes populate both views.
- ``TestExistingMigrationV5BindingByteIdenticalSQL`` — the committed migration v5 binding round-trips byte-identically.
- ``TestInheritedKeyRegression`` — ``Person extends Party`` fixture; legacy and explicit shapes both resolve to the inherited PK.
- ``TestExplicitMappingPKOnly`` — explicit mapping to a non-PK declared property rejected with a precise error.
- ``TestCompositePKCoverageInvariant`` — composite PK requires each PK property covered exactly once; duplicate target rejected with the duplicated PK property and the full effective PK set in the error.
- ``TestRawBindingConsumerGuards`` — ``compile_graph`` and ``graph_spec_from_ontology_binding`` reject dict-shape bindings with the migration path in the error; legacy ``list[str]`` flows through both unchanged.

**Net: 32 new + ~810 prior tests across the touched surface pass** (bigquery_ontology, binding_validation, resolved_spec, ontology_orchestrator, materialize_window, extractor_compilation, ontology_materializer, ontology_property_graph, ontology_graph, ontology_schema_compiler, migration_v5_reference_extractor). ``pyink --check`` + ``isort --check-only`` clean.

## Verification

```bash
PYTHONPATH=src pytest tests/test_binding_explicit_fk_mapping.py
# → 32 passed

PYTHONPATH=src pytest tests/bigquery_ontology/ \
                     tests/test_binding_validation.py \
                     tests/test_resolved_spec.py \
                     tests/test_ontology_orchestrator.py \
                     tests/test_materialize_window.py \
                     tests/test_extractor_compilation.py \
                     tests/test_ontology_materializer.py \
                     tests/test_ontology_property_graph.py \
                     tests/test_ontology_graph.py \
                     tests/test_ontology_schema_compiler.py \
                     tests/test_migration_v5_reference_extractor.py
# → 810+ passed (back-compat preserved across every surface)
```

## Where this fits in the implementation plan

PR C1 in the locked sequencing on [#187](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187):

| PR | Issue(s) | Status |
|---|---|---|
| A | #177 (backfill foundation) | ✅ landed (#188) |
| B1 | #178 part 1 (``extract_graph`` refactor + diagnostics) | open (#189) |
| **C1** (this PR) | #179 part 1 (binding-model dict-shape + list-view shim + consumer guards) | ▶︎ this PR |
| B2 | #178 part 2 (materializer translates diagnostics; deploy IAM) | after B1 + C1 |
| C2 | #179 part 2 (materializer self-edge fix; demo wiring; lift consumer guards) | after C1 |
| D / E / F / G | #180, #181, #184, #185, #186 | per calendar |

C1 branched from upstream/main (parallel to B1; B1 hasn't merged yet). Both are SDK-internal; their diffs don't conflict.

## Review history

| Commit | Review finding addressed |
|---|---|
| ``533a687`` | Initial implementation. |
| ``1c796df`` | P1: inherited-key regression — ``normalize_relationship_columns`` now uses ``_effective_keys`` so endpoints that inherit their PK resolve correctly. P2: explicit ``target_property`` must be an effective PK property; non-PK declared properties rejected. |
| ``897f9bc`` | P3: docstrings / comments aligned with the effective-PK contract; stale "legacy shape was used" wording on ``ResolvedRelationship`` replaced. |
| ``87cccd5`` | P2: composite-PK coverage invariant — canonical mapping is now enforced as a permutation of the endpoint's effective PK properties (duplicate target rejected with the duplicated PK property in the error). |
| ``482bfec`` | P1: raw-binding consumers (``compile_graph`` and ``graph_spec_from_ontology_binding``) reject dict-shape bindings at the boundary with an actionable error; legacy bindings flow through unchanged. |

## Test plan

- [x] All 32 new test cases pass.
- [x] 810+ prior tests across the touched surface still pass — back-compat preserved.
- [x] ``pyink --check`` + ``isort --check-only`` clean.
- [x] Legacy ``list[str]`` shape parses unchanged; canonical mapping populated with the endpoint's effective PK as the default ``target_property``.
- [x] Explicit ``list[dict[str, str]]`` shape parses; canonical mapping pass-through with PK + permutation validation.
- [x] Inherited PKs resolve correctly via ``_effective_keys``.
- [x] Explicit mapping to a non-PK declared property is rejected with the effective PK set listed in the error.
- [x] Composite-PK duplicate-target rejected with the duplicated PK property in the error.
- [x] Migration v5 binding (legacy shape) round-trips byte-identically through ``resolve()``.
- [x] ``ResolvedRelationship.from_columns`` / ``to_columns`` shape unchanged (``tuple[str, ...]``).
- [x] ``compile_graph`` and ``graph_spec_from_ontology_binding`` reject dict-shape bindings at the boundary; legacy bindings flow through unchanged.
- [ ] **(pending — for C2)** ``ontology_materializer._relationship_columns`` reads ``from_column_mapping`` / ``to_column_mapping`` for self-edge support; ``compile_graph`` + ``graph_spec_from_ontology_binding`` consumer guards lifted; ``evolvedFrom`` / ``supersededBy`` re-added to the migration v5 binding.