### PR TITLE
feat(categorical_evaluator): concurrent session scoring in API fallback path (#226)

### DIFF
--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -56,6 +56,7 @@ Example usage::
 
 from __future__ import annotations
 
+import asyncio
 from collections import Counter
 from datetime import datetime
 from datetime import timezone
@@ -134,6 +135,15 @@ class CategoricalEvaluationConfig(BaseModel):
       ge=1,
       le=65536,
       description="Max output tokens for classification response.",
+  )
+  api_concurrency: int = Field(
+      default=5,
+      ge=1,
+      description=(
+          "Max concurrent Gemini API calls when the API fallback path runs "
+          "(used by classify_sessions_via_api). Matches the convention in "
+          "trace_evaluator.py and multi_trial.py."
+      ),
   )
   prompt_version: Optional[str] = Field(
       default=None,
@@ -839,24 +849,40 @@ async def classify_sessions_via_api(
   BigQuery-native ``AI.GENERATE`` path so that results are
   shape-compatible regardless of execution mode.
 
+  Per-session work runs concurrently under a semaphore sized by
+  ``config.api_concurrency`` (default 5, matching the convention in
+  ``trace_evaluator.py`` and ``multi_trial.py``). Output order matches
+  ``transcripts.items()`` insertion order.
+
+  Per-session ``Exception`` is caught inside the worker and converted to
+  a parse-error ``CategoricalSessionResult`` so one bad session does not
+  abort the batch. ``BaseException`` subclasses (``CancelledError``,
+  ``KeyboardInterrupt``, ``SystemExit``) deliberately propagate.
+
   Args:
       transcripts: Maps ``session_id`` to transcript text.
       config: Categorical evaluation configuration.
       endpoint: Model endpoint name.
 
   Returns:
-      One ``CategoricalSessionResult`` per session.
+      One ``CategoricalSessionResult`` per session, in input order.
   """
   prompt_prefix = build_categorical_prompt(config)
-  results: list[CategoricalSessionResult] = []
 
   try:
     from google import genai
     from google.genai import types
+  except ImportError:
+    logger.warning("google-genai not installed; cannot run API fallback.")
+    raise
 
-    client = genai.Client()
+  client = genai.Client()
+  semaphore = asyncio.Semaphore(config.api_concurrency)
 
-    for sid, transcript in transcripts.items():
+  async def _classify_one(
+      sid: str, transcript: str
+  ) -> CategoricalSessionResult:
+    async with semaphore:
       text = transcript
       if len(text) > 25000:
         text = text[:25000] + "\n... [truncated]"
@@ -887,11 +913,9 @@ async def classify_sessions_via_api(
               len(raw_text),
               repr(raw_text[:500]),
           )
-        results.append(
-            CategoricalSessionResult(
-                session_id=sid,
-                metrics=metrics,
-            )
+        return CategoricalSessionResult(
+            session_id=sid,
+            metrics=metrics,
         )
       except Exception as e:
         logger.warning(
@@ -900,25 +924,22 @@ async def classify_sessions_via_api(
             e,
             type(e).__name__,
         )
-        results.append(
-            CategoricalSessionResult(
-                session_id=sid,
-                metrics=[
-                    CategoricalMetricResult(
-                        metric_name=m.name,
-                        parse_error=True,
-                        passed_validation=False,
-                        raw_response=str(e),
-                    )
-                    for m in config.metrics
-                ],
-            )
+        return CategoricalSessionResult(
+            session_id=sid,
+            metrics=[
+                CategoricalMetricResult(
+                    metric_name=m.name,
+                    parse_error=True,
+                    passed_validation=False,
+                    raw_response=str(e),
+                )
+                for m in config.metrics
+            ],
         )
-  except ImportError:
-    logger.warning("google-genai not installed; cannot run API fallback.")
-    raise
 
-  return results
+  tasks = [_classify_one(sid, t) for sid, t in transcripts.items()]
+  results = await asyncio.gather(*tasks)
+  return list(results)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_categorical_evaluator.py
+++ b/tests/test_categorical_evaluator.py
@@ -47,8 +47,14 @@ from bigquery_agent_analytics.categorical_evaluator import parse_classify_row
 # ------------------------------------------------------------------ #
 
 
-def _make_config(include_justification=True):
-  """Builds a two-metric config for testing."""
+def _make_config(include_justification=True, **overrides):
+  """Builds a two-metric config for testing.
+
+  Forwards arbitrary keyword overrides to ``CategoricalEvaluationConfig``
+  so individual tests can set fields like ``api_concurrency``,
+  ``temperature``, or ``max_output_tokens`` without redefining the
+  metric list.
+  """
   return CategoricalEvaluationConfig(
       metrics=[
           CategoricalMetricDefinition(
@@ -85,6 +91,7 @@ def _make_config(include_justification=True):
           ),
       ],
       include_justification=include_justification,
+      **overrides,
   )
 
 
@@ -893,6 +900,69 @@ class TestClassifySessionsViaApi:
     call_args = mock_aio_models.generate_content.call_args
     prompt_sent = call_args[1]["contents"]
     assert "[truncated]" in prompt_sent
+
+  def test_runs_concurrently(self):
+    """Verify multiple sessions can be in-flight simultaneously rather than
+    running strictly one-at-a-time. Asserts max_in_flight > 1 — a direct
+    invariant that doesn't depend on wall-clock timing (which would flake
+    under CI load).
+    """
+    config = _make_config(api_concurrency=5)
+    transcripts = {f"s{i}": f"transcript_{i}" for i in range(10)}
+
+    in_flight = 0
+    max_in_flight = 0
+
+    raw_response = json.dumps(
+        [
+            {"metric_name": "tone", "category": "positive"},
+            {"metric_name": "safety", "category": "safe"},
+        ]
+    )
+
+    async def fake_generate(*args, **kwargs):
+      nonlocal in_flight, max_in_flight
+      in_flight += 1
+      max_in_flight = max(max_in_flight, in_flight)
+      # Yield so other tasks waiting on the semaphore can enter.
+      await asyncio.sleep(0)
+      in_flight -= 1
+      resp = MagicMock()
+      resp.text = raw_response
+      return resp
+
+    # Build the client directly: _make_genai_client wraps in AsyncMock with
+    # side_effect/return_value, which doesn't compose with a custom async
+    # body needed for in-flight tracking.
+    mock_aio_models = MagicMock()
+    mock_aio_models.generate_content = fake_generate
+    mock_aio = MagicMock()
+    mock_aio.models = mock_aio_models
+    mock_client = MagicMock()
+    mock_client.aio = mock_aio
+
+    with _mock_genai_modules(mock_client):
+      results = _run(classify_sessions_via_api(transcripts, config))
+
+    assert len(results) == 10
+    # Output order matches input dict insertion order.
+    assert [r.session_id for r in results] == [f"s{i}" for i in range(10)]
+    assert max_in_flight > 1, (
+        f"Expected concurrent execution under api_concurrency=5, "
+        f"observed max_in_flight={max_in_flight}"
+    )
+
+  def test_api_concurrency_default(self):
+    """Default api_concurrency is 5, matching trace_evaluator / multi_trial."""
+    config = _make_config()
+    assert config.api_concurrency == 5
+
+  def test_api_concurrency_rejects_zero(self):
+    """api_concurrency=0 is rejected at config construction (Pydantic ge=1)
+    rather than at runtime — asyncio.Semaphore(0) would hang every task.
+    """
+    with pytest.raises(ValueError):
+      _make_config(api_concurrency=0)
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Closes #226 — replaces the sequential per-session `for` loop in `classify_sessions_via_api` with `asyncio.Semaphore` + `asyncio.gather`, matching the existing convention in `trace_evaluator.py:735-750` and `multi_trial.py:239-261`.

## What changed

**Producer (`src/bigquery_agent_analytics/categorical_evaluator.py`):**

- `CategoricalEvaluationConfig.api_concurrency: int = Field(default=5, ge=1, ...)` — new public field. Default `5` matches `trace_evaluator`'s convention. Pydantic `ge=1` rejects `0` / negative values at config construction so `asyncio.Semaphore(0)` (which would hang every task) can never be reached at runtime.
- `import asyncio` lifted to module scope.
- Per-session work wrapped in a `_classify_one(sid, transcript)` coroutine guarded by `asyncio.Semaphore(config.api_concurrency)`. The inner `try/except Exception` boundary is preserved so a failing session still produces a parse-error `CategoricalSessionResult` rather than aborting the batch. `BaseException` subclasses (`CancelledError`, `KeyboardInterrupt`, `SystemExit`) deliberately propagate.
- Output order matches input order (gather preserves task order; Python dicts are insertion-ordered since 3.7). Both `client.py` callers — `client.py:1586` (retry loop) and `client.py:1663` (direct fallback) — work unchanged.

**Tests (`tests/test_categorical_evaluator.py`):**

- `test_classify_sessions_runs_concurrently` — drives 10 sessions under `api_concurrency=5` with an async fake that tracks `max_in_flight`. Asserts `max_in_flight > 1` (direct invariant, no wall-clock budget — CI-flake-safe) and verifies output order matches input order.
- `test_api_concurrency_default` — pins default of `5`.
- `test_api_concurrency_rejects_zero` — pins Pydantic `ge=1` so the semaphore-zero hang is unreachable.
- `_make_config()` helper widened to accept `**overrides` so this test (and future ones) can configure `api_concurrency`, `temperature`, `max_output_tokens`, etc. without redefining the metric list.

## Why the inner `except Exception` is the right boundary

`asyncio.gather(*tasks)` is used without `return_exceptions=True`. The inner `try/except Exception` already converts every per-session API failure into a parse-error session result, so no `Exception` escapes `_classify_one`. The decision to not also catch `BaseException` is deliberate:

- `asyncio.CancelledError` — user-initiated cancellation should propagate, not be swallowed and reported as N failed classifications
- `KeyboardInterrupt` — same shape
- `SystemExit` — should terminate, not get mapped to "session classification failed"

## Default value rationale

`5` matches `trace_evaluator.py::evaluate_dataset(..., concurrency=5)`. `multi_trial.py::run_trials(..., concurrency=3)` is slightly lower because trials each issue multiple LLM calls; the categorical-fallback path issues exactly one call per session, so `5` is consistent with the trace-evaluator workload pattern.

## Validation

- `pytest tests/test_categorical_evaluator.py tests/test_categorical_views.py -q` → `141 passed`
- `pyink --config pyproject.toml --check src/.../categorical_evaluator.py tests/test_categorical_evaluator.py` → clean
- `isort --settings-path pyproject.toml --check-only src/.../categorical_evaluator.py tests/test_categorical_evaluator.py` → clean
- `git diff --check origin/main..HEAD` → clean
- The pre-existing `test_api_exception_per_session` (line 814 of the test file) continues to assert that `results[0]` is the successful session and `results[1]` is the failed one — proving output order is preserved under concurrent dispatch without modifying the test.

## Test plan

- [x] Unit tests pass (141 / 141)
- [x] pyink clean
- [x] isort clean
- [x] git diff --check clean
- [x] Output ordering verified by existing `test_api_exception_per_session` and new `test_classify_sessions_runs_concurrently` order assertion
- [x] Invalid concurrency value rejected at config construction by `test_api_concurrency_rejects_zero`

## Scope notes

- **No top-level schema impact.** No changes to BigQuery columns, no migration needed.
- **No caller changes required.** Both `client.py` callers pass `config` to `classify_sessions_via_api(...)`; the function reads `config.api_concurrency` internally. Existing callers automatically pick up the new default.
- **Out of scope per the issue thread:** `return_exceptions=True` defense layer (would swallow cancellation; the issue thread agreed to drop this). `_infer_corrections` mentioned in the issue title doesn't exist — the retry-with-backoff loop at `client.py:1577` is addressed transitively because each retry attempt calls `classify_sessions_via_api(remaining, ...)` in bulk.

Refs: #226
