### PR TITLE
producers: add tracing producer package scaffold + shared writer/drainer

### DIFF
--- a/.github/workflows/producers-ci.yml
+++ b/.github/workflows/producers-ci.yml
@@ -1,0 +1,100 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Producers CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'producers/**'
+      - '.github/workflows/producers-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'producers/**'
+      - '.github/workflows/producers-ci.yml'
+
+concurrency:
+  group: producers-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: producers
+
+jobs:
+  format:
+    name: Producers format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install formatting tools
+        run: pip install "pyink>=24.3.0" "isort>=5.0"
+
+      - name: isort --check
+        run: isort --check-only src/ tests/
+
+      - name: pyink --check
+        run: pyink --check src/ tests/
+
+  test:
+    name: Producers test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --tb=short -q
+
+  build:
+    name: Producers build
+    runs-on: ubuntu-latest
+    needs: [format, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: producers-dist
+          path: producers/dist/

--- a/producers/README.md
+++ b/producers/README.md
@@ -1,0 +1,37 @@
+# bigquery-agent-analytics-tracing
+
+Producer packages and tracing adapters that emit rows into the canonical
+BQAA `agent_events` schema consumed by the
+[`bigquery-agent-analytics`](../) SDK.
+
+This first cut ships only the shared writer and async drainer. Producer
+adapters (OpenAI Agents SDK, Codex CLI wrapper, Claude Code plugin) land in
+follow-up PRs tracked under
+[#229](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/229).
+
+## Install
+
+```bash
+pip install bigquery-agent-analytics-tracing
+pip install "bigquery-agent-analytics-tracing[storage-write]"  # BigQuery Storage Write API path
+```
+
+## Quickstart
+
+```python
+from bigquery_agent_analytics_tracing import (
+    BQAAConfig,
+    BigQueryAgentAnalyticsLogger,
+)
+
+logger = BigQueryAgentAnalyticsLogger(
+    BQAAConfig(project_id="my-project", dataset="agent_analytics", dry_run=True)
+)
+logger.log_event(
+    event_type="STATE_DELTA",
+    content={"hello": "world"},
+)
+```
+
+See the full architecture and roadmap in
+[#229](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/229).

--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -1,0 +1,88 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "bigquery-agent-analytics-tracing"
+version = "0.1.0.dev0"
+description = "Producer packages and Claude/Codex/OpenAI Agents tracing adapters for BigQuery Agent Analytics."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+  {name = "Google LLC"},
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+  "google-cloud-bigquery>=3.0.0",
+]
+
+[project.optional-dependencies]
+storage-write = [
+  "google-cloud-bigquery-storage>=2.24.0",
+  "pyarrow>=14.0.0",
+]
+openai-agents = [
+  "openai-agents>=0.0.5",
+]
+claude-sdk = [
+  "claude-agent-sdk>=0.1.0",
+]
+dev = [
+  "pytest>=7.0",
+  "pytest-asyncio>=0.21",
+  "pyink>=24.3.0",
+  "isort>=5.0",
+]
+
+[project.scripts]
+bqaa-drain = "bigquery_agent_analytics_tracing.drain:main"
+
+[project.urls]
+Homepage = "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"
+Issues = "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bigquery_agent_analytics_tracing"]
+
+[tool.pyink]
+line-length = 80
+pyink-indentation = 2
+pyink-use-majority-quotes = true
+
+[tool.isort]
+profile = "google"
+line_length = 200
+indent = 2
+multi_line_output = 4
+force_sort_within_sections = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/producers/src/bigquery_agent_analytics_tracing/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/__init__.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BigQuery Agent Analytics tracing producers.
+
+Public API:
+
+  * ``BigQueryAgentAnalyticsLogger`` — builds rows in the BQAA
+    ``agent_events`` schema and routes them to spool / dry-run /
+    direct-write.
+  * ``BQAAConfig`` — environment- or constructor-driven configuration.
+  * ``bq_schema`` — the canonical schema, used by both the auto-create
+    path and the drainer's ``insert_rows_json`` fallback.
+
+Producer-specific adapters (OpenAI Agents SDK, Codex CLI wrapper, Claude
+Code plugin) land in follow-up PRs.
+"""
+
+from ._writer_identity import __version__
+from .config import BQAAConfig
+from .logger import BigQueryAgentAnalyticsLogger
+from .schema import bq_schema
+
+__all__ = [
+    "BQAAConfig",
+    "BigQueryAgentAnalyticsLogger",
+    "__version__",
+    "bq_schema",
+]

--- a/producers/src/bigquery_agent_analytics_tracing/_utils.py
+++ b/producers/src/bigquery_agent_analytics_tracing/_utils.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for serialization, hashing, timestamps, file locking, and
+log emission. No dependencies on other package modules so this can be safely
+imported from anywhere in the package."""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from datetime import timezone
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any, Iterator, TYPE_CHECKING
+import uuid
+
+if TYPE_CHECKING:
+  from .config import BQAAConfig
+
+SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "client_secret",
+        "id_token",
+        "password",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
+
+
+def utc_now() -> datetime:
+  return datetime.now(timezone.utc)
+
+
+def timestamp_ms() -> int:
+  return int(time.time() * 1000)
+
+
+def iso_timestamp(value: datetime | None = None) -> str:
+  ts = value or utc_now()
+  return ts.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def hex_id(chars: int) -> str:
+  return uuid.uuid4().hex[:chars]
+
+
+def deterministic_span(seed: str, chars: int = 16) -> str:
+  """Stable hex span id derived from a seed (e.g. tool_use_id).
+
+  Used so that a PostToolUse without a matching PreToolUse can still emit a
+  span_id that correlates with whatever the (missing) start would have
+  produced. Better than ``hex_id`` which yields a fresh random id and breaks
+  span correlation.
+  """
+  if not seed:
+    return hex_id(chars)
+  digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+  return digest[:chars]
+
+
+def to_jsonable(value: Any) -> Any:
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  if isinstance(value, dict):
+    return {str(k): to_jsonable(v) for k, v in value.items()}
+  if isinstance(value, (list, tuple, set)):
+    return [to_jsonable(v) for v in value]
+  if hasattr(value, "model_dump"):
+    return to_jsonable(value.model_dump())
+  if hasattr(value, "to_dict"):
+    return to_jsonable(value.to_dict())
+  return str(value)
+
+
+def truncate(value: Any, max_len: int) -> tuple[Any, bool]:
+  """Recursively truncate strings and redact sensitive dict keys.
+
+  Returns ``(clipped_value, was_truncated)``. ``max_len == -1`` disables
+  truncation. Keys whose lowercase name is in ``SENSITIVE_KEYS`` or starts
+  with ``"temp:"`` are replaced with ``"[REDACTED]"``.
+  """
+  value = to_jsonable(value)
+  if max_len == -1:
+    return value, False
+  if isinstance(value, str):
+    if len(value) > max_len:
+      return value[:max_len] + "...[TRUNCATED]", True
+    return value, False
+  if isinstance(value, list):
+    out = []
+    truncated = False
+    for item in value:
+      next_item, did_truncate = truncate(item, max_len)
+      out.append(next_item)
+      truncated = truncated or did_truncate
+    return out, truncated
+  if isinstance(value, dict):
+    out: dict[str, Any] = {}
+    truncated = False
+    for key, item in value.items():
+      key_lower = str(key).lower()
+      if key_lower in SENSITIVE_KEYS or key_lower.startswith("temp:"):
+        out[key] = "[REDACTED]"
+        continue
+      next_item, did_truncate = truncate(item, max_len)
+      out[key] = next_item
+      truncated = truncated or did_truncate
+    return out, truncated
+  return value, False
+
+
+def safe_json_loads(value: str | None, default: Any) -> Any:
+  if not value:
+    return default
+  try:
+    return json.loads(value)
+  except json.JSONDecodeError:
+    return default
+
+
+@contextlib.contextmanager
+def file_lock(path: Path, mode: int = fcntl.LOCK_EX) -> Iterator[int]:
+  """Open a lockfile exclusively. Blocks until the lock is acquired."""
+  path.parent.mkdir(parents=True, exist_ok=True)
+  fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    fcntl.flock(fd, mode)
+    yield fd
+  finally:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+      os.close(fd)
+
+
+def log_to_file(config: "BQAAConfig", message: str) -> None:
+  """Append a single log line to ``config.log_file``. Silent on failure.
+
+  The drainer and the spool writer share this — debugging signal lives in
+  one place, and a broken log path never crashes the agent's hot path.
+  """
+  if not config.log_file:
+    return
+  try:
+    with open(config.log_file, "a", encoding="utf-8") as handle:
+      handle.write(f"[{iso_timestamp()}] {message}\n")
+  except OSError:
+    pass

--- a/producers/src/bigquery_agent_analytics_tracing/_writer_identity.py
+++ b/producers/src/bigquery_agent_analytics_tracing/_writer_identity.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Writer identity stamped onto every row's `attributes.writer` block.
+
+Two surfaces read this:
+
+  * Every row's `attributes.writer.{plugin,version,label,agent,mode}` block
+    — the queryable surface for self-service adoption analytics.
+  * `AppendRowsRequest.trace_id` on Storage Write API batches — recorded
+    server-side by Google for diagnostics. Not exposed as a column in
+    `INFORMATION_SCHEMA.WRITE_API_TIMELINE_BY_*`, so it cannot power
+    adoption queries; it lets Google Cloud support attribute traffic back
+    to this package during throughput/quota investigations.
+
+Override per deployment with the `BQAA_WRITER_LABEL` env var (e.g. when
+running multiple distinct deployments against one dataset).
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+WRITER_PLUGIN_NAME = "bigquery-agent-analytics-tracing"
+
+
+def get_writer_version() -> str:
+  """Resolve the writer version from package metadata.
+
+  Falls back to ``"0.0.0+local"`` for vendored installs (e.g. a Claude Code
+  plugin that ships the package source without a wheel install) and for
+  source checkouts where the distribution is not installed.
+  """
+  try:
+    return metadata.version(WRITER_PLUGIN_NAME)
+  except metadata.PackageNotFoundError:
+    return "0.0.0+local"
+
+
+__version__ = get_writer_version()
+DEFAULT_WRITER_LABEL = f"{WRITER_PLUGIN_NAME}/{__version__}"

--- a/producers/src/bigquery_agent_analytics_tracing/config.py
+++ b/producers/src/bigquery_agent_analytics_tracing/config.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime configuration for the BQAA tracing logger and drainer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from ._writer_identity import DEFAULT_WRITER_LABEL
+
+BQAA_EVENT_TYPES = frozenset(
+    {
+        "LLM_REQUEST",
+        "LLM_RESPONSE",
+        "TOOL_STARTING",
+        "TOOL_COMPLETED",
+        "HITL_CREDENTIAL_REQUEST",
+        "HITL_CREDENTIAL_REQUEST_COMPLETED",
+        "HITL_CONFIRMATION_REQUEST",
+        "HITL_CONFIRMATION_REQUEST_COMPLETED",
+        "HITL_INPUT_REQUEST",
+        "HITL_INPUT_REQUEST_COMPLETED",
+        "STATE_DELTA",
+    }
+)
+
+DEFAULT_SPOOL_DIR = "/tmp/bqaa-agent-tracing/spool"
+DEFAULT_STATE_DIR = "/tmp/bqaa-agent-tracing"
+DEFAULT_TRANSCRIPT_MAX_BYTES = 256 * 1024  # 256 KB streamed cap per stop event.
+DEFAULT_STATE_TTL_HOURS = 24
+DEFAULT_DRAIN_IDLE_SECONDS = 8.0
+DEFAULT_DRAIN_BATCH_SIZE = 50
+DEFAULT_DRAIN_POLL_SECONDS = 0.5
+DEFAULT_LOG_FILE = "/tmp/bqaa-agent-tracing.log"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+  raw = os.environ.get(name)
+  if raw is None:
+    return default
+  return raw.lower() == "true"
+
+
+@dataclass
+class BQAAConfig:
+  """All knobs the logger and drainer need.
+
+  Construct directly for library use, or call ``BQAAConfig.from_env()`` to
+  pick up the standard ``BQAA_*`` env vars. The env factory is what hook
+  scripts and the drainer subprocess use so producers stay drop-in.
+  """
+
+  project_id: str
+  dataset: str
+  table: str = "agent_events"
+  agent_name: str = "coding-agent"
+  user_id: str = "local-user"
+  enabled: bool = True
+  dry_run: bool = False
+  direct_write: bool = False
+  auto_create_table: bool = True
+  auto_create_dataset: bool = False
+  location: str | None = None
+  max_content_length: int = 5000
+  log_file: str = DEFAULT_LOG_FILE
+  spool_dir: str = DEFAULT_SPOOL_DIR
+  state_dir: str = DEFAULT_STATE_DIR
+  state_ttl_hours: float = DEFAULT_STATE_TTL_HOURS
+  transcript_max_bytes: int = DEFAULT_TRANSCRIPT_MAX_BYTES
+  drain_idle_seconds: float = DEFAULT_DRAIN_IDLE_SECONDS
+  drain_batch_size: int = DEFAULT_DRAIN_BATCH_SIZE
+  drain_poll_seconds: float = DEFAULT_DRAIN_POLL_SECONDS
+  writer_label: str = DEFAULT_WRITER_LABEL
+
+  @classmethod
+  def from_env(cls) -> "BQAAConfig":
+    return cls(
+        project_id=(
+            os.environ.get("BQAA_PROJECT_ID")
+            or os.environ.get("GCP_PROJECT_ID")
+            or os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or ""
+        ),
+        dataset=(
+            os.environ.get("BQAA_DATASET") or os.environ.get("BQ_DATASET") or ""
+        ),
+        table=(
+            os.environ.get("BQAA_TABLE")
+            or os.environ.get("BQ_TABLE")
+            or "agent_events"
+        ),
+        agent_name=os.environ.get("BQAA_AGENT_NAME") or "coding-agent",
+        user_id=(
+            os.environ.get("BQAA_USER_ID")
+            or os.environ.get("USER")
+            or "local-user"
+        ),
+        enabled=_env_bool("BQAA_TRACE_ENABLED", True),
+        dry_run=_env_bool("BQAA_DRY_RUN", False),
+        direct_write=_env_bool("BQAA_DIRECT_WRITE", False),
+        auto_create_table=_env_bool("BQAA_AUTO_CREATE_TABLE", True),
+        auto_create_dataset=_env_bool("BQAA_AUTO_CREATE_DATASET", False),
+        location=os.environ.get("BQAA_LOCATION") or None,
+        max_content_length=int(
+            os.environ.get("BQAA_MAX_CONTENT_LENGTH", "5000")
+        ),
+        log_file=os.environ.get("BQAA_LOG_FILE", DEFAULT_LOG_FILE),
+        spool_dir=os.environ.get("BQAA_SPOOL_DIR", DEFAULT_SPOOL_DIR),
+        state_dir=os.environ.get("BQAA_STATE_DIR", DEFAULT_STATE_DIR),
+        state_ttl_hours=float(
+            os.environ.get("BQAA_STATE_TTL_HOURS", str(DEFAULT_STATE_TTL_HOURS))
+        ),
+        transcript_max_bytes=int(
+            os.environ.get(
+                "BQAA_TRANSCRIPT_MAX_BYTES", str(DEFAULT_TRANSCRIPT_MAX_BYTES)
+            )
+        ),
+        drain_idle_seconds=float(
+            os.environ.get(
+                "BQAA_DRAIN_IDLE_SECONDS", str(DEFAULT_DRAIN_IDLE_SECONDS)
+            )
+        ),
+        drain_batch_size=int(
+            os.environ.get(
+                "BQAA_DRAIN_BATCH_SIZE", str(DEFAULT_DRAIN_BATCH_SIZE)
+            )
+        ),
+        drain_poll_seconds=float(
+            os.environ.get(
+                "BQAA_DRAIN_POLL_SECONDS", str(DEFAULT_DRAIN_POLL_SECONDS)
+            )
+        ),
+        writer_label=(
+            os.environ.get("BQAA_WRITER_LABEL") or DEFAULT_WRITER_LABEL
+        ),
+    )

--- a/producers/src/bigquery_agent_analytics_tracing/drain.py
+++ b/producers/src/bigquery_agent_analytics_tracing/drain.py
@@ -1,0 +1,663 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background drainer for the BQAA spool.
+
+The drainer is launched as a detached subprocess by the logger (see
+``_ensure_drainer`` in ``logger.py``). Its job is to take BQAA rows that
+the producer spooled to disk and write them to BigQuery without blocking
+the host agent.
+
+Design choices:
+
+- Single drainer per spool dir, enforced by an exclusive ``fcntl.flock`` on
+  ``.drainer.pid``. New producer fires that try to spawn a drainer no-op
+  out immediately if the lock is held.
+- Writes use the BigQuery Storage Write API via ``BigQueryWriteAsyncClient``
+  + PyArrow batches when both libraries are importable. Matches the ADK
+  BQAA plugin and avoids streaming-insert quotas.
+- When the Storage Write client or PyArrow are not available, falls back to
+  ``bigquery.Client.insert_rows_json``. Same row contents in either path.
+- Retries transient failures with exponential backoff.
+- Rows that exhaust retries or hit non-retryable errors are moved to
+  ``dead-letter/`` so they can be inspected and replayed.
+- Drainer exits after ``BQAA_DRAIN_IDLE_SECONDS`` of empty polling; the
+  next producer fire spawns a fresh one.
+
+Invocation: ``python -m bigquery_agent_analytics_tracing.drain``. Plugin
+runtimes that vendor the package source without installing the wheel must
+either prepend the vendored package root to ``PYTHONPATH`` on the spawned
+drainer's environment, or ship a small wrapper script that performs the
+``sys.path`` insert and calls ``main()`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import random
+import sys
+import time
+import traceback
+from typing import Any, Iterator
+
+# Storage Write API channels share gRPC state across forks; matches ADK
+# plugin behavior and keeps the channel safe if the host agent forks us.
+os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "1")
+
+from ._utils import log_to_file  # noqa: E402  (after env tweak)
+from ._writer_identity import DEFAULT_WRITER_LABEL  # noqa: E402
+from .config import BQAAConfig  # noqa: E402
+from .schema import bq_schema  # noqa: E402
+
+
+@dataclass
+class _RetryConfig:
+  max_retries: int = 3
+  initial_delay: float = 1.0
+  multiplier: float = 2.0
+  max_delay: float = 10.0
+
+
+@dataclass
+class _Envelope:
+  path: Path
+  config_dict: dict[str, Any]
+  row: dict[str, Any]
+
+
+@contextlib.contextmanager
+def _try_acquire_pidfile(pidfile: Path) -> Iterator[int | None]:
+  """Acquire the drainer pidfile non-blockingly. Yields None if held."""
+  pidfile.parent.mkdir(parents=True, exist_ok=True)
+  fd = os.open(str(pidfile), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+      yield None
+      return
+    try:
+      os.ftruncate(fd, 0)
+      os.write(fd, str(os.getpid()).encode())
+      os.fsync(fd)
+    except OSError:
+      pass
+    try:
+      yield fd
+    finally:
+      try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+      except OSError:
+        pass
+  finally:
+    try:
+      os.close(fd)
+    except OSError:
+      pass
+
+
+def _list_pending(spool: Path) -> list[Path]:
+  if not spool.exists():
+    return []
+  return sorted(p for p in spool.glob("event-*.json") if p.is_file())
+
+
+def _read_envelope(path: Path) -> _Envelope | None:
+  try:
+    raw = path.read_text(encoding="utf-8")
+  except FileNotFoundError:
+    return None
+  except OSError:
+    return None
+  try:
+    data = json.loads(raw)
+  except json.JSONDecodeError:
+    # Corrupt spool entry — dead-letter and move on.
+    _quarantine(path, reason="corrupt-json")
+    return None
+  return _Envelope(
+      path=path,
+      config_dict=data.get("config") or {},
+      row=data.get("row") or {},
+  )
+
+
+def _group_envelopes(
+    envelopes: list[_Envelope],
+) -> dict[tuple, list[_Envelope]]:
+  """Group by destination table + writer label + auto-create policy.
+
+  The writer label is part of the key so a single drainer process can
+  serve envelopes from differently-labeled deployments without bleeding
+  their ``AppendRowsRequest.trace_id`` values together. Auto-create flags
+  are part of the key so the fallback path honors each producer's policy
+  instead of clobbering it with hard-coded defaults.
+  """
+  grouped: dict[tuple, list[_Envelope]] = {}
+  for env in envelopes:
+    cfg = env.config_dict
+    auto_create_table = cfg.get("auto_create_table")
+    auto_create_dataset = cfg.get("auto_create_dataset")
+    key = (
+        cfg.get("project_id"),
+        cfg.get("dataset"),
+        cfg.get("table"),
+        cfg.get("location"),
+        cfg.get("writer_label") or DEFAULT_WRITER_LABEL,
+        True if auto_create_table is None else bool(auto_create_table),
+        False if auto_create_dataset is None else bool(auto_create_dataset),
+    )
+    grouped.setdefault(key, []).append(env)
+  return grouped
+
+
+def _quarantine(path: Path, reason: str) -> None:
+  dead = path.parent / "dead-letter"
+  dead.mkdir(parents=True, exist_ok=True)
+  target = dead / f"{path.stem}.{reason}.json"
+  try:
+    os.replace(path, target)
+  except FileNotFoundError:
+    pass
+  except OSError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Storage Write API path
+# ---------------------------------------------------------------------------
+
+
+def _storage_write_available() -> bool:
+  try:
+    from google.cloud.bigquery_storage_v1 import types as _types  # noqa: F401
+    from google.cloud.bigquery_storage_v1.services.big_query_write.async_client import BigQueryWriteAsyncClient  # noqa: F401
+    import pyarrow  # noqa: F401
+  except Exception:
+    return False
+  return True
+
+
+def _arrow_schema():
+  import pyarrow as pa
+
+  object_ref_type = pa.struct(
+      [
+          pa.field("uri", pa.string()),
+          pa.field("version", pa.string()),
+          pa.field("authorizer", pa.string()),
+          pa.field("details", pa.string()),
+      ]
+  )
+  content_part_type = pa.struct(
+      [
+          pa.field("mime_type", pa.string()),
+          pa.field("uri", pa.string()),
+          pa.field("object_ref", object_ref_type),
+          pa.field("text", pa.string()),
+          pa.field("part_index", pa.int64()),
+          pa.field("part_attributes", pa.string()),
+          pa.field("storage_mode", pa.string()),
+      ]
+  )
+  return pa.schema(
+      [
+          pa.field("timestamp", pa.timestamp("us", tz="UTC"), nullable=False),
+          pa.field("event_type", pa.string()),
+          pa.field("agent", pa.string()),
+          pa.field("session_id", pa.string()),
+          pa.field("invocation_id", pa.string()),
+          pa.field("user_id", pa.string()),
+          pa.field("trace_id", pa.string()),
+          pa.field("span_id", pa.string()),
+          pa.field("parent_span_id", pa.string()),
+          pa.field("content", pa.string()),
+          pa.field("content_parts", pa.list_(content_part_type)),
+          pa.field("attributes", pa.string()),
+          pa.field("latency_ms", pa.string()),
+          pa.field("status", pa.string()),
+          pa.field("error_message", pa.string()),
+          pa.field("is_truncated", pa.bool_()),
+      ]
+  )
+
+
+def _row_to_arrow_dict(row: dict[str, Any]) -> dict[str, Any]:
+  """Adapt a spooled row to the Arrow column shape."""
+  from datetime import datetime
+  from datetime import timezone
+
+  ts_raw = row.get("timestamp")
+  if isinstance(ts_raw, str):
+    try:
+      ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+    except ValueError:
+      ts = datetime.now(timezone.utc)
+  elif isinstance(ts_raw, datetime):
+    ts = ts_raw
+  else:
+    ts = datetime.now(timezone.utc)
+  if ts.tzinfo is None:
+    ts = ts.replace(tzinfo=timezone.utc)
+
+  parts = []
+  for part in row.get("content_parts") or []:
+    ref = part.get("object_ref")
+    if isinstance(ref, dict):
+      details = ref.get("details")
+      if details is not None and not isinstance(details, str):
+        ref = dict(ref)
+        ref["details"] = json.dumps(details, sort_keys=True)
+    parts.append(
+        {
+            "mime_type": part.get("mime_type"),
+            "uri": part.get("uri"),
+            "object_ref": ref,
+            "text": part.get("text"),
+            "part_index": part.get("part_index"),
+            "part_attributes": part.get("part_attributes"),
+            "storage_mode": part.get("storage_mode"),
+        }
+    )
+
+  def _as_json(value: Any) -> str | None:
+    if value is None:
+      return None
+    if isinstance(value, str):
+      return value
+    return json.dumps(value, sort_keys=True, default=str)
+
+  return {
+      "timestamp": ts,
+      "event_type": row.get("event_type"),
+      "agent": row.get("agent"),
+      "session_id": row.get("session_id"),
+      "invocation_id": row.get("invocation_id"),
+      "user_id": row.get("user_id"),
+      "trace_id": row.get("trace_id"),
+      "span_id": row.get("span_id"),
+      "parent_span_id": row.get("parent_span_id"),
+      "content": _as_json(row.get("content")),
+      "content_parts": parts,
+      "attributes": _as_json(row.get("attributes")),
+      "latency_ms": _as_json(row.get("latency_ms")),
+      "status": row.get("status"),
+      "error_message": row.get("error_message"),
+      "is_truncated": bool(row.get("is_truncated")),
+  }
+
+
+async def _write_batch_storage_api(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    rows: list[dict[str, Any]],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    writer_label: str,
+) -> bool:
+  """Write a batch via the Storage Write API. Returns True on success."""
+  from google.api_core.exceptions import InternalServerError
+  from google.api_core.exceptions import ServiceUnavailable
+  from google.api_core.exceptions import TooManyRequests
+  from google.cloud.bigquery_storage_v1 import types as bq_storage_types
+  from google.cloud.bigquery_storage_v1.services.big_query_write.async_client import BigQueryWriteAsyncClient
+  import pyarrow as pa
+
+  del location  # Storage Write API resolves location from the table itself.
+
+  schema = _arrow_schema()
+  arrow_rows = [_row_to_arrow_dict(r) for r in rows]
+  try:
+    record_batch = pa.RecordBatch.from_pylist(arrow_rows, schema=schema)
+  except Exception as exc:
+    log_to_file(config, f"DRAINER arrow_serialize_failed: {exc}")
+    return False
+
+  serialized_schema = schema.serialize().to_pybytes()
+  serialized_batch = record_batch.serialize().to_pybytes()
+  write_stream = (
+      f"projects/{project}/datasets/{dataset}/tables/{table}/_default"
+  )
+
+  client = BigQueryWriteAsyncClient()
+  try:
+    req = bq_storage_types.AppendRowsRequest(
+        write_stream=write_stream,
+        # Writer attribution. Recorded server-side for Google support
+        # diagnostics; not surfaced as a column in
+        # INFORMATION_SCHEMA.WRITE_API_TIMELINE_BY_*. Adoption analytics
+        # use the row-level attributes.writer block instead.
+        trace_id=writer_label,
+    )
+    req.arrow_rows.writer_schema.serialized_schema = serialized_schema
+    req.arrow_rows.rows.serialized_record_batch = serialized_batch
+
+    attempt = 0
+    delay = retry.initial_delay
+    while True:
+      try:
+
+        async def _requests_iter():
+          yield req
+
+        async def _perform():
+          responses = await client.append_rows(_requests_iter())
+          async for response in responses:
+            error = getattr(response, "error", None)
+            error_code = getattr(error, "code", None)
+            if error_code and error_code != 0:
+              error_message = getattr(error, "message", "Unknown error")
+              # gRPC: 4=DEADLINE_EXCEEDED, 13=INTERNAL, 14=UNAVAILABLE
+              if error_code in (4, 13, 14):
+                raise ServiceUnavailable(error_message)
+              raise RuntimeError(
+                  f"non_retryable_storage_error: {error_message}"
+              )
+
+        await asyncio.wait_for(_perform(), timeout=30.0)
+        return True
+
+      except (
+          ServiceUnavailable,
+          TooManyRequests,
+          InternalServerError,
+          asyncio.TimeoutError,
+      ) as exc:
+        attempt += 1
+        if attempt > retry.max_retries:
+          log_to_file(
+              config,
+              f"DRAINER batch_dropped_after_{retry.max_retries + 1}: {exc}",
+          )
+          return False
+        sleep_for = min(delay * (1 + random.random()), retry.max_delay)
+        log_to_file(
+            config,
+            f"DRAINER retry attempt={attempt} sleep={sleep_for:.2f} err={exc}",
+        )
+        await asyncio.sleep(sleep_for)
+        delay *= retry.multiplier
+      except Exception as exc:
+        log_to_file(
+            config,
+            f"DRAINER unexpected_error: {exc}\n{traceback.format_exc()}",
+        )
+        return False
+  finally:
+    # Close the gRPC channel cleanly; ignore errors during shutdown.
+    try:
+      transport = getattr(client, "transport", None)
+      close = getattr(transport, "close", None) if transport else None
+      if close is not None:
+        result = close()
+        if asyncio.iscoroutine(result):
+          await result
+    except Exception:
+      pass
+
+
+# ---------------------------------------------------------------------------
+# insert_rows_json fallback
+# ---------------------------------------------------------------------------
+
+
+def _ensure_table_exists(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    auto_create_table: bool,
+    auto_create_dataset: bool,
+) -> None:
+  from google.cloud import bigquery
+  from google.cloud.exceptions import NotFound
+
+  client = bigquery.Client(project=project, location=location)
+  dataset_id = f"{project}.{dataset}"
+  if auto_create_dataset:
+    try:
+      client.get_dataset(dataset_id)
+    except NotFound:
+      ds = bigquery.Dataset(dataset_id)
+      if location:
+        ds.location = location
+      client.create_dataset(ds)
+  table_id = f"{project}.{dataset}.{table}"
+  try:
+    client.get_table(table_id)
+    return
+  except NotFound:
+    if not auto_create_table:
+      raise
+  bq_table = bigquery.Table(table_id, schema=bq_schema(bigquery))
+  bq_table.time_partitioning = bigquery.TimePartitioning(
+      type_=bigquery.TimePartitioningType.DAY,
+      field="timestamp",
+  )
+  bq_table.clustering_fields = ["event_type", "agent", "user_id"]
+  bq_table.labels = {"adk_schema_version": "1"}
+  client.create_table(bq_table)
+
+
+def _write_batch_insert_rows_json(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    rows: list[dict[str, Any]],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    auto_create_table: bool,
+    auto_create_dataset: bool,
+) -> bool:
+  from google.api_core.exceptions import InternalServerError
+  from google.api_core.exceptions import ServiceUnavailable
+  from google.api_core.exceptions import TooManyRequests
+  from google.cloud import bigquery
+
+  try:
+    _ensure_table_exists(
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        auto_create_table=auto_create_table,
+        auto_create_dataset=auto_create_dataset,
+    )
+  except Exception as exc:
+    log_to_file(config, f"DRAINER ensure_table_failed: {exc}")
+    return False
+
+  client = bigquery.Client(project=project, location=location)
+  table_id = f"{project}.{dataset}.{table}"
+  attempt = 0
+  delay = retry.initial_delay
+  while True:
+    try:
+      errors = client.insert_rows_json(table_id, rows)
+      if errors:
+        log_to_file(config, f"DRAINER insert_rows_json errors: {errors}")
+        return False
+      return True
+    except (
+        ServiceUnavailable,
+        TooManyRequests,
+        InternalServerError,
+    ) as exc:
+      attempt += 1
+      if attempt > retry.max_retries:
+        log_to_file(
+            config,
+            f"DRAINER batch_dropped_after_{retry.max_retries + 1}: {exc}",
+        )
+        return False
+      sleep_for = min(delay * (1 + random.random()), retry.max_delay)
+      time.sleep(sleep_for)
+      delay *= retry.multiplier
+    except Exception as exc:
+      log_to_file(
+          config,
+          f"DRAINER unexpected_error: {exc}\n{traceback.format_exc()}",
+      )
+      return False
+
+
+# ---------------------------------------------------------------------------
+# Drain loop
+# ---------------------------------------------------------------------------
+
+
+async def _drain_group_async(
+    *,
+    key: tuple,
+    envelopes: list[_Envelope],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    use_storage_api: bool,
+) -> None:
+  (
+      project,
+      dataset,
+      table,
+      location,
+      writer_label,
+      auto_create_table,
+      auto_create_dataset,
+  ) = key
+  if not project or not dataset or not table:
+    for env in envelopes:
+      _quarantine(env.path, reason="missing-config")
+    return
+
+  rows = [env.row for env in envelopes]
+  success = False
+  if use_storage_api:
+    success = await _write_batch_storage_api(
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        rows=rows,
+        retry=retry,
+        config=config,
+        writer_label=writer_label or DEFAULT_WRITER_LABEL,
+    )
+    if not success:
+      log_to_file(
+          config,
+          "DRAINER storage_api_failed, falling back to insert_rows_json",
+      )
+
+  if not success:
+    # Fallback / second attempt path. Run in a thread so the event loop
+    # isn't blocked by the synchronous BQ client. Use the per-envelope
+    # auto-create policy that the producer recorded in the spool, not a
+    # hard-coded default that would silently override their settings.
+    success = await asyncio.to_thread(
+        _write_batch_insert_rows_json,
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        rows=rows,
+        retry=retry,
+        config=config,
+        auto_create_table=auto_create_table,
+        auto_create_dataset=auto_create_dataset,
+    )
+
+  if success:
+    for env in envelopes:
+      try:
+        env.path.unlink()
+      except FileNotFoundError:
+        pass
+  else:
+    for env in envelopes:
+      _quarantine(env.path, reason="write-failed")
+
+
+async def _drain_once(config: BQAAConfig, use_storage_api: bool) -> int:
+  spool = Path(config.spool_dir).expanduser()
+  pending = _list_pending(spool)
+  if not pending:
+    return 0
+  envelopes: list[_Envelope] = []
+  for path in pending[: max(1, config.drain_batch_size)]:
+    env = _read_envelope(path)
+    if env is not None:
+      envelopes.append(env)
+  if not envelopes:
+    return 0
+  grouped = _group_envelopes(envelopes)
+  retry = _RetryConfig()
+  await asyncio.gather(
+      *(
+          _drain_group_async(
+              key=key,
+              envelopes=batch,
+              retry=retry,
+              config=config,
+              use_storage_api=use_storage_api,
+          )
+          for key, batch in grouped.items()
+      )
+  )
+  return len(envelopes)
+
+
+async def _run(config: BQAAConfig) -> None:
+  spool = Path(config.spool_dir).expanduser()
+  spool.mkdir(parents=True, exist_ok=True)
+  pidfile = spool / ".drainer.pid"
+  use_storage_api = _storage_write_available()
+  with _try_acquire_pidfile(pidfile) as fd:
+    if fd is None:
+      return
+    idle = 0.0
+    while idle < config.drain_idle_seconds:
+      wrote = await _drain_once(config, use_storage_api=use_storage_api)
+      if wrote == 0:
+        await asyncio.sleep(config.drain_poll_seconds)
+        idle += config.drain_poll_seconds
+      else:
+        idle = 0.0
+
+
+def main(argv: list[str] | None = None) -> int:
+  del argv
+  config = BQAAConfig.from_env()
+  if config.dry_run:
+    return 0
+  try:
+    asyncio.run(_run(config))
+  except Exception as exc:
+    log_to_file(config, f"DRAINER fatal: {exc}\n{traceback.format_exc()}")
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/src/bigquery_agent_analytics_tracing/drain.py
+++ b/producers/src/bigquery_agent_analytics_tracing/drain.py
@@ -265,6 +265,11 @@ def _row_to_arrow_dict(row: dict[str, Any]) -> dict[str, Any]:
       if details is not None and not isinstance(details, str):
         ref = dict(ref)
         ref["details"] = json.dumps(details, sort_keys=True)
+    # part_attributes is declared as pa.string() in the Arrow schema;
+    # match the insert_rows_json path by serializing structured values.
+    part_attrs = part.get("part_attributes")
+    if part_attrs is not None and not isinstance(part_attrs, str):
+      part_attrs = json.dumps(part_attrs, sort_keys=True)
     parts.append(
         {
             "mime_type": part.get("mime_type"),
@@ -272,7 +277,7 @@ def _row_to_arrow_dict(row: dict[str, Any]) -> dict[str, Any]:
             "object_ref": ref,
             "text": part.get("text"),
             "part_index": part.get("part_index"),
-            "part_attributes": part.get("part_attributes"),
+            "part_attributes": part_attrs,
             "storage_mode": part.get("storage_mode"),
         }
     )

--- a/producers/src/bigquery_agent_analytics_tracing/logger.py
+++ b/producers/src/bigquery_agent_analytics_tracing/logger.py
@@ -81,6 +81,11 @@ def _serialize_bq_json_fields(row: dict[str, Any]) -> dict[str, Any]:
         next_object_ref = dict(object_ref)
         next_object_ref["details"] = json.dumps(details, sort_keys=True)
         next_part["object_ref"] = next_object_ref
+    # part_attributes is STRING in the schema; serialize structured values
+    # so callers passing dicts/lists don't break the insert_rows_json path.
+    part_attrs = next_part.get("part_attributes")
+    if part_attrs is not None and not isinstance(part_attrs, str):
+      next_part["part_attributes"] = json.dumps(part_attrs, sort_keys=True)
     parts.append(next_part)
   bq_row["content_parts"] = parts
   return bq_row
@@ -169,21 +174,25 @@ class BigQueryAgentAnalyticsLogger:
     clipped_content, content_truncated = truncate(
         content or {}, self.config.max_content_length
     )
+    # attributes.writer is reserved for package attribution so adoption
+    # queries on attributes.writer.{plugin,version,label,agent,mode} have a
+    # stable contract. A caller-supplied "writer" key is moved to
+    # attributes.writer_caller rather than silently dropping their data.
     merged_attributes = dict(attributes or {})
-    merged_attributes.setdefault(
-        "writer",
-        {
-            "plugin": WRITER_PLUGIN_NAME,
-            "version": WRITER_VERSION,
-            "label": self.config.writer_label,
-            "agent": agent or self.config.agent_name,
-            "mode": (
-                "dry_run"
-                if self.config.dry_run
-                else ("direct" if self.config.direct_write else "spool")
-            ),
-        },
-    )
+    caller_writer = merged_attributes.pop("writer", None)
+    merged_attributes["writer"] = {
+        "plugin": WRITER_PLUGIN_NAME,
+        "version": WRITER_VERSION,
+        "label": self.config.writer_label,
+        "agent": agent or self.config.agent_name,
+        "mode": (
+            "dry_run"
+            if self.config.dry_run
+            else ("direct" if self.config.direct_write else "spool")
+        ),
+    }
+    if caller_writer is not None:
+      merged_attributes["writer_caller"] = caller_writer
     clipped_attributes, attr_truncated = truncate(
         merged_attributes, self.config.max_content_length
     )

--- a/producers/src/bigquery_agent_analytics_tracing/logger.py
+++ b/producers/src/bigquery_agent_analytics_tracing/logger.py
@@ -1,0 +1,450 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Builds rows in the canonical BQAA ``agent_events`` shape and routes them
+to one of three sinks: dry-run log, synchronous direct insert, or async
+spool + drainer.
+
+Hook subprocess (hot path):
+  1. Build the BQAA row.
+  2. Append a JSONL line to ``config.spool_dir`` (sync, ~1 ms).
+  3. Spawn a detached drainer subprocess (idempotent via flock).
+  4. Exit. The host agent never blocks on BigQuery.
+
+The drainer subprocess (``drain.py``) holds an exclusive flock, batches
+spooled rows, writes through the BigQuery Storage Write API when
+available, and falls back to ``insert_rows_json`` otherwise.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import fcntl
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+import uuid
+
+from ._utils import hex_id
+from ._utils import iso_timestamp
+from ._utils import log_to_file
+from ._utils import truncate
+from ._writer_identity import __version__ as WRITER_VERSION
+from ._writer_identity import WRITER_PLUGIN_NAME
+from .config import BQAA_EVENT_TYPES
+from .config import BQAAConfig
+from .schema import bq_schema
+
+
+def content_part(text: str, index: int) -> dict[str, Any]:
+  """Inline-text content part. Multimodal/GCS offload is a follow-up."""
+  return {
+      "mime_type": "text/plain",
+      "uri": None,
+      "object_ref": None,
+      "text": text,
+      "part_index": index,
+      "part_attributes": None,
+      "storage_mode": "INLINE",
+  }
+
+
+def _serialize_bq_json_fields(row: dict[str, Any]) -> dict[str, Any]:
+  """Serialize JSON-typed fields so ``insert_rows_json`` sees strings."""
+  bq_row = dict(row)
+  for field in ("content", "attributes", "latency_ms"):
+    value = bq_row.get(field)
+    if value is not None and not isinstance(value, str):
+      bq_row[field] = json.dumps(value, sort_keys=True)
+  parts = []
+  for part in bq_row.get("content_parts") or []:
+    next_part = dict(part)
+    object_ref = next_part.get("object_ref")
+    if isinstance(object_ref, dict):
+      details = object_ref.get("details")
+      if details is not None and not isinstance(details, str):
+        next_object_ref = dict(object_ref)
+        next_object_ref["details"] = json.dumps(details, sort_keys=True)
+        next_part["object_ref"] = next_object_ref
+    parts.append(next_part)
+  bq_row["content_parts"] = parts
+  return bq_row
+
+
+def _ensure_drainer(config: BQAAConfig) -> None:
+  """Spawn the drainer in a detached subprocess if none is running.
+
+  Uses a non-blocking flock on a pidfile to dedupe; a running drainer holds
+  the lock for its entire lifetime. If we cannot take the lock, a drainer is
+  already running and will pick up our spool file.
+
+  Spawned via ``python -m bigquery_agent_analytics_tracing.drain``. For
+  vendored plugin installs (no wheel on ``BQAA_PYTHON``), set
+  ``PYTHONPATH`` to the vendored package root before the hook fires, or use
+  a plugin-side wrapper script that performs the ``sys.path`` insert.
+  """
+  spool = Path(config.spool_dir).expanduser()
+  spool.mkdir(parents=True, exist_ok=True)
+  pidfile = spool / ".drainer.pid"
+  fd = os.open(str(pidfile), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+      return  # Another drainer is running.
+    fcntl.flock(fd, fcntl.LOCK_UN)
+  finally:
+    os.close(fd)
+
+  python_bin = os.environ.get("BQAA_PYTHON") or sys.executable or "python3"
+  try:
+    subprocess.Popen(
+        [python_bin, "-m", "bigquery_agent_analytics_tracing.drain"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+        env=os.environ.copy(),
+    )
+  except OSError as exc:
+    log_to_file(config, f"DRAINER_SPAWN_FAIL {exc}")
+
+
+class BigQueryAgentAnalyticsLogger:
+  """Builds BQAA rows and routes them to spool / dry-run / sync write.
+
+  Default emit mode is ``spool`` (writes a JSONL line and triggers the
+  async drainer subprocess). ``config.dry_run`` writes to
+  ``config.log_file`` only. ``config.direct_write`` falls back to a
+  synchronous ``insert_rows_json`` call, kept for debugging and parity
+  tests.
+  """
+
+  def __init__(self, config: BQAAConfig | None = None):
+    self.config = config or BQAAConfig.from_env()
+    self._client = None
+    self._table_ready = False
+
+  def log_event(
+      self,
+      *,
+      event_type: str,
+      content: dict[str, Any] | None = None,
+      attributes: dict[str, Any] | None = None,
+      latency_ms: dict[str, Any] | None = None,
+      agent: str | None = None,
+      session_id: str | None = None,
+      invocation_id: str | None = None,
+      user_id: str | None = None,
+      trace_id: str | None = None,
+      span_id: str | None = None,
+      parent_span_id: str | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      timestamp: datetime | None = None,
+      content_parts: list[dict[str, Any]] | None = None,
+      is_truncated: bool = False,
+  ) -> dict[str, Any]:
+    if not self.config.enabled:
+      return {}
+    if event_type not in BQAA_EVENT_TYPES:
+      raise ValueError(f"Unsupported BQAA event_type: {event_type}")
+
+    clipped_content, content_truncated = truncate(
+        content or {}, self.config.max_content_length
+    )
+    merged_attributes = dict(attributes or {})
+    merged_attributes.setdefault(
+        "writer",
+        {
+            "plugin": WRITER_PLUGIN_NAME,
+            "version": WRITER_VERSION,
+            "label": self.config.writer_label,
+            "agent": agent or self.config.agent_name,
+            "mode": (
+                "dry_run"
+                if self.config.dry_run
+                else ("direct" if self.config.direct_write else "spool")
+            ),
+        },
+    )
+    clipped_attributes, attr_truncated = truncate(
+        merged_attributes, self.config.max_content_length
+    )
+    clipped_latency, latency_truncated = truncate(latency_ms or {}, 1000)
+    clipped_parts, parts_truncated = truncate(
+        content_parts or [], self.config.max_content_length
+    )
+
+    row = {
+        "timestamp": iso_timestamp(timestamp),
+        "event_type": event_type,
+        "agent": agent or self.config.agent_name,
+        "session_id": session_id,
+        "invocation_id": invocation_id,
+        "user_id": user_id or self.config.user_id,
+        "trace_id": trace_id,
+        "span_id": span_id or hex_id(16),
+        "parent_span_id": parent_span_id,
+        "content": clipped_content,
+        "content_parts": clipped_parts,
+        "attributes": clipped_attributes,
+        "latency_ms": clipped_latency,
+        "status": status,
+        "error_message": error_message,
+        "is_truncated": bool(
+            is_truncated
+            or content_truncated
+            or attr_truncated
+            or latency_truncated
+            or parts_truncated
+        ),
+    }
+    self._emit_row(row)
+    return row
+
+  def log_llm_request(
+      self,
+      *,
+      prompt: str,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None = None,
+      agent: str | None = None,
+      user_id: str | None = None,
+      system_prompt: str | None = None,
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="LLM_REQUEST",
+        agent=agent,
+        user_id=user_id,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={
+            "system_prompt": system_prompt or "",
+            "prompt": [{"role": "user", "content": prompt}],
+        },
+        content_parts=[content_part(prompt, 0)] if prompt else [],
+        attributes=attributes,
+    )
+
+  def log_llm_response(
+      self,
+      *,
+      response: str,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None = None,
+      agent: str | None = None,
+      user_id: str | None = None,
+      model: str | None = None,
+      usage_metadata: dict[str, int] | None = None,
+      total_ms: int | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      attributes: dict[str, Any] | None = None,
+      is_truncated: bool = False,
+  ) -> dict[str, Any]:
+    usage = usage_metadata or {}
+    attrs = {
+        "model": model or "",
+        "usage_metadata": {
+            "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+            "completion_tokens": int(usage.get("completion_tokens") or 0),
+            "total_tokens": int(usage.get("total_tokens") or 0),
+        },
+    }
+    if attributes:
+      attrs.update(attributes)
+    return self.log_event(
+        event_type="LLM_RESPONSE",
+        agent=agent,
+        user_id=user_id,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={"response": response},
+        content_parts=[content_part(response, 0)] if response else [],
+        attributes=attrs,
+        latency_ms={"total_ms": total_ms} if total_ms is not None else {},
+        status=status,
+        error_message=error_message,
+        is_truncated=is_truncated,
+    )
+
+  def log_tool_starting(
+      self,
+      *,
+      tool: str,
+      args: dict[str, Any],
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None,
+      agent: str | None = None,
+      tool_origin: str = "LOCAL",
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="TOOL_STARTING",
+        agent=agent,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={"tool": tool, "args": args, "tool_origin": tool_origin},
+        attributes=attributes,
+    )
+
+  def log_tool_completed(
+      self,
+      *,
+      tool: str,
+      result: Any,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None,
+      agent: str | None = None,
+      tool_origin: str = "LOCAL",
+      total_ms: int | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="TOOL_COMPLETED",
+        agent=agent,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={
+            "tool": tool,
+            "result": result,
+            "tool_origin": tool_origin,
+        },
+        attributes=attributes,
+        latency_ms={"total_ms": total_ms} if total_ms is not None else {},
+        status=status,
+        error_message=error_message,
+    )
+
+  def _emit_row(self, row: dict[str, Any]) -> None:
+    bq_row = _serialize_bq_json_fields(row)
+    if self.config.dry_run:
+      log_to_file(
+          self.config,
+          "DRY_RUN " + json.dumps(bq_row, sort_keys=True, default=str),
+      )
+      return
+    if not self.config.project_id or not self.config.dataset:
+      raise ValueError(
+          "BQAA_PROJECT_ID/GCP_PROJECT_ID and BQAA_DATASET are required"
+      )
+    if self.config.direct_write:
+      self._direct_insert(bq_row)
+      return
+    self._spool(bq_row)
+
+  def _spool(self, bq_row: dict[str, Any]) -> None:
+    spool = Path(self.config.spool_dir).expanduser()
+    spool.mkdir(parents=True, exist_ok=True)
+    envelope = {
+        "config": {
+            "project_id": self.config.project_id,
+            "dataset": self.config.dataset,
+            "table": self.config.table,
+            "location": self.config.location,
+            "auto_create_table": self.config.auto_create_table,
+            "auto_create_dataset": self.config.auto_create_dataset,
+            "writer_label": self.config.writer_label,
+        },
+        "row": bq_row,
+    }
+    name = f"event-{time.time_ns()}-{os.getpid()}-{uuid.uuid4().hex[:8]}.json"
+    path = spool / name
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps(envelope, sort_keys=True, default=str), encoding="utf-8"
+    )
+    os.replace(tmp, path)
+    _ensure_drainer(self.config)
+
+  def _direct_insert(self, bq_row: dict[str, Any]) -> None:
+    self._ensure_table()
+    errors = self._client.insert_rows_json(self._table_id, [bq_row])
+    if errors:
+      raise RuntimeError(f"BigQuery insert failed: {errors}")
+
+  def _ensure_table(self) -> None:
+    if self._table_ready:
+      return
+    from google.cloud import bigquery
+    from google.cloud.exceptions import NotFound
+
+    self._client = self._client or bigquery.Client(
+        project=self.config.project_id, location=self.config.location
+    )
+    dataset_id = f"{self.config.project_id}.{self.config.dataset}"
+    if self.config.auto_create_dataset:
+      try:
+        self._client.get_dataset(dataset_id)
+      except NotFound:
+        dataset = bigquery.Dataset(dataset_id)
+        if self.config.location:
+          dataset.location = self.config.location
+        self._client.create_dataset(dataset)
+
+    try:
+      self._client.get_table(self._table_id)
+    except NotFound:
+      if not self.config.auto_create_table:
+        raise
+      table = bigquery.Table(self._table_id, schema=bq_schema(bigquery))
+      table.time_partitioning = bigquery.TimePartitioning(
+          type_=bigquery.TimePartitioningType.DAY,
+          field="timestamp",
+      )
+      table.clustering_fields = ["event_type", "agent", "user_id"]
+      table.labels = {"adk_schema_version": "1"}
+      self._client.create_table(table)
+    self._table_ready = True
+
+  @property
+  def _table_id(self) -> str:
+    return (
+        f"{self.config.project_id}."
+        f"{self.config.dataset}."
+        f"{self.config.table}"
+    )

--- a/producers/src/bigquery_agent_analytics_tracing/schema.py
+++ b/producers/src/bigquery_agent_analytics_tracing/schema.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BigQuery ``agent_events`` schema matching the canonical BQAA shape.
+
+Kept as a function so callers pass in their own ``google.cloud.bigquery``
+module — the producer package does not import BigQuery at import time so
+dry-run callers (and unit tests) never need the dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def bq_schema(bigquery: Any) -> list[Any]:
+  """Return the BigQuery schema for the ``agent_events`` table.
+
+  Used by both the direct writer's ``auto_create_table`` path and the
+  drainer's ``insert_rows_json`` fallback. The Storage Write API path
+  declares the same shape as an Arrow schema in ``drain.py``.
+  """
+  return [
+      bigquery.SchemaField("timestamp", "TIMESTAMP", mode="REQUIRED"),
+      bigquery.SchemaField("event_type", "STRING"),
+      bigquery.SchemaField("agent", "STRING"),
+      bigquery.SchemaField("session_id", "STRING"),
+      bigquery.SchemaField("invocation_id", "STRING"),
+      bigquery.SchemaField("user_id", "STRING"),
+      bigquery.SchemaField("trace_id", "STRING"),
+      bigquery.SchemaField("span_id", "STRING"),
+      bigquery.SchemaField("parent_span_id", "STRING"),
+      bigquery.SchemaField("content", "JSON"),
+      bigquery.SchemaField(
+          "content_parts",
+          "RECORD",
+          mode="REPEATED",
+          fields=[
+              bigquery.SchemaField("mime_type", "STRING"),
+              bigquery.SchemaField("uri", "STRING"),
+              bigquery.SchemaField(
+                  "object_ref",
+                  "RECORD",
+                  fields=[
+                      bigquery.SchemaField("uri", "STRING"),
+                      bigquery.SchemaField("version", "STRING"),
+                      bigquery.SchemaField("authorizer", "STRING"),
+                      bigquery.SchemaField("details", "JSON"),
+                  ],
+              ),
+              bigquery.SchemaField("text", "STRING"),
+              bigquery.SchemaField("part_index", "INTEGER"),
+              bigquery.SchemaField("part_attributes", "STRING"),
+              bigquery.SchemaField("storage_mode", "STRING"),
+          ],
+      ),
+      bigquery.SchemaField("attributes", "JSON"),
+      bigquery.SchemaField("latency_ms", "JSON"),
+      bigquery.SchemaField("status", "STRING"),
+      bigquery.SchemaField("error_message", "STRING"),
+      bigquery.SchemaField("is_truncated", "BOOLEAN"),
+  ]

--- a/producers/tests/__init__.py
+++ b/producers/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/producers/tests/test_config.py
+++ b/producers/tests/test_config.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``BQAAConfig`` env-driven construction and defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from bigquery_agent_analytics_tracing._writer_identity import DEFAULT_WRITER_LABEL
+from bigquery_agent_analytics_tracing._writer_identity import WRITER_PLUGIN_NAME
+from bigquery_agent_analytics_tracing.config import BQAAConfig
+from bigquery_agent_analytics_tracing.config import DEFAULT_DRAIN_BATCH_SIZE
+from bigquery_agent_analytics_tracing.config import DEFAULT_DRAIN_IDLE_SECONDS
+from bigquery_agent_analytics_tracing.config import DEFAULT_LOG_FILE
+from bigquery_agent_analytics_tracing.config import DEFAULT_SPOOL_DIR
+from bigquery_agent_analytics_tracing.config import DEFAULT_STATE_DIR
+
+_BQAA_VARS = [
+    "BQAA_PROJECT_ID",
+    "BQAA_DATASET",
+    "BQAA_TABLE",
+    "BQAA_AGENT_NAME",
+    "BQAA_USER_ID",
+    "BQAA_TRACE_ENABLED",
+    "BQAA_DRY_RUN",
+    "BQAA_DIRECT_WRITE",
+    "BQAA_AUTO_CREATE_TABLE",
+    "BQAA_AUTO_CREATE_DATASET",
+    "BQAA_LOCATION",
+    "BQAA_MAX_CONTENT_LENGTH",
+    "BQAA_LOG_FILE",
+    "BQAA_SPOOL_DIR",
+    "BQAA_STATE_DIR",
+    "BQAA_STATE_TTL_HOURS",
+    "BQAA_TRANSCRIPT_MAX_BYTES",
+    "BQAA_DRAIN_IDLE_SECONDS",
+    "BQAA_DRAIN_BATCH_SIZE",
+    "BQAA_DRAIN_POLL_SECONDS",
+    "BQAA_WRITER_LABEL",
+    "GCP_PROJECT_ID",
+    "GOOGLE_CLOUD_PROJECT",
+    "BQ_DATASET",
+    "BQ_TABLE",
+    "USER",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+  for var in _BQAA_VARS:
+    monkeypatch.delenv(var, raising=False)
+  yield
+
+
+def test_from_env_defaults_with_empty_env():
+  config = BQAAConfig.from_env()
+
+  assert config.project_id == ""
+  assert config.dataset == ""
+  assert config.table == "agent_events"
+  assert config.agent_name == "coding-agent"
+  assert config.user_id == "local-user"
+  assert config.enabled is True
+  assert config.dry_run is False
+  assert config.direct_write is False
+  assert config.auto_create_table is True
+  assert config.auto_create_dataset is False
+  assert config.location is None
+  assert config.max_content_length == 5000
+  assert config.log_file == DEFAULT_LOG_FILE
+  assert config.spool_dir == DEFAULT_SPOOL_DIR
+  assert config.state_dir == DEFAULT_STATE_DIR
+  assert config.drain_idle_seconds == DEFAULT_DRAIN_IDLE_SECONDS
+  assert config.drain_batch_size == DEFAULT_DRAIN_BATCH_SIZE
+  assert config.writer_label == DEFAULT_WRITER_LABEL
+
+
+def test_from_env_reads_bqaa_specific_vars(monkeypatch):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "proj-bqaa")
+  monkeypatch.setenv("GCP_PROJECT_ID", "proj-gcp")
+  monkeypatch.setenv("BQAA_DATASET", "agents")
+  monkeypatch.setenv("BQAA_TABLE", "events_v2")
+  monkeypatch.setenv("BQAA_AGENT_NAME", "claude-code")
+  monkeypatch.setenv("BQAA_USER_ID", "alice")
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "false")
+  monkeypatch.setenv("BQAA_DRY_RUN", "true")
+  monkeypatch.setenv("BQAA_DIRECT_WRITE", "true")
+  monkeypatch.setenv("BQAA_AUTO_CREATE_TABLE", "false")
+  monkeypatch.setenv("BQAA_AUTO_CREATE_DATASET", "true")
+  monkeypatch.setenv("BQAA_LOCATION", "US")
+  monkeypatch.setenv("BQAA_MAX_CONTENT_LENGTH", "10000")
+  monkeypatch.setenv("BQAA_WRITER_LABEL", "my-deployment/1.2.3")
+
+  config = BQAAConfig.from_env()
+
+  assert (
+      config.project_id == "proj-bqaa"
+  ), "BQAA_PROJECT_ID wins over GCP_PROJECT_ID"
+  assert config.dataset == "agents"
+  assert config.table == "events_v2"
+  assert config.agent_name == "claude-code"
+  assert config.user_id == "alice"
+  assert config.enabled is False
+  assert config.dry_run is True
+  assert config.direct_write is True
+  assert config.auto_create_table is False
+  assert config.auto_create_dataset is True
+  assert config.location == "US"
+  assert config.max_content_length == 10000
+  assert config.writer_label == "my-deployment/1.2.3"
+
+
+def test_from_env_falls_back_to_gcp_and_bq_legacy_vars(monkeypatch):
+  monkeypatch.setenv("GCP_PROJECT_ID", "proj-gcp")
+  monkeypatch.setenv("BQ_DATASET", "legacy_dataset")
+  monkeypatch.setenv("BQ_TABLE", "legacy_table")
+  monkeypatch.setenv("USER", "legacy-user")
+
+  config = BQAAConfig.from_env()
+
+  assert config.project_id == "proj-gcp"
+  assert config.dataset == "legacy_dataset"
+  assert config.table == "legacy_table"
+  assert config.user_id == "legacy-user"
+
+
+def test_trace_enabled_kill_switch(monkeypatch):
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "false")
+  config = BQAAConfig.from_env()
+  assert config.enabled is False
+
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "true")
+  config = BQAAConfig.from_env()
+  assert config.enabled is True
+
+
+def test_writer_label_defaults_to_package_identity():
+  config = BQAAConfig.from_env()
+  assert config.writer_label.startswith(WRITER_PLUGIN_NAME + "/")
+  assert config.writer_label == DEFAULT_WRITER_LABEL
+
+
+def test_writer_label_env_override_wins(monkeypatch):
+  monkeypatch.setenv("BQAA_WRITER_LABEL", "custom/9.9.9")
+  config = BQAAConfig.from_env()
+  assert config.writer_label == "custom/9.9.9"

--- a/producers/tests/test_drain.py
+++ b/producers/tests/test_drain.py
@@ -238,6 +238,46 @@ def test_pythonpath_invocation_works_for_vendored_plugin(tmp_path):
   ), f"stdout={result.stdout!r} stderr={result.stderr!r}"
 
 
+def test_row_to_arrow_dict_serializes_structured_part_attributes():
+  """part_attributes is pa.string() in the Arrow schema. Structured values
+  must be JSON-serialized so PyArrow can pack the batch."""
+  from bigquery_agent_analytics_tracing.drain import _row_to_arrow_dict
+
+  row = {
+      "timestamp": "2026-05-22T00:00:00.000000Z",
+      "event_type": "STATE_DELTA",
+      "content_parts": [
+          {
+              "mime_type": "text/plain",
+              "uri": None,
+              "object_ref": None,
+              "text": "hi",
+              "part_index": 0,
+              "part_attributes": {"lang": "en", "confidence": 0.9},
+              "storage_mode": "INLINE",
+          },
+          {
+              "mime_type": "text/plain",
+              "uri": None,
+              "object_ref": None,
+              "text": "raw",
+              "part_index": 1,
+              "part_attributes": "already-string",
+              "storage_mode": "INLINE",
+          },
+      ],
+  }
+
+  arrow = _row_to_arrow_dict(row)
+
+  assert isinstance(arrow["content_parts"][0]["part_attributes"], str)
+  assert json.loads(arrow["content_parts"][0]["part_attributes"]) == {
+      "confidence": 0.9,
+      "lang": "en",
+  }
+  assert arrow["content_parts"][1]["part_attributes"] == "already-string"
+
+
 @pytest.mark.skipif(
     not Path("/tmp").exists(), reason="POSIX-only spool path test"
 )

--- a/producers/tests/test_drain.py
+++ b/producers/tests/test_drain.py
@@ -1,0 +1,269 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the drainer packaging — envelope I/O, grouping, dead-letter,
+and packaged-module invocability. Network I/O against BigQuery is covered
+by the gated smoke tests, not this file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from bigquery_agent_analytics_tracing._writer_identity import DEFAULT_WRITER_LABEL
+from bigquery_agent_analytics_tracing.drain import _Envelope
+from bigquery_agent_analytics_tracing.drain import _group_envelopes
+from bigquery_agent_analytics_tracing.drain import _list_pending
+from bigquery_agent_analytics_tracing.drain import _read_envelope
+
+
+def _write_envelope(spool: Path, name: str, config: dict, row: dict) -> Path:
+  spool.mkdir(parents=True, exist_ok=True)
+  path = spool / name
+  path.write_text(
+      json.dumps({"config": config, "row": row}, sort_keys=True),
+      encoding="utf-8",
+  )
+  return path
+
+
+def test_list_pending_returns_only_event_files(tmp_path):
+  spool = tmp_path / "spool"
+  spool.mkdir()
+  (spool / "event-1.json").write_text("{}")
+  (spool / "event-2.json").write_text("{}")
+  (spool / "other.json").write_text("{}")
+  (spool / ".drainer.pid").write_text("123")
+
+  pending = _list_pending(spool)
+
+  assert [p.name for p in pending] == ["event-1.json", "event-2.json"]
+
+
+def test_list_pending_returns_empty_when_spool_absent(tmp_path):
+  assert _list_pending(tmp_path / "missing") == []
+
+
+def test_read_envelope_parses_valid_json(tmp_path):
+  path = _write_envelope(
+      tmp_path / "spool",
+      "event-ok.json",
+      config={"project_id": "p", "dataset": "d", "table": "t"},
+      row={"event_type": "STATE_DELTA"},
+  )
+
+  envelope = _read_envelope(path)
+
+  assert envelope is not None
+  assert envelope.config_dict["project_id"] == "p"
+  assert envelope.row["event_type"] == "STATE_DELTA"
+
+
+def test_read_envelope_quarantines_corrupt_json(tmp_path):
+  spool = tmp_path / "spool"
+  spool.mkdir()
+  corrupt = spool / "event-bad.json"
+  corrupt.write_text("not json {{{")
+
+  result = _read_envelope(corrupt)
+
+  assert result is None
+  assert not corrupt.exists()
+  dead = list((spool / "dead-letter").glob("event-bad.corrupt-json.json"))
+  assert len(dead) == 1
+
+
+def test_group_envelopes_keys_by_destination_and_writer_label():
+  envelopes = [
+      _Envelope(
+          path=Path("a"),
+          config_dict={
+              "project_id": "p1",
+              "dataset": "d",
+              "table": "t",
+              "writer_label": "label-a/1.0",
+          },
+          row={},
+      ),
+      _Envelope(
+          path=Path("b"),
+          config_dict={
+              "project_id": "p1",
+              "dataset": "d",
+              "table": "t",
+              "writer_label": "label-a/1.0",
+          },
+          row={},
+      ),
+      _Envelope(
+          path=Path("c"),
+          config_dict={
+              "project_id": "p2",
+              "dataset": "d",
+              "table": "t",
+              "writer_label": "label-b/1.0",
+          },
+          row={},
+      ),
+  ]
+
+  grouped = _group_envelopes(envelopes)
+
+  assert len(grouped) == 2
+  group_sizes = sorted(len(v) for v in grouped.values())
+  assert group_sizes == [1, 2]
+
+
+def test_group_envelopes_falls_back_to_default_writer_label():
+  envelope = _Envelope(
+      path=Path("a"),
+      config_dict={
+          "project_id": "p",
+          "dataset": "d",
+          "table": "t",
+          # No writer_label — fallback should kick in.
+      },
+      row={},
+  )
+
+  grouped = _group_envelopes([envelope])
+
+  key = next(iter(grouped))
+  # writer_label is the 5th element of the tuple key.
+  assert key[4] == DEFAULT_WRITER_LABEL
+
+
+def test_group_envelopes_honors_per_envelope_auto_create_flags():
+  envelopes = [
+      _Envelope(
+          path=Path("a"),
+          config_dict={
+              "project_id": "p",
+              "dataset": "d",
+              "table": "t",
+              "auto_create_table": True,
+              "auto_create_dataset": False,
+          },
+          row={},
+      ),
+      _Envelope(
+          path=Path("b"),
+          config_dict={
+              "project_id": "p",
+              "dataset": "d",
+              "table": "t",
+              "auto_create_table": False,
+              "auto_create_dataset": True,
+          },
+          row={},
+      ),
+  ]
+
+  grouped = _group_envelopes(envelopes)
+
+  assert len(grouped) == 2, (
+      "differing auto-create policies must land in separate groups so the"
+      " fallback path honors each producer's intent"
+  )
+
+
+def test_drain_module_is_invocable_as_python_m(tmp_path):
+  """The packaged-module spawn (-m bigquery_agent_analytics_tracing.drain)
+  is the canonical wheel-install invocation. With dry_run=true the drainer
+  exits 0 immediately without touching BigQuery."""
+  src_root = Path(__file__).resolve().parents[1] / "src"
+  env = {
+      "PYTHONPATH": str(src_root),
+      "BQAA_DRY_RUN": "true",
+      "BQAA_SPOOL_DIR": str(tmp_path / "spool"),
+      "BQAA_LOG_FILE": str(tmp_path / "bqaa.log"),
+      "PATH": "/usr/bin:/bin",
+  }
+  result = subprocess.run(
+      [sys.executable, "-m", "bigquery_agent_analytics_tracing.drain"],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  assert (
+      result.returncode == 0
+  ), f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+def test_pythonpath_invocation_works_for_vendored_plugin(tmp_path):
+  """Same as above, but uses the PYTHONPATH-based path that the vendored
+  Claude plugin will use (no wheel install required on BQAA_PYTHON)."""
+  # Simulate a vendored plugin: copy the package source to a fresh dir
+  # outside any installed site-packages and verify -m still works with
+  # only PYTHONPATH pointing at it.
+  import shutil
+
+  src_root = Path(__file__).resolve().parents[1] / "src"
+  vendor_dir = tmp_path / "vendored"
+  shutil.copytree(src_root, vendor_dir)
+
+  env = {
+      "PYTHONPATH": str(vendor_dir),
+      "BQAA_DRY_RUN": "true",
+      "BQAA_SPOOL_DIR": str(tmp_path / "spool"),
+      "BQAA_LOG_FILE": str(tmp_path / "bqaa.log"),
+      "PATH": "/usr/bin:/bin",
+  }
+  result = subprocess.run(
+      [sys.executable, "-m", "bigquery_agent_analytics_tracing.drain"],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  assert (
+      result.returncode == 0
+  ), f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+@pytest.mark.skipif(
+    not Path("/tmp").exists(), reason="POSIX-only spool path test"
+)
+def test_envelope_dataclass_round_trip(tmp_path):
+  path = _write_envelope(
+      tmp_path / "spool",
+      "event-rt.json",
+      config={
+          "project_id": "p",
+          "dataset": "d",
+          "table": "t",
+          "location": "US",
+          "writer_label": "rt/1.0",
+          "auto_create_table": True,
+          "auto_create_dataset": False,
+      },
+      row={
+          "event_type": "STATE_DELTA",
+          "content": '{"x":1}',
+          "attributes": '{"writer":{"plugin":"p"}}',
+      },
+  )
+
+  envelope = _read_envelope(path)
+
+  assert envelope is not None
+  assert envelope.path == path
+  assert envelope.config_dict["location"] == "US"
+  assert envelope.row["content"] == '{"x":1}'

--- a/producers/tests/test_logger_row_shape.py
+++ b/producers/tests/test_logger_row_shape.py
@@ -87,7 +87,15 @@ def test_writer_attribution_stamped_on_every_row(dry_run_config):
   assert "version" in writer
 
 
-def test_writer_mode_reflects_routing(tmp_path):
+def test_writer_mode_reflects_routing(tmp_path, monkeypatch):
+  # writer.mode is derived inside log_event before _emit_row runs, so
+  # stubbing _emit_row to a no-op lets us assert all three modes without
+  # hitting BigQuery for the direct/spool cases.
+  monkeypatch.setattr(
+      BigQueryAgentAnalyticsLogger,
+      "_emit_row",
+      lambda self, row: None,
+  )
   for kwargs, expected_mode in [
       ({"dry_run": True, "direct_write": False}, "dry_run"),
       ({"dry_run": False, "direct_write": True}, "direct"),
@@ -101,13 +109,12 @@ def test_writer_mode_reflects_routing(tmp_path):
         state_dir=str(tmp_path / f"state-{expected_mode}"),
         **kwargs,
     )
-    # Direct-write would hit BigQuery; force dry_run for the mode check.
-    config.dry_run = True
     logger = BigQueryAgentAnalyticsLogger(config)
     row = logger.log_event(event_type="STATE_DELTA")
-    # When dry_run is on, the mode is always "dry_run" — the writer block
-    # reflects the actual sink, not the configured intent.
-    assert row["attributes"]["writer"]["mode"] == "dry_run"
+    assert row["attributes"]["writer"]["mode"] == expected_mode, (
+        f"expected mode={expected_mode!r} for kwargs={kwargs!r}, got"
+        f" {row['attributes']['writer']['mode']!r}"
+    )
 
 
 def test_explicit_agent_override_propagates_to_row_and_writer(dry_run_config):

--- a/producers/tests/test_logger_row_shape.py
+++ b/producers/tests/test_logger_row_shape.py
@@ -165,6 +165,76 @@ def test_sensitive_keys_are_redacted(dry_run_config):
   assert row["content"]["nested"]["ok_field"] == "fine"
 
 
+def test_caller_writer_attribute_does_not_suppress_package_attribution(
+    dry_run_config,
+):
+  """attributes.writer is reserved — a caller-supplied writer must not
+  win, or adoption queries on attributes.writer.plugin/version/label/mode
+  silently break the moment a producer passes its own writer-like data.
+  """
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  caller_writer = {"plugin": "spoofed", "version": "99.99", "extra": "x"}
+  row = logger.log_event(
+      event_type="STATE_DELTA",
+      attributes={"writer": caller_writer, "session_metadata": {"k": "v"}},
+  )
+
+  writer = row["attributes"]["writer"]
+  assert writer["plugin"] == WRITER_PLUGIN_NAME
+  assert writer["plugin"] != "spoofed"
+  assert writer["label"] == "bigquery-agent-analytics-tracing/test"
+
+  # Caller's value preserved under a separate key, not silently dropped.
+  assert row["attributes"]["writer_caller"] == caller_writer
+  # Unrelated attributes pass through untouched.
+  assert row["attributes"]["session_metadata"] == {"k": "v"}
+
+
+def test_part_attributes_dict_is_json_serialized_for_bigquery(dry_run_config):
+  """part_attributes is declared as STRING in the schema; structured values
+  must be JSON-serialized so the insert_rows_json path doesn't reject the
+  row and the Storage Write API path doesn't see a non-string."""
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  logger.log_event(
+      event_type="STATE_DELTA",
+      content_parts=[
+          {
+              "mime_type": "text/plain",
+              "uri": None,
+              "object_ref": None,
+              "text": "hi",
+              "part_index": 0,
+              "part_attributes": {"lang": "en", "confidence": 0.9},
+              "storage_mode": "INLINE",
+          },
+          {
+              "mime_type": "text/plain",
+              "uri": None,
+              "object_ref": None,
+              "text": "already-string",
+              "part_index": 1,
+              "part_attributes": "raw-string",
+              "storage_mode": "INLINE",
+          },
+      ],
+  )
+
+  # The dry-run log line carries the BigQuery-shape row (post-serialize).
+  log_text = __import__("pathlib").Path(dry_run_config.log_file).read_text()
+  payload = log_text.split("DRY_RUN ", 1)[1].splitlines()[0]
+  emitted = json.loads(payload)
+  parts = emitted["content_parts"]
+
+  # Dict → JSON string with sorted keys (matches object_ref.details).
+  assert isinstance(parts[0]["part_attributes"], str)
+  assert json.loads(parts[0]["part_attributes"]) == {
+      "confidence": 0.9,
+      "lang": "en",
+  }
+  # Already-string values pass through unchanged.
+  assert parts[1]["part_attributes"] == "raw-string"
+
+
 def test_dry_run_writes_to_log_file_and_not_bigquery(tmp_path, dry_run_config):
   logger = BigQueryAgentAnalyticsLogger(dry_run_config)
   logger.log_event(event_type="STATE_DELTA", content={"smoke": True})

--- a/producers/tests/test_logger_row_shape.py
+++ b/producers/tests/test_logger_row_shape.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``BigQueryAgentAnalyticsLogger`` row shape and routing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bigquery_agent_analytics_tracing._writer_identity import WRITER_PLUGIN_NAME
+from bigquery_agent_analytics_tracing.config import BQAAConfig
+from bigquery_agent_analytics_tracing.logger import BigQueryAgentAnalyticsLogger
+
+
+@pytest.fixture
+def dry_run_config(tmp_path):
+  return BQAAConfig(
+      project_id="test-project",
+      dataset="test_dataset",
+      agent_name="claude-code",
+      dry_run=True,
+      log_file=str(tmp_path / "bqaa.log"),
+      spool_dir=str(tmp_path / "spool"),
+      state_dir=str(tmp_path / "state"),
+      writer_label="bigquery-agent-analytics-tracing/test",
+  )
+
+
+def test_log_event_returns_row_with_canonical_top_level_fields(dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(
+      event_type="STATE_DELTA",
+      content={"hello": "world"},
+      session_id="sess",
+      invocation_id="inv",
+      trace_id="trace",
+      span_id="span",
+  )
+
+  expected_fields = {
+      "timestamp",
+      "event_type",
+      "agent",
+      "session_id",
+      "invocation_id",
+      "user_id",
+      "trace_id",
+      "span_id",
+      "parent_span_id",
+      "content",
+      "content_parts",
+      "attributes",
+      "latency_ms",
+      "status",
+      "error_message",
+      "is_truncated",
+  }
+  assert set(row.keys()) == expected_fields
+  assert row["event_type"] == "STATE_DELTA"
+  assert row["agent"] == "claude-code"
+  assert row["status"] == "OK"
+  assert row["is_truncated"] is False
+
+
+def test_writer_attribution_stamped_on_every_row(dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(event_type="STATE_DELTA", content={"x": 1})
+
+  writer = row["attributes"]["writer"]
+  assert writer["plugin"] == WRITER_PLUGIN_NAME
+  assert writer["label"] == "bigquery-agent-analytics-tracing/test"
+  assert writer["agent"] == "claude-code"
+  assert writer["mode"] == "dry_run"
+  assert "version" in writer
+
+
+def test_writer_mode_reflects_routing(tmp_path):
+  for kwargs, expected_mode in [
+      ({"dry_run": True, "direct_write": False}, "dry_run"),
+      ({"dry_run": False, "direct_write": True}, "direct"),
+      ({"dry_run": False, "direct_write": False}, "spool"),
+  ]:
+    config = BQAAConfig(
+        project_id="p",
+        dataset="d",
+        log_file=str(tmp_path / f"bqaa-{expected_mode}.log"),
+        spool_dir=str(tmp_path / f"spool-{expected_mode}"),
+        state_dir=str(tmp_path / f"state-{expected_mode}"),
+        **kwargs,
+    )
+    # Direct-write would hit BigQuery; force dry_run for the mode check.
+    config.dry_run = True
+    logger = BigQueryAgentAnalyticsLogger(config)
+    row = logger.log_event(event_type="STATE_DELTA")
+    # When dry_run is on, the mode is always "dry_run" — the writer block
+    # reflects the actual sink, not the configured intent.
+    assert row["attributes"]["writer"]["mode"] == "dry_run"
+
+
+def test_explicit_agent_override_propagates_to_row_and_writer(dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(
+      event_type="STATE_DELTA",
+      agent="codex-cli",
+  )
+  assert row["agent"] == "codex-cli"
+  assert row["attributes"]["writer"]["agent"] == "codex-cli"
+
+
+def test_disabled_logger_short_circuits(dry_run_config):
+  dry_run_config.enabled = False
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(event_type="STATE_DELTA")
+  assert row == {}
+
+
+def test_unknown_event_type_raises(dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  with pytest.raises(ValueError, match="Unsupported BQAA event_type"):
+    logger.log_event(event_type="NOT_A_REAL_EVENT")
+
+
+def test_content_truncation_marks_is_truncated(dry_run_config):
+  dry_run_config.max_content_length = 10
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(
+      event_type="STATE_DELTA",
+      content={"text": "x" * 100},
+  )
+  assert row["is_truncated"] is True
+  assert "[TRUNCATED]" in row["content"]["text"]
+
+
+def test_sensitive_keys_are_redacted(dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  row = logger.log_event(
+      event_type="STATE_DELTA",
+      content={
+          "api_key": "very-secret",
+          "nested": {"password": "p4ssw0rd", "ok_field": "fine"},
+      },
+  )
+  assert row["content"]["api_key"] == "[REDACTED]"
+  assert row["content"]["nested"]["password"] == "[REDACTED]"
+  assert row["content"]["nested"]["ok_field"] == "fine"
+
+
+def test_dry_run_writes_to_log_file_and_not_bigquery(tmp_path, dry_run_config):
+  logger = BigQueryAgentAnalyticsLogger(dry_run_config)
+  logger.log_event(event_type="STATE_DELTA", content={"smoke": True})
+
+  log_text = (tmp_path / "bqaa.log").read_text()
+  assert "DRY_RUN" in log_text
+  # The dry-run log line is a single JSON envelope after "DRY_RUN ".
+  dry_payload = log_text.split("DRY_RUN ", 1)[1].splitlines()[0]
+  parsed = json.loads(dry_payload)
+  assert parsed["event_type"] == "STATE_DELTA"
+
+
+def test_spool_mode_writes_envelope_file(tmp_path, monkeypatch):
+  config = BQAAConfig(
+      project_id="test-project",
+      dataset="test_dataset",
+      agent_name="claude-code",
+      spool_dir=str(tmp_path / "spool"),
+      log_file=str(tmp_path / "bqaa.log"),
+      state_dir=str(tmp_path / "state"),
+  )
+
+  # Stub the drainer spawn so the test doesn't fork a real process.
+  spawn_called = []
+
+  def _fake_ensure(_config):
+    spawn_called.append(True)
+
+  monkeypatch.setattr(
+      "bigquery_agent_analytics_tracing.logger._ensure_drainer", _fake_ensure
+  )
+
+  logger = BigQueryAgentAnalyticsLogger(config)
+  logger.log_event(event_type="STATE_DELTA", content={"x": 1})
+
+  spool_files = list((tmp_path / "spool").glob("event-*.json"))
+  assert len(spool_files) == 1
+  envelope = json.loads(spool_files[0].read_text())
+  assert envelope["config"]["project_id"] == "test-project"
+  assert envelope["config"]["dataset"] == "test_dataset"
+  assert envelope["row"]["event_type"] == "STATE_DELTA"
+  # JSON-typed fields are pre-serialized so the drainer's insert_rows_json
+  # fallback can use them as-is.
+  assert isinstance(envelope["row"]["content"], str)
+  assert isinstance(envelope["row"]["attributes"], str)
+  assert spawn_called == [True]
+
+
+def test_direct_write_requires_project_and_dataset():
+  config = BQAAConfig(project_id="", dataset="", direct_write=True)
+  logger = BigQueryAgentAnalyticsLogger(config)
+  with pytest.raises(ValueError, match="BQAA_PROJECT_ID"):
+    logger.log_event(event_type="STATE_DELTA")

--- a/producers/tests/test_schema.py
+++ b/producers/tests/test_schema.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the canonical BQAA ``agent_events`` schema.
+
+Uses fakes that match the ``google.cloud.bigquery`` SchemaField shape so we
+do not require ``google-cloud-bigquery`` to be importable for unit testing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from bigquery_agent_analytics_tracing.schema import bq_schema
+
+
+@dataclass
+class _FakeSchemaField:
+  name: str
+  field_type: str
+  mode: str = "NULLABLE"
+  fields: tuple[Any, ...] = ()
+
+
+class _FakeBigQueryModule:
+
+  def SchemaField(  # noqa: N802 — mirrors google.cloud.bigquery API.
+      self,
+      name: str,
+      field_type: str,
+      mode: str = "NULLABLE",
+      fields=(),
+  ) -> _FakeSchemaField:
+    return _FakeSchemaField(
+        name=name, field_type=field_type, mode=mode, fields=tuple(fields)
+    )
+
+
+EXPECTED_TOP_LEVEL = [
+    ("timestamp", "TIMESTAMP", "REQUIRED"),
+    ("event_type", "STRING", "NULLABLE"),
+    ("agent", "STRING", "NULLABLE"),
+    ("session_id", "STRING", "NULLABLE"),
+    ("invocation_id", "STRING", "NULLABLE"),
+    ("user_id", "STRING", "NULLABLE"),
+    ("trace_id", "STRING", "NULLABLE"),
+    ("span_id", "STRING", "NULLABLE"),
+    ("parent_span_id", "STRING", "NULLABLE"),
+    ("content", "JSON", "NULLABLE"),
+    ("content_parts", "RECORD", "REPEATED"),
+    ("attributes", "JSON", "NULLABLE"),
+    ("latency_ms", "JSON", "NULLABLE"),
+    ("status", "STRING", "NULLABLE"),
+    ("error_message", "STRING", "NULLABLE"),
+    ("is_truncated", "BOOLEAN", "NULLABLE"),
+]
+
+
+def test_top_level_columns_match_adk_bqaa_contract():
+  schema = bq_schema(_FakeBigQueryModule())
+
+  actual = [(f.name, f.field_type, f.mode) for f in schema]
+  assert actual == EXPECTED_TOP_LEVEL
+
+
+def test_content_parts_record_shape():
+  schema = bq_schema(_FakeBigQueryModule())
+  parts = next(f for f in schema if f.name == "content_parts")
+  assert parts.mode == "REPEATED"
+
+  part_fields = {f.name: f for f in parts.fields}
+  assert part_fields["mime_type"].field_type == "STRING"
+  assert part_fields["uri"].field_type == "STRING"
+  assert part_fields["text"].field_type == "STRING"
+  assert part_fields["part_index"].field_type == "INTEGER"
+  assert part_fields["part_attributes"].field_type == "STRING"
+  assert part_fields["storage_mode"].field_type == "STRING"
+
+  object_ref = part_fields["object_ref"]
+  assert object_ref.field_type == "RECORD"
+  ref_fields = {f.name: f.field_type for f in object_ref.fields}
+  assert ref_fields == {
+      "uri": "STRING",
+      "version": "STRING",
+      "authorizer": "STRING",
+      "details": "JSON",
+  }
+
+
+def test_timestamp_is_required():
+  schema = bq_schema(_FakeBigQueryModule())
+  ts = next(f for f in schema if f.name == "timestamp")
+  assert ts.field_type == "TIMESTAMP"
+  assert ts.mode == "REQUIRED"


### PR DESCRIPTION
Refs #229.

First slice of the move tracked in #229. Adds a separate `bigquery-agent-analytics-tracing` distribution under `producers/` with **only** the shared writer/drainer ported from [`Erroration2022/bigquery_agent_analytics_skill`](https://github.com/Erroration2022/bigquery_agent_analytics_skill/tree/main/plugins/bigquery-agent-analytics-tracing). Producer-specific adapters (OpenAI Agents SDK, Codex CLI wrapper, Claude Code plugin) land in follow-up PRs so packaging, versioning, and license mechanics can be settled here without reviewing all integrations at once.

## Scope of this PR

### Package scaffolding
- `producers/pyproject.toml` — separate Hatch wheel, `requires-python = ">=3.10"`, classifiers through 3.14 (matches the consumption SDK). Base dep: `google-cloud-bigquery>=3.0.0`.
- Extras: `storage-write` (`google-cloud-bigquery-storage`, `pyarrow`), `openai-agents`, `claude-sdk`, `dev`.
- Single console script: `bqaa-drain = bigquery_agent_analytics_tracing.drain:main`.
- pyink / isort config mirrors `bigquery-agent-analytics`.

### Ported modules under `src/bigquery_agent_analytics_tracing/`
| Module | What it owns |
|---|---|
| `config.py` | `BQAAConfig` dataclass + `from_env()` + all `BQAA_*` envs incl. `BQAA_TRACE_ENABLED` kill switch and `BQAA_WRITER_LABEL` override |
| `schema.py` | Canonical `agent_events` BigQuery schema |
| `logger.py` | `BigQueryAgentAnalyticsLogger` — dry-run / direct-write / spool routing, per-row writer attribution, JSON-typed field pre-serialization, atomic envelope writes |
| `drain.py` | Async drainer — pidfile flock, Storage Write API via PyArrow when available, `insert_rows_json` fallback, per-envelope auto-create policy preserved, dead-letter quarantine |
| `_writer_identity.py` | `WRITER_PLUGIN_NAME` + `get_writer_version()` via `importlib.metadata` with `"0.0.0+local"` fallback for vendored / dev installs |
| `_utils.py` | Helpers: timestamps, recursive truncation + sensitive-key redaction, file lock, log-file emission. No deps on other package modules. |

### Tests (`tests/`) — 30 unit tests, all green
- **config** — defaults, BQAA-specific env wiring, legacy `GCP_PROJECT_ID` / `BQ_DATASET` / `USER` fallbacks, `BQAA_TRACE_ENABLED` kill switch, writer label default + override
- **schema** — top-level column / mode contract, `content_parts` record shape, `timestamp` required
- **logger row shape** — canonical 16-field row, writer attribution stamped per row, mode reflects routing, agent override propagates, disabled short-circuits, unknown event types raise, truncation marks `is_truncated`, sensitive keys redacted, dry-run lands in log file, spool mode writes envelope file with pre-serialized JSON fields, direct-write requires project+dataset
- **drain** — pending file discovery, envelope parsing, corrupt-JSON dead-letter, grouping by destination + writer label, fallback to default writer label, per-envelope auto-create flags in group key, **`-m bigquery_agent_analytics_tracing.drain` invocability** from both wheel-installed and `PYTHONPATH`-vendored runtimes (the failure mode `-m` alone doesn't cover for the Claude plugin port)

BigQuery round-trip smoke tests stay gated/opt-in and arrive with the per-producer follow-up PRs.

## Notable changes from the source repo

- **Drainer spawn changed from script-path to `python -m bigquery_agent_analytics_tracing.drain`.** Vendored Claude plugin runtimes will need to prepend the vendored package root to `PYTHONPATH` (covered by `test_pythonpath_invocation_works_for_vendored_plugin`).
- **Writer plugin name renamed** `bqaa-coding-agent-plugin` → `bigquery-agent-analytics-tracing` to match the package distribution. Adoption queries that group by `attributes.writer.plugin` will see the new name from v0.1 onward.
- **`WRITER_PLUGIN_VERSION` no longer hardcoded** — resolved at import time via `importlib.metadata.version("bigquery-agent-analytics-tracing")`, falling back to `"0.0.0+local"` so dev / vendored runs are visibly tagged in `attributes.writer.version`. `BQAA_WRITER_LABEL` env override behavior unchanged.
- **All files carry Apache-2.0 headers**; original MIT copies remain in the upstream tracing skill until cutover.

## Schema-compat invariants preserved

- Top-level `agent_events` columns and modes — unchanged (asserted in `test_top_level_columns_match_adk_bqaa_contract`).
- `attributes.writer.{plugin,version,label,agent,mode}` block — preserved per row (asserted in `test_writer_attribution_stamped_on_every_row`).
- `content_parts` record shape (`mime_type`, `uri`, `object_ref` with `details JSON`, `text`, `part_index`, `part_attributes`, `storage_mode`) — unchanged (asserted in `test_content_parts_record_shape`).
- All `BQAA_*` env vars including `BQAA_TRACE_ENABLED`, `BQAA_WRITER_LABEL`, `BQAA_PYTHON`, spool / state / drain knobs — honored.
- `attributes.adk` left absent per the ADK 2.0 boundary decision in #229.

## Not in this PR

- OpenAI Agents SDK trace processor (`bqaa_openai_agents.py` → `openai_agents.py`)
- Codex CLI wrapper (`bqaa_codex.py` → `codex.py` + `bqaa-codex` console script)
- Claude Code plugin (`hooks/`, `commands/`, `scripts/bqaa_hook.py`)
- Claude hook adapter (`ClaudeHookBQAAAdapter` from `bqaa_tracing.py`)
- GCP bootstrap script (`setup_gcp_prereqs.py` → `bqaa-setup`)
- `StateStore` + per-session locking (only used by the Claude hook adapter)
- Live BigQuery smoke tests
- Marketplace artifact build pipeline

Each ships in its own focused PR following this scaffold landing.

## Test plan

- [x] `pytest tests/ -v` — 30/30 pass on Python 3.13.5
- [x] `pyink src/ tests/ --check` — clean
- [x] `isort src/ tests/` — clean
- [x] `python -m bigquery_agent_analytics_tracing.drain` exits 0 in dry-run from both wheel install and `PYTHONPATH`-only invocations
- [ ] CLA bot ack (signed on contributor side)
- [ ] Live BigQuery round-trip — deferred to the producer-adapter PRs

Refs: #229