### PR TITLE
feat(deploy): Terraform module for periodic materialization (#186)

### DIFF
--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -784,11 +784,25 @@ gcloud iam service-accounts delete \
   --project=your-project --quiet
 ```
 
+## Infrastructure-as-Code option
+
+* **Terraform module.** [`terraform/`](./terraform/) ships an
+  IaC mirror of this bash deploy (resolves #186, defaults
+  match the post-#230 surface: split SAs, `max_retries = 2`,
+  `extraction_mode = "ai-fallback"`). The module deploys
+  *configured* infrastructure — graph dataset, both SAs, IAM
+  bindings, Cloud Run Job, Scheduler trigger — and takes the
+  published container image URI as input. Container image
+  build is intentionally outside the module (the bash deploy's
+  Cloud Buildpacks `--source` flow doesn't slot into IaC); the
+  expected pipeline is CI builds → Artifact Registry push →
+  `terraform apply`. See [`terraform/README.md`](./terraform/README.md)
+  for the bash-vs-Terraform comparison and the quickstart.
+
 ## Not in scope here
 
-* **Terraform / Pulumi.** A scripted deploy is easier to read
-  and easier to copy than IaC. IaC can come once the command
-  shape stabilizes.
+* **Pulumi.** A Pulumi equivalent of the Terraform module would
+  be a straightforward port and is open for contribution.
 * **Compiled-bundle materialization.** This example uses the
   plain `from_ontology_binding` extraction path (Gemini-backed).
   For compiled extractors (`--bundles-root`), see

--- a/examples/migration_v5/periodic_materialization/build_image.sh
+++ b/examples/migration_v5/periodic_materialization/build_image.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Stage the periodic-materialization container source + publish to
+# Artifact Registry.
+#
+# This is the image-build counterpart to ``deploy_cloud_run_job.sh``.
+# The bash deploy does build + IAM + Cloud Run Job + Scheduler all
+# inline. The Terraform module (see ``terraform/``) does only the
+# IAM + Cloud Run Job + Scheduler half — it takes the published
+# image URI as input. This helper closes the gap by producing the
+# image the Terraform module needs.
+#
+# The staging layout mirrors what ``deploy_cloud_run_job.sh``
+# section 3 assembles (Procfile + run_job.py + reference_extractor +
+# demo artifacts + vendored SDK source). Keeping the layout
+# byte-identical to the bash deploy's staging dir means a customer
+# can build with this script + deploy with Terraform and get a
+# container behaviorally identical to the bash deploy's
+# ``gcloud run jobs deploy --source`` output.
+
+set -euo pipefail
+
+PROJECT=""
+REPO=""
+REGION="us-central1"
+IMAGE="periodic-materialization"
+TAG=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --project PROJECT_ID --repo AR_REPO [options]
+
+Required:
+  --project PROJECT_ID   GCP project (used for both gcloud builds AND
+                         Artifact Registry).
+  --repo AR_REPO         Artifact Registry repository name (will be
+                         created with --create-repo if absent).
+
+Optional:
+  --region REGION        Artifact Registry region (default: us-central1).
+  --image IMAGE_NAME     Image name within the AR repo (default:
+                         periodic-materialization).
+  --tag TAG              Image tag (default: short git SHA of HEAD, or
+                         a timestamp if HEAD isn't a git ref).
+  --create-repo          Create the AR repo if it doesn't exist.
+  -h | --help            Show this help.
+
+Outputs (last line of stdout):
+  REGION-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG
+
+Pipe the last line into ``terraform apply -var image_uri=\$(...)``.
+EOF
+  exit "${1:-1}"
+}
+
+CREATE_REPO=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)      PROJECT="$2"; shift 2 ;;
+    --repo)         REPO="$2"; shift 2 ;;
+    --region)       REGION="$2"; shift 2 ;;
+    --image)        IMAGE="$2"; shift 2 ;;
+    --tag)          TAG="$2"; shift 2 ;;
+    --create-repo)  CREATE_REPO=true; shift ;;
+    -h|--help)      usage 0 ;;
+    *)              echo "Unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$PROJECT" || -z "$REPO" ]]; then
+  echo "Error: --project and --repo are required." >&2
+  usage 1
+fi
+
+if [[ -z "$TAG" ]]; then
+  # Default tag: short git SHA if HEAD is reachable, timestamp
+  # otherwise. Either keeps tags monotonically increasing so a
+  # later ``terraform apply`` against a fresh tag forces a Cloud
+  # Run revision rollover.
+  if TAG="$(git rev-parse --short HEAD 2>/dev/null)"; then
+    :
+  else
+    TAG="t$(date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARTIFACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${ARTIFACTS_DIR}/../.." && pwd)"
+
+STAGING="$(mktemp -d -t bqaa-build-XXXXXXXX)"
+trap 'rm -rf "$STAGING"' EXIT
+
+echo "==> staging build context at $STAGING" >&2
+
+# Mirror ``deploy_cloud_run_job.sh`` section 3 exactly. The
+# layout here is what the Cloud Run runtime expects:
+#
+#   STAGING/
+#     run_job.py          ← entrypoint (Procfile points here)
+#     reference_extractor.py
+#     ontology.yaml
+#     binding.yaml
+#     table_ddl.sql
+#     requirements.txt    ← ``./sdk_src`` + ancillary deps
+#     Procfile            ← ``web: python run_job.py``
+#     sdk_src/
+#       pyproject.toml
+#       README.md         ← stub (hatch reads ``readme`` field)
+#       src/
+#         bigquery_agent_analytics/
+#         bigquery_ontology/
+#
+# Any drift from the bash deploy's staging output here will
+# show up as a behavioral difference between bash-built and
+# Terraform-built images. The covering test in
+# ``tests/test_materialize_window.py::TestBuildImageStaging``
+# pins these copies to lock the contract.
+
+cp "${SCRIPT_DIR}/run_job.py" "$STAGING/"
+cp "${ARTIFACTS_DIR}/ontology.yaml" "$STAGING/"
+cp "${ARTIFACTS_DIR}/binding.yaml" "$STAGING/"
+cp "${ARTIFACTS_DIR}/table_ddl.sql" "$STAGING/"
+cp "${ARTIFACTS_DIR}/reference_extractor.py" "$STAGING/"
+
+mkdir -p "$STAGING/sdk_src/src"
+cp -r "$REPO_ROOT/src/bigquery_agent_analytics" "$STAGING/sdk_src/src/"
+cp -r "$REPO_ROOT/src/bigquery_ontology" "$STAGING/sdk_src/src/"
+cp "$REPO_ROOT/pyproject.toml" "$STAGING/sdk_src/"
+echo "# bigquery-agent-analytics (vendored for periodic-materialization deploy)" \
+  > "$STAGING/sdk_src/README.md"
+
+cat > "$STAGING/requirements.txt" <<EOF
+# Auto-generated by build_image.sh. Installs the SDK from the
+# vendored source bundled into the build context, so the
+# deployed image uses the same SDK code as the local dry-run.
+./sdk_src
+google-cloud-bigquery>=3.0.0
+pyyaml>=6.0
+EOF
+
+cat > "$STAGING/Procfile" <<EOF
+web: python run_job.py
+EOF
+
+# Make sure the target AR repo exists (idempotent).
+if [[ "$CREATE_REPO" == "true" ]]; then
+  if ! gcloud artifacts repositories describe "$REPO" \
+      --project "$PROJECT" --location "$REGION" >/dev/null 2>&1; then
+    echo "==> creating Artifact Registry repo: $REPO in $REGION" >&2
+    gcloud artifacts repositories create "$REPO" \
+      --repository-format=docker \
+      --location="$REGION" \
+      --project="$PROJECT" \
+      --description="BQAA periodic-materialization images" \
+      --quiet
+  fi
+fi
+
+IMAGE_URI="${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/${IMAGE}:${TAG}"
+echo "==> building + pushing $IMAGE_URI" >&2
+# ``--pack image=URI`` selects Buildpacks (the same builder the
+# bash deploy's ``gcloud run jobs deploy --source`` flow uses).
+# Plain ``--tag`` would require a Dockerfile, which the staging
+# layout intentionally omits — the Procfile + ``requirements.txt``
+# are enough for Buildpacks' Python builder to produce a runnable
+# image.
+gcloud builds submit \
+  --project "$PROJECT" \
+  --pack "image=${IMAGE_URI}" \
+  --quiet \
+  "$STAGING" >&2
+
+# The image URI is the LAST line of stdout — wrappers can do
+# ``IMAGE_URI=$(./build_image.sh ...)`` to capture it.
+echo "$IMAGE_URI"

--- a/examples/migration_v5/periodic_materialization/terraform/.gitignore
+++ b/examples/migration_v5/periodic_materialization/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Terraform local state + provider cache — never commit.
+# Production deploys use remote state (see README's "State file"
+# section); the local files below show up after a local
+# ``terraform init`` / ``apply`` and shouldn't track into git.
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*
+*.tfplan

--- a/examples/migration_v5/periodic_materialization/terraform/README.md
+++ b/examples/migration_v5/periodic_materialization/terraform/README.md
@@ -1,0 +1,171 @@
+# Terraform module — periodic materialization
+
+This module is the Infrastructure-as-Code mirror of [`deploy_cloud_run_job.sh`](../deploy_cloud_run_job.sh). It lands the same six resources the bash deploy does — graph dataset, runtime + scheduler-caller service accounts, IAM bindings, Cloud Run v2 Job, Cloud Scheduler trigger — but as declarative Terraform so it slots into managed-fleet operations (`terraform plan` review, drift detection, multi-environment promotion, etc.).
+
+Resolves [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/186). Defaults match the post-#230 deploy surface: **split runtime + scheduler-caller SAs**, **`max_retries = 2`**, **`extraction_mode = "ai-fallback"`**.
+
+## What this module deploys
+
+| Resource | Terraform type | Mirrors bash deploy section |
+|---|---|---|
+| Graph dataset | `google_bigquery_dataset` | §1 — `bq mk` (pre-create so the runtime SA never needs `bigquery.datasets.create`) |
+| Runtime SA + scheduler-caller SA | `google_service_account` ×2 | §2 — `_ensure_sa` (split by default; `single_sa = true` collapses to one) |
+| Project + dataset IAM grants | `google_project_iam_member`, `google_bigquery_dataset_iam_member` | §3 — `_retry_iam gcloud projects add-iam-policy-binding` and the dataset-level grant block. Terraform's dependency graph handles the IAM-propagation race declaratively (the `depends_on` on the Cloud Run Job resource ensures grants land before the first invocation) |
+| Cloud Run v2 Job | `google_cloud_run_v2_job` | §4 — `gcloud run jobs deploy`. Same env-var set the bash deploy wires (`BQAA_PROJECT_ID`, `BQAA_EVENTS_DATASET_ID`, `BQAA_GRAPH_DATASET_ID`, `BQAA_LOCATION`, `BQAA_LOOKBACK_HOURS`, `BQAA_OVERLAP_MINUTES`, `BQAA_EXTRACTION_MODE`, `BQAA_MAX_RETRIES`, conditionally `BQAA_MAX_SESSIONS`, `BQAA_MAX_SESSION_AGE_HOURS`, `BQAA_REFERENCE_EXTRACTORS_MODULE`) |
+| `roles/run.invoker` on the job → scheduler SA | `google_cloud_run_v2_job_iam_member` | §5 — `_retry_iam gcloud run jobs add-iam-policy-binding` |
+| Cloud Scheduler trigger | `google_cloud_scheduler_job` | §6 — `gcloud scheduler jobs create http` with `--oauth-service-account-email` pointing at the scheduler SA |
+
+## What's intentionally outside the module
+
+**Container image build + publish.** The bash deploy builds the image from local sources via Cloud Buildpacks (`gcloud run jobs deploy --source $STAGING`), vendoring the SDK in and producing an image inline. That flow doesn't slot into IaC — Terraform deploys *configured* infrastructure, not source builds.
+
+The module takes the **published** container image URI as the required `image_uri` variable. The expected pipeline:
+
+```text
+CI (or operator) → docker build → push to Artifact Registry → terraform apply
+```
+
+A minimal local build/publish for the recommended image layout (mirrors what the bash deploy stages):
+
+```bash
+# Build context = the periodic_materialization directory, with the SDK
+# source vendored into ``sdk_src/`` and ``reference_extractor.py`` next
+# to ``run_job.py``. The bash deploy does this in a tmp dir;
+# replicate the staging layout in your build context however your
+# CI prefers.
+
+REGION=us-central1
+PROJECT=my-project
+REPO=bqaa
+IMAGE=periodic-materialization
+TAG=$(git rev-parse --short HEAD)
+gcloud builds submit \
+  --tag "${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/${IMAGE}:${TAG}" \
+  examples/migration_v5/periodic_materialization
+
+# Then point Terraform at the published image:
+terraform apply \
+  -var "project_id=${PROJECT}" \
+  -var "image_uri=${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/${IMAGE}:${TAG}" \
+  ...
+```
+
+## Bash deploy vs Terraform module
+
+| Dimension | `deploy_cloud_run_job.sh` | Terraform module |
+|---|---|---|
+| Source build | ✓ (Cloud Buildpacks from local sources, inline) | — (caller's CI) |
+| Audience | Notebook reader, evaluator, one-shot deploy | Infra team, managed-fleet ops, multi-env |
+| Plan / preview before apply | ✗ | ✓ (`terraform plan`) |
+| Drift detection | ✗ | ✓ (`terraform plan` shows drift) |
+| Idempotent re-apply | ✓ (skip-if-exists per resource) | ✓ (declarative; state file owns reconciliation) |
+| State store | None — re-runs probe live state | Terraform state (recommended: GCS-backed remote state) |
+| Output for downstream wiring | Echo block (string scrape) | `terraform output` (machine-readable) |
+| IAM propagation race | `_retry_iam` shell wrapper | `depends_on` dependency graph |
+| Smoke run | `--smoke` flag | `gcloud run jobs execute` after `terraform apply` |
+
+Both tools land **the same six resources with the same flag surface**. If the bash deploy works for your operations model, this Terraform module is not a forced upgrade — it's a parallel option for customers whose infra teams already operate IaC.
+
+## Quickstart
+
+### 1. Configure your inputs
+
+```hcl
+# terraform.tfvars
+project_id         = "my-project"
+region             = "us-central1"
+events_dataset_id  = "agent_analytics"
+graph_dataset_id   = "migration_v5_graph"
+schedule           = "0 */6 * * *"
+image_uri          = "us-central1-docker.pkg.dev/my-project/bqaa/periodic-materialization:v1"
+# Optional overrides — defaults match the bash deploy
+# extraction_mode       = "ai-fallback"
+# max_retries           = 2
+# max_session_age_hours = 24
+# single_sa             = false
+# location              = "US"
+```
+
+### 2. Init + plan + apply
+
+```bash
+cd examples/migration_v5/periodic_materialization/terraform
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+### 3. Inspect outputs
+
+```bash
+terraform output
+# runtime_sa_email     = "bqaa-periodic-runtime-sa@my-project.iam.gserviceaccount.com"
+# scheduler_sa_email   = "bqaa-periodic-scheduler-sa@my-project.iam.gserviceaccount.com"
+# cloud_run_job_name   = "bqaa-periodic-materialization"
+# scheduler_name       = "bqaa-periodic-materialization-cron"
+# graph_dataset_id     = "migration_v5_graph"
+```
+
+### 4. Optional smoke
+
+```bash
+gcloud run jobs execute "$(terraform output -raw cloud_run_job_name)" \
+  --project "$(terraform output -raw project_id 2>/dev/null || echo my-project)" \
+  --region us-central1 \
+  --wait
+```
+
+### 5. Tear down
+
+```bash
+terraform destroy
+```
+
+The destroy removes every resource the module created (graph dataset, both SAs, all IAM bindings, the Cloud Run Job, the scheduler trigger). The events dataset is **not** managed by the module and is left untouched.
+
+## State file
+
+Use a GCS-backed remote backend for any deployment beyond a single-operator experiment — local state files don't survive operator turnover and don't lock against concurrent applies. Minimal backend block:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "your-tfstate-bucket"
+    prefix = "bqaa/periodic-materialization"
+  }
+}
+```
+
+## Variables
+
+See [`variables.tf`](./variables.tf) for the full surface and the per-variable rationale. Required:
+
+* `project_id`
+* `region`
+* `events_dataset_id`
+* `graph_dataset_id`
+* `schedule`
+* `image_uri`
+
+Optional (defaults match `deploy_cloud_run_job.sh`):
+
+* `location` — `"US"`
+* `job_name` — `"bqaa-periodic-materialization"`
+* `extraction_mode` — `"ai-fallback"`
+* `max_retries` — `2`
+* `max_session_age_hours` — `null` (watchdog disabled)
+* `single_sa` — `false` (split-SA default)
+* `max_sessions` — `null` (unlimited)
+* `lookback_hours` — `6`
+* `overlap_minutes` — `15`
+* `task_timeout_seconds` — `1800`
+
+## Outputs
+
+* `runtime_sa_email`
+* `scheduler_sa_email`
+* `cloud_run_job_name`
+* `scheduler_name`
+* `graph_dataset_id`
+
+See [`outputs.tf`](./outputs.tf) for the full definitions.

--- a/examples/migration_v5/periodic_materialization/terraform/README.md
+++ b/examples/migration_v5/periodic_materialization/terraform/README.md
@@ -17,38 +17,25 @@ Resolves [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-
 
 ## What's intentionally outside the module
 
-**Container image build + publish.** The bash deploy builds the image from local sources via Cloud Buildpacks (`gcloud run jobs deploy --source $STAGING`), vendoring the SDK in and producing an image inline. That flow doesn't slot into IaC — Terraform deploys *configured* infrastructure, not source builds.
+**Container image build + publish.** The bash deploy builds the image from local sources via Cloud Buildpacks (`gcloud run jobs deploy --source $STAGING`), assembling a staging directory with `run_job.py` + `reference_extractor.py` + the demo artifacts + the vendored SDK source + `Procfile` + `requirements.txt` before invoking the build. That staging step is non-trivial — pointing `gcloud builds submit` directly at the `periodic_materialization/` directory would build an image that's missing the SDK source, the demo artifacts, and the Procfile.
 
-The module takes the **published** container image URI as the required `image_uri` variable. The expected pipeline:
-
-```text
-CI (or operator) → docker build → push to Artifact Registry → terraform apply
-```
-
-A minimal local build/publish for the recommended image layout (mirrors what the bash deploy stages):
+The module takes the **published** image URI as the required `image_uri` variable. To produce a Terraform-compatible image, use the bundled [`../build_image.sh`](../build_image.sh) helper — it stages the exact layout `deploy_cloud_run_job.sh` produces in its temp dir, then runs `gcloud builds submit` against that staging dir. Same image contents either way; Terraform just consumes the publish artifact instead of doing the build inline.
 
 ```bash
-# Build context = the periodic_materialization directory, with the SDK
-# source vendored into ``sdk_src/`` and ``reference_extractor.py`` next
-# to ``run_job.py``. The bash deploy does this in a tmp dir;
-# replicate the staging layout in your build context however your
-# CI prefers.
-
-REGION=us-central1
-PROJECT=my-project
-REPO=bqaa
-IMAGE=periodic-materialization
-TAG=$(git rev-parse --short HEAD)
-gcloud builds submit \
-  --tag "${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/${IMAGE}:${TAG}" \
-  examples/migration_v5/periodic_materialization
+# From the repo root.
+IMAGE_URI="$(./examples/migration_v5/periodic_materialization/build_image.sh \
+  --project my-project \
+  --repo bqaa \
+  --region us-central1 \
+  --create-repo)"
+echo "$IMAGE_URI"
+# → us-central1-docker.pkg.dev/my-project/bqaa/periodic-materialization:<tag>
 
 # Then point Terraform at the published image:
-terraform apply \
-  -var "project_id=${PROJECT}" \
-  -var "image_uri=${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/${IMAGE}:${TAG}" \
-  ...
+terraform apply -var "image_uri=$IMAGE_URI" -var "project_id=my-project" ...
 ```
+
+CI pipelines should call `build_image.sh` (or replicate the staging layout themselves) on every commit that touches `run_job.py`, the demo artifacts, or the vendored SDK source.
 
 ## Bash deploy vs Terraform module
 
@@ -67,6 +54,26 @@ terraform apply \
 Both tools land **the same six resources with the same flag surface**. If the bash deploy works for your operations model, this Terraform module is not a forced upgrade — it's a parallel option for customers whose infra teams already operate IaC.
 
 ## Quickstart
+
+### 0. Project APIs
+
+A clean GCP project doesn't have the BigQuery / Cloud Run / Cloud Scheduler / IAM APIs enabled by default. The module enables them on `terraform apply` via `google_project_service` resources (with `disable_on_destroy = false`, so a `terraform destroy` of this module doesn't disable APIs other workloads might depend on). Customers whose central infra repo manages project services elsewhere can set `manage_apis = false`.
+
+If `manage_apis = false`, enable the APIs manually before `terraform apply`:
+
+```bash
+gcloud services enable \
+  bigquery.googleapis.com \
+  run.googleapis.com \
+  cloudscheduler.googleapis.com \
+  iam.googleapis.com \
+  --project=my-project
+
+# Only needed in ai-fallback mode (the default):
+gcloud services enable aiplatform.googleapis.com --project=my-project
+```
+
+For the image-build step (Cloud Buildpacks via `gcloud builds submit`), also enable `cloudbuild.googleapis.com` and `artifactregistry.googleapis.com` — `build_image.sh` invokes those but doesn't auto-enable them.
 
 ### 1. Configure your inputs
 

--- a/examples/migration_v5/periodic_materialization/terraform/README.md
+++ b/examples/migration_v5/periodic_materialization/terraform/README.md
@@ -116,11 +116,16 @@ terraform output
 ### 4. Optional smoke
 
 ```bash
+PROJECT=my-project   # or whatever you set ``project_id`` to in tfvars
+REGION=us-central1   # or your ``region`` tfvars value
+
 gcloud run jobs execute "$(terraform output -raw cloud_run_job_name)" \
-  --project "$(terraform output -raw project_id 2>/dev/null || echo my-project)" \
-  --region us-central1 \
+  --project "$PROJECT" \
+  --region "$REGION" \
   --wait
 ```
+
+`project_id` and `region` aren't exported as Terraform outputs — they're inputs the caller already knows. Either inline them as shown above or, if you'd rather not retype, define them as outputs in your wrapper module that calls this one.
 
 ### 5. Tear down
 
@@ -166,6 +171,8 @@ Optional (defaults match `deploy_cloud_run_job.sh`):
 * `lookback_hours` — `6`
 * `overlap_minutes` — `15`
 * `task_timeout_seconds` — `1800`
+* `manage_apis` — `true` (enables BigQuery / Cloud Run / Cloud Scheduler / IAM / (conditionally) Vertex AI APIs via `google_project_service`; set `false` if your central infra repo manages project services elsewhere)
+* `deletion_protection` — `false` (Cloud Run v2 Job deletion-protection. Default matches the bash deploy's `gcloud run jobs delete` lifecycle — `terraform destroy` works without a separate apply. Production deploys that want the safety net opt in with `true`)
 
 ## Outputs
 

--- a/examples/migration_v5/periodic_materialization/terraform/main.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/main.tf
@@ -43,14 +43,14 @@ locals {
   # comparing the two side-by-side sees the same env surface.
   env_vars = merge(
     {
-      BQAA_PROJECT_ID         = var.project_id
-      BQAA_EVENTS_DATASET_ID  = var.events_dataset_id
-      BQAA_GRAPH_DATASET_ID   = var.graph_dataset_id
-      BQAA_LOCATION           = var.location
-      BQAA_LOOKBACK_HOURS     = tostring(var.lookback_hours)
-      BQAA_OVERLAP_MINUTES    = tostring(var.overlap_minutes)
-      BQAA_EXTRACTION_MODE    = var.extraction_mode
-      BQAA_MAX_RETRIES        = tostring(var.max_retries)
+      BQAA_PROJECT_ID        = var.project_id
+      BQAA_EVENTS_DATASET_ID = var.events_dataset_id
+      BQAA_GRAPH_DATASET_ID  = var.graph_dataset_id
+      BQAA_LOCATION          = var.location
+      BQAA_LOOKBACK_HOURS    = tostring(var.lookback_hours)
+      BQAA_OVERLAP_MINUTES   = tostring(var.overlap_minutes)
+      BQAA_EXTRACTION_MODE   = var.extraction_mode
+      BQAA_MAX_RETRIES       = tostring(var.max_retries)
     },
     var.max_sessions == null ? {} : {
       BQAA_MAX_SESSIONS = tostring(var.max_sessions)
@@ -69,6 +69,49 @@ locals {
   )
 }
 
+# ---- 0. Project services (clean-project bootstrap) ---- #
+
+# A fresh GCP project doesn't have the BigQuery / Cloud Run /
+# Cloud Scheduler / IAM APIs enabled by default. Without these,
+# ``terraform apply`` fails part-way through with confusing
+# "API not enabled" errors per-resource. Enabling them up front
+# matches what the bash deploy's "General prerequisites"
+# section asks customers to do manually.
+#
+# ``disable_on_destroy = false`` is deliberate: another workload
+# on the same project might depend on these APIs, and a
+# ``terraform destroy`` of THIS module shouldn't disable them
+# project-wide.
+#
+# Vertex AI (``aiplatform.googleapis.com``) is conditional on
+# ``extraction_mode`` — only ai-fallback mode calls
+# ``AI.GENERATE``. Mirrors the conditional IAM grant below.
+#
+# Customers whose central infra repo manages project services
+# elsewhere can set ``var.manage_apis = false`` to skip these
+# resources entirely.
+
+locals {
+  required_apis = var.manage_apis ? toset(concat(
+    [
+      "bigquery.googleapis.com",
+      "run.googleapis.com",
+      "cloudscheduler.googleapis.com",
+      "iam.googleapis.com",
+    ],
+    var.extraction_mode == "ai-fallback" ? ["aiplatform.googleapis.com"] : [],
+  )) : toset([])
+}
+
+resource "google_project_service" "required" {
+  for_each = local.required_apis
+
+  project                    = var.project_id
+  service                    = each.value
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
 # ---- 1. Graph dataset ---- #
 
 # Pre-creating the dataset (instead of letting ``run_job.py``'s
@@ -77,9 +120,9 @@ locals {
 # ``bigquery.datasets.create``. Matches the bash deploy's
 # ``bq mk`` step.
 resource "google_bigquery_dataset" "graph" {
-  project    = var.project_id
-  dataset_id = var.graph_dataset_id
-  location   = var.location
+  project     = var.project_id
+  dataset_id  = var.graph_dataset_id
+  location    = var.location
   description = "BQAA periodic-materialization graph dataset (created by Terraform module)."
 
   # Deliberately no ``default_table_expiration_ms`` — the
@@ -87,6 +130,11 @@ resource "google_bigquery_dataset" "graph" {
   # cron runs and accumulate history. The bash deploy's
   # ``1h TTL`` is for the notebook's *throwaway scratch*
   # dataset, not production graph data.
+
+  # Wait for the BigQuery API to be enabled before trying to
+  # create the dataset; otherwise a clean-project ``terraform
+  # apply`` errors here with "BigQuery API has not been used".
+  depends_on = [google_project_service.required]
 }
 
 # ---- 2. Service accounts ---- #
@@ -97,6 +145,8 @@ resource "google_service_account" "runtime" {
   project      = var.project_id
   account_id   = local.runtime_sa_account_id
   display_name = local.runtime_sa_display
+
+  depends_on = [google_project_service.required]
 }
 
 # Scheduler-caller SA: identity for the Cloud Scheduler HTTP
@@ -111,6 +161,8 @@ resource "google_service_account" "scheduler" {
   project      = var.project_id
   account_id   = local.scheduler_sa_account_id
   display_name = local.scheduler_sa_display
+
+  depends_on = [google_project_service.required]
 }
 
 # ---- 3. IAM grants on the runtime SA ---- #
@@ -170,6 +222,17 @@ resource "google_cloud_run_v2_job" "periodic" {
   # explicitly so plan diffs against the bash deploy's
   # post-state stay clean.
   launch_stage = "GA"
+
+  # Cloud Run v2 added a ``deletion_protection`` default of
+  # ``true`` in newer provider releases. Leaving it on would
+  # make ``terraform destroy`` fail with "cannot destroy job
+  # without setting deletion_protection=false and running
+  # ``terraform apply``". The bash deploy has no analogous
+  # block — its ``gcloud run jobs delete`` cleanup just works.
+  # We surface the setting as ``var.deletion_protection`` so
+  # production deploys can opt back in, but the module
+  # default is ``false`` to match the bash deploy's lifecycle.
+  deletion_protection = var.deletion_protection
 
   template {
     # Cloud Run owns the retry policy here. Matches the bash

--- a/examples/migration_v5/periodic_materialization/terraform/main.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/main.tf
@@ -1,0 +1,270 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Module shape mirrors deploy_cloud_run_job.sh's section ordering:
+#   1. Pre-create the graph dataset.
+#   2. Service accounts (split by default; combined under single_sa).
+#   3. Project + dataset IAM grants on the runtime SA.
+#   4. Cloud Run v2 Job (with the env vars the bash deploy wires).
+#   5. roles/run.invoker on the Cloud Run Job for the scheduler SA.
+#   6. Cloud Scheduler trigger.
+#
+# Image build is OUTSIDE the module — Terraform takes the
+# published ``var.image_uri`` as input. The bash deploy's
+# Cloud Buildpacks + ``--source`` flow doesn't slot into IaC.
+
+# ---- Locals ---- #
+
+locals {
+  runtime_sa_account_id = var.single_sa ? "bqaa-periodic-sa" : "bqaa-periodic-runtime-sa"
+  runtime_sa_email      = "${local.runtime_sa_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  runtime_sa_display    = var.single_sa ? "BQAA periodic-materialization runtime + scheduler" : "BQAA periodic-materialization runtime"
+
+  scheduler_sa_account_id = var.single_sa ? "bqaa-periodic-sa" : "bqaa-periodic-scheduler-sa"
+  scheduler_sa_email      = "${local.scheduler_sa_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  scheduler_sa_display    = var.single_sa ? "BQAA periodic-materialization runtime + scheduler" : "BQAA periodic-materialization scheduler caller"
+
+  scheduler_job_name = "${var.job_name}-cron"
+
+  # Env vars wired into the Cloud Run Job. Mirrors the
+  # bash deploy's ENV_VARS array (see
+  # ``deploy_cloud_run_job.sh`` section 4) so a customer
+  # comparing the two side-by-side sees the same env surface.
+  env_vars = merge(
+    {
+      BQAA_PROJECT_ID         = var.project_id
+      BQAA_EVENTS_DATASET_ID  = var.events_dataset_id
+      BQAA_GRAPH_DATASET_ID   = var.graph_dataset_id
+      BQAA_LOCATION           = var.location
+      BQAA_LOOKBACK_HOURS     = tostring(var.lookback_hours)
+      BQAA_OVERLAP_MINUTES    = tostring(var.overlap_minutes)
+      BQAA_EXTRACTION_MODE    = var.extraction_mode
+      BQAA_MAX_RETRIES        = tostring(var.max_retries)
+    },
+    var.max_sessions == null ? {} : {
+      BQAA_MAX_SESSIONS = tostring(var.max_sessions)
+    },
+    var.max_session_age_hours == null ? {} : {
+      BQAA_MAX_SESSION_AGE_HOURS = tostring(var.max_session_age_hours)
+    },
+    # Compiled-only mode points the orchestrator at the
+    # reference extractor module that ships under the demo
+    # (the bash deploy stages ``reference_extractor.py`` next
+    # to ``run_job.py``; a Terraform deploy expects the same
+    # file alongside the entrypoint in the published image).
+    var.extraction_mode == "compiled-only" ? {
+      BQAA_REFERENCE_EXTRACTORS_MODULE = "reference_extractor"
+    } : {},
+  )
+}
+
+# ---- 1. Graph dataset ---- #
+
+# Pre-creating the dataset (instead of letting ``run_job.py``'s
+# ``_ensure_graph_dataset`` create it on first run) keeps the
+# runtime SA's perms narrow — it never needs
+# ``bigquery.datasets.create``. Matches the bash deploy's
+# ``bq mk`` step.
+resource "google_bigquery_dataset" "graph" {
+  project    = var.project_id
+  dataset_id = var.graph_dataset_id
+  location   = var.location
+  description = "BQAA periodic-materialization graph dataset (created by Terraform module)."
+
+  # Deliberately no ``default_table_expiration_ms`` — the
+  # entity / relationship tables are intended to persist across
+  # cron runs and accumulate history. The bash deploy's
+  # ``1h TTL`` is for the notebook's *throwaway scratch*
+  # dataset, not production graph data.
+}
+
+# ---- 2. Service accounts ---- #
+
+# Runtime SA: identity for the Cloud Run Job. Holds the
+# BigQuery (+ optionally Vertex AI) roles below.
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = local.runtime_sa_account_id
+  display_name = local.runtime_sa_display
+}
+
+# Scheduler-caller SA: identity for the Cloud Scheduler HTTP
+# trigger. Holds ONLY ``roles/run.invoker`` on the specific
+# Cloud Run Job (granted in the iam_member resource below).
+# When ``var.single_sa == true``, ``account_id`` collapses to
+# the same value as the runtime SA above — Terraform's
+# duplicate-resource handling would normally reject that, so
+# we gate this resource on ``count``.
+resource "google_service_account" "scheduler" {
+  count        = var.single_sa ? 0 : 1
+  project      = var.project_id
+  account_id   = local.scheduler_sa_account_id
+  display_name = local.scheduler_sa_display
+}
+
+# ---- 3. IAM grants on the runtime SA ---- #
+
+# Project-level: ``bigquery.jobs.create``. Required for any BQ
+# query / DML / load job the orchestrator runs.
+resource "google_project_iam_member" "runtime_bigquery_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+# Project-level: Vertex AI access (only in ai-fallback mode).
+# Without this, ``AI.GENERATE`` returns "user does not have the
+# permission" and the orchestrator silently extracts empty
+# graphs. The bash deploy makes the grant conditional on
+# ``--extraction-mode``; Terraform mirrors that via ``count``.
+# Issue #166's verification surfaced this.
+resource "google_project_iam_member" "runtime_aiplatform_user" {
+  count   = var.extraction_mode == "ai-fallback" ? 1 : 0
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+# Dataset-level: read-only access to the events dataset. The
+# events dataset stays effectively read-only per the README
+# contract — the runtime SA reads ``agent_events`` and never
+# writes here.
+resource "google_bigquery_dataset_iam_member" "runtime_events_viewer" {
+  project    = var.project_id
+  dataset_id = var.events_dataset_id
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+# Dataset-level: read + write on the graph dataset. The
+# materializer's entity / relationship / state-table writes
+# all land here.
+resource "google_bigquery_dataset_iam_member" "runtime_graph_editor" {
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.graph.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+# ---- 4. Cloud Run v2 Job ---- #
+
+resource "google_cloud_run_v2_job" "periodic" {
+  project  = var.project_id
+  location = var.region
+  name     = var.job_name
+
+  # ``DEFAULT`` launch stage matches what ``gcloud run jobs
+  # deploy`` produces — the v2 API exposes a ``launch_stage``
+  # argument but most customers leave it implicit. Set
+  # explicitly so plan diffs against the bash deploy's
+  # post-state stay clean.
+  launch_stage = "GA"
+
+  template {
+    # Cloud Run owns the retry policy here. Matches the bash
+    # deploy's ``--max-retries "$MAX_RETRIES"``; the runtime
+    # also reads BQAA_MAX_RETRIES from env to surface the
+    # value in Cloud Logging (issue #183).
+    task_count  = 1
+    parallelism = 1
+
+    template {
+      service_account = google_service_account.runtime.email
+      max_retries     = var.max_retries
+      timeout         = "${var.task_timeout_seconds}s"
+
+      containers {
+        image = var.image_uri
+
+        dynamic "env" {
+          for_each = local.env_vars
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+    }
+  }
+
+  # Allow IAM bindings on the runtime SA to settle before the
+  # Cloud Run Job starts. Same race the bash deploy's
+  # ``_retry_iam`` defends against — Terraform's dependency
+  # graph lets us express it declaratively instead.
+  depends_on = [
+    google_project_iam_member.runtime_bigquery_job_user,
+    google_bigquery_dataset_iam_member.runtime_events_viewer,
+    google_bigquery_dataset_iam_member.runtime_graph_editor,
+    google_project_iam_member.runtime_aiplatform_user,
+  ]
+}
+
+# ---- 5. roles/run.invoker on the job for the scheduler SA ---- #
+
+# The scheduler-caller SA holds ONLY this binding (least-
+# privilege). The grant lives at the job-resource level, not
+# project-wide — the SA can fire THIS job and nothing else.
+# Under ``var.single_sa``, the binding lands on the same SA
+# the Cloud Run Job runs as.
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.periodic.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${local.scheduler_sa_email}"
+
+  depends_on = [
+    google_service_account.runtime,
+    google_service_account.scheduler,
+  ]
+}
+
+# ---- 6. Cloud Scheduler trigger ---- #
+
+resource "google_cloud_scheduler_job" "periodic_cron" {
+  project  = var.project_id
+  region   = var.region
+  name     = local.scheduler_job_name
+  schedule = var.schedule
+  # UTC is the only sane default for a global SDK; customers
+  # who want local time can override via a wrapper.
+  time_zone = "Etc/UTC"
+
+  http_target {
+    http_method = "POST"
+    # Cloud Run Jobs ``:run`` endpoint. The path uses the v1
+    # namespaces-style URL because Cloud Scheduler's
+    # ``--http-method`` POST requires that shape; the v2 Cloud
+    # Run Job resource is happy to be invoked through it.
+    uri = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.periodic.name}:run"
+
+    oauth_token {
+      service_account_email = local.scheduler_sa_email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  # The scheduler grant must be in place before the trigger
+  # fires the first time.
+  depends_on = [
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+  ]
+}

--- a/examples/migration_v5/periodic_materialization/terraform/outputs.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/outputs.tf
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "runtime_sa_email" {
+  description = "Email of the runtime service account (the Cloud Run Job's identity). Useful for downstream modules wiring additional dataset-level grants — e.g. read access on a second events dataset for a multi-tenant deployment."
+  value       = google_service_account.runtime.email
+}
+
+output "scheduler_sa_email" {
+  description = "Email of the scheduler-caller service account (the Cloud Scheduler trigger's OAuth identity). Under ``var.single_sa`` this equals ``runtime_sa_email``."
+  value       = local.scheduler_sa_email
+}
+
+output "cloud_run_job_name" {
+  description = "Cloud Run Job name. Pass to ``gcloud run jobs execute`` to fire a manual invocation, or use as the ``--job`` selector when listing executions."
+  value       = google_cloud_run_v2_job.periodic.name
+}
+
+output "scheduler_name" {
+  description = "Cloud Scheduler trigger name. Pass to ``gcloud scheduler jobs pause`` / ``resume`` for ops control without re-applying the module."
+  value       = google_cloud_scheduler_job.periodic_cron.name
+}
+
+output "graph_dataset_id" {
+  description = "Materialized graph dataset ID (the BQ dataset the entity / relationship tables + ``_bqaa_materialization_state`` audit table live in)."
+  value       = google_bigquery_dataset.graph.dataset_id
+}

--- a/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
+++ b/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
@@ -23,3 +23,5 @@ image_uri         = "us-central1-docker.pkg.dev/your-project/bqaa/periodic-mater
 # lookback_hours        = 6
 # overlap_minutes       = 15
 # task_timeout_seconds  = 1800
+# manage_apis           = true            # false → caller's central infra repo manages project services
+# deletion_protection   = false           # true → Cloud Run v2 deletion protection on the Job (two-step destroy required)

--- a/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
+++ b/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Copy to ``terraform.tfvars`` and fill in. Required inputs
+# (``project_id``, ``region``, ``events_dataset_id``,
+# ``graph_dataset_id``, ``schedule``, ``image_uri``) have no
+# default — Terraform will error if you ``apply`` without them.
+# Every other variable has a sensible default that matches the
+# bash deploy's post-#230 production posture.
+
+project_id        = "your-project"
+region            = "us-central1"
+events_dataset_id = "agent_analytics"
+graph_dataset_id  = "migration_v5_graph"
+schedule          = "0 */6 * * *"
+image_uri         = "us-central1-docker.pkg.dev/your-project/bqaa/periodic-materialization:v1"
+
+# Optional overrides (commented = use the default)
+# location              = "US"
+# job_name              = "bqaa-periodic-materialization"
+# extraction_mode       = "ai-fallback"   # or "compiled-only"
+# max_retries           = 2
+# max_session_age_hours = 24              # null → orphan watchdog disabled
+# single_sa             = false           # true → combined bqaa-periodic-sa identity
+# max_sessions          = 100             # null → unlimited
+# lookback_hours        = 6
+# overlap_minutes       = 15
+# task_timeout_seconds  = 1800

--- a/examples/migration_v5/periodic_materialization/terraform/variables.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/variables.tf
@@ -65,7 +65,7 @@ variable "job_name" {
 }
 
 variable "extraction_mode" {
-  description = "Extraction path: ``ai-fallback`` (structured extractors + AI.GENERATE for any uncovered span) or ``compiled-only`` (structured extractors only; no LLM calls; uncovered spans surface as typed ``session_orphaned`` failures). The module grants ``roles/aiplatform.user`` to the runtime SA only in ai-fallback mode."
+  description = "Extraction path: ``ai-fallback`` (structured extractors + AI.GENERATE for any uncovered span) or ``compiled-only`` (structured extractors only; no LLM calls; uncovered spans surface as typed ``empty_extraction`` failures with sample diagnostics). The module grants ``roles/aiplatform.user`` to the runtime SA only in ai-fallback mode. Note: ``empty_extraction`` is the failure code for compiled-only extraction gaps; ``session_orphaned`` is a *separate* code emitted by the orphan watchdog (``var.max_session_age_hours``) — they live on different cron paths."
   type        = string
   default     = "ai-fallback"
   validation {
@@ -118,4 +118,16 @@ variable "task_timeout_seconds" {
   description = "Per-task Cloud Run timeout in seconds. Matches the bash deploy script's ``--task-timeout 30m`` (= 1800s). Bump higher if your average session has very long event histories or if AI.GENERATE responses are slow."
   type        = number
   default     = 1800
+}
+
+variable "manage_apis" {
+  description = "If ``true`` (default), the module enables the BigQuery, Cloud Run, Cloud Scheduler, IAM, and (in ai-fallback mode) Vertex AI APIs on the project via ``google_project_service`` with ``disable_on_destroy = false``. Set ``false`` if the operator's central infra repo manages project services elsewhere and granting service-management perms to the deploy SA is undesired."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection" {
+  description = "Cloud Run v2 Job deletion-protection setting. Default ``false`` so ``terraform destroy`` works without a separate ``terraform apply`` to clear the flag (matches the bash deploy's ``gcloud run jobs delete`` lifecycle). Production deploys that want the extra safety net can set ``true`` — at the cost of needing a two-step destroy (apply with ``false``, then destroy)."
+  type        = bool
+  default     = false
 }

--- a/examples/migration_v5/periodic_materialization/terraform/variables.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/variables.tf
@@ -1,0 +1,121 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables mirror the post-#230 deploy-script surface (split SAs
+# + tunable max_retries by default; --single-sa as the escape
+# hatch). The image build is intentionally outside the module —
+# Terraform takes the published container image as input via
+# ``image_uri`` and leaves build/publish to the caller's CI.
+
+# ---- Required inputs ---- #
+
+variable "project_id" {
+  description = "GCP project ID. The graph dataset, service accounts, Cloud Run Job, and Cloud Scheduler trigger all land in this project."
+  type        = string
+}
+
+variable "region" {
+  description = "Cloud Run region (e.g. ``us-central1``). The Cloud Scheduler trigger is created in the same region by convention so a single regional outage doesn't strand the trigger pointing at an unreachable job."
+  type        = string
+}
+
+variable "events_dataset_id" {
+  description = "BigQuery dataset that holds ``agent_events`` (the BQ AA plugin's write target). The runtime SA gets dataset-level ``roles/bigquery.dataViewer`` on this dataset; reads only, never writes."
+  type        = string
+}
+
+variable "graph_dataset_id" {
+  description = "BigQuery dataset where the materialized property-graph tables + the ``_bqaa_materialization_state`` audit table live. The module pre-creates this dataset (so the runtime SA never needs ``bigquery.datasets.create``) and grants the runtime SA ``roles/bigquery.dataEditor`` on it."
+  type        = string
+}
+
+variable "schedule" {
+  description = "Cloud Scheduler cron expression (e.g. ``\"0 */6 * * *\"`` for every six hours). Combined with the orchestrator's ``BQAA_LOOKBACK_HOURS`` + ``BQAA_OVERLAP_MINUTES`` env vars to decide the discovery window per fire."
+  type        = string
+}
+
+variable "image_uri" {
+  description = "Fully-qualified container image URI (``REGION-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG`` or any reachable registry path). Image build + publish are intentionally OUTSIDE this module — the bash deploy script builds from local sources via Cloud Buildpacks; Terraform takes the published image as input so IaC stays declarative. See the README for the recommended build path (CI builds + publishes; Terraform deploys)."
+  type        = string
+}
+
+# ---- Optional inputs (defaults match deploy_cloud_run_job.sh) ---- #
+
+variable "location" {
+  description = "BigQuery dataset location (``US``, ``EU``, region-scoped like ``us-central1``). Must match both the events dataset and the graph dataset — cross-region BQ queries get rejected."
+  type        = string
+  default     = "US"
+}
+
+variable "job_name" {
+  description = "Cloud Run Job name. Default matches the bash deploy script."
+  type        = string
+  default     = "bqaa-periodic-materialization"
+}
+
+variable "extraction_mode" {
+  description = "Extraction path: ``ai-fallback`` (structured extractors + AI.GENERATE for any uncovered span) or ``compiled-only`` (structured extractors only; no LLM calls; uncovered spans surface as typed ``session_orphaned`` failures). The module grants ``roles/aiplatform.user`` to the runtime SA only in ai-fallback mode."
+  type        = string
+  default     = "ai-fallback"
+  validation {
+    condition     = contains(["ai-fallback", "compiled-only"], var.extraction_mode)
+    error_message = "extraction_mode must be 'ai-fallback' or 'compiled-only'."
+  }
+}
+
+variable "max_retries" {
+  description = "Cloud Run Job retry count on failure. The orchestrator's session-level idempotency + append-only state table make additional retries safe. Default 2 matches the deploy script post-#183 (production posture: silently absorb transient BQ slot pressure / rate-limit noise instead of paging on-call)."
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.max_retries >= 0
+    error_message = "max_retries must be >= 0."
+  }
+}
+
+variable "max_session_age_hours" {
+  description = "If set (> 0), enables the orphan-session watchdog (issue #180). Each cron pass additionally scans for sessions whose first event is older than N hours but which never emitted ``AGENT_COMPLETED``; each new orphan surfaces as a typed ``session_orphaned`` failure. ``null`` (default) disables the watchdog."
+  type        = number
+  default     = null
+}
+
+variable "single_sa" {
+  description = "If ``true``, use a single combined service account (``bqaa-periodic-sa``) for both the Cloud Run Job runtime AND the Cloud Scheduler OAuth caller. The default (``false``) creates two SAs — ``bqaa-periodic-runtime-sa`` (BQ + Vertex AI roles) and ``bqaa-periodic-scheduler-sa`` (only ``roles/run.invoker`` on the job) — for least-privilege per #182."
+  type        = bool
+  default     = false
+}
+
+variable "max_sessions" {
+  description = "Cost guardrail: hard cap on the number of sessions materialized per cron run. ``null`` (default) means unlimited."
+  type        = number
+  default     = null
+}
+
+variable "lookback_hours" {
+  description = "Discovery scan window size (hours). The orchestrator scans events whose terminal-event timestamp falls in ``[scan_start, scan_end)`` where ``scan_end = now`` and ``scan_start = max(last_checkpoint - overlap_minutes, now - lookback_hours)``."
+  type        = number
+  default     = 6
+}
+
+variable "overlap_minutes" {
+  description = "Re-scan window for late-arriving events. The orchestrator re-considers events newer than ``last_checkpoint - overlap_minutes`` on every pass so a late insert doesn't get silently skipped. Bump higher (e.g. 60) if the events table sometimes lags ingestion by tens of minutes."
+  type        = number
+  default     = 15
+}
+
+variable "task_timeout_seconds" {
+  description = "Per-task Cloud Run timeout in seconds. Matches the bash deploy script's ``--task-timeout 30m`` (= 1800s). Bump higher if your average session has very long event histories or if AI.GENERATE responses are slow."
+  type        = number
+  default     = 1800
+}

--- a/examples/migration_v5/periodic_materialization/terraform/versions.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/versions.tf
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Provider version pins. The Cloud Run Job resource family
+# (``google_cloud_run_v2_job``) stabilised in google ~> 4.40,
+# the dataset IAM ``google_bigquery_dataset_iam_member`` resource
+# has been stable for years. Pin a generous lower bound rather
+# than a hard exact match so customers on a slightly newer
+# provider keep working — the module's surface only uses
+# long-stable resource arguments.
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.84.0, < 7.0.0"
+    }
+  }
+}

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -4247,6 +4247,22 @@ class TestTerraformModuleSurface:
         "lookback_hours": "6",
         "overlap_minutes": "15",
         "task_timeout_seconds": "1800",
+        # PR #231 review P2: a clean GCP project needs the
+        # BigQuery / Cloud Run / Cloud Scheduler / IAM APIs
+        # enabled before ``terraform apply`` will work. The
+        # module manages them by default; ``false`` is the
+        # opt-out for customers whose central infra repo
+        # manages project services elsewhere.
+        "manage_apis": "true",
+        # PR #231 live-E2E surface: Cloud Run v2 added a
+        # ``deletion_protection`` default of ``true`` in newer
+        # provider releases. The module defaults to ``false`` so
+        # ``terraform destroy`` works without a separate
+        # ``terraform apply`` to clear the flag — matches the
+        # bash deploy's ``gcloud run jobs delete`` lifecycle.
+        # Production deploys that want the safety net opt in via
+        # ``deletion_protection = true``.
+        "deletion_protection": "false",
     }
     for name, want in expected_defaults.items():
       block = self._extract_variable_block(body, name)
@@ -4397,6 +4413,148 @@ class TestTerraformModuleSurface:
         or "outside this module" in readme.lower()
     )
     assert "image_uri" in readme
+
+  def test_readme_points_at_build_image_helper(self):
+    """PR #231 review P1: the README's recommended image-build
+    command must point at ``build_image.sh`` (which assembles the
+    staging layout the runtime expects). Pointing
+    ``gcloud builds submit`` at the bare ``periodic_materialization``
+    dir would produce an image missing the SDK vendor, Procfile,
+    and demo artifacts."""
+    readme = self._read("README.md")
+    assert "build_image.sh" in readme, (
+        "Terraform README must point at the build_image.sh staging "
+        "helper rather than a direct ``gcloud builds submit`` "
+        "against the periodic_materialization directory (which "
+        "lacks the staging layout the runtime needs)"
+    )
+    # The bash deploy's staging layout is documented in
+    # ``build_image.sh``; here we just sanity-check the helper
+    # exists.
+    helper = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "build_image.sh"
+    )
+    assert helper.exists(), (
+        f"build_image.sh missing at {helper} — the Terraform README "
+        f"points at it"
+    )
+    # The script must be executable so customers can call it
+    # directly (no ``bash build_image.sh ...`` workaround).
+    assert (
+        helper.stat().st_mode & 0o111
+    ), "build_image.sh must be marked executable"
+
+  def test_build_image_stages_full_layout(self):
+    """The staging helper must produce the same on-disk layout
+    the bash deploy assembles in its temp dir (Procfile + run_job
+    + reference_extractor + demo artifacts + vendored SDK source
+    + requirements.txt). Any drift would make Terraform-built
+    images behave differently from bash-built ones."""
+    helper = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "build_image.sh"
+    )
+    if not helper.exists():
+      pytest.skip("build_image.sh not present")
+    body = helper.read_text()
+    # Every file the bash deploy stages must be cp'd by the
+    # helper.
+    for needed in (
+        '"${SCRIPT_DIR}/run_job.py"',
+        '"${ARTIFACTS_DIR}/ontology.yaml"',
+        '"${ARTIFACTS_DIR}/binding.yaml"',
+        '"${ARTIFACTS_DIR}/table_ddl.sql"',
+        '"${ARTIFACTS_DIR}/reference_extractor.py"',
+        '"$REPO_ROOT/src/bigquery_agent_analytics"',
+        '"$REPO_ROOT/src/bigquery_ontology"',
+        '"$REPO_ROOT/pyproject.toml"',
+    ):
+      assert needed in body, f"build_image.sh missing staging copy for {needed}"
+    # Procfile + requirements.txt must be emitted, not copied
+    # (the bash deploy generates them inline; this helper
+    # generates the same content).
+    assert "Procfile" in body and "web: python run_job.py" in body
+    assert "./sdk_src" in body, (
+        "requirements.txt must install the SDK from the vendored "
+        "./sdk_src path (same as the bash deploy)"
+    )
+
+  def test_manage_apis_resource_present_with_disable_on_destroy_false(self):
+    """PR #231 review P2: a clean GCP project needs the required
+    APIs enabled. The module manages them via
+    ``google_project_service`` with
+    ``disable_on_destroy = false`` so a ``terraform destroy`` of
+    this module doesn't disable APIs other workloads might use."""
+    body = self._read("main.tf")
+    block = self._extract_resource_block(
+        body, "google_project_service", "required"
+    )
+    assert block is not None, (
+        "main.tf must declare google_project_service.required so "
+        "the apis the bash deploy expects manually-enabled are "
+        "managed by terraform"
+    )
+    # ``disable_on_destroy = false`` protects shared-API workloads.
+    assert "disable_on_destroy         = false" in block or (
+        "disable_on_destroy = false" in block
+    ), (
+        "google_project_service must set disable_on_destroy = false "
+        "so terraform destroy of this module doesn't disable shared "
+        "APIs other workloads on the project depend on"
+    )
+    # Each required API must be in the for_each locals block.
+    for api in (
+        "bigquery.googleapis.com",
+        "run.googleapis.com",
+        "cloudscheduler.googleapis.com",
+        "iam.googleapis.com",
+    ):
+      assert api in body, (
+          f"required API {api!r} must be in the project-service "
+          f"set so clean-project terraform apply doesn't fail with "
+          f"'API not enabled'"
+      )
+    # Vertex AI is conditional on extraction_mode.
+    assert (
+        'var.extraction_mode == "ai-fallback" ? ["aiplatform.googleapis.com"]'
+        in body
+    ), (
+        "aiplatform.googleapis.com must be enabled only in "
+        "ai-fallback mode — compiled-only doesn't call AI.GENERATE"
+    )
+
+  def test_extraction_mode_description_names_correct_failure_code(self):
+    """PR #231 review P3: the operator-facing variable description
+    must name the right failure code. Compiled-only extraction
+    gaps surface as ``empty_extraction`` (from B1's
+    structured-extraction harness). ``session_orphaned`` is a
+    different code emitted by the orphan watchdog
+    (``max_session_age_hours``)."""
+    body = self._read("variables.tf")
+    block = self._extract_variable_block(body, "extraction_mode")
+    assert block is not None
+    assert "empty_extraction" in block, (
+        "extraction_mode description must name 'empty_extraction' "
+        "as the failure code for compiled-only extraction gaps"
+    )
+    # Defensive: if a future edit re-introduces the wrong code,
+    # we want it to fail loud. Allow ``session_orphaned`` to
+    # appear ONLY in a context that explicitly contrasts the two
+    # codes (the post-fix wording does this).
+    if "session_orphaned" in block:
+      assert "separate code" in block or "different" in block.lower(), (
+          "if session_orphaned is mentioned in the extraction_mode "
+          "description, it must be in a contrastive context "
+          "(explaining it's a separate watchdog code), not as the "
+          "failure code for compiled-only"
+      )
 
   @staticmethod
   def _extract_variable_block(body: str, name: str) -> str | None:

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -4162,3 +4162,283 @@ class TestDeployScriptHardening:
         "run_job.py must pass max_retries into the _emit() call so "
         "the Cloud Logging payload carries it"
     )
+
+
+# ====================================================================== #
+# Terraform module surface (#186)                                         #
+# ====================================================================== #
+
+
+class TestTerraformModuleSurface:
+  """Static checks on the Terraform module that mirrors
+  ``deploy_cloud_run_job.sh`` (issue #186). Defaults must match
+  the post-#230 deploy surface: split runtime + scheduler-caller
+  SAs, ``max_retries = 2``, ``extraction_mode = 'ai-fallback'``.
+  Image build is intentionally outside the module — Terraform
+  takes the published container image URI as ``image_uri``.
+
+  These are file-content checks rather than ``terraform validate``
+  runs because the test environment doesn't ship the Terraform
+  binary. The checks pin the contract a customer reads from the
+  module files; a future maintainer who renames a variable / drops
+  a resource / changes a default fails these tests rather than
+  shipping a silently-broken module."""
+
+  def _tf_dir(self) -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "migration_v5"
+        / "periodic_materialization"
+        / "terraform"
+    )
+
+  def _read(self, name: str) -> str:
+    return (self._tf_dir() / name).read_text()
+
+  def test_module_files_present(self):
+    tf = self._tf_dir()
+    if not tf.exists():
+      pytest.skip("terraform module not present in this checkout")
+    for filename in (
+        "versions.tf",
+        "variables.tf",
+        "main.tf",
+        "outputs.tf",
+        "README.md",
+        "terraform.tfvars.example",
+    ):
+      assert (tf / filename).is_file(), f"missing {filename}"
+
+  def test_required_variables_have_no_defaults(self):
+    """The six required inputs must have no ``default`` so a
+    ``terraform apply`` without them errors loud at the boundary
+    (same operator-typo defense the bash deploy's ``required``
+    block provides)."""
+    body = self._read("variables.tf")
+    required = (
+        "project_id",
+        "region",
+        "events_dataset_id",
+        "graph_dataset_id",
+        "schedule",
+        "image_uri",
+    )
+    for name in required:
+      block = self._extract_variable_block(body, name)
+      assert block is not None, f"variable {name!r} missing from variables.tf"
+      assert (
+          "default" not in block
+      ), f"variable {name!r} must not have a default — it's required input"
+
+  def test_optional_variable_defaults_match_deploy_script(self):
+    """Optional vars' defaults must match the bash deploy's
+    post-#230 production posture so Terraform users get the same
+    behavior the README documents."""
+    body = self._read("variables.tf")
+    expected_defaults = {
+        "location": '"US"',
+        "job_name": '"bqaa-periodic-materialization"',
+        "extraction_mode": '"ai-fallback"',
+        "max_retries": "2",
+        "max_session_age_hours": "null",
+        "single_sa": "false",
+        "max_sessions": "null",
+        "lookback_hours": "6",
+        "overlap_minutes": "15",
+        "task_timeout_seconds": "1800",
+    }
+    for name, want in expected_defaults.items():
+      block = self._extract_variable_block(body, name)
+      assert block is not None, f"variable {name!r} missing"
+      assert f"default     = {want}" in block or f"default = {want}" in block, (
+          f"variable {name!r} default must be {want!r}; " f"block:\n{block}"
+      )
+
+  def test_extraction_mode_validation_matches_bash(self):
+    body = self._read("variables.tf")
+    block = self._extract_variable_block(body, "extraction_mode")
+    assert block is not None
+    assert 'contains(["ai-fallback", "compiled-only"]' in block, (
+        "extraction_mode validation must reject typos at the "
+        "Terraform boundary — same protection the bash deploy "
+        "provides via its case statement"
+    )
+
+  def test_outputs_cover_downstream_wiring(self):
+    body = self._read("outputs.tf")
+    for name in (
+        "runtime_sa_email",
+        "scheduler_sa_email",
+        "cloud_run_job_name",
+        "scheduler_name",
+        "graph_dataset_id",
+    ):
+      assert f'output "{name}"' in body, f"output {name!r} missing"
+
+  def test_split_sa_is_default_in_main(self):
+    """Two ``google_service_account`` resources by default; the
+    scheduler-caller SA gated on ``count = var.single_sa ? 0 : 1``
+    so ``--single-sa`` mode collapses to the runtime SA without
+    a duplicate-account-id conflict."""
+    body = self._read("main.tf")
+    assert 'resource "google_service_account" "runtime"' in body
+    assert 'resource "google_service_account" "scheduler"' in body
+    # The scheduler SA must be gated on single_sa.
+    scheduler_block = self._extract_resource_block(
+        body, "google_service_account", "scheduler"
+    )
+    assert scheduler_block is not None
+    assert "count" in scheduler_block, (
+        "scheduler SA resource must use ``count`` to collapse "
+        "to zero instances when ``var.single_sa`` is true"
+    )
+    assert "var.single_sa" in scheduler_block
+
+  def test_aiplatform_user_grant_conditional_on_extraction_mode(self):
+    """The Vertex AI grant must be conditional — granted in
+    ``ai-fallback`` (the default) so ``AI.GENERATE`` works, NOT
+    granted in ``compiled-only`` mode (matches the bash deploy's
+    conditional grant + #166's verification)."""
+    body = self._read("main.tf")
+    block = self._extract_resource_block(
+        body, "google_project_iam_member", "runtime_aiplatform_user"
+    )
+    assert block is not None, (
+        "runtime_aiplatform_user resource missing — needed for "
+        "the conditional Vertex AI grant"
+    )
+    assert "count" in block
+    assert 'var.extraction_mode == "ai-fallback"' in block
+
+  def test_cloud_run_job_uses_runtime_sa_and_max_retries(self):
+    """The Cloud Run v2 Job must point at the runtime SA + propagate
+    the ``var.max_retries`` value — the two flagship #230
+    contract points."""
+    body = self._read("main.tf")
+    block = self._extract_resource_block(
+        body, "google_cloud_run_v2_job", "periodic"
+    )
+    assert block is not None
+    assert "service_account = google_service_account.runtime.email" in block
+    assert "max_retries     = var.max_retries" in block, (
+        "Cloud Run Job must wire var.max_retries (not a literal) "
+        "so the issue #183 tunable applies"
+    )
+    assert "image = var.image_uri" in block, (
+        "Cloud Run Job's container image must come from "
+        "``var.image_uri`` — image build is outside the module"
+    )
+
+  def test_scheduler_invoker_grant_lands_on_scheduler_sa(self):
+    """The ``roles/run.invoker`` grant on the Cloud Run Job must
+    land on the scheduler-caller SA (the SA the scheduler
+    trigger's OAuth identity uses), not the runtime SA — the
+    least-privilege contract from issue #182."""
+    body = self._read("main.tf")
+    block = self._extract_resource_block(
+        body, "google_cloud_run_v2_job_iam_member", "scheduler_invoker"
+    )
+    assert block is not None
+    assert "serviceAccount:${local.scheduler_sa_email}" in block, (
+        "scheduler_invoker grant must use local.scheduler_sa_email "
+        "(NOT runtime SA) so the least-privilege contract holds"
+    )
+
+  def test_scheduler_uses_scheduler_sa_for_oauth(self):
+    body = self._read("main.tf")
+    block = self._extract_resource_block(
+        body, "google_cloud_scheduler_job", "periodic_cron"
+    )
+    assert block is not None
+    assert "service_account_email = local.scheduler_sa_email" in block, (
+        "Cloud Scheduler OAuth identity must be the scheduler-caller "
+        "SA, mirroring the bash deploy's "
+        '``--oauth-service-account-email "$SCHEDULER_SA_EMAIL"``'
+    )
+
+  def test_env_vars_match_deploy_script_surface(self):
+    """The Cloud Run Job env-var set must mirror the bash deploy's
+    ENV_VARS array (issue #186 wants Terraform to land the same
+    runtime config the bash deploy ships)."""
+    body = self._read("main.tf")
+    # Every env var the bash deploy sets must appear in the
+    # locals block's env_vars map.
+    for env_name in (
+        "BQAA_PROJECT_ID",
+        "BQAA_EVENTS_DATASET_ID",
+        "BQAA_GRAPH_DATASET_ID",
+        "BQAA_LOCATION",
+        "BQAA_LOOKBACK_HOURS",
+        "BQAA_OVERLAP_MINUTES",
+        "BQAA_EXTRACTION_MODE",
+        "BQAA_MAX_RETRIES",
+        "BQAA_MAX_SESSIONS",
+        "BQAA_MAX_SESSION_AGE_HOURS",
+        "BQAA_REFERENCE_EXTRACTORS_MODULE",
+    ):
+      assert env_name in body, (
+          f"env var {env_name!r} missing from the Cloud Run Job "
+          f"config — Terraform must wire the same env surface as "
+          f"the bash deploy"
+      )
+
+  def test_image_build_documented_as_outside_module(self):
+    """README must spell out that the container image build /
+    publish is outside the module so customers don't expect the
+    Cloud Buildpacks ``--source`` flow the bash deploy uses."""
+    readme = self._read("README.md")
+    # The README must spell out the out-of-scope decision in plain
+    # text so a customer reading top-to-bottom hits it before they
+    # try to ``terraform apply`` without a published image.
+    assert "image build" in readme.lower()
+    assert (
+        "outside the module" in readme.lower()
+        or "outside this module" in readme.lower()
+    )
+    assert "image_uri" in readme
+
+  @staticmethod
+  def _extract_variable_block(body: str, name: str) -> str | None:
+    """Slice out one ``variable "name" { ... }`` block.
+
+    Brace-counting parser — Terraform syntax allows nested ``{``
+    in ``validation`` / ``description`` heredocs (we don't use
+    heredocs in this module, but the parser handles them
+    anyway). Returns None when the variable doesn't exist.
+    """
+    needle = f'variable "{name}" {{'
+    start = body.find(needle)
+    if start == -1:
+      return None
+    depth = 0
+    i = start
+    while i < len(body):
+      if body[i] == "{":
+        depth += 1
+      elif body[i] == "}":
+        depth -= 1
+        if depth == 0:
+          return body[start : i + 1]
+      i += 1
+    return None
+
+  @staticmethod
+  def _extract_resource_block(
+      body: str, resource_type: str, name: str
+  ) -> str | None:
+    needle = f'resource "{resource_type}" "{name}" {{'
+    start = body.find(needle)
+    if start == -1:
+      return None
+    depth = 0
+    i = start
+    while i < len(body):
+      if body[i] == "{":
+        depth += 1
+      elif body[i] == "}":
+        depth -= 1
+        if depth == 0:
+          return body[start : i + 1]
+      i += 1
+    return None


### PR DESCRIPTION
## Summary

Closes #186. Mirrors the post-#230 \`deploy_cloud_run_job.sh\` surface as a declarative Terraform module so customers whose infra teams operate IaC (plan / drift detection / multi-env promotion) have a parallel deploy path. Defaults match the bash deploy's production posture: **split runtime + scheduler-caller SAs**, **\`max_retries = 2\`**, **\`extraction_mode = \"ai-fallback\"\`**.

## Module layout

\`examples/migration_v5/periodic_materialization/terraform/\`:

| File | Purpose |
|---|---|
| \`versions.tf\` | Provider pin (\`hashicorp/google >= 4.84, < 7\`); Terraform >= 1.5 |
| \`variables.tf\` | 14 vars — 6 required + 8 optional with bash-deploy-matching defaults |
| \`main.tf\` | Six-section module mirroring bash deploy sections 1–6 |
| \`outputs.tf\` | 5 outputs (runtime_sa_email, scheduler_sa_email, cloud_run_job_name, scheduler_name, graph_dataset_id) |
| \`README.md\` | Bash-vs-Terraform comparison table + quickstart + out-of-scope rationale |
| \`terraform.tfvars.example\` | Copy-paste starter |

## Surface mirror (bash section → Terraform resource)

| Bash deploy section | Terraform resource |
|---|---|
| §1 \`bq mk\` graph dataset | \`google_bigquery_dataset.graph\` |
| §2 \`_ensure_sa\` runtime SA | \`google_service_account.runtime\` |
| §2 \`_ensure_sa\` scheduler SA (split-SA default) | \`google_service_account.scheduler\` (gated \`count = var.single_sa ? 0 : 1\`) |
| §3 \`roles/bigquery.jobUser\` (project) | \`google_project_iam_member.runtime_bigquery_job_user\` |
| §3 \`roles/aiplatform.user\` (project, ai-fallback only) | \`google_project_iam_member.runtime_aiplatform_user\` (gated on \`extraction_mode\`) |
| §3 dataset-level events Viewer | \`google_bigquery_dataset_iam_member.runtime_events_viewer\` |
| §3 dataset-level graph Editor | \`google_bigquery_dataset_iam_member.runtime_graph_editor\` |
| §4 \`gcloud run jobs deploy\` | \`google_cloud_run_v2_job.periodic\` (image from \`var.image_uri\`) |
| §5 \`run.invoker\` on the job → scheduler SA | \`google_cloud_run_v2_job_iam_member.scheduler_invoker\` |
| §6 \`gcloud scheduler jobs create http\` | \`google_cloud_scheduler_job.periodic_cron\` |

## Intentionally out of scope

**Container image build / publish.** The bash deploy uses \`gcloud run jobs deploy --source\` with Cloud Buildpacks to build inline. That flow doesn't slot into IaC — Terraform deploys *configured* infrastructure, not source builds. The module takes \`var.image_uri\` as a required input; image build belongs to the caller's CI pipeline (typical: CI builds + pushes to Artifact Registry → Terraform applies referencing the published tag). The Terraform README documents the recommended \`gcloud builds submit\` example and the CI → registry → \`terraform apply\` flow.

## Main README update

The \"Not in scope here\" section's \"Terraform / Pulumi\" bullet was removed and replaced with an \"Infrastructure-as-Code option\" subsection pointing at \`terraform/\`. The Pulumi bullet stays as an open-for-contribution gap.

## Tests (+12 in \`TestTerraformModuleSurface\`; 147 \`materialize_window\` total)

Static surface checks (no Terraform binary required — pinned via file-content parsing with a brace-counting block extractor) covering:

* All six files present.
* Six required variables have no \`default\` (operator-typo defense at the boundary).
* Eight optional variable defaults match the bash deploy's production posture.
* \`extraction_mode\` validation rejects typos at the Terraform boundary.
* All five outputs exist.
* Split-SA default + scheduler SA's \`count = var.single_sa ? 0 : 1\` gate.
* Conditional \`roles/aiplatform.user\` grant gated on \`extraction_mode\`.
* Cloud Run Job wires \`google_service_account.runtime.email\`, \`var.max_retries\`, and \`var.image_uri\` (#182 + #183 contract).
* Scheduler invoker grant lands on the scheduler-caller SA, NOT the runtime SA (least-privilege per #182).
* Scheduler OAuth identity is the scheduler-caller SA.
* All 11 \`BQAA_*\` env vars the bash deploy sets are wired into the Cloud Run Job.
* README documents the image-build out-of-scope decision explicitly.

\`pyink --check\` + \`isort --check-only\` clean.

## Test plan
- [x] \`python -m pytest tests/test_materialize_window.py::TestTerraformModuleSurface\` — 12 pass
- [x] \`python -m pytest tests/\` — 3130 pass, 15 skipped
- [x] \`pyink --check\` + \`isort --check-only\` — clean
- [ ] Live \`terraform init / plan / apply\` against a real GCP project (reviewer / merger-side; the static surface tests pin the contract but can't substitute for actually running \`terraform apply\`)