### PR TITLE
producers: marketplace polish — /bqaa-setup slash command + IAM docs

### DIFF
--- a/plugins/claude_code/.claude-plugin/plugin.json
+++ b/plugins/claude_code/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "name": "Google LLC"
   },
   "repository": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK",
+  "homepage": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/plugins/claude_code",
   "license": "Apache-2.0",
   "keywords": [
     "bigquery",

--- a/plugins/claude_code/MARKETPLACE.md
+++ b/plugins/claude_code/MARKETPLACE.md
@@ -1,0 +1,112 @@
+# Claude Code marketplace submission
+
+Reference for submitting `bigquery-agent-analytics-tracing` to the
+[Claude Code plugin marketplace](https://docs.claude.com/en/docs/claude-code/plugins).
+Keep updated whenever metadata or install model changes.
+
+## Pre-submission checklist
+
+- [ ] `.claude-plugin/plugin.json` fields are final
+  - [ ] `name` matches the PyPI distribution: `bigquery-agent-analytics-tracing`
+  - [ ] `description` is under one sentence and accurate
+  - [ ] `version` matches the `tracing-vX.Y.Z` release tag (the build
+        script stamps this at release time; manual edits will be
+        overwritten)
+  - [ ] `author.name = "Google LLC"`
+  - [ ] `repository` points at the GoogleCloudPlatform repo
+  - [ ] `homepage` (if set) resolves to a public docs page
+  - [ ] `license` is `Apache-2.0`
+  - [ ] `keywords` cover the discoverability terms users will search
+        for: `bigquery`, `agent-analytics`, `observability`, `tracing`,
+        `claude-code`
+  - [ ] All nine hooks declared with `${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh`
+- [ ] `/bqaa-setup` slash command discoverable via `commands/bqaa-setup.md`
+- [ ] `hooks/common.sh` and `scripts/run_setup_check.sh` are executable
+      (`chmod +x`) in source control
+- [ ] Plugin tarball produced by the release pipeline contains:
+  - [ ] `.claude-plugin/plugin.json` (version stamped)
+  - [ ] `hooks/` — all nine `*.sh` files + `common.sh`
+  - [ ] `commands/bqaa-setup.md`
+  - [ ] `scripts/run_setup_check.sh`
+  - [ ] `vendor/bigquery_agent_analytics_tracing/` (full package source)
+  - [ ] `vendor/bigquery_agent_analytics_tracing-X.Y.Z.dist-info/METADATA`
+        (so `importlib.metadata.version()` resolves correctly)
+- [ ] Tarball excludes `__pycache__`, `*.pyc`, `.gitignore`
+
+## Runtime dependency model
+
+Users **do not** need to `pip install bigquery-agent-analytics-tracing`.
+The plugin vendors its own copy of the package. They DO need:
+
+| Dep | Required? | Used for |
+|---|---|---|
+| `google-cloud-bigquery` | yes | both writer paths |
+| `google-cloud-bigquery-storage` | optional | Storage Write API (lower latency, recommended for production) |
+| `pyarrow` | optional | Storage Write API row encoding |
+
+`BQAA_PYTHON` (or `python3` if unset) is the interpreter the hooks
+exec. The `/bqaa-setup` command checks all of this and prints the
+exact `pip install ...` line for any missing dep.
+
+## BigQuery IAM requirements
+
+The service account or user credentials the plugin's `BQAA_PYTHON`
+will use (via ADC) needs:
+
+| Role | Why |
+|---|---|
+| `roles/bigquery.dataEditor` on the destination dataset | write rows into `agent_events` |
+| `roles/bigquery.user` on the project | run queries, list datasets, etc. |
+| `roles/bigquery.metadataViewer` on the destination dataset | (only when `BQAA_AUTO_CREATE_TABLE=true`) read schema before deciding to create |
+
+The plugin emits rows under the credentials' identity — there is no
+per-user impersonation. Set `BQAA_AGENT_NAME` to disambiguate
+multiple producers writing to the same dataset.
+
+## Install path (pre-marketplace)
+
+See [`README.md`](README.md#installing-the-plugin) for the curl-and-extract
+recipe. Until marketplace listing is live this is the official path.
+
+## Manual verification before each marketplace bump
+
+Run on a clean environment (no `bigquery-agent-analytics-tracing` wheel
+on `BQAA_PYTHON`):
+
+1. Download the release tarball for the version you're submitting:
+   ```bash
+   VERSION=X.Y.Z
+   curl -L \
+     "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
+     | tar -xz -C ~/.claude/plugins
+   ```
+2. Configure Claude Code to load the plugin per the
+   [Claude Code plugins docs](https://docs.claude.com/en/docs/claude-code/plugins).
+3. Inside a Claude Code session:
+   - Run `/bqaa-setup` — expect a "READY" status (after configuring env
+     vars + installing runtime deps as instructed).
+   - Submit a real prompt. Confirm a row lands in
+     `${BQAA_PROJECT_ID}.${BQAA_DATASET}.agent_events`:
+     ```sql
+     SELECT event_type, attributes.writer.version, attributes.writer.label
+     FROM `${BQAA_PROJECT_ID}.${BQAA_DATASET}.agent_events`
+     ORDER BY timestamp DESC
+     LIMIT 5
+     ```
+   - `attributes.writer.version` and `attributes.writer.label` must
+     reflect the version you just installed — NOT `0.0.0+local`. If
+     they do, the vendored `.dist-info` is missing or stale.
+4. Confirm `BQAA_TRACE_ENABLED=false` cleanly disables emission with
+   no errors in the agent log.
+
+## Submission process
+
+1. Cut a `tracing-vX.Y.Z` release per [`producers/RELEASING.md`](../../producers/RELEASING.md).
+2. Run the manual verification above against the published tarball.
+3. Submit the plugin to the marketplace per
+   [Claude Code's marketplace submission docs](https://docs.claude.com/en/docs/claude-code/plugins).
+   Point the submission at the GitHub release URL.
+4. Update this file's checklist completion status.
+5. After acceptance, update [`README.md`](README.md) to remove the
+   "until marketplace listing is live" hedge and point at the
+   marketplace listing.

--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -12,10 +12,18 @@ plugins/claude_code/
 ├── hooks/
 │   ├── common.sh            # shared hook entry (PYTHONPATH + python -m)
 │   └── <hook>.sh            # one per Claude Code hook
+├── commands/
+│   └── bqaa-setup.md        # /bqaa-setup slash command
+├── scripts/
+│   └── run_setup_check.sh   # /bqaa-setup wrapper (PYTHONPATH + python -m)
+├── MARKETPLACE.md           # submission checklist + IAM + verification
 └── vendor/                  # generated at build time (git-ignored)
-    └── bigquery_agent_analytics_tracing/
-                             # vendored package source — copied from
-                             # producers/src/ by build_claude_plugin.py
+    ├── bigquery_agent_analytics_tracing/
+    │                          # vendored package source — copied from
+    │                          # producers/src/ by build_claude_plugin.py
+    └── bigquery_agent_analytics_tracing-<version>.dist-info/
+                               # PEP 376 metadata so importlib.metadata
+                               # resolves the right version at runtime
 ```
 
 `vendor/` is never source-controlled. The build script
@@ -46,8 +54,14 @@ itself, but the Python under `BQAA_PYTHON` still needs:
   Storage Write API path; the drainer falls back to `insert_rows_json`
   when these are unavailable.
 
-A future `/bqaa-setup` slash command (planned in #234 step 5) will
-surface a single `pip install ...` line for missing deps.
+Run the `/bqaa-setup` slash command inside Claude Code to check env
+vars + runtime deps and get a copy-pasteable `pip install …` line for
+anything missing. The command is advisory only — it never mutates
+shell rc files or installs packages on your behalf. See
+[`commands/bqaa-setup.md`](commands/bqaa-setup.md).
+
+BigQuery IAM requirements and submission checklist live in
+[`MARKETPLACE.md`](MARKETPLACE.md).
 
 ## Installing the plugin
 

--- a/plugins/claude_code/commands/bqaa-setup.md
+++ b/plugins/claude_code/commands/bqaa-setup.md
@@ -1,0 +1,55 @@
+---
+description: Check BQAA tracing setup — env vars, Python runtime deps, vendored package import. Advisory only; never mutates the environment.
+---
+
+# /bqaa-setup
+
+Run the BQAA tracing setup check and report what (if anything) needs fixing
+before agent events can land in BigQuery.
+
+## What to do
+
+1. Invoke the wrapper script:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/run_setup_check.sh"
+   ```
+
+   The wrapper sets `PYTHONPATH` to the vendored package root and runs
+   `python -m bigquery_agent_analytics_tracing.setup_check`. Exit code is
+   `0` when the runtime is ready, `1` when something required is missing
+   or unconfigured.
+
+2. Surface the script's output to the user verbatim. The check is designed
+   to be copy-pasteable — it already prints the exact `pip install ...`
+   command for any missing dep and the exact `export BQAA_PROJECT_ID=...`
+   line for any missing env var.
+
+3. **Do not** modify the user's shell rc files, install packages on their
+   behalf, or run any GCP API calls in this command. This is advisory
+   only — if the user wants a guided install, they can run the suggested
+   commands themselves.
+
+## What the check covers
+
+- `BQAA_PROJECT_ID` — required. Falls back to `GCP_PROJECT_ID` /
+  `GOOGLE_CLOUD_PROJECT` if unset.
+- `BQAA_DATASET` — required. Falls back to `BQ_DATASET` if unset.
+- `BQAA_PYTHON` — the interpreter the hooks will exec; defaults to the
+  current `python3`. The check verifies it can import the tracing
+  package and required runtime deps.
+- `google-cloud-bigquery` — always required (both writer paths use it).
+- `google-cloud-bigquery-storage` + `pyarrow` — required only for the
+  lower-latency Storage Write path; absence is reported as advisory
+  (the drainer falls back to `insert_rows_json`).
+
+## What the check does NOT do
+
+- Create a BigQuery dataset or table.
+- Grant IAM permissions.
+- Install pip packages.
+- Edit shell rc files or `~/.claude/settings.json`.
+
+For the bootstrap that actually does those things, see
+[`plugins/claude_code/MARKETPLACE.md`](../MARKETPLACE.md#bigquery-iam-requirements)
+for the IAM model and the manual `gcloud` / `bq` commands.

--- a/plugins/claude_code/scripts/run_setup_check.sh
+++ b/plugins/claude_code/scripts/run_setup_check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper for the /bqaa-setup slash command. Mirrors hooks/common.sh so
+# the vendored package resolves from PYTHONPATH without a wheel install.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+PYTHON_BIN="${BQAA_PYTHON:-python3}"
+
+export PYTHONPATH="${PLUGIN_DIR}/vendor:${PYTHONPATH:-}"
+
+exec "$PYTHON_BIN" -m bigquery_agent_analytics_tracing.setup_check "$@"

--- a/plugins/claude_code/scripts/run_setup_check.sh
+++ b/plugins/claude_code/scripts/run_setup_check.sh
@@ -15,13 +15,36 @@
 
 # Wrapper for the /bqaa-setup slash command. Mirrors hooks/common.sh so
 # the vendored package resolves from PYTHONPATH without a wheel install.
+#
+# Runner vs. target distinction:
+#   * RUNNER_PYTHON is the interpreter that executes the setup_check
+#     module. It must work — otherwise the diagnostic itself fails at
+#     the shell layer (`bash: exec: $BQAA_PYTHON: No such file`) and
+#     the user sees a raw shell error instead of an actionable
+#     report.
+#   * BQAA_PYTHON is the interpreter the hooks will use at runtime.
+#     The setup_check module probes it internally — its job is
+#     specifically to diagnose a broken BQAA_PYTHON. Don't conflate
+#     the two.
+#
+# Prefer BQAA_PYTHON as the runner when it works, fall back to
+# python3 (always assumed available) so /bqaa-setup never silently
+# breaks on the most common misconfiguration.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
-PYTHON_BIN="${BQAA_PYTHON:-python3}"
+
+RUNNER_PYTHON="${BQAA_PYTHON:-python3}"
+# Quick liveness check: if the configured interpreter cannot even
+# exec a no-op, fall back to python3. setup_check.py still probes
+# BQAA_PYTHON internally and surfaces the interpreter_error in the
+# report.
+if ! "$RUNNER_PYTHON" -c "pass" >/dev/null 2>&1; then
+  RUNNER_PYTHON="python3"
+fi
 
 export PYTHONPATH="${PLUGIN_DIR}/vendor:${PYTHONPATH:-}"
 
-exec "$PYTHON_BIN" -m bigquery_agent_analytics_tracing.setup_check "$@"
+exec "$RUNNER_PYTHON" -m bigquery_agent_analytics_tracing.setup_check "$@"

--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 [project.scripts]
 bqaa-drain = "bigquery_agent_analytics_tracing.drain:main"
 bqaa-claude-hook = "bigquery_agent_analytics_tracing.claude_code:main"
+bqaa-check-setup = "bigquery_agent_analytics_tracing.setup_check:main"
 
 [project.urls]
 Homepage = "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"

--- a/producers/src/bigquery_agent_analytics_tracing/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/__init__.py
@@ -27,6 +27,9 @@ Producer modules:
 
   * ``claude_code`` — Claude Code hook adapter + ``main()`` entry.
     Console script: ``bqaa-claude-hook``.
+  * ``setup_check`` — advisory check for env vars + runtime deps.
+    Console script: ``bqaa-check-setup``. Used by the ``/bqaa-setup``
+    Claude Code slash command.
 
 OpenAI Agents SDK and Codex CLI adapters land in follow-up PRs.
 """

--- a/producers/src/bigquery_agent_analytics_tracing/setup_check.py
+++ b/producers/src/bigquery_agent_analytics_tracing/setup_check.py
@@ -83,9 +83,19 @@ class _SetupReport:
   project_id: str | None
   dataset: str | None
   trace_enabled: bool
+  # Non-None when the configured interpreter cannot be executed
+  # (FileNotFoundError, permission denied, timeout, non-zero exit on a
+  # trivial command). Surfacing this separately tells the user "fix
+  # BQAA_PYTHON" instead of N misleading "import failed" lines that
+  # all stem from the same root cause.
+  interpreter_error: str | None = None
   package_imports: list[_ImportProbe] = field(default_factory=list)
   required_imports: list[_ImportProbe] = field(default_factory=list)
   storage_write_imports: list[_ImportProbe] = field(default_factory=list)
+
+  @property
+  def python_ok(self) -> bool:
+    return self.interpreter_error is None
 
   @property
   def env_ok(self) -> bool:
@@ -93,19 +103,26 @@ class _SetupReport:
 
   @property
   def package_ok(self) -> bool:
-    return all(p.ok for p in self.package_imports)
+    # Empty list when interpreter is broken — explicitly gate on
+    # python_ok so vacuous all([]) doesn't report True.
+    return self.python_ok and all(p.ok for p in self.package_imports)
 
   @property
   def required_deps_ok(self) -> bool:
-    return all(p.ok for p in self.required_imports)
+    return self.python_ok and all(p.ok for p in self.required_imports)
 
   @property
   def storage_write_ok(self) -> bool:
-    return all(p.ok for p in self.storage_write_imports)
+    return self.python_ok and all(p.ok for p in self.storage_write_imports)
 
   @property
   def all_ok(self) -> bool:
-    return self.env_ok and self.package_ok and self.required_deps_ok
+    return (
+        self.python_ok
+        and self.env_ok
+        and self.package_ok
+        and self.required_deps_ok
+    )
 
 
 def _resolve_python_bin() -> str:
@@ -118,17 +135,71 @@ def _resolve_python_bin() -> str:
   return os.environ.get("BQAA_PYTHON") or sys.executable
 
 
+def _probe_interpreter(python_bin: str) -> str | None:
+  """Verify ``python_bin`` can be executed. Returns None on success or
+  a one-line error string. Catches the common
+  misconfigurations (path doesn't exist, not executable, hangs)
+  before the import probes shell out N times and trip on the same
+  root cause.
+  """
+  try:
+    proc = subprocess.run(
+        [python_bin, "-c", "pass"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+  except FileNotFoundError:
+    return f"interpreter not found: {python_bin}"
+  except PermissionError:
+    return f"interpreter not executable: {python_bin}"
+  except OSError as exc:
+    return f"interpreter exec error: {python_bin} ({exc})"
+  except subprocess.TimeoutExpired:
+    return f"interpreter timed out: {python_bin}"
+  if proc.returncode != 0:
+    err = (proc.stderr or proc.stdout or "non-zero exit").strip()
+    err = err.splitlines()[-1] if err.splitlines() else err
+    return f"interpreter exited non-zero: {err}"
+  return None
+
+
 def _probe_imports(
     python_bin: str, modules: Iterable[tuple[str, str]]
 ) -> list[_ImportProbe]:
   results: list[_ImportProbe] = []
   for module, install_name in modules:
-    proc = subprocess.run(
-        [python_bin, "-c", f"import {module}"],
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
+    # Defensive catches for the same conditions ``_probe_interpreter``
+    # handles. ``collect_report`` skips this loop entirely when the
+    # interpreter is broken, but keep the catches so a direct caller
+    # never sees a raw OSError from a misconfigured python_bin.
+    try:
+      proc = subprocess.run(
+          [python_bin, "-c", f"import {module}"],
+          capture_output=True,
+          text=True,
+          timeout=15,
+      )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=f"interpreter unavailable: {exc}",
+          )
+      )
+      continue
+    except subprocess.TimeoutExpired:
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=f"interpreter timed out: {python_bin}",
+          )
+      )
+      continue
     if proc.returncode == 0:
       results.append(
           _ImportProbe(module=module, install_name=install_name, ok=True)
@@ -151,10 +222,26 @@ def _probe_imports(
 
 def collect_report(python_bin: str | None = None) -> _SetupReport:
   """Run the full set of checks against ``python_bin`` (or BQAA_PYTHON
-  fallback) and return a structured report."""
+  fallback) and return a structured report.
+
+  If the interpreter can't be executed (bad ``BQAA_PYTHON`` is the most
+  common case), skip the import probes — they'd all fail with the same
+  underlying error — and surface the interpreter problem directly
+  via ``_SetupReport.interpreter_error``.
+  """
   resolved = python_bin or _resolve_python_bin()
+  interpreter_error = _probe_interpreter(resolved)
+  if interpreter_error is not None:
+    package_imports: list[_ImportProbe] = []
+    required_imports: list[_ImportProbe] = []
+    storage_write_imports: list[_ImportProbe] = []
+  else:
+    package_imports = _probe_imports(resolved, _PACKAGE_IMPORTS)
+    required_imports = _probe_imports(resolved, _REQUIRED_IMPORTS)
+    storage_write_imports = _probe_imports(resolved, _STORAGE_WRITE_IMPORTS)
   return _SetupReport(
       python_bin=resolved,
+      interpreter_error=interpreter_error,
       project_id=(
           os.environ.get("BQAA_PROJECT_ID")
           or os.environ.get("GCP_PROJECT_ID")
@@ -167,9 +254,9 @@ def collect_report(python_bin: str | None = None) -> _SetupReport:
       trace_enabled=(
           os.environ.get("BQAA_TRACE_ENABLED", "true").lower() == "true"
       ),
-      package_imports=_probe_imports(resolved, _PACKAGE_IMPORTS),
-      required_imports=_probe_imports(resolved, _REQUIRED_IMPORTS),
-      storage_write_imports=_probe_imports(resolved, _STORAGE_WRITE_IMPORTS),
+      package_imports=package_imports,
+      required_imports=required_imports,
+      storage_write_imports=storage_write_imports,
   )
 
 
@@ -182,6 +269,12 @@ def _format_report(report: _SetupReport) -> str:
   lines.append("BQAA tracing setup check")
   lines.append("=" * 32)
   lines.append(f"Python interpreter: {report.python_bin}")
+  if report.interpreter_error:
+    lines.append(f"  [{miss_mark}] {report.interpreter_error}")
+    lines.append(
+        "  Fix: point BQAA_PYTHON at a working python3 interpreter,"
+        " or unset it to use the default."
+    )
   lines.append(f"BQAA_TRACE_ENABLED: {'on' if report.trace_enabled else 'off'}")
   if not report.trace_enabled:
     lines.append(
@@ -189,6 +282,14 @@ def _format_report(report: _SetupReport) -> str:
         " (or unset it) to enable."
     )
   lines.append("")
+
+  if report.interpreter_error:
+    # Skip the per-import sections — they're all empty when the
+    # interpreter is broken, and printing empty checklists is noise.
+    lines.append("Import + env checks skipped: interpreter unavailable.")
+    lines.append("")
+    lines.append("Status: ACTION NEEDED")
+    return "\n".join(lines) + "\n"
 
   lines.append("Required env vars:")
   lines.append(
@@ -264,6 +365,7 @@ def _report_to_json(report: _SetupReport) -> str:
   return json.dumps(
       {
           **asdict(report),
+          "python_ok": report.python_ok,
           "env_ok": report.env_ok,
           "package_ok": report.package_ok,
           "required_deps_ok": report.required_deps_ok,

--- a/producers/src/bigquery_agent_analytics_tracing/setup_check.py
+++ b/producers/src/bigquery_agent_analytics_tracing/setup_check.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Advisory setup check for the BQAA tracing runtime.
+
+Surfaces:
+
+  * BQAA_PROJECT_ID / BQAA_DATASET — required env vars.
+  * BQAA_PYTHON — optional, defaults to the current interpreter; we
+    sanity-check it can import the runtime deps.
+  * google-cloud-bigquery — always required.
+  * google-cloud-bigquery-storage + pyarrow — required only for the
+    Storage Write API path; absent is OK (drainer falls back to
+    insert_rows_json).
+  * bigquery_agent_analytics_tracing itself — sanity check the
+    vendored layout works on BQAA_PYTHON.
+
+This script is **advisory-only**. It never mutates the environment,
+shell rc files, GCP resources, or IAM. It only reports what is
+missing and prints the exact `pip install ...` line you'd run to fix
+it. The interactive setup that actually creates a dataset / grants
+IAM is intentionally out of scope here — keep that as a separate
+explicit step.
+
+Driver: the `bqaa-check-setup` console script and the `/bqaa-setup`
+Claude Code slash command both call ``main()``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+# Modules whose absence blocks the writer entirely.
+_REQUIRED_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("google.cloud.bigquery", "google-cloud-bigquery"),
+)
+
+# Modules whose absence only disables the Storage Write API path;
+# drainer falls back to insert_rows_json.
+_STORAGE_WRITE_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("google.cloud.bigquery_storage_v1", "google-cloud-bigquery-storage"),
+    ("pyarrow", "pyarrow"),
+)
+
+# Sanity-check the tracing package itself imports on the target
+# interpreter — catches a misconfigured PYTHONPATH on vendored
+# plugin runtimes before any hook fires.
+_PACKAGE_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("bigquery_agent_analytics_tracing", "bigquery-agent-analytics-tracing"),
+)
+
+
+@dataclass
+class _ImportProbe:
+  module: str
+  install_name: str
+  ok: bool
+  error: str | None = None
+
+
+@dataclass
+class _SetupReport:
+  python_bin: str
+  project_id: str | None
+  dataset: str | None
+  trace_enabled: bool
+  package_imports: list[_ImportProbe] = field(default_factory=list)
+  required_imports: list[_ImportProbe] = field(default_factory=list)
+  storage_write_imports: list[_ImportProbe] = field(default_factory=list)
+
+  @property
+  def env_ok(self) -> bool:
+    return bool(self.project_id) and bool(self.dataset)
+
+  @property
+  def package_ok(self) -> bool:
+    return all(p.ok for p in self.package_imports)
+
+  @property
+  def required_deps_ok(self) -> bool:
+    return all(p.ok for p in self.required_imports)
+
+  @property
+  def storage_write_ok(self) -> bool:
+    return all(p.ok for p in self.storage_write_imports)
+
+  @property
+  def all_ok(self) -> bool:
+    return self.env_ok and self.package_ok and self.required_deps_ok
+
+
+def _resolve_python_bin() -> str:
+  """Pick the interpreter we'll check against.
+
+  ``BQAA_PYTHON`` is what hook shell wrappers exec when firing the
+  hook, so that's the truth for the runtime. If unset, use whichever
+  python invoked us (matches the shell default of ``python3``).
+  """
+  return os.environ.get("BQAA_PYTHON") or sys.executable
+
+
+def _probe_imports(
+    python_bin: str, modules: Iterable[tuple[str, str]]
+) -> list[_ImportProbe]:
+  results: list[_ImportProbe] = []
+  for module, install_name in modules:
+    proc = subprocess.run(
+        [python_bin, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode == 0:
+      results.append(
+          _ImportProbe(module=module, install_name=install_name, ok=True)
+      )
+    else:
+      # The first nonempty stderr line is the most useful — strip
+      # the traceback noise.
+      err = (proc.stderr or proc.stdout or "import failed").strip()
+      err = err.splitlines()[-1] if err.splitlines() else err
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=err,
+          )
+      )
+  return results
+
+
+def collect_report(python_bin: str | None = None) -> _SetupReport:
+  """Run the full set of checks against ``python_bin`` (or BQAA_PYTHON
+  fallback) and return a structured report."""
+  resolved = python_bin or _resolve_python_bin()
+  return _SetupReport(
+      python_bin=resolved,
+      project_id=(
+          os.environ.get("BQAA_PROJECT_ID")
+          or os.environ.get("GCP_PROJECT_ID")
+          or os.environ.get("GOOGLE_CLOUD_PROJECT")
+          or None
+      ),
+      dataset=(
+          os.environ.get("BQAA_DATASET") or os.environ.get("BQ_DATASET") or None
+      ),
+      trace_enabled=(
+          os.environ.get("BQAA_TRACE_ENABLED", "true").lower() == "true"
+      ),
+      package_imports=_probe_imports(resolved, _PACKAGE_IMPORTS),
+      required_imports=_probe_imports(resolved, _REQUIRED_IMPORTS),
+      storage_write_imports=_probe_imports(resolved, _STORAGE_WRITE_IMPORTS),
+  )
+
+
+def _format_report(report: _SetupReport) -> str:
+  """Human-readable, copy-pasteable advisory output."""
+  lines: list[str] = []
+  ok_mark = "OK"
+  miss_mark = "MISSING"
+
+  lines.append("BQAA tracing setup check")
+  lines.append("=" * 32)
+  lines.append(f"Python interpreter: {report.python_bin}")
+  lines.append(f"BQAA_TRACE_ENABLED: {'on' if report.trace_enabled else 'off'}")
+  if not report.trace_enabled:
+    lines.append(
+        "  Note: emission is disabled. Set BQAA_TRACE_ENABLED=true"
+        " (or unset it) to enable."
+    )
+  lines.append("")
+
+  lines.append("Required env vars:")
+  lines.append(
+      f"  [{ok_mark if report.project_id else miss_mark}]"
+      f" BQAA_PROJECT_ID = {report.project_id or '(unset)'}"
+  )
+  lines.append(
+      f"  [{ok_mark if report.dataset else miss_mark}]"
+      f" BQAA_DATASET    = {report.dataset or '(unset)'}"
+  )
+  if not report.env_ok:
+    lines.append("")
+    lines.append("Fix: export the missing variables, e.g.")
+    if not report.project_id:
+      lines.append("  export BQAA_PROJECT_ID=your-gcp-project")
+    if not report.dataset:
+      lines.append("  export BQAA_DATASET=agent_analytics")
+  lines.append("")
+
+  lines.append("Package import:")
+  for probe in report.package_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.package_ok:
+    lines.append("")
+    lines.append(
+        "Fix: install the tracing wheel on BQAA_PYTHON, or point"
+        " PYTHONPATH at the vendored plugin's vendor/ directory."
+    )
+    lines.append(
+        f"  {report.python_bin} -m pip install bigquery-agent-analytics-tracing"
+    )
+  lines.append("")
+
+  lines.append("Required runtime deps:")
+  for probe in report.required_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.required_deps_ok:
+    missing = [p.install_name for p in report.required_imports if not p.ok]
+    lines.append("")
+    lines.append(f"Fix: {report.python_bin} -m pip install {' '.join(missing)}")
+  lines.append("")
+
+  lines.append("Storage Write API deps (optional):")
+  for probe in report.storage_write_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.storage_write_ok:
+    missing = [p.install_name for p in report.storage_write_imports if not p.ok]
+    lines.append("")
+    lines.append(
+        "Optional fix for the lower-latency Storage Write path"
+        " (drainer falls back to insert_rows_json without these):"
+    )
+    lines.append(f"  {report.python_bin} -m pip install {' '.join(missing)}")
+  lines.append("")
+
+  lines.append("Status: " + ("READY" if report.all_ok else "ACTION NEEDED"))
+  return "\n".join(lines) + "\n"
+
+
+def _report_to_json(report: _SetupReport) -> str:
+  return json.dumps(
+      {
+          **asdict(report),
+          "env_ok": report.env_ok,
+          "package_ok": report.package_ok,
+          "required_deps_ok": report.required_deps_ok,
+          "storage_write_ok": report.storage_write_ok,
+          "all_ok": report.all_ok,
+      },
+      indent=2,
+      sort_keys=True,
+  )
+
+
+def main(argv: list[str] | None = None) -> int:
+  """Exit 0 when everything required is in place, 1 otherwise.
+
+  The non-zero exit is what lets the slash command flag "fix this"
+  vs. "you're good." Storage Write deps are intentionally not part
+  of the exit code: the drainer fallback exists so a missing pyarrow
+  is not a hard blocker.
+  """
+  parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  parser.add_argument(
+      "--json",
+      action="store_true",
+      help="Emit a JSON report instead of human-readable text.",
+  )
+  args = parser.parse_args(argv)
+  report = collect_report()
+  if args.json:
+    sys.stdout.write(_report_to_json(report) + "\n")
+  else:
+    sys.stdout.write(_format_report(report))
+  return 0 if report.all_ok else 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/tests/test_build_claude_plugin.py
+++ b/producers/tests/test_build_claude_plugin.py
@@ -551,6 +551,47 @@ def test_vendored_plugin_run_setup_check_succeeds_when_env_set(
   assert report["dataset"] == "ok-ds"
 
 
+def test_run_setup_check_wrapper_falls_back_when_bqaa_python_unrunnable(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  """Regression: if BQAA_PYTHON points at a path that doesn't exist,
+  the wrapper's `exec "$BQAA_PYTHON"` would fail at the shell layer
+  before setup_check.py ever runs — defeating the whole point of
+  /bqaa-setup. The wrapper must fall back to python3 as the runner
+  so the diagnostic itself survives; setup_check.py then reports
+  the broken BQAA_PYTHON via interpreter_error."""
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  wrapper = PLUGIN_DIR / "scripts" / "run_setup_check.sh"
+  env = {
+      "PATH": "/usr/bin:/bin:/usr/local/bin",
+      "BQAA_PYTHON": "/nonexistent/python-binary-xyz",
+      "BQAA_PROJECT_ID": "p",
+      "BQAA_DATASET": "d",
+  }
+  result = subprocess.run(
+      ["bash", str(wrapper), "--json"],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  # Exit 1 because the report flags interpreter_error — but the
+  # process completes cleanly with a structured JSON payload, not a
+  # bash exec failure.
+  assert result.returncode == 1, (
+      f"wrapper should fall back to python3 and exit 1 via setup_check;"
+      f" stdout={result.stdout!r} stderr={result.stderr!r}"
+  )
+  # The shell-layer failure mode prints to stderr without producing
+  # JSON. If we see JSON, the fallback worked.
+  payload = json.loads(result.stdout)
+  assert payload["python_ok"] is False
+  assert payload["all_ok"] is False
+  assert payload["interpreter_error"]
+  assert "/nonexistent/python-binary-xyz" in payload["interpreter_error"]
+
+
 def test_vendored_plugin_respects_trace_enabled_kill_switch_via_shell(
     tmp_path, restore_manifest, cleanup_vendor
 ):

--- a/producers/tests/test_build_claude_plugin.py
+++ b/producers/tests/test_build_claude_plugin.py
@@ -220,6 +220,20 @@ def test_build_produces_vendor_tree_and_tarball(
       n.endswith("vendor/bigquery_agent_analytics_tracing/claude_code.py")
       for n in names
   )
+  # /bqaa-setup slash command + its wrapper must ride along so the
+  # marketplace install gets the full UX, not just the hooks.
+  assert any(
+      n.endswith("commands/bqaa-setup.md") for n in names
+  ), f"slash command missing from tarball; names={names!r}"
+  assert any(
+      n.endswith("scripts/run_setup_check.sh") for n in names
+  ), f"setup-check wrapper missing from tarball; names={names!r}"
+  # MARKETPLACE.md is the submission checklist + IAM doc; bundle it
+  # so anyone installing from the tarball can find the IAM
+  # requirements alongside the code.
+  assert any(
+      n.endswith("MARKETPLACE.md") for n in names
+  ), f"MARKETPLACE.md missing from tarball; names={names!r}"
   # PEP 376 .dist-info/METADATA must ride along so importlib.metadata
   # can resolve the vendored install's version at runtime.
   assert any(
@@ -468,6 +482,73 @@ def test_vendored_plugin_spools_and_spawns_drainer_with_inherited_pythonpath(
       f"drainer did not inherit PYTHONPATH={vendor_root!r};"
       f" got: {log_text!r}"
   )
+
+
+def test_vendored_plugin_run_setup_check_resolves_versioned_package(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  """The /bqaa-setup wrapper must resolve the vendored package on
+  ``BQAA_PYTHON`` without a wheel install. Run it with no required
+  env vars set and assert it reports ACTION NEEDED with exit 1 plus
+  the actual resolved package version (proving import worked)."""
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  wrapper = PLUGIN_DIR / "scripts" / "run_setup_check.sh"
+  assert wrapper.is_file(), "run_setup_check.sh missing from plugin tree"
+
+  env = {
+      "PATH": "/usr/bin:/bin",
+      "BQAA_PYTHON": sys.executable,
+      # Deliberately unset env vars so the check reports ACTION NEEDED.
+  }
+  result = subprocess.run(
+      ["bash", str(wrapper), "--json"],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  assert (
+      result.returncode == 1
+  ), f"missing env vars must yield exit 1; stderr={result.stderr!r}"
+  report = json.loads(result.stdout)
+  # Package import resolved against vendor/ → version is the real
+  # resolved version, not "0.0.0+local".
+  assert (
+      report["package_ok"] is True
+  ), "vendored package import failed — PYTHONPATH wiring is broken"
+  assert report["env_ok"] is False
+  assert report["project_id"] is None
+  assert report["dataset"] is None
+
+
+def test_vendored_plugin_run_setup_check_succeeds_when_env_set(
+    tmp_path, restore_manifest, cleanup_vendor
+):
+  build_claude_plugin.build(dist_dir=tmp_path / "dist", skip_tar=True)
+
+  wrapper = PLUGIN_DIR / "scripts" / "run_setup_check.sh"
+  env = {
+      "PATH": "/usr/bin:/bin",
+      "BQAA_PYTHON": sys.executable,
+      "BQAA_PROJECT_ID": "ok-proj",
+      "BQAA_DATASET": "ok-ds",
+  }
+  result = subprocess.run(
+      ["bash", str(wrapper), "--json"],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=15,
+  )
+  # Required deps are installed in the test venv, so exit 0.
+  assert (
+      result.returncode == 0
+  ), f"check should pass with env + deps in place; stderr={result.stderr!r}"
+  report = json.loads(result.stdout)
+  assert report["all_ok"] is True
+  assert report["project_id"] == "ok-proj"
+  assert report["dataset"] == "ok-ds"
 
 
 def test_vendored_plugin_respects_trace_enabled_kill_switch_via_shell(

--- a/producers/tests/test_setup_check.py
+++ b/producers/tests/test_setup_check.py
@@ -50,9 +50,15 @@ def _isolate_env(monkeypatch):
 
 @pytest.fixture
 def fake_probes(monkeypatch):
-  """Replace the subprocess-driven probe with an in-memory mapping so
-  tests don't shell out to python."""
-  state: dict[str, dict[str, str | None]] = {"missing": {}, "extras": {}}
+  """Replace the subprocess-driven probes with in-memory mappings so
+  tests don't shell out to python. Interpreter probe defaults to
+  success (None); set ``state["interpreter_error"]`` to simulate a
+  bad BQAA_PYTHON."""
+  state: dict[str, object] = {
+      "missing": {},
+      "extras": {},
+      "interpreter_error": None,
+  }
 
   def _fake_probe(python_bin, modules):
     results = []
@@ -70,7 +76,11 @@ def fake_probes(monkeypatch):
       )
     return results
 
+  def _fake_interpreter(_python_bin):
+    return state["interpreter_error"]
+
   monkeypatch.setattr(setup_check, "_probe_imports", _fake_probe)
+  monkeypatch.setattr(setup_check, "_probe_interpreter", _fake_interpreter)
   return state
 
 
@@ -89,7 +99,59 @@ def test_resolve_python_bin_falls_back_to_sys_executable():
 
 
 # ---------------------------------------------------------------------------
-# collect_report
+# Interpreter probe (real subprocess, no fake)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_interpreter_succeeds_on_current_python():
+  assert setup_check._probe_interpreter(sys.executable) is None
+
+
+def test_probe_interpreter_reports_missing_binary():
+  err = setup_check._probe_interpreter("/nonexistent/python-binary-xyz")
+  assert err is not None
+  assert "not found" in err.lower() or "no such file" in err.lower()
+
+
+def test_probe_imports_handles_missing_binary_without_raising():
+  """Defensive catch — even if collect_report's interpreter probe is
+  bypassed, a direct call to _probe_imports with a bad python must
+  not raise. The /bqaa-setup UX is "always produce an actionable
+  report"; a raw OSError defeats that."""
+  probes = setup_check._probe_imports(
+      "/nonexistent/python-binary-xyz",
+      [("anything", "anything")],
+  )
+  assert len(probes) == 1
+  assert probes[0].ok is False
+  assert probes[0].error and "interpreter" in probes[0].error.lower()
+
+
+def test_collect_report_surfaces_interpreter_error_from_real_bad_path(
+    monkeypatch,
+):
+  """End-to-end (real subprocess): a bad BQAA_PYTHON must produce a
+  report with interpreter_error set, all_ok=False, and no traceback."""
+  monkeypatch.setenv("BQAA_PYTHON", "/nonexistent/python-binary-xyz")
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+
+  report = collect_report()
+
+  assert report.interpreter_error is not None
+  assert report.python_ok is False
+  assert report.all_ok is False
+  # Per-import sections are skipped (empty) — printing N copies of
+  # the same root cause is noise.
+  assert report.package_imports == []
+  assert report.required_imports == []
+  assert report.storage_write_imports == []
+  # env_ok is still True (vars are set); python_ok is what fails.
+  assert report.env_ok is True
+
+
+# ---------------------------------------------------------------------------
+# collect_report (with fake probes)
 # ---------------------------------------------------------------------------
 
 
@@ -184,6 +246,28 @@ def test_report_trace_disabled_via_env(monkeypatch, fake_probes):
   assert report.all_ok
 
 
+def test_report_interpreter_error_breaks_all_ok(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["interpreter_error"] = "interpreter not found: /bad/path"
+
+  report = collect_report()
+
+  assert report.python_ok is False
+  assert report.interpreter_error == "interpreter not found: /bad/path"
+  assert report.all_ok is False
+  # When interpreter is broken, import probes are skipped — empty
+  # lists rather than N misleading per-module failures.
+  assert report.package_imports == []
+  assert report.required_imports == []
+  assert report.storage_write_imports == []
+  # Even though the lists are empty, the *_ok properties are False
+  # (gated on python_ok), not vacuously True.
+  assert report.package_ok is False
+  assert report.required_deps_ok is False
+  assert report.storage_write_ok is False
+
+
 # ---------------------------------------------------------------------------
 # _format_report / main output
 # ---------------------------------------------------------------------------
@@ -229,6 +313,26 @@ def test_format_report_warns_when_trace_disabled(monkeypatch, fake_probes):
 
   assert "BQAA_TRACE_ENABLED" in text
   assert "off" in text.lower()
+
+
+def test_format_report_surfaces_interpreter_error_actionably(
+    monkeypatch, fake_probes
+):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["interpreter_error"] = "interpreter not found: /bad/path"
+
+  text = _format_report(collect_report())
+
+  assert "interpreter not found: /bad/path" in text
+  assert "BQAA_PYTHON" in text
+  assert "ACTION NEEDED" in text
+  # The "Required env vars" / "Required runtime deps" / "Storage
+  # Write" checklists are skipped — they'd be empty anyway and
+  # printing them adds noise. The "skipped" line tells the user
+  # why.
+  assert "skipped" in text.lower()
+  assert "Required env vars:" not in text
 
 
 # ---------------------------------------------------------------------------
@@ -288,3 +392,37 @@ def test_main_json_mode_exit_one_with_actionable_payload(
   assert parsed["all_ok"] is False
   missing = [p for p in parsed["required_imports"] if not p["ok"]]
   assert any(p["install_name"] == "google-cloud-bigquery" for p in missing)
+
+
+def test_main_json_mode_interpreter_error_payload(
+    monkeypatch, fake_probes, capsys
+):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["interpreter_error"] = "interpreter not found: /bad/path"
+
+  rc = main(argv=["--json"])
+
+  assert rc == 1
+  parsed = json.loads(capsys.readouterr().out)
+  assert parsed["interpreter_error"] == "interpreter not found: /bad/path"
+  assert parsed["python_ok"] is False
+  assert parsed["all_ok"] is False
+
+
+def test_main_bad_bqaa_python_does_not_crash(monkeypatch, capsys):
+  """Regression: a misconfigured BQAA_PYTHON used to bubble a raw
+  FileNotFoundError out of subprocess.run, defeating the /bqaa-setup
+  UX. Real subprocess this time — no fake_probes fixture — to prove
+  the production path doesn't crash."""
+  monkeypatch.setenv("BQAA_PYTHON", "/nonexistent/python-binary-xyz")
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+
+  rc = main(argv=["--json"])
+
+  assert rc == 1
+  parsed = json.loads(capsys.readouterr().out)
+  assert parsed["python_ok"] is False
+  assert parsed["interpreter_error"] is not None
+  assert "/nonexistent/python-binary-xyz" in parsed["interpreter_error"]

--- a/producers/tests/test_setup_check.py
+++ b/producers/tests/test_setup_check.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the advisory setup-check module."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from bigquery_agent_analytics_tracing import setup_check
+from bigquery_agent_analytics_tracing.setup_check import _format_report
+from bigquery_agent_analytics_tracing.setup_check import _ImportProbe
+from bigquery_agent_analytics_tracing.setup_check import _resolve_python_bin
+from bigquery_agent_analytics_tracing.setup_check import _SetupReport
+from bigquery_agent_analytics_tracing.setup_check import collect_report
+from bigquery_agent_analytics_tracing.setup_check import main
+
+_ALL_BQAA_ENV = [
+    "BQAA_PROJECT_ID",
+    "BQAA_DATASET",
+    "BQAA_PYTHON",
+    "BQAA_TRACE_ENABLED",
+    "GCP_PROJECT_ID",
+    "GOOGLE_CLOUD_PROJECT",
+    "BQ_DATASET",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+  for name in _ALL_BQAA_ENV:
+    monkeypatch.delenv(name, raising=False)
+  yield
+
+
+@pytest.fixture
+def fake_probes(monkeypatch):
+  """Replace the subprocess-driven probe with an in-memory mapping so
+  tests don't shell out to python."""
+  state: dict[str, dict[str, str | None]] = {"missing": {}, "extras": {}}
+
+  def _fake_probe(python_bin, modules):
+    results = []
+    for module, install_name in modules:
+      missing_map: dict[str, str | None] = state["missing"]
+      err = missing_map.get(module)
+      ok = module not in missing_map
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=ok,
+              error=err if not ok else None,
+          )
+      )
+    return results
+
+  monkeypatch.setattr(setup_check, "_probe_imports", _fake_probe)
+  return state
+
+
+# ---------------------------------------------------------------------------
+# _resolve_python_bin
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_python_bin_prefers_bqaa_python(monkeypatch):
+  monkeypatch.setenv("BQAA_PYTHON", "/custom/python")
+  assert _resolve_python_bin() == "/custom/python"
+
+
+def test_resolve_python_bin_falls_back_to_sys_executable():
+  assert _resolve_python_bin() == sys.executable
+
+
+# ---------------------------------------------------------------------------
+# collect_report
+# ---------------------------------------------------------------------------
+
+
+def test_report_all_ok(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "proj")
+  monkeypatch.setenv("BQAA_DATASET", "ds")
+
+  report = collect_report()
+
+  assert report.env_ok
+  assert report.package_ok
+  assert report.required_deps_ok
+  assert report.storage_write_ok
+  assert report.all_ok
+  assert report.trace_enabled is True
+
+
+def test_report_env_missing(fake_probes):
+  report = collect_report()
+  assert not report.env_ok
+  assert not report.all_ok
+  assert report.project_id is None
+  assert report.dataset is None
+
+
+def test_report_falls_back_to_legacy_gcp_env_vars(monkeypatch, fake_probes):
+  monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "legacy-proj")
+  monkeypatch.setenv("BQ_DATASET", "legacy-ds")
+
+  report = collect_report()
+
+  assert report.project_id == "legacy-proj"
+  assert report.dataset == "legacy-ds"
+  assert report.env_ok
+
+
+def test_report_required_dep_missing_breaks_all_ok(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["missing"][
+      "google.cloud.bigquery"
+  ] = "ModuleNotFoundError: No module named 'google'"
+
+  report = collect_report()
+
+  assert not report.required_deps_ok
+  assert not report.all_ok
+  assert any(
+      not p.ok and p.install_name == "google-cloud-bigquery"
+      for p in report.required_imports
+  )
+
+
+def test_report_storage_write_missing_does_not_break_all_ok(
+    monkeypatch, fake_probes
+):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["missing"]["pyarrow"] = "No module named 'pyarrow'"
+
+  report = collect_report()
+
+  assert not report.storage_write_ok
+  # all_ok is True because pyarrow is optional — drainer falls back to
+  # insert_rows_json without it.
+  assert report.all_ok
+
+
+def test_report_package_import_missing_breaks_all_ok(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["missing"][
+      "bigquery_agent_analytics_tracing"
+  ] = "ModuleNotFoundError"
+
+  report = collect_report()
+
+  assert not report.package_ok
+  assert not report.all_ok
+
+
+def test_report_trace_disabled_via_env(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "false")
+
+  report = collect_report()
+
+  assert report.trace_enabled is False
+  # Disabled trace doesn't change all_ok — that's about prerequisites,
+  # not runtime intent.
+  assert report.all_ok
+
+
+# ---------------------------------------------------------------------------
+# _format_report / main output
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_includes_pip_install_hints_for_missing_required(
+    monkeypatch, fake_probes
+):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  fake_probes["missing"]["google.cloud.bigquery"] = "missing"
+
+  text = _format_report(collect_report())
+
+  assert "pip install google-cloud-bigquery" in text
+  assert "ACTION NEEDED" in text
+
+
+def test_format_report_includes_env_export_hints_for_missing_env(fake_probes):
+  text = _format_report(collect_report())
+
+  assert "export BQAA_PROJECT_ID=" in text
+  assert "export BQAA_DATASET=" in text
+  assert "ACTION NEEDED" in text
+
+
+def test_format_report_ready_when_all_good(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+
+  text = _format_report(collect_report())
+
+  assert "READY" in text
+  assert "ACTION NEEDED" not in text
+
+
+def test_format_report_warns_when_trace_disabled(monkeypatch, fake_probes):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+  monkeypatch.setenv("BQAA_TRACE_ENABLED", "false")
+
+  text = _format_report(collect_report())
+
+  assert "BQAA_TRACE_ENABLED" in text
+  assert "off" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_zero_when_ready(monkeypatch, fake_probes, capsys):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+
+  rc = main(argv=[])
+
+  assert rc == 0
+  out = capsys.readouterr().out
+  assert "READY" in out
+
+
+def test_main_exits_one_when_required_missing(monkeypatch, fake_probes, capsys):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  # No BQAA_DATASET -> env_ok is False -> exit 1.
+  rc = main(argv=[])
+  assert rc == 1
+
+
+def test_main_json_mode_emits_structured_report(
+    monkeypatch, fake_probes, capsys
+):
+  monkeypatch.setenv("BQAA_PROJECT_ID", "p")
+  monkeypatch.setenv("BQAA_DATASET", "d")
+
+  rc = main(argv=["--json"])
+
+  assert rc == 0
+  parsed = json.loads(capsys.readouterr().out)
+  assert parsed["project_id"] == "p"
+  assert parsed["dataset"] == "d"
+  assert parsed["all_ok"] is True
+  assert parsed["env_ok"] is True
+  assert parsed["required_deps_ok"] is True
+  # Probe lists round-trip.
+  assert any(
+      p["module"] == "google.cloud.bigquery" and p["ok"]
+      for p in parsed["required_imports"]
+  )
+
+
+def test_main_json_mode_exit_one_with_actionable_payload(
+    monkeypatch, fake_probes, capsys
+):
+  fake_probes["missing"]["google.cloud.bigquery"] = "missing"
+
+  rc = main(argv=["--json"])
+
+  assert rc == 1
+  parsed = json.loads(capsys.readouterr().out)
+  assert parsed["all_ok"] is False
+  missing = [p for p in parsed["required_imports"] if not p["ok"]]
+  assert any(p["install_name"] == "google-cloud-bigquery" for p in missing)


### PR DESCRIPTION
Maps to **step 5 of #234** — final marketplace-readiness slice for the Claude Code plugin. After this lands, the plugin tarball produced by `release-tracing.yml` is ready to submit to the Claude Code marketplace.

Refs #234, #229.

## New: `/bqaa-setup` slash command

| Component | Purpose |
|---|---|
| `producers/src/bigquery_agent_analytics_tracing/setup_check.py` | Advisory check: env vars (`BQAA_PROJECT_ID`/`BQAA_DATASET`, plus legacy `GCP_PROJECT_ID`/`BQ_DATASET` fallbacks), `BQAA_PYTHON` interpreter, vendored package import (sanity-check the layout works), required deps (`google-cloud-bigquery`), optional Storage Write deps (`google-cloud-bigquery-storage`, `pyarrow`). Human-readable text by default; JSON with `--json`. Exit 0 when ready, 1 when required deps/env missing. Storage Write deps are reported but do not affect exit code (drainer falls back to `insert_rows_json` without them). |
| Console script | `bqaa-check-setup = setup_check:main` |
| `plugins/claude_code/commands/bqaa-setup.md` | Claude Code slash command markdown. Tells Claude to run the wrapper, surface output verbatim, and explicitly **not** modify shell rc files or install packages on the user's behalf. |
| `plugins/claude_code/scripts/run_setup_check.sh` | Wrapper mirroring `hooks/common.sh` — sets `PYTHONPATH` to `vendor/`, execs `python -m bigquery_agent_analytics_tracing.setup_check`. Works in vendored runtime with no wheel install. |

**Design call:** the setup check is advisory-only. It never mutates shell config, never installs packages, never touches GCP IAM. The interactive bootstrap that does those things (the source repo's `setup_gcp_prereqs.py`) stays out of this PR — that's a separate explicit choice. Documented in `MARKETPLACE.md`'s "BigQuery IAM requirements" section so users know what to do manually.

## Marketplace docs

| File | Contents |
|---|---|
| `plugins/claude_code/MARKETPLACE.md` (new) | Pre-submission checklist (manifest fields, executable bits, tarball contents), runtime dependency model table, BigQuery IAM requirements (`bigquery.dataEditor` on dataset, `bigquery.user` on project, `bigquery.metadataViewer` when `BQAA_AUTO_CREATE_TABLE=true`), pre-marketplace install path, manual verification recipe (download → `/bqaa-setup` → real prompt → query `agent_events` and assert `attributes.writer.version` reflects the installed version). |
| `plugins/claude_code/README.md` | Updated layout diagram to show `commands/`, `scripts/`, `MARKETPLACE.md`, `vendor/dist-info/`. Cross-links to `/bqaa-setup` and `MARKETPLACE.md` from the runtime-deps section. |
| `plugins/claude_code/.claude-plugin/plugin.json` | Added `homepage` field pointing at the plugin's GitHub tree directory for richer marketplace listings. Existing fields verified against the submission checklist. |

## Tests — 19 new, 94 total, all green

- **`setup_check` unit tests (16)** — env resolution, legacy env fallbacks (`GCP_PROJECT_ID`/`BQ_DATASET`), required-dep missing breaks `all_ok`, storage-write missing does NOT break `all_ok`, package import missing breaks `all_ok`, `BQAA_TRACE_ENABLED=false` flagged in report without changing `all_ok`, format output includes pip install hints + env export hints + "READY"/"ACTION NEEDED" markers, `main()` exit codes (0 ready / 1 not ready), `--json` emits structured payload, JSON exit code matches text mode
- **Plugin artifact tests (3 new)**:
  - Tarball includes `commands/bqaa-setup.md`, `scripts/run_setup_check.sh`, and `MARKETPLACE.md`
  - **Vendored `/bqaa-setup` smoke (no wheel install)** — runs `bash scripts/run_setup_check.sh --json` with `BQAA_PYTHON=$(sys.executable)` and `PYTHONPATH` unset (the wrapper sets it). Asserts `package_ok=True` (vendored import works), `env_ok=False` (vars deliberately unset), exit 1
  - Same wrapper with env vars set asserts `all_ok=True`, exit 0

## Verified end-to-end

Ran the standalone build, inspected the marketplace tarball — all expected paths present:

```
bigquery-agent-analytics-tracing-claude-code-0.1.0.dev0/
├── .claude-plugin/plugin.json
├── MARKETPLACE.md
├── README.md
├── commands/bqaa-setup.md
├── hooks/{common,session_start,user_prompt_submit,pre_tool_use,
│         post_tool_use,stop,subagent_stop,notification,
│         permission_request,session_end}.sh
├── scripts/run_setup_check.sh
└── vendor/
    ├── bigquery_agent_analytics_tracing/
    │   ├── __init__.py, _utils.py, _writer_identity.py,
    │   ├── claude_code.py, config.py, drain.py, logger.py,
    │   ├── schema.py, setup_check.py
    └── bigquery_agent_analytics_tracing-0.1.0.dev0.dist-info/METADATA
```

## Acceptance criteria from #234 covered here

- [x] Plugin artifact is ready for Claude Code marketplace submission
- [x] `/bqaa-setup` slash command for interactive install guidance (advisory only, per design call above)
- [x] Plugin metadata polish (homepage added, all submission-checklist fields verified)

## Test plan

- [x] `pytest tests/ -q` — 94/94 pass on Python 3.13.5
- [x] `pyink src/ tests/ scripts/ --check` — clean
- [x] `isort src/ tests/ scripts/ --check-only` — clean
- [x] `python scripts/build_claude_plugin.py` produces all three artifacts; tarball contains all expected paths
- [x] `bash plugins/claude_code/scripts/run_setup_check.sh --json` in a vendored layout (no wheel install) — exit 1 with `package_ok=True, env_ok=False` when vars unset; exit 0 with `all_ok=True` when vars set
- [x] Manifest restored to `0.0.0+local` placeholder so source-controlled diff stays minimal
- [ ] Producers CI green on the PR head after maintainer approves the first-time-fork gate
- [ ] Manual marketplace submission dry-run per `MARKETPLACE.md#manual-verification-before-each-marketplace-bump`

## What this PR intentionally does NOT do

- Submit to the marketplace (that's a one-time human action after this PR lands; checklist is in `MARKETPLACE.md`)
- Bootstrap GCP/IAM resources (the original source repo's `setup_gcp_prereqs.py`; out of scope for marketplace readiness, advisory `/bqaa-setup` is what users get for now)
- Bump the package version (still `0.1.0.dev0`; the first marketplace submission will be the first real version bump)