### PR TITLE
plugins: warn about duplicate BQAA installs before announcement

### DIFF
--- a/plugins/claude_code/MARKETPLACE.md
+++ b/plugins/claude_code/MARKETPLACE.md
@@ -73,6 +73,12 @@ recipe. Until marketplace listing is live this is the official path.
 Run on a clean environment (no `bigquery-agent-analytics-tracing` wheel
 on `BQAA_PYTHON`):
 
+0. Make sure no prior BQAA Claude Code plugin is active in the test
+   session — `/plugin list` should show no `bigquery-agent-analytics-tracing`
+   entry from any marketplace. Disable/uninstall any duplicates before
+   proceeding, or you'll see doubled hook rows in `agent_events` and
+   not be able to attribute them cleanly. Running multiple BQAA
+   tracing plugins at once duplicates every hook write.
 1. Download the release tarball for the version you're submitting:
    ```bash
    VERSION=X.Y.Z

--- a/plugins/claude_code/README.md
+++ b/plugins/claude_code/README.md
@@ -65,6 +65,13 @@ BigQuery IAM requirements and submission checklist live in
 
 ## Installing the plugin
 
+> **If you previously installed an older BQAA Claude Code plugin from
+> another marketplace or local path, remove or disable it before
+> installing this catalog version.** Running multiple BQAA tracing
+> plugins at once can duplicate hook events in BigQuery. Check
+> existing installs with `/plugin list` and uninstall any duplicates
+> with `/plugin uninstall <name>@<marketplace>` before continuing.
+
 This repo serves a Claude Code marketplace catalog at
 [`/.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json).
 From a Claude Code session:

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/MARKETPLACE.md
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/MARKETPLACE.md
@@ -73,6 +73,12 @@ recipe. Until marketplace listing is live this is the official path.
 Run on a clean environment (no `bigquery-agent-analytics-tracing` wheel
 on `BQAA_PYTHON`):
 
+0. Make sure no prior BQAA Claude Code plugin is active in the test
+   session — `/plugin list` should show no `bigquery-agent-analytics-tracing`
+   entry from any marketplace. Disable/uninstall any duplicates before
+   proceeding, or you'll see doubled hook rows in `agent_events` and
+   not be able to attribute them cleanly. Running multiple BQAA
+   tracing plugins at once duplicates every hook write.
 1. Download the release tarball for the version you're submitting:
    ```bash
    VERSION=X.Y.Z

--- a/plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md
+++ b/plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md
@@ -65,6 +65,13 @@ BigQuery IAM requirements and submission checklist live in
 
 ## Installing the plugin
 
+> **If you previously installed an older BQAA Claude Code plugin from
+> another marketplace or local path, remove or disable it before
+> installing this version.** Running multiple BQAA tracing plugins at
+> once can duplicate hook events in BigQuery. Check existing installs
+> with `/plugin list` and uninstall any duplicates with
+> `/plugin uninstall <name>@<marketplace>` before continuing.
+
 Until the plugin is submitted to the Claude Code marketplace, install
 from a GitHub release tarball:
 


### PR DESCRIPTION
Tiny follow-up to #252. Adds a "remove the old one first" note to the install docs so users with a prior BQAA plugin install from a different marketplace name don't accidentally end up running two plugins against the same hooks and writing every event to BigQuery twice.

Surfaced during the #252 marketplace-validate dry-run — the test session had a pre-existing \`bigquery-agent-analytics-tracing@bigquery-agent-analytics-plugin\` install (from a different marketplace), and adding \`bqaa-tracing\` and installing again would have left both enabled. Duplicate hook writes are easy to miss and hard to attribute after the fact.

## Edits

| File | Change |
|---|---|
| \`plugins/claude_code/README.md\` | Callout at the top of "Installing the plugin" section |
| \`plugins/claude_code/MARKETPLACE.md\` | New step 0 in "Manual verification before each marketplace bump" |
| \`plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md\` | Same callout (dist copy) |
| \`plugins/claude_code_dist/bigquery-agent-analytics-tracing/MARKETPLACE.md\` | Same step 0 (dist copy) |

All four locations use the same wording so source and dist stay in sync once the next release sync overwrites the dist copies.

## Note on dist drift

\`plugins/claude_code_dist/bigquery-agent-analytics-tracing/README.md\` is currently lagging the source README (it's a verbatim copy of the \`tracing-v0.1.0\` tarball, which was built before #252's README rewrite landed). The callout was added without re-syncing the rest of the dist README — this PR's scope is the duplicate-install note only, not a full dist re-sync. The next release cut + dist sync will re-converge everything.

## Scope

Docs only; no schema/manifest changes. \`.claude-plugin/marketplace.json\` untouched.

## Test plan

- [x] All four files diff cleanly
- [x] Producer tests still pass (no source changes; not re-run since touch is docs-only)
- [ ] Producers CI green on PR head