### PR TITLE
producers: add Claude Code hook producer (claude_code module)

### DIFF
--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
 
 [project.scripts]
 bqaa-drain = "bigquery_agent_analytics_tracing.drain:main"
+bqaa-claude-hook = "bigquery_agent_analytics_tracing.claude_code:main"
 
 [project.urls]
 Homepage = "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"

--- a/producers/src/bigquery_agent_analytics_tracing/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/__init__.py
@@ -23,8 +23,12 @@ Public API:
   * ``bq_schema`` — the canonical schema, used by both the auto-create
     path and the drainer's ``insert_rows_json`` fallback.
 
-Producer-specific adapters (OpenAI Agents SDK, Codex CLI wrapper, Claude
-Code plugin) land in follow-up PRs.
+Producer modules:
+
+  * ``claude_code`` — Claude Code hook adapter + ``main()`` entry.
+    Console script: ``bqaa-claude-hook``.
+
+OpenAI Agents SDK and Codex CLI adapters land in follow-up PRs.
 """
 
 from ._writer_identity import __version__

--- a/producers/src/bigquery_agent_analytics_tracing/claude_code.py
+++ b/producers/src/bigquery_agent_analytics_tracing/claude_code.py
@@ -1,0 +1,702 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Claude Code hook producer for BQAA.
+
+Maps Claude Code's native hooks (``SessionStart``, ``UserPromptSubmit``,
+``PreToolUse``, ``PostToolUse``, ``Stop``, ``SubagentStop``,
+``Notification``, ``PermissionRequest``, ``SessionEnd``) onto BQAA
+``agent_events`` rows. Each hook receives a JSON payload on stdin and
+this module's ``main()`` is the entry that hook shell wrappers invoke.
+
+State lives in two on-disk JSON stores guarded by ``fcntl.flock``:
+
+  * ``state_<session>.json`` — session-scoped state (session id, current
+    trace/span/invocation, transcript bookmark, agent identity).
+  * ``tool_<session>_<tool_use_id>.json`` — per-tool state so concurrent
+    ``PreToolUse`` fires for parallel tools cannot clobber each other's
+    ``start_ms`` / ``span_id``.
+
+Stale state files older than ``BQAA_STATE_TTL_HOURS`` are purged on the
+next ``SessionStart`` so long-running shells do not leak.
+
+Default ``attributes.source`` values mirror what the upstream tracing
+skill emits today so adoption queries that key off
+``attributes.session_metadata.source`` keep working:
+
+  * Most events: ``"claude_code"``
+  * SubagentStop:  ``"claude_code_subagent"``
+  * Notification:  ``"claude_code_notification"``
+  * PermissionRequest: ``"claude_code_permission_request"``
+  * SessionEnd:    ``"claude_code_session_end"``
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from datetime import timezone
+import fcntl
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+from typing import Any, Iterator
+
+from ._utils import deterministic_span
+from ._utils import hex_id
+from ._utils import iso_timestamp
+from ._utils import log_to_file
+from ._utils import safe_json_loads
+from ._utils import timestamp_ms
+from ._utils import to_jsonable
+from .config import BQAAConfig
+from .config import DEFAULT_STATE_DIR
+from .logger import BigQueryAgentAnalyticsLogger
+
+CLAUDE_CODE_DEFAULT_AGENT = "claude-code"
+
+
+# ----------------------------------------------------------------------------
+# Transcript reader
+# ----------------------------------------------------------------------------
+
+
+def _read_transcript_since(
+    path: str, start_line: int, max_bytes: int
+) -> tuple[str, str, dict[str, int], bool]:
+  """Stream-read the Claude Code transcript and stop after ``max_bytes``.
+
+  Returns ``(output_text, model, usage, was_truncated)``. The transcript
+  is a JSONL file of message objects; we read assistant lines after
+  ``start_line`` (set on ``UserPromptSubmit``) until the byte cap is
+  reached.
+  """
+  output_parts: list[str] = []
+  bytes_collected = 0
+  was_truncated = False
+  model = ""
+  usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+  if not path:
+    return "", model, usage, False
+  transcript = Path(path).expanduser()
+  if not transcript.exists():
+    return "", model, usage, False
+
+  with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+    for line_no, line in enumerate(handle, start=1):
+      if line_no <= start_line or not line.strip():
+        continue
+      item = safe_json_loads(line, {})
+      if item.get("type") != "assistant":
+        continue
+      message = item.get("message") or {}
+      model = message.get("model") or model
+      text = _text_from_content(message.get("content"))
+      if text:
+        if max_bytes > 0:
+          encoded = text.encode("utf-8", "replace")
+          remaining = max_bytes - bytes_collected
+          if remaining <= 0:
+            was_truncated = True
+          elif len(encoded) > remaining:
+            output_parts.append(
+                encoded[:remaining].decode("utf-8", "replace")
+                + "...[TRUNCATED]"
+            )
+            bytes_collected = max_bytes
+            was_truncated = True
+          else:
+            output_parts.append(text)
+            bytes_collected += len(encoded)
+        else:
+          output_parts.append(text)
+      raw_usage = message.get("usage") or {}
+      usage["prompt_tokens"] += int(raw_usage.get("input_tokens") or 0)
+      usage["prompt_tokens"] += int(
+          raw_usage.get("cache_read_input_tokens") or 0
+      )
+      usage["prompt_tokens"] += int(
+          raw_usage.get("cache_creation_input_tokens") or 0
+      )
+      usage["completion_tokens"] += int(raw_usage.get("output_tokens") or 0)
+  usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+  return "\n".join(output_parts), model, usage, was_truncated
+
+
+def _text_from_content(content: Any) -> str:
+  if isinstance(content, str):
+    return content
+  if isinstance(content, list):
+    pieces = []
+    for item in content:
+      if isinstance(item, dict) and item.get("type") == "text":
+        pieces.append(str(item.get("text", "")))
+      elif isinstance(item, str):
+        pieces.append(item)
+    return "\n".join(p for p in pieces if p)
+  return ""
+
+
+def _line_count(path: str) -> int:
+  if not path:
+    return 0
+  transcript = Path(path).expanduser()
+  if not transcript.exists():
+    return 0
+  with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+    return sum(1 for _ in handle)
+
+
+# ----------------------------------------------------------------------------
+# State store with file locking
+# ----------------------------------------------------------------------------
+
+
+class _LockedJSONStore:
+  """Atomic read-modify-write JSON store guarded by ``fcntl.flock``."""
+
+  def __init__(self, path: Path):
+    self.path = path
+    self.path.parent.mkdir(parents=True, exist_ok=True)
+
+  @contextlib.contextmanager
+  def transaction(self) -> Iterator[dict[str, Any]]:
+    fd = os.open(str(self.path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX)
+      try:
+        with os.fdopen(fd, "r+", encoding="utf-8", closefd=False) as handle:
+          handle.seek(0)
+          raw = handle.read()
+          state = safe_json_loads(raw, {}) if raw.strip() else {}
+          yield state
+          handle.seek(0)
+          handle.truncate()
+          handle.write(json.dumps(state, sort_keys=True))
+          handle.flush()
+          os.fsync(fd)
+      finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+      try:
+        os.close(fd)
+      except OSError:
+        pass
+
+  def read(self) -> dict[str, Any]:
+    if not self.path.exists():
+      return {}
+    with self.transaction() as state:
+      return dict(state)
+
+  def remove(self) -> None:
+    try:
+      self.path.unlink()
+    except FileNotFoundError:
+      pass
+
+
+class StateStore:
+  """Per-session state with locked RMW + per-tool sub-files.
+
+  Session-scoped fields live in ``state_<session>.json``. Per-tool
+  sub-state lives in ``tool_<session>_<tool_use_id>.json`` so concurrent
+  ``PreToolUse`` fires for parallel tools do not clobber each other's
+  ``start_ms`` / ``span_id``.
+  """
+
+  def __init__(self, key: str, root: str = DEFAULT_STATE_DIR):
+    safe_key = (
+        "".join(ch for ch in key if ch.isalnum() or ch in "._-") or "default"
+    )
+    self.key = safe_key
+    self.root = Path(root).expanduser()
+    self.root.mkdir(parents=True, exist_ok=True)
+    self._session_store = _LockedJSONStore(self.root / f"state_{safe_key}.json")
+    self._cache: dict[str, Any] = self._session_store.read()
+
+  def get(self, key: str, default: Any = None) -> Any:
+    return self._cache.get(key, default)
+
+  def set(self, key: str, value: Any) -> None:
+    self.update({key: value})
+
+  def update(self, values: dict[str, Any]) -> None:
+    with self._session_store.transaction() as state:
+      state.update(values)
+      self._cache = dict(state)
+
+  def delete(self, *keys: str) -> None:
+    with self._session_store.transaction() as state:
+      for key in keys:
+        state.pop(key, None)
+      self._cache = dict(state)
+
+  def remove(self) -> None:
+    self._session_store.remove()
+    for path in self.root.glob(f"tool_{self.key}_*.json"):
+      try:
+        path.unlink()
+      except FileNotFoundError:
+        pass
+
+  # -- Per-tool sub-state ---------------------------------------------------
+
+  def _tool_path(self, tool_use_id: str) -> Path:
+    safe = (
+        "".join(ch for ch in tool_use_id if ch.isalnum() or ch in "._-")
+        or "unknown"
+    )
+    return self.root / f"tool_{self.key}_{safe}.json"
+
+  def set_tool(self, tool_use_id: str, value: dict[str, Any]) -> None:
+    store = _LockedJSONStore(self._tool_path(tool_use_id))
+    with store.transaction() as state:
+      state.clear()
+      state.update(value)
+
+  def pop_tool(self, tool_use_id: str) -> dict[str, Any]:
+    path = self._tool_path(tool_use_id)
+    store = _LockedJSONStore(path)
+    with store.transaction() as state:
+      value = dict(state)
+    try:
+      path.unlink()
+    except FileNotFoundError:
+      pass
+    return value
+
+
+def cleanup_stale_state(root: str | Path, ttl_hours: float) -> int:
+  """Remove state and per-tool files older than ``ttl_hours``.
+
+  Returns the number of files removed. No-op when ``ttl_hours <= 0``.
+  """
+  if ttl_hours <= 0:
+    return 0
+  base = Path(root).expanduser()
+  if not base.exists():
+    return 0
+  cutoff = time.time() - ttl_hours * 3600
+  removed = 0
+  for path in base.iterdir():
+    if not path.is_file():
+      continue
+    name = path.name
+    if not (
+        name.startswith("state_") or name.startswith("tool_")
+    ) or not name.endswith(".json"):
+      continue
+    try:
+      mtime = path.stat().st_mtime
+    except FileNotFoundError:
+      continue
+    if mtime < cutoff:
+      try:
+        path.unlink()
+        removed += 1
+      except FileNotFoundError:
+        pass
+  return removed
+
+
+# ----------------------------------------------------------------------------
+# Tool helpers
+# ----------------------------------------------------------------------------
+
+
+def _tool_origin(tool_name: Any) -> str:
+  name = str(tool_name or "")
+  if name.lower().startswith("mcp__"):
+    return "MCP"
+  if name in {"Task", "Subagent"}:
+    return "SUB_AGENT"
+  return "LOCAL"
+
+
+def _tool_status(result: Any) -> tuple[str, str | None]:
+  if isinstance(result, dict):
+    if result.get("is_error") or result.get("error"):
+      return "ERROR", str(
+          result.get("error") or result.get("message") or "tool error"
+      )
+  text = str(result or "")
+  if text.lower().startswith("error:"):
+    return "ERROR", text[:1000]
+  return "OK", None
+
+
+# ----------------------------------------------------------------------------
+# Hook adapter
+# ----------------------------------------------------------------------------
+
+
+class ClaudeHookBQAAAdapter:
+  """Dispatches Claude Code hook payloads to ``BigQueryAgentAnalyticsLogger``."""
+
+  def __init__(self, logger: BigQueryAgentAnalyticsLogger | None = None):
+    self.logger = logger or BigQueryAgentAnalyticsLogger()
+    self.config = self.logger.config
+
+  def process(self, hook_name: str, payload: dict[str, Any]) -> None:
+    state = StateStore(self._state_key(payload), root=self.config.state_dir)
+    if hook_name == "SessionStart":
+      self._session_start(payload, state)
+    elif hook_name == "UserPromptSubmit":
+      self._user_prompt_submit(payload, state)
+    elif hook_name == "PreToolUse":
+      self._pre_tool_use(payload, state)
+    elif hook_name == "PostToolUse":
+      self._post_tool_use(payload, state)
+    elif hook_name == "Stop":
+      self._stop(payload, state)
+    elif hook_name == "SubagentStop":
+      self._subagent_stop(payload, state)
+    elif hook_name == "Notification":
+      self._notification(payload, state)
+    elif hook_name == "PermissionRequest":
+      self._permission_request(payload, state)
+    elif hook_name == "SessionEnd":
+      self._session_end(payload, state)
+
+  def _state_key(self, payload: dict[str, Any]) -> str:
+    return (
+        str(payload.get("session_id") or "")
+        or os.environ.get("CLAUDE_SESSION_KEY", "")
+        or str(os.getppid())
+    )
+
+  def _ensure_session(self, payload: dict[str, Any], state: StateStore) -> None:
+    if state.get("session_id"):
+      return
+    self._session_start(payload, state)
+
+  def _session_start(self, payload: dict[str, Any], state: StateStore) -> None:
+    cwd = payload.get("cwd") or os.getcwd()
+    session_id = payload.get("session_id") or hex_id(32)
+    state.update(
+        {
+            "session_id": session_id,
+            "project_name": (
+                os.environ.get("BQAA_PROJECT_NAME") or Path(cwd).name
+            ),
+            "agent": (
+                os.environ.get("BQAA_AGENT_NAME") or CLAUDE_CODE_DEFAULT_AGENT
+            ),
+            "user_id": os.environ.get("BQAA_USER_ID") or os.environ.get("USER"),
+            "trace_count": int(state.get("trace_count", 0)),
+            "session_start_ms": timestamp_ms(),
+        }
+    )
+    try:
+      cleanup_stale_state(self.config.state_dir, self.config.state_ttl_hours)
+    except OSError:
+      pass
+
+  def _user_prompt_submit(
+      self, payload: dict[str, Any], state: StateStore
+  ) -> None:
+    self._ensure_session(payload, state)
+    trace_count = int(state.get("trace_count", 0)) + 1
+    trace_id = hex_id(32)
+    span_id = hex_id(16)
+    invocation_id = payload.get("invocation_id") or hex_id(32)
+    prompt = str(payload.get("prompt") or "")
+    transcript = str(payload.get("transcript_path") or "")
+    state.update(
+        {
+            "trace_count": trace_count,
+            "current_trace_id": trace_id,
+            "current_span_id": span_id,
+            "current_invocation_id": invocation_id,
+            "current_prompt": prompt,
+            "current_start_ms": timestamp_ms(),
+            "transcript_path": transcript,
+            "transcript_start_line": _line_count(transcript),
+        }
+    )
+    self.logger.log_llm_request(
+        prompt=prompt,
+        session_id=state.get("session_id"),
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        agent=state.get("agent"),
+        user_id=state.get("user_id"),
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "cwd": payload.get("cwd"),
+                "source": "claude_code",
+                "trace_number": trace_count,
+            },
+            "custom_tags": {"assistant": "claude_code"},
+        },
+    )
+
+  def _pre_tool_use(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    tool_use_id = str(payload.get("tool_use_id") or hex_id(16))
+    span_id = deterministic_span(tool_use_id)
+    tool_name = str(payload.get("tool_name") or "unknown")
+    state.set_tool(
+        tool_use_id,
+        {
+            "start_ms": timestamp_ms(),
+            "span_id": span_id,
+            "tool_name": tool_name,
+        },
+    )
+    self.logger.log_tool_starting(
+        tool=tool_name,
+        args=to_jsonable(payload.get("tool_input") or {}),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id") or hex_id(32),
+        trace_id=state.get("current_trace_id") or hex_id(32),
+        span_id=span_id,
+        parent_span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        tool_origin=_tool_origin(tool_name),
+        attributes={"source": "claude_code"},
+    )
+
+  def _post_tool_use(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    tool_use_id = str(payload.get("tool_use_id") or "")
+    tool_state = state.pop_tool(tool_use_id) if tool_use_id else {}
+    start_ms = int(tool_state.get("start_ms") or timestamp_ms())
+    tool_name = str(
+        payload.get("tool_name") or tool_state.get("tool_name") or "unknown"
+    )
+    # If Pre never fired we still want correlation — derive deterministically.
+    span_id = tool_state.get("span_id") or deterministic_span(tool_use_id)
+    result = payload.get("tool_response")
+    status, error_message = _tool_status(result)
+    self.logger.log_tool_completed(
+        tool=tool_name,
+        result=to_jsonable(result),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id") or hex_id(32),
+        trace_id=state.get("current_trace_id") or hex_id(32),
+        span_id=span_id,
+        parent_span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        tool_origin=_tool_origin(tool_name),
+        total_ms=max(0, timestamp_ms() - start_ms),
+        status=status,
+        error_message=error_message,
+        attributes={"source": "claude_code"},
+    )
+
+  def _stop(self, payload: dict[str, Any], state: StateStore) -> None:
+    if not state.get("current_trace_id"):
+      return
+    transcript = str(
+        payload.get("transcript_path") or state.get("transcript_path") or ""
+    )
+    output, model, usage, was_truncated = _read_transcript_since(
+        transcript,
+        int(state.get("transcript_start_line") or 0),
+        self.config.transcript_max_bytes,
+    )
+    output = output or str(payload.get("response") or "(No response captured)")
+    start_ms = int(state.get("current_start_ms") or timestamp_ms())
+    self.logger.log_llm_response(
+        response=output,
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        user_id=state.get("user_id"),
+        model=model or str(payload.get("model") or ""),
+        usage_metadata=usage,
+        total_ms=max(0, timestamp_ms() - start_ms),
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "source": "claude_code",
+                "trace_number": state.get("trace_count"),
+            },
+            "custom_tags": {"assistant": "claude_code"},
+        },
+        is_truncated=was_truncated,
+    )
+    state.delete(
+        "current_trace_id",
+        "current_span_id",
+        "current_invocation_id",
+        "current_prompt",
+        "current_start_ms",
+        "transcript_path",
+        "transcript_start_line",
+    )
+
+  def _subagent_stop(self, payload: dict[str, Any], state: StateStore) -> None:
+    if not state.get("current_trace_id"):
+      return
+    transcript = str(payload.get("agent_transcript_path") or "")
+    output, model, usage, was_truncated = _read_transcript_since(
+        transcript, 0, self.config.transcript_max_bytes
+    )
+    agent_name = str(
+        payload.get("agent_type") or payload.get("agent_id") or "subagent"
+    )
+    self.logger.log_llm_response(
+        response=output or str(payload.get("output") or ""),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        agent=agent_name,
+        user_id=state.get("user_id"),
+        model=model,
+        usage_metadata=usage,
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "source": "claude_code_subagent",
+            },
+            "custom_tags": {
+                "assistant": "claude_code",
+                "subagent_id": payload.get("agent_id"),
+            },
+        },
+        is_truncated=was_truncated,
+    )
+
+  def _notification(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="STATE_DELTA",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={
+            "notification": {
+                "title": payload.get("title"),
+                "message": payload.get("message"),
+                "type": payload.get("notification_type") or "info",
+            }
+        },
+        attributes={
+            "state_delta": {
+                "source": "claude_code_notification",
+                "notification_type": (
+                    payload.get("notification_type") or "info"
+                ),
+            }
+        },
+    )
+
+  def _permission_request(
+      self, payload: dict[str, Any], state: StateStore
+  ) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="HITL_CONFIRMATION_REQUEST",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={
+            "permission": payload.get("permission"),
+            "tool": payload.get("tool_name"),
+            "args": to_jsonable(payload.get("tool_input") or {}),
+        },
+        attributes={
+            "session_metadata": {"source": "claude_code_permission_request"},
+            "custom_tags": {"assistant": "claude_code"},
+        },
+    )
+
+  def _session_end(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="STATE_DELTA",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={"session_end": True},
+        attributes={
+            "state_delta": {
+                "source": "claude_code_session_end",
+                "trace_count": state.get("trace_count", 0),
+                "duration_ms": max(
+                    0,
+                    timestamp_ms()
+                    - int(state.get("session_start_ms") or timestamp_ms()),
+                ),
+            }
+        },
+    )
+    state.remove()
+
+
+# ----------------------------------------------------------------------------
+# Entry points
+# ----------------------------------------------------------------------------
+
+
+def run_claude_hook(
+    hook_name: str, payload: dict[str, Any] | None = None
+) -> None:
+  """Convenience: dispatch a single hook payload through a fresh adapter."""
+  adapter = ClaudeHookBQAAAdapter()
+  adapter.process(hook_name, payload or {})
+
+
+def main(argv: list[str] | None = None) -> int:
+  """Hook entry: read JSON payload from stdin, dispatch by hook name.
+
+  Invoked by hook shell wrappers as
+  ``python -m bigquery_agent_analytics_tracing.claude_code <HookName>``
+  or via the ``bqaa-claude-hook`` console script. Errors are logged but
+  never propagated so the host agent's hot path stays clean.
+  """
+  argv = argv if argv is not None else sys.argv[1:]
+  if not argv:
+    print("usage: bqaa-claude-hook <ClaudeHookName>", file=sys.stderr)
+    return 2
+  hook_name = argv[0]
+  raw = sys.stdin.read()
+  payload = safe_json_loads(raw, {}) if raw.strip() else {}
+  config = BQAAConfig.from_env()
+  if not config.enabled:
+    return 0
+  try:
+    ClaudeHookBQAAAdapter(BigQueryAgentAnalyticsLogger(config)).process(
+        hook_name, payload
+    )
+  except Exception as exc:  # Hooks must never break the calling agent.
+    log_to_file(
+        config, f"ERROR hook={hook_name}: {exc}\n{traceback.format_exc()}"
+    )
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/tests/test_claude_code.py
+++ b/producers/tests/test_claude_code.py
@@ -1,0 +1,623 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Claude Code hook producer.
+
+State store + per-hook dispatch are exercised via dry-run mode so no
+BigQuery client is required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from bigquery_agent_analytics_tracing.claude_code import _read_transcript_since
+from bigquery_agent_analytics_tracing.claude_code import _tool_origin
+from bigquery_agent_analytics_tracing.claude_code import _tool_status
+from bigquery_agent_analytics_tracing.claude_code import CLAUDE_CODE_DEFAULT_AGENT
+from bigquery_agent_analytics_tracing.claude_code import ClaudeHookBQAAAdapter
+from bigquery_agent_analytics_tracing.claude_code import cleanup_stale_state
+from bigquery_agent_analytics_tracing.claude_code import main
+from bigquery_agent_analytics_tracing.claude_code import run_claude_hook
+from bigquery_agent_analytics_tracing.claude_code import StateStore
+from bigquery_agent_analytics_tracing.config import BQAAConfig
+from bigquery_agent_analytics_tracing.logger import BigQueryAgentAnalyticsLogger
+
+# ----------------------------------------------------------------------------
+# Fixtures + helpers
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dry_run_config(tmp_path):
+  return BQAAConfig(
+      project_id="test-project",
+      dataset="test_dataset",
+      agent_name="coding-agent",
+      dry_run=True,
+      log_file=str(tmp_path / "bqaa.log"),
+      spool_dir=str(tmp_path / "spool"),
+      state_dir=str(tmp_path / "state"),
+      writer_label="bigquery-agent-analytics-tracing/test",
+      transcript_max_bytes=64 * 1024,
+  )
+
+
+@pytest.fixture
+def adapter(dry_run_config):
+  return ClaudeHookBQAAAdapter(BigQueryAgentAnalyticsLogger(dry_run_config))
+
+
+def _emitted_rows(log_file: str) -> list[dict]:
+  path = Path(log_file)
+  if not path.exists():
+    return []
+  rows: list[dict] = []
+  for line in path.read_text().splitlines():
+    if "DRY_RUN " not in line:
+      continue
+    rows.append(json.loads(line.split("DRY_RUN ", 1)[1]))
+  return rows
+
+
+# ----------------------------------------------------------------------------
+# Tool helpers
+# ----------------------------------------------------------------------------
+
+
+def test_tool_origin_classifies_mcp_subagent_and_local():
+  assert _tool_origin("mcp__github__create_issue") == "MCP"
+  assert _tool_origin("Task") == "SUB_AGENT"
+  assert _tool_origin("Subagent") == "SUB_AGENT"
+  assert _tool_origin("Bash") == "LOCAL"
+  assert _tool_origin(None) == "LOCAL"
+
+
+def test_tool_status_detects_error_dict_and_error_prefix_string():
+  assert _tool_status({"is_error": True, "error": "boom"}) == ("ERROR", "boom")
+  assert _tool_status({"error": "x", "message": "y"}) == ("ERROR", "x")
+  assert _tool_status("Error: timed out")[0] == "ERROR"
+  assert _tool_status("ok output") == ("OK", None)
+  assert _tool_status(None) == ("OK", None)
+
+
+# ----------------------------------------------------------------------------
+# State store
+# ----------------------------------------------------------------------------
+
+
+def test_state_store_round_trips_session_and_tool_state(tmp_path):
+  store = StateStore("session-abc", root=str(tmp_path))
+  store.update({"session_id": "s1", "agent": "claude-code"})
+
+  reread = StateStore("session-abc", root=str(tmp_path))
+  assert reread.get("session_id") == "s1"
+  assert reread.get("agent") == "claude-code"
+
+  store.set_tool("tool-1", {"start_ms": 123, "span_id": "abc"})
+  store.set_tool("tool-2", {"start_ms": 456, "span_id": "def"})
+
+  popped = store.pop_tool("tool-1")
+  assert popped == {"start_ms": 123, "span_id": "abc"}
+  assert not (tmp_path / "tool_session-abc_tool-1.json").exists()
+  assert (tmp_path / "tool_session-abc_tool-2.json").exists()
+
+
+def test_state_store_remove_clears_session_and_per_tool_files(tmp_path):
+  store = StateStore("s", root=str(tmp_path))
+  store.update({"session_id": "s"})
+  store.set_tool("t1", {"x": 1})
+  store.set_tool("t2", {"x": 2})
+
+  store.remove()
+
+  assert not (tmp_path / "state_s.json").exists()
+  assert list(tmp_path.glob("tool_s_*.json")) == []
+
+
+def test_state_store_sanitizes_unsafe_keys(tmp_path):
+  store = StateStore("../weird/key!", root=str(tmp_path))
+  store.update({"x": 1})
+  # No path traversal — file lands inside tmp_path with a sanitized name.
+  files = list(tmp_path.glob("state_*.json"))
+  assert len(files) == 1
+  assert files[0].parent == tmp_path
+
+
+def test_cleanup_stale_state_removes_old_files(tmp_path):
+  recent = tmp_path / "state_recent.json"
+  stale = tmp_path / "state_stale.json"
+  unrelated = tmp_path / "other.json"
+  for path in (recent, stale, unrelated):
+    path.write_text("{}")
+  import os
+
+  # Make `stale` 25 hours old; ttl is 24h.
+  past = (time_now := __import__("time").time()) - 25 * 3600
+  os.utime(stale, (past, past))
+
+  removed = cleanup_stale_state(tmp_path, ttl_hours=24)
+
+  assert removed == 1
+  assert recent.exists()
+  assert not stale.exists()
+  assert unrelated.exists()
+  del time_now  # quiet linter
+
+
+def test_cleanup_stale_state_noop_when_ttl_disabled(tmp_path):
+  assert cleanup_stale_state(tmp_path, ttl_hours=0) == 0
+  assert cleanup_stale_state(tmp_path, ttl_hours=-1) == 0
+
+
+# ----------------------------------------------------------------------------
+# Transcript reader
+# ----------------------------------------------------------------------------
+
+
+def test_read_transcript_since_collects_assistant_text_and_usage(tmp_path):
+  transcript = tmp_path / "transcript.jsonl"
+  transcript.write_text(
+      "\n".join(
+          [
+              json.dumps({"type": "user", "message": {"content": "hi"}}),
+              json.dumps(
+                  {
+                      "type": "assistant",
+                      "message": {
+                          "model": "claude-opus-4-7",
+                          "content": [{"type": "text", "text": "hello"}],
+                          "usage": {
+                              "input_tokens": 10,
+                              "cache_read_input_tokens": 2,
+                              "output_tokens": 5,
+                          },
+                      },
+                  }
+              ),
+              json.dumps(
+                  {
+                      "type": "assistant",
+                      "message": {
+                          "content": [{"type": "text", "text": "world"}]
+                      },
+                  }
+              ),
+          ]
+      )
+      + "\n"
+  )
+
+  text, model, usage, truncated = _read_transcript_since(
+      str(transcript), start_line=0, max_bytes=1024
+  )
+
+  assert text == "hello\nworld"
+  assert model == "claude-opus-4-7"
+  assert usage["prompt_tokens"] == 12
+  assert usage["completion_tokens"] == 5
+  assert usage["total_tokens"] == 17
+  assert truncated is False
+
+
+def test_read_transcript_since_truncates_at_max_bytes(tmp_path):
+  transcript = tmp_path / "t.jsonl"
+  transcript.write_text(
+      json.dumps(
+          {
+              "type": "assistant",
+              "message": {"content": [{"type": "text", "text": "x" * 5000}]},
+          }
+      )
+      + "\n"
+  )
+
+  text, _, _, truncated = _read_transcript_since(
+      str(transcript), start_line=0, max_bytes=100
+  )
+
+  assert truncated is True
+  assert "[TRUNCATED]" in text
+  assert len(text) <= 120  # 100 bytes + suffix
+
+
+def test_read_transcript_since_skips_lines_before_start(tmp_path):
+  transcript = tmp_path / "t.jsonl"
+  transcript.write_text(
+      "\n".join(
+          [
+              json.dumps(
+                  {
+                      "type": "assistant",
+                      "message": {"content": [{"type": "text", "text": "OLD"}]},
+                  }
+              ),
+              json.dumps(
+                  {
+                      "type": "assistant",
+                      "message": {"content": [{"type": "text", "text": "NEW"}]},
+                  }
+              ),
+          ]
+      )
+      + "\n"
+  )
+
+  text, _, _, _ = _read_transcript_since(
+      str(transcript), start_line=1, max_bytes=1024
+  )
+
+  assert "OLD" not in text
+  assert "NEW" in text
+
+
+def test_read_transcript_since_missing_path_is_safe():
+  text, model, usage, truncated = _read_transcript_since(
+      "/does/not/exist", 0, 1024
+  )
+  assert text == ""
+  assert model == ""
+  assert usage["total_tokens"] == 0
+  assert truncated is False
+
+
+# ----------------------------------------------------------------------------
+# Hook dispatch
+# ----------------------------------------------------------------------------
+
+
+def test_session_start_initializes_session_state(adapter, monkeypatch):
+  monkeypatch.setenv("BQAA_AGENT_NAME", "claude-code")
+  adapter.process("SessionStart", {"session_id": "abc123", "cwd": "/tmp/proj"})
+
+  state = StateStore("abc123", root=adapter.config.state_dir)
+  assert state.get("session_id") == "abc123"
+  assert state.get("agent") == "claude-code"
+  assert state.get("project_name") == "proj"
+  assert state.get("trace_count") == 0
+
+
+def test_user_prompt_submit_emits_llm_request_with_session_metadata(
+    adapter, dry_run_config
+):
+  adapter.process("SessionStart", {"session_id": "s1", "cwd": "/tmp/x"})
+  adapter.process(
+      "UserPromptSubmit",
+      {"session_id": "s1", "prompt": "do thing", "transcript_path": ""},
+  )
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  llm_request = [r for r in rows if r["event_type"] == "LLM_REQUEST"]
+  assert len(llm_request) == 1
+  row = llm_request[0]
+  attrs = json.loads(row["attributes"])
+  assert attrs["session_metadata"]["source"] == "claude_code"
+  assert attrs["session_metadata"]["trace_number"] == 1
+  assert attrs["custom_tags"]["assistant"] == "claude_code"
+  assert attrs["writer"]["plugin"] == "bigquery-agent-analytics-tracing"
+
+
+def test_pre_then_post_tool_use_share_span_id(adapter, dry_run_config):
+  adapter.process("SessionStart", {"session_id": "s1"})
+  adapter.process("UserPromptSubmit", {"session_id": "s1", "prompt": "p"})
+
+  payload = {
+      "session_id": "s1",
+      "tool_use_id": "tool-xyz",
+      "tool_name": "Bash",
+      "tool_input": {"command": "ls"},
+  }
+  adapter.process("PreToolUse", payload)
+  adapter.process(
+      "PostToolUse",
+      {**payload, "tool_response": "ok"},
+  )
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  pre = next(r for r in rows if r["event_type"] == "TOOL_STARTING")
+  post = next(r for r in rows if r["event_type"] == "TOOL_COMPLETED")
+  assert pre["span_id"] == post["span_id"], (
+      "PostToolUse must reuse the span_id PreToolUse stamped, so the"
+      " trace shows one span per tool call"
+  )
+  assert post["status"] == "OK"
+
+
+def test_post_tool_use_without_pre_derives_deterministic_span(
+    adapter, dry_run_config
+):
+  adapter.process("SessionStart", {"session_id": "s1"})
+  adapter.process("UserPromptSubmit", {"session_id": "s1", "prompt": "p"})
+
+  adapter.process(
+      "PostToolUse",
+      {
+          "session_id": "s1",
+          "tool_use_id": "orphan-tool",
+          "tool_name": "Bash",
+          "tool_response": "ok",
+      },
+  )
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  post = next(r for r in rows if r["event_type"] == "TOOL_COMPLETED")
+  # Deterministic span from the seed "orphan-tool".
+  from bigquery_agent_analytics_tracing._utils import deterministic_span
+
+  assert post["span_id"] == deterministic_span("orphan-tool")
+
+
+def test_post_tool_use_error_dict_marks_row_as_error(adapter, dry_run_config):
+  adapter.process("SessionStart", {"session_id": "s1"})
+  adapter.process("UserPromptSubmit", {"session_id": "s1", "prompt": "p"})
+  adapter.process(
+      "PostToolUse",
+      {
+          "session_id": "s1",
+          "tool_use_id": "t1",
+          "tool_name": "Bash",
+          "tool_response": {"is_error": True, "error": "boom"},
+      },
+  )
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  post = next(r for r in rows if r["event_type"] == "TOOL_COMPLETED")
+  assert post["status"] == "ERROR"
+  assert post["error_message"] == "boom"
+
+
+def test_stop_emits_llm_response_with_transcript_content(
+    adapter, dry_run_config, tmp_path
+):
+  # UserPromptSubmit bookmarks the current transcript line count; Stop
+  # reads everything appended after that point. Mirror the real Claude
+  # Code flow: prompt fires first, assistant response is written to the
+  # transcript next, then Stop fires.
+  transcript = tmp_path / "transcript.jsonl"
+  transcript.write_text(
+      json.dumps({"type": "user", "message": {"content": "question?"}}) + "\n"
+  )
+
+  adapter.process("SessionStart", {"session_id": "s1"})
+  adapter.process(
+      "UserPromptSubmit",
+      {
+          "session_id": "s1",
+          "prompt": "question?",
+          "transcript_path": str(transcript),
+      },
+  )
+
+  with transcript.open("a") as fh:
+    fh.write(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [{"type": "text", "text": "the answer is 42"}],
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                },
+            }
+        )
+        + "\n"
+    )
+
+  adapter.process(
+      "Stop", {"session_id": "s1", "transcript_path": str(transcript)}
+  )
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  resp = next(r for r in rows if r["event_type"] == "LLM_RESPONSE")
+  content = json.loads(resp["content"])
+  assert "the answer is 42" in content["response"]
+  attrs = json.loads(resp["attributes"])
+  assert attrs["model"] == "claude-opus-4-7"
+  assert attrs["usage_metadata"]["completion_tokens"] == 3
+
+
+def test_stop_without_active_trace_is_noop(adapter, dry_run_config):
+  adapter.process("SessionStart", {"session_id": "s1"})
+  # No UserPromptSubmit -> no current_trace_id -> Stop drops on the floor.
+  adapter.process("Stop", {"session_id": "s1"})
+  rows = _emitted_rows(dry_run_config.log_file)
+  assert not any(r["event_type"] == "LLM_RESPONSE" for r in rows)
+
+
+def test_notification_emits_state_delta(adapter, dry_run_config):
+  adapter.process(
+      "Notification",
+      {
+          "session_id": "s1",
+          "title": "Permission needed",
+          "message": "Allow?",
+          "notification_type": "permission",
+      },
+  )
+  rows = _emitted_rows(dry_run_config.log_file)
+  note = next(r for r in rows if r["event_type"] == "STATE_DELTA")
+  attrs = json.loads(note["attributes"])
+  assert attrs["state_delta"]["source"] == "claude_code_notification"
+  assert attrs["state_delta"]["notification_type"] == "permission"
+
+
+def test_permission_request_emits_hitl_event(adapter, dry_run_config):
+  adapter.process(
+      "PermissionRequest",
+      {
+          "session_id": "s1",
+          "permission": "Bash",
+          "tool_name": "Bash",
+          "tool_input": {"command": "rm"},
+      },
+  )
+  rows = _emitted_rows(dry_run_config.log_file)
+  hitl = next(r for r in rows if r["event_type"] == "HITL_CONFIRMATION_REQUEST")
+  attrs = json.loads(hitl["attributes"])
+  assert attrs["session_metadata"]["source"] == "claude_code_permission_request"
+
+
+def test_session_end_emits_state_delta_and_clears_state(
+    adapter, dry_run_config
+):
+  adapter.process("SessionStart", {"session_id": "s1"})
+  adapter.process("SessionEnd", {"session_id": "s1"})
+
+  rows = _emitted_rows(dry_run_config.log_file)
+  end = [
+      r
+      for r in rows
+      if r["event_type"] == "STATE_DELTA"
+      and json.loads(r["attributes"])["state_delta"]["source"]
+      == "claude_code_session_end"
+  ]
+  assert len(end) == 1
+
+  # State files for the session are gone.
+  state_dir = Path(dry_run_config.state_dir)
+  assert not (state_dir / "state_s1.json").exists()
+
+
+def test_unknown_hook_name_is_silent(adapter, dry_run_config):
+  adapter.process("NotARealHook", {"session_id": "s1"})
+  rows = _emitted_rows(dry_run_config.log_file)
+  assert rows == []
+
+
+def test_run_claude_hook_emits_through_env_config(monkeypatch, tmp_path):
+  monkeypatch.setenv("BQAA_DRY_RUN", "true")
+  monkeypatch.setenv("BQAA_LOG_FILE", str(tmp_path / "envrun.log"))
+  monkeypatch.setenv("BQAA_SPOOL_DIR", str(tmp_path / "spool"))
+  monkeypatch.setenv("BQAA_STATE_DIR", str(tmp_path / "state"))
+
+  run_claude_hook("SessionStart", {"session_id": "envtest", "cwd": "/tmp/p"})
+  run_claude_hook(
+      "UserPromptSubmit",
+      {"session_id": "envtest", "prompt": "x", "transcript_path": ""},
+  )
+
+  rows = _emitted_rows(str(tmp_path / "envrun.log"))
+  assert any(r["event_type"] == "LLM_REQUEST" for r in rows)
+
+
+# ----------------------------------------------------------------------------
+# main() entry
+# ----------------------------------------------------------------------------
+
+
+def test_main_returns_2_when_no_hook_name(monkeypatch, capsys):
+  monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+  rc = main(argv=[])
+  err = capsys.readouterr().err
+  assert rc == 2
+  assert "usage:" in err
+
+
+def test_main_short_circuits_when_trace_disabled(monkeypatch, tmp_path):
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "false")
+  monkeypatch.setenv("BQAA_DRY_RUN", "true")
+  monkeypatch.setenv("BQAA_LOG_FILE", str(tmp_path / "off.log"))
+  monkeypatch.setenv("BQAA_SPOOL_DIR", str(tmp_path / "spool"))
+  monkeypatch.setenv("BQAA_STATE_DIR", str(tmp_path / "state"))
+  monkeypatch.setattr(
+      sys, "stdin", io.StringIO(json.dumps({"session_id": "s1"}))
+  )
+
+  rc = main(argv=["SessionStart"])
+
+  assert rc == 0
+  assert not (tmp_path / "off.log").exists()
+
+
+def test_main_dispatches_via_stdin_payload(monkeypatch, tmp_path):
+  monkeypatch.setenv("BQAA_DRY_RUN", "true")
+  monkeypatch.setenv("BQAA_LOG_FILE", str(tmp_path / "stdin.log"))
+  monkeypatch.setenv("BQAA_SPOOL_DIR", str(tmp_path / "spool"))
+  monkeypatch.setenv("BQAA_STATE_DIR", str(tmp_path / "state"))
+  payload = json.dumps(
+      {"session_id": "s1", "prompt": "hi", "transcript_path": ""}
+  )
+
+  # SessionStart first to seed state, then UserPromptSubmit emits the row.
+  monkeypatch.setattr(
+      sys, "stdin", io.StringIO(json.dumps({"session_id": "s1"}))
+  )
+  assert main(argv=["SessionStart"]) == 0
+  monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+  assert main(argv=["UserPromptSubmit"]) == 0
+
+  log_text = (tmp_path / "stdin.log").read_text()
+  assert "LLM_REQUEST" in log_text
+
+
+def test_main_never_raises_on_hook_error(monkeypatch, tmp_path):
+  """An adapter exception must be logged, not propagated, so the host
+  agent's hot path stays clean."""
+  monkeypatch.setenv("BQAA_DRY_RUN", "true")
+  monkeypatch.setenv("BQAA_LOG_FILE", str(tmp_path / "err.log"))
+  monkeypatch.setenv("BQAA_SPOOL_DIR", str(tmp_path / "spool"))
+  monkeypatch.setenv("BQAA_STATE_DIR", str(tmp_path / "state"))
+
+  def _boom(self, hook_name, payload):
+    raise RuntimeError("synthetic")
+
+  monkeypatch.setattr(ClaudeHookBQAAAdapter, "process", _boom)
+  monkeypatch.setattr(sys, "stdin", io.StringIO("{}"))
+
+  rc = main(argv=["SessionStart"])
+  assert rc == 0
+  assert "synthetic" in (tmp_path / "err.log").read_text()
+
+
+# ----------------------------------------------------------------------------
+# Module is invocable as `python -m`
+# ----------------------------------------------------------------------------
+
+
+def test_claude_code_module_is_invocable_as_python_m(tmp_path):
+  src_root = Path(__file__).resolve().parents[1] / "src"
+  env = {
+      "PYTHONPATH": str(src_root),
+      "BQAA_DRY_RUN": "true",
+      "BQAA_LOG_FILE": str(tmp_path / "m.log"),
+      "BQAA_SPOOL_DIR": str(tmp_path / "spool"),
+      "BQAA_STATE_DIR": str(tmp_path / "state"),
+      "PATH": "/usr/bin:/bin",
+  }
+  result = subprocess.run(
+      [
+          sys.executable,
+          "-m",
+          "bigquery_agent_analytics_tracing.claude_code",
+          "SessionStart",
+      ],
+      env=env,
+      input=json.dumps({"session_id": "s1"}),
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  assert (
+      result.returncode == 0
+  ), f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+def test_claude_code_default_agent_constant_is_stable():
+  assert CLAUDE_CODE_DEFAULT_AGENT == "claude-code"


### PR DESCRIPTION
Maps to **step 1 of #234** — adds the Claude Code producer surface to the `bigquery-agent-analytics-tracing` package. Plugin artifact + release plumbing land in follow-up PRs (steps 2/3/4/5 of #234).

Refs #234, #229.

## What's in this PR

### New module: `bigquery_agent_analytics_tracing.claude_code`

| Component | Purpose |
|---|---|
| `ClaudeHookBQAAAdapter` | Dispatches all nine Claude Code hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SubagentStop, Notification, PermissionRequest, SessionEnd) onto `BigQueryAgentAnalyticsLogger`. Preserves upstream `attributes.session_metadata.source` semantics (`claude_code`, `claude_code_subagent`, `claude_code_notification`, `claude_code_permission_request`, `claude_code_session_end`). |
| `StateStore` + `_LockedJSONStore` | Per-session + per-tool on-disk state guarded by `fcntl.flock`. Concurrent `PreToolUse` fires for parallel tools each land in their own `tool_<session>_<id>.json`, preventing `span_id` / `start_ms` clobbering. |
| `cleanup_stale_state` | Fired on `SessionStart`; purges files older than `BQAA_STATE_TTL_HOURS`. |
| `_read_transcript_since` | Streams the assistant portion of a Claude transcript, accumulating output text + usage tokens up to `BQAA_TRANSCRIPT_MAX_BYTES`. |
| `main()` | Stdin-JSON hook entry. Errors logged via `log_to_file` but never propagated so the host agent's hot path stays clean. Respects `BQAA_TRACE_ENABLED=false` as a clean short-circuit. |
| `run_claude_hook()` | Library convenience helper. |

### Console script
- `bqaa-claude-hook = bigquery_agent_analytics_tracing.claude_code:main` added to `pyproject.toml`.

### Tests — 29 new, 62 total, all green

- **Tool helpers** — `_tool_origin` MCP / SUB_AGENT / LOCAL classification; `_tool_status` error-dict and `Error:` prefix detection
- **StateStore** — round-trips session + per-tool state, `remove()` clears both, key sanitization blocks path traversal, `cleanup_stale_state` honors TTL
- **Transcript reader** — accumulates assistant text + usage, truncates at `max_bytes` with `[TRUNCATED]` marker, skips lines before bookmark, missing path is safe
- **Hook dispatch**:
  - SessionStart initializes state (session_id, agent, project_name)
  - UserPromptSubmit emits LLM_REQUEST with session metadata
  - Pre+PostToolUse pair share `span_id`
  - Post-without-Pre derives a deterministic span from `tool_use_id`
  - Error tool result marks row as `ERROR` with `error_message`
  - Stop reads transcript output and emits LLM_RESPONSE with model + usage; sequenced realistically (prompt → bookmark → assistant write → Stop)
  - Stop without active trace is a no-op
  - Notification → STATE_DELTA with `claude_code_notification` source
  - PermissionRequest → HITL_CONFIRMATION_REQUEST with `claude_code_permission_request` source
  - SessionEnd → STATE_DELTA + on-disk state cleared
  - Unknown hook name is silent
- **`main()` entry** — argv missing → exit 2 + usage; `BQAA_TRACE_ENABLED=false` short-circuits without touching disk; stdin JSON dispatches correctly; adapter exceptions are logged but never raised
- **Subprocess smoke** — `python -m bigquery_agent_analytics_tracing.claude_code SessionStart` exits 0 with `PYTHONPATH`-only invocation (vendored-plugin path)

## Schema / contract invariants preserved

- All rows go through `BigQueryAgentAnalyticsLogger` so the reserved `attributes.writer` block from #232 stamps correctly. Claude-specific metadata lives under `attributes.session_metadata`, `attributes.custom_tags`, `attributes.state_delta` — no collision with the writer namespace.
- `attributes.adk` left absent per the ADK 2.0 boundary in #229.
- Default agent: `claude-code` (constant `CLAUDE_CODE_DEFAULT_AGENT`), overridable via `BQAA_AGENT_NAME`. Matches upstream behavior.
- Env-controlled kill switch (`BQAA_TRACE_ENABLED=false`) and dry-run / spool / direct-write routing inherited from the scaffold PR.

## Not in this PR (follow-up sequence per #234)

| Follow-up PR | Maps to | Scope |
|---|---|---|
| **B** | steps 2+3 | `plugins/claude_code/` source tree + `scripts/build_claude_plugin.py` that vendors `src/` at build time; `bqaa_drain_entry.py` wrapper so the vendored drainer works without a wheel install; CI builds the artifact |
| **C** | step 4 | `.github/workflows/release-tracing.yml` triggered by `tracing-v*` tags; TestPyPI → PyPI for the wheel, uploads plugin artifact in same job |
| **D** | step 5 | Plugin manifest polish + install docs + `/bqaa-setup` interactive-vs-headless clarification + marketplace submission notes |

## Test plan

- [x] `pytest tests/ -q` — 62/62 pass on Python 3.13.5
- [x] `pyink src/ tests/ --check` — clean
- [x] `isort src/ tests/` — clean
- [x] `python -m build` produces wheel + sdist
- [x] `python -m bigquery_agent_analytics_tracing.claude_code SessionStart` exits 0 with `PYTHONPATH`-only env
- [ ] Producers CI — green across 3.10/3.11/3.12/3.13/3.14 after maintainer approves the first-time-fork gate
- [ ] CLA bot ack (already signed)
- [ ] Live BigQuery round-trip — deferred to PR B