### PR TITLE
feat(materialize_window): --extraction-mode + compiled-only diagnostics (#178)

### DIFF
--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -117,14 +117,17 @@ Optional:
   --job-name NAME              Cloud Run Job name
                                (default: bqaa-periodic-materialization).
   --smoke                      After deploy, run the job once + tail logs.
-  --extraction-mode MODE       'ai-fallback' (default) — structured extractors
-                               run and AI.GENERATE fills any gaps; existing
-                               behavior. 'compiled-only' — structured
-                               extractors only; no AI.GENERATE call; skips
-                               the roles/aiplatform.user IAM grant on the
-                               runtime SA. Pick 'compiled-only' for regulated
-                               deploys that must not have an LLM in the
-                               extraction path.
+  --extraction-mode MODE       'ai-fallback' (default; only supported value
+                               on this deploy path today). The SDK also
+                               supports 'compiled-only' (structured
+                               extractors only, no AI.GENERATE) — accessible
+                               via the CLI when the caller wires bundles
+                               themselves — but this deploy script does
+                               not yet stage compiled-bundle artifacts into
+                               the Cloud Run image, so 'compiled-only' is
+                               rejected here. A follow-up PR will wire
+                               bundles + reference extractor into the
+                               deploy artifact.
   -h | --help                  Show this help.
 EOF
   exit "${1:-1}"
@@ -183,10 +186,53 @@ done
 # rejects unknown values too, but failing here means an operator
 # typo (e.g. ``compiled_only`` with an underscore) doesn't spend
 # 3 minutes on a Cloud Build before raising.
+#
+# ``compiled-only`` is intentionally REJECTED at the deploy
+# boundary even though the SDK supports it. Reason: this deploy
+# script does not yet wire ``BQAA_BUNDLES_ROOT`` /
+# ``BQAA_REFERENCE_EXTRACTORS_MODULE`` into the Cloud Run image,
+# so a deployed compiled-only run would silently skip both
+# AI.GENERATE and the structured extractors — producing empty
+# graphs with no diagnostic surface instead of the typed
+# "compiled extractors didn't cover this span" failure the SDK's
+# compiled-only mode advertises. Lifting this restriction needs a
+# follow-up PR that vendors the bundles + the reference extractor
+# into the deploy artifact and threads them as env vars. Until
+# then, customers who want compiled-only run ``bqaa-materialize-
+# window --extraction-mode=compiled-only --bundles-root ...
+# --reference-extractors-module ...`` directly (e.g., from a
+# custom Cloud Run image they build themselves).
 case "$EXTRACTION_MODE" in
-  ai-fallback|compiled-only) ;;
+  ai-fallback) ;;
+  compiled-only)
+    cat >&2 <<'COMPILED_ONLY_NOT_READY'
+Error: --extraction-mode=compiled-only is not yet supported on the
+Cloud Run deploy path.
+
+The SDK accepts compiled-only mode (and the test suite proves it
+makes zero AI.GENERATE calls), but this deploy script does not yet
+stage the compiled extractor bundles / reference extractor module
+into the Cloud Run image. Running compiled-only here would skip
+both AI.GENERATE *and* the structured extractors and produce
+empty graphs with no diagnostic surface — a worse failure mode
+than the ai-fallback default.
+
+Until a follow-up PR wires bundles + reference extractor into the
+deploy artifact, use one of:
+
+  * --extraction-mode=ai-fallback  (the default; existing behavior)
+  * Run the CLI directly from a Cloud Run image you build, with
+    your own bundles wired:
+        bqaa-materialize-window \
+            --extraction-mode=compiled-only \
+            --bundles-root /path/to/bundles \
+            --reference-extractors-module your.reference.module \
+            ...
+COMPILED_ONLY_NOT_READY
+    exit 1
+    ;;
   *)
-    echo "Error: --extraction-mode must be 'ai-fallback' or 'compiled-only'; got '$EXTRACTION_MODE'." >&2
+    echo "Error: --extraction-mode must be 'ai-fallback'; got '$EXTRACTION_MODE'." >&2
     exit 1
     ;;
 esac
@@ -357,23 +403,23 @@ _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
 # checking ``rows_materialized``). The verification round in
 # #166 surfaced this — the deploy looks ``ok=true`` but the
 # entity tables stay empty.
-# Conditional ``roles/aiplatform.user`` grant. Only needed when
-# the orchestrator's extraction path actually calls AI.GENERATE.
-# In ``--extraction-mode=compiled-only`` mode the SDK skips
-# ``_extract_via_ai_generate`` entirely (asserted by
-# ``tests/test_materialize_window.py``'s zero-LLM-call coverage),
-# so the grant is dropped to keep the runtime SA's blast radius
-# minimal — table stakes for regulated-industry deploys.
-if [[ "$EXTRACTION_MODE" == "ai-fallback" ]]; then
-  echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
-  _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
-    --member "serviceAccount:${SA_EMAIL}" \
-    --role roles/aiplatform.user \
-    --condition=None \
-    --quiet
-else
-  echo "==> skipping roles/aiplatform.user grant (--extraction-mode=$EXTRACTION_MODE; no AI.GENERATE calls)"
-fi
+# ``roles/aiplatform.user`` is always granted on the deploy path
+# because this script only accepts ``--extraction-mode=ai-fallback``
+# (see the validator above; ``compiled-only`` is rejected until
+# bundles wiring lands). A follow-up PR that wires bundles into the
+# deploy image will revisit this grant to make it conditional on
+# ``--extraction-mode``: in compiled-only mode the SDK is already
+# proven (by ``TestCompiledOnlyMakesZeroLLMCalls``) to make zero
+# AI.GENERATE calls, so the role becomes safe to drop and the
+# script can both skip the add and ``remove-iam-policy-binding``
+# any pre-existing grant on the same SA (relevant when a customer
+# transitions an ai-fallback deploy to compiled-only).
+echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
+_retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role roles/aiplatform.user \
+  --condition=None \
+  --quiet
 
 # Dataset-level IAM via the BigQuery Python client (the
 # ``AccessEntry``-based update API — legacy and fully

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -91,6 +91,7 @@ OVERLAP_MINUTES="15"
 MAX_SESSIONS=""
 JOB_NAME="bqaa-periodic-materialization"
 SMOKE=false
+EXTRACTION_MODE="ai-fallback"
 
 # Print usage. Exit code is the caller's choice: ``usage 0``
 # for ``--help`` (success), ``usage 1`` for parse / required-arg
@@ -116,6 +117,14 @@ Optional:
   --job-name NAME              Cloud Run Job name
                                (default: bqaa-periodic-materialization).
   --smoke                      After deploy, run the job once + tail logs.
+  --extraction-mode MODE       'ai-fallback' (default) — structured extractors
+                               run and AI.GENERATE fills any gaps; existing
+                               behavior. 'compiled-only' — structured
+                               extractors only; no AI.GENERATE call; skips
+                               the roles/aiplatform.user IAM grant on the
+                               runtime SA. Pick 'compiled-only' for regulated
+                               deploys that must not have an LLM in the
+                               extraction path.
   -h | --help                  Show this help.
 EOF
   exit "${1:-1}"
@@ -152,6 +161,7 @@ while [[ $# -gt 0 ]]; do
     --max-sessions)    require_arg "$1" "${2-}"; MAX_SESSIONS="$2"; shift 2 ;;
     --job-name)        require_arg "$1" "${2-}"; JOB_NAME="$2"; shift 2 ;;
     --smoke)           SMOKE=true; shift ;;
+    --extraction-mode) require_arg "$1" "${2-}"; EXTRACTION_MODE="$2"; shift 2 ;;
     -h|--help)         usage 0 ;;
     *)                 echo "Unknown argument: $1" >&2; usage 1 ;;
   esac
@@ -168,6 +178,18 @@ for var in PROJECT REGION EVENTS_DATASET GRAPH_DATASET SCHEDULE; do
     exit 1
   fi
 done
+
+# Validate ``--extraction-mode`` at the boundary. The materializer
+# rejects unknown values too, but failing here means an operator
+# typo (e.g. ``compiled_only`` with an underscore) doesn't spend
+# 3 minutes on a Cloud Build before raising.
+case "$EXTRACTION_MODE" in
+  ai-fallback|compiled-only) ;;
+  *)
+    echo "Error: --extraction-mode must be 'ai-fallback' or 'compiled-only'; got '$EXTRACTION_MODE'." >&2
+    exit 1
+    ;;
+esac
 
 SCHEDULER_NAME="${JOB_NAME}-cron"
 
@@ -335,12 +357,23 @@ _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
 # checking ``rows_materialized``). The verification round in
 # #166 surfaced this — the deploy looks ``ok=true`` but the
 # entity tables stay empty.
-echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
-_retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
-  --member "serviceAccount:${SA_EMAIL}" \
-  --role roles/aiplatform.user \
-  --condition=None \
-  --quiet
+# Conditional ``roles/aiplatform.user`` grant. Only needed when
+# the orchestrator's extraction path actually calls AI.GENERATE.
+# In ``--extraction-mode=compiled-only`` mode the SDK skips
+# ``_extract_via_ai_generate`` entirely (asserted by
+# ``tests/test_materialize_window.py``'s zero-LLM-call coverage),
+# so the grant is dropped to keep the runtime SA's blast radius
+# minimal — table stakes for regulated-industry deploys.
+if [[ "$EXTRACTION_MODE" == "ai-fallback" ]]; then
+  echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
+  _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role roles/aiplatform.user \
+    --condition=None \
+    --quiet
+else
+  echo "==> skipping roles/aiplatform.user grant (--extraction-mode=$EXTRACTION_MODE; no AI.GENERATE calls)"
+fi
 
 # Dataset-level IAM via the BigQuery Python client (the
 # ``AccessEntry``-based update API — legacy and fully
@@ -474,6 +507,7 @@ ENV_VARS=(
   "BQAA_LOCATION=${BQ_LOCATION}"
   "BQAA_LOOKBACK_HOURS=${LOOKBACK_HOURS}"
   "BQAA_OVERLAP_MINUTES=${OVERLAP_MINUTES}"
+  "BQAA_EXTRACTION_MODE=${EXTRACTION_MODE}"
 )
 if [[ -n "${MAX_SESSIONS}" ]]; then
   ENV_VARS+=("BQAA_MAX_SESSIONS=${MAX_SESSIONS}")

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -72,10 +72,16 @@ Env vars (all set by the deploy script via
   existing behavior (structured extractors + AI.GENERATE for
   gaps). ``compiled-only`` skips ``AI.GENERATE`` entirely; any
   span the compiled extractors don't cover surfaces as a typed
-  ``empty_extraction`` failure with sample diagnostics. Set
-  ``compiled-only`` when you also drop ``roles/aiplatform.user``
-  from the runtime SA (the deploy script does both together
-  when ``--extraction-mode=compiled-only`` is passed).
+  ``empty_extraction`` failure with sample diagnostics. The SDK
+  surface for ``compiled-only`` is fully supported, but
+  ``deploy_cloud_run_job.sh`` rejects it today because that script
+  does not yet stage bundles / a reference extractor module into
+  the Cloud Run image — a follow-up PR will wire the bundles and
+  lift the deploy reject (and make the
+  ``roles/aiplatform.user`` grant conditional). Until then,
+  customers who want compiled-only build their own Cloud Run
+  image and set ``BQAA_BUNDLES_ROOT`` /
+  ``BQAA_REFERENCE_EXTRACTORS_MODULE`` themselves.
 
 Exit codes mirror the CLI:
 

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -67,6 +67,15 @@ Env vars (all set by the deploy script via
   folded into the state-key SHA so a backfill / re-extraction
   run writes its state rows in a distinct namespace from the
   steady-state cron. Recommended whenever ``BQAA_BACKFILL=true``.
+* ``BQAA_EXTRACTION_MODE`` (default ``ai-fallback``) — one of
+  ``ai-fallback`` or ``compiled-only``. ``ai-fallback`` keeps the
+  existing behavior (structured extractors + AI.GENERATE for
+  gaps). ``compiled-only`` skips ``AI.GENERATE`` entirely; any
+  span the compiled extractors don't cover surfaces as a typed
+  ``empty_extraction`` failure with sample diagnostics. Set
+  ``compiled-only`` when you also drop ``roles/aiplatform.user``
+  from the runtime SA (the deploy script does both together
+  when ``--extraction-mode=compiled-only`` is passed).
 
 Exit codes mirror the CLI:
 
@@ -347,6 +356,13 @@ def main() -> int:
   from_time_raw = os.environ.get("BQAA_FROM") or None
   to_time_raw = os.environ.get("BQAA_TO") or None
   state_key_suffix = os.environ.get("BQAA_STATE_KEY_SUFFIX") or None
+  # Default ``ai-fallback`` keeps the legacy extract_graph(...,
+  # use_ai_generate=True) path; ``compiled-only`` opts into B1's
+  # diagnostics-emitting path with no AI calls. The materializer's
+  # own validator rejects any other value at the boundary.
+  extraction_mode = (
+      os.environ.get("BQAA_EXTRACTION_MODE") or "ai-fallback"
+  ).strip()
 
   _emit(
       "INFO",
@@ -362,6 +378,7 @@ def main() -> int:
       from_time=from_time_raw,
       to_time=to_time_raw,
       state_key_suffix=state_key_suffix,
+      extraction_mode=extraction_mode,
   )
 
   try:
@@ -434,6 +451,7 @@ def main() -> int:
         from_time=parsed_from,
         to_time=parsed_to,
         state_key_suffix=state_key_suffix,
+        extraction_mode=extraction_mode,
     )
 
     # Structured JSON report for Cloud Logging. Cloud Logging

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1895,6 +1895,21 @@ def materialize_window(
             "state_key and a fresh checkpoint stream."
         ),
     ),
+    extraction_mode: str = typer.Option(
+        "ai-fallback",
+        "--extraction-mode",
+        help=(
+            "Extraction path for each session's events. "
+            "'ai-fallback' (default) — structured extractors run "
+            "and AI.GENERATE fills any gaps; existing behavior. "
+            "'compiled-only' — structured extractors only; no AI "
+            "call; unhandled spans surface as typed "
+            "'empty_extraction' failures with sample diagnostics. "
+            "Pick 'compiled-only' to drop roles/aiplatform.user "
+            "from the runtime SA (no LLM calls under this mode, "
+            "asserted by SDK tests)."
+        ),
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -1952,6 +1967,7 @@ def materialize_window(
         backfill=backfill,
         from_time=parsed_from,
         to_time=parsed_to,
+        extraction_mode=extraction_mode,
         state_key_suffix=state_key_suffix,
     )
     typer.echo(format_output(result.to_json(), fmt))

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -133,6 +133,29 @@ _STATE_TABLE_MODE_MIGRATIONS = (
 STATE_MODE_STEADY = "steady"
 STATE_MODE_BACKFILL = "backfill"
 
+# Extraction modes (B2, issue #178 follow-up).
+#
+# ``ai-fallback`` is the default and the existing behavior: structured
+# extractors run when registered, ``AI.GENERATE`` fills any gaps. The
+# call into :func:`OntologyGraphManager.extract_graph` stays on the
+# legacy bool surface so existing call-stacks are unaffected.
+#
+# ``compiled-only`` opts into B1's orthogonal-flag surface with
+# ``on_unhandled_span="fail"``: structured extractors run, ``AI.GENERATE``
+# is NOT called, and unhandled spans surface as
+# ``ExtractionDiagnostic`` codes (``structured_unhandled`` or
+# ``extractor_exception``). The orchestrator translates those codes
+# into a typed ``empty_extraction`` failure on the session ahead of
+# the materializer's row-count classifier so the failure surface
+# carries the diagnostic samples directly. Customers running with
+# this mode can drop ``roles/aiplatform.user`` from the runtime
+# service account (zero AI calls is asserted by a covering test).
+EXTRACTION_MODE_AI_FALLBACK = "ai-fallback"
+EXTRACTION_MODE_COMPILED_ONLY = "compiled-only"
+_VALID_EXTRACTION_MODES = frozenset(
+    {EXTRACTION_MODE_AI_FALLBACK, EXTRACTION_MODE_COMPILED_ONLY}
+)
+
 
 # Identifier validation for BQ identifiers we interpolate into SQL.
 # Mirrors ``bq_bundle_mirror._TABLE_ID_PATTERN``. Each segment of
@@ -564,6 +587,84 @@ def make_outcome_counter() -> tuple[Callable[[str, Any], None], dict[str, int]]:
 # ------------------------------------------------------------------ #
 
 
+def _classify_compiled_only_diagnostics(
+    session: Any, graph: Any
+) -> Optional[Any]:
+  """Translate B1's ``ExtractionDiagnostic`` codes into a typed
+  ``empty_extraction`` ``SessionResult`` for compiled-only mode.
+
+  Returns ``None`` when the session's diagnostic stream is clean
+  (no ``structured_unhandled`` or ``extractor_exception``) — the
+  caller should proceed with materialization. Returns a populated
+  ``SessionResult`` otherwise.
+
+  Compiled-only mode treats any ``structured_unhandled`` or
+  ``extractor_exception`` count as a session-level failure: the
+  whole point of opting into compiled-only is to forbid silent
+  AI.GENERATE billing on extractor gaps. Partial coverage is not
+  acceptable in this mode; operators wanting "best-effort" should
+  use ``ai-fallback``. The translation runs ahead of
+  ``materialize_with_status`` so the failure surface carries the
+  diagnostic samples directly (specific span_id / event_type) —
+  more actionable than the row-count classifier's generic
+  "extraction returned empty" string.
+
+  Args:
+    session: The ``DiscoveredSession`` being processed (used for
+      ``session_id`` / ``completion_timestamp`` on the result).
+    graph: The ``ExtractedGraph`` returned by ``extract_graph(...,
+      on_unhandled_span="fail")``.
+
+  Returns:
+    ``None`` when no unhandled / exception diagnostics fired, or a
+    ``SessionResult`` with ``ok=False``, ``error_code='empty_extraction'``,
+    and ``error_detail`` carrying up to 10 diagnostic samples for
+    log readability.
+  """
+  unhandled_count = 0
+  exception_count = 0
+  samples: list[str] = []
+  for diag in getattr(graph, "diagnostics", []) or []:
+    code = getattr(diag, "diagnostic_code", None)
+    if code not in ("structured_unhandled", "extractor_exception"):
+      continue
+    if code == "structured_unhandled":
+      unhandled_count += 1
+    else:
+      exception_count += 1
+    if len(samples) < 10:
+      sample = (
+          f"{code} span_id={diag.span_id!r} " f"event_type={diag.event_type!r}"
+      )
+      detail = getattr(diag, "detail", None)
+      if detail:
+        sample += f" detail={detail!r}"
+      samples.append(sample)
+  if unhandled_count == 0 and exception_count == 0:
+    return None
+  total = unhandled_count + exception_count
+  more_note = ""
+  if total > len(samples):
+    more_note = f" (+{total - len(samples)} more not shown)"
+  return SessionResult(
+      session_id=session.session_id,
+      ok=False,
+      completion_timestamp=session.completion_timestamp,
+      error_code="empty_extraction",
+      error_detail=(
+          f"compiled-only extraction-mode: "
+          f"{unhandled_count} structured_unhandled + "
+          f"{exception_count} extractor_exception diagnostic(s) "
+          f"fired on this session{more_note}. The compiled "
+          "extractor set does not cover every event type seen "
+          "here. To resolve, either extend the compiled "
+          "extractors (preferred) or re-run with "
+          "``--extraction-mode=ai-fallback`` to let AI.GENERATE "
+          "fill the gaps. Sample diagnostics: " + "; ".join(samples)
+      ),
+  )
+
+
 def _iso(value: _dt.datetime) -> str:
   """Coerce to UTC isoformat with a trailing ``Z`` for JSON."""
   if value.tzinfo is None:
@@ -646,6 +747,7 @@ def run_materialize_window(
     from_time: Optional[_dt.datetime] = None,
     to_time: Optional[_dt.datetime] = None,
     state_key_suffix: Optional[str] = None,
+    extraction_mode: str = EXTRACTION_MODE_AI_FALLBACK,
 ) -> MaterializeWindowResult:
   """The end-to-end run.
 
@@ -699,7 +801,24 @@ def run_materialize_window(
       steady-state run (backfill, ad-hoc re-extraction) so the
       run's state rows occupy a distinct ``state_key`` namespace
       and do not advance the steady-state checkpoint.
+    extraction_mode: One of :data:`EXTRACTION_MODE_AI_FALLBACK`
+      (default) or :data:`EXTRACTION_MODE_COMPILED_ONLY`. Default
+      preserves the legacy ``extract_graph(..., use_ai_generate=True)``
+      path. ``compiled-only`` routes through B1's orthogonal-flag
+      surface with ``on_unhandled_span="fail"`` so ``AI.GENERATE``
+      is never called and structured-extractor gaps surface as
+      typed ``empty_extraction`` failures (with sample diagnostics
+      in ``error_detail``) ahead of the materializer's row-count
+      classifier.
   """
+  # Extraction-mode validation. Reject the typo at the boundary so
+  # downstream code never has to handle an unknown mode silently.
+  if extraction_mode not in _VALID_EXTRACTION_MODES:
+    raise ValueError(
+        f"--extraction-mode must be one of "
+        f"{sorted(_VALID_EXTRACTION_MODES)!r}; got {extraction_mode!r}."
+    )
+
   # Numeric guardrails — reject nonsense at the boundary so the
   # orchestrator's downstream arithmetic (timedeltas, LIMIT clauses)
   # never produces a "scan into the future" or an unbounded loop.
@@ -1099,9 +1218,40 @@ def run_materialize_window(
   session_results: list[SessionResult] = []
   for session in discovered:
     try:
-      graph = manager.extract_graph(
-          session_ids=[session.session_id], use_ai_generate=True
-      )
+      if extraction_mode == EXTRACTION_MODE_COMPILED_ONLY:
+        # Orthogonal-flag surface (B1): structured extractors only,
+        # no ``AI.GENERATE`` call, unhandled spans surface as
+        # ``structured_unhandled`` / ``extractor_exception``
+        # diagnostics in ``graph.diagnostics``. We translate those
+        # to a typed ``empty_extraction`` failure below — before
+        # the row-count classifier so compiled-only's failure
+        # detail carries the diagnostic samples directly.
+        graph = manager.extract_graph(
+            session_ids=[session.session_id],
+            use_ai_generate=False,
+            run_structured=True,
+            on_unhandled_span="fail",
+        )
+      else:
+        # Default ``ai-fallback`` mode keeps the legacy bool path —
+        # zero behavior change vs pre-#178 for every existing
+        # caller (notebook, run_job.py, anyone calling the CLI
+        # without ``--extraction-mode``).
+        graph = manager.extract_graph(
+            session_ids=[session.session_id], use_ai_generate=True
+        )
+
+      # Compiled-only failure surface: translate B1 diagnostics
+      # into a typed ``empty_extraction`` row when the structured
+      # extractors didn't cover the session.
+      if extraction_mode == EXTRACTION_MODE_COMPILED_ONLY:
+        failure_result = _classify_compiled_only_diagnostics(session, graph)
+        if failure_result is not None:
+          session_results.append(failure_result)
+          # Conservative stop, same shape as exception path below —
+          # the checkpoint advances only to the prior success.
+          break
+
       mat = materializer.materialize_with_status(graph, [session.session_id])
       # Capture per-session table statuses so the JSON report can
       # show cleanup_status / insert_status per bound table — the

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -25,6 +25,8 @@ Live BigQuery integration is covered separately (a follow-up).
 from __future__ import annotations
 
 import datetime as _dt
+import pathlib
+import subprocess
 from unittest import mock
 
 import pytest
@@ -2950,3 +2952,104 @@ class TestCompiledOnlyMakesZeroLLMCalls:
     assert isinstance(result, ExtractedGraph)
     assert mgr._extract_via_ai_generate.called is False
     assert mgr._extract_payloads.called is False
+
+
+# ====================================================================== #
+# Deploy-script boundary (PR B2 review P1)                                 #
+# ====================================================================== #
+
+
+class TestDeployScriptExtractionModeBoundary:
+  """Mechanically verifies the deploy-script reject for
+  ``--extraction-mode=compiled-only``. The reject is in shell, not
+  Python, so we shell out — but the contract still belongs in the
+  test suite because B2's PR body advertises the rejection as the
+  gate behavior."""
+
+  def _deploy_script_path(self) -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "deploy_cloud_run_job.sh"
+    )
+
+  def test_compiled_only_rejected_with_actionable_error(self):
+    """``--extraction-mode=compiled-only`` must exit non-zero with
+    an error pointing at the missing bundles wiring and the CLI-
+    direct workaround. Customers who shell-trap this error need
+    the migration path in the message."""
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--project",
+            "p",
+            "--region",
+            "us-central1",
+            "--events-dataset",
+            "e",
+            "--graph-dataset",
+            "g",
+            "--schedule",
+            "0 */6 * * *",
+            "--extraction-mode",
+            "compiled-only",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode != 0
+    msg = result.stdout + result.stderr
+    assert "compiled-only is not yet supported" in msg
+    assert "bundles-root" in msg
+    assert "ai-fallback" in msg
+
+  def test_deploy_script_shell_syntax_clean(self):
+    """``bash -n`` confirms the new validator block + the
+    restored unconditional IAM grant parse cleanly."""
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        ["bash", "-n", str(script)], capture_output=True, text=True
+    )
+    assert (
+        result.returncode == 0
+    ), f"deploy script has a shell syntax error: {result.stderr}"
+
+  def test_invalid_extraction_mode_value_rejected(self):
+    """Operator typo path (``compiled_only`` with underscore, etc.)
+    — the catch-all branch must reject with a clear error."""
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--project",
+            "p",
+            "--region",
+            "us-central1",
+            "--events-dataset",
+            "e",
+            "--graph-dataset",
+            "g",
+            "--schedule",
+            "0 */6 * * *",
+            "--extraction-mode",
+            "compiled_only",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode != 0
+    msg = result.stdout + result.stderr
+    assert "must be 'ai-fallback'" in msg

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2866,16 +2866,22 @@ class TestCompiledOnlyMode:
 
 
 class TestCompiledOnlyMakesZeroLLMCalls:
-  """The contract that justifies dropping ``roles/aiplatform.user``
-  from the runtime SA's IAM in ``deploy_cloud_run_job.sh`` when
-  ``--extraction-mode=compiled-only`` is selected.
+  """The SDK contract that *will* justify dropping
+  ``roles/aiplatform.user`` from the runtime SA's IAM once a
+  follow-up PR vendors compiled-extractor bundles into
+  ``deploy_cloud_run_job.sh``. B2 ships compiled-only mode at the
+  SDK / CLI / Python API surface but rejects
+  ``--extraction-mode=compiled-only`` on the deploy script today
+  because the bundles aren't yet staged into the Cloud Run image
+  (see ``TestDeployScriptExtractionModeBoundary``).
 
   Asserts at the orchestrator boundary that compiled-only mode
   passes ``use_ai_generate=False`` to ``extract_graph`` and that
   the manager's ``_extract_via_ai_generate`` is never called. B1
   already pins that ``on_unhandled_span='fail'`` skips the AI
   branch; this test pins the materialize_window contract that
-  routes through B1 correctly.
+  routes through B1 correctly so a future regression is caught
+  here before a customer's runtime SA starts billing Vertex AI.
   """
 
   def test_compiled_only_extract_graph_use_ai_generate_is_false(

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2521,3 +2521,432 @@ class TestEnsureStateTableMigration:
         "mode column on every call so pre-migration tables get patched "
         "without a destructive migration"
     )
+
+
+# ====================================================================== #
+# Extraction mode (PR B2, issue #178 follow-up)                            #
+# ====================================================================== #
+
+
+def _diag(code, **kwargs):
+  """Build an ExtractionDiagnostic from kwargs without a Pydantic import
+  chain in every test (keeps the dict-construction explicit and lets
+  tests pass plain values regardless of the Pydantic version's
+  ``model_construct`` quirks)."""
+  from bigquery_agent_analytics.extracted_models import ExtractionDiagnostic
+
+  return ExtractionDiagnostic(diagnostic_code=code, **kwargs)
+
+
+def _patch_orchestrator_for_extraction(
+    monkeypatch,
+    *,
+    diagnostics_per_session=None,
+    nodes_per_session=None,
+):
+  """Patch ``_build_manager`` and ``OntologyMaterializer`` so the
+  orchestrator runs end-to-end without BQ. Returns a tracker dict
+  with the call counts the tests assert on.
+  """
+  from bigquery_agent_analytics import materialize_window as mw_mod
+  from bigquery_agent_analytics.extracted_models import ExtractedGraph
+  from bigquery_agent_analytics.extracted_models import ExtractedNode
+
+  diagnostics_per_session = diagnostics_per_session or {}
+  nodes_per_session = nodes_per_session or {}
+
+  tracker = {
+      "extract_calls": [],  # list of (session_id, kwargs) tuples
+  }
+
+  class _FakeManager:
+
+    def __init__(self):
+      self.spec = mock.Mock()
+      self.extractors = {"E": lambda *_args, **_kw: None}
+
+    def extract_graph(self, session_ids, *args, **kwargs):
+      tracker["extract_calls"].append((tuple(session_ids), dict(kwargs)))
+      sid = session_ids[0]
+      return ExtractedGraph(
+          name="g",
+          nodes=[
+              ExtractedNode(node_id=f"n-{sid}", entity_name="E")
+              for _ in range(nodes_per_session.get(sid, 0))
+          ],
+          diagnostics=diagnostics_per_session.get(sid, []),
+      )
+
+  class _FakeMaterializeStatus:
+
+    def __init__(self, row_counts, table_statuses):
+      self.row_counts = row_counts
+      self.table_statuses = table_statuses
+
+  class _FakeMaterializer:
+
+    def __init__(self, *_args, **_kwargs):
+      pass
+
+    def materialize_with_status(self, graph, session_ids):
+      # Mirror what the real materializer would return: one row per
+      # node, status entries with rows_attempted = rows_inserted.
+      n = len(graph.nodes)
+      table_statuses = {}
+      if n:
+        table_statuses["E"] = mock.Mock(
+            table_ref="t",
+            rows_attempted=n,
+            rows_inserted=n,
+            cleanup_status="deleted",
+            insert_status="inserted",
+            idempotent=True,
+        )
+      return _FakeMaterializeStatus(
+          row_counts={"E": n} if n else {},
+          table_statuses=table_statuses,
+      )
+
+  monkeypatch.setattr(mw_mod, "_build_manager", lambda **_kw: _FakeManager())
+  monkeypatch.setattr(
+      "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer",
+      _FakeMaterializer,
+  )
+  return tracker
+
+
+class TestExtractionModeFlag:
+  """Boundary contract for the new ``--extraction-mode`` flag."""
+
+  def test_unknown_extraction_mode_rejected(self, fixture_paths):
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(ValueError, match=r"--extraction-mode must be one of"):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          extraction_mode="LLM_ONLY",
+      )
+
+  def test_default_is_ai_fallback(self, fixture_paths, monkeypatch):
+    """``extraction_mode`` defaults to ``ai-fallback`` — existing
+    callers see the legacy ``extract_graph(..., use_ai_generate=True)``
+    path with no behavior change."""
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(monkeypatch)
+    client = _stub_bq_client(
+        [
+            _FakeBQRow(
+                session_id="s1",
+                completion_timestamp=_dt.datetime.now(_dt.timezone.utc),
+            )
+        ]
+    )
+    mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=_dt.datetime.now(_dt.timezone.utc),
+    )
+    assert len(tracker["extract_calls"]) == 1
+    _, kwargs = tracker["extract_calls"][0]
+    assert kwargs == {"use_ai_generate": True}, (
+        "default path must use the legacy bool surface so existing "
+        "callers see byte-identical extraction behavior"
+    )
+
+
+class TestCompiledOnlyMode:
+  """``extraction_mode='compiled-only'`` routes through B1's
+  orthogonal-flag surface AND translates diagnostics into typed
+  ``empty_extraction`` failures."""
+
+  def test_compiled_only_uses_orthogonal_flags(
+      self, fixture_paths, monkeypatch
+  ):
+    """The actual ``extract_graph`` invocation in compiled-only
+    mode uses ``run_structured=True, use_ai_generate=False,
+    on_unhandled_span='fail'`` — the B1 contract."""
+    ontology_yaml, binding_yaml = fixture_paths
+    # Empty diagnostics → clean session.
+    tracker = _patch_orchestrator_for_extraction(
+        monkeypatch,
+        nodes_per_session={
+            "s1": 3
+        },  # at least one row so empty-extraction guard doesn't trip
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    assert len(tracker["extract_calls"]) == 1
+    _, kwargs = tracker["extract_calls"][0]
+    assert kwargs == {
+        "use_ai_generate": False,
+        "run_structured": True,
+        "on_unhandled_span": "fail",
+    }, "compiled-only must opt into B1's orthogonal-flag surface"
+
+  def test_unhandled_diagnostic_surfaces_empty_extraction(
+      self, fixture_paths, monkeypatch
+  ):
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(
+        monkeypatch,
+        diagnostics_per_session={
+            "s1": [
+                _diag(
+                    "structured_unhandled",
+                    span_id="span-x",
+                    event_type="UNKNOWN",
+                ),
+            ],
+        },
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    assert result.ok is False, (
+        "an unhandled diagnostic in compiled-only mode must flip "
+        "the session result to ok=False"
+    )
+    assert result.failures, "failures[] must surface the diagnostic"
+    assert result.failures[0]["error_code"] == "empty_extraction"
+    detail = result.failures[0]["error_detail"]
+    assert "span-x" in detail and "UNKNOWN" in detail, (
+        "error_detail must name the offending span_id + event_type so "
+        "operators can grep Cloud Logging for the failing event shape"
+    )
+
+  def test_extractor_exception_diagnostic_surfaces_empty_extraction(
+      self, fixture_paths, monkeypatch
+  ):
+    """``extractor_exception`` diagnostics (extractor raised, B1's
+    ``capture_extractor_exceptions=True`` path) are also fatal in
+    compiled-only mode."""
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(
+        monkeypatch,
+        diagnostics_per_session={
+            "s1": [
+                _diag(
+                    "extractor_exception",
+                    span_id="span-boom",
+                    event_type="E",
+                    detail="RuntimeError: extractor crashed",
+                ),
+            ],
+        },
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    assert result.ok is False
+    assert result.failures[0]["error_code"] == "empty_extraction"
+    detail = result.failures[0]["error_detail"]
+    assert "span-boom" in detail
+    assert "extractor crashed" in detail, (
+        "the captured exception detail must surface in error_detail "
+        "so operators can pinpoint the extractor bug"
+    )
+
+  def test_compiled_only_clean_session_passes(self, fixture_paths, monkeypatch):
+    """When the diagnostic stream has only handled codes (no
+    unhandled, no exception), compiled-only mode passes
+    materialization normally."""
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(
+        monkeypatch,
+        diagnostics_per_session={
+            "s1": [
+                _diag("structured_fully_handled", span_id="span-1"),
+                _diag("structured_partially_handled", span_id="span-2"),
+            ],
+        },
+        nodes_per_session={"s1": 5},
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    assert result.ok is True
+    assert not result.failures
+    assert result.sessions_materialized == 1
+
+  def test_diagnostic_samples_capped_at_ten(self, fixture_paths, monkeypatch):
+    """The error_detail caps diagnostic samples at 10 + says how
+    many more exist — keeps Cloud Logging payloads readable when a
+    customer's session has dozens of unhandled spans."""
+    ontology_yaml, binding_yaml = fixture_paths
+    many = [
+        _diag(
+            "structured_unhandled",
+            span_id=f"span-{i}",
+            event_type=f"TYPE_{i}",
+        )
+        for i in range(25)
+    ]
+    _patch_orchestrator_for_extraction(
+        monkeypatch, diagnostics_per_session={"s1": many}
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    result = mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    detail = result.failures[0]["error_detail"]
+    # Counts surface in the prose: "25 structured_unhandled" total.
+    assert "25 structured_unhandled" in detail
+    # The "(+N more not shown)" note appears (15 more = 25 - 10 cap).
+    assert "+15 more" in detail
+
+
+class TestCompiledOnlyMakesZeroLLMCalls:
+  """The contract that justifies dropping ``roles/aiplatform.user``
+  from the runtime SA's IAM in ``deploy_cloud_run_job.sh`` when
+  ``--extraction-mode=compiled-only`` is selected.
+
+  Asserts at the orchestrator boundary that compiled-only mode
+  passes ``use_ai_generate=False`` to ``extract_graph`` and that
+  the manager's ``_extract_via_ai_generate`` is never called. B1
+  already pins that ``on_unhandled_span='fail'`` skips the AI
+  branch; this test pins the materialize_window contract that
+  routes through B1 correctly.
+  """
+
+  def test_compiled_only_extract_graph_use_ai_generate_is_false(
+      self, fixture_paths, monkeypatch
+  ):
+    """The ``extract_graph`` kwargs in compiled-only mode include
+    ``use_ai_generate=False``. Any future regression that flips
+    this to True trips the test before a customer's runtime SA
+    starts charging Vertex AI for calls it shouldn't be making."""
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(
+        monkeypatch,
+        nodes_per_session={"s1": 1},
+    )
+    now = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client(
+        [_FakeBQRow(session_id="s1", completion_timestamp=now)]
+    )
+    mw.run_materialize_window(
+        project_id="test-proj",
+        dataset_id="test_ds",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=now,
+        extraction_mode="compiled-only",
+    )
+    for _, kwargs in tracker["extract_calls"]:
+      assert kwargs.get("use_ai_generate") is False, (
+          "compiled-only must NOT pass use_ai_generate=True; that "
+          "would route through _extract_via_ai_generate and bill "
+          "Vertex AI on a deploy where roles/aiplatform.user has "
+          "intentionally been dropped"
+      )
+      assert kwargs.get("on_unhandled_span") == "fail", (
+          "compiled-only must pass on_unhandled_span='fail' so B1's "
+          "_extract_graph_impl skips the AI branch (and the stub "
+          "branch); any other value risks an LLM call"
+      )
+
+  def test_compiled_only_does_not_call_extract_via_ai_generate(self):
+    """Inline B1-style integration: build a real
+    ``OntologyGraphManager``-shaped object whose
+    ``_extract_via_ai_generate`` raises if called, and verify
+    that ``on_unhandled_span='fail'`` never reaches it. Belt-
+    and-braces for the materializer→extract_graph contract."""
+    from bigquery_agent_analytics.extracted_models import ExtractedGraph
+    from bigquery_agent_analytics.ontology_graph import OntologyGraphManager
+
+    mgr = OntologyGraphManager.__new__(OntologyGraphManager)
+    mgr.extractors = {}
+    mgr.spec = mock.Mock()
+    mgr.spec.name = "g"
+    mgr._fetch_raw_events = mock.Mock(return_value=[])
+    mgr._extract_via_ai_generate = mock.Mock(
+        side_effect=AssertionError(
+            "_extract_via_ai_generate must NOT be called in compiled-only mode"
+        )
+    )
+    mgr._extract_payloads = mock.Mock(
+        side_effect=AssertionError(
+            "_extract_payloads must NOT be called in compiled-only mode"
+        )
+    )
+    result = mgr.extract_graph(
+        ["s1"],
+        use_ai_generate=False,
+        run_structured=True,
+        on_unhandled_span="fail",
+    )
+    # No assertion error fired — neither branch was called.
+    assert isinstance(result, ExtractedGraph)
+    assert mgr._extract_via_ai_generate.called is False
+    assert mgr._extract_payloads.called is False


### PR DESCRIPTION
PR B2 from the [issue #187 implementation plan](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187). Closes (the materializer side of) [#178](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/178).

Wires B1's ``ExtractedGraph.diagnostics`` channel (#189) into ``bqaa-materialize-window`` so customers can run with **no ``AI.GENERATE`` calls** and get a typed ``empty_extraction`` failure surface when the compiled extractors don't cover an event.

## What ships

### ``--extraction-mode`` flag (CLI + env + Python API)

| Mode | Behavior | Available on |
|---|---|---|
| ``ai-fallback`` *(default)* | Existing behavior. ``extract_graph(..., use_ai_generate=True)`` on the legacy bool surface; structured extractors run when registered, ``AI.GENERATE`` fills any gaps. No diagnostics emitted. | CLI, env, **deploy script** |
| ``compiled-only`` | Routes through B1's orthogonal-flag surface: ``run_structured=True, use_ai_generate=False, on_unhandled_span='fail'``. ``AI.GENERATE`` is NEVER called. ``structured_unhandled`` + ``extractor_exception`` diagnostics translate into a typed ``empty_extraction`` failure with sample diagnostics in ``error_detail``. | CLI, env, ❌ **rejected on the deploy script** until a follow-up wires bundles |

Three surfaces accept the flag:

- **CLI:** ``bqaa-materialize-window --extraction-mode <mode>``.
- **Env:** ``BQAA_EXTRACTION_MODE`` in ``run_job.py``.
- **Deploy:** ``deploy_cloud_run_job.sh --extraction-mode ai-fallback`` only; ``compiled-only`` is rejected at the option-validation boundary with an actionable error that names the missing bundles wiring AND the CLI-direct escape hatch. See "Deploy-path scoping" below.

### Diagnostic translation in the orchestrator

New ``_classify_compiled_only_diagnostics(session, graph)`` reads ``graph.diagnostics`` after each session's extraction. In ``compiled-only`` mode, any ``structured_unhandled`` or ``extractor_exception`` code produces a ``SessionResult`` with ``ok=False``, ``error_code='empty_extraction'``, and an ``error_detail`` carrying:

- the unhandled / exception count breakdown,
- up to 10 sample diagnostics (``span_id``, ``event_type``, captured exception detail),
- a ``"+N more not shown"`` note when the diagnostic stream is longer than the cap,
- explicit guidance: extend the compiled extractor set, or re-run with ``--extraction-mode=ai-fallback``.

Runs ahead of the materializer's row-count classifier so the failure surface carries the actionable diagnostic samples directly rather than the generic "extraction returned empty" string.

### Zero-LLM-call guarantee

``TestCompiledOnlyMakesZeroLLMCalls::test_compiled_only_does_not_call_extract_via_ai_generate`` builds a real ``OntologyGraphManager`` whose ``_extract_via_ai_generate`` and ``_extract_payloads`` raise ``AssertionError`` if called, then runs ``extract_graph(..., on_unhandled_span='fail')`` and asserts neither branch fired. If a future regression flips ``use_ai_generate`` to ``True`` in the compiled-only path, the test trips before a customer's runtime SA starts billing Vertex AI.

This is the contract that, once the bundles-wiring follow-up lands, will justify dropping ``roles/aiplatform.user`` from the runtime SA. In this PR the deploy script still grants the role unconditionally because compiled-only isn't yet reachable through the deploy path (see below).

## Deploy-path scoping

The first round of review caught a real gap: ``deploy_cloud_run_job.sh --extraction-mode=compiled-only`` set the env var but never staged ``BQAA_BUNDLES_ROOT`` / ``BQAA_REFERENCE_EXTRACTORS_MODULE`` into the Cloud Run image, so deployed compiled-only ran with no extractors registered, ``extract_graph`` skipped the structured pass entirely, and the result was a silently empty graph — worse failure mode than ai-fallback's default.

This PR fixes it by **rejecting ``--extraction-mode=compiled-only`` at the deploy script** with an actionable error that names:

- the missing piece (bundles + reference extractor staging),
- the CLI escape hatch (``bqaa-materialize-window --extraction-mode=compiled-only --bundles-root ... --reference-extractors-module ...``),
- the supported alternative (``ai-fallback``).

A follow-up PR will vendor the bundles + reference extractor into the deploy artifact and lift this restriction. At that point the conditional ``roles/aiplatform.user`` grant + the idempotent ``remove-iam-policy-binding`` for transitioning deploys both make sense; until then the deploy script grants the IAM unconditionally because only ai-fallback is supported.

## Compatibility

- Existing callers of ``run_materialize_window`` see byte-identical behavior — ``extraction_mode`` defaults to ``ai-fallback``, which keeps the legacy ``extract_graph(..., use_ai_generate=True)`` path. Asserted by ``test_default_is_ai_fallback``.
- CLI continues to work without ``--extraction-mode`` (defaults to ``ai-fallback``).
- ``BQAA_EXTRACTION_MODE`` empty / unset → ``ai-fallback``.
- ``run_materialize_window`` gains ``extraction_mode`` as a keyword-only arg with a safe default; no positional callers affected.
- Deploy script still accepts ``--extraction-mode ai-fallback`` (the default + only supported value here); typos and ``compiled-only`` both fail at the boundary with clear messages.

## Tests

**12 new test cases** across four test classes (in addition to the 86 prior tests, all still passing):

- ``TestExtractionModeFlag`` — boundary validation; default preserves the legacy bool surface.
- ``TestCompiledOnlyMode`` — orthogonal-flag kwargs threaded through; ``structured_unhandled`` and ``extractor_exception`` diagnostics both surface as ``empty_extraction``; clean diagnostic stream passes materialization normally; the 10-sample cap with ``+N more`` overflow note.
- ``TestCompiledOnlyMakesZeroLLMCalls`` — the IAM-drop justifier: ``use_ai_generate=False`` is passed AND ``_extract_via_ai_generate`` is never reached.
- ``TestDeployScriptExtractionModeBoundary`` — shell-out subprocess tests pinning the deploy-script rejects (``compiled-only`` rejected with the migration path in the error; ``bash -n`` clean; operator typo rejected too).

**Net: 98 tests pass (86 prior + 12 new).** ``pyink --check`` + ``isort --check-only`` clean. ``bash -n deploy_cloud_run_job.sh`` clean.

## Review history

| Commit | Review finding addressed |
|---|---|
| ``f79a3bc`` | Initial implementation — CLI / env / deploy flag, diagnostic translation, conditional IAM. |
| ``a2ff076`` | P1: deploy path didn't actually run compiled extractors (no bundles staged). Rejected ``--extraction-mode=compiled-only`` at the deploy boundary with an actionable error pointing at the CLI escape hatch. P2: conditional IAM logic became moot once compiled-only is rejected; restored unconditional grant + comment for the follow-up PR that wires bundles. |

## Where this fits in the implementation plan

PR B2 in the locked sequencing on [#187](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187):

| PR | Issue(s) | Status |
|---|---|---|
| A | #177 (backfill foundation) | ✅ landed (#188) |
| B1 | #178 part 1 (extract_graph refactor + diagnostics) | ✅ landed (#189) |
| C1 | #179 part 1 (binding-model dict-shape + list-view shim) | ✅ landed (#191) |
| **B2** (this PR) | #178 part 2 (--extraction-mode wiring + diagnostic translation; deploy-script reject pending bundles) | ▶︎ this PR |
| Follow-up | Vendor bundles + reference extractor into the deploy artifact; lift the compiled-only reject; make ``roles/aiplatform.user`` conditional + idempotently remove on transitions | next |
| C2 | #179 part 2 (materializer self-edge fix; lift consumer guards) | next |
| D / E / F / G | #180, #181, #184, #185, #186 | per calendar |

## Test plan

- [x] All 12 new test cases pass.
- [x] 86 prior tests still pass — back-compat preserved.
- [x] ``pyink --check`` + ``isort --check-only`` clean.
- [x] ``bash -n deploy_cloud_run_job.sh`` clean.
- [x] ``compiled-only`` mode proven to make zero LLM calls at the SDK level.
- [x] Deploy script rejects ``--extraction-mode=compiled-only`` with the CLI escape hatch in the error.
- [x] Diagnostic translation surfaces ``structured_unhandled`` and ``extractor_exception`` with sample span_id / event_type / detail.
- [ ] **(pending — for the follow-up PR)** Vendor bundles + reference extractor into the deploy artifact so ``deploy_cloud_run_job.sh --extraction-mode=compiled-only`` works end-to-end with no ``AI.GENERATE`` calls; flip the IAM grant conditional + add the idempotent ``remove-iam-policy-binding`` for transition deploys.