### PR TITLE
producers: bump tracing 0.1.0.dev0 → 0.1.0 for first release

### DIFF
--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -71,7 +71,7 @@ from a GitHub release tarball:
 ```bash
 # Pick a released version from
 # https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases
-VERSION=0.1.0.dev0
+VERSION=0.1.0
 
 mkdir -p ~/.claude/plugins
 curl -L \

--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigquery-agent-analytics-tracing"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Producer packages and Claude/Codex/OpenAI Agents tracing adapters for BigQuery Agent Analytics."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
First real release of `bigquery-agent-analytics-tracing`. Per the practical path in #242 — merge this, then tag `tracing-v0.1.0` to fire the release pipeline.

## Changes

| File | Diff |
|---|---|
| `producers/pyproject.toml` | `version = "0.1.0.dev0"` → `version = "0.1.0"` |
| `plugins/claude_code/README.md` | install example `VERSION=0.1.0.dev0` → `VERSION=0.1.0` so the curl actually resolves a real release URL post-tag |

## What's not touched

- `plugins/claude_code/.claude-plugin/plugin.json` keeps its `"0.0.0+local"` placeholder — the build script stamps the resolved version at release time per #237.
- No test fixtures hardcoded `0.1.0.dev0`; all tests resolve the version dynamically via `importlib.metadata`, so they keep passing across the bump.

## What happens after merge

```bash
git checkout main && git pull --ff-only
git tag -a tracing-v0.1.0 -m "tracing 0.1.0"
git push origin tracing-v0.1.0
```

`release-tracing.yml` (from #239) takes over:

1. `verify` — confirms tag matches `pyproject.toml` (`tracing-v0.1.0` ↔ `0.1.0`), runs tests on 3.12.
2. `build` — wheel + sdist + Claude Code plugin tarball. Asserts all three artifacts land.
3. `github-release` — attaches the wheel, sdist, and plugin tarball to the `tracing-v0.1.0` release with auto-generated notes.
4. `publish-testpypi` — uploads wheel + sdist to TestPyPI (gated on `github-release` per the d134337 fix on #239).
5. `publish-pypi` — same to PyPI, with `pypi` environment manual approval gate.

Plugin tarball ships as a GitHub release asset only, never on PyPI. Tarball name: `bigquery-agent-analytics-tracing-claude-code-0.1.0.tar.gz`.

## Verified locally

- `pytest tests/ -q` — 103/103 pass
- `python scripts/build_claude_plugin.py` produces `bigquery-agent-analytics-tracing-claude-code-0.1.0.tar.gz`; vendored `.dist-info` reports `Version: 0.1.0`; `importlib.metadata.version()` resolves to `"0.1.0"`
- Plugin manifest restored to `0.0.0+local` placeholder before commit so source-controlled diff stays minimal

## Pre-merge maintainer action (if not already done)

Configure Trusted Publishers on TestPyPI and PyPI per `producers/RELEASING.md` ("PyPI Trusted Publishing setup"). Until both publishers exist, `publish-testpypi` and `publish-pypi` will fail with a clear OIDC error — `build` and `github-release` are independent and will still complete, so the tag and the GitHub release tarball are not blocked on PyPI side config.

## Test plan

- [x] Tests pass after the bump
- [x] Wheel/sdist/plugin tarball build with the new version
- [ ] After merge: tag `tracing-v0.1.0` → release pipeline produces the expected artifacts
- [ ] Producers CI green on this PR
- [ ] CLA bot ack

Refs #229, #234, #242.