### PR TITLE
release(0.3.2): migration-v5 production track + CHANGELOG + tracker cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release highlights
+
+The migration-v5 production track lands the design-partner asks from
+[#187](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187)
+end-to-end: backfill mode, compiled-only extraction (with zero-LLM
+guarantee), explicit FK→PK mapping that re-enables MAKO self-edges,
+an opt-in orphan-session watchdog, the Beat 5 feedback / reward
+loop in both the demo and the live notebook, hardened deploy
+defaults (split SAs + tunable retries), and a Terraform module
+mirroring the bash deploy. The 0.3.1 cron path is now complete
+for audit-critical production deployments.
+
+### Added
+
+- **Backfill mode for `materialize_window`** ([#188](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/188),
+  closes [#177](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/177))
+  — `bqaa-materialize-window --backfill --from / --to --state-key-suffix`
+  runs a one-shot historical window with isolated state-table
+  rows (the suffix folds into the `state_key` hash, so backfill
+  rows can't advance the steady-state cron checkpoint).
+- **Compiled-only extraction mode + deploy path** ([#192](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/192),
+  [#193](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/193),
+  closes [#178](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/178))
+  — `--extraction-mode=compiled-only` routes the orchestrator
+  through structured extractors only, never calls `AI.GENERATE`,
+  surfaces uncovered spans as typed `empty_extraction` failures
+  with sample diagnostics. The deploy script (`#193`) stages
+  `reference_extractor.py` into the container, wires
+  `BQAA_REFERENCE_EXTRACTORS_MODULE`, and makes
+  `roles/aiplatform.user` conditional (idempotently removes the
+  grant when transitioning an existing ai-fallback deploy to
+  compiled-only). `TestCompiledOnlyMakesZeroLLMCalls` proves the
+  zero-LLM contract.
+- **Explicit FK→PK mapping for binding columns** ([#191](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/191),
+  [#222](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/222),
+  closes [#179](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/179))
+  — `from_columns` / `to_columns` accept `list[dict[str, str]]`
+  shape (`[{src_decision_execution_id: id}]`) in addition to the
+  legacy `list[str]`. Materializer, validators, and the PG DDL
+  compiler consume the canonical
+  `ResolvedRelationship.from_column_mapping`. MAKO's
+  `evolvedFrom` / `supersededBy` self-edges are re-added to the
+  migration v5 binding.
+- **Orphan-session watchdog** ([#224](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/224),
+  closes [#180](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/180))
+  — opt-in via `--max-session-age-hours N`. Each cron pass scans
+  for sessions whose first event is older than the cutoff but
+  which never emitted `AGENT_COMPLETED`; flags them as
+  `session_orphaned` failures and records the running set in the
+  state table (`mode='orphan_scan'` + `mode='orphan_ledger'`
+  rows). Strict `>` watermark, explicit timestamp-bound partition
+  pruning on the resolved-orphan probe.
+- **Migration v5 Beat 5 — feedback / reward loop** ([#227](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/227),
+  [#228](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/228),
+  closes [#181](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/181),
+  [#184](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/184),
+  [#185](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/185))
+  — demo scope grows from 6 → 11 entities and 9 → 14
+  relationships. Adds `BusinessConstraint`,
+  `ConstraintApplication`, `RejectionReason`, `OutcomeSignal`,
+  `RewardComputation` + their edges. The demo agent emits four
+  new tools (`apply_constraint`, `record_rejection`,
+  `record_outcome_signal`, `compute_reward`); the reference
+  extractor covers all four; the notebook's new Beat 5 cells run
+  the two payoff GQL traversals end-to-end against a live
+  BigQuery scratch dataset (29 / 29 cells executed, counts 1–29,
+  6 unique reward rows + 8 unique rejection rows verified live).
+- **Split runtime + scheduler-caller SAs by default** ([#230](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/230),
+  closes [#182](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/182))
+  — `deploy_cloud_run_job.sh` creates two SAs by default:
+  `bqaa-periodic-runtime-sa` (BigQuery + Vertex AI roles) and
+  `bqaa-periodic-scheduler-sa` (only `roles/run.invoker` on the
+  job). `--single-sa` is the escape hatch for the pre-#182
+  combined identity. Least-privilege: scheduler-caller never
+  needs BigQuery permissions.
+- **Tunable `--max-retries` on Cloud Run Job** ([#230](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/230),
+  closes [#183](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/183))
+  — default 2 (was hard-coded 1). The orchestrator's session-
+  level idempotency + append-only state table make additional
+  retries safe. The retry count flows into `BQAA_MAX_RETRIES` on
+  the job's env so the runtime's startup log surfaces it in
+  `jsonPayload.max_retries` — operators correlating Cloud
+  Monitoring alert noise with retry behaviour see the policy
+  without `gcloud run jobs describe`.
+- **Terraform module for periodic materialization** ([#231](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/231),
+  closes [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/186))
+  — `examples/migration_v5/periodic_materialization/terraform/`
+  mirrors the bash deploy's resources (graph dataset, both SAs,
+  IAM bindings, Cloud Run v2 Job, Scheduler trigger) with
+  defaults matching `deploy_cloud_run_job.sh`'s post-#230
+  surface. New `build_image.sh` helper produces the staging
+  layout the runtime needs. Image build/publish are intentionally
+  outside the module — `var.image_uri` takes the published
+  container image. `var.manage_apis` enables the required APIs
+  on a clean project; `var.deletion_protection` matches the bash
+  deploy's lifecycle. Live-verified end-to-end against
+  `test-project-0728-467323`.
+
+### Fixed
+
+- **Orphan-watchdog empty-array streaming-insert crash hotfix** ([#225](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/225))
+  — BigQuery's streaming-insert API rejects empty
+  `ARRAY<STRING>` values with `Field value of
+  flagged_session_ids cannot be empty.`. Pre-fix, every cron
+  pass after [#224](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/224)
+  crashed at insert time. Fix: omit nullable columns from the
+  `insert_rows_json` payload when their value is `None` or
+  empty.
+
 ## [0.3.1] - 2026-05-18
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-22
+
 ### Release highlights
 
 The migration-v5 production track lands the design-partner asks from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ guarantee), explicit FK→PK mapping that re-enables MAKO self-edges,
 an opt-in orphan-session watchdog, the Beat 5 feedback / reward
 loop in both the demo and the live notebook, hardened deploy
 defaults (split SAs + tunable retries), and a Terraform module
-mirroring the bash deploy. The 0.3.1 cron path is now complete
-for audit-critical production deployments.
+mirroring the bash deploy. The migration-v5 cron path is now
+complete for audit-critical production deployments.
 
 ### Added
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -301,8 +301,10 @@ The script:
    under `sdk_src/`. The deploy-time `requirements.txt`
    installs the SDK from `./sdk_src` (not PyPI) so the
    deployed image uses the same code as the local dry-run.
-   This avoids depending on a PyPI release that may not yet
-   contain `materialize_window` (added in PR #162).
+   This keeps the deploy in lockstep with any in-flight SDK
+   changes the customer is iterating on locally; once the SDK
+   features they depend on have all shipped to PyPI they can
+   swap the vendored install for a pinned PyPI version.
 5. **Deploys the Cloud Run Job** via `gcloud run jobs deploy
    --source <staging>` (Buildpacks autodetects Python) with
    `--service-account` pointing at the SA. The job's runtime
@@ -803,13 +805,13 @@ gcloud iam service-accounts delete \
 
 * **Pulumi.** A Pulumi equivalent of the Terraform module would
   be a straightforward port and is open for contribution.
-* **Compiled-bundle materialization.** This example uses the
-  plain `from_ontology_binding` extraction path (Gemini-backed).
-  For compiled extractors (`--bundles-root`), see
-  `docs/extractor_compilation/` and PR #152.
-* **Backfill mode.** A separate `--backfill --from / --to`
-  CLI mode is on the roadmap (per #161); for now, run the
-  CLI manually with a wider `--lookback-hours` to catch up.
+* **Compiled-bundle materialization with fingerprint-stable
+  pre-built bundles.** The deploy script supports compiled-only
+  extraction via the runtime reference extractor
+  (`--extraction-mode=compiled-only`, see the IAM matrix above —
+  this drops `roles/aiplatform.user` entirely). For
+  fingerprint-stable *compiled bundles* (the `--bundles-root`
+  path), see `docs/extractor_compilation/` and PR #152.
 
 ## Troubleshooting
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -182,11 +182,20 @@ no Cloud Run required. Useful for shaking out the env-var setup
 before paying for a deploy:
 
 ```bash
-# From the repo root, install the SDK in editable mode. The
-# example uses bigquery_agent_analytics.materialize_window
-# (added in PR #162); this isn't in the 0.3.0 PyPI release
-# yet, so install from local until 0.4.0 ships.
+# Two equivalent install paths:
+#
+# (a) Editable from the repo root — picks up any in-flight SDK
+#     changes you're iterating on locally. The deploy script's
+#     vendored-SDK staging uses the same source tree, so a
+#     local dry-run and a Cloud Run deploy execute the same
+#     code.
 pip install -e .
+
+# (b) Pinned from PyPI — once your in-flight changes are
+#     published. ``bigquery-agent-analytics.materialize_window``
+#     has been on PyPI since 0.3.1, so a published install
+#     works for any cron path this README documents.
+pip install 'bigquery-agent-analytics>=0.3.1'
 
 # Then install the example's ancillary deps:
 pip install -r examples/migration_v5/periodic_materialization/requirements.txt

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -182,22 +182,25 @@ no Cloud Run required. Useful for shaking out the env-var setup
 before paying for a deploy:
 
 ```bash
-# Two equivalent install paths:
+# Choose ONE install path (they're mutually exclusive — running
+# both leaves you on the published wheel, not your local edits):
 #
-# (a) Editable from the repo root — picks up any in-flight SDK
+# (a) Editable from the repo root — picks up in-flight SDK
 #     changes you're iterating on locally. The deploy script's
 #     vendored-SDK staging uses the same source tree, so a
 #     local dry-run and a Cloud Run deploy execute the same
-#     code.
+#     code. Use this when you're modifying the SDK and want to
+#     test before publishing.
 pip install -e .
+#
+# (b) Pinned from PyPI — once you're on a stable SDK version.
+#     0.3.2 is the migration-v5 production-track release
+#     (compiled-only deploy, backfill, orphan watchdog,
+#     Terraform module, split SAs, ``--max-retries``). Use this
+#     for unmodified production use.
+pip install 'bigquery-agent-analytics>=0.3.2'
 
-# (b) Pinned from PyPI — once your in-flight changes are
-#     published. ``bigquery-agent-analytics.materialize_window``
-#     has been on PyPI since 0.3.1, so a published install
-#     works for any cron path this README documents.
-pip install 'bigquery-agent-analytics>=0.3.1'
-
-# Then install the example's ancillary deps:
+# Either way, install the example's ancillary deps:
 pip install -r examples/migration_v5/periodic_materialization/requirements.txt
 
 BQAA_PROJECT_ID=your-project \

--- a/examples/migration_v5/periodic_materialization/requirements.txt
+++ b/examples/migration_v5/periodic_materialization/requirements.txt
@@ -21,11 +21,16 @@
 #   # Then install this example's ancillary deps:
 #   pip install -r examples/migration_v5/periodic_materialization/requirements.txt
 #
-# Pinning a PyPI version (alternative to editable-mode install):
-# replace the ``pip install -e .`` step with
-# ``pip install 'bigquery-agent-analytics>=0.3.1'`` — the quotes
-# are required so the shell doesn't interpret ``>=`` as a
-# redirection operator.
+# Pinning a PyPI version (alternative — NOT in addition — to the
+# editable-mode install above): use ``pip install
+# 'bigquery-agent-analytics>=0.3.2'`` *instead of* ``pip install
+# -e .``. Don't run both: the published wheel install would
+# replace any in-flight local edits with the released code.
+# The quotes are required so the shell doesn't interpret ``>=``
+# as a redirection operator. 0.3.2 is the migration-v5
+# production-track release — earlier versions lack the
+# compiled-only deploy path, backfill, orphan watchdog, and
+# Terraform module this README documents.
 
 google-cloud-bigquery>=3.0.0
 pyyaml>=6.0

--- a/examples/migration_v5/periodic_materialization/requirements.txt
+++ b/examples/migration_v5/periodic_materialization/requirements.txt
@@ -8,9 +8,10 @@
 # deploy script bundles the local SDK source into the staging
 # dir and installs it from there (``./sdk_src``), so the
 # deployed image uses the same SDK code as the local dry-run.
-# This avoids depending on a PyPI release that may not yet
-# contain ``bigquery-agent-analytics.materialize_window``
-# (added in PR #162; not yet in the 0.3.0 release).
+# This keeps the deploy in lockstep with any in-flight SDK
+# changes the customer is iterating on locally — once they pin
+# to a published SDK version they can swap ``./sdk_src`` for a
+# PyPI line in the deploy's generated requirements.
 #
 # Local dry-run install path:
 #
@@ -20,10 +21,9 @@
 #   # Then install this example's ancillary deps:
 #   pip install -r examples/migration_v5/periodic_materialization/requirements.txt
 #
-# Once a PyPI release containing materialize_window ships
-# (>=0.4.0), this file can pin the published version directly
-# (e.g., ``bigquery-agent-analytics>=0.4.0,<0.5.0``) and the
-# ``pip install -e .`` step won't be needed.
+# Pinning a PyPI version (alternative to editable-mode install):
+# replace the ``pip install -e .`` step with
+# ``pip install bigquery-agent-analytics>=0.3.1``.
 
 google-cloud-bigquery>=3.0.0
 pyyaml>=6.0

--- a/examples/migration_v5/periodic_materialization/requirements.txt
+++ b/examples/migration_v5/periodic_materialization/requirements.txt
@@ -23,7 +23,9 @@
 #
 # Pinning a PyPI version (alternative to editable-mode install):
 # replace the ``pip install -e .`` step with
-# ``pip install bigquery-agent-analytics>=0.3.1``.
+# ``pip install 'bigquery-agent-analytics>=0.3.1'`` — the quotes
+# are required so the shell doesn't interpret ``>=`` as a
+# redirection operator.
 
 google-cloud-bigquery>=3.0.0
 pyyaml>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigquery-agent-analytics"
-version = "0.3.1"
+version = "0.3.2"
 description = "SDK for analyzing and evaluating agent traces stored in BigQuery."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts release **0.3.2**, the migration-v5 production-track release. Bundles the CHANGELOG entry, the tracker / docs cleanup, and the version bump in one PR so a fresh checkout right after merge can \`pip install 'bigquery-agent-analytics>=0.3.2'\` and pick up every piece of the track.

## Release contents (0.3.2)

The full migration-v5 production track [Yahoo design-partner asks, #187]: backfill, compiled-only extraction + deploy path, explicit FK→PK mapping with self-edges, opt-in orphan-session watchdog (+ hotfix), Beat 5 feedback/reward loop in both the demo and the live notebook, hardened deploy defaults (split SAs + tunable retries), and a Terraform module mirroring the bash deploy. See [CHANGELOG.md](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/CHANGELOG.md) \`[0.3.2]\` for the full Added + Fixed surface with PR refs.

| Theme | PR(s) | Issue closed |
|---|---|---|
| Backfill mode | #188 | #177 |
| Compiled-only + deploy path | #192, #193 | #178 |
| FK→PK mapping + self-edges | #191, #222 | #179 |
| Orphan watchdog (+ hotfix) | #224, #225 | #180 |
| Beat 5 — feedback / reward loop (ontology + extractor + notebook) | #227, #228 | #181, #184, #185 |
| Split SAs + tunable \`--max-retries\` | #230 | #182, #183 |
| Terraform module | #231 | #186 |

## Changes in this PR

* **\`pyproject.toml\`** — \`version\` bumped \`0.3.1 → 0.3.2\`.
* **\`CHANGELOG.md\`** — the \`[Unreleased]\` block I added earlier in this PR promoted to \`[0.3.2] - 2026-05-22\`; fresh empty \`[Unreleased]\` heading stays at the top for the next round of work.
* **Doc sweep** — removed two now-completed items from \`periodic_materialization/README.md\`'s \"Not in scope\" (backfill mode shipped in #188; compiled-bundle framing refreshed) and rewrote the vendored-SDK install rationale in both the README and \`requirements.txt\`.
* **Local-dry-run install block** (P2 nit, refined through round-3 review) — reframed as **\"Choose ONE install path (they're mutually exclusive — running both leaves you on the published wheel, not your local edits)\"**: (a) editable from repo for in-flight SDK iteration, OR (b) PyPI-pinned via \`pip install 'bigquery-agent-analytics>=0.3.2'\` for unmodified production use. Same shape in both the README and \`requirements.txt\`.
* **Shell-quoting fix** (P3 nit) — \`requirements.txt\` PyPI-pin example single-quoted so \`>=\` isn't interpreted as redirection.
* **CHANGELOG closer wording** (round-3 P3) — \`[0.3.2]\` release-highlights tail no longer says \"The 0.3.1 cron path is now complete\" inside a 0.3.2 block; reworded to \"The migration-v5 cron path is now complete\" so the version naming stays consistent.

## Build verification

\`\`\`
$ python -m build --sdist --wheel
Successfully built bigquery_agent_analytics-0.3.2.tar.gz and bigquery_agent_analytics-0.3.2-py3-none-any.whl

$ twine check dist/*
Checking dist/bigquery_agent_analytics-0.3.2-py3-none-any.whl: PASSED
Checking dist/bigquery_agent_analytics-0.3.2.tar.gz: PASSED

$ pip install dist/bigquery_agent_analytics-0.3.2-py3-none-any.whl   # fresh venv
$ python -c \"import bigquery_agent_analytics; from importlib.metadata import version; print(version('bigquery-agent-analytics'))\"
0.3.2
\`\`\`

## Out of scope

* **PyPI upload + GitHub release** — requires the maintainer's PyPI/GH credentials. Steps after merge: \`git tag v0.3.2 && git push --tags\`, \`twine upload dist/*\`, draft a GitHub Release referencing the CHANGELOG \`[0.3.2]\` block.
* **\`#187\` master tracker** — refreshed [via gh issue comment](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/187#issuecomment-4522239069) with the completed-matrix; stays open until 0.3.2 is published. **Individual issues #178, #179, #180, #181, #183, #184, #185** closed with PR refs.

## Test plan
- [x] \`python -m pytest tests/test_materialize_window.py\` — 151 pass
- [x] \`python -m pytest tests/\` — 3130 pass, 15 skipped
- [x] \`python -m build --sdist --wheel\` + \`twine check\` — pass
- [x] Wheel install + version metadata + module import sanity — pass
- [x] No new \"PyPI may not yet contain\" / \"future PR\" claims in the touched files
