### PR TITLE
producers: add Claude Code plugin artifact build (vendor + tar)

### DIFF
--- a/.github/workflows/producers-ci.yml
+++ b/.github/workflows/producers-ci.yml
@@ -19,11 +19,13 @@ on:
     branches: [main]
     paths:
       - 'producers/**'
+      - 'plugins/claude_code/**'
       - '.github/workflows/producers-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'producers/**'
+      - 'plugins/claude_code/**'
       - '.github/workflows/producers-ci.yml'
 
 concurrency:
@@ -91,7 +93,19 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: List artifacts
+      - name: List wheel/sdist
+        run: ls -la dist/
+
+      - name: Install built wheel for plugin build
+        # Make `importlib.metadata.version` resolve correctly so the
+        # plugin manifest gets a real version stamped in, not the
+        # pyproject fallback.
+        run: pip install dist/bigquery_agent_analytics_tracing-*.whl
+
+      - name: Build Claude Code plugin artifact
+        run: python scripts/build_claude_plugin.py
+
+      - name: List plugin artifact
         run: ls -la dist/
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/producers-ci.yml
+++ b/.github/workflows/producers-ci.yml
@@ -51,10 +51,10 @@ jobs:
         run: pip install "pyink>=24.3.0" "isort>=5.0"
 
       - name: isort --check
-        run: isort --check-only src/ tests/
+        run: isort --check-only src/ tests/ scripts/
 
       - name: pyink --check
-        run: pyink --check src/ tests/
+        run: pyink --check src/ tests/ scripts/
 
   test:
     name: Producers test (Python ${{ matrix.python-version }})

--- a/plugins/claude_code/.claude-plugin/plugin.json
+++ b/plugins/claude_code/.claude-plugin/plugin.json
@@ -1,0 +1,109 @@
+{
+  "name": "bigquery-agent-analytics-tracing",
+  "description": "Stream Claude Code hook traces to Google BigQuery Agent Analytics agent_events.",
+  "version": "0.0.0+local",
+  "author": {
+    "name": "Google LLC"
+  },
+  "repository": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK",
+  "license": "Apache-2.0",
+  "keywords": [
+    "bigquery",
+    "agent-analytics",
+    "observability",
+    "tracing",
+    "claude-code"
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.sh\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt_submit.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_tool_use.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post_tool_use.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent_stop.sh\""
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.sh\""
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/permission_request.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session_end.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude_code/.gitignore
+++ b/plugins/claude_code/.gitignore
@@ -1,0 +1,5 @@
+# Vendored package source — populated at build time by
+# producers/scripts/build_claude_plugin.py. The source of truth lives in
+# producers/src/bigquery_agent_analytics_tracing/; vendor/ is never
+# checked in to avoid drift.
+vendor/

--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -1,0 +1,61 @@
+# BigQuery Agent Analytics — Claude Code plugin
+
+Native Claude Code plugin that streams hook events to the BigQuery
+Agent Analytics `agent_events` table.
+
+## Layout
+
+```
+plugins/claude_code/
+├── .claude-plugin/
+│   └── plugin.json          # native Claude Code manifest
+├── hooks/
+│   ├── common.sh            # shared hook entry (PYTHONPATH + python -m)
+│   └── <hook>.sh            # one per Claude Code hook
+└── vendor/                  # generated at build time (git-ignored)
+    └── bigquery_agent_analytics_tracing/
+                             # vendored package source — copied from
+                             # producers/src/ by build_claude_plugin.py
+```
+
+`vendor/` is never source-controlled. The build script
+[`producers/scripts/build_claude_plugin.py`](../../producers/scripts/build_claude_plugin.py)
+copies the canonical package source into `vendor/` and stamps the
+resolved version into `.claude-plugin/plugin.json` at release time —
+so the wheel and the plugin always ship the same code.
+
+## Runtime model
+
+1. Claude Code fires a hook (e.g. `PreToolUse`) per the manifest.
+2. The matching `hooks/<hook>.sh` execs `hooks/common.sh <HookName>`.
+3. `common.sh` prepends `${CLAUDE_PLUGIN_ROOT}/vendor` to `PYTHONPATH`
+   and execs
+   `python -m bigquery_agent_analytics_tracing.claude_code <HookName>`.
+4. The hook process writes one spool envelope and spawns the drainer
+   subprocess. The drainer inherits the same `PYTHONPATH` via
+   `os.environ.copy()` so the vendored package resolves on the spawned
+   process too — no separate wheel install required on `BQAA_PYTHON`.
+
+## Required runtime deps on `BQAA_PYTHON`
+
+The plugin does **not** require installing `bigquery-agent-analytics-tracing`
+itself, but the Python under `BQAA_PYTHON` still needs:
+
+- `google-cloud-bigquery` — required for both writer paths.
+- `google-cloud-bigquery-storage` + `pyarrow` — required only for the
+  Storage Write API path; the drainer falls back to `insert_rows_json`
+  when these are unavailable.
+
+A future `/bqaa-setup` slash command (planned in #234 step 5) will
+surface a single `pip install ...` line for missing deps.
+
+## Building the artifact
+
+```bash
+cd producers
+python scripts/build_claude_plugin.py
+# → plugins/claude_code/vendor/bigquery_agent_analytics_tracing/
+# → producers/dist/bigquery-agent-analytics-tracing-claude-code-X.Y.Z.tar.gz
+```
+
+CI runs the same script and uploads the tarball as a workflow artifact.

--- a/plugins/claude_code/hooks/common.sh
+++ b/plugins/claude_code/hooks/common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared hook entry. Each hooks/<hook_name>.sh execs this with its hook
+# name as $1.
+#
+# Vendored package: bigquery_agent_analytics_tracing/ lives under
+# vendor/ in the plugin tree. Prepending it to PYTHONPATH lets the
+# `-m bigquery_agent_analytics_tracing.claude_code` invocation work
+# without `pip install bigquery-agent-analytics-tracing` — and the
+# drainer subprocess inherits the same PYTHONPATH via os.environ when
+# the logger spawns it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+PYTHON_BIN="${BQAA_PYTHON:-python3}"
+
+if [[ "${BQAA_TRACE_ENABLED:-true}" != "true" ]]; then
+  exit 0
+fi
+
+export PYTHONPATH="${PLUGIN_DIR}/vendor:${PYTHONPATH:-}"
+
+exec "$PYTHON_BIN" -m bigquery_agent_analytics_tracing.claude_code "$1"

--- a/plugins/claude_code/hooks/notification.sh
+++ b/plugins/claude_code/hooks/notification.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" Notification

--- a/plugins/claude_code/hooks/permission_request.sh
+++ b/plugins/claude_code/hooks/permission_request.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PermissionRequest

--- a/plugins/claude_code/hooks/post_tool_use.sh
+++ b/plugins/claude_code/hooks/post_tool_use.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PostToolUse

--- a/plugins/claude_code/hooks/pre_tool_use.sh
+++ b/plugins/claude_code/hooks/pre_tool_use.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PreToolUse

--- a/plugins/claude_code/hooks/session_end.sh
+++ b/plugins/claude_code/hooks/session_end.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SessionEnd

--- a/plugins/claude_code/hooks/session_start.sh
+++ b/plugins/claude_code/hooks/session_start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SessionStart

--- a/plugins/claude_code/hooks/stop.sh
+++ b/plugins/claude_code/hooks/stop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" Stop

--- a/plugins/claude_code/hooks/subagent_stop.sh
+++ b/plugins/claude_code/hooks/subagent_stop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SubagentStop

--- a/plugins/claude_code/hooks/user_prompt_submit.sh
+++ b/plugins/claude_code/hooks/user_prompt_submit.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" UserPromptSubmit

--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
   "pytest-asyncio>=0.21",
   "pyink>=24.3.0",
   "isort>=5.0",
+  "tomli>=1.1; python_version < '3.11'",
 ]
 
 [project.scripts]

--- a/producers/scripts/build_claude_plugin.py
+++ b/producers/scripts/build_claude_plugin.py
@@ -37,7 +37,13 @@ from pathlib import Path
 import shutil
 import sys
 import tarfile
-import tomllib
+
+# tomllib is stdlib on Python 3.11+; fall back to the `tomli`
+# backport on 3.10 (declared as a conditional dev dependency).
+try:
+  import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on 3.10.
+  import tomli as tomllib
 
 PACKAGE_DIST_NAME = "bigquery-agent-analytics-tracing"
 PACKAGE_IMPORT_NAME = "bigquery_agent_analytics_tracing"

--- a/producers/scripts/build_claude_plugin.py
+++ b/producers/scripts/build_claude_plugin.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the Claude Code plugin artifact.
+
+What this does:
+  1. Copies producers/src/bigquery_agent_analytics_tracing/ into
+     plugins/claude_code/vendor/ so the plugin runs without a
+     `pip install bigquery-agent-analytics-tracing` on `BQAA_PYTHON`.
+  2. Resolves the producer package version (from installed metadata
+     when available, else from producers/pyproject.toml) and stamps it
+     into plugins/claude_code/.claude-plugin/plugin.json.
+  3. Tars the plugin tree into
+     producers/dist/bigquery-agent-analytics-tracing-claude-code-<version>.tar.gz.
+
+Run from anywhere — paths are anchored relative to this file. CI runs
+this after `pytest` and uploads the tarball as a workflow artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib import metadata
+import json
+from pathlib import Path
+import shutil
+import sys
+import tarfile
+import tomllib
+
+PACKAGE_DIST_NAME = "bigquery-agent-analytics-tracing"
+PACKAGE_IMPORT_NAME = "bigquery_agent_analytics_tracing"
+PLUGIN_DIR_NAME = "claude_code"
+PLUGIN_ARTIFACT_PREFIX = f"{PACKAGE_DIST_NAME}-claude-code"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRODUCERS_DIR = REPO_ROOT / "producers"
+PACKAGE_SRC = PRODUCERS_DIR / "src" / PACKAGE_IMPORT_NAME
+PLUGIN_DIR = REPO_ROOT / "plugins" / PLUGIN_DIR_NAME
+MANIFEST_PATH = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+DEFAULT_DIST_DIR = PRODUCERS_DIR / "dist"
+
+
+def resolve_version() -> str:
+  """Return the producer package version.
+
+  Prefers installed distribution metadata (matches what `__version__`
+  resolves to at runtime). Falls back to reading the producer
+  pyproject.toml when the package is not installed (CI / fresh checkout).
+  """
+  try:
+    return metadata.version(PACKAGE_DIST_NAME)
+  except metadata.PackageNotFoundError:
+    pass
+  pyproject = PRODUCERS_DIR / "pyproject.toml"
+  with pyproject.open("rb") as fh:
+    return tomllib.load(fh)["project"]["version"]
+
+
+def vendor_package(*, dry_run: bool = False) -> Path:
+  """Copy the producer package source into the plugin's vendor/ tree."""
+  vendor_root = PLUGIN_DIR / "vendor"
+  target = vendor_root / PACKAGE_IMPORT_NAME
+  if dry_run:
+    return target
+  if not PACKAGE_SRC.is_dir():
+    raise FileNotFoundError(
+        f"Package source not found at {PACKAGE_SRC}; "
+        "run from a checkout of the producers/ tree."
+    )
+  if target.exists():
+    shutil.rmtree(target)
+  vendor_root.mkdir(parents=True, exist_ok=True)
+  shutil.copytree(
+      PACKAGE_SRC,
+      target,
+      ignore=shutil.ignore_patterns(
+          "__pycache__", "*.pyc", "*.pyo", "*.egg-info"
+      ),
+  )
+  return target
+
+
+def stamp_manifest_version(version: str, *, dry_run: bool = False) -> dict:
+  """Write the resolved version into .claude-plugin/plugin.json."""
+  with MANIFEST_PATH.open("r", encoding="utf-8") as fh:
+    manifest = json.load(fh)
+  manifest["version"] = version
+  if dry_run:
+    return manifest
+  # Preserve trailing newline + 2-space indent so diffs stay minimal.
+  rendered = json.dumps(manifest, indent=2, sort_keys=False) + "\n"
+  MANIFEST_PATH.write_text(rendered, encoding="utf-8")
+  return manifest
+
+
+def build_tarball(version: str, dist_dir: Path) -> Path:
+  """Tar the plugin tree under dist_dir, return the tarball path.
+
+  Excludes .gitignore and __pycache__ so the artifact is exactly what
+  marketplace users will install.
+  """
+  dist_dir.mkdir(parents=True, exist_ok=True)
+  archive_name = f"{PLUGIN_ARTIFACT_PREFIX}-{version}"
+  tar_path = dist_dir / f"{archive_name}.tar.gz"
+  if tar_path.exists():
+    tar_path.unlink()
+
+  def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    name = Path(info.name).name
+    if name in {".gitignore", "__pycache__"}:
+      return None
+    if name.endswith((".pyc", ".pyo")):
+      return None
+    return info
+
+  with tarfile.open(tar_path, "w:gz") as tar:
+    tar.add(PLUGIN_DIR, arcname=archive_name, filter=_filter)
+  return tar_path
+
+
+def build(
+    *,
+    dist_dir: Path = DEFAULT_DIST_DIR,
+    skip_tar: bool = False,
+) -> dict:
+  """Vendor + stamp + (optionally) tar. Returns a summary dict."""
+  version = resolve_version()
+  vendor_target = vendor_package()
+  manifest = stamp_manifest_version(version)
+  tar_path: Path | None = None
+  if not skip_tar:
+    tar_path = build_tarball(version, dist_dir)
+  return {
+      "version": version,
+      "vendor_target": str(vendor_target),
+      "manifest_version": manifest["version"],
+      "tar_path": str(tar_path) if tar_path else None,
+  }
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  parser.add_argument(
+      "--dist-dir",
+      type=Path,
+      default=DEFAULT_DIST_DIR,
+      help="Where to write the plugin tarball (default: producers/dist)",
+  )
+  parser.add_argument(
+      "--skip-tar",
+      action="store_true",
+      help="Only vendor + stamp, skip the tarball.",
+  )
+  args = parser.parse_args(argv)
+  summary = build(dist_dir=args.dist_dir, skip_tar=args.skip_tar)
+  json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+  sys.stdout.write("\n")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/scripts/build_claude_plugin.py
+++ b/producers/scripts/build_claude_plugin.py
@@ -75,7 +75,12 @@ def resolve_version() -> str:
 
 
 def vendor_package(*, dry_run: bool = False) -> Path:
-  """Copy the producer package source into the plugin's vendor/ tree."""
+  """Copy the producer package source into the plugin's vendor/ tree.
+
+  Wipes ``vendor/`` first so stale ``.dist-info`` directories from an
+  older version do not accumulate (``importlib.metadata.version()``
+  would otherwise see two distributions and pick one nondeterministically).
+  """
   vendor_root = PLUGIN_DIR / "vendor"
   target = vendor_root / PACKAGE_IMPORT_NAME
   if dry_run:
@@ -85,8 +90,8 @@ def vendor_package(*, dry_run: bool = False) -> Path:
         f"Package source not found at {PACKAGE_SRC}; "
         "run from a checkout of the producers/ tree."
     )
-  if target.exists():
-    shutil.rmtree(target)
+  if vendor_root.exists():
+    shutil.rmtree(vendor_root)
   vendor_root.mkdir(parents=True, exist_ok=True)
   shutil.copytree(
       PACKAGE_SRC,
@@ -96,6 +101,33 @@ def vendor_package(*, dry_run: bool = False) -> Path:
       ),
   )
   return target
+
+
+def write_vendor_dist_info(version: str) -> Path:
+  """Write a minimal PEP 376 ``.dist-info/METADATA`` alongside the
+  vendored package so ``importlib.metadata.version()`` resolves.
+
+  Without this, a vendored-plugin runtime (no wheel install on
+  ``BQAA_PYTHON``) leaves ``__version__`` at the ``"0.0.0+local"``
+  fallback and every emitted row's ``attributes.writer.version`` is
+  ``"0.0.0+local"`` — silently undermining the adoption-query
+  contract for marketplace installs.
+
+  Wheel-installed runtimes (when someone pip-installs
+  ``bigquery-agent-analytics-tracing``) keep their own metadata; this
+  file only matters when the package is on ``PYTHONPATH`` without
+  pip's site-packages alongside.
+  """
+  vendor_root = PLUGIN_DIR / "vendor"
+  dist_info = vendor_root / f"{PACKAGE_IMPORT_NAME}-{version}.dist-info"
+  dist_info.mkdir(parents=True, exist_ok=True)
+  (dist_info / "METADATA").write_text(
+      f"Metadata-Version: 2.1\n"
+      f"Name: {PACKAGE_DIST_NAME}\n"
+      f"Version: {version}\n",
+      encoding="utf-8",
+  )
+  return dist_info
 
 
 def stamp_manifest_version(version: str, *, dry_run: bool = False) -> dict:
@@ -144,6 +176,7 @@ def build(
   """Vendor + stamp + (optionally) tar. Returns a summary dict."""
   version = resolve_version()
   vendor_target = vendor_package()
+  dist_info = write_vendor_dist_info(version)
   manifest = stamp_manifest_version(version)
   tar_path: Path | None = None
   if not skip_tar:
@@ -151,6 +184,7 @@ def build(
   return {
       "version": version,
       "vendor_target": str(vendor_target),
+      "vendor_dist_info": str(dist_info),
       "manifest_version": manifest["version"],
       "tar_path": str(tar_path) if tar_path else None,
   }

--- a/producers/tests/test_build_claude_plugin.py
+++ b/producers/tests/test_build_claude_plugin.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Claude Code plugin artifact build script.
+
+Covers:
+  * vendor copy lands at the expected path
+  * manifest version is stamped from package metadata
+  * tarball contains the manifest, hooks, and vendored package
+  * a vendored plugin layout can actually fire a hook (PYTHONPATH +
+    python -m bigquery_agent_analytics_tracing.claude_code)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+# scripts/ lives next to tests/ under producers/, but is not on
+# sys.path by default — pyproject only puts src/ there. Append it so
+# the build module is importable from tests.
+_PRODUCERS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PRODUCERS_DIR / "scripts"))
+
+import build_claude_plugin  # noqa: E402  (after sys.path tweak)
+
+REPO_ROOT = _PRODUCERS_DIR.parent
+PLUGIN_DIR = REPO_ROOT / "plugins" / "claude_code"
+MANIFEST_PATH = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+
+
+@pytest.fixture
+def restore_manifest():
+  """Snapshot the manifest before each test and restore after.
+
+  Tests call ``build_claude_plugin.build()`` which mutates the on-disk
+  manifest in place. Without this fixture the working copy would drift.
+  """
+  original = MANIFEST_PATH.read_text(encoding="utf-8")
+  yield
+  MANIFEST_PATH.write_text(original, encoding="utf-8")
+
+
+@pytest.fixture
+def cleanup_vendor():
+  yield
+  vendor_root = PLUGIN_DIR / "vendor"
+  if vendor_root.exists():
+    shutil.rmtree(vendor_root)
+
+
+# ---------------------------------------------------------------------------
+# resolve_version
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_version_returns_a_string():
+  v = build_claude_plugin.resolve_version()
+  assert isinstance(v, str) and len(v) > 0
+
+
+def test_resolve_version_matches_pyproject_when_package_uninstalled(
+    monkeypatch,
+):
+  # Force the importlib.metadata branch to fail so the pyproject
+  # fallback is exercised; matches what CI does in a fresh checkout
+  # before `pip install -e .`.
+  from importlib import metadata as _md
+
+  def _raise(_name):
+    raise _md.PackageNotFoundError("bigquery-agent-analytics-tracing")
+
+  monkeypatch.setattr(build_claude_plugin.metadata, "version", _raise)
+
+  import tomllib
+
+  pyproject = _PRODUCERS_DIR / "pyproject.toml"
+  with pyproject.open("rb") as fh:
+    expected = tomllib.load(fh)["project"]["version"]
+  assert build_claude_plugin.resolve_version() == expected
+
+
+# ---------------------------------------------------------------------------
+# vendor_package + stamp_manifest_version
+# ---------------------------------------------------------------------------
+
+
+def test_vendor_package_copies_module_files(cleanup_vendor):
+  target = build_claude_plugin.vendor_package()
+
+  assert target.is_dir()
+  assert (target / "__init__.py").is_file()
+  assert (target / "claude_code.py").is_file()
+  assert (target / "drain.py").is_file()
+  assert (target / "logger.py").is_file()
+  assert (target / "schema.py").is_file()
+  assert (target / "config.py").is_file()
+  assert (target / "_utils.py").is_file()
+  assert (target / "_writer_identity.py").is_file()
+
+
+def test_vendor_package_ignores_pycache(cleanup_vendor, tmp_path):
+  # Drop a fake __pycache__ under the source so we can verify it does
+  # not get copied. Use a temp checkout root to avoid polluting the
+  # live src/ tree.
+  fake_src_root = tmp_path / "producers" / "src"
+  fake_pkg = fake_src_root / build_claude_plugin.PACKAGE_IMPORT_NAME
+  fake_pkg.mkdir(parents=True)
+  (fake_pkg / "__init__.py").write_text("")
+  (fake_pkg / "__pycache__").mkdir()
+  (fake_pkg / "__pycache__" / "stale.pyc").write_bytes(b"\x00")
+
+  # Run the copy step with PACKAGE_SRC pointed at the fake tree.
+  src_backup = build_claude_plugin.PACKAGE_SRC
+  build_claude_plugin.PACKAGE_SRC = fake_pkg
+  try:
+    target = build_claude_plugin.vendor_package()
+    assert (target / "__init__.py").is_file()
+    assert not (target / "__pycache__").exists()
+  finally:
+    build_claude_plugin.PACKAGE_SRC = src_backup
+
+
+def test_stamp_manifest_version_writes_resolved_version(restore_manifest):
+  build_claude_plugin.stamp_manifest_version("9.9.9-test")
+
+  written = json.loads(MANIFEST_PATH.read_text())
+  assert written["version"] == "9.9.9-test"
+  # Other manifest fields untouched.
+  assert written["name"] == "bigquery-agent-analytics-tracing"
+  assert "SessionStart" in written["hooks"]
+
+
+# ---------------------------------------------------------------------------
+# build() end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_build_produces_vendor_tree_and_tarball(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  summary = build_claude_plugin.build(dist_dir=tmp_path / "dist")
+
+  assert summary["version"] == build_claude_plugin.resolve_version()
+  assert summary["manifest_version"] == summary["version"]
+  assert Path(summary["vendor_target"]).is_dir()
+  assert Path(summary["tar_path"]).is_file()
+
+  # Tarball name has the version baked in.
+  tar_path = Path(summary["tar_path"])
+  assert summary["version"] in tar_path.name
+  assert tar_path.name.startswith(build_claude_plugin.PLUGIN_ARTIFACT_PREFIX)
+
+  # Tar contents include the manifest, hooks, and vendored module.
+  with tarfile.open(tar_path, "r:gz") as tar:
+    names = tar.getnames()
+  assert any(n.endswith(".claude-plugin/plugin.json") for n in names)
+  assert any(n.endswith("hooks/common.sh") for n in names)
+  assert any(n.endswith("hooks/session_start.sh") for n in names)
+  assert any(
+      n.endswith("vendor/bigquery_agent_analytics_tracing/claude_code.py")
+      for n in names
+  )
+  # __pycache__ excluded.
+  assert not any("__pycache__" in n for n in names)
+  # .gitignore excluded so marketplace users don't see internal-only files.
+  assert not any(n.endswith("/.gitignore") for n in names)
+
+
+def test_build_skip_tar_only_vendors_and_stamps(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  summary = build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+  assert summary["tar_path"] is None
+  assert Path(summary["vendor_target"]).is_dir()
+  assert not (tmp_path / "dist").exists()
+
+
+# ---------------------------------------------------------------------------
+# Real vendored-plugin hook fires through python -m without wheel install
+# ---------------------------------------------------------------------------
+
+
+def test_vendored_plugin_can_run_claude_hook_via_python_m(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  """End-to-end sanity: build the plugin, then run the hook entry the
+  same way ``hooks/common.sh`` does — PYTHONPATH=vendor + python -m —
+  with no tracing wheel installed on the subprocess's Python. Mirrors
+  the marketplace install path."""
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  log_file = tmp_path / "bqaa.log"
+  spool_dir = tmp_path / "spool"
+  state_dir = tmp_path / "state"
+  vendor_root = PLUGIN_DIR / "vendor"
+
+  env = {
+      # PYTHONPATH points only at the vendor tree — no producers/src/
+      # so the test exercises the marketplace install model.
+      "PYTHONPATH": str(vendor_root),
+      "BQAA_DRY_RUN": "true",
+      "BQAA_LOG_FILE": str(log_file),
+      "BQAA_SPOOL_DIR": str(spool_dir),
+      "BQAA_STATE_DIR": str(state_dir),
+      "PATH": "/usr/bin:/bin",
+  }
+  result = subprocess.run(
+      [
+          sys.executable,
+          "-m",
+          "bigquery_agent_analytics_tracing.claude_code",
+          "SessionStart",
+      ],
+      env=env,
+      input=json.dumps({"session_id": "vendored", "cwd": str(tmp_path)}),
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  assert (
+      result.returncode == 0
+  ), f"stdout={result.stdout!r} stderr={result.stderr!r}"
+  # SessionStart only sets state; check the state file landed.
+  assert (state_dir / "state_vendored.json").is_file()
+
+
+def test_vendored_plugin_can_run_user_prompt_submit_and_emit_row(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  log_file = tmp_path / "bqaa.log"
+  spool_dir = tmp_path / "spool"
+  state_dir = tmp_path / "state"
+  vendor_root = PLUGIN_DIR / "vendor"
+
+  base_env = {
+      "PYTHONPATH": str(vendor_root),
+      "BQAA_DRY_RUN": "true",
+      "BQAA_LOG_FILE": str(log_file),
+      "BQAA_SPOOL_DIR": str(spool_dir),
+      "BQAA_STATE_DIR": str(state_dir),
+      "PATH": "/usr/bin:/bin",
+  }
+
+  def _fire(hook, payload):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bigquery_agent_analytics_tracing.claude_code",
+            hook,
+        ],
+        env=base_env,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+  ss = _fire("SessionStart", {"session_id": "s1", "cwd": str(tmp_path)})
+  assert ss.returncode == 0, ss.stderr
+  ups = _fire(
+      "UserPromptSubmit",
+      {"session_id": "s1", "prompt": "hi", "transcript_path": ""},
+  )
+  assert ups.returncode == 0, ups.stderr
+
+  # One LLM_REQUEST row should have landed in the dry-run log.
+  text = log_file.read_text()
+  rows = [
+      json.loads(line.split("DRY_RUN ", 1)[1])
+      for line in text.splitlines()
+      if "DRY_RUN " in line
+  ]
+  assert any(
+      r["event_type"] == "LLM_REQUEST" for r in rows
+  ), f"no LLM_REQUEST in vendored-plugin log: {text}"
+
+
+def test_vendored_plugin_respects_trace_enabled_kill_switch_via_shell(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  """common.sh checks ``BQAA_TRACE_ENABLED`` before launching python.
+  Verify the shell exits 0 without spawning anything when it's off."""
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  common_sh = PLUGIN_DIR / "hooks" / "session_start.sh"
+  assert common_sh.is_file()
+
+  env = os.environ.copy()
+  env.update(
+      {
+          "BQAA_TRACE_ENABLED": "false",
+          "PYTHONPATH": str(PLUGIN_DIR / "vendor"),
+          "BQAA_DRY_RUN": "true",
+          "BQAA_LOG_FILE": str(tmp_path / "bqaa.log"),
+          "BQAA_SPOOL_DIR": str(tmp_path / "spool"),
+          "BQAA_STATE_DIR": str(tmp_path / "state"),
+          # Force python_bin to a path that would error if invoked, to prove
+          # the shell short-circuits before trying to exec it.
+          "BQAA_PYTHON": "/nonexistent/python-that-would-fail",
+      }
+  )
+  result = subprocess.run(
+      ["bash", str(common_sh)],
+      env=env,
+      input="{}",
+      capture_output=True,
+      text=True,
+      timeout=10,
+  )
+  assert result.returncode == 0, (
+      f"BQAA_TRACE_ENABLED=false should short-circuit cleanly;"
+      f" stderr={result.stderr!r}"
+  )
+  # No log file written because we never reached python.
+  assert not (tmp_path / "bqaa.log").exists()

--- a/producers/tests/test_build_claude_plugin.py
+++ b/producers/tests/test_build_claude_plugin.py
@@ -142,6 +142,44 @@ def test_vendor_package_ignores_pycache(cleanup_vendor, tmp_path):
     build_claude_plugin.PACKAGE_SRC = src_backup
 
 
+def test_write_vendor_dist_info_creates_pep_376_metadata(cleanup_vendor):
+  # The METADATA file is what importlib.metadata.version() reads to
+  # resolve a vendored install. Generate one alongside the vendored
+  # package and verify shape.
+  build_claude_plugin.vendor_package()
+  dist_info = build_claude_plugin.write_vendor_dist_info("9.9.9-test")
+
+  assert dist_info.name == (
+      f"{build_claude_plugin.PACKAGE_IMPORT_NAME}-9.9.9-test.dist-info"
+  )
+  metadata_text = (dist_info / "METADATA").read_text(encoding="utf-8")
+  assert "Metadata-Version: 2.1" in metadata_text
+  assert f"Name: {build_claude_plugin.PACKAGE_DIST_NAME}" in metadata_text
+  assert "Version: 9.9.9-test" in metadata_text
+
+
+def test_vendor_package_wipes_stale_dist_info(cleanup_vendor):
+  # Drop a stale dist-info to simulate an older build's leftovers,
+  # then re-vendor and confirm only the fresh tree is present.
+  build_claude_plugin.vendor_package()
+  stale = (
+      build_claude_plugin.PLUGIN_DIR
+      / "vendor"
+      / f"{build_claude_plugin.PACKAGE_IMPORT_NAME}-0.0.1-old.dist-info"
+  )
+  stale.mkdir()
+  (stale / "METADATA").write_text(
+      "Metadata-Version: 2.1\nName: x\nVersion: 0.0.1-old\n"
+  )
+
+  build_claude_plugin.vendor_package()
+
+  assert not stale.exists(), (
+      "stale dist-info from an older build must be cleared so"
+      " importlib.metadata.version() does not see two distributions"
+  )
+
+
 def test_stamp_manifest_version_writes_resolved_version(restore_manifest):
   build_claude_plugin.stamp_manifest_version("9.9.9-test")
 
@@ -182,6 +220,13 @@ def test_build_produces_vendor_tree_and_tarball(
       n.endswith("vendor/bigquery_agent_analytics_tracing/claude_code.py")
       for n in names
   )
+  # PEP 376 .dist-info/METADATA must ride along so importlib.metadata
+  # can resolve the vendored install's version at runtime.
+  assert any(
+      n.endswith(".dist-info/METADATA")
+      and f"{build_claude_plugin.PACKAGE_IMPORT_NAME}-{summary['version']}" in n
+      for n in names
+  ), f"vendored .dist-info missing from tarball; names={names!r}"
   # __pycache__ excluded.
   assert not any("__pycache__" in n for n in names)
   # .gitignore excluded so marketplace users don't see internal-only files.
@@ -388,6 +433,24 @@ def test_vendored_plugin_spools_and_spawns_drainer_with_inherited_pythonpath(
   envelope = json.loads(spool_files[0].read_text())
   assert envelope["row"]["event_type"] == "LLM_REQUEST"
   assert envelope["config"]["project_id"] == "fake-project"
+
+  # 1a. attributes.writer.version must reflect the resolved package
+  # version, NOT the "0.0.0+local" fallback. This is the
+  # adoption-query contract for marketplace installs: every row from
+  # the vendored plugin reports the same version that the artifact
+  # was built from.
+  resolved_version = build_claude_plugin.resolve_version()
+  writer = json.loads(envelope["row"]["attributes"])["writer"]
+  assert writer["version"] == resolved_version, (
+      f"vendored runtime stamped writer.version={writer['version']!r};"
+      f" expected {resolved_version!r}. Likely the .dist-info under"
+      " vendor/ is missing or stale."
+  )
+  assert writer["version"] != "0.0.0+local", (
+      "writer.version fell back to local sentinel — vendored .dist-info"
+      " resolution is broken"
+  )
+  assert writer["label"].endswith(f"/{resolved_version}")
 
   # 2. Drainer subprocess was actually spawned with the right -m args.
   assert (

--- a/producers/tests/test_build_claude_plugin.py
+++ b/producers/tests/test_build_claude_plugin.py
@@ -90,7 +90,10 @@ def test_resolve_version_matches_pyproject_when_package_uninstalled(
 
   monkeypatch.setattr(build_claude_plugin.metadata, "version", _raise)
 
-  import tomllib
+  try:
+    import tomllib
+  except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
   pyproject = _PRODUCERS_DIR / "pyproject.toml"
   with pyproject.open("rb") as fh:
@@ -295,6 +298,113 @@ def test_vendored_plugin_can_run_user_prompt_submit_and_emit_row(
   assert any(
       r["event_type"] == "LLM_REQUEST" for r in rows
   ), f"no LLM_REQUEST in vendored-plugin log: {text}"
+
+
+def test_vendored_plugin_spools_and_spawns_drainer_with_inherited_pythonpath(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  """The full vendored runtime model: hook process imports from
+  ``PYTHONPATH=vendor`` (no wheel install), the logger writes a real
+  spool envelope (not dry-run), and the drainer subprocess is spawned
+  with ``PYTHONPATH`` inherited via ``os.environ.copy()`` — so it can
+  import the vendored package on its own.
+
+  Uses a fake recorder as ``BQAA_PYTHON`` so the drainer spawn never
+  has to talk to BigQuery. The recorder logs its argv + the inherited
+  ``PYTHONPATH`` and exits 0; the test asserts both.
+  """
+  import time as _time
+
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  spool_dir = tmp_path / "spool"
+  state_dir = tmp_path / "state"
+  vendor_root = PLUGIN_DIR / "vendor"
+  log_file = tmp_path / "bqaa.log"
+  recorder_log = tmp_path / "drainer-recorder.log"
+  recorder = tmp_path / "fake_drainer.sh"
+  recorder.write_text(
+      "#!/bin/bash\n"
+      f"printf 'ARGS=%s\\n' \"$*\" >> {recorder_log}\n"
+      f"printf 'PYTHONPATH=%s\\n' \"$PYTHONPATH\" >> {recorder_log}\n"
+      "exit 0\n"
+  )
+  recorder.chmod(0o755)
+
+  env = {
+      "PYTHONPATH": str(vendor_root),
+      # Real routing (not dry-run); project/dataset must be set so the
+      # logger does not raise. The recorder catches the drainer spawn
+      # before any BigQuery client is built.
+      "BQAA_PROJECT_ID": "fake-project",
+      "BQAA_DATASET": "fake_dataset",
+      "BQAA_DRY_RUN": "false",
+      "BQAA_DIRECT_WRITE": "false",
+      "BQAA_SPOOL_DIR": str(spool_dir),
+      "BQAA_STATE_DIR": str(state_dir),
+      "BQAA_LOG_FILE": str(log_file),
+      "BQAA_PYTHON": str(recorder),
+      "PATH": "/usr/bin:/bin",
+  }
+
+  def _fire(hook, payload):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bigquery_agent_analytics_tracing.claude_code",
+            hook,
+        ],
+        env=env,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+  ss = _fire("SessionStart", {"session_id": "vp-d", "cwd": str(tmp_path)})
+  assert ss.returncode == 0, ss.stderr
+  ups = _fire(
+      "UserPromptSubmit",
+      {"session_id": "vp-d", "prompt": "hi", "transcript_path": ""},
+  )
+  assert ups.returncode == 0, ups.stderr
+
+  # The hook is detached from the drainer spawn — give the recorder a
+  # short window to flush its log line. ~3s ceiling so this never
+  # silently hangs CI.
+  deadline = _time.time() + 3.0
+  while _time.time() < deadline:
+    if recorder_log.exists() and recorder_log.read_text().strip():
+      break
+    _time.sleep(0.05)
+
+  # 1. Real spool envelope was written (not dry-run path).
+  spool_files = list(spool_dir.glob("event-*.json"))
+  assert spool_files, (
+      "hook should have written a spool envelope under non-dry-run routing;"
+      f" log={log_file.read_text() if log_file.exists() else '(none)'}"
+  )
+  envelope = json.loads(spool_files[0].read_text())
+  assert envelope["row"]["event_type"] == "LLM_REQUEST"
+  assert envelope["config"]["project_id"] == "fake-project"
+
+  # 2. Drainer subprocess was actually spawned with the right -m args.
+  assert (
+      recorder_log.exists()
+  ), "drainer spawn never fired the recorder — vendored runtime is broken"
+  log_text = recorder_log.read_text()
+  assert (
+      "-m bigquery_agent_analytics_tracing.drain" in log_text
+  ), f"drainer argv missing -m invocation: {log_text!r}"
+
+  # 3. PYTHONPATH was inherited so the drainer can import the vendored
+  # package without a wheel install — the exact runtime contract for
+  # the marketplace path.
+  assert f"PYTHONPATH={vendor_root}" in log_text, (
+      f"drainer did not inherit PYTHONPATH={vendor_root!r};"
+      f" got: {log_text!r}"
+  )
 
 
 def test_vendored_plugin_respects_trace_enabled_kill_switch_via_shell(


### PR DESCRIPTION
Maps to **steps 2 + 3 of #234** — adds the plugin source tree, the vendoring build script, and the CI wiring that produces the marketplace-installable artifact. Release-to-PyPI plumbing stays out of scope (PR C / step 4).

Refs #234, #229.

## Plugin tree (`plugins/claude_code/`)

| Path | Purpose |
|---|---|
| `.claude-plugin/plugin.json` | Native Claude Code manifest declaring all nine hooks. Version is a placeholder (`0.0.0+local`) that the build script stamps with the resolved value at release time. |
| `hooks/common.sh` | Shared shell entry. Sets `PYTHONPATH` to the vendored package root, then execs `python -m bigquery_agent_analytics_tracing.claude_code <HookName>`. The drainer subprocess inherits the same `PYTHONPATH` via `os.environ.copy()` — covers the failure mode #234 step 3 calls out. Respects `BQAA_TRACE_ENABLED=false` as a clean short-circuit before spawning Python. |
| `hooks/<hook>.sh` × 9 | One-line stubs that exec common.sh with the hook name. |
| `.gitignore` | Excludes `vendor/` so the canonical source is always `producers/src/` — no drift between the wheel and the plugin. |
| `README.md` | Runtime model, layout, build instructions, required runtime deps on `BQAA_PYTHON`. |

## Build script (`producers/scripts/build_claude_plugin.py`)

| Function | Behavior |
|---|---|
| `resolve_version()` | Prefers installed distribution metadata (matches what `__version__` resolves to at runtime), falls back to reading `producers/pyproject.toml` for fresh checkouts. |
| `vendor_package()` | Copies `producers/src/bigquery_agent_analytics_tracing/` into `plugins/claude_code/vendor/`, skipping `__pycache__` / `*.pyc`. |
| `stamp_manifest_version()` | Writes the resolved version into `.claude-plugin/plugin.json` so wheel and plugin always ship the same version label. |
| `build_tarball()` | Tars the plugin tree into `producers/dist/bigquery-agent-analytics-tracing-claude-code-<version>.tar.gz`, excluding `.gitignore` and `__pycache__` so the artifact is exactly what marketplace install sees. |
| `main()` | argparse CLI (`--dist-dir`, `--skip-tar`). Emits a JSON summary on stdout for CI to log. |

## CI (`.github/workflows/producers-ci.yml`)

- `plugins/claude_code/**` added to `paths:` triggers.
- Build job: installs the wheel produced by `python -m build`, then invokes `python scripts/build_claude_plugin.py`. Installing the wheel first makes `importlib.metadata.version` resolve correctly so the manifest gets a real version stamped, not the pyproject fallback.
- The existing `producers-dist` upload artifact now carries both the wheel/sdist and the plugin tarball.

## Tests — 10 new, 72 total, all green

- `resolve_version` — returns non-empty string; pyproject fallback exercised when `importlib.metadata.version` is forced to fail
- `vendor_package` — copies every expected module file; skips `__pycache__` via a temp fake-source fixture
- `stamp_manifest_version` — version writes correctly, other manifest fields untouched. Snapshot-restore fixture protects the source-controlled manifest from test drift
- `build` end-to-end — tarball name has version baked in, contains manifest + hooks + vendored module, excludes `__pycache__` and `.gitignore`
- `build(skip_tar=True)` — only vendors and stamps, no tarball
- **Vendored plugin end-to-end** — fires `SessionStart` and `UserPromptSubmit` via `python -m bigquery_agent_analytics_tracing.claude_code` with `PYTHONPATH` pointing only at `vendor/` (no `producers/src/` on path). Asserts the SessionStart state file landed and the LLM_REQUEST row hit the dry-run log. This is exactly the runtime model marketplace users will experience.
- `BQAA_TRACE_ENABLED=false` shell short-circuit — invokes `hooks/session_start.sh` with the kill switch on plus a deliberately invalid `BQAA_PYTHON`; asserts exit 0 and no log file written, proving the shell exits before trying to launch Python.

## Acceptance criteria from #234 covered here

- [x] Hook → spool → drainer works from the vendored plugin path with `BQAA_TRACE_ENABLED=true` (vendored plugin smoke tests)
- [x] `BQAA_TRACE_ENABLED=false` cleanly disables emission (shell short-circuit test)
- [x] Dry-run writes expected rows without BigQuery access (carried over from PR A + exercised in vendored plugin tests)
- [x] CI builds the wheel/sdist and plugin artifact
- [x] Plugin artifact is generated from source rather than maintained as a second vendored copy

Deferred to follow-up PRs per #234:
- [ ] `pip install bigquery-agent-analytics-tracing` from PyPI — PR C (step 4)
- [ ] TestPyPI smoke install — PR C (step 4)
- [ ] Marketplace metadata polish + install docs + `/bqaa-setup` interactive flow — PR D (step 5)

## Test plan

- [x] `pytest tests/ -q` — 72/72 pass on Python 3.13.5
- [x] `pyink src/ tests/ scripts/ --check` — clean
- [x] `isort src/ tests/ scripts/` — clean
- [x] `python scripts/build_claude_plugin.py` produces wheel + sdist + plugin tarball
- [x] Vendored plugin: `python -m bigquery_agent_analytics_tracing.claude_code SessionStart` with `PYTHONPATH=plugins/claude_code/vendor` exits 0
- [x] `BQAA_TRACE_ENABLED=false bash plugins/claude_code/hooks/session_start.sh` exits 0 without spawning Python
- [ ] Producers CI — green after maintainer approves the first-time-fork gate
- [ ] Live BigQuery round-trip with the vendored plugin — recommended manual smoke before merging