### PR TITLE
feat(materialize_window): orphan-session watchdog (#180)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -644,7 +644,7 @@ fixed. Today, the same situation would produce `ok=false` with
 
 ### Failure-mode surface (post-#167)
 
-The orchestrator distinguishes two zero-row session outcomes
+The orchestrator distinguishes three session-level outcomes
 that look identical from `rows_materialized` alone:
 
 * **`empty_extraction`** — extraction (AI.GENERATE or compiled
@@ -663,10 +663,32 @@ that look identical from `rows_materialized` alone:
   schema drift the binding-validate pre-flight missed, or
   streaming-buffer pinning.
 
-In both cases: `ok=false`, CLI exit 1, the cron run shows up
-as a failed execution in Cloud Monitoring. Alert directly on
+* **`session_orphaned`** *(only when `--max-session-age-hours`
+  is set, issue #180)* — a session's first event landed before
+  the configured cutoff but the session never emitted
+  `AGENT_COMPLETED`. The orphan-watchdog scan flagged it as
+  in-flight-too-long. `failures[].error_detail` names the
+  session_id, the cutoff timestamp, and the missing terminal
+  event_type, plus a remediation hint pointing at the
+  cumulative ledger row (`mode='orphan_ledger'`) in the state
+  table. Diagnose by triaging the underlying agent failure or
+  by emitting the missing terminal event (the watchdog drops
+  the session from the ledger on its next pass once
+  `AGENT_COMPLETED` appears).
+
+In all three cases: `ok=false`, CLI exit 1, the cron run shows
+up as a failed execution in Cloud Monitoring. Alert directly on
 `jsonPayload.ok=false` plus `jsonPayload.failures[].error_code`
 for the failure-mode breakdown — no second-line check needed.
+
+The orphan watchdog also persists a structured audit trail in
+the state table: `mode='orphan_scan'` for the per-cron-pass
+delta (`flagged_session_ids` = sessions newly flagged this
+scan, `orphan_watermark` = the scan's cutoff that becomes the
+next scan's exclusive `>` boundary) and `mode='orphan_ledger'`
+for the cumulative running set after the resolved-orphan
+sweep. Operators reading the ledger see "what's currently
+unresolved" without having to diff across runs.
 
 ## Cleanup and redeploy
 

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -92,6 +92,7 @@ MAX_SESSIONS=""
 JOB_NAME="bqaa-periodic-materialization"
 SMOKE=false
 EXTRACTION_MODE="ai-fallback"
+MAX_SESSION_AGE_HOURS=""
 
 # Print usage. Exit code is the caller's choice: ``usage 0``
 # for ``--help`` (success), ``usage 1`` for parse / required-arg
@@ -128,6 +129,16 @@ Optional:
                                roles/aiplatform.user grant and idempotently
                                removes any pre-existing grant from a prior
                                ai-fallback deploy of the same SA.
+  --max-session-age-hours N    Enable the orphan-session watchdog (issue
+                               #180). When set, each cron pass additionally
+                               scans for sessions whose first event is
+                               older than N hours but which never emitted
+                               AGENT_COMPLETED. Each new orphan surfaces
+                               as a typed 'session_orphaned' failure in
+                               the JSON report; the state table records
+                               per-scan + cumulative audit rows. Disabled
+                               by default; skipped automatically in any
+                               backfill run.
   -h | --help                  Show this help.
 EOF
   exit "${1:-1}"
@@ -165,6 +176,8 @@ while [[ $# -gt 0 ]]; do
     --job-name)        require_arg "$1" "${2-}"; JOB_NAME="$2"; shift 2 ;;
     --smoke)           SMOKE=true; shift ;;
     --extraction-mode) require_arg "$1" "${2-}"; EXTRACTION_MODE="$2"; shift 2 ;;
+    --max-session-age-hours)
+                       require_arg "$1" "${2-}"; MAX_SESSION_AGE_HOURS="$2"; shift 2 ;;
     -h|--help)         usage 0 ;;
     *)                 echo "Unknown argument: $1" >&2; usage 1 ;;
   esac
@@ -562,6 +575,13 @@ fi
 # set it themselves on a custom image.
 if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
   ENV_VARS+=("BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor")
+fi
+# Orphan-session watchdog (issue #180). Only wired when the
+# operator explicitly opts in via ``--max-session-age-hours``;
+# default deploys ship without the watchdog so they don't pay
+# the extra discovery query.
+if [[ -n "${MAX_SESSION_AGE_HOURS}" ]]; then
+  ENV_VARS+=("BQAA_MAX_SESSION_AGE_HOURS=${MAX_SESSION_AGE_HOURS}")
 fi
 # Comma-join for --set-env-vars (no shell-quoting issues since
 # all values are simple identifiers / numbers).

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -88,6 +88,14 @@ Env vars (all set by the deploy script via
   When unset, the reference module's ``EXTRACTORS`` registry
   is used directly — the simpler compiled-only path that
   needs no offline bundle-build step.
+* ``BQAA_MAX_SESSION_AGE_HOURS`` (default unset) — enables the
+  orphan-session watchdog (issue #180). When set to a positive
+  number, the orchestrator additionally scans for sessions
+  whose first event is older than N hours but which never
+  emitted ``AGENT_COMPLETED``. Each new orphan surfaces as a
+  typed ``session_orphaned`` failure in the JSON report; the
+  state table records per-scan + cumulative audit rows. Skipped
+  automatically in ``BQAA_BACKFILL=true`` mode.
 
 Exit codes mirror the CLI:
 
@@ -387,6 +395,20 @@ def main() -> int:
       os.environ.get("BQAA_REFERENCE_EXTRACTORS_MODULE") or None
   )
   bundles_root = os.environ.get("BQAA_BUNDLES_ROOT") or None
+  # Orphan-session watchdog (issue #180). Unset means disabled —
+  # mirrors the CLI flag. ``_optional_env_float`` raises ``exit 2``
+  # on a non-numeric value at the boundary, and the materializer's
+  # own validator rejects ``<= 0`` so a deployed
+  # ``BQAA_MAX_SESSION_AGE_HOURS=-1`` typo fails fast instead of
+  # producing a degenerate cutoff.
+  max_session_age_hours_raw = os.environ.get("BQAA_MAX_SESSION_AGE_HOURS")
+  max_session_age_hours: Optional[float]
+  if max_session_age_hours_raw is None or not max_session_age_hours_raw.strip():
+    max_session_age_hours = None
+  else:
+    max_session_age_hours = _optional_env_float(
+        "BQAA_MAX_SESSION_AGE_HOURS", 0.0
+    )
 
   _emit(
       "INFO",
@@ -405,6 +427,7 @@ def main() -> int:
       extraction_mode=extraction_mode,
       bundles_root=bundles_root,
       reference_extractors_module=reference_extractors_module,
+      max_session_age_hours=max_session_age_hours,
   )
 
   try:
@@ -480,6 +503,7 @@ def main() -> int:
         extraction_mode=extraction_mode,
         bundles_root=bundles_root,
         reference_extractors_module=reference_extractors_module,
+        max_session_age_hours=max_session_age_hours,
     )
 
     # Structured JSON report for Cloud Logging. Cloud Logging

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1910,6 +1910,22 @@ def materialize_window(
             "asserted by SDK tests)."
         ),
     ),
+    max_session_age_hours: Optional[float] = typer.Option(
+        None,
+        "--max-session-age-hours",
+        help=(
+            "Enable the orphan-session watchdog (issue #180). When "
+            "set, the orchestrator additionally scans for sessions "
+            "whose first event is older than N hours but which "
+            "never emitted the completion event. Each new orphan "
+            "surfaces as a typed 'session_orphaned' failure in the "
+            "JSON report; the state table records per-scan "
+            "(mode='orphan_scan') and cumulative "
+            "(mode='orphan_ledger') audit rows under the same "
+            "state_key. Disabled by default; skipped in --backfill "
+            "mode."
+        ),
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -1969,6 +1985,7 @@ def materialize_window(
         to_time=parsed_to,
         extraction_mode=extraction_mode,
         state_key_suffix=state_key_suffix,
+        max_session_age_hours=max_session_age_hours,
     )
     typer.echo(format_output(result.to_json(), fmt))
     if not result.ok:

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -114,24 +114,54 @@ CREATE TABLE IF NOT EXISTS `{table_ref}` (
   ok BOOL NOT NULL,
   error_detail STRING,
   report_json STRING,
-  mode STRING
+  mode STRING,
+  orphan_watermark TIMESTAMP,
+  flagged_session_ids ARRAY<STRING>
 )
 PARTITION BY DATE(run_started_at)
 CLUSTER BY state_key, run_started_at
 """
 
-# ``mode`` was added to the schema in the ``--backfill`` follow-up
-# (issue #177). Older state tables were created without it; running
-# ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS`` on every
-# ``ensure_state_table`` call is idempotent in BigQuery and brings
-# pre-existing tables up to the current schema without a destructive
-# migration. Reads default missing rows to ``mode='steady'``.
+# Additive schema migrations. Older state tables were created
+# without these columns; running ``ALTER TABLE ... ADD COLUMN IF
+# NOT EXISTS`` on every ``ensure_state_table`` call is idempotent
+# in BigQuery and brings pre-existing tables up to the current
+# schema without a destructive migration. Reads of the migrated
+# columns on rows written by older SDK versions return ``NULL``;
+# callers default missing values per-column:
+#
+# * ``mode`` -> ``STATE_MODE_STEADY`` (issue #177, backfill follow-up).
+# * ``orphan_watermark`` -> ``None`` (issue #180, orphan watchdog).
+# * ``flagged_session_ids`` -> ``[]`` (issue #180).
 _STATE_TABLE_MODE_MIGRATIONS = (
     "ALTER TABLE `{table_ref}` ADD COLUMN IF NOT EXISTS mode STRING",
+    "ALTER TABLE `{table_ref}` ADD COLUMN IF NOT EXISTS orphan_watermark TIMESTAMP",
+    (
+        "ALTER TABLE `{table_ref}` ADD COLUMN IF NOT EXISTS"
+        " flagged_session_ids ARRAY<STRING>"
+    ),
 )
 
 STATE_MODE_STEADY = "steady"
 STATE_MODE_BACKFILL = "backfill"
+# Orphan watchdog modes (issue #180).
+#
+# ``orphan_scan`` is a per-scan audit row — one row per cron pass
+# when ``max_session_age_hours`` is enabled. ``sessions_discovered``
+# holds the count of orphan sessions newly flagged in THIS scan,
+# ``flagged_session_ids`` holds those new session_ids, and
+# ``orphan_watermark`` holds the upper bound (``cutoff_at``) of the
+# scan window so the next pass uses strict ``>`` on the same column.
+#
+# ``orphan_ledger`` is the cumulative ledger row written alongside
+# every ``orphan_scan``. ``flagged_session_ids`` holds the running
+# set of all unresolved orphan session_ids known for this state_key.
+# Append-only by run, with reads picking the most recent row per
+# state_key — same shape as the steady checkpoint, so a future
+# ``orphan_scan`` filters its discovery against the read-back
+# ledger's flagged set even on scans that find zero new orphans.
+STATE_MODE_ORPHAN_SCAN = "orphan_scan"
+STATE_MODE_ORPHAN_LEDGER = "orphan_ledger"
 
 # Extraction modes (B2, issue #178 follow-up).
 #
@@ -227,6 +257,15 @@ class StateRow:
   error_detail: Optional[str] = None
   report_json: Optional[str] = None
   mode: str = STATE_MODE_STEADY
+  # Orphan-watchdog fields (issue #180). Populated only for rows
+  # whose ``mode`` is :data:`STATE_MODE_ORPHAN_SCAN` (the per-scan
+  # audit row carries that scan's newly-flagged session_ids and the
+  # cutoff watermark) or :data:`STATE_MODE_ORPHAN_LEDGER` (the
+  # cumulative ledger carries the running set of all unresolved
+  # orphan session_ids and the advancing scan watermark). Left at
+  # the dataclass defaults for steady / backfill rows.
+  orphan_watermark: Optional[_dt.datetime] = None
+  flagged_session_ids: Optional[tuple[str, ...]] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -252,10 +291,16 @@ class MaterializeWindowResult:
   # reading ``compiled_outcomes`` cross-reference with this to
   # confirm which bundle ran.
   compile_bundle_fingerprint: Optional[str] = None
+  # Orphan-watchdog result (issue #180). Populated only when the
+  # caller passes ``max_session_age_hours``. ``None`` means the
+  # watchdog was disabled for this run (default). The string
+  # forward-reference resolves at runtime because the actual class
+  # is declared further down in the module.
+  orphan_result: Optional["OrphanScanResult"] = None
 
   def to_json(self) -> dict[str, Any]:
     """JSON-serializable dict (timestamps → ISO 8601 UTC strings)."""
-    return {
+    payload = {
         "run_id": self.run_id,
         "state_key": self.state_key,
         "window_start": _iso(self.window_start),
@@ -272,6 +317,17 @@ class MaterializeWindowResult:
         "ok": self.ok,
         "compile_bundle_fingerprint": self.compile_bundle_fingerprint,
     }
+    if self.orphan_result is not None:
+      payload["orphan"] = {
+          "cutoff_at": _iso(self.orphan_result.cutoff_at),
+          "previous_watermark": _iso_optional(
+              self.orphan_result.previous_watermark
+          ),
+          "new_orphans": list(self.orphan_result.new_orphans),
+          "resolved_orphans": list(self.orphan_result.resolved_orphans),
+          "cumulative_flagged": list(self.orphan_result.cumulative_flagged),
+      }
+    return payload
 
 
 # ------------------------------------------------------------------ #
@@ -543,10 +599,365 @@ def append_state_row(
       "error_detail": row.error_detail,
       "report_json": row.report_json,
       "mode": row.mode,
+      "orphan_watermark": _iso_optional(row.orphan_watermark),
+      # ``insert_rows_json`` accepts a list of strings for an
+      # ARRAY<STRING> column. ``None`` is encoded as a NULL ARRAY
+      # at the column level — distinct from the empty array which
+      # signals "scan ran, zero unresolved orphans".
+      "flagged_session_ids": (
+          list(row.flagged_session_ids)
+          if row.flagged_session_ids is not None
+          else None
+      ),
   }
   errors = bq_client.insert_rows_json(state_table_ref, [payload])
   if errors:
     raise RuntimeError(f"insert into {state_table_ref} failed: {errors!r}")
+
+
+# ------------------------------------------------------------------ #
+# Orphan watchdog (issue #180)                                          #
+# ------------------------------------------------------------------ #
+#
+# Three SQL helpers + one orchestrator-level scan function. The
+# helpers are kept as pure SQL-builders so tests can pin the
+# query shape without round-tripping through a fake BigQuery
+# client, and so the discovery query is auditable.
+#
+# The watchdog model has three durable shapes in the state table:
+#
+# 1. ``orphan_ledger`` — one most-recent row per ``state_key``,
+#    carrying the cumulative set of unresolved orphan session_ids
+#    in ``flagged_session_ids`` and the upper-bound scan watermark
+#    in ``orphan_watermark``.
+# 2. ``orphan_scan`` — one row per cron pass, carrying that scan's
+#    *newly* flagged session_ids (the delta) and the same watermark.
+# 3. ``ok=false`` failures threaded into the regular run's
+#    ``failures[]`` with ``error_code='session_orphaned'`` so
+#    existing Cloud Monitoring alerts on the failure surface fire
+#    immediately — no separate alert wiring per #167's classifier.
+
+
+@dataclasses.dataclass(frozen=True)
+class OrphanLedger:
+  """Read-side view of the most recent ``orphan_ledger`` row."""
+
+  orphan_watermark: Optional[_dt.datetime]
+  flagged_session_ids: tuple[str, ...]
+
+  @classmethod
+  def empty(cls) -> "OrphanLedger":
+    """Initial state for a fresh deploy / state_key never scanned."""
+    return cls(orphan_watermark=None, flagged_session_ids=())
+
+
+@dataclasses.dataclass(frozen=True)
+class OrphanScanResult:
+  """Result of one orphan-watchdog scan."""
+
+  cutoff_at: _dt.datetime
+  previous_watermark: Optional[_dt.datetime]
+  new_orphans: tuple[str, ...]
+  resolved_orphans: tuple[str, ...]
+  cumulative_flagged: tuple[str, ...]
+
+
+def build_orphan_select_sql(events_table_ref: str) -> str:
+  """SQL: sessions whose ``MIN(timestamp)`` falls in
+  ``(@orphan_watermark, @cutoff_at]`` and which never emitted
+  ``AGENT_COMPLETED``.
+
+  ``@orphan_watermark`` uses strict ``>`` so the boundary session
+  from the previous scan isn't reconsidered — matches the
+  steady checkpoint's exclusive-lower-bound semantics. ``@cutoff_at``
+  is the inclusive upper bound (the orchestrator computes it as
+  ``now - max_session_age_hours`` so anything more recent has had
+  enough time to emit a terminal event).
+
+  The discovery is by ``MIN(timestamp)`` (first event) rather than
+  ``MAX``: an in-flight session that started before the cutoff but
+  is still emitting events is the orphan-watchdog's concern; a
+  session whose newest event is before the cutoff but which started
+  even earlier was already covered by a prior scan.
+
+  ``@already_flagged`` (the previous ledger's cumulative set) is
+  excluded with ``NOT IN UNNEST(...)`` so the per-scan ``orphan_scan``
+  row records only the delta — operators reading the audit trail
+  see "how many new orphans appeared this scan" without having to
+  diff against the previous scan's set themselves. The
+  ``orphan_ledger`` row written alongside ``orphan_scan`` carries
+  the full cumulative set after the resolve step.
+  """
+  return f"""\
+WITH session_envelope AS (
+  SELECT
+    session_id,
+    MIN(timestamp) AS first_event_at,
+    COUNTIF(event_type = 'AGENT_COMPLETED') AS terminal_event_count
+  FROM `{events_table_ref}`
+  WHERE timestamp > COALESCE(@orphan_watermark, TIMESTAMP('1970-01-01'))
+    AND timestamp <= @cutoff_at
+  GROUP BY session_id
+)
+SELECT session_id, first_event_at
+FROM session_envelope
+WHERE terminal_event_count = 0
+  AND session_id NOT IN UNNEST(@already_flagged)
+ORDER BY first_event_at, session_id
+"""
+
+
+def build_resolved_orphan_sql(events_table_ref: str) -> str:
+  """SQL: subset of the previously-flagged orphan session_ids
+  that have since emitted ``AGENT_COMPLETED``.
+
+  Run after the discovery query so the orchestrator can drop
+  resolved orphans from the cumulative ledger. The "resolved"
+  signal is real-world: a late terminal event arrived, the
+  steady cron will pick the session up on its next pass, and the
+  watchdog's running ledger should not keep flagging it as
+  unresolved.
+
+  The probe is bounded to the previously-flagged set to keep
+  scan cost proportional to the unresolved-orphan count rather
+  than the full events table — the watchdog is a low-traffic
+  signal compared to the steady cron, and we don't want it to
+  dominate query bytes.
+  """
+  return f"""\
+SELECT DISTINCT session_id
+FROM `{events_table_ref}`
+WHERE session_id IN UNNEST(@previously_flagged)
+  AND event_type = 'AGENT_COMPLETED'
+"""
+
+
+def build_orphan_ledger_select_sql(state_table_ref: str) -> str:
+  """Most recent ``orphan_ledger`` row for a given ``state_key``.
+
+  Mirrors :func:`build_state_select_sql` (mode='steady') but
+  filters on ``mode = 'orphan_ledger'`` so the steady checkpoint
+  doesn't interfere — they share the same state_key but live in
+  disjoint row groups.
+
+  Returns ``flagged_session_ids`` (ARRAY<STRING>) and
+  ``orphan_watermark`` (TIMESTAMP). The
+  :class:`OrphanLedger.empty` factory is used when no row exists
+  yet (fresh deploy / state_key never scanned).
+  """
+  state_table_ref_quoted = "`" + state_table_ref + "`"
+  return (
+      f"SELECT\n"
+      f"  state_key,\n"
+      f"  run_started_at,\n"
+      f"  orphan_watermark,\n"
+      f"  flagged_session_ids\n"
+      f"FROM {state_table_ref_quoted}\n"
+      f"WHERE state_key = @state_key\n"
+      f"  AND mode = '{STATE_MODE_ORPHAN_LEDGER}'\n"
+      f"ORDER BY run_started_at DESC\n"
+      f"LIMIT 1\n"
+  )
+
+
+def read_orphan_ledger(
+    bq_client: Any, state_table_ref: str, state_key: str
+) -> OrphanLedger:
+  """Load the most recent ``orphan_ledger`` row for ``state_key``,
+  or :meth:`OrphanLedger.empty` when none exists."""
+  from google.cloud import bigquery
+
+  rows = list(
+      bq_client.query(
+          build_orphan_ledger_select_sql(state_table_ref),
+          job_config=bigquery.QueryJobConfig(
+              query_parameters=[
+                  bigquery.ScalarQueryParameter(
+                      "state_key", "STRING", state_key
+                  ),
+              ]
+          ),
+      ).result()
+  )
+  if not rows:
+    return OrphanLedger.empty()
+  row = rows[0]
+  flagged_raw = getattr(row, "flagged_session_ids", None) or ()
+  return OrphanLedger(
+      orphan_watermark=getattr(row, "orphan_watermark", None),
+      flagged_session_ids=tuple(flagged_raw),
+  )
+
+
+def discover_orphan_sessions(
+    bq_client: Any,
+    events_table_ref: str,
+    *,
+    orphan_watermark: Optional[_dt.datetime],
+    cutoff_at: _dt.datetime,
+    already_flagged: tuple[str, ...],
+) -> tuple[str, ...]:
+  """Query for new orphan session_ids in
+  ``(orphan_watermark, cutoff_at]``."""
+  from google.cloud import bigquery
+
+  rows = list(
+      bq_client.query(
+          build_orphan_select_sql(events_table_ref),
+          job_config=bigquery.QueryJobConfig(
+              query_parameters=[
+                  bigquery.ScalarQueryParameter(
+                      "orphan_watermark", "TIMESTAMP", orphan_watermark
+                  ),
+                  bigquery.ScalarQueryParameter(
+                      "cutoff_at", "TIMESTAMP", cutoff_at
+                  ),
+                  bigquery.ArrayQueryParameter(
+                      "already_flagged", "STRING", list(already_flagged)
+                  ),
+              ]
+          ),
+      ).result()
+  )
+  return tuple(r.session_id for r in rows)
+
+
+def probe_resolved_orphans(
+    bq_client: Any,
+    events_table_ref: str,
+    *,
+    previously_flagged: tuple[str, ...],
+) -> tuple[str, ...]:
+  """Subset of ``previously_flagged`` that now has terminal events."""
+  if not previously_flagged:
+    return ()
+  from google.cloud import bigquery
+
+  rows = list(
+      bq_client.query(
+          build_resolved_orphan_sql(events_table_ref),
+          job_config=bigquery.QueryJobConfig(
+              query_parameters=[
+                  bigquery.ArrayQueryParameter(
+                      "previously_flagged",
+                      "STRING",
+                      list(previously_flagged),
+                  ),
+              ]
+          ),
+      ).result()
+  )
+  return tuple(r.session_id for r in rows)
+
+
+def run_orphan_watchdog(
+    bq_client: Any,
+    *,
+    events_table_ref: str,
+    state_table_ref: str,
+    state_key: str,
+    run_id: str,
+    run_started_at: _dt.datetime,
+    max_session_age_hours: float,
+) -> OrphanScanResult:
+  """End-to-end orphan-watchdog scan.
+
+  Reads the most recent ``orphan_ledger`` row, runs the discovery
+  query against ``(orphan_watermark, cutoff_at]``, probes for
+  late-arriving terminal events on previously-flagged session_ids,
+  and writes two state rows:
+
+  * ``orphan_scan`` — audit row for this scan: new orphans only,
+    cutoff watermark.
+  * ``orphan_ledger`` — cumulative set after the resolve step:
+    ``(previous_flagged - resolved) ∪ new_orphans``.
+
+  The cutoff is computed as ``run_started_at - max_session_age_hours``
+  and stored as both ``scan_end`` (this scan's audit window upper
+  bound) and ``orphan_watermark`` (the next scan's exclusive lower
+  bound — strict ``>`` skips the boundary session). The advance is
+  unconditional: even if zero new orphans are found, the watermark
+  advances so the next scan does less work.
+
+  Returns the result so the orchestrator can thread the new orphans
+  into the run's ``failures[]`` as ``session_orphaned`` typed
+  failures.
+  """
+  if max_session_age_hours <= 0:
+    raise ValueError(
+        f"max_session_age_hours must be > 0; got {max_session_age_hours!r}"
+    )
+  cutoff_at = run_started_at - _dt.timedelta(hours=max_session_age_hours)
+
+  ledger = read_orphan_ledger(bq_client, state_table_ref, state_key)
+  new_orphans = discover_orphan_sessions(
+      bq_client,
+      events_table_ref,
+      orphan_watermark=ledger.orphan_watermark,
+      cutoff_at=cutoff_at,
+      already_flagged=ledger.flagged_session_ids,
+  )
+  resolved_orphans = probe_resolved_orphans(
+      bq_client,
+      events_table_ref,
+      previously_flagged=ledger.flagged_session_ids,
+  )
+
+  # Cumulative ledger: drop resolved, union new. Preserve previous
+  # declaration order for stable diffs, then append new orphans in
+  # the order discovery returned them (sorted by ``first_event_at``).
+  resolved_set = set(resolved_orphans)
+  carry_forward = tuple(
+      s for s in ledger.flagged_session_ids if s not in resolved_set
+  )
+  cumulative_flagged = carry_forward + new_orphans
+
+  audit_row = StateRow(
+      state_key=state_key,
+      run_id=run_id,
+      run_started_at=run_started_at,
+      scan_start=ledger.orphan_watermark
+      or _dt.datetime(1970, 1, 1, tzinfo=_dt.timezone.utc),
+      scan_end=cutoff_at,
+      last_completion_at=None,
+      sessions_discovered=len(new_orphans),
+      sessions_materialized=0,
+      sessions_failed=len(new_orphans),
+      ok=len(new_orphans) == 0,
+      error_detail=None,
+      report_json=None,
+      mode=STATE_MODE_ORPHAN_SCAN,
+      orphan_watermark=cutoff_at,
+      flagged_session_ids=new_orphans,
+  )
+  ledger_row = StateRow(
+      state_key=state_key,
+      run_id=run_id,
+      run_started_at=run_started_at,
+      scan_start=ledger.orphan_watermark
+      or _dt.datetime(1970, 1, 1, tzinfo=_dt.timezone.utc),
+      scan_end=cutoff_at,
+      last_completion_at=None,
+      sessions_discovered=len(cumulative_flagged),
+      sessions_materialized=0,
+      sessions_failed=len(cumulative_flagged),
+      ok=len(cumulative_flagged) == 0,
+      error_detail=None,
+      report_json=None,
+      mode=STATE_MODE_ORPHAN_LEDGER,
+      orphan_watermark=cutoff_at,
+      flagged_session_ids=cumulative_flagged,
+  )
+  append_state_row(bq_client, state_table_ref, audit_row)
+  append_state_row(bq_client, state_table_ref, ledger_row)
+
+  return OrphanScanResult(
+      cutoff_at=cutoff_at,
+      previous_watermark=ledger.orphan_watermark,
+      new_orphans=new_orphans,
+      resolved_orphans=resolved_orphans,
+      cumulative_flagged=cumulative_flagged,
+  )
 
 
 # ------------------------------------------------------------------ #
@@ -748,6 +1159,7 @@ def run_materialize_window(
     to_time: Optional[_dt.datetime] = None,
     state_key_suffix: Optional[str] = None,
     extraction_mode: str = EXTRACTION_MODE_AI_FALLBACK,
+    max_session_age_hours: Optional[float] = None,
 ) -> MaterializeWindowResult:
   """The end-to-end run.
 
@@ -810,7 +1222,35 @@ def run_materialize_window(
       typed ``empty_extraction`` failures (with sample diagnostics
       in ``error_detail``) ahead of the materializer's row-count
       classifier.
+    max_session_age_hours: If set (and > 0), enables the
+      orphan-session watchdog (issue #180). After the steady
+      discover+materialize pass, the orchestrator additionally
+      scans for sessions whose first event is older than the
+      cutoff but which never emitted ``AGENT_COMPLETED``. Each
+      new orphan surfaces as a typed
+      ``error_code='session_orphaned'`` entry in ``failures[]``
+      and flips ``ok`` to False — slotting into PR #167's
+      failure-mode classifier so existing Cloud Monitoring
+      alerts fire without separate wiring. The watchdog state
+      lives in the same state table under
+      ``mode='orphan_scan'`` (per-pass audit) +
+      ``mode='orphan_ledger'`` (cumulative ledger) rows; the
+      scan watermark advances unconditionally so the next pass
+      does less work. Skipped in ``backfill=True`` mode
+      (backfill runs scan a fixed historical window where the
+      "what's still in-flight?" question is undefined).
+      ``None`` (default) disables the watchdog.
   """
+  # Orphan-watchdog validation. Like the numeric guardrails below,
+  # a typo at the boundary (``--max-session-age-hours=-1`` or ``0``)
+  # is rejected here rather than producing a "scan into the future"
+  # cutoff or a degenerate "everything is an orphan" cutoff.
+  if max_session_age_hours is not None and max_session_age_hours <= 0:
+    raise ValueError(
+        f"--max-session-age-hours must be > 0 when set; got "
+        f"{max_session_age_hours!r}"
+    )
+
   # Extraction-mode validation. Reject the typo at the boundary so
   # downstream code never has to handle an unknown mode silently.
   if extraction_mode not in _VALID_EXTRACTION_MODES:
@@ -1437,6 +1877,50 @@ def run_materialize_window(
       if not r.ok
   ]
 
+  # Orphan-watchdog scan (issue #180). Runs after the steady pass
+  # so a partial steady failure doesn't block the watchdog signal,
+  # and so the steady state row is written with its own counts
+  # before the orphan rows are appended. Disabled in backfill mode
+  # (the "what's still in-flight?" question is undefined when the
+  # scan window is a fixed historical slice).
+  orphan_result: Optional[OrphanScanResult] = None
+  orphan_failures: list[dict[str, Any]] = []
+  if max_session_age_hours is not None and not backfill:
+    qualified_events_ref = (
+        events_table
+        if events_table.count(".") >= 2
+        else f"{project_id}.{dataset_id}.{events_table}"
+    )
+    orphan_result = run_orphan_watchdog(
+        client,
+        events_table_ref=qualified_events_ref,
+        state_table_ref=state_table_ref,
+        state_key=state_key,
+        run_id=run_id,
+        run_started_at=run_started,
+        max_session_age_hours=max_session_age_hours,
+    )
+    cutoff_iso = orphan_result.cutoff_at.isoformat()
+    for orphan_session_id in orphan_result.new_orphans:
+      orphan_failures.append(
+          {
+              "session_id": orphan_session_id,
+              "error_code": "session_orphaned",
+              "error_detail": (
+                  f"session {orphan_session_id!r} has first event older than "
+                  f"{max_session_age_hours} hours (cutoff {cutoff_iso}) but "
+                  f"never emitted '{completion_event_type}'. The orphan "
+                  f"watchdog flagged it on this scan and recorded it in the "
+                  f"cumulative ledger (state_key={state_key!r}, "
+                  f"mode='{STATE_MODE_ORPHAN_LEDGER}'). Resolve by either "
+                  f"emitting the missing terminal event (the watchdog will "
+                  f"drop the session from the ledger on its next pass) or "
+                  f"triaging the underlying agent failure."
+              ),
+          }
+      )
+
+  combined_failures = failures + orphan_failures
   result = _build_result(
       run_id=run_id,
       state_key=state_key,
@@ -1447,11 +1931,17 @@ def run_materialize_window(
       sessions_discovered=len(discovered),
       session_results=session_results,
       compiled_outcomes=outcomes_counts,
-      ok=ok and not failures,
+      ok=ok and not combined_failures,
       compile_bundle_fingerprint=compile_bundle_fingerprint,
+      extra_failures=orphan_failures,
+      orphan_result=orphan_result,
   )
 
-  # Append-only state row.
+  # Append-only state row for the steady pass. The orphan watchdog
+  # writes its own ``orphan_scan`` + ``orphan_ledger`` rows inside
+  # ``run_orphan_watchdog`` above, so the steady row only reports
+  # the steady-pass counts here — keeping the audit trail per-row
+  # type.
   append_state_row(
       client,
       state_table_ref,
@@ -1465,7 +1955,7 @@ def run_materialize_window(
           sessions_discovered=len(discovered),
           sessions_materialized=sum(1 for r in session_results if r.ok),
           sessions_failed=len(failures),
-          ok=result.ok,
+          ok=ok and not failures,
           error_detail=(failures[0]["error_detail"] if failures else None),
           report_json=json.dumps(result.to_json()),
           mode=current_state_mode,
@@ -1730,6 +2220,8 @@ def _build_result(
     compiled_outcomes: dict[str, int],
     ok: bool,
     compile_bundle_fingerprint: Optional[str] = None,
+    extra_failures: Optional[Sequence[dict[str, Any]]] = None,
+    orphan_result: Optional[OrphanScanResult] = None,
 ) -> MaterializeWindowResult:
   rows_materialized: dict[str, int] = {}
   # Aggregate per-session table_statuses into the report with
@@ -1773,6 +2265,13 @@ def _build_result(
       for r in session_results
       if not r.ok
   ]
+  # Orphan-watchdog failures (issue #180) are merged into the
+  # report's ``failures[]`` so the existing #167 classifier +
+  # Cloud Monitoring alerts surface them without separate wiring.
+  # They also count toward ``sessions_failed`` so the operator-
+  # visible "did this run cleanly?" signal is honest.
+  if extra_failures:
+    failures.extend(extra_failures)
 
   return MaterializeWindowResult(
       run_id=run_id,
@@ -1790,4 +2289,5 @@ def _build_result(
       failures=failures,
       ok=ok,
       compile_bundle_fingerprint=compile_bundle_fingerprint,
+      orphan_result=orphan_result,
   )

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -693,7 +693,7 @@ WITH session_envelope AS (
   SELECT
     session_id,
     MIN(timestamp) AS first_event_at,
-    COUNTIF(event_type = 'AGENT_COMPLETED') AS terminal_event_count
+    COUNTIF(event_type = @completion_event_type) AS terminal_event_count
   FROM `{events_table_ref}`
   WHERE timestamp > COALESCE(@orphan_watermark, TIMESTAMP('1970-01-01'))
     AND timestamp <= @cutoff_at
@@ -709,7 +709,7 @@ ORDER BY first_event_at, session_id
 
 def build_resolved_orphan_sql(events_table_ref: str) -> str:
   """SQL: subset of the previously-flagged orphan session_ids
-  that have since emitted ``AGENT_COMPLETED``.
+  that have since emitted the configured terminal event.
 
   Run after the discovery query so the orchestrator can drop
   resolved orphans from the cumulative ledger. The "resolved"
@@ -718,17 +718,35 @@ def build_resolved_orphan_sql(events_table_ref: str) -> str:
   watchdog's running ledger should not keep flagging it as
   unresolved.
 
-  The probe is bounded to the previously-flagged set to keep
-  scan cost proportional to the unresolved-orphan count rather
-  than the full events table — the watchdog is a low-traffic
-  signal compared to the steady cron, and we don't want it to
-  dominate query bytes.
+  Two predicates jointly bound the scan cost:
+
+  * ``session_id IN UNNEST(@previously_flagged)`` keeps the row
+    fan-out small even on huge events tables.
+  * ``timestamp > @resolve_lower_bound AND timestamp <=
+    @resolve_upper_bound`` enables partition pruning on the
+    plugin's timestamp-partitioned table. Without it, BigQuery
+    would scan every partition once the ledger held any flagged
+    session — turning the watchdog into a query-byte regression
+    as the customer's event history grows.
+
+  The orchestrator passes ``resolve_lower_bound`` =
+  ``previous_orphan_watermark`` (advances every scan; events
+  before that cutoff were either resolved earlier or never had
+  a terminal event in scope) and ``resolve_upper_bound`` =
+  ``run_started_at``. Late terminal events whose ``timestamp``
+  is more than ``max_session_age_hours`` in the past
+  (theoretically possible if an agent emits with a stale
+  emission time) won't be picked up — operators with that
+  pattern should widen the bound, but the common case keeps the
+  partition predicate tight.
   """
   return f"""\
 SELECT DISTINCT session_id
 FROM `{events_table_ref}`
 WHERE session_id IN UNNEST(@previously_flagged)
-  AND event_type = 'AGENT_COMPLETED'
+  AND event_type = @completion_event_type
+  AND timestamp > @resolve_lower_bound
+  AND timestamp <= @resolve_upper_bound
 """
 
 
@@ -796,9 +814,18 @@ def discover_orphan_sessions(
     orphan_watermark: Optional[_dt.datetime],
     cutoff_at: _dt.datetime,
     already_flagged: tuple[str, ...],
+    completion_event_type: str,
 ) -> tuple[str, ...]:
   """Query for new orphan session_ids in
-  ``(orphan_watermark, cutoff_at]``."""
+  ``(orphan_watermark, cutoff_at]``.
+
+  ``completion_event_type`` mirrors ``run_materialize_window``'s
+  ``--completion-event-type`` flag — the terminal-event name the
+  watchdog scans for. Defaults flow from the orchestrator so a
+  deploy configured for a custom terminal event (e.g.
+  ``MY_TERMINAL``) doesn't get false ``session_orphaned``
+  failures the steady cron just successfully materialized.
+  """
   from google.cloud import bigquery
 
   rows = list(
@@ -815,6 +842,11 @@ def discover_orphan_sessions(
                   bigquery.ArrayQueryParameter(
                       "already_flagged", "STRING", list(already_flagged)
                   ),
+                  bigquery.ScalarQueryParameter(
+                      "completion_event_type",
+                      "STRING",
+                      completion_event_type,
+                  ),
               ]
           ),
       ).result()
@@ -827,8 +859,19 @@ def probe_resolved_orphans(
     events_table_ref: str,
     *,
     previously_flagged: tuple[str, ...],
+    completion_event_type: str,
+    resolve_lower_bound: _dt.datetime,
+    resolve_upper_bound: _dt.datetime,
 ) -> tuple[str, ...]:
-  """Subset of ``previously_flagged`` that now has terminal events."""
+  """Subset of ``previously_flagged`` that now has terminal events
+  in ``(resolve_lower_bound, resolve_upper_bound]``.
+
+  The timestamp bounds let BigQuery prune partitions on the
+  plugin's timestamp-partitioned events table. Without them, the
+  probe scans every partition once the ledger has any flagged
+  session — turning the watchdog into a query-byte regression as
+  event history grows.
+  """
   if not previously_flagged:
     return ()
   from google.cloud import bigquery
@@ -842,6 +885,21 @@ def probe_resolved_orphans(
                       "previously_flagged",
                       "STRING",
                       list(previously_flagged),
+                  ),
+                  bigquery.ScalarQueryParameter(
+                      "completion_event_type",
+                      "STRING",
+                      completion_event_type,
+                  ),
+                  bigquery.ScalarQueryParameter(
+                      "resolve_lower_bound",
+                      "TIMESTAMP",
+                      resolve_lower_bound,
+                  ),
+                  bigquery.ScalarQueryParameter(
+                      "resolve_upper_bound",
+                      "TIMESTAMP",
+                      resolve_upper_bound,
                   ),
               ]
           ),
@@ -859,6 +917,7 @@ def run_orphan_watchdog(
     run_id: str,
     run_started_at: _dt.datetime,
     max_session_age_hours: float,
+    completion_event_type: str = DEFAULT_COMPLETION_EVENT_TYPE,
 ) -> OrphanScanResult:
   """End-to-end orphan-watchdog scan.
 
@@ -896,11 +955,26 @@ def run_orphan_watchdog(
       orphan_watermark=ledger.orphan_watermark,
       cutoff_at=cutoff_at,
       already_flagged=ledger.flagged_session_ids,
+      completion_event_type=completion_event_type,
+  )
+  # Resolved-orphan probe lower bound: use the previous orphan
+  # watermark when present (events written before that cutoff
+  # were already in scope of a prior scan); fall back to the
+  # epoch for the bootstrap case where the previous ledger never
+  # advanced a watermark — when ``previously_flagged`` is empty
+  # the probe short-circuits and the bound isn't sent anyway, so
+  # this fallback path is only exercised by a future code path
+  # that pre-seeds the ledger.
+  resolve_lower_bound = ledger.orphan_watermark or _dt.datetime(
+      1970, 1, 1, tzinfo=_dt.timezone.utc
   )
   resolved_orphans = probe_resolved_orphans(
       bq_client,
       events_table_ref,
       previously_flagged=ledger.flagged_session_ids,
+      completion_event_type=completion_event_type,
+      resolve_lower_bound=resolve_lower_bound,
+      resolve_upper_bound=run_started_at,
   )
 
   # Cumulative ledger: drop resolved, union new. Preserve previous
@@ -1899,6 +1973,7 @@ def run_materialize_window(
         run_id=run_id,
         run_started_at=run_started,
         max_session_age_hours=max_session_age_hours,
+        completion_event_type=completion_event_type,
     )
     cutoff_iso = orphan_result.cutoff_at.isoformat()
     for orphan_session_id in orphan_result.new_orphans:

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -3512,7 +3512,12 @@ class TestOrphanWatchdogBuilders:
 
   def test_orphan_select_filters_terminal_event_count_zero(self):
     sql = mw.build_orphan_select_sql("p.d.agent_events")
-    assert "COUNTIF(event_type = 'AGENT_COMPLETED')" in sql
+    # ``completion_event_type`` must be parameter-bound, not a
+    # literal — operators using ``--completion-event-type=MY_TERMINAL``
+    # would otherwise see the watchdog flag sessions the steady
+    # cron just successfully materialized (PR #224 P1).
+    assert "event_type = @completion_event_type" in sql
+    assert "'AGENT_COMPLETED'" not in sql
     assert "terminal_event_count = 0" in sql
 
   def test_orphan_select_excludes_already_flagged(self):
@@ -3531,7 +3536,18 @@ class TestOrphanWatchdogBuilders:
     # The probe must be parameterized on the previously-flagged set
     # rather than scanning the full events table.
     assert "IN UNNEST(@previously_flagged)" in sql
-    assert "event_type = 'AGENT_COMPLETED'" in sql
+    # Completion event type is parameter-bound (PR #224 P1).
+    assert "event_type = @completion_event_type" in sql
+    assert "'AGENT_COMPLETED'" not in sql
+
+  def test_resolved_orphan_sql_has_timestamp_partition_predicate(self):
+    """PR #224 P2: without a timestamp predicate, the resolve probe
+    can't prune partitions on the plugin's timestamp-partitioned
+    events table — turning the watchdog into a query-byte
+    regression as event history grows. Pin both bounds."""
+    sql = mw.build_resolved_orphan_sql("p.d.agent_events")
+    assert "timestamp > @resolve_lower_bound" in sql
+    assert "timestamp <= @resolve_upper_bound" in sql
 
 
 class TestOrphanWatchdogScan:
@@ -3695,6 +3711,101 @@ class TestOrphanWatchdogScan:
           run_started_at=_dt.datetime.now(_dt.timezone.utc),
           max_session_age_hours=0,
       )
+
+  def test_custom_completion_event_type_is_query_bound(self):
+    """PR #224 P1: the watchdog must use the configured
+    ``completion_event_type`` (matching the steady cron's
+    ``--completion-event-type``) as a parameter binding, not the
+    hardcoded ``'AGENT_COMPLETED'`` literal. Without this, deploys
+    with a custom terminal event would see the watchdog falsely
+    flag sessions that the steady cron just materialized."""
+    from google.cloud.bigquery import ArrayQueryParameter
+    from google.cloud.bigquery import ScalarQueryParameter
+
+    now = _dt.datetime(2026, 5, 20, 18, 0, tzinfo=_dt.timezone.utc)
+    client = self._stub(
+        ledger_rows=[
+            _orphan_state_row(
+                "orphan_ledger",
+                flagged=("orphan-A",),
+                watermark=now - _dt.timedelta(hours=7),
+            )
+        ],
+        discovery_rows=[],
+        resolved_rows=[],
+    )
+    mw.run_orphan_watchdog(
+        client,
+        events_table_ref="p.d.agent_events",
+        state_table_ref="p.d._bqaa_materialization_state",
+        state_key="sk",
+        run_id="run-custom",
+        run_started_at=now,
+        max_session_age_hours=6.0,
+        completion_event_type="MY_TERMINAL",
+    )
+    # Extract every ScalarQueryParameter named completion_event_type
+    # across the discovery + resolve calls and assert they all
+    # carry the custom event name. Both queries must respect it.
+    completion_params = []
+    for call in client.query.call_args_list:
+      job_config = call.kwargs.get("job_config")
+      if job_config is None:
+        continue
+      for param in job_config.query_parameters:
+        if (
+            isinstance(param, ScalarQueryParameter)
+            and param.name == "completion_event_type"
+        ):
+          completion_params.append(param.value)
+    assert (
+        len(completion_params) >= 2
+    ), "completion_event_type must be bound on both discovery and resolve probes"
+    assert all(
+        v == "MY_TERMINAL" for v in completion_params
+    ), f"watchdog must forward the configured event_type; saw {completion_params!r}"
+
+  def test_resolved_probe_passes_timestamp_partition_bounds(self):
+    """PR #224 P2: the resolve probe must carry
+    ``resolve_lower_bound`` and ``resolve_upper_bound`` so BigQuery
+    can prune partitions. Lower bound = previous ledger watermark,
+    upper bound = run_started_at."""
+    from google.cloud.bigquery import ScalarQueryParameter
+
+    now = _dt.datetime(2026, 5, 20, 18, 0, tzinfo=_dt.timezone.utc)
+    prior_watermark = now - _dt.timedelta(hours=6, minutes=30)
+    client = self._stub(
+        ledger_rows=[
+            _orphan_state_row(
+                "orphan_ledger",
+                flagged=("orphan-A",),
+                watermark=prior_watermark,
+            )
+        ],
+        discovery_rows=[],
+        resolved_rows=[],
+    )
+    mw.run_orphan_watchdog(
+        client,
+        events_table_ref="p.d.agent_events",
+        state_table_ref="p.d._bqaa_materialization_state",
+        state_key="sk",
+        run_id="run-bounds",
+        run_started_at=now,
+        max_session_age_hours=6.0,
+    )
+    # The third query call is the resolve probe (ledger read,
+    # discovery, resolve — in that order).
+    resolve_call = client.query.call_args_list[2]
+    params = {
+        p.name: p
+        for p in resolve_call.kwargs["job_config"].query_parameters
+        if isinstance(p, ScalarQueryParameter)
+    }
+    assert "resolve_lower_bound" in params
+    assert "resolve_upper_bound" in params
+    assert params["resolve_lower_bound"].value == prior_watermark
+    assert params["resolve_upper_bound"].value == now
 
 
 class TestOrphanWatchdogOrchestratorIntegration:

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -485,7 +485,8 @@ def _stub_bq_client(discovered_rows):
   """A BigQuery client whose ``.query()`` returns:
   - the CREATE TABLE response (anything; we just check it was called)
   - one response per additive schema-migration ALTER
-    (currently: ``ADD COLUMN IF NOT EXISTS mode STRING``)
+    (currently three: ``mode``, ``orphan_watermark``,
+    ``flagged_session_ids``)
   - the state-table read (empty → bootstrap)
   - the discovery query (returns ``discovered_rows``)
   ``.insert_rows_json`` returns [] (no errors).
@@ -499,7 +500,9 @@ def _stub_bq_client(discovered_rows):
   # ``src/bigquery_agent_analytics/materialize_window.py``.
   results = [
       mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
-      mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
+      mock.Mock(result=mock.Mock(return_value=[])),  # ALTER mode
+      mock.Mock(result=mock.Mock(return_value=[])),  # ALTER orphan_watermark
+      mock.Mock(result=mock.Mock(return_value=[])),  # ALTER flagged_session_ids
       mock.Mock(result=mock.Mock(return_value=[])),  # state read
       mock.Mock(result=mock.Mock(return_value=discovered_rows)),  # discovery
   ]
@@ -818,6 +821,12 @@ class TestCheckpointCarryForward:
         side_effect=[
             mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
             mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER orphan_watermark
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER flagged_session_ids
             mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
             mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
         ]
@@ -1528,7 +1537,13 @@ class TestCheckpointNeverRegresses:
     client.query = mock.Mock(
         side_effect=[
             mock.Mock(result=mock.Mock(return_value=[])),  # DDL
-            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
+            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER mode
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER orphan_watermark
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER flagged_session_ids
             mock.Mock(result=mock.Mock(return_value=[state_row])),  # state read
             mock.Mock(result=mock.Mock(return_value=discovered)),  # discovery
         ]
@@ -1590,7 +1605,13 @@ class TestCheckpointNeverRegresses:
     client.query = mock.Mock(
         side_effect=[
             mock.Mock(result=mock.Mock(return_value=[])),  # CREATE TABLE
-            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER ADD mode
+            mock.Mock(result=mock.Mock(return_value=[])),  # ALTER mode
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER orphan_watermark
+            mock.Mock(
+                result=mock.Mock(return_value=[])
+            ),  # ALTER flagged_session_ids
             mock.Mock(result=mock.Mock(return_value=[state_row])),
             mock.Mock(result=mock.Mock(return_value=discovered)),
         ]
@@ -2535,14 +2556,25 @@ class TestEnsureStateTableMigration:
     mw.ensure_state_table(client, "p.d._bqaa_materialization_state")
     queries = [args[0][0] for args in client.query.call_args_list]
     create = next(q for q in queries if q.startswith("CREATE TABLE"))
-    assert (
-        "mode STRING" in create
-    ), "fresh tables must include the mode column in the initial DDL"
+    # Fresh tables include every current column in the initial DDL —
+    # ``mode`` (issue #177) plus the orphan-watchdog columns
+    # (issue #180: ``orphan_watermark``, ``flagged_session_ids``).
+    assert "mode STRING" in create
+    assert "orphan_watermark TIMESTAMP" in create
+    assert "flagged_session_ids ARRAY<STRING>" in create
     alters = [q for q in queries if q.startswith("ALTER TABLE")]
-    assert any("ADD COLUMN IF NOT EXISTS mode STRING" in q for q in alters), (
-        "ensure_state_table must run ADD COLUMN IF NOT EXISTS for the "
-        "mode column on every call so pre-migration tables get patched "
-        "without a destructive migration"
+    # Every additive column has an idempotent ADD COLUMN IF NOT
+    # EXISTS so pre-migration tables get patched up without a
+    # destructive migration.
+    assert any("ADD COLUMN IF NOT EXISTS mode STRING" in q for q in alters)
+    assert any(
+        "ADD COLUMN IF NOT EXISTS orphan_watermark TIMESTAMP" in q
+        for q in alters
+    )
+    assert any(
+        "ADD COLUMN IF NOT EXISTS" in q
+        and "flagged_session_ids ARRAY<STRING>" in q
+        for q in alters
     )
 
 
@@ -3442,3 +3474,299 @@ class TestDeployScriptExtractionModeBoundary:
         "deploy script must propagate a non-zero smoke exit code"
         " before the compiled-only IAM remove runs"
     )
+
+
+# ====================================================================== #
+# Orphan-session watchdog (PR D, issue #180)                              #
+# ====================================================================== #
+
+
+def _orphan_state_row(mode, *, flagged=(), watermark=None, run_started_at=None):
+  """Build a fake BQ row matching the ``orphan_ledger`` /
+  ``orphan_scan`` read shape."""
+  row = mock.Mock()
+  row.state_key = "sk"
+  row.run_started_at = run_started_at or _dt.datetime(
+      2026, 5, 20, tzinfo=_dt.timezone.utc
+  )
+  row.orphan_watermark = watermark
+  row.flagged_session_ids = list(flagged)
+  row.mode = mode
+  return row
+
+
+class TestOrphanWatchdogBuilders:
+  """Pin the SQL shape the watchdog emits. Two reasons: (1) the
+  discovery query has to use strict ``>`` on the watermark so the
+  boundary session from the previous scan isn't reconsidered;
+  (2) the cumulative ledger's running-set exclusion must be in
+  the WHERE clause, not a post-filter, so BigQuery doesn't scan
+  already-flagged sessions on every pass."""
+
+  def test_orphan_select_uses_strict_gt_on_watermark(self):
+    sql = mw.build_orphan_select_sql("p.d.agent_events")
+    assert "timestamp > COALESCE(@orphan_watermark" in sql, (
+        "discovery must use strict `>` on the watermark so the "
+        "boundary session isn't reconsidered on the next scan"
+    )
+
+  def test_orphan_select_filters_terminal_event_count_zero(self):
+    sql = mw.build_orphan_select_sql("p.d.agent_events")
+    assert "COUNTIF(event_type = 'AGENT_COMPLETED')" in sql
+    assert "terminal_event_count = 0" in sql
+
+  def test_orphan_select_excludes_already_flagged(self):
+    sql = mw.build_orphan_select_sql("p.d.agent_events")
+    assert "NOT IN UNNEST(@already_flagged)" in sql
+
+  def test_orphan_ledger_select_filters_on_ledger_mode_only(self):
+    sql = mw.build_orphan_ledger_select_sql("p.d._bqaa_materialization_state")
+    # State table is shared across mode kinds; the ledger read
+    # must filter on mode='orphan_ledger' so a fresh steady row
+    # doesn't shadow the most recent ledger.
+    assert "mode = 'orphan_ledger'" in sql
+
+  def test_resolved_orphan_sql_bounded_to_flagged_set(self):
+    sql = mw.build_resolved_orphan_sql("p.d.agent_events")
+    # The probe must be parameterized on the previously-flagged set
+    # rather than scanning the full events table.
+    assert "IN UNNEST(@previously_flagged)" in sql
+    assert "event_type = 'AGENT_COMPLETED'" in sql
+
+
+class TestOrphanWatchdogScan:
+  """End-to-end scan via a stub BigQuery client. Covers the
+  read-ledger / discover / probe-resolved / write-rows flow."""
+
+  def _stub(self, *, ledger_rows, discovery_rows, resolved_rows):
+    """Sequence: ledger select → discovery → resolved probe.
+    ``ensure_state_table`` is NOT called by ``run_orphan_watchdog``
+    itself (the caller handles that)."""
+    client = mock.Mock()
+    client.query = mock.Mock(
+        side_effect=[
+            mock.Mock(result=mock.Mock(return_value=ledger_rows)),
+            mock.Mock(result=mock.Mock(return_value=discovery_rows)),
+            mock.Mock(result=mock.Mock(return_value=resolved_rows)),
+        ]
+    )
+    client.insert_rows_json = mock.Mock(return_value=[])
+    return client
+
+  def test_first_scan_flags_new_orphans_and_writes_both_rows(self):
+    """Fresh state_key, no ledger row yet. Discovery returns two
+    in-flight sessions. Both audit + ledger rows must be written
+    with the new orphans + the cutoff watermark."""
+    now = _dt.datetime(2026, 5, 20, 12, 0, tzinfo=_dt.timezone.utc)
+    client = self._stub(
+        ledger_rows=[],
+        discovery_rows=[
+            mock.Mock(
+                session_id="orphan-A",
+                first_event_at=now - _dt.timedelta(hours=12),
+            ),
+            mock.Mock(
+                session_id="orphan-B",
+                first_event_at=now - _dt.timedelta(hours=18),
+            ),
+        ],
+        resolved_rows=[],
+    )
+    result = mw.run_orphan_watchdog(
+        client,
+        events_table_ref="p.d.agent_events",
+        state_table_ref="p.d._bqaa_materialization_state",
+        state_key="sk",
+        run_id="run-1",
+        run_started_at=now,
+        max_session_age_hours=6.0,
+    )
+    assert result.new_orphans == ("orphan-A", "orphan-B")
+    assert result.cumulative_flagged == ("orphan-A", "orphan-B")
+    assert result.resolved_orphans == ()
+    assert result.previous_watermark is None
+    assert result.cutoff_at == now - _dt.timedelta(hours=6)
+
+    # Two state rows written (audit + ledger).
+    assert client.insert_rows_json.call_count == 2
+    audit_payload = client.insert_rows_json.call_args_list[0][0][1][0]
+    ledger_payload = client.insert_rows_json.call_args_list[1][0][1][0]
+    assert audit_payload["mode"] == mw.STATE_MODE_ORPHAN_SCAN
+    assert audit_payload["flagged_session_ids"] == ["orphan-A", "orphan-B"]
+    assert ledger_payload["mode"] == mw.STATE_MODE_ORPHAN_LEDGER
+    assert ledger_payload["flagged_session_ids"] == ["orphan-A", "orphan-B"]
+
+  def test_carries_forward_previously_flagged_unless_resolved(self):
+    """Second scan with previously-flagged sessions. One resolved
+    (late terminal event arrived), one new orphan discovered.
+    Cumulative ledger = (prior - resolved) ∪ new."""
+    now = _dt.datetime(2026, 5, 20, 18, 0, tzinfo=_dt.timezone.utc)
+    prior_watermark = now - _dt.timedelta(hours=6, minutes=30)
+    client = self._stub(
+        ledger_rows=[
+            _orphan_state_row(
+                "orphan_ledger",
+                flagged=("orphan-A", "orphan-B", "orphan-C"),
+                watermark=prior_watermark,
+            )
+        ],
+        discovery_rows=[
+            mock.Mock(
+                session_id="orphan-D",
+                first_event_at=now - _dt.timedelta(hours=10),
+            )
+        ],
+        # Late terminal event for orphan-B → drop from ledger.
+        resolved_rows=[mock.Mock(session_id="orphan-B")],
+    )
+    result = mw.run_orphan_watchdog(
+        client,
+        events_table_ref="p.d.agent_events",
+        state_table_ref="p.d._bqaa_materialization_state",
+        state_key="sk",
+        run_id="run-2",
+        run_started_at=now,
+        max_session_age_hours=6.0,
+    )
+    assert result.new_orphans == ("orphan-D",)
+    assert result.resolved_orphans == ("orphan-B",)
+    # Order: carry-forward (in original ledger order, minus
+    # resolved) + newly discovered. The append order matters for
+    # operators reading the ledger as a stable diff target.
+    assert result.cumulative_flagged == (
+        "orphan-A",
+        "orphan-C",
+        "orphan-D",
+    )
+    assert result.previous_watermark == prior_watermark
+
+  def test_empty_scan_still_writes_ledger_so_running_set_persists(self):
+    """No new orphans this scan, but the ledger row must still be
+    written so the cumulative set survives. Without this, a quiet
+    scan would drop the running set and next scan would re-flag
+    everything."""
+    now = _dt.datetime(2026, 5, 20, 18, 0, tzinfo=_dt.timezone.utc)
+    prior_watermark = now - _dt.timedelta(hours=6, minutes=30)
+    client = self._stub(
+        ledger_rows=[
+            _orphan_state_row(
+                "orphan_ledger",
+                flagged=("orphan-A",),
+                watermark=prior_watermark,
+            )
+        ],
+        discovery_rows=[],
+        resolved_rows=[],
+    )
+    result = mw.run_orphan_watchdog(
+        client,
+        events_table_ref="p.d.agent_events",
+        state_table_ref="p.d._bqaa_materialization_state",
+        state_key="sk",
+        run_id="run-3",
+        run_started_at=now,
+        max_session_age_hours=6.0,
+    )
+    assert result.new_orphans == ()
+    assert result.resolved_orphans == ()
+    # Running set persists.
+    assert result.cumulative_flagged == ("orphan-A",)
+    # Ledger row written with the carry-forward set so next scan
+    # reads the same running set even on a no-op scan.
+    assert client.insert_rows_json.call_count == 2
+    ledger_payload = client.insert_rows_json.call_args_list[1][0][1][0]
+    assert ledger_payload["flagged_session_ids"] == ["orphan-A"]
+    # Watermark advances every scan, regardless of outcome —
+    # next scan's `>` boundary moves forward so cost stays bounded.
+    # ``_iso`` shortens ``+00:00`` to ``Z`` in the serialized form.
+    expected_cutoff = now - _dt.timedelta(hours=6)
+    assert ledger_payload["orphan_watermark"] == (
+        expected_cutoff.isoformat().replace("+00:00", "Z")
+    )
+
+  def test_rejects_non_positive_max_session_age_hours(self):
+    with pytest.raises(ValueError, match="must be > 0"):
+      mw.run_orphan_watchdog(
+          mock.Mock(),
+          events_table_ref="p.d.agent_events",
+          state_table_ref="p.d._bqaa_materialization_state",
+          state_key="sk",
+          run_id="r",
+          run_started_at=_dt.datetime.now(_dt.timezone.utc),
+          max_session_age_hours=0,
+      )
+
+
+class TestOrphanWatchdogOrchestratorIntegration:
+  """The orchestrator threads orphan_result through
+  MaterializeWindowResult and surfaces typed
+  ``session_orphaned`` failures so existing #167 alerting fires."""
+
+  def test_max_session_age_hours_none_skips_watchdog(
+      self, fixture_paths, monkeypatch
+  ):
+    """Default off: no orphan-related queries, no `orphan` key in
+    the JSON payload, ok stays True."""
+    ontology_yaml, binding_yaml = fixture_paths
+    _patch_orchestrator_for_extraction(monkeypatch)
+    client = _stub_bq_client([])
+    result = mw.run_materialize_window(
+        project_id="p",
+        dataset_id="d",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=_dt.datetime.now(_dt.timezone.utc),
+    )
+    assert result.orphan_result is None
+    assert "orphan" not in result.to_json()
+    assert result.ok is True
+
+  def test_max_session_age_hours_skipped_in_backfill_mode(
+      self, fixture_paths, monkeypatch
+  ):
+    """Backfill scans a fixed historical window where the
+    ``what's still in-flight?`` question is undefined. The
+    watchdog must skip even if the flag is set on a backfill run."""
+    ontology_yaml, binding_yaml = fixture_paths
+    _patch_orchestrator_for_extraction(monkeypatch)
+    client = _stub_bq_client([])
+    result = mw.run_materialize_window(
+        project_id="p",
+        dataset_id="d",
+        ontology_path=str(ontology_yaml),
+        binding_path=str(binding_yaml),
+        lookback_hours=6.0,
+        validate_binding=False,
+        bq_client=client,
+        run_started_at=_dt.datetime.now(_dt.timezone.utc),
+        backfill=True,
+        from_time=_dt.datetime(2026, 4, 1, tzinfo=_dt.timezone.utc),
+        to_time=_dt.datetime(2026, 4, 8, tzinfo=_dt.timezone.utc),
+        state_key_suffix="backfill-april",
+        max_session_age_hours=6.0,
+    )
+    assert result.orphan_result is None
+
+  def test_invalid_max_session_age_hours_rejected_at_boundary(
+      self, fixture_paths
+  ):
+    """Negative / zero values are operator typos — fail fast at
+    the boundary rather than producing a degenerate cutoff."""
+    ontology_yaml, binding_yaml = fixture_paths
+    for bad in (0, -1, -0.5):
+      with pytest.raises(
+          ValueError, match=r"--max-session-age-hours must be > 0"
+      ):
+        mw.run_materialize_window(
+            project_id="p",
+            dataset_id="d",
+            ontology_path=str(ontology_yaml),
+            binding_path=str(binding_yaml),
+            lookback_hours=6.0,
+            validate_binding=False,
+            bq_client=_stub_bq_client([]),
+            max_session_age_hours=bad,
+        )


### PR DESCRIPTION
## Summary

Closes the audit gap that #180 surfaces: sessions that fail, time out, or
crash without emitting \`AGENT_COMPLETED\` are never materialized AND
never recorded as failures. For audit-critical deployments where the
contract is \"every decision must be auditable,\" this is a silent gap — a
failed session looks identical to one that hasn't happened yet.

PR D adds an opt-in orphan watchdog that runs alongside each cron pass
when \`--max-session-age-hours <N>\` is set. New orphans surface as
typed \`session_orphaned\` failures in the existing #167 failure-mode
classifier, so Cloud Monitoring alerts on \`ok=false\` keep working
without new wiring. The state table grows two new row kinds for the
operator-visible audit trail.

Part of #187 sequencing: A (#188) → B1 (#189) → C1 (#191) → B2 (#192) →
deploy-path (#193) → C2 (#222) → **this** → demo/content expansion (Beat 5,
MAKO coverage, Terraform/hardening).

## What changes

### SDK — schema additions

| Column | Purpose |
|---|---|
| \`orphan_watermark TIMESTAMP\` | Upper bound of the most recent scan window. Next scan uses strict \`>\` on this column so the boundary session isn't reconsidered. |
| \`flagged_session_ids ARRAY<STRING>\` | Cumulative ledger of unresolved orphan session_ids per state_key, or per-scan delta on the audit row. |

Two idempotent \`ALTER TABLE ... ADD COLUMN IF NOT EXISTS\` migrations
alongside the existing \`mode\` migration so pre-D state tables get
patched without a destructive migration.

### SDK — state-row modes

* \`orphan_scan\` — per-pass audit row. \`flagged_session_ids\` carries only
  the **new** orphans flagged in this scan (the delta); \`orphan_watermark\`
  carries this scan's cutoff.
* \`orphan_ledger\` — cumulative ledger row written alongside every
  \`orphan_scan\`. \`flagged_session_ids\` carries the full running set
  after the resolve sweep. Append-only by run; reads pick the most recent
  row per state_key (mirroring the steady-checkpoint pattern).

### SDK — scan logic (\`run_orphan_watchdog\`)

1. Read the most recent \`orphan_ledger\` row for \`state_key\` (or empty).
2. Discover sessions whose \`MIN(timestamp)\` falls in
   \`(orphan_watermark, cutoff_at]\`, have \`terminal_event_count = 0\`,
   and aren't already in the cumulative ledger. \`cutoff_at\` =
   \`run_started_at - max_session_age_hours\`.
3. Probe for resolved orphans: previously-flagged session_ids that now
   have \`AGENT_COMPLETED\`. Drop them from the cumulative ledger.
4. Write \`orphan_scan\` (delta) + \`orphan_ledger\` (cumulative after
   resolve). Watermark advances unconditionally so the next scan's \`>\`
   boundary moves forward even on no-op scans.

### Orchestrator + CLI integration

* New optional kwarg \`max_session_age_hours: Optional[float]\` on
  \`run_materialize_window\`. \`None\` disables the watchdog (default);
  positive values enable it. Boundary check rejects \`<= 0\` at the
  same level as \`--lookback-hours\`.
* Skipped automatically in \`backfill=True\` mode.
* The watchdog runs **after** the steady pass writes its row, so a
  partial steady failure doesn't block the watchdog signal and the
  per-mode audit-row stream stays cleanly partitioned.
* New orphans get threaded into \`MaterializeWindowResult.failures[]\`
  as \`error_code='session_orphaned'\` entries with a remediation hint
  pointing at the ledger.
* \`MaterializeWindowResult.to_json()\` adds an \`orphan\` key when the
  watchdog ran so operators can pivot Cloud Logging filters on
  \`jsonPayload.orphan.cumulative_flagged\`.
* \`bqaa materialize-window --max-session-age-hours N\` CLI flag.

### Deploy path (migration v5)

* \`run_job.py\` reads \`BQAA_MAX_SESSION_AGE_HOURS\`.
* \`deploy_cloud_run_job.sh\` adds \`--max-session-age-hours N\`; the
  env var is wired only when the operator opts in (default deploys
  don't pay the extra discovery query).
* \`README.md\`'s Failure-mode surface section grows a third bullet
  (\`session_orphaned\`) plus a paragraph on the state-table audit
  trail.

## Tests (3097 passing; +12 new on \`materialize_window\`)

* \`TestOrphanWatchdogBuilders\` (5) — SQL shape: strict \`>\` on
  watermark, \`terminal_event_count = 0\` filter,
  \`NOT IN UNNEST(@already_flagged)\` exclusion, ledger read filtered
  on \`mode='orphan_ledger'\`, resolved-orphan probe bounded by the
  \`previously_flagged\` set.
* \`TestOrphanWatchdogScan\` (4) — end-to-end via stub client: first
  scan flags new orphans + writes both rows; second scan carries
  forward, drops resolved, appends new; empty scan still writes
  ledger so running set persists across no-op scans; \`<= 0\`
  rejected at boundary.
* \`TestOrphanWatchdogOrchestratorIntegration\` (3) — \`None\` skips
  the watchdog (no \`orphan\` key in payload); backfill mode skips
  even when set; invalid values fail fast at the orchestrator
  boundary.
* \`TestEnsureStateTableMigration\` grew to assert the two new
  \`ADD COLUMN IF NOT EXISTS\` migrations + the new columns in the
  initial DDL.

## Test plan
- [x] \`python -m pytest tests/\` — 3097 pass, 15 skipped
- [x] \`python -m pyink --check\` + \`python -m isort --check-only\` — clean
- [x] \`bash -n examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh\` — clean
- [ ] Live Cloud Run run with \`--max-session-age-hours\` set against a real events stream that has unfinished sessions (reviewer / merger-side; the unit + integration tests cover the SQL shape and orchestrator wiring, but the cross-run watermark + ledger persistence story belongs to a live verification)