### PR TITLE
producers: add release-tracing.yml + release runbook + install docs

### DIFF
--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -166,7 +166,12 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
-    needs: [verify, build]
+    # Depend on github-release too: the plugin tarball ships ONLY as a
+    # GitHub release asset, so if that step fails we must not let the
+    # wheel/sdist reach PyPI. Otherwise the "wheel and plugin always
+    # go together" invariant from RELEASING.md breaks silently.
+    # publish-pypi inherits the guard transitively via needs: publish-testpypi.
+    needs: [verify, build, github-release]
     environment:
       name: testpypi
       url: https://test.pypi.org/p/bigquery-agent-analytics-tracing

--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -1,0 +1,215 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Release the `bigquery-agent-analytics-tracing` package and the
+# Claude Code plugin tarball.
+#
+# Trigger: push a `tracing-vX.Y.Z` tag whose version matches
+# `producers/pyproject.toml`'s `[project].version`. The tag namespace
+# is distinct from the root `vX.Y.Z` tags used by the consumption SDK
+# so the two release pipelines never collide.
+#
+# Pipeline:
+#   verify          - tag matches pyproject; run producer tests on 3.12
+#   build           - wheel + sdist + Claude Code plugin tarball
+#   github-release  - attach all artifacts to the GitHub release for
+#                     this tag, with auto-generated release notes
+#   publish-testpypi - upload wheel + sdist to TestPyPI via Trusted
+#                      Publishing (no secrets)
+#   publish-pypi    - same, to PyPI (gated by the `pypi` environment
+#                     so maintainers can require manual approval)
+#
+# Trusted Publishing setup (one-time, on the PyPI side):
+#   - https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+#   - Project: bigquery-agent-analytics-tracing
+#   - Owner:   GoogleCloudPlatform
+#   - Repo:    BigQuery-Agent-Analytics-SDK
+#   - Workflow: release-tracing.yml
+#   - Environment: testpypi / pypi (match the `environment:` blocks
+#     below). Until the project + trusted publisher are configured on
+#     TestPyPI/PyPI, the publish jobs will fail with a clear error —
+#     `build` and `github-release` still produce + attach artifacts so
+#     the release tag is not blocked.
+
+name: Release tracing
+
+on:
+  push:
+    tags:
+      - 'tracing-v*'
+
+concurrency:
+  group: release-tracing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify version + tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: producers
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches pyproject version
+        id: version
+        run: |
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG="${GITHUB_REF_NAME#tracing-v}"
+          echo "Package version: ${PKG_VERSION}"
+          echo "Release tag:     ${GITHUB_REF_NAME} (extracted: ${TAG})"
+          if [ "${PKG_VERSION}" != "${TAG}" ]; then
+            echo "::error::Version mismatch: producers/pyproject.toml has ${PKG_VERSION} but tag is ${GITHUB_REF_NAME} (expected tracing-v${PKG_VERSION})"
+            exit 1
+          fi
+          echo "version=${PKG_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Install producers with dev deps
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --tb=short -q
+
+  build:
+    name: Build wheel + plugin tarball
+    runs-on: ubuntu-latest
+    needs: verify
+    defaults:
+      run:
+        working-directory: producers
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Install built wheel
+        # importlib.metadata.version() needs to see the dist-info so
+        # build_claude_plugin.py stamps the real version (not the
+        # pyproject fallback). Installing the wheel mirrors the
+        # producers-ci build path exactly.
+        run: pip install dist/bigquery_agent_analytics_tracing-*.whl
+
+      - name: Build Claude Code plugin tarball
+        run: python scripts/build_claude_plugin.py
+
+      - name: Verify all expected artifacts are present
+        run: |
+          ls -la dist/
+          test -f dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz \
+            || (echo "::error::missing sdist" && exit 1)
+          test -f dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl \
+            || (echo "::error::missing wheel" && exit 1)
+          test -f dist/bigquery-agent-analytics-tracing-claude-code-${{ needs.verify.outputs.version }}.tar.gz \
+            || (echo "::error::missing plugin tarball" && exit 1)
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-tracing-dist
+          path: producers/dist/
+          if-no-files-found: error
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: [verify, build]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-tracing-dist
+          path: dist/
+
+      - name: List downloaded artifacts
+        run: ls -la dist/
+
+      - name: Create release with artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Tracing ${{ github.ref_name }}"
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl
+            dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz
+            dist/bigquery-agent-analytics-tracing-claude-code-${{ needs.verify.outputs.version }}.tar.gz
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [verify, build]
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/bigquery-agent-analytics-tracing
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-tracing-dist
+          path: dist/
+
+      - name: Strip non-PyPI artifacts
+        # The plugin tarball is a release artifact, not a PyPI
+        # distribution. Filename uses hyphens in
+        # 'bigquery-agent-analytics-tracing-claude-code-*' so it's
+        # distinguishable from the underscore-named sdist.
+        run: |
+          rm -f dist/bigquery-agent-analytics-tracing-claude-code-*.tar.gz
+          ls -la dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [verify, publish-testpypi]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bigquery-agent-analytics-tracing
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-tracing-dist
+          path: dist/
+
+      - name: Strip non-PyPI artifacts
+        run: |
+          rm -f dist/bigquery-agent-analytics-tracing-claude-code-*.tar.gz
+          ls -la dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,19 @@ on:
   release:
     types: [published]
 
+# The release event has no tag-pattern filter, so any published
+# release fires this workflow. The producer pipeline publishes
+# `tracing-vX.Y.Z` releases (release-tracing.yml); without this
+# guard, every producer release would also trigger root SDK
+# publishing and fail version verification.
+#
+# Root SDK tags use the plain `vX.Y.Z` pattern; producer tags use
+# `tracing-vX.Y.Z`. Only the root pattern starts with literal `v`,
+# so this is an unambiguous boundary.
 jobs:
   build:
     name: Build package
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -49,6 +49,34 @@ itself, but the Python under `BQAA_PYTHON` still needs:
 A future `/bqaa-setup` slash command (planned in #234 step 5) will
 surface a single `pip install ...` line for missing deps.
 
+## Installing the plugin
+
+Until the plugin is submitted to the Claude Code marketplace, install
+from a GitHub release tarball:
+
+```bash
+# Pick a released version from
+# https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases
+VERSION=0.1.0.dev0
+
+mkdir -p ~/.claude/plugins
+curl -L \
+  "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
+  | tar -xz -C ~/.claude/plugins
+
+# Configure BigQuery destination + runtime deps (one-time).
+export BQAA_PROJECT_ID=your-gcp-project
+export BQAA_DATASET=agent_analytics
+pip install google-cloud-bigquery               # always
+pip install google-cloud-bigquery-storage pyarrow  # Storage Write path
+```
+
+Then point Claude Code at the unpacked plugin directory per the
+[Claude Code plugins docs](https://docs.claude.com/en/docs/claude-code/plugins).
+
+Marketplace submission is tracked in
+[#234 step 5](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/234).
+
 ## Building the artifact
 
 ```bash
@@ -58,4 +86,7 @@ python scripts/build_claude_plugin.py
 # → producers/dist/bigquery-agent-analytics-tracing-claude-code-X.Y.Z.tar.gz
 ```
 
-CI runs the same script and uploads the tarball as a workflow artifact.
+CI builds the same tarball on every release tag (see
+[producers/RELEASING.md](../../producers/RELEASING.md)). On regular PRs
+the plugin tarball is uploaded as a workflow artifact via the
+`producers-ci.yml` `build` job.

--- a/producers/README.md
+++ b/producers/README.md
@@ -4,19 +4,24 @@ Producer packages and tracing adapters that emit rows into the canonical
 BQAA `agent_events` schema consumed by the
 [`bigquery-agent-analytics`](../) SDK.
 
-This first cut ships only the shared writer and async drainer. Producer
-adapters (OpenAI Agents SDK, Codex CLI wrapper, Claude Code plugin) land in
-follow-up PRs tracked under
-[#229](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/229).
-
 ## Install
 
 ```bash
+# Core writer + drainer.
 pip install bigquery-agent-analytics-tracing
-pip install "bigquery-agent-analytics-tracing[storage-write]"  # BigQuery Storage Write API path
+
+# Storage Write API path (lower-latency, recommended for production).
+pip install "bigquery-agent-analytics-tracing[storage-write]"
 ```
 
-## Quickstart
+For dev work in this repo:
+
+```bash
+cd producers
+pip install -e ".[dev]"
+```
+
+## Quickstart (library)
 
 ```python
 from bigquery_agent_analytics_tracing import (
@@ -33,5 +38,42 @@ logger.log_event(
 )
 ```
 
-See the full architecture and roadmap in
-[#229](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/229).
+## Quickstart (Claude Code plugin)
+
+If you run Claude Code, the
+[Claude Code plugin artifact](../plugins/claude_code/) wires up all
+nine hooks for you. Until marketplace submission lands, install from
+a GitHub release tarball:
+
+```bash
+# Pick the version that matches the wheel you have installed.
+VERSION=$(python -c "from bigquery_agent_analytics_tracing import __version__; print(__version__)")
+mkdir -p ~/.claude/plugins
+curl -L \
+  "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
+  | tar -xz -C ~/.claude/plugins
+```
+
+The plugin tarball vendors its own copy of the tracing package, so
+the `BQAA_PYTHON` interpreter does **not** need
+`bigquery-agent-analytics-tracing` installed — only its runtime deps
+(`google-cloud-bigquery` always; `google-cloud-bigquery-storage` +
+`pyarrow` for the Storage Write path). See the
+[plugin README](../plugins/claude_code/README.md) for the full runtime
+model.
+
+## Releases
+
+Releases are cut by pushing a `tracing-vX.Y.Z` tag whose version
+matches `pyproject.toml`. Full runbook in [`RELEASING.md`](RELEASING.md).
+The release pipeline (`.github/workflows/release-tracing.yml`) builds
+and publishes the wheel + sdist to TestPyPI then PyPI via Trusted
+Publishing, and attaches the wheel, sdist, and Claude Code plugin
+tarball to the GitHub release for that tag.
+
+## Roadmap
+
+Producer adapters tracked under
+[#229](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/229)
+and the publish/plugin milestone under
+[#234](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/234).

--- a/producers/RELEASING.md
+++ b/producers/RELEASING.md
@@ -81,7 +81,8 @@ tar -tzf /tmp/plugin.tar.gz | head
 ## If something goes wrong
 
 - **`verify` fails on version mismatch** — the tag must equal
-  `tracing-v$(jq -r .version pyproject.toml)`. Re-tag and re-push.
+  `tracing-v$(python -c "import tomllib; print(tomllib.load(open('producers/pyproject.toml','rb'))['project']['version'])")`.
+  Re-tag and re-push.
 - **`build` fails on missing plugin tarball** — the build script's
   `importlib.metadata.version` lookup probably hit
   `PackageNotFoundError`; the `Install built wheel` step should have
@@ -92,7 +93,10 @@ tar -tzf /tmp/plugin.tar.gz | head
 - **`publish-pypi` fails the same way** — same fix on the PyPI side.
 
 If a release ships a broken artifact, do **not** delete the tag.
-Yank the PyPI release and ship a `tracing-vX.Y.Z+1` patch.
+Yank the PyPI release and ship the next patch version
+(e.g. `tracing-v0.1.0` → `tracing-v0.1.1`). Avoid PEP 440 local
+version identifiers (the `+local` suffix) — PyPI rejects them on
+upload.
 
 ## PyPI Trusted Publishing setup (one-time)
 

--- a/producers/RELEASING.md
+++ b/producers/RELEASING.md
@@ -1,0 +1,116 @@
+# Releasing `bigquery-agent-analytics-tracing`
+
+This document covers cutting a release of the producer package and the
+Claude Code plugin tarball. Both ride the same version on the same
+tag, so users always know which wheel and which plugin go together.
+
+Release pipeline lives in
+[`.github/workflows/release-tracing.yml`](../.github/workflows/release-tracing.yml).
+The tag namespace (`tracing-vX.Y.Z`) is distinct from the root SDK's
+`vX.Y.Z` tags so the two pipelines never collide.
+
+## Pre-flight
+
+1. `producers/pyproject.toml` `[project].version` is the version
+   you're about to release.
+2. `producers-ci.yml` is green on `main` for the commit you're
+   tagging.
+3. Any user-facing changes since the prior release have a one-line
+   note ready for the GitHub release body (the workflow uses
+   `generate_release_notes: true`; supplement with handwritten notes
+   only if needed).
+4. PyPI side: project + Trusted Publisher are already configured.
+   Setup is one-time per project — see "PyPI Trusted Publishing
+   setup" below.
+
+## Cut the release
+
+Run from a clean checkout of `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+VERSION=$(python -c "import tomllib; print(tomllib.load(open('producers/pyproject.toml','rb'))['project']['version'])")
+echo "Tagging tracing-v${VERSION}"
+git tag -a "tracing-v${VERSION}" -m "tracing ${VERSION}"
+git push origin "tracing-v${VERSION}"
+```
+
+The workflow takes over from there. Total wall-clock is ~5 minutes.
+
+## What CI does
+
+1. **`verify`** — confirms the tag matches `pyproject.toml`, then
+   runs the producer test suite on Python 3.12.
+2. **`build`** — `python -m build` for wheel + sdist, then
+   `python scripts/build_claude_plugin.py` for the plugin tarball.
+   Verifies all three expected artifacts landed in `dist/`.
+3. **`github-release`** — creates the GitHub release for the tag with
+   auto-generated notes and attaches all three artifacts.
+4. **`publish-testpypi`** — uploads wheel + sdist to TestPyPI via
+   Trusted Publishing (no secrets). The plugin tarball is stripped
+   from the upload set before this step.
+5. **`publish-pypi`** — same, to PyPI. Gated by the `pypi`
+   environment, so maintainers can require manual approval here
+   without blocking the GitHub release.
+
+The plugin tarball is **never** uploaded to PyPI — it ships only as a
+GitHub release asset.
+
+## Verifying the release
+
+```bash
+# TestPyPI install
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            bigquery-agent-analytics-tracing==${VERSION}
+
+# PyPI install (after publish-pypi job completes)
+pip install bigquery-agent-analytics-tracing==${VERSION}
+
+# Sanity check
+python -c "from bigquery_agent_analytics_tracing import __version__; print(__version__)"
+# → ${VERSION}
+
+# Claude Code plugin tarball
+curl -L https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz \
+  -o /tmp/plugin.tar.gz
+tar -tzf /tmp/plugin.tar.gz | head
+```
+
+## If something goes wrong
+
+- **`verify` fails on version mismatch** — the tag must equal
+  `tracing-v$(jq -r .version pyproject.toml)`. Re-tag and re-push.
+- **`build` fails on missing plugin tarball** — the build script's
+  `importlib.metadata.version` lookup probably hit
+  `PackageNotFoundError`; the `Install built wheel` step should have
+  prevented this. Check that step's logs and rebuild.
+- **`publish-testpypi` fails with OIDC error** — Trusted Publisher is
+  not configured on the TestPyPI side. The GitHub release is still
+  good; configure TestPyPI then re-run the `publish-testpypi` job.
+- **`publish-pypi` fails the same way** — same fix on the PyPI side.
+
+If a release ships a broken artifact, do **not** delete the tag.
+Yank the PyPI release and ship a `tracing-vX.Y.Z+1` patch.
+
+## PyPI Trusted Publishing setup (one-time)
+
+Open <https://pypi.org/manage/account/publishing/> (and the same on
+TestPyPI) and add a publisher with:
+
+| Field | Value |
+|---|---|
+| PyPI project name | `bigquery-agent-analytics-tracing` |
+| Owner | `GoogleCloudPlatform` |
+| Repository | `BigQuery-Agent-Analytics-SDK` |
+| Workflow filename | `release-tracing.yml` |
+| Environment | `pypi` (or `testpypi` on TestPyPI) |
+
+These names must match exactly — the `environment:` blocks in the
+workflow are the binding contract.
+
+Until both publishers are configured, the `publish-testpypi` and
+`publish-pypi` jobs will fail with a clear error. The `build` and
+`github-release` jobs are independent and will still complete, so
+the tag stays valid.


### PR DESCRIPTION
Maps to **step 4 of #234** — release automation for the tracing wheel and the Claude Code plugin tarball.

Refs #234, #229.

## Workflow (`.github/workflows/release-tracing.yml`)

Trigger: push of a `tracing-vX.Y.Z` tag. Distinct from the root SDK's `vX.Y.Z` tag namespace so the two release pipelines never collide.

| Job | Behavior |
|---|---|
| `verify` | Tag must equal `tracing-v\$(pyproject.version)`; runs the producer test suite on Python 3.12. |
| `build` | `python -m build` → wheel + sdist. Installs the wheel so `importlib.metadata.version` resolves. Then `python scripts/build_claude_plugin.py` → plugin tarball. Asserts all three expected artifacts landed before uploading them as the shared `release-tracing-dist` workflow artifact. |
| `github-release` | Creates the GitHub release with auto-generated notes; attaches wheel, sdist, plugin tarball. |
| `publish-testpypi` | Uploads wheel + sdist to TestPyPI via Trusted Publishing (no secrets). Plugin tarball stripped from upload set. |
| `publish-pypi` | Same, to PyPI. Gated by the `pypi` environment so maintainers can require manual approval without blocking the GitHub release. |

The plugin tarball is never uploaded to PyPI — it ships only as a GitHub release asset. The strip step filters by the hyphenated `bigquery-agent-analytics-tracing-claude-code-*` filename pattern, which is distinct from the underscore-named wheel/sdist.

## Release runbook (`producers/RELEASING.md`)

Step-by-step: pre-flight, tag, what CI does, how to verify (TestPyPI install, PyPI install, plugin tarball download), what to do on failure modes, and the one-time PyPI/TestPyPI Trusted Publisher configuration.

## Trusted Publishing setup (one-time, maintainer action)

Per `producers/RELEASING.md`, the Google PyPI/TestPyPI accounts need a Trusted Publisher with:

| Field | Value |
|---|---|
| PyPI project | `bigquery-agent-analytics-tracing` |
| Owner | `GoogleCloudPlatform` |
| Repository | `BigQuery-Agent-Analytics-SDK` |
| Workflow filename | `release-tracing.yml` |
| Environment | `pypi` (and `testpypi`) |

Until both publishers are configured, `publish-testpypi` and `publish-pypi` will fail with a clear OIDC error. **`build` and `github-release` are independent** and complete normally — so the tag and GitHub release artifacts are still valid even before PyPI is wired up. This was intentional so a maintainer can cut a tag immediately without blocking on PyPI side configuration.

## User-facing install docs

- `producers/README.md` — pip install steps for the package + Claude Code plugin tarball workflow (download from GitHub release, extract under `~/.claude/plugins/`). Pointer to the release runbook. Removed stale "first cut, follow-ups pending" language now that the producer + plugin tracks have landed.
- `plugins/claude_code/README.md` — marketplace-pending install steps (curl tarball, extract, set `BQAA_*` + pip install runtime deps). Cross-link to release runbook for build mechanics.

## Acceptance criteria from #234 covered here

- [x] CI builds the wheel/sdist and plugin artifact (already in producers-ci; release-tracing rebuilds + publishes)
- [x] TestPyPI smoke install passes before PyPI publish (job order + environment gate enforces this)
- [x] Maintainer can cut a release with a single `git tag tracing-vX.Y.Z && git push origin tracing-vX.Y.Z`

Deferred to follow-up PR D (step 5 of #234):
- [ ] Plugin manifest polish + marketplace submission
- [ ] `/bqaa-setup` slash command for interactive install guidance
- [ ] Marketplace submission checklist

## Test plan

- [x] Workflow YAML parses (`python -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] Full local dry-run of the build chain (the same commands the workflow runs): `python -m build` → install wheel → `build_claude_plugin.py` → all three artifacts produced in `producers/dist/`
- [x] `pytest producers/tests/ -q` — 75/75 pass on Python 3.13.5 (no test changes, just confirming no regressions)
- [x] Manifest restored to `0.0.0+local` placeholder so source-controlled diff stays minimal
- [ ] Producers CI green on the PR head after maintainer approves the first-time-fork gate
- [ ] First real release tag cuts cleanly (requires Trusted Publisher config on PyPI side — pre-merge or as a follow-up)

## What this PR intentionally does NOT do

- Bump the package version (still `0.1.0.dev0`). A separate PR will bump to a real release version when maintainers are ready.
- Touch the existing root `release.yml` or `ci.yml`. The two release pipelines are fully independent.
- Configure the PyPI side. That's a maintainer action documented in `RELEASING.md`.