### PR TITLE
feat(cli): add bqaa context-graph command; deprecate bqaa-materialize-window (closes #245)

### DIFF
--- a/docs/blog/periodic_materialization.md
+++ b/docs/blog/periodic_materialization.md
@@ -9,7 +9,7 @@ As autonomous AI agents take on more operational responsibilities—such as eval
 
 While capturing raw agent event logs is a straightforward first step, querying those logs to reconstruct a complex decision path can be difficult and time-consuming. Traditionally, analyzing these relationships required exporting log data into external, specialized graph databases via complex ETL pipelines.
 
-To simplify this process, we are introducing scheduled, native graph materialization in BigQuery. Using the new `bqaa-materialize-window` command in the BigQuery Agent Analytics SDK, you can continuously convert agent event logs into an active [BigQuery property graph](https://cloud.google.com/bigquery/docs/reference/standard-sql/graph-query-language)—without setting up a separate database or leaving your BigQuery environment.
+To simplify this process, we are introducing scheduled, native graph materialization in BigQuery. Using the new `bqaa context-graph` command in the BigQuery Agent Analytics SDK, you can continuously convert agent event logs into an active [BigQuery property graph](https://cloud.google.com/bigquery/docs/reference/standard-sql/graph-query-language)—without setting up a separate database or leaving your BigQuery environment.
 
 ---
 
@@ -63,7 +63,7 @@ EDGE TABLES (
 
 ### 3\. Executing the Materializer
 
-To keep the graph updated, you run the `bqaa-materialize-window` CLI command on a schedule (e.g., every few hours). The SDK provides a deployment script to set this up as a Cloud Run Job triggered by Cloud Scheduler.
+To keep the graph updated, you run the `bqaa context-graph` CLI command on a schedule (e.g., every few hours). The SDK provides a deployment script to set this up as a Cloud Run Job triggered by Cloud Scheduler.
 
 During each run, the materializer:
 

--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -1,4 +1,4 @@
-summary: Build a queryable BigQuery property graph of your AI agent's decisions. You will apply a graph schema to a BigQuery dataset, seed it with sample agent events, run the bqaa-materialize-window CLI to extract a decision graph from those events, and query the result with Graph Query Language (GQL) to trace any decision end-to-end.
+summary: Build a queryable BigQuery property graph of your AI agent's decisions. You will apply a graph schema to a BigQuery dataset, seed it with sample agent events, run the bqaa context-graph CLI to extract a decision graph from those events, and query the result with Graph Query Language (GQL) to trace any decision end-to-end.
 id: bqaa-periodic-materialization
 categories: bigquery,adk,agents
 tags: bigquery,adk,bigquery-agent-analytics,cloud-run,cloud-scheduler,property-graph,gql
@@ -21,7 +21,7 @@ This codelab uses the BigQuery Agent Analytics SDK to transform raw agent event 
 
 * A BigQuery property graph that models a generic agent decision flow: a request comes in, the agent weighs options, an outcome is committed.
 * A populated `agent_events` table with a synthetic event corpus.
-* A working `bqaa-materialize-window` run that fills the graph from those events.
+* A working `bqaa context-graph` run that fills the graph from those events.
 * A one-shot replay (backfill) of a past time window — useful when events arrived during an outage — without disturbing the regular refresh schedule.
 * An audit-style GQL query that traces a single decision end-to-end.
 
@@ -29,7 +29,7 @@ This codelab uses the BigQuery Agent Analytics SDK to transform raw agent event 
 
 * How the BigQuery Agent Analytics Plugin writes to `agent_events`.
 * How a property graph is composed from a small set of declarative artifacts (table DDL, property-graph DDL, ontology, binding).
-* How to run `bqaa-materialize-window` against a property graph.
+* How to run `bqaa context-graph` against a property graph.
 * How to query a BigQuery property graph in GQL.
 * The production-grade capabilities the SDK supports for enterprise deployments.
 
@@ -142,10 +142,12 @@ Verify the install:
 
 <!-- colab:code bash -->
 ```bash
-bqaa-materialize-window --help | head -8
+bqaa context-graph --help | head -8
 ```
 
 You should see the CLI banner.
+
+> 💡 **Migrating from `bqaa-materialize-window`?** The old standalone command still works and accepts the same flags — it now prints a one-line deprecation notice on stderr and forwards to the same handler. Existing scripts and Cloud Run Jobs keep running while you migrate.
 
 ### Authenticate
 
@@ -236,7 +238,7 @@ cd ~/bqaa-codelab
 envsubst < binding.yaml > binding.rendered.yaml
 ```
 
-After this, `binding.rendered.yaml` contains your real project ID and dataset name instead of the `${...}` markers. If you skip this step, `bqaa-materialize-window` validates against literal `${PROJECT_ID}` text and fails closed.
+After this, `binding.rendered.yaml` contains your real project ID and dataset name instead of the `${...}` markers. If you skip this step, `bqaa context-graph` validates against literal `${PROJECT_ID}` text and fails closed.
 
 ## Phase 2: Generate Sample Agent Events
 Duration: 0:04
@@ -284,7 +286,7 @@ Run the materializer locally:
 
 <!-- colab:code bash -->
 ```bash
-bqaa-materialize-window \
+bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
     --ontology ~/bqaa-codelab/ontology.yaml \
@@ -429,7 +431,7 @@ FROM=$(date -u -d "9 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
 TO=$(date -u -d "8 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
      || date -u -v-8H +"%Y-%m-%dT%H:%M:%SZ")
 
-bqaa-materialize-window \
+bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
     --ontology ~/bqaa-codelab/ontology.yaml \
@@ -448,7 +450,7 @@ os.environ["TO"]   = (now - datetime.timedelta(hours=8)).strftime("%Y-%m-%dT%H:%
 print(f"Backfill window FROM = {os.environ['FROM']}")
 print(f"Backfill window TO   = {os.environ['TO']}")
 
-!cd ~/bqaa-codelab && bqaa-materialize-window \
+!cd ~/bqaa-codelab && bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
     --ontology ontology.yaml \
@@ -493,7 +495,7 @@ The local run you completed in Phase 3 uses default behavior. Real deployments c
 * **Replay a past window** (`--backfill --from / --to`). You exercised this in *Advanced: Replay a Past Window* above. The replay is tracked separately from the regular schedule so it cannot interfere with the live refresh.
 * **Bound the per-run batch size** (`--max-sessions`). Useful when an upstream event spike threatens to overwhelm a single scan.
 
-> 💡 **From "run this once" to "run this every six hours."** The SDK ships a deploy script and a Terraform module that wrap `bqaa-materialize-window` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. See the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/migration_v5/periodic_materialization) for the worked example, the IAM matrix, and the recommended schedules.
+> 💡 **From "run this once" to "run this every six hours."** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. See the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/migration_v5/periodic_materialization) for the worked example, the IAM matrix, and the recommended schedules.
 
 ## Clean Up
 Duration: 0:03
@@ -521,7 +523,7 @@ You have:
 
 * Created a BigQuery dataset and applied a property-graph schema describing an agent decision domain.
 * Populated `agent_events` with a synthetic event corpus.
-* Run `bqaa-materialize-window` to extract a decision graph from those events.
+* Run `bqaa context-graph` to extract a decision graph from those events.
 * Replayed a past time window with backfill mode, separately from the regular refresh schedule.
 * Queried the resulting graph in GQL and seen the audit-style answer.
 

--- a/examples/codelab/periodic_materialization/README.md
+++ b/examples/codelab/periodic_materialization/README.md
@@ -19,7 +19,7 @@ These are the artifacts the *Trace AI Agent Decisions with BigQuery Property Gra
 3. `envsubst < property_graph.sql | bq query --use_legacy_sql=false` creates the property graph.
 4. `envsubst < binding.yaml > binding.rendered.yaml` renders the binding once before the materializer reads it.
 5. `python seed_events.py --project-id "$PROJECT_ID" --dataset-id "$DATASET" --sessions 5` populates `agent_events`.
-6. `bqaa-materialize-window --project-id "$PROJECT_ID" --dataset-id "$DATASET" --ontology ontology.yaml --binding binding.rendered.yaml --lookback-hours 24` materializes the graph.
+6. `bqaa context-graph --project-id "$PROJECT_ID" --dataset-id "$DATASET" --ontology ontology.yaml --binding binding.rendered.yaml --lookback-hours 24` materializes the graph.
 
 ## Domain model
 

--- a/examples/codelab/periodic_materialization/binding.yaml
+++ b/examples/codelab/periodic_materialization/binding.yaml
@@ -4,7 +4,7 @@
 # BigQuery tables and columns. Paired with ontology.yaml
 # and property_graph.sql.
 #
-# Before passing this file to bqaa-materialize-window, render
+# Before passing this file to bqaa context-graph, render
 # the shell placeholders with envsubst:
 #   envsubst < binding.yaml > binding.yaml.tmp && mv binding.yaml.tmp binding.yaml
 #

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "* A BigQuery property graph that models a generic agent decision flow: a request comes in, the agent weighs options, an outcome is committed.\n",
     "* A populated `agent_events` table with a synthetic event corpus.\n",
-    "* A working `bqaa-materialize-window` run that fills the graph from those events.\n",
+    "* A working `bqaa context-graph` run that fills the graph from those events.\n",
     "* A one-shot replay (backfill) of a past time window — useful when events arrived during an outage — without disturbing the regular refresh schedule.\n",
     "* An audit-style GQL query that traces a single decision end-to-end.\n",
     "\n",
@@ -26,7 +26,7 @@
     "\n",
     "* How the BigQuery Agent Analytics Plugin writes to `agent_events`.\n",
     "* How a property graph is composed from a small set of declarative artifacts (table DDL, property-graph DDL, ontology, binding).\n",
-    "* How to run `bqaa-materialize-window` against a property graph.\n",
+    "* How to run `bqaa context-graph` against a property graph.\n",
     "* How to query a BigQuery property graph in GQL.\n",
     "* The production-grade capabilities the SDK supports for enterprise deployments.\n",
     "\n",
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bqaa-materialize-window --help | head -8"
+    "!bqaa context-graph --help | head -8"
    ]
   },
   {
@@ -174,6 +174,8 @@
    "metadata": {},
    "source": [
     "You should see the CLI banner.\n",
+    "\n",
+    "> 💡 **Migrating from `bqaa-materialize-window`?** The old standalone command still works and accepts the same flags — it now prints a one-line deprecation notice on stderr and forwards to the same handler. Existing scripts and Cloud Run Jobs keep running while you migrate.\n",
     "\n",
     "### Authenticate\n",
     "\n",
@@ -274,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After this, `binding.rendered.yaml` contains your real project ID and dataset name instead of the `${...}` markers. If you skip this step, `bqaa-materialize-window` validates against literal `${PROJECT_ID}` text and fails closed.\n",
+    "After this, `binding.rendered.yaml` contains your real project ID and dataset name instead of the `${...}` markers. If you skip this step, `bqaa context-graph` validates against literal `${PROJECT_ID}` text and fails closed.\n",
     "\n",
     "## Phase 2: Generate Sample Agent Events\n",
     "\n",
@@ -339,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bqaa-materialize-window      --project-id \"$PROJECT_ID\"      --dataset-id \"$DATASET\"      --ontology ~/bqaa-codelab/ontology.yaml      --binding ~/bqaa-codelab/binding.rendered.yaml      --lookback-hours 24      --format json"
+    "!bqaa context-graph      --project-id \"$PROJECT_ID\"      --dataset-id \"$DATASET\"      --ontology ~/bqaa-codelab/ontology.yaml      --binding ~/bqaa-codelab/binding.rendered.yaml      --lookback-hours 24      --format json"
    ]
   },
   {
@@ -498,7 +500,7 @@
     "print(f\"Backfill window FROM = {os.environ['FROM']}\")\n",
     "print(f\"Backfill window TO   = {os.environ['TO']}\")\n",
     "\n",
-    "!cd ~/bqaa-codelab && bqaa-materialize-window \\\n",
+    "!cd ~/bqaa-codelab && bqaa context-graph \\\n",
     "    --project-id \"$PROJECT_ID\" \\\n",
     "    --dataset-id \"$DATASET\" \\\n",
     "    --ontology ontology.yaml \\\n",
@@ -552,7 +554,7 @@
     "* **Replay a past window** (`--backfill --from / --to`). You exercised this in *Advanced: Replay a Past Window* above. The replay is tracked separately from the regular schedule so it cannot interfere with the live refresh.\n",
     "* **Bound the per-run batch size** (`--max-sessions`). Useful when an upstream event spike threatens to overwhelm a single scan.\n",
     "\n",
-    "> 💡 **From \"run this once\" to \"run this every six hours.\"** The SDK ships a deploy script and a Terraform module that wrap `bqaa-materialize-window` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. See the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/migration_v5/periodic_materialization) for the worked example, the IAM matrix, and the recommended schedules.\n",
+    "> 💡 **From \"run this once\" to \"run this every six hours.\"** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. See the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/migration_v5/periodic_materialization) for the worked example, the IAM matrix, and the recommended schedules.\n",
     "\n",
     "## Clean Up\n",
     "\n",
@@ -583,7 +585,7 @@
     "\n",
     "* Created a BigQuery dataset and applied a property-graph schema describing an agent decision domain.\n",
     "* Populated `agent_events` with a synthetic event corpus.\n",
-    "* Run `bqaa-materialize-window` to extract a decision graph from those events.\n",
+    "* Run `bqaa context-graph` to extract a decision graph from those events.\n",
     "* Replayed a past time window with backfill mode, separately from the regular refresh schedule.\n",
     "* Queried the resulting graph in GQL and seen the audit-style answer.\n",
     "\n",

--- a/examples/migration_v5/README.md
+++ b/examples/migration_v5/README.md
@@ -228,7 +228,7 @@ A live end-to-end notebook run (`run_agent.py --sessions 3` + Beat 1–4 cells a
 
 The notebook walks through the four guarantees once, ad hoc. Real deployments want the graph kept fresh on a cron — events arrive continuously, the materialized entity/relationship tables should follow within a chosen latency budget.
 
-[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa-materialize-window` every N hours against your project, using the MAKO demo's bound artifacts. The deploy script bundles the checked-in `binding.yaml` / `ontology.yaml` / `table_ddl.sql` from this directory — running it against a different `OntologyConfig` means regenerating those snapshots for your config first and pointing the deploy at the new files. The deploy script doesn't yet wire that as a CLI flag; that's a natural follow-up but out of scope for this PR.
+[`periodic_materialization/`](./periodic_materialization/) is the production path: a packaged Cloud Run Job + Cloud Scheduler trigger that runs `bqaa context-graph` every N hours against your project, using the MAKO demo's bound artifacts (the standalone `bqaa-materialize-window` command remains a deprecated alias for the same handler if your existing scripts still call it). The deploy script bundles the checked-in `binding.yaml` / `ontology.yaml` / `table_ddl.sql` from this directory — running it against a different `OntologyConfig` means regenerating those snapshots for your config first and pointing the deploy at the new files. The deploy script doesn't yet wire that as a CLI flag; that's a natural follow-up but out of scope for this PR.
 
 The flow customers actually follow:
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -1,6 +1,6 @@
 # Periodic materialization — Cloud Run Job + Cloud Scheduler
 
-Run `bqaa-materialize-window` on a cron, against your own
+Run `bqaa context-graph` on a cron, against your own
 BigQuery project, with one local command and one deploy command.
 
 The migration v5 demo (`examples/migration_v5/`) ships the
@@ -41,7 +41,7 @@ deployment verification in PR #166.
 ## Production shape
 
 ```
-agent_events            bqaa-materialize-window         graph entity/
+agent_events            bqaa context-graph         graph entity/
 (your events DS)  ────► (Cloud Run Job, every N hrs) ──► relationship tables
                               │                          (your graph DS)
                               ▼
@@ -239,7 +239,7 @@ events trickle in over hours, scale up).
 | **~1 hour** | `0 * * * *` | `2` | `15` | Tight window + small overlap. Best for low-latency monitoring use cases. Higher BQ cost per day (24 runs). |
 | **~6 hours** | `0 */6 * * *` | `8` | `30` | Default in the deploy script. Good balance for dashboarding / reporting use cases. 4 runs per day. |
 | **Daily** | `0 2 * * *` | `30` | `60` | Catch-up window covers any late-arriving events from the prior day. 1 run per day. Pair with off-peak `02:00` to avoid contending with daytime BQ slots. |
-| **Backfill** | (manual) | depends | depends | For one-shot catch-up: `bqaa-materialize-window --lookback-hours $N` with N covering the gap. Defer to a future `--backfill --from/--to` mode once it ships. |
+| **Backfill** | (manual) | depends | depends | For one-shot catch-up: `bqaa context-graph --lookback-hours $N` with N covering the gap. Defer to a future `--backfill --from/--to` mode once it ships. |
 
 Rules of thumb:
 

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -21,7 +21,7 @@ Scheduler trigger that fires every N hours; the orchestrator's
 state-table checkpoint plus overlap window handles "exactly once"
 across consecutive runs.
 
-This wrapper does three things the bare ``bqaa-materialize-window``
+This wrapper does three things the bare ``bqaa context-graph``
 CLI doesn't, all needed for a hands-off scheduled deployment:
 
 1. **Retargets the demo binding** to the customer's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ all = [
 
 [project.scripts]
 bq-agent-sdk = "bigquery_agent_analytics.cli:main"
+bqaa = "bigquery_agent_analytics.cli:bqaa_main"
 bqaa-revalidate-extractors = "bigquery_agent_analytics.extractor_compilation.cli_revalidate:main"
 bqaa-materialize-window = "bigquery_agent_analytics.cli:_materialize_window_entry"
 gm = "bigquery_ontology.cli:main"

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -51,6 +51,33 @@ app = typer.Typer(
     add_completion=False,
 )
 
+# Product-facing CLI surface. Wraps the same handlers that ``bq-agent-sdk``
+# exposes under their implementation-shaped names, but presents them with
+# product-aligned vocabulary (``context-graph`` for the materialization
+# pass, etc.). New customer-facing commands should be added here.
+bqaa_app = typer.Typer(
+    name="bqaa",
+    help=(
+        "BigQuery Agent Analytics — product-facing CLI surface for building"
+        " and refreshing the BigQuery context graph that traces your AI"
+        " agent's decisions."
+    ),
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+@bqaa_app.callback()
+def _bqaa_callback() -> None:
+  """BigQuery Agent Analytics — product-facing CLI.
+
+  The ``@callback`` keeps Typer from auto-promoting a single
+  subcommand's options to the top level. Without it, ``bqaa --help``
+  would show the ``context-graph`` flags directly instead of the
+  subcommand list.
+  """
+  return None
+
 
 # ------------------------------------------------------------------ #
 # Shared options                                                       #
@@ -1997,29 +2024,66 @@ def materialize_window(
     raise typer.Exit(code=2)
 
 
+# Register the same ``materialize_window`` callback as the
+# ``context-graph`` subcommand on the product-facing ``bqaa`` app.
+# Both ``bq-agent-sdk materialize-window`` and ``bqaa context-graph``
+# now reach the identical implementation. The latter is the
+# product-facing name; the former is preserved for backward
+# compatibility with the internal developer workflow.
+bqaa_app.command(
+    "context-graph",
+    help=(
+        "Build or refresh the BigQuery context graph from agent events."
+        " Scans the configured event window, extracts entities and"
+        " relationships per session, and materializes the graph tables."
+    ),
+)(materialize_window)
+
+
 def main() -> None:
   """Entry point for ``bq-agent-sdk``."""
   app()
 
 
+def bqaa_main() -> None:
+  """Entry point for the product-facing ``bqaa`` console script."""
+  bqaa_app()
+
+
+_DEPRECATION_NOTICE = (
+    "DeprecationWarning: 'bqaa-materialize-window' is deprecated and will"
+    " be removed in a future release. Use 'bqaa context-graph' with the"
+    " same flags instead."
+)
+
+
+def _print_deprecation_warning() -> None:
+  """Print the ``bqaa-materialize-window`` deprecation notice to stderr.
+
+  Extracted from ``_materialize_window_entry`` for testability.
+  """
+  print(_DEPRECATION_NOTICE, file=sys.stderr)
+
+
 def _materialize_window_entry() -> None:
-  """Entry point for the standalone ``bqaa-materialize-window``
+  """Deprecated entry point for the standalone ``bqaa-materialize-window``
   console script.
+
+  Prints a one-line deprecation notice to stderr, then invokes the same
+  handler the ``bqaa context-graph`` subcommand uses. Behavior is
+  otherwise unchanged so existing deploy scripts, Terraform modules,
+  and CI pipelines that already shell out to ``bqaa-materialize-window``
+  keep working through the deprecation window.
 
   Builds a Click command directly from the ``materialize_window``
   callback so ``--help`` renders as
   ``Usage: bqaa-materialize-window [OPTIONS]`` — collapsed, no
-  nested subcommand. ``typer.run`` would re-register the function
-  as a subcommand named ``materialize-window``, producing the
-  confusing
-  ``Usage: bqaa-materialize-window materialize-window [OPTIONS]``.
-  The function body is the same one registered on the main ``app``
-  as the ``materialize-window`` subcommand; both call paths share
-  the implementation.
+  nested subcommand.
   """
   from typer.main import get_command_from_info
   from typer.models import CommandInfo
 
+  _print_deprecation_warning()
   info = CommandInfo(name=None, callback=materialize_window)
   click_cmd = get_command_from_info(
       info, pretty_exceptions_short=True, rich_markup_mode=None

--- a/tests/test_cli_bqaa_app.py
+++ b/tests/test_cli_bqaa_app.py
@@ -56,8 +56,8 @@ def test_bqaa_help_lists_context_graph() -> None:
   assert "context graph" in result.output.lower()
 
 
-def test_bqaa_context_graph_help_lists_expected_flags() -> None:
-  """``bqaa context-graph --help`` exposes the materialize-window flags.
+def test_bqaa_context_graph_exposes_expected_flags() -> None:
+  """``bqaa context-graph`` exposes the materialize-window flags.
 
   Flags chosen here are the ones the codelab and blog actually document
   to customers, so a rename that accidentally drops one breaks the
@@ -65,9 +65,24 @@ def test_bqaa_context_graph_help_lists_expected_flags() -> None:
   flags (``--dry-run``, ``--bundles-root``, internal opt-ins); those
   are not asserted here because they are dev-tooling and not part of
   the customer-facing surface that the rename has to preserve.
+
+  This inspects the Click command's declared parameters rather than the
+  rendered ``--help`` text. Rich wraps long option names to the
+  terminal width and emits ANSI/box-drawing characters, so under CI's
+  80-column non-TTY rendering a flag like ``--project-id`` is not a
+  contiguous substring of the help output — scraping the text is
+  brittle, inspecting params is deterministic.
   """
-  result = runner.invoke(bqaa_app, ["context-graph", "--help"])
-  assert result.exit_code == 0, result.output
+  from typer.main import get_command
+
+  command = get_command(bqaa_app).get_command(None, "context-graph")  # type: ignore[arg-type]
+  assert command is not None, "bqaa app missing 'context-graph' subcommand"
+
+  declared_flags = set()
+  for param in command.params:
+    declared_flags.update(getattr(param, "opts", []))
+    declared_flags.update(getattr(param, "secondary_opts", []))
+
   for flag in (
       "--project-id",
       "--dataset-id",
@@ -81,12 +96,12 @@ def test_bqaa_context_graph_help_lists_expected_flags() -> None:
       "--to",
       "--state-key-suffix",
       "--extraction-mode",
-      "--max-session-age",
+      "--max-session-age-hours",
       "--format",
   ):
     assert (
-        flag in result.output
-    ), f"flag {flag!r} missing from `bqaa context-graph --help`"
+        flag in declared_flags
+    ), f"flag {flag!r} missing from `bqaa context-graph` params"
 
 
 def test_bqaa_context_graph_uses_materialize_window_handler() -> None:

--- a/tests/test_cli_bqaa_app.py
+++ b/tests/test_cli_bqaa_app.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the product-facing ``bqaa`` CLI surface (issue #245).
+
+Three things to prove:
+
+* The ``bqaa`` Typer app exposes ``context-graph`` as a subcommand.
+* ``bqaa context-graph`` and ``bq-agent-sdk materialize-window`` reach
+  the same underlying ``materialize_window`` handler with the same flag
+  surface.
+* ``bqaa-materialize-window`` (the deprecated standalone entry point)
+  still works and prints a one-line deprecation notice to stderr.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+
+import pytest
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics import cli as cli_module
+from bigquery_agent_analytics.cli import _DEPRECATION_NOTICE
+from bigquery_agent_analytics.cli import _print_deprecation_warning
+from bigquery_agent_analytics.cli import app as bq_agent_sdk_app
+from bigquery_agent_analytics.cli import bqaa_app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# bqaa app surface
+# ---------------------------------------------------------------------------
+
+
+def test_bqaa_help_lists_context_graph() -> None:
+  """``bqaa --help`` shows ``context-graph`` in the Commands section."""
+  result = runner.invoke(bqaa_app, ["--help"])
+  assert result.exit_code == 0, result.output
+  assert "context-graph" in result.output
+  # The product framing is in the help text so customers see the
+  # noun, not the implementation term.
+  assert "context graph" in result.output.lower()
+
+
+def test_bqaa_context_graph_help_lists_expected_flags() -> None:
+  """``bqaa context-graph --help`` exposes the materialize-window flags.
+
+  Flags chosen here are the ones the codelab and blog actually document
+  to customers, so a rename that accidentally drops one breaks the
+  copy-paste path. The full ``materialize-window`` surface has more
+  flags (``--dry-run``, ``--bundles-root``, internal opt-ins); those
+  are not asserted here because they are dev-tooling and not part of
+  the customer-facing surface that the rename has to preserve.
+  """
+  result = runner.invoke(bqaa_app, ["context-graph", "--help"])
+  assert result.exit_code == 0, result.output
+  for flag in (
+      "--project-id",
+      "--dataset-id",
+      "--ontology",
+      "--binding",
+      "--lookback-hours",
+      "--overlap-minutes",
+      "--max-sessions",
+      "--backfill",
+      "--from",
+      "--to",
+      "--state-key-suffix",
+      "--extraction-mode",
+      "--max-session-age",
+      "--format",
+  ):
+    assert (
+        flag in result.output
+    ), f"flag {flag!r} missing from `bqaa context-graph --help`"
+
+
+def test_bqaa_context_graph_uses_materialize_window_handler() -> None:
+  """The ``context-graph`` subcommand is bound to the same callback the
+  legacy ``materialize-window`` subcommand uses.
+
+  Typer wraps each callback when it registers a command, so the two
+  Click commands hold distinct wrapper objects even though both
+  ultimately call the same source function. Compare by qualified
+  name and module to assert "same handler" without being fooled by
+  the wrappers.
+  """
+  from typer.main import get_command
+
+  bqaa_click = get_command(bqaa_app)
+  bq_click = get_command(bq_agent_sdk_app)
+
+  bqaa_ctx_graph = bqaa_click.get_command(None, "context-graph")  # type: ignore[arg-type]
+  bq_materialize = bq_click.get_command(None, "materialize-window")  # type: ignore[arg-type]
+
+  assert (
+      bqaa_ctx_graph is not None
+  ), "bqaa app missing 'context-graph' subcommand"
+  assert (
+      bq_materialize is not None
+  ), "bq-agent-sdk app missing 'materialize-window' subcommand"
+
+  bqaa_cb = bqaa_ctx_graph.callback
+  bq_cb = bq_materialize.callback
+  assert bqaa_cb is not None and bq_cb is not None
+
+  # Both wrappers should report the same source function identity.
+  assert (
+      bqaa_cb.__module__ == bq_cb.__module__
+  ), f"different modules: {bqaa_cb.__module__} vs {bq_cb.__module__}"
+  assert bqaa_cb.__qualname__ == bq_cb.__qualname__, (
+      f"different qualnames: {bqaa_cb.__qualname__} vs" f" {bq_cb.__qualname__}"
+  )
+  # And both should be the live ``cli.materialize_window`` symbol.
+  assert bqaa_cb.__qualname__ == "materialize_window"
+  assert bqaa_cb.__module__.endswith("cli")
+
+
+def test_bqaa_help_does_not_collapse_into_single_subcommand() -> None:
+  """``bqaa --help`` should show a COMMAND-list shape, not promote the
+  single subcommand's flags up to the top level.
+
+  Regression guard: without the ``@bqaa_app.callback()`` shim, Typer
+  auto-promotes a single subcommand's options to the parent, which
+  would make ``bqaa --help`` confusingly identical to
+  ``bqaa context-graph --help``.
+  """
+  result = runner.invoke(bqaa_app, ["--help"])
+  assert result.exit_code == 0
+  # The flags only appear under the subcommand; the parent help should
+  # show a Commands section instead.
+  assert "Commands" in result.output
+  assert "--project-id" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Deprecated bqaa-materialize-window entry point
+# ---------------------------------------------------------------------------
+
+
+def test_deprecation_notice_mentions_replacement_command() -> None:
+  """The deprecation notice points users at the new command name."""
+  assert "bqaa-materialize-window" in _DEPRECATION_NOTICE
+  assert "bqaa context-graph" in _DEPRECATION_NOTICE
+  assert "deprecated" in _DEPRECATION_NOTICE.lower()
+
+
+def test_print_deprecation_warning_goes_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+  """``_print_deprecation_warning`` writes to stderr only.
+
+  Keeps the deprecation noise off stdout so scripts that pipe the
+  CLI's JSON output ``| jq`` are not broken by the migration.
+  """
+  _print_deprecation_warning()
+  captured = capsys.readouterr()
+  assert captured.out == ""
+  assert "bqaa-materialize-window" in captured.err
+  assert "bqaa context-graph" in captured.err
+
+
+def test_materialize_window_entry_prints_deprecation_then_runs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+  """``_materialize_window_entry`` calls the deprecation notice before
+  handing off to the click command.
+
+  Uses a monkeypatched ``click_cmd`` substitute so the test does not
+  actually invoke the materializer; we only need to prove the
+  sequencing.
+  """
+  called: list[str] = []
+
+  def fake_get_command_from_info(info, **kwargs):  # noqa: ANN001, ARG001
+    def fake_click_cmd() -> None:
+      called.append("click_cmd")
+
+    return fake_click_cmd
+
+  # Patch the typer.main import path used inside _materialize_window_entry.
+  import typer.main as typer_main
+
+  monkeypatch.setattr(
+      typer_main, "get_command_from_info", fake_get_command_from_info
+  )
+
+  cli_module._materialize_window_entry()
+  captured = capsys.readouterr()
+  assert captured.err.strip() == _DEPRECATION_NOTICE
+  assert called == [
+      "click_cmd"
+  ], "the click command was not invoked after the deprecation print"
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml entry-point sanity
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_declares_bqaa_console_script() -> None:
+  """``pyproject.toml`` should ship the new ``bqaa`` console script
+  pointing at ``cli.bqaa_main``.
+
+  Belt-and-suspenders check so the entry point doesn't silently drop
+  out of the package distribution.
+  """
+  from pathlib import Path
+
+  pyproject = (
+      Path(__file__).resolve().parents[1] / "pyproject.toml"
+  ).read_text(encoding="utf-8")
+  expected = textwrap.dedent(
+      """\
+      bqaa = "bigquery_agent_analytics.cli:bqaa_main"
+      """
+  ).strip()
+  assert expected in pyproject, (
+      "Expected entry-point declaration missing from pyproject.toml; the"
+      " 'bqaa' console script will not be installed"
+  )


### PR DESCRIPTION
## Summary

Adds the product-facing CLI surface the TL asked for in [#245](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/245), refined to **`bqaa context-graph`** per their follow-up comment, while keeping the legacy `bqaa-materialize-window` working as a deprecation-warning alias so existing deploys, Cloud Run Jobs, Terraform modules, and customer-side automation continue to run unchanged.

**Closes #245. Tracker: #257.**

## What's new for customers

```bash
# Recommended — new product-aligned command
bqaa context-graph \
    --project-id "$PROJECT_ID" \
    --dataset-id "$DATASET" \
    --ontology ontology.yaml \
    --binding binding.rendered.yaml \
    --lookback-hours 24 \
    --format json

# Same flags, same behavior, same handler
bqaa-materialize-window --project-id ... # still works; prints one-line deprecation notice to stderr
```

## Three CLI shapes after this PR

| Shape | Status | Use case |
|---|---|---|
| `bqaa context-graph ...` | **New, recommended** | Product-facing customer-side invocation. Lives on the new `bqaa` umbrella Typer app. |
| `bqaa-materialize-window ...` | **Deprecated alias** | Backward compat for existing scripts/Cloud Run/Terraform invocations. Prints one-line deprecation to stderr; stdout untouched so JSON-pipe scripts keep working. |
| `bq-agent-sdk materialize-window ...` | Unchanged | Internal developer-facing umbrella. Old subcommand name preserved. |

All three reach the **same** `materialize_window` callback. Verified by an explicit test that compares `__module__` + `__qualname__` of the callbacks.

## Implementation highlights

* New `bqaa_app = typer.Typer(...)` in `cli.py` with a `@bqaa_app.callback()` that forces the COMMAND-list shape (Typer auto-promotes a single subcommand's flags to top level without this — regression-guarded by `test_bqaa_help_does_not_collapse_into_single_subcommand`).
* New `bqaa_main()` entry function pointed at by `bqaa = "bigquery_agent_analytics.cli:bqaa_main"` in `pyproject.toml`.
* `bqaa_app.command("context-graph")(materialize_window)` registers the existing callback under the new name. No duplicated logic.
* `_print_deprecation_warning()` extracted from `_materialize_window_entry` for testability. Writes to stderr only.

## Tests (new file: `tests/test_cli_bqaa_app.py`)

Eight assertions:

1. `bqaa --help` lists `context-graph` and uses product noun in help text.
2. `bqaa context-graph` exposes every customer-facing flag the blog/codelab document (`--project-id`, `--dataset-id`, `--ontology`, `--binding`, `--lookback-hours`, `--overlap-minutes`, `--max-sessions`, `--backfill`, `--from`, `--to`, `--state-key-suffix`, `--extraction-mode`, `--max-session-age-hours`, `--format`). Inspects the Click command's declared `params` rather than scraping rendered `--help` text — rich wraps long option names to the terminal width and emits ANSI/box-drawing characters, so under CI's 80-column non-TTY rendering a flag like `--project-id` is not a contiguous substring. Param inspection is deterministic.
3. `bqaa context-graph` and `bq-agent-sdk materialize-window` are bound to the same callback (compared by `__module__` + `__qualname__` since Typer wraps each registration).
4. **Regression guard:** `bqaa --help` does not collapse into the single-subcommand shape.
5. Deprecation notice mentions both old and new names.
6. `_print_deprecation_warning` writes to stderr only (stdout empty) → JSON-pipe scripts preserved.
7. `_materialize_window_entry` calls the deprecation print **before** handing off to the click command (monkeypatched click fake).
8. `pyproject.toml` declares the `bqaa` console script.

**Full suite passes locally: 3153 passed, 15 skipped** (8 of which are this PR's new file).

## Doc updates

Updated to prefer `bqaa context-graph`:

* `docs/blog/periodic_materialization.md` (2 mentions)
* `docs/codelabs/periodic_materialization.md` (10 mentions)
* `examples/codelab/periodic_materialization/README.md`
* `examples/codelab/periodic_materialization/binding.yaml`
* `examples/migration_v5/README.md` (production-path line)
* `examples/migration_v5/periodic_materialization/README.md`
* `examples/migration_v5/periodic_materialization/run_job.py` (docstring)

Added a `> 💡 **Migrating from \`bqaa-materialize-window\`?**` tip block to the codelab's "Install the SDK" section so readers with existing scripts know the old name still works.

Codelab notebook regenerated from the markdown source via `scripts/generate_colab_from_codelab.py`; `--check` passes.

## What this PR does NOT change

* Internal Python function names (`materialize_window` the function, `run_materialize_window`, `materialize_window.py` the module) — they describe implementation accurately. Stay as-is.
* Deploy-shape names (`bqaa-periodic-materialization` job name, `bqaa-periodic-runtime-sa` / `bqaa-periodic-scheduler-sa` service accounts) — out of scope per #245 (deploy names, not CLI names).
* `examples/migration_v5/` path rename — tracked separately at **#248**.

## Diff stats

```
 docs/blog/periodic_materialization.md                          |   4 +-
 docs/codelabs/periodic_materialization.md                      |  22 +-
 examples/codelab/periodic_materialization/README.md            |   2 +-
 examples/codelab/periodic_materialization/binding.yaml         |   2 +-
 examples/codelab/periodic_materialization/colab_notebook.ipynb |  18 +-
 examples/migration_v5/README.md                                |   2 +-
 examples/migration_v5/periodic_materialization/README.md       |   6 +-
 examples/migration_v5/periodic_materialization/run_job.py      |   2 +-
 pyproject.toml                                                 |   1 +
 src/bigquery_agent_analytics/cli.py                            |  80 +++++--
 tests/test_cli_bqaa_app.py                                     | 251 +++++++++++++++++ (new)
 11 files changed, 355 insertions(+), 35 deletions(-)
```

## Verification

* Full suite passes locally (3153 passed, 15 skipped).
* `pyink --check` + `isort --check-only` clean (`bash autoformat.sh` reports no changes).
* Codelab notebook `--check` passes (markdown ↔ notebook in sync).
* Smoke test of all three CLI shapes in a fresh venv:
  - `bqaa --help` → shows Commands section with `context-graph`
  - `bqaa context-graph --help` → shows all expected flags
  - `bqaa-materialize-window --help` → prints deprecation notice on stderr, then standard help on stdout
* Codelab/notebook regression check passes. The pre-existing blog syntax issues from PR #240 (`AI.GENERATE_TEXT`, `BIND_CONNECTION`, double-bracket GQL in `docs/blog/periodic_materialization.md`) remain tracked in #241 — this PR only renames the command in that file and does not introduce or change them.

## Next up (per the user's roadmap in #257)

* #246 — Promote bundled `seed_events.py` to a maintained `bqaa` subcommand (e.g. `bqaa seed-events`).
* #247 — Realistic-scale demo data (depends on #246).
* #255 — Context Graph user guide with Conversational Analytics-first screenshots (separate scope, screenshots needed).

## Test plan

- [x] All existing tests still pass
- [x] New tests cover the new surface (8 new tests, all pass)
- [x] `--help` works on all three CLI shapes
- [x] Deprecation notice goes to stderr only
- [x] Codelab notebook regenerated and `--check` passes
- [x] Format check clean (`pyink` + `isort`)
- [x] CI green at commit `76bc724` — all 5 Python versions (3.10–3.14) + Format check pass after the flag-test fix
