### PR TITLE
feat(deploy): split runtime + scheduler SAs by default; tunable --max-retries (#182 + #183)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -92,23 +92,36 @@ hard `ok=false` since PR #167).
 
 ### Required IAM
 
-The deploy script creates a single runtime service account
-(`bqaa-periodic-sa@PROJECT.iam.gserviceaccount.com`) and grants
-the minimum set of roles. Operators with appropriate write
-permissions can override or split the SAs later — the structure
-makes it a small edit.
+The deploy script creates **two** service accounts by default
+(production posture, per issue #182):
 
-| Scope | Role | Why |
-|---|---|---|
-| Project | `roles/bigquery.jobUser` | Run BQ jobs (DDL, discovery, state writes) |
-| Project | `roles/aiplatform.user` | Call `AI.GENERATE` for entity extraction. Granted in `--extraction-mode=ai-fallback` (default); skipped (and idempotently removed if pre-existing) in `--extraction-mode=compiled-only` |
-| Cloud Run Job | `roles/run.invoker` | Cloud Scheduler invokes the job. Granted on the specific job resource, not project-wide |
-| Events DS | `roles/bigquery.dataViewer` | Read `agent_events`; events stay read-only |
-| Graph DS | `roles/bigquery.dataEditor` | Write entity/relationship tables + `_bqaa_materialization_state` |
+* `bqaa-periodic-runtime-sa@PROJECT.iam.gserviceaccount.com`
+  — the Cloud Run Job's runtime identity. Holds the BigQuery +
+  (conditionally) Vertex AI roles below.
+* `bqaa-periodic-scheduler-sa@PROJECT.iam.gserviceaccount.com`
+  — the Cloud Scheduler trigger's OAuth identity. Holds only
+  `roles/run.invoker` on the specific Cloud Run Job. No
+  BigQuery, no Vertex AI, no project-wide perms.
 
-The deploy script handles every grant. For production
-hardening, split the runtime SA from the scheduler-caller SA;
-the script's structure makes that a small edit.
+Pass `--single-sa` to fall back to the pre-#182 combined
+identity (`bqaa-periodic-sa@PROJECT.iam.gserviceaccount.com`)
+when the two-SA model isn't worth the operational overhead.
+
+| Scope | Role | Granted to | Why |
+|---|---|---|---|
+| Project | `roles/bigquery.jobUser` | runtime SA | Run BQ jobs (DDL, discovery, state writes) |
+| Project | `roles/aiplatform.user` | runtime SA | Call `AI.GENERATE` for entity extraction. Granted in `--extraction-mode=ai-fallback` (default); skipped (and idempotently removed if pre-existing) in `--extraction-mode=compiled-only` |
+| Cloud Run Job | `roles/run.invoker` | **scheduler-caller SA** | Cloud Scheduler invokes the job. Granted on the specific job resource, not project-wide. With `--single-sa` this lands on the same SA as the runtime |
+| Events DS | `roles/bigquery.dataViewer` | runtime SA | Read `agent_events`; events stay read-only |
+| Graph DS | `roles/bigquery.dataEditor` | runtime SA | Write entity/relationship tables + `_bqaa_materialization_state` |
+
+The split keeps the scheduler-caller narrow: it can fire the
+job and nothing else. Combining the two paths (`--single-sa`)
+gives the scheduler caller broader permissions than it ever
+exercises — least-privilege violation that matters in
+regulated industries (advertising, financial services,
+healthcare). The deploy script handles every grant for both
+modes.
 
 ### General prerequisites
 
@@ -251,13 +264,15 @@ The script:
 
 1. **Pre-creates the graph dataset** (`bq mk`, idempotent) so
    the runtime SA never needs `bigquery.datasets.create`.
-2. **Creates a service account** (`bqaa-periodic-sa@…`) if
-   absent. This SA serves two roles: **runtime identity** for
-   the Cloud Run Job (does the BigQuery work) and **scheduler
-   caller** for the Cloud Scheduler HTTP trigger. For
-   production, splitting these into separate SAs is reasonable
-   hardening; the script's structure makes that a small edit.
-3. **Grants narrow IAM** to the SA:
+2. **Creates two service accounts** by default (issue #182):
+   `bqaa-periodic-runtime-sa@…` (runtime identity — does the
+   BigQuery work) and `bqaa-periodic-scheduler-sa@…`
+   (scheduler caller — fires the Cloud Run Job's HTTP
+   trigger). Pass `--single-sa` to fall back to the combined
+   `bqaa-periodic-sa@…` identity for both paths.
+3. **Grants narrow IAM** to the runtime SA (the
+   scheduler-caller SA only gets `roles/run.invoker` on the
+   job in section 5 below):
    * Project-level `roles/bigquery.jobUser` —
      `bigquery.jobs.create` only.
    * Project-level `roles/aiplatform.user` — required in the
@@ -518,13 +533,30 @@ failed, the insert still happens, producing duplicates that the
 *next* successful delete cleans up.
 
 **Idempotent retries.** Cloud Run Job retry policy: this script
-sets `--max-retries 1`. If a transient BQ error fails a run,
-Cloud Run retries once; the orchestrator's checkpoint plus
-session-level idempotency ensure no double-counting. For
-sustained failure (e.g., binding drift), the second retry will
-also fail and the scheduled fire will be reported as failed in
-Cloud Monitoring. Set up an alert on
-`logging.googleapis.com/log_entry_count` with severity `ERROR`.
+sets `--max-retries 2` by default (issue #183), tunable via
+the `--max-retries N` flag. The orchestrator's checkpoint +
+session-level idempotency mean additional retries are safe —
+each retry resumes from the last successful session, no
+double-counting. For transient BigQuery slot pressure or
+short-lived rate-limiting events, two retries silently
+absorb the noise; the on-call doesn't get paged for a
+condition the next scheduled fire would have recovered from
+anyway. For sustained failure (e.g., binding drift) all
+retries also fail and the scheduled fire shows up as a failed
+execution in Cloud Monitoring.
+
+The retry count surfaces in every run's startup log payload
+(`jsonPayload.max_retries`) via the `BQAA_MAX_RETRIES` env
+var the deploy script sets — operators correlating alert noise
+with retry behaviour see it in Cloud Logging without
+`gcloud run jobs describe`. Cost-minimizing deployments can
+pass `--max-retries 1` (or `0` to disable); production
+deployments running every few hours benefit from the
+`2` default.
+
+Set up an alert on `logging.googleapis.com/log_entry_count`
+with severity `ERROR` — that fires only after all retries
+have exhausted.
 
 ## Verified Cloud Run deployment evidence
 
@@ -695,8 +727,10 @@ unresolved" without having to diff across runs.
 ### Redeploy (no resource churn)
 
 Re-running the deploy script with the same flags is fully
-idempotent — same service account (`bqaa-periodic-sa`), same
-job name, same Scheduler trigger name, same graph dataset. The
+idempotent — same service account(s)
+(`bqaa-periodic-runtime-sa` + `bqaa-periodic-scheduler-sa` by
+default; `bqaa-periodic-sa` under `--single-sa`), same job
+name, same Scheduler trigger name, same graph dataset. The
 existing IAM bindings are detected and skipped (`already
 granted (READER)` etc.); only the container image gets rebuilt
 to reflect any source changes. Run after any code change to
@@ -723,11 +757,20 @@ bq --project_id=your-project rm -r -f your_graph_dataset
 ```
 
 The events dataset is never modified by the deploy and stays
-untouched. The runtime service account (`bqaa-periodic-sa`)
-persists across teardowns — drop it manually if you're
-permanently retiring the deployment:
+untouched. The service accounts persist across teardowns —
+drop them manually if you're permanently retiring the
+deployment (omit either delete if you used `--single-sa`):
 
 ```bash
+# Default (split-SA) deploys:
+gcloud iam service-accounts delete \
+  bqaa-periodic-runtime-sa@your-project.iam.gserviceaccount.com \
+  --project=your-project --quiet
+gcloud iam service-accounts delete \
+  bqaa-periodic-scheduler-sa@your-project.iam.gserviceaccount.com \
+  --project=your-project --quiet
+
+# Single-SA deploys (--single-sa):
 gcloud iam service-accounts delete \
   bqaa-periodic-sa@your-project.iam.gserviceaccount.com \
   --project=your-project --quiet

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -309,11 +309,12 @@ The script:
    identity is the SA, **not** the Compute Engine default
    service account — important, since the default SA may lack
    the dataset-level perms above.
-6. **Grants `roles/run.invoker`** on the job to the same SA
-   (the scheduler-caller side of the cross-product).
+6. **Grants `roles/run.invoker`** on the job to the
+   scheduler-caller SA (`bqaa-periodic-scheduler-sa` by default;
+   the same SA as the runtime under `--single-sa`).
 7. **Creates / updates a Cloud Scheduler HTTP job** that POSTs
-   to the Cloud Run Jobs `:run` endpoint with the SA's OAuth
-   identity.
+   to the Cloud Run Jobs `:run` endpoint with the
+   scheduler-caller SA's OAuth identity.
 
 ## Inspecting results
 
@@ -601,8 +602,15 @@ schedule: 0 */6 * * *
 state: ENABLED
 ```
 
-The OAuth identity matches the runtime SA — same SA serves
-both runtime and scheduler-caller as designed.
+**This evidence was captured pre-#182**, before the split-SA
+default. The OAuth identity here matches the runtime SA because
+the deploy at the time used the single combined
+``bqaa-periodic-sa``. New default deploys (post-#182) wire the
+scheduler trigger to a separate ``bqaa-periodic-scheduler-sa``
+that holds only ``roles/run.invoker`` on the job — the OAuth
+identity above would now read ``bqaa-periodic-scheduler-sa@…``
+instead. Pass ``--single-sa`` to restore the pre-#182 combined
+identity shown here.
 
 **IAM contract** verified post-deploy via the BigQuery client:
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -823,6 +823,8 @@ inserts fail. The deploy script grants `roles/bigquery.user` +
 `roles/bigquery.dataEditor` to cover this.
 
 **Scheduler fires but the job doesn't run** — IAM. Confirm the
-scheduler's service account (`bqaa-periodic-sa@…`) has
+scheduler's service account
+(`bqaa-periodic-scheduler-sa@…` by default, or
+`bqaa-periodic-sa@…` under `--single-sa`) has
 `roles/run.invoker` on the job. The deploy script grants this;
 if you renamed the SA or job, regrant manually.

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -93,6 +93,16 @@ JOB_NAME="bqaa-periodic-materialization"
 SMOKE=false
 EXTRACTION_MODE="ai-fallback"
 MAX_SESSION_AGE_HOURS=""
+# Production posture by default: split runtime + scheduler-caller
+# SAs (issue #182). ``--single-sa`` is the escape hatch for
+# customers who explicitly want the simpler combined identity.
+SINGLE_SA=false
+# Cloud Run Job retry policy (issue #183). The orchestrator's
+# session-level idempotency + append-only state table make
+# additional retries safe. Default 2 (was hard-coded 1) so
+# transient BQ slot pressure / short-lived rate limits don't
+# page on-call when a retry would have silently recovered.
+MAX_RETRIES="2"
 
 # Print usage. Exit code is the caller's choice: ``usage 0``
 # for ``--help`` (success), ``usage 1`` for parse / required-arg
@@ -139,6 +149,25 @@ Optional:
                                per-scan + cumulative audit rows. Disabled
                                by default; skipped automatically in any
                                backfill run.
+  --single-sa                  Use a single combined service account
+                               (bqaa-periodic-sa) for both the Cloud Run
+                               Job runtime identity AND the Cloud
+                               Scheduler OAuth caller. Default: two SAs
+                               (bqaa-periodic-runtime-sa with the BigQuery
+                               + Vertex AI roles, bqaa-periodic-scheduler-sa
+                               with only roles/run.invoker on the job).
+                               The split is the production-posture default
+                               per issue #182 — least-privilege: the
+                               scheduler-caller never needs the runtime's
+                               BigQuery permissions.
+  --max-retries N              Cloud Run Job retry count on failure
+                               (default: 2). The orchestrator's session-
+                               level idempotency + append-only state
+                               table make additional retries safe. The
+                               value is also wired as BQAA_MAX_RETRIES
+                               into the job's env so the run's Cloud
+                               Logging payload surfaces it. Per issue
+                               #183.
   -h | --help                  Show this help.
 EOF
   exit "${1:-1}"
@@ -178,6 +207,8 @@ while [[ $# -gt 0 ]]; do
     --extraction-mode) require_arg "$1" "${2-}"; EXTRACTION_MODE="$2"; shift 2 ;;
     --max-session-age-hours)
                        require_arg "$1" "${2-}"; MAX_SESSION_AGE_HOURS="$2"; shift 2 ;;
+    --single-sa)       SINGLE_SA=true; shift ;;
+    --max-retries)     require_arg "$1" "${2-}"; MAX_RETRIES="$2"; shift 2 ;;
     -h|--help)         usage 0 ;;
     *)                 echo "Unknown argument: $1" >&2; usage 1 ;;
   esac
@@ -212,6 +243,16 @@ case "$EXTRACTION_MODE" in
     exit 1
     ;;
 esac
+
+# Validate ``--max-retries`` at the boundary (issue #183). A typo
+# like ``--max-retries=-1`` would otherwise be forwarded to
+# ``gcloud run jobs deploy`` which rejects it with a less obvious
+# error after the build. Accept any non-negative integer; gcloud
+# itself caps the upper bound.
+if ! [[ "$MAX_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "Error: --max-retries must be a non-negative integer; got '$MAX_RETRIES'." >&2
+  exit 1
+fi
 
 SCHEDULER_NAME="${JOB_NAME}-cron"
 
@@ -280,29 +321,61 @@ else
 fi
 
 # ----------------------------------------------------------- #
-# 2. Service account (runtime identity + scheduler caller)     #
+# 2. Service accounts (runtime identity + scheduler caller)    #
 # ----------------------------------------------------------- #
 #
-# A single service account is used for both:
-#   * The Cloud Run Job runtime (``--service-account`` below).
-#     This SA does the actual BigQuery work — reads events,
+# Per issue #182, the production-posture default is **two**
+# service accounts:
+#
+#   * ``$RUNTIME_SA_EMAIL`` — the Cloud Run Job's runtime
+#     identity (``--service-account`` on ``gcloud run jobs
+#     deploy``). Holds the BigQuery + (conditionally) Vertex AI
+#     roles below. Does the actual BigQuery work: reads events,
 #     writes entity rows, writes state-table rows.
-#   * The Cloud Scheduler caller (OAuth identity on the HTTP
-#     trigger). The SA also needs ``roles/run.invoker`` on the
-#     job to invoke itself.
+#   * ``$SCHEDULER_SA_EMAIL`` — the Cloud Scheduler trigger's
+#     OAuth identity (``--oauth-service-account-email`` on
+#     ``gcloud scheduler jobs create http``). Holds
+#     ``roles/run.invoker`` on the specific Cloud Run Job only.
+#     No BigQuery or Vertex AI perms.
 #
-# Combining the two identities keeps the IAM story simple. For
-# production, splitting them (separate SA for scheduler vs job
-# runtime) is reasonable hardening; the script is structured so
-# swapping in two SAs is a small edit.
+# The split keeps the scheduler-caller narrow: it can fire the
+# job and nothing else. Combining the two paths (the old default,
+# now opt-in via ``--single-sa``) gives the scheduler caller
+# broader permissions than it ever exercises — least-privilege
+# violation that matters in regulated industries.
 #
-# Grant order matters: create the SA + grant BigQuery perms
-# BEFORE the job deploys, so the job's first invocation has the
-# right identity. The job's ``--service-account`` arg refers to
-# the SA we just set up.
+# Grant order matters: create the SA(s) + grant BigQuery perms
+# to the runtime SA BEFORE the job deploys, so the job's first
+# invocation has the right identity. The job's
+# ``--service-account`` arg refers to ``$RUNTIME_SA_EMAIL``.
 
-SA_NAME="bqaa-periodic-sa"
-SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+if [[ "$SINGLE_SA" == "true" ]]; then
+  # Combined-identity mode (escape hatch). Mirrors the pre-#182
+  # default — one ``bqaa-periodic-sa`` that holds both the
+  # BigQuery / Vertex AI roles and ``roles/run.invoker``. Keep
+  # the original SA name so existing deploys re-running with
+  # ``--single-sa`` keep using their existing identity.
+  RUNTIME_SA_NAME="bqaa-periodic-sa"
+  SCHEDULER_SA_NAME="bqaa-periodic-sa"
+  RUNTIME_SA_DISPLAY="BQAA periodic-materialization runtime + scheduler"
+  SCHEDULER_SA_DISPLAY="$RUNTIME_SA_DISPLAY"
+else
+  # Split-SA mode (default, production posture).
+  RUNTIME_SA_NAME="bqaa-periodic-runtime-sa"
+  SCHEDULER_SA_NAME="bqaa-periodic-scheduler-sa"
+  RUNTIME_SA_DISPLAY="BQAA periodic-materialization runtime"
+  SCHEDULER_SA_DISPLAY="BQAA periodic-materialization scheduler caller"
+fi
+RUNTIME_SA_EMAIL="${RUNTIME_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+SCHEDULER_SA_EMAIL="${SCHEDULER_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+# ``$SA_EMAIL`` is preserved as an alias for the runtime SA so
+# downstream blocks (dataset-level IAM grants, deferred-IAM-remove
+# remediation hints, summary echoes) keep their existing
+# references. Anything that needs the scheduler caller uses
+# ``$SCHEDULER_SA_EMAIL`` explicitly.
+SA_NAME="$RUNTIME_SA_NAME"
+SA_EMAIL="$RUNTIME_SA_EMAIL"
 
 # Retry an IAM-binding command on the IAM-propagation race.
 # ``gcloud iam service-accounts create`` returns success once
@@ -335,14 +408,23 @@ _retry_iam() {
   return 1
 }
 
-if ! gcloud iam service-accounts describe "$SA_EMAIL" \
-    --project "$PROJECT" >/dev/null 2>&1; then
-  echo "==> creating service account: $SA_EMAIL"
-  gcloud iam service-accounts create "$SA_NAME" \
-    --display-name "BQAA periodic-materialization runtime + scheduler" \
-    --project "$PROJECT"
-else
-  echo "==> service account exists: $SA_EMAIL"
+_ensure_sa() {
+  local sa_name="$1"
+  local sa_email="$2"
+  local display="$3"
+  if ! gcloud iam service-accounts describe "$sa_email" \
+      --project "$PROJECT" >/dev/null 2>&1; then
+    echo "==> creating service account: $sa_email"
+    gcloud iam service-accounts create "$sa_name" \
+      --display-name "$display" \
+      --project "$PROJECT"
+  else
+    echo "==> service account exists: $sa_email"
+  fi
+}
+_ensure_sa "$RUNTIME_SA_NAME" "$RUNTIME_SA_EMAIL" "$RUNTIME_SA_DISPLAY"
+if [[ "$SINGLE_SA" != "true" ]]; then
+  _ensure_sa "$SCHEDULER_SA_NAME" "$SCHEDULER_SA_EMAIL" "$SCHEDULER_SA_DISPLAY"
 fi
 
 # IAM grants for the runtime SA — narrowed to dataset-level
@@ -583,6 +665,12 @@ fi
 if [[ -n "${MAX_SESSION_AGE_HOURS}" ]]; then
   ENV_VARS+=("BQAA_MAX_SESSION_AGE_HOURS=${MAX_SESSION_AGE_HOURS}")
 fi
+# Surface the Cloud Run Job's retry count to the runtime so it
+# can echo it in the structured startup log — operators
+# correlating alert noise with retry behaviour see it in Cloud
+# Logging without having to ``gcloud run jobs describe`` per
+# alert (issue #183).
+ENV_VARS+=("BQAA_MAX_RETRIES=${MAX_RETRIES}")
 # Comma-join for --set-env-vars (no shell-quoting issues since
 # all values are simple identifiers / numbers).
 ENV_VAR_FLAG="$(IFS=','; echo "${ENV_VARS[*]}")"
@@ -601,10 +689,10 @@ gcloud run jobs deploy "$JOB_NAME" \
   --project "$PROJECT" \
   --region "$REGION" \
   --source "$STAGING" \
-  --service-account "$SA_EMAIL" \
+  --service-account "$RUNTIME_SA_EMAIL" \
   --set-env-vars "$ENV_VAR_FLAG" \
   --task-timeout 30m \
-  --max-retries 1
+  --max-retries "$MAX_RETRIES"
 
 # ----------------------------------------------------------- #
 # 5. Enable Cloud Scheduler API + grant invoker on the job     #
@@ -615,16 +703,16 @@ gcloud services enable cloudscheduler.googleapis.com \
   --project "$PROJECT" \
   --quiet
 
-# Grant the SA invoker on the specific Cloud Run Job so the
-# scheduler trigger can fire it. (The SA is both the runtime
-# identity AND the scheduler caller; ``roles/run.invoker`` on
-# the job is the cross-product permission for the scheduler
-# side.)
-echo "==> granting roles/run.invoker on $JOB_NAME to $SA_EMAIL"
+# Grant ``roles/run.invoker`` on the specific Cloud Run Job so
+# the scheduler trigger can fire it. In split-SA mode this is
+# the ONLY role the scheduler-caller SA holds — least-privilege.
+# In ``--single-sa`` mode, ``$SCHEDULER_SA_EMAIL == $RUNTIME_SA_EMAIL``
+# so the grant lands on the same SA the runtime uses.
+echo "==> granting roles/run.invoker on $JOB_NAME to $SCHEDULER_SA_EMAIL"
 gcloud run jobs add-iam-policy-binding "$JOB_NAME" \
   --project "$PROJECT" \
   --region "$REGION" \
-  --member "serviceAccount:${SA_EMAIL}" \
+  --member "serviceAccount:${SCHEDULER_SA_EMAIL}" \
   --role roles/run.invoker \
   --quiet >/dev/null
 
@@ -644,7 +732,7 @@ if gcloud scheduler jobs describe "$SCHEDULER_NAME" \
     --schedule "$SCHEDULE" \
     --uri "$JOB_URI" \
     --http-method POST \
-    --oauth-service-account-email "$SA_EMAIL"
+    --oauth-service-account-email "$SCHEDULER_SA_EMAIL"
 else
   echo "==> creating Cloud Scheduler job: $SCHEDULER_NAME"
   gcloud scheduler jobs create http "$SCHEDULER_NAME" \
@@ -653,14 +741,20 @@ else
     --schedule "$SCHEDULE" \
     --uri "$JOB_URI" \
     --http-method POST \
-    --oauth-service-account-email "$SA_EMAIL"
+    --oauth-service-account-email "$SCHEDULER_SA_EMAIL"
 fi
 
 echo
 echo "Cloud Run Job:       projects/${PROJECT}/locations/${REGION}/jobs/${JOB_NAME}"
 echo "Cloud Scheduler:     projects/${PROJECT}/locations/${REGION}/jobs/${SCHEDULER_NAME}"
 echo "Schedule:            ${SCHEDULE}"
-echo "Service account:     ${SA_EMAIL}"
+echo "Max retries:         ${MAX_RETRIES}"
+if [[ "$SINGLE_SA" == "true" ]]; then
+  echo "Service account:     ${RUNTIME_SA_EMAIL} (single-sa mode)"
+else
+  echo "Runtime SA:          ${RUNTIME_SA_EMAIL}"
+  echo "Scheduler-caller SA: ${SCHEDULER_SA_EMAIL}"
+fi
 
 # ----------------------------------------------------------- #
 # 7. Optional smoke run                                        #

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -32,8 +32,14 @@
 #    ``bigquery.datasets.create`` — narrows the runtime IAM
 #    surface to dataset-level grants.
 #
-# 2. Creates the runtime + scheduler service account
-#    (``bqaa-periodic-sa``) if absent, and grants:
+# 2. Creates the runtime + scheduler-caller service accounts
+#    if absent. Default: two SAs — ``bqaa-periodic-runtime-sa``
+#    (holds the BigQuery + Vertex AI roles below) and
+#    ``bqaa-periodic-scheduler-sa`` (holds only
+#    ``roles/run.invoker`` on the job, wired in section 5).
+#    Under ``--single-sa``: a single ``bqaa-periodic-sa`` that
+#    serves both paths (the pre-#182 default). The runtime SA
+#    is granted:
 #      * project-level ``roles/bigquery.jobUser`` (jobs.create).
 #      * project-level ``roles/aiplatform.user`` (the MAKO
 #        demo's extraction path calls ``AI.GENERATE``, which

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -64,11 +64,14 @@
 #    ``--set-env-vars``.
 #
 # 5. Enables the Cloud Scheduler API if it isn't already, and
-#    grants the same SA ``roles/run.invoker`` on the job so
-#    the scheduler trigger can actually invoke it.
+#    grants the scheduler-caller SA ``roles/run.invoker`` on
+#    the job so the scheduler trigger can actually invoke it.
+#    Default: ``bqaa-periodic-scheduler-sa``. Under
+#    ``--single-sa``: ``bqaa-periodic-sa`` (same as runtime).
 #
 # 6. Creates / updates the Cloud Scheduler job pointing at the
-#    Cloud Run Jobs ``:run`` endpoint, authenticated as the SA.
+#    Cloud Run Jobs ``:run`` endpoint, authenticated as the
+#    scheduler-caller SA.
 #
 # 7. If ``--smoke`` is passed, executes the job once via
 #    ``gcloud run jobs execute --wait`` and tails the logs —
@@ -708,13 +711,25 @@ gcloud services enable cloudscheduler.googleapis.com \
 # the ONLY role the scheduler-caller SA holds — least-privilege.
 # In ``--single-sa`` mode, ``$SCHEDULER_SA_EMAIL == $RUNTIME_SA_EMAIL``
 # so the grant lands on the same SA the runtime uses.
+#
+# Wrapped in ``_retry_iam`` because the same IAM-propagation race
+# the project-level grants above defend against also bites here
+# on a fresh split-SA deploy: ``bqaa-periodic-scheduler-sa`` was
+# created a few seconds earlier in section 2, but
+# ``gcloud run jobs add-iam-policy-binding`` can read from a
+# different IAM replica that hasn't seen the new SA yet and
+# returns ``INVALID_ARGUMENT: Service account ... does not exist``.
+# Before this wrapper landed, fresh split-SA deploys could fail
+# at this step after the Cloud Run Job was already deployed but
+# before the scheduler trigger was wired — leaving the deploy
+# half-done with no scheduler invoker grant.
 echo "==> granting roles/run.invoker on $JOB_NAME to $SCHEDULER_SA_EMAIL"
-gcloud run jobs add-iam-policy-binding "$JOB_NAME" \
+_retry_iam gcloud run jobs add-iam-policy-binding "$JOB_NAME" \
   --project "$PROJECT" \
   --region "$REGION" \
   --member "serviceAccount:${SCHEDULER_SA_EMAIL}" \
   --role roles/run.invoker \
-  --quiet >/dev/null
+  --quiet
 
 # ----------------------------------------------------------- #
 # 6. Create / update the Cloud Scheduler trigger               #

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -55,6 +55,13 @@ Env vars (all set by the deploy script via
   events table sometimes lags ingestion by tens of minutes.
 * ``BQAA_MAX_SESSIONS`` (default unset/unlimited) — cost
   guardrail.
+* ``BQAA_MAX_RETRIES`` (default unset) — informational only.
+  The deploy script (issue #183) sets this to the
+  ``gcloud run jobs deploy --max-retries`` value so the
+  runtime's startup log can surface it in Cloud Logging;
+  operators correlating alerts with retry behaviour see the
+  policy without ``gcloud run jobs describe``. The job itself
+  doesn't act on this value — Cloud Run owns the retry policy.
 * ``BQAA_BACKFILL`` (default ``false``) — set ``true`` to run a
   one-shot backfill of a fixed historical window instead of the
   steady-state cron. When set, ``BQAA_FROM`` and ``BQAA_TO`` are
@@ -428,6 +435,12 @@ def main() -> int:
       bundles_root=bundles_root,
       reference_extractors_module=reference_extractors_module,
       max_session_age_hours=max_session_age_hours,
+      # Informational only — surfaces the Cloud Run Job's
+      # ``--max-retries`` setting so operators reading Cloud
+      # Logging see the retry policy alongside the run's other
+      # config (issue #183). Cloud Run owns the actual retry
+      # behaviour; the runtime doesn't act on this value.
+      max_retries=os.environ.get("BQAA_MAX_RETRIES") or None,
   )
 
   try:

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -3966,3 +3966,172 @@ class TestOrphanWatchdogOrchestratorIntegration:
             bq_client=_stub_bq_client([]),
             max_session_age_hours=bad,
         )
+
+
+# ====================================================================== #
+# Deploy-script boundary (issues #182 + #183 — split SAs + max-retries)   #
+# ====================================================================== #
+
+
+class TestDeployScriptHardening:
+  """Static checks on ``deploy_cloud_run_job.sh`` for the
+  production-posture defaults introduced by issues #182 + #183:
+  split runtime + scheduler-caller SAs by default with
+  ``--single-sa`` as the escape hatch, and ``--max-retries`` as
+  a CLI-tunable knob (default 2) that propagates both into the
+  ``gcloud run jobs deploy`` command and the runtime env."""
+
+  def _deploy_script_path(self) -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "deploy_cloud_run_job.sh"
+    )
+
+  def _script_body(self) -> str:
+    return self._deploy_script_path().read_text()
+
+  def test_deploy_script_shell_syntax_clean_after_hardening(self):
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        ["bash", "-n", str(script)], capture_output=True, text=True
+    )
+    assert (
+        result.returncode == 0
+    ), f"deploy script has a shell syntax error: {result.stderr}"
+
+  def test_split_sa_is_default_runtime_and_scheduler_distinct(self):
+    """The script must define the two SA names so the runtime
+    holds BigQuery/Vertex roles and the scheduler-caller holds
+    only ``roles/run.invoker`` — the least-privilege story
+    issue #182 wants as the default."""
+    body = self._script_body()
+    assert (
+        "bqaa-periodic-runtime-sa" in body
+    ), "default deploy must create a dedicated runtime SA"
+    assert (
+        "bqaa-periodic-scheduler-sa" in body
+    ), "default deploy must create a dedicated scheduler-caller SA"
+    # Both SAs created via ``_ensure_sa`` calls.
+    assert (
+        '_ensure_sa "$RUNTIME_SA_NAME"' in body
+        and '_ensure_sa "$SCHEDULER_SA_NAME"' in body
+    ), "deploy script must create runtime + scheduler SAs"
+
+  def test_single_sa_flag_falls_back_to_combined_identity(self):
+    """``--single-sa`` flips back to the pre-#182 combined SA so
+    customers who want the simpler identity model still have an
+    explicit opt-in."""
+    body = self._script_body()
+    assert "--single-sa" in body
+    assert (
+        "SINGLE_SA=false" in body
+    ), "the production default must be SINGLE_SA=false"
+    # The combined-identity branch sets both names to the legacy
+    # ``bqaa-periodic-sa`` so re-running with ``--single-sa``
+    # on an existing combined deploy doesn't strand the old SA.
+    assert (
+        'if [[ "$SINGLE_SA" == "true" ]]; then' in body
+        and 'RUNTIME_SA_NAME="bqaa-periodic-sa"' in body
+        and 'SCHEDULER_SA_NAME="bqaa-periodic-sa"' in body
+    )
+
+  def test_cloud_run_uses_runtime_sa_scheduler_uses_scheduler_sa(self):
+    """The two SAs must be wired to the right gcloud commands:
+    ``--service-account`` on the Cloud Run Job points at the
+    runtime SA (its BigQuery work needs the BQ roles); the
+    scheduler's ``--oauth-service-account-email`` points at the
+    scheduler-caller SA (only needs ``roles/run.invoker``)."""
+    body = self._script_body()
+    assert '--service-account "$RUNTIME_SA_EMAIL"' in body
+    assert (
+        '--oauth-service-account-email "$SCHEDULER_SA_EMAIL"' in body
+    ), "scheduler must use scheduler-caller SA, not runtime SA"
+    # Scheduler invoker grant lands on the scheduler-caller SA.
+    assert '--member "serviceAccount:${SCHEDULER_SA_EMAIL}"' in body, (
+        "roles/run.invoker on the Cloud Run Job must be granted "
+        "to the scheduler-caller SA, not the runtime SA"
+    )
+
+  def test_max_retries_flag_default_two_and_propagates(self):
+    """``--max-retries`` defaults to 2 (issue #183 — was hard-
+    coded 1) and propagates both into ``gcloud run jobs deploy``
+    and the Cloud Run Job's env so the runtime's startup log
+    surfaces it."""
+    body = self._script_body()
+    assert (
+        'MAX_RETRIES="2"' in body
+    ), "deploy script must default --max-retries to 2"
+    assert (
+        "--max-retries) " in body or "--max-retries)" in body
+    ), "deploy script must accept --max-retries as a CLI flag"
+    # The gcloud invocation must use the variable, not a literal.
+    assert '--max-retries "$MAX_RETRIES"' in body, (
+        "gcloud run jobs deploy must pass the configured retry "
+        "count via the $MAX_RETRIES variable (was hard-coded 1)"
+    )
+    # And the runtime env must carry it for Cloud Logging
+    # correlation.
+    assert "BQAA_MAX_RETRIES=${MAX_RETRIES}" in body, (
+        "deploy script must surface BQAA_MAX_RETRIES in the env "
+        "var array so the runtime startup log can echo it"
+    )
+
+  def test_max_retries_rejects_non_integer(self):
+    """Operator typo: ``--max-retries abc`` must fail at the
+    deploy boundary, not surface as a less-obvious gcloud error
+    after the build."""
+    script = self._deploy_script_path()
+    if not script.exists():
+      pytest.skip("deploy script not present in this checkout")
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--project",
+            "p",
+            "--region",
+            "us-central1",
+            "--events-dataset",
+            "e",
+            "--graph-dataset",
+            "g",
+            "--schedule",
+            "0 */6 * * *",
+            "--max-retries",
+            "abc",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "non-negative integer" in (result.stdout + result.stderr)
+
+  def test_run_job_reads_bqaa_max_retries_into_startup_log(self):
+    """The runtime entrypoint must read ``BQAA_MAX_RETRIES``
+    and include it in the structured startup log so operators
+    correlating Cloud Monitoring alert noise with retry behaviour
+    see the retry policy without ``gcloud run jobs describe``
+    (issue #183)."""
+    run_job = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "run_job.py"
+    )
+    if not run_job.exists():
+      pytest.skip("run_job.py not present in this checkout")
+    body = run_job.read_text()
+    assert "BQAA_MAX_RETRIES" in body
+    # The startup log must thread the value through so it lands
+    # in jsonPayload.
+    assert "max_retries=" in body, (
+        "run_job.py must pass max_retries into the _emit() call so "
+        "the Cloud Logging payload carries it"
+    )

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -4057,6 +4057,33 @@ class TestDeployScriptHardening:
         "to the scheduler-caller SA, not the runtime SA"
     )
 
+  def test_scheduler_invoker_grant_uses_retry_iam(self):
+    """PR #230 review P1: the same IAM-propagation race that
+    ``_retry_iam`` defends against on the project-level grants
+    also bites on the job-level ``roles/run.invoker`` grant —
+    the scheduler-caller SA was created seconds earlier in the
+    script's section 2, and ``gcloud run jobs add-iam-policy-
+    binding`` can read from a different replica that hasn't
+    seen it yet. Pre-fix the script ran the bare ``gcloud``
+    invocation; first-time split-SA deploys could fail here
+    after the Cloud Run Job was already deployed but before
+    the scheduler trigger was wired."""
+    body = self._script_body()
+    # The invoker grant must be wrapped in ``_retry_iam`` (just
+    # like the project-level grants), not run bare.
+    assert "_retry_iam gcloud run jobs add-iam-policy-binding" in body, (
+        "the scheduler-caller invoker grant must use _retry_iam to "
+        "tolerate the IAM-propagation race on fresh split-SA deploys"
+    )
+    # And it must NOT keep the pre-fix bare invocation around
+    # (defensive — a future refactor that re-introduces a
+    # second un-wrapped grant would slip through otherwise).
+    assert "\ngcloud run jobs add-iam-policy-binding" not in body, (
+        "no bare ``gcloud run jobs add-iam-policy-binding`` left "
+        "in the script — every invoker grant must route through "
+        "_retry_iam"
+    )
+
   def test_max_retries_flag_default_two_and_propagates(self):
     """``--max-retries`` defaults to 2 (issue #183 — was hard-
     coded 1) and propagates both into ``gcloud run jobs deploy``


### PR DESCRIPTION
## Summary

Two production-posture hardening changes to the periodic-materialization deploy script, the last bash deploy gap before the Terraform module copy lands. Closes #182 + #183.

## #182 — Split runtime + scheduler-caller SAs by default

Pre-#182, a single \`bqaa-periodic-sa\` served both as the Cloud Run Job's runtime identity AND the Cloud Scheduler trigger's OAuth caller. The combined SA holds project-level \`roles/bigquery.jobUser\` + (conditionally) \`roles/aiplatform.user\`, dataset-level \`roles/bigquery.dataEditor\`, and job-level \`roles/run.invoker\`. The scheduler-caller path only ever needs \`roles/run.invoker\` — combining the two paths gives the scheduler broader permissions than it ever exercises. Least-privilege violation that matters in regulated industries.

**Now**: two SAs by default.

| SA | Holds | Wired to |
|---|---|---|
| \`bqaa-periodic-runtime-sa@…\` | BigQuery jobUser + dataset-level Viewer/Editor + (conditionally) \`roles/aiplatform.user\` | \`gcloud run jobs deploy --service-account\` |
| \`bqaa-periodic-scheduler-sa@…\` | only \`roles/run.invoker\` on the specific Cloud Run Job | \`gcloud scheduler jobs create http --oauth-service-account-email\` |

\`--single-sa\` is the escape hatch — restores the pre-#182 \`bqaa-periodic-sa\` combined identity so existing deploys keep their existing SA when re-running with this flag.

## #183 — \`--max-retries N\` flag (default 2)

\`gcloud run jobs deploy\` had \`--max-retries 1\` hard-coded. For transient BigQuery slot pressure or short-lived rate-limiting events, one retry can be insufficient — the cron run fails, on-call gets paged, and the next scheduled fire would have succeeded anyway. The orchestrator's session-level idempotency + append-only state table mean additional retries are safe.

**Now**: \`--max-retries N\` is a deploy-script flag, defaulting to \`2\` (production posture). The value also flows into the Cloud Run Job's env as \`BQAA_MAX_RETRIES\` so the runtime's structured startup log surfaces it in \`jsonPayload.max_retries\` — operators correlating Cloud Monitoring alert noise with retry behaviour see the policy without having to \`gcloud run jobs describe\` per alert.

## README updates

* IAM matrix grew a \"Granted to\" column showing which SA holds which role (runtime SA vs scheduler-caller SA).
* \"What this deploys\" item 2 rewritten to name both SAs + the \`--single-sa\` flag.
* \"Idempotent retries\" rewritten: \`--max-retries 2\` default, tunable, retries are safe because of session-level idempotency, retry count visible in Cloud Logging.
* Cleanup section's \`gcloud iam service-accounts delete\` snippets cover both split-SA and single-SA modes.
* Historical pre-#182 verified-evidence block flagged as such with a note pointing at \`--single-sa\` for the original shape.
* Troubleshooting + walkthrough prose updated to name the scheduler-caller SA explicitly with the \`--single-sa\` carve-out.

## Tests (+8 new in \`TestDeployScriptHardening\`; **135** \`materialize_window\` tests pass)

* Shell syntax check (\`bash -n\`) on the rewritten script.
* Split-SA default: both SA names present; \`_ensure_sa\` invoked for both.
* \`--single-sa\` flag exists; \`SINGLE_SA=false\` is the production default; combined-mode maps both SA names back to \`bqaa-periodic-sa\` for back-compat.
* Cloud Run \`--service-account\` → runtime SA; scheduler \`--oauth-service-account-email\` → scheduler SA; the \`run.invoker\` grant on the job lands on the scheduler SA.
* \`MAX_RETRIES=\"2\"\` default, \`--max-retries\` accepted, \`gcloud run jobs deploy --max-retries \"\$MAX_RETRIES\"\` (not the hard-coded \`1\`), \`BQAA_MAX_RETRIES=\${MAX_RETRIES}\` in the env-var array.
* Operator-typo path: \`--max-retries abc\` rejected at the boundary with \"non-negative integer\" message.
* \`run_job.py\` reads \`BQAA_MAX_RETRIES\` and threads it through the startup log payload.
* **\`test_scheduler_invoker_grant_uses_retry_iam\`** (new on review round 1): the scheduler invoker grant on the Cloud Run Job is wrapped in \`_retry_iam\` (defends against the same IAM-propagation race the project-level grants defend against — fresh split-SA deploys could otherwise fail here after the Cloud Run Job was deployed but before the scheduler trigger was wired). Pin includes a negative assertion that no bare \`gcloud run jobs add-iam-policy-binding\` invocation is left in the script.

Lint + isort clean.

## Test plan
- [x] \`python -m pytest tests/test_materialize_window.py\` — 135 pass (+8 new)
- [x] \`python -m pytest tests/\` — 3118 pass, 15 skipped
- [x] \`bash -n examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh\` — clean
- [x] \`pyink --check\` + \`isort --check-only\` — clean
- [ ] Live deploy against a real GCP project to verify the split-SA mode end-to-end (reviewer / merger-side; the static checks cover all the flag-wiring contract, the IAM-retry-wrapper contract, and the bash syntax)

After this lands, the deploy surface is stable — Terraform module PR (#186) can mirror it.