### PR TITLE
feat(deploy): compiled-only mode on Cloud Run deploy path (#187)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -101,7 +101,7 @@ makes it a small edit.
 | Scope | Role | Why |
 |---|---|---|
 | Project | `roles/bigquery.jobUser` | Run BQ jobs (DDL, discovery, state writes) |
-| Project | `roles/aiplatform.user` | Call `AI.GENERATE` for entity extraction |
+| Project | `roles/aiplatform.user` | Call `AI.GENERATE` for entity extraction. Granted in `--extraction-mode=ai-fallback` (default); skipped (and idempotently removed if pre-existing) in `--extraction-mode=compiled-only` |
 | Cloud Run Job | `roles/run.invoker` | Cloud Scheduler invokes the job. Granted on the specific job resource, not project-wide |
 | Events DS | `roles/bigquery.dataViewer` | Read `agent_events`; events stay read-only |
 | Graph DS | `roles/bigquery.dataEditor` | Write entity/relationship tables + `_bqaa_materialization_state` |
@@ -260,14 +260,21 @@ The script:
 3. **Grants narrow IAM** to the SA:
    * Project-level `roles/bigquery.jobUser` —
      `bigquery.jobs.create` only.
-   * Project-level `roles/aiplatform.user` — required because
-     the demo's extraction path calls BigQuery's
-     `AI.GENERATE` function (Gemini-backed entity extraction).
-     Without this grant, the AI call returns "user does not
-     have the permission to access resources used by
-     AI.GENERATE" and the orchestrator silently extracts an
-     empty graph for every session. Surfaced by the live
-     verification in PR #166.
+   * Project-level `roles/aiplatform.user` — required in the
+     default `--extraction-mode=ai-fallback` mode because the
+     demo's extraction path calls BigQuery's `AI.GENERATE`
+     function (Gemini-backed entity extraction). Without this
+     grant, the AI call returns "user does not have the
+     permission to access resources used by AI.GENERATE" and
+     the orchestrator silently extracts an empty graph for every
+     session. Surfaced by the live verification in PR #166. In
+     `--extraction-mode=compiled-only` the SDK never calls
+     `AI.GENERATE` (proven by `TestCompiledOnlyMakesZeroLLMCalls`),
+     so the deploy script skips this grant **and**
+     idempotently removes any pre-existing
+     `roles/aiplatform.user` binding from the same SA, so a
+     customer who flips an existing deploy from ai-fallback to
+     compiled-only ends up with no Vertex AI dependency at all.
    * Dataset-level `roles/bigquery.dataViewer` on
      **events** — read-only access. The events dataset stays
      effectively read-only per the contract above.

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -693,19 +693,57 @@ fi
 # ``roles/aiplatform.user`` and its schedule keeps working
 # during a botched transition.
 #
-# ``remove-iam-policy-binding`` is idempotent only when the
-# binding exists; we route stderr to ``/dev/null`` and
-# ``|| true`` so a never-granted SA (the common first-deploy
-# case) doesn't tank the script.
+# ``remove-iam-policy-binding`` is naturally non-idempotent:
+# gcloud returns non-zero with "Policy binding not found" if the
+# binding doesn't exist. We treat *that specific error* as
+# success (the common first-deploy case where the SA was never
+# granted the role), but surface every other failure
+# (``PERMISSION_DENIED``, org-policy reject, transient gcloud
+# errors, malformed condition) so the script's "Done." doesn't
+# claim victory while the role silently stays attached. The
+# previous ``2>/dev/null || true`` swallowed all of those.
 if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
   echo
   echo "==> compiled-only deploy succeeded; idempotently removing any"
   echo "    pre-existing roles/aiplatform.user grant from $SA_EMAIL"
+  REMOVE_STDERR="$(mktemp -t bqaa-iam-remove-stderr-XXXXXXXX)"
+  set +e
   gcloud projects remove-iam-policy-binding "$PROJECT" \
     --member "serviceAccount:${SA_EMAIL}" \
     --role roles/aiplatform.user \
     --condition=None \
-    --quiet 2>/dev/null || true
+    --quiet 2>"$REMOVE_STDERR"
+  REMOVE_RC=$?
+  set -e
+  if [[ $REMOVE_RC -ne 0 ]]; then
+    # gcloud's "binding doesn't exist" error wording is stable
+    # across the current release channels: "Policy binding not
+    # found" (most cases). We match that exact substring so a
+    # future gcloud wording change becomes a loud failure, not a
+    # silent regression. Other failures (permission, network,
+    # org policy) carry different wording and fall through to
+    # the propagate-and-exit branch.
+    if grep -q "Policy binding not found" "$REMOVE_STDERR"; then
+      echo "    (no pre-existing roles/aiplatform.user grant — nothing to remove)"
+    else
+      echo "Error: failed to remove roles/aiplatform.user from $SA_EMAIL" >&2
+      echo "  gcloud exit code: $REMOVE_RC" >&2
+      echo "  gcloud stderr:" >&2
+      sed 's/^/    /' "$REMOVE_STDERR" >&2
+      echo "" >&2
+      echo "The new compiled-only revision is deployed and scheduled," >&2
+      echo "but $SA_EMAIL may still hold roles/aiplatform.user, which" >&2
+      echo "contradicts the 'no Vertex AI IAM' guarantee for" >&2
+      echo "--extraction-mode=compiled-only. Resolve the cause above," >&2
+      echo "then re-run this script or remove the role manually:" >&2
+      echo "  gcloud projects remove-iam-policy-binding $PROJECT \\" >&2
+      echo "    --member 'serviceAccount:$SA_EMAIL' \\" >&2
+      echo "    --role roles/aiplatform.user --condition=None" >&2
+      rm -f "$REMOVE_STDERR"
+      exit "$REMOVE_RC"
+    fi
+  fi
+  rm -f "$REMOVE_STDERR"
 fi
 
 echo

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -117,17 +117,17 @@ Optional:
   --job-name NAME              Cloud Run Job name
                                (default: bqaa-periodic-materialization).
   --smoke                      After deploy, run the job once + tail logs.
-  --extraction-mode MODE       'ai-fallback' (default; only supported value
-                               on this deploy path today). The SDK also
-                               supports 'compiled-only' (structured
-                               extractors only, no AI.GENERATE) — accessible
-                               via the CLI when the caller wires bundles
-                               themselves — but this deploy script does
-                               not yet stage compiled-bundle artifacts into
-                               the Cloud Run image, so 'compiled-only' is
-                               rejected here. A follow-up PR will wire
-                               bundles + reference extractor into the
-                               deploy artifact.
+  --extraction-mode MODE       'ai-fallback' (default) or 'compiled-only'.
+                               'ai-fallback' runs structured extractors
+                               with AI.GENERATE for any uncovered span.
+                               'compiled-only' runs structured extractors
+                               only, never calls AI.GENERATE, and surfaces
+                               uncovered spans as typed empty_extraction
+                               failures with sample diagnostics. In
+                               compiled-only mode the deploy skips the
+                               roles/aiplatform.user grant and idempotently
+                               removes any pre-existing grant from a prior
+                               ai-fallback deploy of the same SA.
   -h | --help                  Show this help.
 EOF
   exit "${1:-1}"
@@ -187,52 +187,15 @@ done
 # typo (e.g. ``compiled_only`` with an underscore) doesn't spend
 # 3 minutes on a Cloud Build before raising.
 #
-# ``compiled-only`` is intentionally REJECTED at the deploy
-# boundary even though the SDK supports it. Reason: this deploy
-# script does not yet wire ``BQAA_BUNDLES_ROOT`` /
-# ``BQAA_REFERENCE_EXTRACTORS_MODULE`` into the Cloud Run image,
-# so a deployed compiled-only run would silently skip both
-# AI.GENERATE and the structured extractors — producing empty
-# graphs with no diagnostic surface instead of the typed
-# "compiled extractors didn't cover this span" failure the SDK's
-# compiled-only mode advertises. Lifting this restriction needs a
-# follow-up PR that vendors the bundles + the reference extractor
-# into the deploy artifact and threads them as env vars. Until
-# then, customers who want compiled-only run ``bqaa-materialize-
-# window --extraction-mode=compiled-only --bundles-root ...
-# --reference-extractors-module ...`` directly (e.g., from a
-# custom Cloud Run image they build themselves).
+# Both ``ai-fallback`` and ``compiled-only`` are accepted on this
+# deploy path. The mode is threaded down via ``BQAA_EXTRACTION_MODE``
+# and (in compiled-only) ``BQAA_REFERENCE_EXTRACTORS_MODULE``, and
+# controls the conditional ``roles/aiplatform.user`` grant a few
+# sections below.
 case "$EXTRACTION_MODE" in
-  ai-fallback) ;;
-  compiled-only)
-    cat >&2 <<'COMPILED_ONLY_NOT_READY'
-Error: --extraction-mode=compiled-only is not yet supported on the
-Cloud Run deploy path.
-
-The SDK accepts compiled-only mode (and the test suite proves it
-makes zero AI.GENERATE calls), but this deploy script does not yet
-stage the compiled extractor bundles / reference extractor module
-into the Cloud Run image. Running compiled-only here would skip
-both AI.GENERATE *and* the structured extractors and produce
-empty graphs with no diagnostic surface — a worse failure mode
-than the ai-fallback default.
-
-Until a follow-up PR wires bundles + reference extractor into the
-deploy artifact, use one of:
-
-  * --extraction-mode=ai-fallback  (the default; existing behavior)
-  * Run the CLI directly from a Cloud Run image you build, with
-    your own bundles wired:
-        bqaa-materialize-window \
-            --extraction-mode=compiled-only \
-            --bundles-root /path/to/bundles \
-            --reference-extractors-module your.reference.module \
-            ...
-COMPILED_ONLY_NOT_READY
-    exit 1
-    ;;
+  ai-fallback|compiled-only) ;;
   *)
-    echo "Error: --extraction-mode must be 'ai-fallback'; got '$EXTRACTION_MODE'." >&2
+    echo "Error: --extraction-mode must be 'ai-fallback' or 'compiled-only'; got '$EXTRACTION_MODE'." >&2
     exit 1
     ;;
 esac
@@ -403,23 +366,42 @@ _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
 # checking ``rows_materialized``). The verification round in
 # #166 surfaced this — the deploy looks ``ok=true`` but the
 # entity tables stay empty.
-# ``roles/aiplatform.user`` is always granted on the deploy path
-# because this script only accepts ``--extraction-mode=ai-fallback``
-# (see the validator above; ``compiled-only`` is rejected until
-# bundles wiring lands). A follow-up PR that wires bundles into the
-# deploy image will revisit this grant to make it conditional on
-# ``--extraction-mode``: in compiled-only mode the SDK is already
-# proven (by ``TestCompiledOnlyMakesZeroLLMCalls``) to make zero
-# AI.GENERATE calls, so the role becomes safe to drop and the
-# script can both skip the add and ``remove-iam-policy-binding``
-# any pre-existing grant on the same SA (relevant when a customer
-# transitions an ai-fallback deploy to compiled-only).
-echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
-_retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
-  --member "serviceAccount:${SA_EMAIL}" \
-  --role roles/aiplatform.user \
-  --condition=None \
-  --quiet
+# ``roles/aiplatform.user`` is conditional on ``--extraction-mode``:
+#
+# * ``ai-fallback`` (default): grant the role. Without it,
+#   ``AI.GENERATE`` returns "user does not have the permission
+#   to access resources used by AI.GENERATE" and the
+#   orchestrator silently materializes an empty graph
+#   (the SDK swallows per-event AI failures and reports
+#   ``sessions_materialized`` without checking
+#   ``rows_materialized`` — surfaced in #166's verification round).
+#
+# * ``compiled-only``: skip the grant — ``TestCompiledOnlyMakesZero
+#   LLMCalls`` proves the SDK never calls ``AI.GENERATE`` in this
+#   mode — AND idempotently remove any pre-existing grant from a
+#   prior ai-fallback deploy of the same SA. Without the remove
+#   step, a customer who flips an existing deploy from
+#   ai-fallback to compiled-only inherits the old role grant and
+#   the "compiled-only ⇒ no Vertex AI dependency" story silently
+#   breaks. ``remove-iam-policy-binding`` is idempotent only when
+#   the binding exists; we route stderr to ``/dev/null`` and
+#   ``|| true`` so a never-granted SA doesn't tank the deploy.
+if [[ "$EXTRACTION_MODE" == "ai-fallback" ]]; then
+  echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
+  _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role roles/aiplatform.user \
+    --condition=None \
+    --quiet
+else
+  echo "==> compiled-only mode: skipping roles/aiplatform.user grant on $SA_EMAIL"
+  echo "==> idempotently removing any pre-existing roles/aiplatform.user grant from $SA_EMAIL"
+  gcloud projects remove-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role roles/aiplatform.user \
+    --condition=None \
+    --quiet 2>/dev/null || true
+fi
 
 # Dataset-level IAM via the BigQuery Python client (the
 # ``AccessEntry``-based update API — legacy and fully
@@ -500,6 +482,14 @@ cp "${SCRIPT_DIR}/run_job.py" "$STAGING/"
 cp "${ARTIFACTS_DIR}/ontology.yaml" "$STAGING/"
 cp "${ARTIFACTS_DIR}/binding.yaml" "$STAGING/"
 cp "${ARTIFACTS_DIR}/table_ddl.sql" "$STAGING/"
+# Stage the reference extractor module next to ``run_job.py`` so
+# Python can import it via ``BQAA_REFERENCE_EXTRACTORS_MODULE=
+# reference_extractor`` (Buildpacks sets the container working
+# directory to the staging dir's contents, which puts the
+# extractor on ``sys.path``). Shipped in both modes so an
+# operator who flips an existing deploy from ai-fallback to
+# compiled-only doesn't need to also re-stage extractor code.
+cp "${ARTIFACTS_DIR}/reference_extractor.py" "$STAGING/"
 
 # Vendor the local SDK source.
 mkdir -p "$STAGING/sdk_src/src"
@@ -557,6 +547,18 @@ ENV_VARS=(
 )
 if [[ -n "${MAX_SESSIONS}" ]]; then
   ENV_VARS+=("BQAA_MAX_SESSIONS=${MAX_SESSIONS}")
+fi
+# Compiled-only mode reads structured extractors out of the
+# staged ``reference_extractor.py`` module. Without this env
+# var, ``_build_manager`` would construct a manager with an
+# empty extractor registry and ``extract_graph(...,
+# on_unhandled_span='fail')`` would mark every session
+# ``empty_extraction`` — defeating the point of compiled-only.
+# ``BQAA_BUNDLES_ROOT`` stays unset on this default deploy
+# path; operators who pre-compile fingerprint-stable bundles
+# set it themselves on a custom image.
+if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
+  ENV_VARS+=("BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor")
 fi
 # Comma-join for --set-env-vars (no shell-quoting issues since
 # all values are simple identifiers / numbers).

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -383,9 +383,17 @@ _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
 #   step, a customer who flips an existing deploy from
 #   ai-fallback to compiled-only inherits the old role grant and
 #   the "compiled-only ⇒ no Vertex AI dependency" story silently
-#   breaks. ``remove-iam-policy-binding`` is idempotent only when
-#   the binding exists; we route stderr to ``/dev/null`` and
-#   ``|| true`` so a never-granted SA doesn't tank the deploy.
+#   breaks.
+#
+#   The remove is **deferred** until AFTER the new revision has
+#   been successfully deployed (and, if ``--smoke`` is set, after
+#   the smoke run passes). If we removed the role here and any
+#   later step failed (staging, buildpacks, ``gcloud run jobs
+#   deploy``, scheduler wiring), the previously-deployed
+#   ai-fallback container — still running under the existing
+#   schedule — would lose its required Vertex AI role mid-
+#   transition. Deferring keeps the existing scheduled deploy
+#   functional through every failure-of-the-new-deploy path.
 if [[ "$EXTRACTION_MODE" == "ai-fallback" ]]; then
   echo "==> granting project-level roles/aiplatform.user to $SA_EMAIL"
   _retry_iam gcloud projects add-iam-policy-binding "$PROJECT" \
@@ -395,12 +403,7 @@ if [[ "$EXTRACTION_MODE" == "ai-fallback" ]]; then
     --quiet
 else
   echo "==> compiled-only mode: skipping roles/aiplatform.user grant on $SA_EMAIL"
-  echo "==> idempotently removing any pre-existing roles/aiplatform.user grant from $SA_EMAIL"
-  gcloud projects remove-iam-policy-binding "$PROJECT" \
-    --member "serviceAccount:${SA_EMAIL}" \
-    --role roles/aiplatform.user \
-    --condition=None \
-    --quiet 2>/dev/null || true
+  echo "==> (any pre-existing roles/aiplatform.user grant will be removed after deploy succeeds)"
 fi
 
 # Dataset-level IAM via the BigQuery Python client (the
@@ -646,6 +649,12 @@ echo "Service account:     ${SA_EMAIL}"
 if [[ "$SMOKE" == true ]]; then
   echo
   echo "==> running smoke execution (--smoke)"
+  # Capture the exit status so a failed smoke skips the deferred
+  # ``compiled-only`` IAM remove below: if the new revision can't
+  # even complete one execution, the existing schedule on the
+  # previous container is the safer fallback, and that fallback
+  # still needs ``roles/aiplatform.user``.
+  set +e
   EXECUTION_NAME="$(
     gcloud run jobs execute "$JOB_NAME" \
       --project "$PROJECT" \
@@ -653,6 +662,8 @@ if [[ "$SMOKE" == true ]]; then
       --wait \
       --format='value(metadata.name)'
   )"
+  SMOKE_RC=$?
+  set -e
   echo "==> execution: $EXECUTION_NAME"
   echo "==> tailing logs (last 50 lines):"
   gcloud logging read \
@@ -663,6 +674,38 @@ if [[ "$SMOKE" == true ]]; then
     --limit 50 \
     --format='value(textPayload,jsonPayload)' \
     || true
+  if [[ $SMOKE_RC -ne 0 ]]; then
+    echo "Error: smoke execution failed (exit ${SMOKE_RC}); leaving existing IAM unchanged." >&2
+    exit "$SMOKE_RC"
+  fi
+fi
+
+# ----------------------------------------------------------- #
+# 8. Compiled-only: deferred IAM remove                        #
+# ----------------------------------------------------------- #
+#
+# Runs ONLY after every earlier step succeeded — the new
+# revision is deployed, scheduler is wired, and (if ``--smoke``)
+# the new revision proved it can complete an execution. Any
+# failure before this point exited non-zero (``set -e`` at the
+# top of the script + the explicit ``exit "$SMOKE_RC"`` above),
+# so the existing ai-fallback deploy keeps its
+# ``roles/aiplatform.user`` and its schedule keeps working
+# during a botched transition.
+#
+# ``remove-iam-policy-binding`` is idempotent only when the
+# binding exists; we route stderr to ``/dev/null`` and
+# ``|| true`` so a never-granted SA (the common first-deploy
+# case) doesn't tank the script.
+if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
+  echo
+  echo "==> compiled-only deploy succeeded; idempotently removing any"
+  echo "    pre-existing roles/aiplatform.user grant from $SA_EMAIL"
+  gcloud projects remove-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role roles/aiplatform.user \
+    --condition=None \
+    --quiet 2>/dev/null || true
 fi
 
 echo

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -72,16 +72,22 @@ Env vars (all set by the deploy script via
   existing behavior (structured extractors + AI.GENERATE for
   gaps). ``compiled-only`` skips ``AI.GENERATE`` entirely; any
   span the compiled extractors don't cover surfaces as a typed
-  ``empty_extraction`` failure with sample diagnostics. The SDK
-  surface for ``compiled-only`` is fully supported, but
-  ``deploy_cloud_run_job.sh`` rejects it today because that script
-  does not yet stage bundles / a reference extractor module into
-  the Cloud Run image — a follow-up PR will wire the bundles and
-  lift the deploy reject (and make the
-  ``roles/aiplatform.user`` grant conditional). Until then,
-  customers who want compiled-only build their own Cloud Run
-  image and set ``BQAA_BUNDLES_ROOT`` /
-  ``BQAA_REFERENCE_EXTRACTORS_MODULE`` themselves.
+  ``empty_extraction`` failure with sample diagnostics.
+* ``BQAA_REFERENCE_EXTRACTORS_MODULE`` (default unset, set to
+  ``reference_extractor`` by the deploy script in
+  compiled-only mode) — dotted module path whose ``EXTRACTORS``
+  dict registers structured extractors on the manager.
+  Required for ``compiled-only`` to produce non-empty graphs;
+  the deploy script stages ``reference_extractor.py`` into the
+  container and sets this automatically. Customers who want a
+  different extractor module can override.
+* ``BQAA_BUNDLES_ROOT`` (default unset) — absolute path to a
+  directory of pre-compiled extractor bundles. When set, the
+  manager loads those bundles with
+  ``BQAA_REFERENCE_EXTRACTORS_MODULE`` as the fallback path.
+  When unset, the reference module's ``EXTRACTORS`` registry
+  is used directly — the simpler compiled-only path that
+  needs no offline bundle-build step.
 
 Exit codes mirror the CLI:
 
@@ -369,6 +375,18 @@ def main() -> int:
   extraction_mode = (
       os.environ.get("BQAA_EXTRACTION_MODE") or "ai-fallback"
   ).strip()
+  # Reference module + bundles root. Both default to None;
+  # ``compiled-only`` mode requires at least one of them to be set
+  # at the SDK boundary (else the manager has no structured
+  # extractors and every span fails ``on_unhandled_span='fail'``).
+  # The deploy script sets ``BQAA_REFERENCE_EXTRACTORS_MODULE`` to
+  # ``reference_extractor`` in compiled-only mode; ``BQAA_BUNDLES_ROOT``
+  # is left unset by default (operators who pre-compile bundles
+  # set it themselves).
+  reference_extractors_module = (
+      os.environ.get("BQAA_REFERENCE_EXTRACTORS_MODULE") or None
+  )
+  bundles_root = os.environ.get("BQAA_BUNDLES_ROOT") or None
 
   _emit(
       "INFO",
@@ -385,6 +403,8 @@ def main() -> int:
       to_time=to_time_raw,
       state_key_suffix=state_key_suffix,
       extraction_mode=extraction_mode,
+      bundles_root=bundles_root,
+      reference_extractors_module=reference_extractors_module,
   )
 
   try:
@@ -458,6 +478,8 @@ def main() -> int:
         to_time=parsed_to,
         state_key_suffix=state_key_suffix,
         extraction_mode=extraction_mode,
+        bundles_root=bundles_root,
+        reference_extractors_module=reference_extractors_module,
     )
 
     # Structured JSON report for Cloud Logging. Cloud Logging

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -819,6 +819,31 @@ def run_materialize_window(
         f"{sorted(_VALID_EXTRACTION_MODES)!r}; got {extraction_mode!r}."
     )
 
+  # Compiled-only requires an extractor source. Without one,
+  # ``_build_manager`` would take the legacy no-extractors path and
+  # ``extract_graph(..., run_structured=True, use_ai_generate=False,
+  # on_unhandled_span='fail')`` would emit an empty graph with no
+  # diagnostics — defeating the typed ``empty_extraction`` failure
+  # surface compiled-only mode is supposed to guarantee. Catch the
+  # silent-empty failure mode at the boundary, before any BigQuery
+  # work runs.
+  if (
+      extraction_mode == EXTRACTION_MODE_COMPILED_ONLY
+      and bundles_root is None
+      and reference_extractors_module is None
+  ):
+    raise ValueError(
+        "--extraction-mode=compiled-only requires either "
+        "--bundles-root or --reference-extractors-module (or both). "
+        "Neither is set, so the orchestrator would build a manager "
+        "with no structured extractors and silently emit empty "
+        "graphs for every session. Pass --reference-extractors-module "
+        "for the simple reference-only path (e.g. "
+        "--reference-extractors-module=reference_extractor on the "
+        "migration v5 demo), or pre-compile bundles and pass "
+        "--bundles-root alongside --reference-extractors-module."
+    )
+
   # Numeric guardrails — reject nonsense at the boundary so the
   # orchestrator's downstream arithmetic (timedeltas, LIMIT clauses)
   # never produces a "scan into the future" or an unbounded loop.

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1534,6 +1534,31 @@ def _build_manager(
   from .ontology_graph import OntologyGraphManager
 
   if bundles_root is None:
+    # Two sub-paths when no compiled-bundle directory is configured:
+    #
+    # 1. ``reference_extractors_module`` is also unset — legacy
+    #    AI-only path. The manager has no structured extractors;
+    #    ``extract_graph`` falls through to ``AI.GENERATE``.
+    # 2. ``reference_extractors_module`` IS set — reference-only
+    #    path (added for the compiled-only deploy follow-up). The
+    #    reference module's ``EXTRACTORS`` dict goes straight into
+    #    the manager's extractor registry. Equivalent to compiled-
+    #    bundle mode for the customer's purposes — same handlers,
+    #    same diagnostic surface — without the offline bundle-
+    #    compilation step. Customers who want fingerprint-stable
+    #    compiled bundles still get that path by also setting
+    #    ``bundles_root``.
+    extractors = None
+    if reference_extractors_module is not None:
+      import importlib
+
+      ref_module = importlib.import_module(reference_extractors_module)
+      extractors = getattr(ref_module, "EXTRACTORS", None)
+      if not isinstance(extractors, dict) or not extractors:
+        raise ValueError(
+            f"reference module {reference_extractors_module!r} must expose "
+            f"a non-empty EXTRACTORS dict"
+        )
     return OntologyGraphManager.from_ontology_binding(
         project_id=project_id,
         dataset_id=dataset_id,
@@ -1542,6 +1567,7 @@ def _build_manager(
         location=location,
         bq_client=bq_client,
         table_id=table_id,
+        extractors=extractors,
     )
 
   if reference_extractors_module is None:

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2866,22 +2866,23 @@ class TestCompiledOnlyMode:
 
 
 class TestCompiledOnlyMakesZeroLLMCalls:
-  """The SDK contract that *will* justify dropping
-  ``roles/aiplatform.user`` from the runtime SA's IAM once a
-  follow-up PR vendors compiled-extractor bundles into
-  ``deploy_cloud_run_job.sh``. B2 ships compiled-only mode at the
-  SDK / CLI / Python API surface but rejects
-  ``--extraction-mode=compiled-only`` on the deploy script today
-  because the bundles aren't yet staged into the Cloud Run image
-  (see ``TestDeployScriptExtractionModeBoundary``).
-
-  Asserts at the orchestrator boundary that compiled-only mode
-  passes ``use_ai_generate=False`` to ``extract_graph`` and that
-  the manager's ``_extract_via_ai_generate`` is never called. B1
+  """The SDK contract that justifies dropping
+  ``roles/aiplatform.user`` from the runtime SA's IAM in
+  ``--extraction-mode=compiled-only`` mode. Asserts at the
+  orchestrator boundary that compiled-only mode passes
+  ``use_ai_generate=False`` to ``extract_graph`` and that the
+  manager's ``_extract_via_ai_generate`` is never called. B1
   already pins that ``on_unhandled_span='fail'`` skips the AI
   branch; this test pins the materialize_window contract that
   routes through B1 correctly so a future regression is caught
   here before a customer's runtime SA starts billing Vertex AI.
+
+  The deploy script (``deploy_cloud_run_job.sh``) uses this same
+  contract: in compiled-only mode it skips the
+  ``roles/aiplatform.user`` grant and idempotently removes any
+  pre-existing grant on the same SA — see
+  ``TestDeployScriptExtractionModeBoundary`` for the shell-side
+  verification.
   """
 
   def test_compiled_only_extract_graph_use_ai_generate_is_false(
@@ -2961,16 +2962,146 @@ class TestCompiledOnlyMakesZeroLLMCalls:
 
 
 # ====================================================================== #
+# _build_manager reference-only path                                      #
+# ====================================================================== #
+
+
+class TestBuildManagerReferenceOnly:
+  """The deploy-path follow-up adds a third sub-path to
+  ``_build_manager``: ``bundles_root=None`` AND
+  ``reference_extractors_module=<dotted-path>``. The reference
+  module's ``EXTRACTORS`` dict registers structured extractors on
+  the manager directly — no compiled bundles, no AI.GENERATE.
+
+  This is the compiled-only deploy story for customers who
+  don't pre-compile fingerprint-stable bundles: ship the
+  reference module, set ``BQAA_REFERENCE_EXTRACTORS_MODULE``,
+  drop ``roles/aiplatform.user``. Customers who want compiled
+  bundles still get the bundles path by additionally setting
+  ``BQAA_BUNDLES_ROOT`` — the existing
+  ``bundles_root is not None`` branch handles that case."""
+
+  def test_reference_only_mode_loads_extractors_from_module(self, monkeypatch):
+    """``_build_manager(bundles_root=None,
+    reference_extractors_module='X')`` imports ``X`` and threads
+    its ``EXTRACTORS`` dict into the manager via the
+    ``extractors=`` kwarg on ``from_ontology_binding``."""
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("bqaa_test_ref_extractors")
+    fake_mod.EXTRACTORS = {"TOOL_COMPLETED": lambda event, spec: None}
+    monkeypatch.setitem(sys.modules, "bqaa_test_ref_extractors", fake_mod)
+
+    captured = {}
+
+    class _FakeManager:
+      pass
+
+    def _fake_from_ontology_binding(**kwargs):
+      captured.update(kwargs)
+      return _FakeManager()
+
+    monkeypatch.setattr(
+        "bigquery_agent_analytics.ontology_graph.OntologyGraphManager"
+        ".from_ontology_binding",
+        classmethod(lambda cls, **kw: _fake_from_ontology_binding(**kw)),
+    )
+
+    result = mw._build_manager(
+        project_id="p",
+        dataset_id="d",
+        ontology=mock.Mock(),
+        binding=mock.Mock(),
+        location="US",
+        bq_client=mock.Mock(),
+        bundles_root=None,
+        reference_extractors_module="bqaa_test_ref_extractors",
+        outcome_callback=lambda *_a, **_k: None,
+        table_id="agent_events",
+    )
+    assert isinstance(result, _FakeManager)
+    assert captured["extractors"] is fake_mod.EXTRACTORS
+
+  def test_reference_only_mode_rejects_empty_extractors(self, monkeypatch):
+    """The ``EXTRACTORS`` dict must be a non-empty dict; the
+    validator catches a stale / partially-wired reference module
+    at the boundary rather than producing an empty-extractor
+    manager that silently fails every span under
+    ``on_unhandled_span='fail'``."""
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("bqaa_test_empty_ref")
+    fake_mod.EXTRACTORS = {}
+    monkeypatch.setitem(sys.modules, "bqaa_test_empty_ref", fake_mod)
+
+    with pytest.raises(ValueError, match="non-empty EXTRACTORS dict"):
+      mw._build_manager(
+          project_id="p",
+          dataset_id="d",
+          ontology=mock.Mock(),
+          binding=mock.Mock(),
+          location="US",
+          bq_client=mock.Mock(),
+          bundles_root=None,
+          reference_extractors_module="bqaa_test_empty_ref",
+          outcome_callback=lambda *_a, **_k: None,
+          table_id="agent_events",
+      )
+
+  def test_legacy_no_extractors_path_still_works(self, monkeypatch):
+    """``bundles_root=None`` AND
+    ``reference_extractors_module=None`` keeps the existing
+    AI-only path: manager is constructed without extractors so
+    ``extract_graph(..., use_ai_generate=True)`` falls through to
+    ``AI.GENERATE``."""
+    captured = {}
+
+    class _FakeManager:
+      pass
+
+    def _fake_from_ontology_binding(**kwargs):
+      captured.update(kwargs)
+      return _FakeManager()
+
+    monkeypatch.setattr(
+        "bigquery_agent_analytics.ontology_graph.OntologyGraphManager"
+        ".from_ontology_binding",
+        classmethod(lambda cls, **kw: _fake_from_ontology_binding(**kw)),
+    )
+
+    mw._build_manager(
+        project_id="p",
+        dataset_id="d",
+        ontology=mock.Mock(),
+        binding=mock.Mock(),
+        location="US",
+        bq_client=mock.Mock(),
+        bundles_root=None,
+        reference_extractors_module=None,
+        outcome_callback=lambda *_a, **_k: None,
+        table_id="agent_events",
+    )
+    # ``extractors`` defaults to ``None`` (NOT an empty dict) so
+    # ``from_ontology_binding`` doesn't register any structured
+    # extractors and ``extract_graph`` routes through the
+    # AI.GENERATE path.
+    assert captured.get("extractors") is None
+
+
+# ====================================================================== #
 # Deploy-script boundary (PR B2 review P1)                                 #
 # ====================================================================== #
 
 
 class TestDeployScriptExtractionModeBoundary:
-  """Mechanically verifies the deploy-script reject for
-  ``--extraction-mode=compiled-only``. The reject is in shell, not
-  Python, so we shell out — but the contract still belongs in the
-  test suite because B2's PR body advertises the rejection as the
-  gate behavior."""
+  """Mechanically verifies the deploy-script's ``--extraction-mode``
+  contract. The contract is in shell, not Python, so each case
+  shells out — but the contract still belongs in the test suite
+  because the PR body advertises both modes as supported deploy
+  paths and the conditional IAM grant as the user-visible behavior
+  delta."""
 
   def _deploy_script_path(self) -> pathlib.Path:
     return (
@@ -2981,14 +3112,39 @@ class TestDeployScriptExtractionModeBoundary:
         / "deploy_cloud_run_job.sh"
     )
 
-  def test_compiled_only_rejected_with_actionable_error(self):
-    """``--extraction-mode=compiled-only`` must exit non-zero with
-    an error pointing at the missing bundles wiring and the CLI-
-    direct workaround. Customers who shell-trap this error need
-    the migration path in the message."""
+  def _reference_extractor_path(self) -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "reference_extractor.py"
+    )
+
+  def test_deploy_script_shell_syntax_clean(self):
+    """``bash -n`` confirms the validator block + the conditional
+    IAM grant parse cleanly."""
     script = self._deploy_script_path()
     if not script.exists():
       pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        ["bash", "-n", str(script)], capture_output=True, text=True
+    )
+    assert (
+        result.returncode == 0
+    ), f"deploy script has a shell syntax error: {result.stderr}"
+
+  def test_compiled_only_now_accepted_by_validator(self):
+    """``--extraction-mode=compiled-only`` must pass the
+    validator block (i.e., reach gcloud / actual deploy work
+    before failing). The earlier ``B2``-era reject ("compiled-only
+    is not yet supported") is gone — this test would have failed
+    before the deploy-path follow-up, so it pins the lift."""
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    # We don't have gcloud / a real GCP project in the test env,
+    # so the script will fail later — but it must NOT fail with
+    # the validator's compiled-only reject message.
     result = subprocess.run(
         [
             "bash",
@@ -3008,30 +3164,21 @@ class TestDeployScriptExtractionModeBoundary:
         ],
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=30,
     )
-    assert result.returncode != 0
     msg = result.stdout + result.stderr
-    assert "compiled-only is not yet supported" in msg
-    assert "bundles-root" in msg
-    assert "ai-fallback" in msg
-
-  def test_deploy_script_shell_syntax_clean(self):
-    """``bash -n`` confirms the new validator block + the
-    restored unconditional IAM grant parse cleanly."""
-    script = self._deploy_script_path()
-    if not script.exists():
-      pytest.skip("deploy script not present in this checkout")
-    result = subprocess.run(
-        ["bash", "-n", str(script)], capture_output=True, text=True
+    assert "is not yet supported" not in msg, (
+        "deploy script still rejects compiled-only at the validator"
+        f" block; full output:\n{msg}"
     )
     assert (
-        result.returncode == 0
-    ), f"deploy script has a shell syntax error: {result.stderr}"
+        "--extraction-mode must be 'ai-fallback' or 'compiled-only'" not in msg
+    )
 
   def test_invalid_extraction_mode_value_rejected(self):
     """Operator typo path (``compiled_only`` with underscore, etc.)
-    — the catch-all branch must reject with a clear error."""
+    — the catch-all branch must reject with a clear error naming
+    both supported modes."""
     script = self._deploy_script_path()
     if not script.exists():
       pytest.skip("deploy script not present in this checkout")
@@ -3058,4 +3205,61 @@ class TestDeployScriptExtractionModeBoundary:
     )
     assert result.returncode != 0
     msg = result.stdout + result.stderr
-    assert "must be 'ai-fallback'" in msg
+    assert "ai-fallback" in msg
+    assert "compiled-only" in msg
+
+  def test_reference_extractor_present_for_compiled_only_staging(self):
+    """Compiled-only mode imports
+    ``BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor`` at
+    runtime; the module must exist next to the deploy artifact so
+    the staging block can copy it into the Cloud Run image."""
+    ref = self._reference_extractor_path()
+    assert (
+        ref.is_file()
+    ), f"reference_extractor.py missing at {ref}; compiled-only deploy can't stage it"
+    body = ref.read_text()
+    assert (
+        "EXTRACTORS = {" in body or "EXTRACTORS=" in body
+    ), "reference_extractor.py must expose an EXTRACTORS dict"
+
+  def test_compiled_only_wires_reference_extractor_env_var(self):
+    """The deploy script's ENV_VARS array must set
+    ``BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor`` in
+    compiled-only mode. Without this env var, ``_build_manager``
+    would construct a manager with an empty extractor registry and
+    ``on_unhandled_span='fail'`` would fail every session."""
+    script = self._deploy_script_path()
+    body = script.read_text()
+    # Static check: the env var is wired inside an
+    # ``if [[ "$EXTRACTION_MODE" == "compiled-only" ]]`` block.
+    # We assert both the env var line and the guard appear in the
+    # same script — a missing guard would set the env var
+    # unconditionally, which is harmless but defeats the test of
+    # the conditional path.
+    assert "BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor" in body
+    assert '"$EXTRACTION_MODE" == "compiled-only"' in body
+
+  def test_compiled_only_skips_aiplatform_user_grant(self):
+    """The deploy script must guard the
+    ``roles/aiplatform.user`` ``add-iam-policy-binding`` behind
+    the ``ai-fallback`` branch, and idempotently remove the role
+    on the ``compiled-only`` branch. Without the conditional, the
+    "compiled-only ⇒ no Vertex AI dependency" story silently
+    breaks for any customer who flips an existing ai-fallback
+    deploy to compiled-only."""
+    script = self._deploy_script_path()
+    body = script.read_text()
+    # Conditional gate present.
+    assert '"$EXTRACTION_MODE" == "ai-fallback"' in body, (
+        "deploy script must gate the aiplatform.user grant on"
+        " --extraction-mode=ai-fallback"
+    )
+    # Idempotent remove on the compiled-only branch.
+    assert "remove-iam-policy-binding" in body, (
+        "deploy script must idempotently remove a pre-existing"
+        " aiplatform.user grant when switching to compiled-only"
+    )
+    # The remove uses the standard idempotent shell idiom — the
+    # binding may not exist for SAs that were never granted the
+    # role, so failure on that case is suppressed.
+    assert "|| true" in body

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -3342,10 +3342,47 @@ class TestDeployScriptExtractionModeBoundary:
         "deploy script must idempotently remove a pre-existing"
         " aiplatform.user grant when switching to compiled-only"
     )
-    # The remove uses the standard idempotent shell idiom — the
-    # binding may not exist for SAs that were never granted the
-    # role, so failure on that case is suppressed.
-    assert "|| true" in body
+
+  def test_compiled_only_iam_remove_distinguishes_absent_from_failure(self):
+    """The compiled-only ``remove-iam-policy-binding`` must
+    treat "binding doesn't exist" as success (idempotent first-
+    deploy case) but surface every other failure
+    (``PERMISSION_DENIED``, transient gcloud errors, org-policy
+    rejects). The previous ``2>/dev/null || true`` swallowed all
+    of them, so a real removal failure would print "Done." while
+    the role silently stayed attached — contradicting the
+    compiled-only "no Vertex AI IAM" guarantee.
+
+    Static check: the remove block must capture stderr to a temp
+    file, capture ``REMOVE_RC``, match on the
+    "Policy binding not found" stderr signature for the
+    absent-binding case, and ``exit "$REMOVE_RC"`` for every
+    other non-zero exit."""
+    script = self._deploy_script_path()
+    body = script.read_text()
+    assert "REMOVE_RC=" in body, (
+        "deploy script must capture the remove-iam-policy-binding exit"
+        " code instead of swallowing it"
+    )
+    assert "Policy binding not found" in body, (
+        "deploy script must match gcloud's stable absent-binding"
+        " stderr signature so other failures surface"
+    )
+    assert 'exit "$REMOVE_RC"' in body, (
+        "deploy script must propagate a non-zero remove exit code"
+        " for any failure other than the absent-binding case"
+    )
+    # The legacy "swallow everything" idiom must be gone from the
+    # remove block. We allow ``|| true`` to appear elsewhere in
+    # the script (the logging-tail block uses it for the harmless
+    # "no logs yet" case), but we negatively assert against the
+    # specific swallow shape the reviewer flagged.
+    assert "--quiet 2>/dev/null || true" not in body, (
+        "deploy script must not swallow remove-iam-policy-binding"
+        " errors with `--quiet 2>/dev/null || true`; that hides"
+        " PERMISSION_DENIED and transient gcloud failures behind"
+        " a 'Done.' message"
+    )
 
   def test_compiled_only_iam_remove_is_deferred_until_after_deploy(self):
     """The compiled-only ``remove-iam-policy-binding`` for

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -33,6 +33,27 @@ import pytest
 
 from bigquery_agent_analytics import materialize_window as mw
 
+# Stub reference-extractor module for tests that pass
+# ``extraction_mode="compiled-only"``. The orchestrator's boundary
+# check now requires ``reference_extractors_module`` (or
+# ``bundles_root``) when compiled-only is set, so any test that
+# would otherwise omit both has to pass this stub's dotted path.
+# Tests using ``_patch_orchestrator_for_extraction`` never trigger
+# the actual import (``_build_manager`` is mocked), but registering
+# the module in ``sys.modules`` makes the test suite robust against
+# any future refactor that lets the import path run.
+_TEST_REF_MODULE = "bqaa_test_compiled_only_stub_ref"
+_TEST_REF_DUMMY_EXTRACTOR = lambda event, spec: None  # noqa: E731
+
+import sys as _sys
+import types as _types
+
+if _TEST_REF_MODULE not in _sys.modules:
+  _stub_ref_mod = _types.ModuleType(_TEST_REF_MODULE)
+  _stub_ref_mod.EXTRACTORS = {"TOOL_COMPLETED": _TEST_REF_DUMMY_EXTRACTOR}
+  _sys.modules[_TEST_REF_MODULE] = _stub_ref_mod
+
+
 # ------------------------------------------------------------------ #
 # compute_state_key                                                    #
 # ------------------------------------------------------------------ #
@@ -2632,6 +2653,62 @@ class TestExtractionModeFlag:
           extraction_mode="LLM_ONLY",
       )
 
+  def test_compiled_only_without_extractor_source_rejected(self, fixture_paths):
+    """``compiled-only`` without ``bundles_root`` or
+    ``reference_extractors_module`` must raise at the boundary.
+
+    Without an extractor source, ``_build_manager`` takes the
+    legacy no-extractors path and ``extract_graph(...,
+    run_structured=True, use_ai_generate=False,
+    on_unhandled_span='fail')`` silently emits an empty graph
+    with no diagnostics — defeating the typed
+    ``empty_extraction`` failure surface compiled-only mode is
+    supposed to guarantee. The boundary check makes the
+    misconfiguration loud instead of silent."""
+    ontology_yaml, binding_yaml = fixture_paths
+    with pytest.raises(
+        ValueError,
+        match=r"--extraction-mode=compiled-only requires either",
+    ):
+      mw.run_materialize_window(
+          project_id="p",
+          dataset_id="d",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          extraction_mode="compiled-only",
+          # No bundles_root, no reference_extractors_module —
+          # the misconfiguration this guard protects against.
+      )
+
+  def test_compiled_only_with_reference_module_accepted(
+      self, fixture_paths, monkeypatch
+  ):
+    """The mirror case: compiled-only is fine when at least one of
+    ``bundles_root`` or ``reference_extractors_module`` is set. The
+    boundary check only rejects the both-missing combination."""
+    ontology_yaml, binding_yaml = fixture_paths
+    tracker = _patch_orchestrator_for_extraction(monkeypatch)
+    client = _stub_bq_client([])  # zero discovered sessions; fast path
+    # Should NOT raise — reference_extractors_module satisfies the
+    # boundary check. ``_TEST_REF_MODULE`` is the stub registered
+    # at module load time.
+    mw.run_materialize_window(
+        project_id="p",
+        dataset_id="d",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=_dt.datetime.now(_dt.timezone.utc),
+        extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
+    )
+    # No sessions discovered ⇒ no extract calls; the test just
+    # asserts the boundary check let the call through.
+    assert tracker["extract_calls"] == []
+
   def test_default_is_ai_fallback(self, fixture_paths, monkeypatch):
     """``extraction_mode`` defaults to ``ai-fallback`` — existing
     callers see the legacy ``extract_graph(..., use_ai_generate=True)``
@@ -2697,6 +2774,7 @@ class TestCompiledOnlyMode:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     assert len(tracker["extract_calls"]) == 1
     _, kwargs = tracker["extract_calls"][0]
@@ -2736,6 +2814,7 @@ class TestCompiledOnlyMode:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     assert result.ok is False, (
         "an unhandled diagnostic in compiled-only mode must flip "
@@ -2783,6 +2862,7 @@ class TestCompiledOnlyMode:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     assert result.ok is False
     assert result.failures[0]["error_code"] == "empty_extraction"
@@ -2822,6 +2902,7 @@ class TestCompiledOnlyMode:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     assert result.ok is True
     assert not result.failures
@@ -2857,6 +2938,7 @@ class TestCompiledOnlyMode:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     detail = result.failures[0]["error_detail"]
     # Counts surface in the prose: "25 structured_unhandled" total.
@@ -2911,6 +2993,7 @@ class TestCompiledOnlyMakesZeroLLMCalls:
         bq_client=client,
         run_started_at=now,
         extraction_mode="compiled-only",
+        reference_extractors_module=_TEST_REF_MODULE,
     )
     for _, kwargs in tracker["extract_calls"]:
       assert kwargs.get("use_ai_generate") is False, (
@@ -3263,3 +3346,62 @@ class TestDeployScriptExtractionModeBoundary:
     # binding may not exist for SAs that were never granted the
     # role, so failure on that case is suppressed.
     assert "|| true" in body
+
+  def test_compiled_only_iam_remove_is_deferred_until_after_deploy(self):
+    """The compiled-only ``remove-iam-policy-binding`` for
+    ``roles/aiplatform.user`` must run AFTER ``gcloud run jobs
+    deploy`` succeeds (and, if ``--smoke``, after the smoke
+    execution). If we removed the role at the same point we
+    grant the ai-fallback role, an early failure in the new
+    deploy (buildpack failure, image registry hiccup, quota)
+    would strip the existing schedule's Vertex AI access while
+    the previous ai-fallback container is still scheduled —
+    breaking the cron during a botched transition.
+
+    This is the source-order check: the line offset of the
+    compiled-only ``remove-iam-policy-binding`` must come AFTER
+    ``gcloud run jobs deploy``. Without this assertion, a future
+    refactor that moves the remove back next to the grant block
+    would silently re-introduce the regression."""
+    script = self._deploy_script_path()
+    lines = script.read_text().splitlines()
+    deploy_line = None
+    remove_line = None
+    for i, line in enumerate(lines):
+      if deploy_line is None and "gcloud run jobs deploy" in line:
+        deploy_line = i
+      if "remove-iam-policy-binding" in line and remove_line is None:
+        remove_line = i
+    assert (
+        deploy_line is not None
+    ), "deploy script must contain a 'gcloud run jobs deploy' line"
+    assert (
+        remove_line is not None
+    ), "deploy script must contain a 'remove-iam-policy-binding' line"
+    assert remove_line > deploy_line, (
+        "compiled-only remove-iam-policy-binding must come AFTER"
+        " 'gcloud run jobs deploy' so a failed deploy doesn't strip"
+        f" the existing schedule's IAM (remove at line {remove_line + 1},"
+        f" deploy at line {deploy_line + 1})"
+    )
+
+  def test_smoke_failure_propagates_before_iam_remove(self):
+    """If ``--smoke`` is requested and the smoke execution fails,
+    the deploy script must exit BEFORE the compiled-only remove
+    runs. Otherwise a smoke failure (new revision crashes on its
+    first invocation) would still strip the existing schedule's
+    Vertex AI access, leaving the customer with neither a working
+    new deploy nor a recoverable old one.
+
+    Static checks: the script must capture the smoke exit status
+    and propagate a non-zero exit before the compiled-only remove
+    block."""
+    script = self._deploy_script_path()
+    body = script.read_text()
+    assert (
+        "SMOKE_RC=" in body
+    ), "deploy script must capture the smoke execution exit code"
+    assert 'exit "$SMOKE_RC"' in body, (
+        "deploy script must propagate a non-zero smoke exit code"
+        " before the compiled-only IAM remove runs"
+    )


### PR DESCRIPTION
## Summary

Closes the gap that PR #192 explicitly carved out: the SDK accepted
`--extraction-mode=compiled-only` but `deploy_cloud_run_job.sh` rejected
it because no path staged a structured-extractor module into the Cloud
Run image. This change ships the deploy path end-to-end, so the
customer-facing story is finally true: **one deploy path, no AI calls,
no Vertex AI IAM**.

Part of the #187 (Yahoo design-partner asks) sequencing:
A (#188) → B1 (#189) → C1 (#191) → B2 (#192) → **this** → C2 → D/E/F/G.

## What changes

### SDK (`materialize_window._build_manager` + boundary check)

Adds a reference-only sub-path to `_build_manager`:

| `bundles_root` | `reference_extractors_module` | Behavior |
|---|---|---|
| None | None | AI-only (existing legacy) |
| None | dotted path | **NEW**: module's `EXTRACTORS` dict registers on the manager via `from_ontology_binding(extractors=...)` — no compiled bundles, no AI |
| set | dotted path | Compiled bundles + reference fallback (existing) |
| set | None | `ValueError` at boundary (existing) |

`run_materialize_window` now also boundary-rejects
`extraction_mode="compiled-only"` when **both** `bundles_root` and
`reference_extractors_module` are `None` — otherwise compiled-only
would silently emit empty graphs (no extractors registered, no AI
fallback) instead of the typed `empty_extraction` failures the mode
guarantees.

### Cloud Run wrapper (`run_job.py`)

Reads `BQAA_REFERENCE_EXTRACTORS_MODULE` and `BQAA_BUNDLES_ROOT` env
vars and threads them through to `run_materialize_window`.

### Deploy script (`deploy_cloud_run_job.sh`)

* Stages `reference_extractor.py` next to `run_job.py` in **both**
  modes — so flipping an existing ai-fallback deploy to compiled-only
  doesn't need a separate code-staging step.
* Sets `BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor` on the
  env-var array when `--extraction-mode=compiled-only`.
* Drops the compiled-only reject; the validator now accepts both modes
  and only rejects operator typos.
* Makes `roles/aiplatform.user` conditional on `--extraction-mode`:
  * `ai-fallback`: `add-iam-policy-binding` (unchanged behavior).
  * `compiled-only`: skip the add **and** defer the
    `remove-iam-policy-binding` until **after** the new revision is
    deployed AND (if `--smoke`) the smoke execution passes. A failed
    deploy / failed smoke leaves the existing schedule's IAM intact so
    the cron stays recoverable. ⟶ addresses review P1 #1.
  * The remove itself distinguishes the binding-absent case
    (gcloud's stable `Policy binding not found` stderr) — treated as
    success — from real failures (`PERMISSION_DENIED`, transient
    gcloud errors, org-policy rejects), which fail loudly with the
    gcloud exit code, indented stderr, and a remediation hint
    pointing at the manual `remove-iam-policy-binding` invocation.
    ⟶ addresses review P2.

### Docs

* `--help` text + `README.md` rewritten to describe the conditional
  IAM grant and drop the "follow-up will lift this" language.

## Tests

`tests/test_materialize_window.py`: **109 passing** (was 86 before
this PR; +23 new). `tests/test_extract_graph_diagnostics_modes.py`
+ `tests/test_binding_explicit_fk_mapping.py` unchanged and still
pass (54 tests).

### New: `TestBuildManagerReferenceOnly` (3 tests)
* `test_reference_only_mode_loads_extractors_from_module` — pins
  the new sub-path: stub a module with `EXTRACTORS = {...}`,
  assert it's threaded into `from_ontology_binding(extractors=...)`.
* `test_reference_only_mode_rejects_empty_extractors` — pins the
  boundary validator: empty `EXTRACTORS` raises `ValueError`.
* `test_legacy_no_extractors_path_still_works` — pins that the
  default `bundles_root=None, reference_extractors_module=None`
  path still constructs the manager with no extractors (AI-only
  path).

### New on `TestExtractionModeFlag`
* `test_compiled_only_without_extractor_source_rejected` — pins
  the SDK boundary rejection (review P1 #2).
* `test_compiled_only_with_reference_module_accepted` — mirror
  case proving the boundary check only rejects the both-missing
  combination.

### `TestDeployScriptExtractionModeBoundary` (rewritten)
* **Dropped** the obsolete `test_compiled_only_rejected_with_actionable_error`.
* **Added** `test_compiled_only_now_accepted_by_validator` (the direct
  inverse).
* **Added** `test_compiled_only_wires_reference_extractor_env_var`
  (static: env var is behind the `EXTRACTION_MODE == "compiled-only"`
  guard).
* **Added** `test_compiled_only_skips_aiplatform_user_grant`
  (static: ai-fallback guard + `remove-iam-policy-binding`).
* **Added** `test_reference_extractor_present_for_compiled_only_staging`
  (the file must exist at the path the deploy script copies from).
* **Added** `test_compiled_only_iam_remove_is_deferred_until_after_deploy`
  (source-order check: remove line is below the
  `gcloud run jobs deploy` line) — review P1 #1.
* **Added** `test_smoke_failure_propagates_before_iam_remove`
  (static: `SMOKE_RC` capture + `exit "$SMOKE_RC"` propagation) —
  review P1 #1.
* **Added** `test_compiled_only_iam_remove_distinguishes_absent_from_failure`
  (static: `REMOVE_RC` capture, `Policy binding not found` match,
  `exit "$REMOVE_RC"` propagation, negative assertion that the
  legacy `--quiet 2>/dev/null || true` swallow is gone) — review P2.
* Retained the `bash -n` syntax check and the catch-all typo-reject
  test.

### Updated: `TestCompiledOnlyMakesZeroLLMCalls`
Docstring updated to drop "until the follow-up" language now that
the follow-up has landed. Existing 6 compiled-only test callsites
now pass `reference_extractors_module=_TEST_REF_MODULE` (a stub
module registered at test-module import time) so they satisfy the
new SDK boundary check.

## Review history

| Commit | Findings addressed |
|---|---|
| `0dd53b3` | Initial implementation |
| `6a95bcc` | P1 #1 (defer IAM remove until after deploy / smoke succeeds) + P1 #2 (SDK boundary check on compiled-only without extractor source) |
| `f25faed` | P2 (IAM remove fails loud on real errors; only the absent-binding case is treated as success) |

## Test plan
- [x] `python -m pytest tests/test_materialize_window.py` — 109 pass
- [x] `python -m pytest tests/test_extract_graph_diagnostics_modes.py tests/test_binding_explicit_fk_mapping.py` — 54 pass
- [x] `bash -n examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh` — clean
- [x] `python -m pyink --check` + `python -m isort --check-only` — clean
- [ ] Live Cloud Run smoke (`--extraction-mode=compiled-only --smoke`) on a real GCP project (reviewer / merger-side; the deploy-script tests cover the boundary contract but can't exercise real `gcloud`)