### PR TITLE
plugins: add Claude Code marketplace catalog + 0.1.0 dist folder

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "bqaa-tracing",
+  "owner": {
+    "name": "Google LLC",
+    "url": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"
+  },
+  "plugins": [
+    {
+      "name": "bigquery-agent-analytics-tracing",
+      "description": "Stream Claude Code hook traces to Google BigQuery Agent Analytics agent_events.",
+      "version": "0.1.0",
+      "source": "./plugins/claude_code_dist/bigquery-agent-analytics-tracing",
+      "author": {
+        "name": "Google LLC"
+      },
+      "homepage": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/plugins/claude_code",
+      "repository": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK",
+      "license": "Apache-2.0",
+      "keywords": [
+        "bigquery",
+        "agent-analytics",
+        "observability",
+        "tracing",
+        "claude-code"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "bqaa-tracing",
+  "description": "Claude Code tracing plugins for BigQuery Agent Analytics.",
   "owner": {
     "name": "Google LLC",
     "url": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"

--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -74,6 +74,24 @@ From a Claude Code session:
 /plugin install bigquery-agent-analytics-tracing@bqaa-tracing
 ```
 
+> **Important: add the marketplace via the Git source form
+> (`<owner>/<repo>`), not via a direct URL to `marketplace.json`.**
+> The catalog uses a relative `source` path
+> (`./plugins/claude_code_dist/...`), which Claude Code can only
+> resolve when the marketplace was added as a Git checkout — that's
+> what provides the surrounding repo files the relative path points
+> into. A direct-URL `add` would fetch only the catalog JSON and the
+> plugin install would fail to resolve.
+
+For a faster clone — the SDK repo carries the consumption SDK + tests
+in addition to the plugin tree — use a sparse checkout if your Claude
+Code version supports it:
+
+```
+/plugin marketplace add GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK --sparse .claude-plugin plugins/claude_code_dist
+/plugin install bigquery-agent-analytics-tracing@bqaa-tracing
+```
+
 Then configure BigQuery destination + runtime deps (one-time):
 
 ```bash

--- a/plugins/claude_code_dist/README.md
+++ b/plugins/claude_code_dist/README.md
@@ -4,6 +4,13 @@ This directory holds the **built** plugin artifacts that the Claude Code
 marketplace catalog at [`/.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
 serves to users.
 
+The catalog uses a **relative** plugin `source` pointing into this
+directory. That means users must add the marketplace via the Git
+source form (`/plugin marketplace add <owner>/<repo>`), **not** by
+passing a direct URL to `marketplace.json` — Claude Code can only
+resolve `./plugins/claude_code_dist/...` when the surrounding repo
+checkout is available locally.
+
 ## Why this exists
 
 The source of truth for the plugin lives at

--- a/plugins/claude_code_dist/README.md
+++ b/plugins/claude_code_dist/README.md
@@ -1,0 +1,59 @@
+# Claude Code plugin distribution
+
+This directory holds the **built** plugin artifacts that the Claude Code
+marketplace catalog at [`/.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
+serves to users.
+
+## Why this exists
+
+The source of truth for the plugin lives at
+[`plugins/claude_code/`](../claude_code/). That directory uses
+`0.0.0+local` as a manifest placeholder and gitignores `vendor/` so the
+canonical package source under `producers/src/` and the plugin tree
+cannot drift.
+
+The marketplace can't install from that form. It needs:
+
+- A `plugin.json` stamped with a real version (not the placeholder).
+- A populated `vendor/` directory.
+- A `vendor/<pkg>-<version>.dist-info/METADATA` so
+  `importlib.metadata.version()` resolves at runtime.
+
+Those are exactly what
+[`producers/scripts/build_claude_plugin.py`](../../producers/scripts/build_claude_plugin.py)
+produces, and what the `tracing-vX.Y.Z` release tag attaches to its
+GitHub release as `bigquery-agent-analytics-tracing-claude-code-X.Y.Z.tar.gz`.
+
+This directory is **the expanded tarball, committed**, so the marketplace
+catalog's relative-path `source` can serve it.
+
+## Release routine for this directory
+
+After each `tracing-vX.Y.Z` cut:
+
+```bash
+VERSION=X.Y.Z
+WORK=$(mktemp -d)
+curl -sSL \
+  "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
+  -o "$WORK/plugin.tar.gz"
+tar -xzf "$WORK/plugin.tar.gz" -C "$WORK"
+
+rm -rf plugins/claude_code_dist/bigquery-agent-analytics-tracing
+cp -R "$WORK/bigquery-agent-analytics-tracing-claude-code-${VERSION}" \
+      plugins/claude_code_dist/bigquery-agent-analytics-tracing
+```
+
+Then bump `.claude-plugin/marketplace.json`'s `version` field and PR.
+
+Manual for v0.1.0; automate in a follow-up PR (cross-repo workflow
+trigger on `tracing-v*` tags from `release-tracing.yml`).
+
+## Do not edit the contents directly
+
+`plugins/claude_code_dist/bigquery-agent-analytics-tracing/` is a verbatim
+copy of the released tarball. Edits there get overwritten on the next
+release sync. Send patches to:
+
+- [`producers/src/bigquery_agent_analytics_tracing/`](../../producers/src/bigquery_agent_analytics_tracing/) — for the vendored Python.
+- [`plugins/claude_code/`](../claude_code/) — for the plugin manifest, hooks, slash commands, scripts, and docs.

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/.claude-plugin/plugin.json
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/.claude-plugin/plugin.json
@@ -1,0 +1,110 @@
+{
+  "name": "bigquery-agent-analytics-tracing",
+  "description": "Stream Claude Code hook traces to Google BigQuery Agent Analytics agent_events.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Google LLC"
+  },
+  "repository": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK",
+  "homepage": "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/plugins/claude_code",
+  "license": "Apache-2.0",
+  "keywords": [
+    "bigquery",
+    "agent-analytics",
+    "observability",
+    "tracing",
+    "claude-code"
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.sh\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt_submit.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_tool_use.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post_tool_use.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent_stop.sh\""
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.sh\""
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/permission_request.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session_end.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/MARKETPLACE.md
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/MARKETPLACE.md
@@ -1,0 +1,112 @@
+# Claude Code marketplace submission
+
+Reference for submitting `bigquery-agent-analytics-tracing` to the
+[Claude Code plugin marketplace](https://docs.claude.com/en/docs/claude-code/plugins).
+Keep updated whenever metadata or install model changes.
+
+## Pre-submission checklist
+
+- [ ] `.claude-plugin/plugin.json` fields are final
+  - [ ] `name` matches the PyPI distribution: `bigquery-agent-analytics-tracing`
+  - [ ] `description` is under one sentence and accurate
+  - [ ] `version` matches the `tracing-vX.Y.Z` release tag (the build
+        script stamps this at release time; manual edits will be
+        overwritten)
+  - [ ] `author.name = "Google LLC"`
+  - [ ] `repository` points at the GoogleCloudPlatform repo
+  - [ ] `homepage` (if set) resolves to a public docs page
+  - [ ] `license` is `Apache-2.0`
+  - [ ] `keywords` cover the discoverability terms users will search
+        for: `bigquery`, `agent-analytics`, `observability`, `tracing`,
+        `claude-code`
+  - [ ] All nine hooks declared with `${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh`
+- [ ] `/bqaa-setup` slash command discoverable via `commands/bqaa-setup.md`
+- [ ] `hooks/common.sh` and `scripts/run_setup_check.sh` are executable
+      (`chmod +x`) in source control
+- [ ] Plugin tarball produced by the release pipeline contains:
+  - [ ] `.claude-plugin/plugin.json` (version stamped)
+  - [ ] `hooks/` — all nine `*.sh` files + `common.sh`
+  - [ ] `commands/bqaa-setup.md`
+  - [ ] `scripts/run_setup_check.sh`
+  - [ ] `vendor/bigquery_agent_analytics_tracing/` (full package source)
+  - [ ] `vendor/bigquery_agent_analytics_tracing-X.Y.Z.dist-info/METADATA`
+        (so `importlib.metadata.version()` resolves correctly)
+- [ ] Tarball excludes `__pycache__`, `*.pyc`, `.gitignore`
+
+## Runtime dependency model
+
+Users **do not** need to `pip install bigquery-agent-analytics-tracing`.
+The plugin vendors its own copy of the package. They DO need:
+
+| Dep | Required? | Used for |
+|---|---|---|
+| `google-cloud-bigquery` | yes | both writer paths |
+| `google-cloud-bigquery-storage` | optional | Storage Write API (lower latency, recommended for production) |
+| `pyarrow` | optional | Storage Write API row encoding |
+
+`BQAA_PYTHON` (or `python3` if unset) is the interpreter the hooks
+exec. The `/bqaa-setup` command checks all of this and prints the
+exact `pip install ...` line for any missing dep.
+
+## BigQuery IAM requirements
+
+The service account or user credentials the plugin's `BQAA_PYTHON`
+will use (via ADC) needs:
+
+| Role | Why |
+|---|---|
+| `roles/bigquery.dataEditor` on the destination dataset | write rows into `agent_events` |
+| `roles/bigquery.user` on the project | run queries, list datasets, etc. |
+| `roles/bigquery.metadataViewer` on the destination dataset | (only when `BQAA_AUTO_CREATE_TABLE=true`) read schema before deciding to create |
+
+The plugin emits rows under the credentials' identity — there is no
+per-user impersonation. Set `BQAA_AGENT_NAME` to disambiguate
+multiple producers writing to the same dataset.
+
+## Install path (pre-marketplace)
+
+See [`README.md`](README.md#installing-the-plugin) for the curl-and-extract
+recipe. Until marketplace listing is live this is the official path.
+
+## Manual verification before each marketplace bump
+
+Run on a clean environment (no `bigquery-agent-analytics-tracing` wheel
+on `BQAA_PYTHON`):
+
+1. Download the release tarball for the version you're submitting:
+   ```bash
+   VERSION=X.Y.Z
+   curl -L \
+     "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
+     | tar -xz -C ~/.claude/plugins
+   ```
+2. Configure Claude Code to load the plugin per the
+   [Claude Code plugins docs](https://docs.claude.com/en/docs/claude-code/plugins).
+3. Inside a Claude Code session:
+   - Run `/bqaa-setup` — expect a "READY" status (after configuring env
+     vars + installing runtime deps as instructed).
+   - Submit a real prompt. Confirm a row lands in
+     `${BQAA_PROJECT_ID}.${BQAA_DATASET}.agent_events`:
+     ```sql
+     SELECT event_type, attributes.writer.version, attributes.writer.label
+     FROM `${BQAA_PROJECT_ID}.${BQAA_DATASET}.agent_events`
+     ORDER BY timestamp DESC
+     LIMIT 5
+     ```
+   - `attributes.writer.version` and `attributes.writer.label` must
+     reflect the version you just installed — NOT `0.0.0+local`. If
+     they do, the vendored `.dist-info` is missing or stale.
+4. Confirm `BQAA_TRACE_ENABLED=false` cleanly disables emission with
+   no errors in the agent log.
+
+## Submission process
+
+1. Cut a `tracing-vX.Y.Z` release per [`producers/RELEASING.md`](../../producers/RELEASING.md).
+2. Run the manual verification above against the published tarball.
+3. Submit the plugin to the marketplace per
+   [Claude Code's marketplace submission docs](https://docs.claude.com/en/docs/claude-code/plugins).
+   Point the submission at the GitHub release URL.
+4. Update this file's checklist completion status.
+5. After acceptance, update [`README.md`](README.md) to remove the
+   "until marketplace listing is live" hedge and point at the
+   marketplace listing.

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md
@@ -65,48 +65,31 @@ BigQuery IAM requirements and submission checklist live in
 
 ## Installing the plugin
 
-This repo serves a Claude Code marketplace catalog at
-[`/.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json).
-From a Claude Code session:
-
-```
-/plugin marketplace add GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
-/plugin install bigquery-agent-analytics-tracing@bqaa-tracing
-```
-
-Then configure BigQuery destination + runtime deps (one-time):
+Until the plugin is submitted to the Claude Code marketplace, install
+from a GitHub release tarball:
 
 ```bash
-export BQAA_PROJECT_ID=your-gcp-project
-export BQAA_DATASET=agent_analytics
-pip install google-cloud-bigquery                  # always
-pip install google-cloud-bigquery-storage pyarrow  # Storage Write path (optional)
-```
-
-Run `/bqaa-setup` inside Claude Code to verify the env vars and runtime
-deps are correctly configured before relying on tracing.
-
-### Submission to Anthropic's official marketplace
-
-Tracked in [#251](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/251)
-(track B5). Until then, the self-hosted catalog above is the canonical
-install path.
-
-### Manual install from the GitHub release (fallback)
-
-If you can't use the marketplace catalog, download the plugin tarball
-attached to the matching `tracing-vX.Y.Z` GitHub release:
-
-```bash
+# Pick a released version from
+# https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases
 VERSION=0.1.0
+
 mkdir -p ~/.claude/plugins
 curl -L \
   "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
   | tar -xz -C ~/.claude/plugins
+
+# Configure BigQuery destination + runtime deps (one-time).
+export BQAA_PROJECT_ID=your-gcp-project
+export BQAA_DATASET=agent_analytics
+pip install google-cloud-bigquery               # always
+pip install google-cloud-bigquery-storage pyarrow  # Storage Write path
 ```
 
 Then point Claude Code at the unpacked plugin directory per the
 [Claude Code plugins docs](https://docs.claude.com/en/docs/claude-code/plugins).
+
+Marketplace submission is tracked in
+[#234 step 5](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/234).
 
 ## Building the artifact
 

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/commands/bqaa-setup.md
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/commands/bqaa-setup.md
@@ -1,0 +1,55 @@
+---
+description: Check BQAA tracing setup — env vars, Python runtime deps, vendored package import. Advisory only; never mutates the environment.
+---
+
+# /bqaa-setup
+
+Run the BQAA tracing setup check and report what (if anything) needs fixing
+before agent events can land in BigQuery.
+
+## What to do
+
+1. Invoke the wrapper script:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/run_setup_check.sh"
+   ```
+
+   The wrapper sets `PYTHONPATH` to the vendored package root and runs
+   `python -m bigquery_agent_analytics_tracing.setup_check`. Exit code is
+   `0` when the runtime is ready, `1` when something required is missing
+   or unconfigured.
+
+2. Surface the script's output to the user verbatim. The check is designed
+   to be copy-pasteable — it already prints the exact `pip install ...`
+   command for any missing dep and the exact `export BQAA_PROJECT_ID=...`
+   line for any missing env var.
+
+3. **Do not** modify the user's shell rc files, install packages on their
+   behalf, or run any GCP API calls in this command. This is advisory
+   only — if the user wants a guided install, they can run the suggested
+   commands themselves.
+
+## What the check covers
+
+- `BQAA_PROJECT_ID` — required. Falls back to `GCP_PROJECT_ID` /
+  `GOOGLE_CLOUD_PROJECT` if unset.
+- `BQAA_DATASET` — required. Falls back to `BQ_DATASET` if unset.
+- `BQAA_PYTHON` — the interpreter the hooks will exec; defaults to the
+  current `python3`. The check verifies it can import the tracing
+  package and required runtime deps.
+- `google-cloud-bigquery` — always required (both writer paths use it).
+- `google-cloud-bigquery-storage` + `pyarrow` — required only for the
+  lower-latency Storage Write path; absence is reported as advisory
+  (the drainer falls back to `insert_rows_json`).
+
+## What the check does NOT do
+
+- Create a BigQuery dataset or table.
+- Grant IAM permissions.
+- Install pip packages.
+- Edit shell rc files or `~/.claude/settings.json`.
+
+For the bootstrap that actually does those things, see
+[`plugins/claude_code/MARKETPLACE.md`](../MARKETPLACE.md#bigquery-iam-requirements)
+for the IAM model and the manual `gcloud` / `bq` commands.

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/common.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared hook entry. Each hooks/<hook_name>.sh execs this with its hook
+# name as $1.
+#
+# Vendored package: bigquery_agent_analytics_tracing/ lives under
+# vendor/ in the plugin tree. Prepending it to PYTHONPATH lets the
+# `-m bigquery_agent_analytics_tracing.claude_code` invocation work
+# without `pip install bigquery-agent-analytics-tracing` — and the
+# drainer subprocess inherits the same PYTHONPATH via os.environ when
+# the logger spawns it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+PYTHON_BIN="${BQAA_PYTHON:-python3}"
+
+if [[ "${BQAA_TRACE_ENABLED:-true}" != "true" ]]; then
+  exit 0
+fi
+
+export PYTHONPATH="${PLUGIN_DIR}/vendor:${PYTHONPATH:-}"
+
+exec "$PYTHON_BIN" -m bigquery_agent_analytics_tracing.claude_code "$1"

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/notification.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/notification.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" Notification

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/permission_request.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/permission_request.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PermissionRequest

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/post_tool_use.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/post_tool_use.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PostToolUse

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/pre_tool_use.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/pre_tool_use.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" PreToolUse

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/session_end.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/session_end.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SessionEnd

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/session_start.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/session_start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SessionStart

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/stop.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/stop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" Stop

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/subagent_stop.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/subagent_stop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" SubagentStop

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/user_prompt_submit.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/hooks/user_prompt_submit.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$(dirname "${BASH_SOURCE[0]}")/common.sh" UserPromptSubmit

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/scripts/run_setup_check.sh
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/scripts/run_setup_check.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper for the /bqaa-setup slash command. Mirrors hooks/common.sh so
+# the vendored package resolves from PYTHONPATH without a wheel install.
+#
+# Runner vs. target distinction:
+#   * RUNNER_PYTHON is the interpreter that executes the setup_check
+#     module. It must work — otherwise the diagnostic itself fails at
+#     the shell layer (`bash: exec: $BQAA_PYTHON: No such file`) and
+#     the user sees a raw shell error instead of an actionable
+#     report.
+#   * BQAA_PYTHON is the interpreter the hooks will use at runtime.
+#     The setup_check module probes it internally — its job is
+#     specifically to diagnose a broken BQAA_PYTHON. Don't conflate
+#     the two.
+#
+# Prefer BQAA_PYTHON as the runner when it works, fall back to
+# python3 (always assumed available) so /bqaa-setup never silently
+# breaks on the most common misconfiguration.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+
+RUNNER_PYTHON="${BQAA_PYTHON:-python3}"
+# Quick liveness check: if the configured interpreter cannot even
+# exec a no-op, fall back to python3. setup_check.py still probes
+# BQAA_PYTHON internally and surfaces the interpreter_error in the
+# report.
+if ! "$RUNNER_PYTHON" -c "pass" >/dev/null 2>&1; then
+  RUNNER_PYTHON="python3"
+fi
+
+export PYTHONPATH="${PLUGIN_DIR}/vendor:${PYTHONPATH:-}"
+
+exec "$RUNNER_PYTHON" -m bigquery_agent_analytics_tracing.setup_check "$@"

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing-0.1.0.dist-info/METADATA
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing-0.1.0.dist-info/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: bigquery-agent-analytics-tracing
+Version: 0.1.0

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/__init__.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BigQuery Agent Analytics tracing producers.
+
+Public API:
+
+  * ``BigQueryAgentAnalyticsLogger`` — builds rows in the BQAA
+    ``agent_events`` schema and routes them to spool / dry-run /
+    direct-write.
+  * ``BQAAConfig`` — environment- or constructor-driven configuration.
+  * ``bq_schema`` — the canonical schema, used by both the auto-create
+    path and the drainer's ``insert_rows_json`` fallback.
+
+Producer modules:
+
+  * ``claude_code`` — Claude Code hook adapter + ``main()`` entry.
+    Console script: ``bqaa-claude-hook``.
+  * ``setup_check`` — advisory check for env vars + runtime deps.
+    Console script: ``bqaa-check-setup``. Used by the ``/bqaa-setup``
+    Claude Code slash command.
+
+OpenAI Agents SDK and Codex CLI adapters land in follow-up PRs.
+"""
+
+from ._writer_identity import __version__
+from .config import BQAAConfig
+from .logger import BigQueryAgentAnalyticsLogger
+from .schema import bq_schema
+
+__all__ = [
+    "BQAAConfig",
+    "BigQueryAgentAnalyticsLogger",
+    "__version__",
+    "bq_schema",
+]

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/_utils.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/_utils.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for serialization, hashing, timestamps, file locking, and
+log emission. No dependencies on other package modules so this can be safely
+imported from anywhere in the package."""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from datetime import timezone
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any, Iterator, TYPE_CHECKING
+import uuid
+
+if TYPE_CHECKING:
+  from .config import BQAAConfig
+
+SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "client_secret",
+        "id_token",
+        "password",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
+
+
+def utc_now() -> datetime:
+  return datetime.now(timezone.utc)
+
+
+def timestamp_ms() -> int:
+  return int(time.time() * 1000)
+
+
+def iso_timestamp(value: datetime | None = None) -> str:
+  ts = value or utc_now()
+  return ts.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def hex_id(chars: int) -> str:
+  return uuid.uuid4().hex[:chars]
+
+
+def deterministic_span(seed: str, chars: int = 16) -> str:
+  """Stable hex span id derived from a seed (e.g. tool_use_id).
+
+  Used so that a PostToolUse without a matching PreToolUse can still emit a
+  span_id that correlates with whatever the (missing) start would have
+  produced. Better than ``hex_id`` which yields a fresh random id and breaks
+  span correlation.
+  """
+  if not seed:
+    return hex_id(chars)
+  digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+  return digest[:chars]
+
+
+def to_jsonable(value: Any) -> Any:
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  if isinstance(value, dict):
+    return {str(k): to_jsonable(v) for k, v in value.items()}
+  if isinstance(value, (list, tuple, set)):
+    return [to_jsonable(v) for v in value]
+  if hasattr(value, "model_dump"):
+    return to_jsonable(value.model_dump())
+  if hasattr(value, "to_dict"):
+    return to_jsonable(value.to_dict())
+  return str(value)
+
+
+def truncate(value: Any, max_len: int) -> tuple[Any, bool]:
+  """Recursively truncate strings and redact sensitive dict keys.
+
+  Returns ``(clipped_value, was_truncated)``. ``max_len == -1`` disables
+  truncation. Keys whose lowercase name is in ``SENSITIVE_KEYS`` or starts
+  with ``"temp:"`` are replaced with ``"[REDACTED]"``.
+  """
+  value = to_jsonable(value)
+  if max_len == -1:
+    return value, False
+  if isinstance(value, str):
+    if len(value) > max_len:
+      return value[:max_len] + "...[TRUNCATED]", True
+    return value, False
+  if isinstance(value, list):
+    out = []
+    truncated = False
+    for item in value:
+      next_item, did_truncate = truncate(item, max_len)
+      out.append(next_item)
+      truncated = truncated or did_truncate
+    return out, truncated
+  if isinstance(value, dict):
+    out: dict[str, Any] = {}
+    truncated = False
+    for key, item in value.items():
+      key_lower = str(key).lower()
+      if key_lower in SENSITIVE_KEYS or key_lower.startswith("temp:"):
+        out[key] = "[REDACTED]"
+        continue
+      next_item, did_truncate = truncate(item, max_len)
+      out[key] = next_item
+      truncated = truncated or did_truncate
+    return out, truncated
+  return value, False
+
+
+def safe_json_loads(value: str | None, default: Any) -> Any:
+  if not value:
+    return default
+  try:
+    return json.loads(value)
+  except json.JSONDecodeError:
+    return default
+
+
+@contextlib.contextmanager
+def file_lock(path: Path, mode: int = fcntl.LOCK_EX) -> Iterator[int]:
+  """Open a lockfile exclusively. Blocks until the lock is acquired."""
+  path.parent.mkdir(parents=True, exist_ok=True)
+  fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    fcntl.flock(fd, mode)
+    yield fd
+  finally:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+      os.close(fd)
+
+
+def log_to_file(config: "BQAAConfig", message: str) -> None:
+  """Append a single log line to ``config.log_file``. Silent on failure.
+
+  The drainer and the spool writer share this — debugging signal lives in
+  one place, and a broken log path never crashes the agent's hot path.
+  """
+  if not config.log_file:
+    return
+  try:
+    with open(config.log_file, "a", encoding="utf-8") as handle:
+      handle.write(f"[{iso_timestamp()}] {message}\n")
+  except OSError:
+    pass

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/_writer_identity.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/_writer_identity.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Writer identity stamped onto every row's `attributes.writer` block.
+
+Two surfaces read this:
+
+  * Every row's `attributes.writer.{plugin,version,label,agent,mode}` block
+    — the queryable surface for self-service adoption analytics.
+  * `AppendRowsRequest.trace_id` on Storage Write API batches — recorded
+    server-side by Google for diagnostics. Not exposed as a column in
+    `INFORMATION_SCHEMA.WRITE_API_TIMELINE_BY_*`, so it cannot power
+    adoption queries; it lets Google Cloud support attribute traffic back
+    to this package during throughput/quota investigations.
+
+Override per deployment with the `BQAA_WRITER_LABEL` env var (e.g. when
+running multiple distinct deployments against one dataset).
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+WRITER_PLUGIN_NAME = "bigquery-agent-analytics-tracing"
+
+
+def get_writer_version() -> str:
+  """Resolve the writer version from package metadata.
+
+  Falls back to ``"0.0.0+local"`` for vendored installs (e.g. a Claude Code
+  plugin that ships the package source without a wheel install) and for
+  source checkouts where the distribution is not installed.
+  """
+  try:
+    return metadata.version(WRITER_PLUGIN_NAME)
+  except metadata.PackageNotFoundError:
+    return "0.0.0+local"
+
+
+__version__ = get_writer_version()
+DEFAULT_WRITER_LABEL = f"{WRITER_PLUGIN_NAME}/{__version__}"

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/claude_code.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/claude_code.py
@@ -1,0 +1,702 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Claude Code hook producer for BQAA.
+
+Maps Claude Code's native hooks (``SessionStart``, ``UserPromptSubmit``,
+``PreToolUse``, ``PostToolUse``, ``Stop``, ``SubagentStop``,
+``Notification``, ``PermissionRequest``, ``SessionEnd``) onto BQAA
+``agent_events`` rows. Each hook receives a JSON payload on stdin and
+this module's ``main()`` is the entry that hook shell wrappers invoke.
+
+State lives in two on-disk JSON stores guarded by ``fcntl.flock``:
+
+  * ``state_<session>.json`` — session-scoped state (session id, current
+    trace/span/invocation, transcript bookmark, agent identity).
+  * ``tool_<session>_<tool_use_id>.json`` — per-tool state so concurrent
+    ``PreToolUse`` fires for parallel tools cannot clobber each other's
+    ``start_ms`` / ``span_id``.
+
+Stale state files older than ``BQAA_STATE_TTL_HOURS`` are purged on the
+next ``SessionStart`` so long-running shells do not leak.
+
+Default ``attributes.source`` values mirror what the upstream tracing
+skill emits today so adoption queries that key off
+``attributes.session_metadata.source`` keep working:
+
+  * Most events: ``"claude_code"``
+  * SubagentStop:  ``"claude_code_subagent"``
+  * Notification:  ``"claude_code_notification"``
+  * PermissionRequest: ``"claude_code_permission_request"``
+  * SessionEnd:    ``"claude_code_session_end"``
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from datetime import timezone
+import fcntl
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+from typing import Any, Iterator
+
+from ._utils import deterministic_span
+from ._utils import hex_id
+from ._utils import iso_timestamp
+from ._utils import log_to_file
+from ._utils import safe_json_loads
+from ._utils import timestamp_ms
+from ._utils import to_jsonable
+from .config import BQAAConfig
+from .config import DEFAULT_STATE_DIR
+from .logger import BigQueryAgentAnalyticsLogger
+
+CLAUDE_CODE_DEFAULT_AGENT = "claude-code"
+
+
+# ----------------------------------------------------------------------------
+# Transcript reader
+# ----------------------------------------------------------------------------
+
+
+def _read_transcript_since(
+    path: str, start_line: int, max_bytes: int
+) -> tuple[str, str, dict[str, int], bool]:
+  """Stream-read the Claude Code transcript and stop after ``max_bytes``.
+
+  Returns ``(output_text, model, usage, was_truncated)``. The transcript
+  is a JSONL file of message objects; we read assistant lines after
+  ``start_line`` (set on ``UserPromptSubmit``) until the byte cap is
+  reached.
+  """
+  output_parts: list[str] = []
+  bytes_collected = 0
+  was_truncated = False
+  model = ""
+  usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+  if not path:
+    return "", model, usage, False
+  transcript = Path(path).expanduser()
+  if not transcript.exists():
+    return "", model, usage, False
+
+  with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+    for line_no, line in enumerate(handle, start=1):
+      if line_no <= start_line or not line.strip():
+        continue
+      item = safe_json_loads(line, {})
+      if item.get("type") != "assistant":
+        continue
+      message = item.get("message") or {}
+      model = message.get("model") or model
+      text = _text_from_content(message.get("content"))
+      if text:
+        if max_bytes > 0:
+          encoded = text.encode("utf-8", "replace")
+          remaining = max_bytes - bytes_collected
+          if remaining <= 0:
+            was_truncated = True
+          elif len(encoded) > remaining:
+            output_parts.append(
+                encoded[:remaining].decode("utf-8", "replace")
+                + "...[TRUNCATED]"
+            )
+            bytes_collected = max_bytes
+            was_truncated = True
+          else:
+            output_parts.append(text)
+            bytes_collected += len(encoded)
+        else:
+          output_parts.append(text)
+      raw_usage = message.get("usage") or {}
+      usage["prompt_tokens"] += int(raw_usage.get("input_tokens") or 0)
+      usage["prompt_tokens"] += int(
+          raw_usage.get("cache_read_input_tokens") or 0
+      )
+      usage["prompt_tokens"] += int(
+          raw_usage.get("cache_creation_input_tokens") or 0
+      )
+      usage["completion_tokens"] += int(raw_usage.get("output_tokens") or 0)
+  usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+  return "\n".join(output_parts), model, usage, was_truncated
+
+
+def _text_from_content(content: Any) -> str:
+  if isinstance(content, str):
+    return content
+  if isinstance(content, list):
+    pieces = []
+    for item in content:
+      if isinstance(item, dict) and item.get("type") == "text":
+        pieces.append(str(item.get("text", "")))
+      elif isinstance(item, str):
+        pieces.append(item)
+    return "\n".join(p for p in pieces if p)
+  return ""
+
+
+def _line_count(path: str) -> int:
+  if not path:
+    return 0
+  transcript = Path(path).expanduser()
+  if not transcript.exists():
+    return 0
+  with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+    return sum(1 for _ in handle)
+
+
+# ----------------------------------------------------------------------------
+# State store with file locking
+# ----------------------------------------------------------------------------
+
+
+class _LockedJSONStore:
+  """Atomic read-modify-write JSON store guarded by ``fcntl.flock``."""
+
+  def __init__(self, path: Path):
+    self.path = path
+    self.path.parent.mkdir(parents=True, exist_ok=True)
+
+  @contextlib.contextmanager
+  def transaction(self) -> Iterator[dict[str, Any]]:
+    fd = os.open(str(self.path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX)
+      try:
+        with os.fdopen(fd, "r+", encoding="utf-8", closefd=False) as handle:
+          handle.seek(0)
+          raw = handle.read()
+          state = safe_json_loads(raw, {}) if raw.strip() else {}
+          yield state
+          handle.seek(0)
+          handle.truncate()
+          handle.write(json.dumps(state, sort_keys=True))
+          handle.flush()
+          os.fsync(fd)
+      finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+      try:
+        os.close(fd)
+      except OSError:
+        pass
+
+  def read(self) -> dict[str, Any]:
+    if not self.path.exists():
+      return {}
+    with self.transaction() as state:
+      return dict(state)
+
+  def remove(self) -> None:
+    try:
+      self.path.unlink()
+    except FileNotFoundError:
+      pass
+
+
+class StateStore:
+  """Per-session state with locked RMW + per-tool sub-files.
+
+  Session-scoped fields live in ``state_<session>.json``. Per-tool
+  sub-state lives in ``tool_<session>_<tool_use_id>.json`` so concurrent
+  ``PreToolUse`` fires for parallel tools do not clobber each other's
+  ``start_ms`` / ``span_id``.
+  """
+
+  def __init__(self, key: str, root: str = DEFAULT_STATE_DIR):
+    safe_key = (
+        "".join(ch for ch in key if ch.isalnum() or ch in "._-") or "default"
+    )
+    self.key = safe_key
+    self.root = Path(root).expanduser()
+    self.root.mkdir(parents=True, exist_ok=True)
+    self._session_store = _LockedJSONStore(self.root / f"state_{safe_key}.json")
+    self._cache: dict[str, Any] = self._session_store.read()
+
+  def get(self, key: str, default: Any = None) -> Any:
+    return self._cache.get(key, default)
+
+  def set(self, key: str, value: Any) -> None:
+    self.update({key: value})
+
+  def update(self, values: dict[str, Any]) -> None:
+    with self._session_store.transaction() as state:
+      state.update(values)
+      self._cache = dict(state)
+
+  def delete(self, *keys: str) -> None:
+    with self._session_store.transaction() as state:
+      for key in keys:
+        state.pop(key, None)
+      self._cache = dict(state)
+
+  def remove(self) -> None:
+    self._session_store.remove()
+    for path in self.root.glob(f"tool_{self.key}_*.json"):
+      try:
+        path.unlink()
+      except FileNotFoundError:
+        pass
+
+  # -- Per-tool sub-state ---------------------------------------------------
+
+  def _tool_path(self, tool_use_id: str) -> Path:
+    safe = (
+        "".join(ch for ch in tool_use_id if ch.isalnum() or ch in "._-")
+        or "unknown"
+    )
+    return self.root / f"tool_{self.key}_{safe}.json"
+
+  def set_tool(self, tool_use_id: str, value: dict[str, Any]) -> None:
+    store = _LockedJSONStore(self._tool_path(tool_use_id))
+    with store.transaction() as state:
+      state.clear()
+      state.update(value)
+
+  def pop_tool(self, tool_use_id: str) -> dict[str, Any]:
+    path = self._tool_path(tool_use_id)
+    store = _LockedJSONStore(path)
+    with store.transaction() as state:
+      value = dict(state)
+    try:
+      path.unlink()
+    except FileNotFoundError:
+      pass
+    return value
+
+
+def cleanup_stale_state(root: str | Path, ttl_hours: float) -> int:
+  """Remove state and per-tool files older than ``ttl_hours``.
+
+  Returns the number of files removed. No-op when ``ttl_hours <= 0``.
+  """
+  if ttl_hours <= 0:
+    return 0
+  base = Path(root).expanduser()
+  if not base.exists():
+    return 0
+  cutoff = time.time() - ttl_hours * 3600
+  removed = 0
+  for path in base.iterdir():
+    if not path.is_file():
+      continue
+    name = path.name
+    if not (
+        name.startswith("state_") or name.startswith("tool_")
+    ) or not name.endswith(".json"):
+      continue
+    try:
+      mtime = path.stat().st_mtime
+    except FileNotFoundError:
+      continue
+    if mtime < cutoff:
+      try:
+        path.unlink()
+        removed += 1
+      except FileNotFoundError:
+        pass
+  return removed
+
+
+# ----------------------------------------------------------------------------
+# Tool helpers
+# ----------------------------------------------------------------------------
+
+
+def _tool_origin(tool_name: Any) -> str:
+  name = str(tool_name or "")
+  if name.lower().startswith("mcp__"):
+    return "MCP"
+  if name in {"Task", "Subagent"}:
+    return "SUB_AGENT"
+  return "LOCAL"
+
+
+def _tool_status(result: Any) -> tuple[str, str | None]:
+  if isinstance(result, dict):
+    if result.get("is_error") or result.get("error"):
+      return "ERROR", str(
+          result.get("error") or result.get("message") or "tool error"
+      )
+  text = str(result or "")
+  if text.lower().startswith("error:"):
+    return "ERROR", text[:1000]
+  return "OK", None
+
+
+# ----------------------------------------------------------------------------
+# Hook adapter
+# ----------------------------------------------------------------------------
+
+
+class ClaudeHookBQAAAdapter:
+  """Dispatches Claude Code hook payloads to ``BigQueryAgentAnalyticsLogger``."""
+
+  def __init__(self, logger: BigQueryAgentAnalyticsLogger | None = None):
+    self.logger = logger or BigQueryAgentAnalyticsLogger()
+    self.config = self.logger.config
+
+  def process(self, hook_name: str, payload: dict[str, Any]) -> None:
+    state = StateStore(self._state_key(payload), root=self.config.state_dir)
+    if hook_name == "SessionStart":
+      self._session_start(payload, state)
+    elif hook_name == "UserPromptSubmit":
+      self._user_prompt_submit(payload, state)
+    elif hook_name == "PreToolUse":
+      self._pre_tool_use(payload, state)
+    elif hook_name == "PostToolUse":
+      self._post_tool_use(payload, state)
+    elif hook_name == "Stop":
+      self._stop(payload, state)
+    elif hook_name == "SubagentStop":
+      self._subagent_stop(payload, state)
+    elif hook_name == "Notification":
+      self._notification(payload, state)
+    elif hook_name == "PermissionRequest":
+      self._permission_request(payload, state)
+    elif hook_name == "SessionEnd":
+      self._session_end(payload, state)
+
+  def _state_key(self, payload: dict[str, Any]) -> str:
+    return (
+        str(payload.get("session_id") or "")
+        or os.environ.get("CLAUDE_SESSION_KEY", "")
+        or str(os.getppid())
+    )
+
+  def _ensure_session(self, payload: dict[str, Any], state: StateStore) -> None:
+    if state.get("session_id"):
+      return
+    self._session_start(payload, state)
+
+  def _session_start(self, payload: dict[str, Any], state: StateStore) -> None:
+    cwd = payload.get("cwd") or os.getcwd()
+    session_id = payload.get("session_id") or hex_id(32)
+    state.update(
+        {
+            "session_id": session_id,
+            "project_name": (
+                os.environ.get("BQAA_PROJECT_NAME") or Path(cwd).name
+            ),
+            "agent": (
+                os.environ.get("BQAA_AGENT_NAME") or CLAUDE_CODE_DEFAULT_AGENT
+            ),
+            "user_id": os.environ.get("BQAA_USER_ID") or os.environ.get("USER"),
+            "trace_count": int(state.get("trace_count", 0)),
+            "session_start_ms": timestamp_ms(),
+        }
+    )
+    try:
+      cleanup_stale_state(self.config.state_dir, self.config.state_ttl_hours)
+    except OSError:
+      pass
+
+  def _user_prompt_submit(
+      self, payload: dict[str, Any], state: StateStore
+  ) -> None:
+    self._ensure_session(payload, state)
+    trace_count = int(state.get("trace_count", 0)) + 1
+    trace_id = hex_id(32)
+    span_id = hex_id(16)
+    invocation_id = payload.get("invocation_id") or hex_id(32)
+    prompt = str(payload.get("prompt") or "")
+    transcript = str(payload.get("transcript_path") or "")
+    state.update(
+        {
+            "trace_count": trace_count,
+            "current_trace_id": trace_id,
+            "current_span_id": span_id,
+            "current_invocation_id": invocation_id,
+            "current_prompt": prompt,
+            "current_start_ms": timestamp_ms(),
+            "transcript_path": transcript,
+            "transcript_start_line": _line_count(transcript),
+        }
+    )
+    self.logger.log_llm_request(
+        prompt=prompt,
+        session_id=state.get("session_id"),
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        agent=state.get("agent"),
+        user_id=state.get("user_id"),
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "cwd": payload.get("cwd"),
+                "source": "claude_code",
+                "trace_number": trace_count,
+            },
+            "custom_tags": {"assistant": "claude_code"},
+        },
+    )
+
+  def _pre_tool_use(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    tool_use_id = str(payload.get("tool_use_id") or hex_id(16))
+    span_id = deterministic_span(tool_use_id)
+    tool_name = str(payload.get("tool_name") or "unknown")
+    state.set_tool(
+        tool_use_id,
+        {
+            "start_ms": timestamp_ms(),
+            "span_id": span_id,
+            "tool_name": tool_name,
+        },
+    )
+    self.logger.log_tool_starting(
+        tool=tool_name,
+        args=to_jsonable(payload.get("tool_input") or {}),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id") or hex_id(32),
+        trace_id=state.get("current_trace_id") or hex_id(32),
+        span_id=span_id,
+        parent_span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        tool_origin=_tool_origin(tool_name),
+        attributes={"source": "claude_code"},
+    )
+
+  def _post_tool_use(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    tool_use_id = str(payload.get("tool_use_id") or "")
+    tool_state = state.pop_tool(tool_use_id) if tool_use_id else {}
+    start_ms = int(tool_state.get("start_ms") or timestamp_ms())
+    tool_name = str(
+        payload.get("tool_name") or tool_state.get("tool_name") or "unknown"
+    )
+    # If Pre never fired we still want correlation — derive deterministically.
+    span_id = tool_state.get("span_id") or deterministic_span(tool_use_id)
+    result = payload.get("tool_response")
+    status, error_message = _tool_status(result)
+    self.logger.log_tool_completed(
+        tool=tool_name,
+        result=to_jsonable(result),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id") or hex_id(32),
+        trace_id=state.get("current_trace_id") or hex_id(32),
+        span_id=span_id,
+        parent_span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        tool_origin=_tool_origin(tool_name),
+        total_ms=max(0, timestamp_ms() - start_ms),
+        status=status,
+        error_message=error_message,
+        attributes={"source": "claude_code"},
+    )
+
+  def _stop(self, payload: dict[str, Any], state: StateStore) -> None:
+    if not state.get("current_trace_id"):
+      return
+    transcript = str(
+        payload.get("transcript_path") or state.get("transcript_path") or ""
+    )
+    output, model, usage, was_truncated = _read_transcript_since(
+        transcript,
+        int(state.get("transcript_start_line") or 0),
+        self.config.transcript_max_bytes,
+    )
+    output = output or str(payload.get("response") or "(No response captured)")
+    start_ms = int(state.get("current_start_ms") or timestamp_ms())
+    self.logger.log_llm_response(
+        response=output,
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=state.get("current_span_id"),
+        agent=state.get("agent"),
+        user_id=state.get("user_id"),
+        model=model or str(payload.get("model") or ""),
+        usage_metadata=usage,
+        total_ms=max(0, timestamp_ms() - start_ms),
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "source": "claude_code",
+                "trace_number": state.get("trace_count"),
+            },
+            "custom_tags": {"assistant": "claude_code"},
+        },
+        is_truncated=was_truncated,
+    )
+    state.delete(
+        "current_trace_id",
+        "current_span_id",
+        "current_invocation_id",
+        "current_prompt",
+        "current_start_ms",
+        "transcript_path",
+        "transcript_start_line",
+    )
+
+  def _subagent_stop(self, payload: dict[str, Any], state: StateStore) -> None:
+    if not state.get("current_trace_id"):
+      return
+    transcript = str(payload.get("agent_transcript_path") or "")
+    output, model, usage, was_truncated = _read_transcript_since(
+        transcript, 0, self.config.transcript_max_bytes
+    )
+    agent_name = str(
+        payload.get("agent_type") or payload.get("agent_id") or "subagent"
+    )
+    self.logger.log_llm_response(
+        response=output or str(payload.get("output") or ""),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        agent=agent_name,
+        user_id=state.get("user_id"),
+        model=model,
+        usage_metadata=usage,
+        attributes={
+            "session_metadata": {
+                "project_name": state.get("project_name"),
+                "source": "claude_code_subagent",
+            },
+            "custom_tags": {
+                "assistant": "claude_code",
+                "subagent_id": payload.get("agent_id"),
+            },
+        },
+        is_truncated=was_truncated,
+    )
+
+  def _notification(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="STATE_DELTA",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={
+            "notification": {
+                "title": payload.get("title"),
+                "message": payload.get("message"),
+                "type": payload.get("notification_type") or "info",
+            }
+        },
+        attributes={
+            "state_delta": {
+                "source": "claude_code_notification",
+                "notification_type": (
+                    payload.get("notification_type") or "info"
+                ),
+            }
+        },
+    )
+
+  def _permission_request(
+      self, payload: dict[str, Any], state: StateStore
+  ) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="HITL_CONFIRMATION_REQUEST",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={
+            "permission": payload.get("permission"),
+            "tool": payload.get("tool_name"),
+            "args": to_jsonable(payload.get("tool_input") or {}),
+        },
+        attributes={
+            "session_metadata": {"source": "claude_code_permission_request"},
+            "custom_tags": {"assistant": "claude_code"},
+        },
+    )
+
+  def _session_end(self, payload: dict[str, Any], state: StateStore) -> None:
+    self._ensure_session(payload, state)
+    self.logger.log_event(
+        event_type="STATE_DELTA",
+        agent=state.get("agent"),
+        session_id=state.get("session_id"),
+        invocation_id=state.get("current_invocation_id"),
+        trace_id=state.get("current_trace_id"),
+        span_id=hex_id(16),
+        parent_span_id=state.get("current_span_id"),
+        content={"session_end": True},
+        attributes={
+            "state_delta": {
+                "source": "claude_code_session_end",
+                "trace_count": state.get("trace_count", 0),
+                "duration_ms": max(
+                    0,
+                    timestamp_ms()
+                    - int(state.get("session_start_ms") or timestamp_ms()),
+                ),
+            }
+        },
+    )
+    state.remove()
+
+
+# ----------------------------------------------------------------------------
+# Entry points
+# ----------------------------------------------------------------------------
+
+
+def run_claude_hook(
+    hook_name: str, payload: dict[str, Any] | None = None
+) -> None:
+  """Convenience: dispatch a single hook payload through a fresh adapter."""
+  adapter = ClaudeHookBQAAAdapter()
+  adapter.process(hook_name, payload or {})
+
+
+def main(argv: list[str] | None = None) -> int:
+  """Hook entry: read JSON payload from stdin, dispatch by hook name.
+
+  Invoked by hook shell wrappers as
+  ``python -m bigquery_agent_analytics_tracing.claude_code <HookName>``
+  or via the ``bqaa-claude-hook`` console script. Errors are logged but
+  never propagated so the host agent's hot path stays clean.
+  """
+  argv = argv if argv is not None else sys.argv[1:]
+  if not argv:
+    print("usage: bqaa-claude-hook <ClaudeHookName>", file=sys.stderr)
+    return 2
+  hook_name = argv[0]
+  raw = sys.stdin.read()
+  payload = safe_json_loads(raw, {}) if raw.strip() else {}
+  config = BQAAConfig.from_env()
+  if not config.enabled:
+    return 0
+  try:
+    ClaudeHookBQAAAdapter(BigQueryAgentAnalyticsLogger(config)).process(
+        hook_name, payload
+    )
+  except Exception as exc:  # Hooks must never break the calling agent.
+    log_to_file(
+        config, f"ERROR hook={hook_name}: {exc}\n{traceback.format_exc()}"
+    )
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/config.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/config.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime configuration for the BQAA tracing logger and drainer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from ._writer_identity import DEFAULT_WRITER_LABEL
+
+BQAA_EVENT_TYPES = frozenset(
+    {
+        "LLM_REQUEST",
+        "LLM_RESPONSE",
+        "TOOL_STARTING",
+        "TOOL_COMPLETED",
+        "HITL_CREDENTIAL_REQUEST",
+        "HITL_CREDENTIAL_REQUEST_COMPLETED",
+        "HITL_CONFIRMATION_REQUEST",
+        "HITL_CONFIRMATION_REQUEST_COMPLETED",
+        "HITL_INPUT_REQUEST",
+        "HITL_INPUT_REQUEST_COMPLETED",
+        "STATE_DELTA",
+    }
+)
+
+DEFAULT_SPOOL_DIR = "/tmp/bqaa-agent-tracing/spool"
+DEFAULT_STATE_DIR = "/tmp/bqaa-agent-tracing"
+DEFAULT_TRANSCRIPT_MAX_BYTES = 256 * 1024  # 256 KB streamed cap per stop event.
+DEFAULT_STATE_TTL_HOURS = 24
+DEFAULT_DRAIN_IDLE_SECONDS = 8.0
+DEFAULT_DRAIN_BATCH_SIZE = 50
+DEFAULT_DRAIN_POLL_SECONDS = 0.5
+DEFAULT_LOG_FILE = "/tmp/bqaa-agent-tracing.log"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+  raw = os.environ.get(name)
+  if raw is None:
+    return default
+  return raw.lower() == "true"
+
+
+@dataclass
+class BQAAConfig:
+  """All knobs the logger and drainer need.
+
+  Construct directly for library use, or call ``BQAAConfig.from_env()`` to
+  pick up the standard ``BQAA_*`` env vars. The env factory is what hook
+  scripts and the drainer subprocess use so producers stay drop-in.
+  """
+
+  project_id: str
+  dataset: str
+  table: str = "agent_events"
+  agent_name: str = "coding-agent"
+  user_id: str = "local-user"
+  enabled: bool = True
+  dry_run: bool = False
+  direct_write: bool = False
+  auto_create_table: bool = True
+  auto_create_dataset: bool = False
+  location: str | None = None
+  max_content_length: int = 5000
+  log_file: str = DEFAULT_LOG_FILE
+  spool_dir: str = DEFAULT_SPOOL_DIR
+  state_dir: str = DEFAULT_STATE_DIR
+  state_ttl_hours: float = DEFAULT_STATE_TTL_HOURS
+  transcript_max_bytes: int = DEFAULT_TRANSCRIPT_MAX_BYTES
+  drain_idle_seconds: float = DEFAULT_DRAIN_IDLE_SECONDS
+  drain_batch_size: int = DEFAULT_DRAIN_BATCH_SIZE
+  drain_poll_seconds: float = DEFAULT_DRAIN_POLL_SECONDS
+  writer_label: str = DEFAULT_WRITER_LABEL
+
+  @classmethod
+  def from_env(cls) -> "BQAAConfig":
+    return cls(
+        project_id=(
+            os.environ.get("BQAA_PROJECT_ID")
+            or os.environ.get("GCP_PROJECT_ID")
+            or os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or ""
+        ),
+        dataset=(
+            os.environ.get("BQAA_DATASET") or os.environ.get("BQ_DATASET") or ""
+        ),
+        table=(
+            os.environ.get("BQAA_TABLE")
+            or os.environ.get("BQ_TABLE")
+            or "agent_events"
+        ),
+        agent_name=os.environ.get("BQAA_AGENT_NAME") or "coding-agent",
+        user_id=(
+            os.environ.get("BQAA_USER_ID")
+            or os.environ.get("USER")
+            or "local-user"
+        ),
+        enabled=_env_bool("BQAA_TRACE_ENABLED", True),
+        dry_run=_env_bool("BQAA_DRY_RUN", False),
+        direct_write=_env_bool("BQAA_DIRECT_WRITE", False),
+        auto_create_table=_env_bool("BQAA_AUTO_CREATE_TABLE", True),
+        auto_create_dataset=_env_bool("BQAA_AUTO_CREATE_DATASET", False),
+        location=os.environ.get("BQAA_LOCATION") or None,
+        max_content_length=int(
+            os.environ.get("BQAA_MAX_CONTENT_LENGTH", "5000")
+        ),
+        log_file=os.environ.get("BQAA_LOG_FILE", DEFAULT_LOG_FILE),
+        spool_dir=os.environ.get("BQAA_SPOOL_DIR", DEFAULT_SPOOL_DIR),
+        state_dir=os.environ.get("BQAA_STATE_DIR", DEFAULT_STATE_DIR),
+        state_ttl_hours=float(
+            os.environ.get("BQAA_STATE_TTL_HOURS", str(DEFAULT_STATE_TTL_HOURS))
+        ),
+        transcript_max_bytes=int(
+            os.environ.get(
+                "BQAA_TRANSCRIPT_MAX_BYTES", str(DEFAULT_TRANSCRIPT_MAX_BYTES)
+            )
+        ),
+        drain_idle_seconds=float(
+            os.environ.get(
+                "BQAA_DRAIN_IDLE_SECONDS", str(DEFAULT_DRAIN_IDLE_SECONDS)
+            )
+        ),
+        drain_batch_size=int(
+            os.environ.get(
+                "BQAA_DRAIN_BATCH_SIZE", str(DEFAULT_DRAIN_BATCH_SIZE)
+            )
+        ),
+        drain_poll_seconds=float(
+            os.environ.get(
+                "BQAA_DRAIN_POLL_SECONDS", str(DEFAULT_DRAIN_POLL_SECONDS)
+            )
+        ),
+        writer_label=(
+            os.environ.get("BQAA_WRITER_LABEL") or DEFAULT_WRITER_LABEL
+        ),
+    )

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/drain.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/drain.py
@@ -1,0 +1,668 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background drainer for the BQAA spool.
+
+The drainer is launched as a detached subprocess by the logger (see
+``_ensure_drainer`` in ``logger.py``). Its job is to take BQAA rows that
+the producer spooled to disk and write them to BigQuery without blocking
+the host agent.
+
+Design choices:
+
+- Single drainer per spool dir, enforced by an exclusive ``fcntl.flock`` on
+  ``.drainer.pid``. New producer fires that try to spawn a drainer no-op
+  out immediately if the lock is held.
+- Writes use the BigQuery Storage Write API via ``BigQueryWriteAsyncClient``
+  + PyArrow batches when both libraries are importable. Matches the ADK
+  BQAA plugin and avoids streaming-insert quotas.
+- When the Storage Write client or PyArrow are not available, falls back to
+  ``bigquery.Client.insert_rows_json``. Same row contents in either path.
+- Retries transient failures with exponential backoff.
+- Rows that exhaust retries or hit non-retryable errors are moved to
+  ``dead-letter/`` so they can be inspected and replayed.
+- Drainer exits after ``BQAA_DRAIN_IDLE_SECONDS`` of empty polling; the
+  next producer fire spawns a fresh one.
+
+Invocation: ``python -m bigquery_agent_analytics_tracing.drain``. Plugin
+runtimes that vendor the package source without installing the wheel must
+either prepend the vendored package root to ``PYTHONPATH`` on the spawned
+drainer's environment, or ship a small wrapper script that performs the
+``sys.path`` insert and calls ``main()`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import random
+import sys
+import time
+import traceback
+from typing import Any, Iterator
+
+# Storage Write API channels share gRPC state across forks; matches ADK
+# plugin behavior and keeps the channel safe if the host agent forks us.
+os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "1")
+
+from ._utils import log_to_file  # noqa: E402  (after env tweak)
+from ._writer_identity import DEFAULT_WRITER_LABEL  # noqa: E402
+from .config import BQAAConfig  # noqa: E402
+from .schema import bq_schema  # noqa: E402
+
+
+@dataclass
+class _RetryConfig:
+  max_retries: int = 3
+  initial_delay: float = 1.0
+  multiplier: float = 2.0
+  max_delay: float = 10.0
+
+
+@dataclass
+class _Envelope:
+  path: Path
+  config_dict: dict[str, Any]
+  row: dict[str, Any]
+
+
+@contextlib.contextmanager
+def _try_acquire_pidfile(pidfile: Path) -> Iterator[int | None]:
+  """Acquire the drainer pidfile non-blockingly. Yields None if held."""
+  pidfile.parent.mkdir(parents=True, exist_ok=True)
+  fd = os.open(str(pidfile), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+      yield None
+      return
+    try:
+      os.ftruncate(fd, 0)
+      os.write(fd, str(os.getpid()).encode())
+      os.fsync(fd)
+    except OSError:
+      pass
+    try:
+      yield fd
+    finally:
+      try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+      except OSError:
+        pass
+  finally:
+    try:
+      os.close(fd)
+    except OSError:
+      pass
+
+
+def _list_pending(spool: Path) -> list[Path]:
+  if not spool.exists():
+    return []
+  return sorted(p for p in spool.glob("event-*.json") if p.is_file())
+
+
+def _read_envelope(path: Path) -> _Envelope | None:
+  try:
+    raw = path.read_text(encoding="utf-8")
+  except FileNotFoundError:
+    return None
+  except OSError:
+    return None
+  try:
+    data = json.loads(raw)
+  except json.JSONDecodeError:
+    # Corrupt spool entry — dead-letter and move on.
+    _quarantine(path, reason="corrupt-json")
+    return None
+  return _Envelope(
+      path=path,
+      config_dict=data.get("config") or {},
+      row=data.get("row") or {},
+  )
+
+
+def _group_envelopes(
+    envelopes: list[_Envelope],
+) -> dict[tuple, list[_Envelope]]:
+  """Group by destination table + writer label + auto-create policy.
+
+  The writer label is part of the key so a single drainer process can
+  serve envelopes from differently-labeled deployments without bleeding
+  their ``AppendRowsRequest.trace_id`` values together. Auto-create flags
+  are part of the key so the fallback path honors each producer's policy
+  instead of clobbering it with hard-coded defaults.
+  """
+  grouped: dict[tuple, list[_Envelope]] = {}
+  for env in envelopes:
+    cfg = env.config_dict
+    auto_create_table = cfg.get("auto_create_table")
+    auto_create_dataset = cfg.get("auto_create_dataset")
+    key = (
+        cfg.get("project_id"),
+        cfg.get("dataset"),
+        cfg.get("table"),
+        cfg.get("location"),
+        cfg.get("writer_label") or DEFAULT_WRITER_LABEL,
+        True if auto_create_table is None else bool(auto_create_table),
+        False if auto_create_dataset is None else bool(auto_create_dataset),
+    )
+    grouped.setdefault(key, []).append(env)
+  return grouped
+
+
+def _quarantine(path: Path, reason: str) -> None:
+  dead = path.parent / "dead-letter"
+  dead.mkdir(parents=True, exist_ok=True)
+  target = dead / f"{path.stem}.{reason}.json"
+  try:
+    os.replace(path, target)
+  except FileNotFoundError:
+    pass
+  except OSError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Storage Write API path
+# ---------------------------------------------------------------------------
+
+
+def _storage_write_available() -> bool:
+  try:
+    from google.cloud.bigquery_storage_v1 import types as _types  # noqa: F401
+    from google.cloud.bigquery_storage_v1.services.big_query_write.async_client import BigQueryWriteAsyncClient  # noqa: F401
+    import pyarrow  # noqa: F401
+  except Exception:
+    return False
+  return True
+
+
+def _arrow_schema():
+  import pyarrow as pa
+
+  object_ref_type = pa.struct(
+      [
+          pa.field("uri", pa.string()),
+          pa.field("version", pa.string()),
+          pa.field("authorizer", pa.string()),
+          pa.field("details", pa.string()),
+      ]
+  )
+  content_part_type = pa.struct(
+      [
+          pa.field("mime_type", pa.string()),
+          pa.field("uri", pa.string()),
+          pa.field("object_ref", object_ref_type),
+          pa.field("text", pa.string()),
+          pa.field("part_index", pa.int64()),
+          pa.field("part_attributes", pa.string()),
+          pa.field("storage_mode", pa.string()),
+      ]
+  )
+  return pa.schema(
+      [
+          pa.field("timestamp", pa.timestamp("us", tz="UTC"), nullable=False),
+          pa.field("event_type", pa.string()),
+          pa.field("agent", pa.string()),
+          pa.field("session_id", pa.string()),
+          pa.field("invocation_id", pa.string()),
+          pa.field("user_id", pa.string()),
+          pa.field("trace_id", pa.string()),
+          pa.field("span_id", pa.string()),
+          pa.field("parent_span_id", pa.string()),
+          pa.field("content", pa.string()),
+          pa.field("content_parts", pa.list_(content_part_type)),
+          pa.field("attributes", pa.string()),
+          pa.field("latency_ms", pa.string()),
+          pa.field("status", pa.string()),
+          pa.field("error_message", pa.string()),
+          pa.field("is_truncated", pa.bool_()),
+      ]
+  )
+
+
+def _row_to_arrow_dict(row: dict[str, Any]) -> dict[str, Any]:
+  """Adapt a spooled row to the Arrow column shape."""
+  from datetime import datetime
+  from datetime import timezone
+
+  ts_raw = row.get("timestamp")
+  if isinstance(ts_raw, str):
+    try:
+      ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+    except ValueError:
+      ts = datetime.now(timezone.utc)
+  elif isinstance(ts_raw, datetime):
+    ts = ts_raw
+  else:
+    ts = datetime.now(timezone.utc)
+  if ts.tzinfo is None:
+    ts = ts.replace(tzinfo=timezone.utc)
+
+  parts = []
+  for part in row.get("content_parts") or []:
+    ref = part.get("object_ref")
+    if isinstance(ref, dict):
+      details = ref.get("details")
+      if details is not None and not isinstance(details, str):
+        ref = dict(ref)
+        ref["details"] = json.dumps(details, sort_keys=True)
+    # part_attributes is declared as pa.string() in the Arrow schema;
+    # match the insert_rows_json path by serializing structured values.
+    part_attrs = part.get("part_attributes")
+    if part_attrs is not None and not isinstance(part_attrs, str):
+      part_attrs = json.dumps(part_attrs, sort_keys=True)
+    parts.append(
+        {
+            "mime_type": part.get("mime_type"),
+            "uri": part.get("uri"),
+            "object_ref": ref,
+            "text": part.get("text"),
+            "part_index": part.get("part_index"),
+            "part_attributes": part_attrs,
+            "storage_mode": part.get("storage_mode"),
+        }
+    )
+
+  def _as_json(value: Any) -> str | None:
+    if value is None:
+      return None
+    if isinstance(value, str):
+      return value
+    return json.dumps(value, sort_keys=True, default=str)
+
+  return {
+      "timestamp": ts,
+      "event_type": row.get("event_type"),
+      "agent": row.get("agent"),
+      "session_id": row.get("session_id"),
+      "invocation_id": row.get("invocation_id"),
+      "user_id": row.get("user_id"),
+      "trace_id": row.get("trace_id"),
+      "span_id": row.get("span_id"),
+      "parent_span_id": row.get("parent_span_id"),
+      "content": _as_json(row.get("content")),
+      "content_parts": parts,
+      "attributes": _as_json(row.get("attributes")),
+      "latency_ms": _as_json(row.get("latency_ms")),
+      "status": row.get("status"),
+      "error_message": row.get("error_message"),
+      "is_truncated": bool(row.get("is_truncated")),
+  }
+
+
+async def _write_batch_storage_api(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    rows: list[dict[str, Any]],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    writer_label: str,
+) -> bool:
+  """Write a batch via the Storage Write API. Returns True on success."""
+  from google.api_core.exceptions import InternalServerError
+  from google.api_core.exceptions import ServiceUnavailable
+  from google.api_core.exceptions import TooManyRequests
+  from google.cloud.bigquery_storage_v1 import types as bq_storage_types
+  from google.cloud.bigquery_storage_v1.services.big_query_write.async_client import BigQueryWriteAsyncClient
+  import pyarrow as pa
+
+  del location  # Storage Write API resolves location from the table itself.
+
+  schema = _arrow_schema()
+  arrow_rows = [_row_to_arrow_dict(r) for r in rows]
+  try:
+    record_batch = pa.RecordBatch.from_pylist(arrow_rows, schema=schema)
+  except Exception as exc:
+    log_to_file(config, f"DRAINER arrow_serialize_failed: {exc}")
+    return False
+
+  serialized_schema = schema.serialize().to_pybytes()
+  serialized_batch = record_batch.serialize().to_pybytes()
+  write_stream = (
+      f"projects/{project}/datasets/{dataset}/tables/{table}/_default"
+  )
+
+  client = BigQueryWriteAsyncClient()
+  try:
+    req = bq_storage_types.AppendRowsRequest(
+        write_stream=write_stream,
+        # Writer attribution. Recorded server-side for Google support
+        # diagnostics; not surfaced as a column in
+        # INFORMATION_SCHEMA.WRITE_API_TIMELINE_BY_*. Adoption analytics
+        # use the row-level attributes.writer block instead.
+        trace_id=writer_label,
+    )
+    req.arrow_rows.writer_schema.serialized_schema = serialized_schema
+    req.arrow_rows.rows.serialized_record_batch = serialized_batch
+
+    attempt = 0
+    delay = retry.initial_delay
+    while True:
+      try:
+
+        async def _requests_iter():
+          yield req
+
+        async def _perform():
+          responses = await client.append_rows(_requests_iter())
+          async for response in responses:
+            error = getattr(response, "error", None)
+            error_code = getattr(error, "code", None)
+            if error_code and error_code != 0:
+              error_message = getattr(error, "message", "Unknown error")
+              # gRPC: 4=DEADLINE_EXCEEDED, 13=INTERNAL, 14=UNAVAILABLE
+              if error_code in (4, 13, 14):
+                raise ServiceUnavailable(error_message)
+              raise RuntimeError(
+                  f"non_retryable_storage_error: {error_message}"
+              )
+
+        await asyncio.wait_for(_perform(), timeout=30.0)
+        return True
+
+      except (
+          ServiceUnavailable,
+          TooManyRequests,
+          InternalServerError,
+          asyncio.TimeoutError,
+      ) as exc:
+        attempt += 1
+        if attempt > retry.max_retries:
+          log_to_file(
+              config,
+              f"DRAINER batch_dropped_after_{retry.max_retries + 1}: {exc}",
+          )
+          return False
+        sleep_for = min(delay * (1 + random.random()), retry.max_delay)
+        log_to_file(
+            config,
+            f"DRAINER retry attempt={attempt} sleep={sleep_for:.2f} err={exc}",
+        )
+        await asyncio.sleep(sleep_for)
+        delay *= retry.multiplier
+      except Exception as exc:
+        log_to_file(
+            config,
+            f"DRAINER unexpected_error: {exc}\n{traceback.format_exc()}",
+        )
+        return False
+  finally:
+    # Close the gRPC channel cleanly; ignore errors during shutdown.
+    try:
+      transport = getattr(client, "transport", None)
+      close = getattr(transport, "close", None) if transport else None
+      if close is not None:
+        result = close()
+        if asyncio.iscoroutine(result):
+          await result
+    except Exception:
+      pass
+
+
+# ---------------------------------------------------------------------------
+# insert_rows_json fallback
+# ---------------------------------------------------------------------------
+
+
+def _ensure_table_exists(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    auto_create_table: bool,
+    auto_create_dataset: bool,
+) -> None:
+  from google.cloud import bigquery
+  from google.cloud.exceptions import NotFound
+
+  client = bigquery.Client(project=project, location=location)
+  dataset_id = f"{project}.{dataset}"
+  if auto_create_dataset:
+    try:
+      client.get_dataset(dataset_id)
+    except NotFound:
+      ds = bigquery.Dataset(dataset_id)
+      if location:
+        ds.location = location
+      client.create_dataset(ds)
+  table_id = f"{project}.{dataset}.{table}"
+  try:
+    client.get_table(table_id)
+    return
+  except NotFound:
+    if not auto_create_table:
+      raise
+  bq_table = bigquery.Table(table_id, schema=bq_schema(bigquery))
+  bq_table.time_partitioning = bigquery.TimePartitioning(
+      type_=bigquery.TimePartitioningType.DAY,
+      field="timestamp",
+  )
+  bq_table.clustering_fields = ["event_type", "agent", "user_id"]
+  bq_table.labels = {"adk_schema_version": "1"}
+  client.create_table(bq_table)
+
+
+def _write_batch_insert_rows_json(
+    *,
+    project: str,
+    dataset: str,
+    table: str,
+    location: str | None,
+    rows: list[dict[str, Any]],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    auto_create_table: bool,
+    auto_create_dataset: bool,
+) -> bool:
+  from google.api_core.exceptions import InternalServerError
+  from google.api_core.exceptions import ServiceUnavailable
+  from google.api_core.exceptions import TooManyRequests
+  from google.cloud import bigquery
+
+  try:
+    _ensure_table_exists(
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        auto_create_table=auto_create_table,
+        auto_create_dataset=auto_create_dataset,
+    )
+  except Exception as exc:
+    log_to_file(config, f"DRAINER ensure_table_failed: {exc}")
+    return False
+
+  client = bigquery.Client(project=project, location=location)
+  table_id = f"{project}.{dataset}.{table}"
+  attempt = 0
+  delay = retry.initial_delay
+  while True:
+    try:
+      errors = client.insert_rows_json(table_id, rows)
+      if errors:
+        log_to_file(config, f"DRAINER insert_rows_json errors: {errors}")
+        return False
+      return True
+    except (
+        ServiceUnavailable,
+        TooManyRequests,
+        InternalServerError,
+    ) as exc:
+      attempt += 1
+      if attempt > retry.max_retries:
+        log_to_file(
+            config,
+            f"DRAINER batch_dropped_after_{retry.max_retries + 1}: {exc}",
+        )
+        return False
+      sleep_for = min(delay * (1 + random.random()), retry.max_delay)
+      time.sleep(sleep_for)
+      delay *= retry.multiplier
+    except Exception as exc:
+      log_to_file(
+          config,
+          f"DRAINER unexpected_error: {exc}\n{traceback.format_exc()}",
+      )
+      return False
+
+
+# ---------------------------------------------------------------------------
+# Drain loop
+# ---------------------------------------------------------------------------
+
+
+async def _drain_group_async(
+    *,
+    key: tuple,
+    envelopes: list[_Envelope],
+    retry: _RetryConfig,
+    config: BQAAConfig,
+    use_storage_api: bool,
+) -> None:
+  (
+      project,
+      dataset,
+      table,
+      location,
+      writer_label,
+      auto_create_table,
+      auto_create_dataset,
+  ) = key
+  if not project or not dataset or not table:
+    for env in envelopes:
+      _quarantine(env.path, reason="missing-config")
+    return
+
+  rows = [env.row for env in envelopes]
+  success = False
+  if use_storage_api:
+    success = await _write_batch_storage_api(
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        rows=rows,
+        retry=retry,
+        config=config,
+        writer_label=writer_label or DEFAULT_WRITER_LABEL,
+    )
+    if not success:
+      log_to_file(
+          config,
+          "DRAINER storage_api_failed, falling back to insert_rows_json",
+      )
+
+  if not success:
+    # Fallback / second attempt path. Run in a thread so the event loop
+    # isn't blocked by the synchronous BQ client. Use the per-envelope
+    # auto-create policy that the producer recorded in the spool, not a
+    # hard-coded default that would silently override their settings.
+    success = await asyncio.to_thread(
+        _write_batch_insert_rows_json,
+        project=project,
+        dataset=dataset,
+        table=table,
+        location=location,
+        rows=rows,
+        retry=retry,
+        config=config,
+        auto_create_table=auto_create_table,
+        auto_create_dataset=auto_create_dataset,
+    )
+
+  if success:
+    for env in envelopes:
+      try:
+        env.path.unlink()
+      except FileNotFoundError:
+        pass
+  else:
+    for env in envelopes:
+      _quarantine(env.path, reason="write-failed")
+
+
+async def _drain_once(config: BQAAConfig, use_storage_api: bool) -> int:
+  spool = Path(config.spool_dir).expanduser()
+  pending = _list_pending(spool)
+  if not pending:
+    return 0
+  envelopes: list[_Envelope] = []
+  for path in pending[: max(1, config.drain_batch_size)]:
+    env = _read_envelope(path)
+    if env is not None:
+      envelopes.append(env)
+  if not envelopes:
+    return 0
+  grouped = _group_envelopes(envelopes)
+  retry = _RetryConfig()
+  await asyncio.gather(
+      *(
+          _drain_group_async(
+              key=key,
+              envelopes=batch,
+              retry=retry,
+              config=config,
+              use_storage_api=use_storage_api,
+          )
+          for key, batch in grouped.items()
+      )
+  )
+  return len(envelopes)
+
+
+async def _run(config: BQAAConfig) -> None:
+  spool = Path(config.spool_dir).expanduser()
+  spool.mkdir(parents=True, exist_ok=True)
+  pidfile = spool / ".drainer.pid"
+  use_storage_api = _storage_write_available()
+  with _try_acquire_pidfile(pidfile) as fd:
+    if fd is None:
+      return
+    idle = 0.0
+    while idle < config.drain_idle_seconds:
+      wrote = await _drain_once(config, use_storage_api=use_storage_api)
+      if wrote == 0:
+        await asyncio.sleep(config.drain_poll_seconds)
+        idle += config.drain_poll_seconds
+      else:
+        idle = 0.0
+
+
+def main(argv: list[str] | None = None) -> int:
+  del argv
+  config = BQAAConfig.from_env()
+  if config.dry_run:
+    return 0
+  try:
+    asyncio.run(_run(config))
+  except Exception as exc:
+    log_to_file(config, f"DRAINER fatal: {exc}\n{traceback.format_exc()}")
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/logger.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/logger.py
@@ -1,0 +1,459 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Builds rows in the canonical BQAA ``agent_events`` shape and routes them
+to one of three sinks: dry-run log, synchronous direct insert, or async
+spool + drainer.
+
+Hook subprocess (hot path):
+  1. Build the BQAA row.
+  2. Append a JSONL line to ``config.spool_dir`` (sync, ~1 ms).
+  3. Spawn a detached drainer subprocess (idempotent via flock).
+  4. Exit. The host agent never blocks on BigQuery.
+
+The drainer subprocess (``drain.py``) holds an exclusive flock, batches
+spooled rows, writes through the BigQuery Storage Write API when
+available, and falls back to ``insert_rows_json`` otherwise.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import fcntl
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+import uuid
+
+from ._utils import hex_id
+from ._utils import iso_timestamp
+from ._utils import log_to_file
+from ._utils import truncate
+from ._writer_identity import __version__ as WRITER_VERSION
+from ._writer_identity import WRITER_PLUGIN_NAME
+from .config import BQAA_EVENT_TYPES
+from .config import BQAAConfig
+from .schema import bq_schema
+
+
+def content_part(text: str, index: int) -> dict[str, Any]:
+  """Inline-text content part. Multimodal/GCS offload is a follow-up."""
+  return {
+      "mime_type": "text/plain",
+      "uri": None,
+      "object_ref": None,
+      "text": text,
+      "part_index": index,
+      "part_attributes": None,
+      "storage_mode": "INLINE",
+  }
+
+
+def _serialize_bq_json_fields(row: dict[str, Any]) -> dict[str, Any]:
+  """Serialize JSON-typed fields so ``insert_rows_json`` sees strings."""
+  bq_row = dict(row)
+  for field in ("content", "attributes", "latency_ms"):
+    value = bq_row.get(field)
+    if value is not None and not isinstance(value, str):
+      bq_row[field] = json.dumps(value, sort_keys=True)
+  parts = []
+  for part in bq_row.get("content_parts") or []:
+    next_part = dict(part)
+    object_ref = next_part.get("object_ref")
+    if isinstance(object_ref, dict):
+      details = object_ref.get("details")
+      if details is not None and not isinstance(details, str):
+        next_object_ref = dict(object_ref)
+        next_object_ref["details"] = json.dumps(details, sort_keys=True)
+        next_part["object_ref"] = next_object_ref
+    # part_attributes is STRING in the schema; serialize structured values
+    # so callers passing dicts/lists don't break the insert_rows_json path.
+    part_attrs = next_part.get("part_attributes")
+    if part_attrs is not None and not isinstance(part_attrs, str):
+      next_part["part_attributes"] = json.dumps(part_attrs, sort_keys=True)
+    parts.append(next_part)
+  bq_row["content_parts"] = parts
+  return bq_row
+
+
+def _ensure_drainer(config: BQAAConfig) -> None:
+  """Spawn the drainer in a detached subprocess if none is running.
+
+  Uses a non-blocking flock on a pidfile to dedupe; a running drainer holds
+  the lock for its entire lifetime. If we cannot take the lock, a drainer is
+  already running and will pick up our spool file.
+
+  Spawned via ``python -m bigquery_agent_analytics_tracing.drain``. For
+  vendored plugin installs (no wheel on ``BQAA_PYTHON``), set
+  ``PYTHONPATH`` to the vendored package root before the hook fires, or use
+  a plugin-side wrapper script that performs the ``sys.path`` insert.
+  """
+  spool = Path(config.spool_dir).expanduser()
+  spool.mkdir(parents=True, exist_ok=True)
+  pidfile = spool / ".drainer.pid"
+  fd = os.open(str(pidfile), os.O_CREAT | os.O_RDWR, 0o600)
+  try:
+    try:
+      fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+      return  # Another drainer is running.
+    fcntl.flock(fd, fcntl.LOCK_UN)
+  finally:
+    os.close(fd)
+
+  python_bin = os.environ.get("BQAA_PYTHON") or sys.executable or "python3"
+  try:
+    subprocess.Popen(
+        [python_bin, "-m", "bigquery_agent_analytics_tracing.drain"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+        env=os.environ.copy(),
+    )
+  except OSError as exc:
+    log_to_file(config, f"DRAINER_SPAWN_FAIL {exc}")
+
+
+class BigQueryAgentAnalyticsLogger:
+  """Builds BQAA rows and routes them to spool / dry-run / sync write.
+
+  Default emit mode is ``spool`` (writes a JSONL line and triggers the
+  async drainer subprocess). ``config.dry_run`` writes to
+  ``config.log_file`` only. ``config.direct_write`` falls back to a
+  synchronous ``insert_rows_json`` call, kept for debugging and parity
+  tests.
+  """
+
+  def __init__(self, config: BQAAConfig | None = None):
+    self.config = config or BQAAConfig.from_env()
+    self._client = None
+    self._table_ready = False
+
+  def log_event(
+      self,
+      *,
+      event_type: str,
+      content: dict[str, Any] | None = None,
+      attributes: dict[str, Any] | None = None,
+      latency_ms: dict[str, Any] | None = None,
+      agent: str | None = None,
+      session_id: str | None = None,
+      invocation_id: str | None = None,
+      user_id: str | None = None,
+      trace_id: str | None = None,
+      span_id: str | None = None,
+      parent_span_id: str | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      timestamp: datetime | None = None,
+      content_parts: list[dict[str, Any]] | None = None,
+      is_truncated: bool = False,
+  ) -> dict[str, Any]:
+    if not self.config.enabled:
+      return {}
+    if event_type not in BQAA_EVENT_TYPES:
+      raise ValueError(f"Unsupported BQAA event_type: {event_type}")
+
+    clipped_content, content_truncated = truncate(
+        content or {}, self.config.max_content_length
+    )
+    # attributes.writer is reserved for package attribution so adoption
+    # queries on attributes.writer.{plugin,version,label,agent,mode} have a
+    # stable contract. A caller-supplied "writer" key is moved to
+    # attributes.writer_caller rather than silently dropping their data.
+    merged_attributes = dict(attributes or {})
+    caller_writer = merged_attributes.pop("writer", None)
+    merged_attributes["writer"] = {
+        "plugin": WRITER_PLUGIN_NAME,
+        "version": WRITER_VERSION,
+        "label": self.config.writer_label,
+        "agent": agent or self.config.agent_name,
+        "mode": (
+            "dry_run"
+            if self.config.dry_run
+            else ("direct" if self.config.direct_write else "spool")
+        ),
+    }
+    if caller_writer is not None:
+      merged_attributes["writer_caller"] = caller_writer
+    clipped_attributes, attr_truncated = truncate(
+        merged_attributes, self.config.max_content_length
+    )
+    clipped_latency, latency_truncated = truncate(latency_ms or {}, 1000)
+    clipped_parts, parts_truncated = truncate(
+        content_parts or [], self.config.max_content_length
+    )
+
+    row = {
+        "timestamp": iso_timestamp(timestamp),
+        "event_type": event_type,
+        "agent": agent or self.config.agent_name,
+        "session_id": session_id,
+        "invocation_id": invocation_id,
+        "user_id": user_id or self.config.user_id,
+        "trace_id": trace_id,
+        "span_id": span_id or hex_id(16),
+        "parent_span_id": parent_span_id,
+        "content": clipped_content,
+        "content_parts": clipped_parts,
+        "attributes": clipped_attributes,
+        "latency_ms": clipped_latency,
+        "status": status,
+        "error_message": error_message,
+        "is_truncated": bool(
+            is_truncated
+            or content_truncated
+            or attr_truncated
+            or latency_truncated
+            or parts_truncated
+        ),
+    }
+    self._emit_row(row)
+    return row
+
+  def log_llm_request(
+      self,
+      *,
+      prompt: str,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None = None,
+      agent: str | None = None,
+      user_id: str | None = None,
+      system_prompt: str | None = None,
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="LLM_REQUEST",
+        agent=agent,
+        user_id=user_id,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={
+            "system_prompt": system_prompt or "",
+            "prompt": [{"role": "user", "content": prompt}],
+        },
+        content_parts=[content_part(prompt, 0)] if prompt else [],
+        attributes=attributes,
+    )
+
+  def log_llm_response(
+      self,
+      *,
+      response: str,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None = None,
+      agent: str | None = None,
+      user_id: str | None = None,
+      model: str | None = None,
+      usage_metadata: dict[str, int] | None = None,
+      total_ms: int | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      attributes: dict[str, Any] | None = None,
+      is_truncated: bool = False,
+  ) -> dict[str, Any]:
+    usage = usage_metadata or {}
+    attrs = {
+        "model": model or "",
+        "usage_metadata": {
+            "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+            "completion_tokens": int(usage.get("completion_tokens") or 0),
+            "total_tokens": int(usage.get("total_tokens") or 0),
+        },
+    }
+    if attributes:
+      attrs.update(attributes)
+    return self.log_event(
+        event_type="LLM_RESPONSE",
+        agent=agent,
+        user_id=user_id,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={"response": response},
+        content_parts=[content_part(response, 0)] if response else [],
+        attributes=attrs,
+        latency_ms={"total_ms": total_ms} if total_ms is not None else {},
+        status=status,
+        error_message=error_message,
+        is_truncated=is_truncated,
+    )
+
+  def log_tool_starting(
+      self,
+      *,
+      tool: str,
+      args: dict[str, Any],
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None,
+      agent: str | None = None,
+      tool_origin: str = "LOCAL",
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="TOOL_STARTING",
+        agent=agent,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={"tool": tool, "args": args, "tool_origin": tool_origin},
+        attributes=attributes,
+    )
+
+  def log_tool_completed(
+      self,
+      *,
+      tool: str,
+      result: Any,
+      session_id: str,
+      invocation_id: str,
+      trace_id: str,
+      span_id: str,
+      parent_span_id: str | None,
+      agent: str | None = None,
+      tool_origin: str = "LOCAL",
+      total_ms: int | None = None,
+      status: str = "OK",
+      error_message: str | None = None,
+      attributes: dict[str, Any] | None = None,
+  ) -> dict[str, Any]:
+    return self.log_event(
+        event_type="TOOL_COMPLETED",
+        agent=agent,
+        session_id=session_id,
+        invocation_id=invocation_id,
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        content={
+            "tool": tool,
+            "result": result,
+            "tool_origin": tool_origin,
+        },
+        attributes=attributes,
+        latency_ms={"total_ms": total_ms} if total_ms is not None else {},
+        status=status,
+        error_message=error_message,
+    )
+
+  def _emit_row(self, row: dict[str, Any]) -> None:
+    bq_row = _serialize_bq_json_fields(row)
+    if self.config.dry_run:
+      log_to_file(
+          self.config,
+          "DRY_RUN " + json.dumps(bq_row, sort_keys=True, default=str),
+      )
+      return
+    if not self.config.project_id or not self.config.dataset:
+      raise ValueError(
+          "BQAA_PROJECT_ID/GCP_PROJECT_ID and BQAA_DATASET are required"
+      )
+    if self.config.direct_write:
+      self._direct_insert(bq_row)
+      return
+    self._spool(bq_row)
+
+  def _spool(self, bq_row: dict[str, Any]) -> None:
+    spool = Path(self.config.spool_dir).expanduser()
+    spool.mkdir(parents=True, exist_ok=True)
+    envelope = {
+        "config": {
+            "project_id": self.config.project_id,
+            "dataset": self.config.dataset,
+            "table": self.config.table,
+            "location": self.config.location,
+            "auto_create_table": self.config.auto_create_table,
+            "auto_create_dataset": self.config.auto_create_dataset,
+            "writer_label": self.config.writer_label,
+        },
+        "row": bq_row,
+    }
+    name = f"event-{time.time_ns()}-{os.getpid()}-{uuid.uuid4().hex[:8]}.json"
+    path = spool / name
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps(envelope, sort_keys=True, default=str), encoding="utf-8"
+    )
+    os.replace(tmp, path)
+    _ensure_drainer(self.config)
+
+  def _direct_insert(self, bq_row: dict[str, Any]) -> None:
+    self._ensure_table()
+    errors = self._client.insert_rows_json(self._table_id, [bq_row])
+    if errors:
+      raise RuntimeError(f"BigQuery insert failed: {errors}")
+
+  def _ensure_table(self) -> None:
+    if self._table_ready:
+      return
+    from google.cloud import bigquery
+    from google.cloud.exceptions import NotFound
+
+    self._client = self._client or bigquery.Client(
+        project=self.config.project_id, location=self.config.location
+    )
+    dataset_id = f"{self.config.project_id}.{self.config.dataset}"
+    if self.config.auto_create_dataset:
+      try:
+        self._client.get_dataset(dataset_id)
+      except NotFound:
+        dataset = bigquery.Dataset(dataset_id)
+        if self.config.location:
+          dataset.location = self.config.location
+        self._client.create_dataset(dataset)
+
+    try:
+      self._client.get_table(self._table_id)
+    except NotFound:
+      if not self.config.auto_create_table:
+        raise
+      table = bigquery.Table(self._table_id, schema=bq_schema(bigquery))
+      table.time_partitioning = bigquery.TimePartitioning(
+          type_=bigquery.TimePartitioningType.DAY,
+          field="timestamp",
+      )
+      table.clustering_fields = ["event_type", "agent", "user_id"]
+      table.labels = {"adk_schema_version": "1"}
+      self._client.create_table(table)
+    self._table_ready = True
+
+  @property
+  def _table_id(self) -> str:
+    return (
+        f"{self.config.project_id}."
+        f"{self.config.dataset}."
+        f"{self.config.table}"
+    )

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/schema.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/schema.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BigQuery ``agent_events`` schema matching the canonical BQAA shape.
+
+Kept as a function so callers pass in their own ``google.cloud.bigquery``
+module — the producer package does not import BigQuery at import time so
+dry-run callers (and unit tests) never need the dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def bq_schema(bigquery: Any) -> list[Any]:
+  """Return the BigQuery schema for the ``agent_events`` table.
+
+  Used by both the direct writer's ``auto_create_table`` path and the
+  drainer's ``insert_rows_json`` fallback. The Storage Write API path
+  declares the same shape as an Arrow schema in ``drain.py``.
+  """
+  return [
+      bigquery.SchemaField("timestamp", "TIMESTAMP", mode="REQUIRED"),
+      bigquery.SchemaField("event_type", "STRING"),
+      bigquery.SchemaField("agent", "STRING"),
+      bigquery.SchemaField("session_id", "STRING"),
+      bigquery.SchemaField("invocation_id", "STRING"),
+      bigquery.SchemaField("user_id", "STRING"),
+      bigquery.SchemaField("trace_id", "STRING"),
+      bigquery.SchemaField("span_id", "STRING"),
+      bigquery.SchemaField("parent_span_id", "STRING"),
+      bigquery.SchemaField("content", "JSON"),
+      bigquery.SchemaField(
+          "content_parts",
+          "RECORD",
+          mode="REPEATED",
+          fields=[
+              bigquery.SchemaField("mime_type", "STRING"),
+              bigquery.SchemaField("uri", "STRING"),
+              bigquery.SchemaField(
+                  "object_ref",
+                  "RECORD",
+                  fields=[
+                      bigquery.SchemaField("uri", "STRING"),
+                      bigquery.SchemaField("version", "STRING"),
+                      bigquery.SchemaField("authorizer", "STRING"),
+                      bigquery.SchemaField("details", "JSON"),
+                  ],
+              ),
+              bigquery.SchemaField("text", "STRING"),
+              bigquery.SchemaField("part_index", "INTEGER"),
+              bigquery.SchemaField("part_attributes", "STRING"),
+              bigquery.SchemaField("storage_mode", "STRING"),
+          ],
+      ),
+      bigquery.SchemaField("attributes", "JSON"),
+      bigquery.SchemaField("latency_ms", "JSON"),
+      bigquery.SchemaField("status", "STRING"),
+      bigquery.SchemaField("error_message", "STRING"),
+      bigquery.SchemaField("is_truncated", "BOOLEAN"),
+  ]

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/setup_check.py
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/vendor/bigquery_agent_analytics_tracing/setup_check.py
@@ -1,0 +1,404 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Advisory setup check for the BQAA tracing runtime.
+
+Surfaces:
+
+  * BQAA_PROJECT_ID / BQAA_DATASET — required env vars.
+  * BQAA_PYTHON — optional, defaults to the current interpreter; we
+    sanity-check it can import the runtime deps.
+  * google-cloud-bigquery — always required.
+  * google-cloud-bigquery-storage + pyarrow — required only for the
+    Storage Write API path; absent is OK (drainer falls back to
+    insert_rows_json).
+  * bigquery_agent_analytics_tracing itself — sanity check the
+    vendored layout works on BQAA_PYTHON.
+
+This script is **advisory-only**. It never mutates the environment,
+shell rc files, GCP resources, or IAM. It only reports what is
+missing and prints the exact `pip install ...` line you'd run to fix
+it. The interactive setup that actually creates a dataset / grants
+IAM is intentionally out of scope here — keep that as a separate
+explicit step.
+
+Driver: the `bqaa-check-setup` console script and the `/bqaa-setup`
+Claude Code slash command both call ``main()``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+# Modules whose absence blocks the writer entirely.
+_REQUIRED_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("google.cloud.bigquery", "google-cloud-bigquery"),
+)
+
+# Modules whose absence only disables the Storage Write API path;
+# drainer falls back to insert_rows_json.
+_STORAGE_WRITE_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("google.cloud.bigquery_storage_v1", "google-cloud-bigquery-storage"),
+    ("pyarrow", "pyarrow"),
+)
+
+# Sanity-check the tracing package itself imports on the target
+# interpreter — catches a misconfigured PYTHONPATH on vendored
+# plugin runtimes before any hook fires.
+_PACKAGE_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("bigquery_agent_analytics_tracing", "bigquery-agent-analytics-tracing"),
+)
+
+
+@dataclass
+class _ImportProbe:
+  module: str
+  install_name: str
+  ok: bool
+  error: str | None = None
+
+
+@dataclass
+class _SetupReport:
+  python_bin: str
+  project_id: str | None
+  dataset: str | None
+  trace_enabled: bool
+  # Non-None when the configured interpreter cannot be executed
+  # (FileNotFoundError, permission denied, timeout, non-zero exit on a
+  # trivial command). Surfacing this separately tells the user "fix
+  # BQAA_PYTHON" instead of N misleading "import failed" lines that
+  # all stem from the same root cause.
+  interpreter_error: str | None = None
+  package_imports: list[_ImportProbe] = field(default_factory=list)
+  required_imports: list[_ImportProbe] = field(default_factory=list)
+  storage_write_imports: list[_ImportProbe] = field(default_factory=list)
+
+  @property
+  def python_ok(self) -> bool:
+    return self.interpreter_error is None
+
+  @property
+  def env_ok(self) -> bool:
+    return bool(self.project_id) and bool(self.dataset)
+
+  @property
+  def package_ok(self) -> bool:
+    # Empty list when interpreter is broken — explicitly gate on
+    # python_ok so vacuous all([]) doesn't report True.
+    return self.python_ok and all(p.ok for p in self.package_imports)
+
+  @property
+  def required_deps_ok(self) -> bool:
+    return self.python_ok and all(p.ok for p in self.required_imports)
+
+  @property
+  def storage_write_ok(self) -> bool:
+    return self.python_ok and all(p.ok for p in self.storage_write_imports)
+
+  @property
+  def all_ok(self) -> bool:
+    return (
+        self.python_ok
+        and self.env_ok
+        and self.package_ok
+        and self.required_deps_ok
+    )
+
+
+def _resolve_python_bin() -> str:
+  """Pick the interpreter we'll check against.
+
+  ``BQAA_PYTHON`` is what hook shell wrappers exec when firing the
+  hook, so that's the truth for the runtime. If unset, use whichever
+  python invoked us (matches the shell default of ``python3``).
+  """
+  return os.environ.get("BQAA_PYTHON") or sys.executable
+
+
+def _probe_interpreter(python_bin: str) -> str | None:
+  """Verify ``python_bin`` can be executed. Returns None on success or
+  a one-line error string. Catches the common
+  misconfigurations (path doesn't exist, not executable, hangs)
+  before the import probes shell out N times and trip on the same
+  root cause.
+  """
+  try:
+    proc = subprocess.run(
+        [python_bin, "-c", "pass"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+  except FileNotFoundError:
+    return f"interpreter not found: {python_bin}"
+  except PermissionError:
+    return f"interpreter not executable: {python_bin}"
+  except OSError as exc:
+    return f"interpreter exec error: {python_bin} ({exc})"
+  except subprocess.TimeoutExpired:
+    return f"interpreter timed out: {python_bin}"
+  if proc.returncode != 0:
+    err = (proc.stderr or proc.stdout or "non-zero exit").strip()
+    err = err.splitlines()[-1] if err.splitlines() else err
+    return f"interpreter exited non-zero: {err}"
+  return None
+
+
+def _probe_imports(
+    python_bin: str, modules: Iterable[tuple[str, str]]
+) -> list[_ImportProbe]:
+  results: list[_ImportProbe] = []
+  for module, install_name in modules:
+    # Defensive catches for the same conditions ``_probe_interpreter``
+    # handles. ``collect_report`` skips this loop entirely when the
+    # interpreter is broken, but keep the catches so a direct caller
+    # never sees a raw OSError from a misconfigured python_bin.
+    try:
+      proc = subprocess.run(
+          [python_bin, "-c", f"import {module}"],
+          capture_output=True,
+          text=True,
+          timeout=15,
+      )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=f"interpreter unavailable: {exc}",
+          )
+      )
+      continue
+    except subprocess.TimeoutExpired:
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=f"interpreter timed out: {python_bin}",
+          )
+      )
+      continue
+    if proc.returncode == 0:
+      results.append(
+          _ImportProbe(module=module, install_name=install_name, ok=True)
+      )
+    else:
+      # The first nonempty stderr line is the most useful — strip
+      # the traceback noise.
+      err = (proc.stderr or proc.stdout or "import failed").strip()
+      err = err.splitlines()[-1] if err.splitlines() else err
+      results.append(
+          _ImportProbe(
+              module=module,
+              install_name=install_name,
+              ok=False,
+              error=err,
+          )
+      )
+  return results
+
+
+def collect_report(python_bin: str | None = None) -> _SetupReport:
+  """Run the full set of checks against ``python_bin`` (or BQAA_PYTHON
+  fallback) and return a structured report.
+
+  If the interpreter can't be executed (bad ``BQAA_PYTHON`` is the most
+  common case), skip the import probes — they'd all fail with the same
+  underlying error — and surface the interpreter problem directly
+  via ``_SetupReport.interpreter_error``.
+  """
+  resolved = python_bin or _resolve_python_bin()
+  interpreter_error = _probe_interpreter(resolved)
+  if interpreter_error is not None:
+    package_imports: list[_ImportProbe] = []
+    required_imports: list[_ImportProbe] = []
+    storage_write_imports: list[_ImportProbe] = []
+  else:
+    package_imports = _probe_imports(resolved, _PACKAGE_IMPORTS)
+    required_imports = _probe_imports(resolved, _REQUIRED_IMPORTS)
+    storage_write_imports = _probe_imports(resolved, _STORAGE_WRITE_IMPORTS)
+  return _SetupReport(
+      python_bin=resolved,
+      interpreter_error=interpreter_error,
+      project_id=(
+          os.environ.get("BQAA_PROJECT_ID")
+          or os.environ.get("GCP_PROJECT_ID")
+          or os.environ.get("GOOGLE_CLOUD_PROJECT")
+          or None
+      ),
+      dataset=(
+          os.environ.get("BQAA_DATASET") or os.environ.get("BQ_DATASET") or None
+      ),
+      trace_enabled=(
+          os.environ.get("BQAA_TRACE_ENABLED", "true").lower() == "true"
+      ),
+      package_imports=package_imports,
+      required_imports=required_imports,
+      storage_write_imports=storage_write_imports,
+  )
+
+
+def _format_report(report: _SetupReport) -> str:
+  """Human-readable, copy-pasteable advisory output."""
+  lines: list[str] = []
+  ok_mark = "OK"
+  miss_mark = "MISSING"
+
+  lines.append("BQAA tracing setup check")
+  lines.append("=" * 32)
+  lines.append(f"Python interpreter: {report.python_bin}")
+  if report.interpreter_error:
+    lines.append(f"  [{miss_mark}] {report.interpreter_error}")
+    lines.append(
+        "  Fix: point BQAA_PYTHON at a working python3 interpreter,"
+        " or unset it to use the default."
+    )
+  lines.append(f"BQAA_TRACE_ENABLED: {'on' if report.trace_enabled else 'off'}")
+  if not report.trace_enabled:
+    lines.append(
+        "  Note: emission is disabled. Set BQAA_TRACE_ENABLED=true"
+        " (or unset it) to enable."
+    )
+  lines.append("")
+
+  if report.interpreter_error:
+    # Skip the per-import sections — they're all empty when the
+    # interpreter is broken, and printing empty checklists is noise.
+    lines.append("Import + env checks skipped: interpreter unavailable.")
+    lines.append("")
+    lines.append("Status: ACTION NEEDED")
+    return "\n".join(lines) + "\n"
+
+  lines.append("Required env vars:")
+  lines.append(
+      f"  [{ok_mark if report.project_id else miss_mark}]"
+      f" BQAA_PROJECT_ID = {report.project_id or '(unset)'}"
+  )
+  lines.append(
+      f"  [{ok_mark if report.dataset else miss_mark}]"
+      f" BQAA_DATASET    = {report.dataset or '(unset)'}"
+  )
+  if not report.env_ok:
+    lines.append("")
+    lines.append("Fix: export the missing variables, e.g.")
+    if not report.project_id:
+      lines.append("  export BQAA_PROJECT_ID=your-gcp-project")
+    if not report.dataset:
+      lines.append("  export BQAA_DATASET=agent_analytics")
+  lines.append("")
+
+  lines.append("Package import:")
+  for probe in report.package_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.package_ok:
+    lines.append("")
+    lines.append(
+        "Fix: install the tracing wheel on BQAA_PYTHON, or point"
+        " PYTHONPATH at the vendored plugin's vendor/ directory."
+    )
+    lines.append(
+        f"  {report.python_bin} -m pip install bigquery-agent-analytics-tracing"
+    )
+  lines.append("")
+
+  lines.append("Required runtime deps:")
+  for probe in report.required_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.required_deps_ok:
+    missing = [p.install_name for p in report.required_imports if not p.ok]
+    lines.append("")
+    lines.append(f"Fix: {report.python_bin} -m pip install {' '.join(missing)}")
+  lines.append("")
+
+  lines.append("Storage Write API deps (optional):")
+  for probe in report.storage_write_imports:
+    mark = ok_mark if probe.ok else miss_mark
+    line = f"  [{mark}] import {probe.module}"
+    if not probe.ok and probe.error:
+      line += f" — {probe.error}"
+    lines.append(line)
+  if not report.storage_write_ok:
+    missing = [p.install_name for p in report.storage_write_imports if not p.ok]
+    lines.append("")
+    lines.append(
+        "Optional fix for the lower-latency Storage Write path"
+        " (drainer falls back to insert_rows_json without these):"
+    )
+    lines.append(f"  {report.python_bin} -m pip install {' '.join(missing)}")
+  lines.append("")
+
+  lines.append("Status: " + ("READY" if report.all_ok else "ACTION NEEDED"))
+  return "\n".join(lines) + "\n"
+
+
+def _report_to_json(report: _SetupReport) -> str:
+  return json.dumps(
+      {
+          **asdict(report),
+          "python_ok": report.python_ok,
+          "env_ok": report.env_ok,
+          "package_ok": report.package_ok,
+          "required_deps_ok": report.required_deps_ok,
+          "storage_write_ok": report.storage_write_ok,
+          "all_ok": report.all_ok,
+      },
+      indent=2,
+      sort_keys=True,
+  )
+
+
+def main(argv: list[str] | None = None) -> int:
+  """Exit 0 when everything required is in place, 1 otherwise.
+
+  The non-zero exit is what lets the slash command flag "fix this"
+  vs. "you're good." Storage Write deps are intentionally not part
+  of the exit code: the drainer fallback exists so a missing pyarrow
+  is not a hard blocker.
+  """
+  parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  parser.add_argument(
+      "--json",
+      action="store_true",
+      help="Emit a JSON report instead of human-readable text.",
+  )
+  args = parser.parse_args(argv)
+  report = collect_report()
+  if args.json:
+    sys.stdout.write(_report_to_json(report) + "\n")
+  else:
+    sys.stdout.write(_format_report(report))
+  return 0 if report.all_ok else 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/README.md
+++ b/producers/README.md
@@ -50,13 +50,17 @@ serves at [`/.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.jso
 /plugin install bigquery-agent-analytics-tracing@bqaa-tracing
 ```
 
+Add the marketplace by `<owner>/<repo>`, **not** by a direct URL to
+`marketplace.json` — the catalog's `source` is a relative path that
+Claude Code can only resolve from a Git checkout. See the
+[plugin README](../plugins/claude_code/README.md#installing-the-plugin)
+for the sparse-checkout variant and details.
+
 The plugin vendors its own copy of the tracing package, so the
 `BQAA_PYTHON` interpreter does **not** need
 `bigquery-agent-analytics-tracing` installed — only its runtime deps
 (`google-cloud-bigquery` always; `google-cloud-bigquery-storage` +
-`pyarrow` for the Storage Write path). See the
-[plugin README](../plugins/claude_code/README.md) for the full runtime
-model and the manual-install fallback.
+`pyarrow` for the Storage Write path).
 
 ## Releases
 

--- a/producers/README.md
+++ b/producers/README.md
@@ -42,25 +42,21 @@ logger.log_event(
 
 If you run Claude Code, the
 [Claude Code plugin artifact](../plugins/claude_code/) wires up all
-nine hooks for you. Until marketplace submission lands, install from
-a GitHub release tarball:
+nine hooks for you. Install via the marketplace catalog this repo
+serves at [`/.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json):
 
-```bash
-# Pick the version that matches the wheel you have installed.
-VERSION=$(python -c "from bigquery_agent_analytics_tracing import __version__; print(__version__)")
-mkdir -p ~/.claude/plugins
-curl -L \
-  "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
-  | tar -xz -C ~/.claude/plugins
+```
+/plugin marketplace add GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
+/plugin install bigquery-agent-analytics-tracing@bqaa-tracing
 ```
 
-The plugin tarball vendors its own copy of the tracing package, so
-the `BQAA_PYTHON` interpreter does **not** need
+The plugin vendors its own copy of the tracing package, so the
+`BQAA_PYTHON` interpreter does **not** need
 `bigquery-agent-analytics-tracing` installed — only its runtime deps
 (`google-cloud-bigquery` always; `google-cloud-bigquery-storage` +
 `pyarrow` for the Storage Write path). See the
 [plugin README](../plugins/claude_code/README.md) for the full runtime
-model.
+model and the manual-install fallback.
 
 ## Releases
 


### PR DESCRIPTION
Maps to **issue #251 track B**. Makes `bigquery-agent-analytics-tracing` installable via `/plugin install` rather than the curl-and-tar fallback, while avoiding the GoogleCloudPlatform-org repo-creation step the standalone-distribution-repo approach would have needed.

Refs #229, #234, #251.

## Layout

```
.claude-plugin/
└── marketplace.json                           # NEW: catalog at repo root

plugins/
├── claude_code/                               # unchanged (source of truth)
│   ├── .claude-plugin/plugin.json             #   placeholder "0.0.0+local"
│   ├── hooks/, commands/, scripts/, ...
│   └── vendor/                                #   gitignored
└── claude_code_dist/                          # NEW: marketplace-installable form
    ├── README.md                              #   "generated from release tarball"
    └── bigquery-agent-analytics-tracing/      #   verbatim tracing-v0.1.0 tarball
        ├── .claude-plugin/plugin.json         #     stamped "0.1.0"
        ├── hooks/, commands/, scripts/, ...
        ├── vendor/bigquery_agent_analytics_tracing/
        ├── vendor/bigquery_agent_analytics_tracing-0.1.0.dist-info/METADATA
        ├── MARKETPLACE.md
        └── README.md
```

## marketplace.json

```json
{
  "name": "bqaa-tracing",
  "owner": { "name": "Google LLC", "url": "..." },
  "plugins": [
    {
      "name": "bigquery-agent-analytics-tracing",
      "version": "0.1.0",
      "source": "./plugins/claude_code_dist/bigquery-agent-analytics-tracing",
      ...
    }
  ]
}
```

Relative-path `source` resolves into the in-repo dist folder. No extra repo needed.

## Why two trees (`claude_code/` and `claude_code_dist/`)

| | `plugins/claude_code/` | `plugins/claude_code_dist/.../` |
|---|---|---|
| Purpose | Source of truth — what we edit | Marketplace-installable artifact |
| `plugin.json` version | `"0.0.0+local"` placeholder | Stamped real version |
| `vendor/` | gitignored | Committed (vendored Python + `.dist-info/METADATA`) |
| Drift risk vs `producers/src/` | None (vendor regenerated each build) | Re-synced from release tarball each version cut |
| Marketplace-resolvable? | No (placeholder version + no vendor) | Yes |

The dist folder is the expanded `tracing-v0.1.0` release tarball, verbatim — `plugin.json` stamped at `0.1.0`, populated `vendor/`, and `vendor/.../bigquery_agent_analytics_tracing-0.1.0.dist-info/METADATA` so `importlib.metadata.version()` resolves at runtime (the vendored-runtime fix from #237 / [PR 242 dry-run](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/242#issuecomment-4549835370) — `attributes.writer.version` lands as `0.1.0`, not `0.0.0+local`).

## User-facing install path

Replaces the curl-and-extract recipe in `plugins/claude_code/README.md` and `producers/README.md` with the marketplace flow:

```
/plugin marketplace add GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK
/plugin install bigquery-agent-analytics-tracing@bqaa-tracing
```

Curl path retained in both READMEs as a documented fallback for environments without marketplace plugin support.

## Release-sync routine

Per-release, after `tracing-vX.Y.Z` cuts:

```bash
VERSION=X.Y.Z
WORK=$(mktemp -d)
curl -sSL \
  "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/releases/download/tracing-v${VERSION}/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz" \
  -o "$WORK/plugin.tar.gz"
tar -xzf "$WORK/plugin.tar.gz" -C "$WORK"
rm -rf plugins/claude_code_dist/bigquery-agent-analytics-tracing
cp -R "$WORK/bigquery-agent-analytics-tracing-claude-code-${VERSION}" \
      plugins/claude_code_dist/bigquery-agent-analytics-tracing
# bump .claude-plugin/marketplace.json's `version` field, PR.
```

Documented in `plugins/claude_code_dist/README.md`. Manual for v0.1.0; cross-repo workflow automation is a follow-up.

## Pre-validation

`claude plugin validate .` requires the Claude CLI; I ran an equivalent JSON+layout check locally instead, asserting:

- catalog JSON parses
- `source` relative path resolves to a directory containing `.claude-plugin/plugin.json`
- catalog `version`, dist `plugin.json` `version`, and `.dist-info/METADATA` `Version:` field all equal `0.1.0`
- All nine Claude Code hooks declared in `plugin.json.hooks`
- `vendor/bigquery_agent_analytics_tracing/` contains every expected module file
- `commands/bqaa-setup.md` + `scripts/run_setup_check.sh` present
- All `hooks/*.sh` have executable bits

Output:
```
=== layout passes pre-validation ===
```

## Producer tests

103/103 still pass — no producer code changes, only docs + the new top-level catalog + dist files.

## Open questions before going public

1. **Field naming.** `marketplace.json` shape (`source` as bare string vs `source.type` object, etc.) varies between Claude Code doc snapshots. Worth one `claude plugin validate .` run against the current CLI before announcing — easy fix if the schema requires a different shape (e.g., `{ "type": "relative", "path": "..." }` instead of bare path string).
2. **Fresh-session install smoke.** Deferred from #242 dry-run (loading the plugin into the live session would have logged this conversation to BQ). After this PR merges + `claude plugin validate .` passes, manual test via a fresh Claude Code session: `/plugin marketplace add ...` → `/plugin install ...` → `/bqaa-setup` → send a prompt → query `agent_events` and assert `attributes.writer.version = '0.1.0'`.

## Test plan

- [x] catalog JSON + layout validation script passes locally
- [x] `tracing-v0.1.0` tarball SHA matches what's in the dist folder
- [x] producer tests 103/103 pass
- [ ] `claude plugin validate .` against current Claude CLI (maintainer action)
- [ ] Fresh-session smoke (maintainer action; recommend a test/scratch BQ dataset to avoid mixing with prod rows)
- [ ] Producers CI green on PR head after first-time-fork approval