### PR TITLE
fix(materialize_window): orphan watchdog crashes on every cron pass — empty-array insert rejected by BigQuery (#180 hotfix)

### DIFF
--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -584,32 +584,52 @@ def append_state_row(
     bq_client: Any, state_table_ref: str, row: StateRow
 ) -> None:
   """Append a state row. Uses ``insert_rows_json`` (streaming
-  insert) — cheaper than an INSERT job for tiny single-row writes."""
-  payload = {
+  insert) — cheaper than an INSERT job for tiny single-row writes.
+
+  Two BigQuery streaming-insert quirks shape the payload assembly:
+
+  * **Empty ARRAY columns must be omitted, not sent as ``[]``.**
+    Sending ``{"flagged_session_ids": []}`` triggers BigQuery's
+    "Field value of flagged_session_ids cannot be empty" rejection
+    (surfaced as the very first failure when the orphan-watchdog
+    PR #224 went live — every scan with zero new/cumulative
+    orphans crashed). Omitting the field stores NULL, which is
+    the right "scan ran, no orphans" semantic anyway: the
+    ``mode='orphan_scan'`` row's other fields already convey the
+    "scan ran" signal.
+  * **NULL TIMESTAMP fields are safe to send as ``None``** —
+    ``insert_rows_json`` translates that into a NULL cell. But
+    we already special-case via ``_iso_optional`` to keep the
+    omitted-field pattern consistent across both column kinds.
+  """
+  payload: dict[str, Any] = {
       "state_key": row.state_key,
       "run_id": row.run_id,
       "run_started_at": _iso(row.run_started_at),
       "scan_start": _iso(row.scan_start),
       "scan_end": _iso(row.scan_end),
-      "last_completion_at": _iso_optional(row.last_completion_at),
       "sessions_discovered": row.sessions_discovered,
       "sessions_materialized": row.sessions_materialized,
       "sessions_failed": row.sessions_failed,
       "ok": row.ok,
-      "error_detail": row.error_detail,
-      "report_json": row.report_json,
       "mode": row.mode,
-      "orphan_watermark": _iso_optional(row.orphan_watermark),
-      # ``insert_rows_json`` accepts a list of strings for an
-      # ARRAY<STRING> column. ``None`` is encoded as a NULL ARRAY
-      # at the column level — distinct from the empty array which
-      # signals "scan ran, zero unresolved orphans".
-      "flagged_session_ids": (
-          list(row.flagged_session_ids)
-          if row.flagged_session_ids is not None
-          else None
-      ),
   }
+  if row.last_completion_at is not None:
+    payload["last_completion_at"] = _iso(row.last_completion_at)
+  if row.error_detail is not None:
+    payload["error_detail"] = row.error_detail
+  if row.report_json is not None:
+    payload["report_json"] = row.report_json
+  if row.orphan_watermark is not None:
+    payload["orphan_watermark"] = _iso(row.orphan_watermark)
+  # Omit the ARRAY field entirely when there's nothing to write —
+  # see the empty-array quirk in the docstring above. The truthy
+  # check folds ``None`` and ``()`` into the same omit branch;
+  # both store as NULL in BQ, and the distinction between "field
+  # didn't apply on this row kind" and "scan ran with zero" is
+  # carried by the ``mode`` column.
+  if row.flagged_session_ids:
+    payload["flagged_session_ids"] = list(row.flagged_session_ids)
   errors = bq_client.insert_rows_json(state_table_ref, [payload])
   if errors:
     raise RuntimeError(f"insert into {state_table_ref} failed: {errors!r}")

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -597,10 +597,13 @@ def append_state_row(
     the right "scan ran, no orphans" semantic anyway: the
     ``mode='orphan_scan'`` row's other fields already convey the
     "scan ran" signal.
-  * **NULL TIMESTAMP fields are safe to send as ``None``** —
-    ``insert_rows_json`` translates that into a NULL cell. But
-    we already special-case via ``_iso_optional`` to keep the
-    omitted-field pattern consistent across both column kinds.
+  * **Nullable TIMESTAMP / STRING fields are also omitted when
+    ``None``.** ``insert_rows_json`` does accept explicit
+    ``None`` for nullable scalars, but applying the same omit-
+    when-empty pattern across every nullable column keeps the
+    payload shape internally consistent and avoids future
+    regressions if other column types pick up the same
+    empty-value rejection that ``ARRAY<STRING>`` already has.
   """
   payload: dict[str, Any] = {
       "state_key": row.state_key,

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -2543,6 +2543,91 @@ class TestStateRowModeColumn:
     assert payload["mode"] == "backfill"
 
 
+class TestAppendStateRowOmitsEmptyArrays:
+  """BigQuery's streaming-insert API rejects empty-array values
+  for ARRAY<STRING> columns with "Field value of
+  flagged_session_ids cannot be empty." Live verification of PR
+  #224 surfaced this on the very first cron pass when the
+  watchdog wrote an ``orphan_scan`` row with zero new orphans.
+  The fix omits ``flagged_session_ids`` from the payload when
+  there's nothing to write (storing NULL); BigQuery accepts
+  that and operators can still distinguish row kinds via the
+  ``mode`` column."""
+
+  def _state_row(self, **overrides):
+    base = dict(
+        state_key="sk",
+        run_id="rid",
+        run_started_at=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_start=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        scan_end=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+        last_completion_at=None,
+        sessions_discovered=0,
+        sessions_materialized=0,
+        sessions_failed=0,
+        ok=True,
+    )
+    base.update(overrides)
+    return mw.StateRow(**base)
+
+  def test_steady_row_omits_array_field_when_none(self):
+    """Default StateRow (steady-mode caller) leaves
+    ``flagged_session_ids=None``. The serialized payload must
+    omit the field entirely so BigQuery stores NULL — the
+    pre-#224 row shape."""
+    client = mock.Mock()
+    client.insert_rows_json = mock.Mock(return_value=[])
+    mw.append_state_row(client, "p.d.t", self._state_row())
+    payload = client.insert_rows_json.call_args[0][1][0]
+    assert "flagged_session_ids" not in payload
+    # Same omit-when-None rule for the other nullable columns.
+    assert "orphan_watermark" not in payload
+    assert "last_completion_at" not in payload
+
+  def test_orphan_scan_with_zero_orphans_omits_array(self):
+    """The crash reproducer: ``run_orphan_watchdog`` builds an
+    ``orphan_scan`` row with ``flagged_session_ids=()`` on a
+    zero-orphan scan. Sending ``[]`` as the JSON value crashed
+    BigQuery; omitting the field stores NULL and the row writes
+    cleanly."""
+    client = mock.Mock()
+    client.insert_rows_json = mock.Mock(return_value=[])
+    cutoff = _dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc)
+    mw.append_state_row(
+        client,
+        "p.d.t",
+        self._state_row(
+            mode=mw.STATE_MODE_ORPHAN_SCAN,
+            orphan_watermark=cutoff,
+            flagged_session_ids=(),  # the crash trigger
+        ),
+    )
+    payload = client.insert_rows_json.call_args[0][1][0]
+    assert "flagged_session_ids" not in payload
+    # Watermark IS populated on orphan rows and must be sent.
+    assert payload["orphan_watermark"] == cutoff.isoformat().replace(
+        "+00:00", "Z"
+    )
+    assert payload["mode"] == mw.STATE_MODE_ORPHAN_SCAN
+
+  def test_orphan_row_with_flagged_sessions_sends_array(self):
+    """The non-empty path stays unchanged: a populated
+    ``flagged_session_ids`` tuple serializes as a list."""
+    client = mock.Mock()
+    client.insert_rows_json = mock.Mock(return_value=[])
+    mw.append_state_row(
+        client,
+        "p.d.t",
+        self._state_row(
+            mode=mw.STATE_MODE_ORPHAN_LEDGER,
+            orphan_watermark=_dt.datetime(2026, 5, 20, tzinfo=_dt.timezone.utc),
+            flagged_session_ids=("orphan-A", "orphan-B"),
+        ),
+    )
+    payload = client.insert_rows_json.call_args[0][1][0]
+    assert payload["flagged_session_ids"] == ["orphan-A", "orphan-B"]
+
+
 class TestEnsureStateTableMigration:
   """``ensure_state_table`` runs the schema-evolution ALTERs every call.
   ``ADD COLUMN IF NOT EXISTS`` is idempotent in BigQuery; the test


### PR DESCRIPTION
## Summary

**Critical**: live verification of PR #224 against \`test-project-0728-467323\` surfaced an insert-time crash on the very first cron pass. BigQuery's streaming-insert API rejects empty \`ARRAY<STRING>\` values with:

\`\`\`
Field value of flagged_session_ids cannot be empty.
\`\`\`

The previous \`append_state_row\` serialization sent \`\"flagged_session_ids\": []\` whenever the \`StateRow\`'s tuple was empty — i.e. on every steady-state row, every backfill row, and every zero-orphan watchdog scan. Net effect: every cron pass after PR #224 merged would crash at insert time and report exit code 2 (\"unexpected internal error\") in Cloud Logging.

## Fix

Build the \`insert_rows_json\` payload incrementally: nullable columns (\`last_completion_at\`, \`error_detail\`, \`report_json\`, \`orphan_watermark\`, \`flagged_session_ids\`) are only added to the payload when they have a value. Missing fields default to NULL on the BQ side — the right \"this row kind doesn't populate that column\" semantic — and avoid the empty-array rejection.

The truthy check on \`flagged_session_ids\` folds \`None\` and \`()\` into the same omit branch (both store as NULL). The distinction between \"field didn't apply on this row kind\" and \"scan ran with zero orphans\" is carried by the \`mode\` column.

## Tests (+3 new)

New class \`TestAppendStateRowOmitsEmptyArrays\`:
* \`test_steady_row_omits_array_field_when_none\` — pins the pre-#224 steady-row payload shape (nullable columns absent).
* \`test_orphan_scan_with_zero_orphans_omits_array\` — the unit-level reproducer: a \`StateRow(mode=STATE_MODE_ORPHAN_SCAN, flagged_session_ids=())\` produces a payload **without** the field; \`orphan_watermark\` (which IS populated on orphan rows) is still sent.
* \`test_orphan_row_with_flagged_sessions_sends_array\` — the non-empty path stays unchanged.

Full suite: **3103 passed**, 15 skipped.

## Live verification (post-fix)

Re-deployed against the same repro environment, with two synthesized orphans (\`129ea426-...\`, \`12f9922c-...\`) plus four pre-existing incomplete sessions in \`agent_analytics_demo\`. After dropping the prior state table to start clean:

| Signal | Value |
|---|---|
| Run exit code | 1 (expected: \`ok=false\` with orphan failures) |
| \`failures[]\` entries | 6 × \`error_code='session_orphaned'\` with the exact PR #224 prose, cutoff timestamp, and ledger pointer |
| \`orphan\` JSON payload | \`new_orphans=[6 ids], cumulative_flagged=[same 6], previous_watermark=None, resolved_orphans=[]\` |
| State-table rows from this pass | \`orphan_scan\` (delta, 6), \`orphan_ledger\` (cumulative, 6), \`steady\` (0) |

Failure prose verbatim:
\`\`\`
session 'fa596607-...' has first event older than 24.0 hours
(cutoff 2026-05-20T07:03:11.423669+00:00) but never emitted
'AGENT_COMPLETED'. The orphan watchdog flagged it on this scan
and recorded it in the cumulative ledger (state_key='...',
mode='orphan_ledger'). Resolve by either emitting the missing
terminal event (the watchdog will drop the session from the
ledger on its next pass) or triaging the underlying agent failure.
\`\`\`

## Test plan
- [x] \`python -m pytest tests/\` — 3103 pass
- [x] \`python -m pyink --check\` + \`python -m isort --check-only\` — clean
- [x] Live Cloud Run smoke against synthesized orphans — passes end-to-end
- [x] Live state-table inspection — \`orphan_scan\` + \`orphan_ledger\` + \`steady\` rows written cleanly

This is a no-grace-period fix — without it, every deployed cron pass against \`_bqaa_materialization_state\` crashes. Merging this before any further work on D follow-ups (or any new PRs that touch the state table).