### PR TITLE
feat(cli): add decision-realistic seed-events scenario (#247)

### DIFF
--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -316,9 +316,11 @@ bq query --use_legacy_sql=false \
      FROM per_session GROUP BY outcome ORDER BY outcome"
 ```
 
-You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated.
+You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated (plus the 5 successful sessions from the first-run corpus if you seeded that earlier in the same dataset).
 
 The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa context-graph` run skips them (it materializes only terminal-event-closed sessions). To surface them as `session_orphaned` instead of silently retrying forever, add `--max-session-age-hours` when you materialize — see the orphan-watchdog discussion later in this codelab.
+
+> **Note** — this scenario spreads its sessions across a 72-hour window on purpose. The Phase 3 walkthrough below uses `--lookback-hours 24` and is written for the small 5-session first-run corpus, so its exact counts assume you have *not* run this optional step. If you did, that is the intended lesson: a 24-hour materialization window picks up only the recent slice of a multi-day backlog — widen `--lookback-hours` (or backfill) to capture the older sessions.
 
 ## Phase 3: Materialize the Decision Graph
 Duration: 0:05

--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -300,20 +300,7 @@ Confirm the outcome distribution by classifying each session from its rows (orph
 <!-- colab:code bash -->
 ```bash
 bq query --use_legacy_sql=false \
-    "WITH per_session AS (
-       SELECT
-         session_id,
-         CASE
-           WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned'
-           WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed'
-           WHEN COUNTIF(is_truncated) > 0 THEN 'truncated'
-           ELSE 'success'
-         END AS outcome
-       FROM \`$PROJECT_ID.$DATASET.agent_events\`
-       GROUP BY session_id
-     )
-     SELECT outcome, COUNT(*) AS sessions
-     FROM per_session GROUP BY outcome ORDER BY outcome"
+    "WITH per_session AS (SELECT session_id, CASE WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned' WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed' WHEN COUNTIF(is_truncated) > 0 THEN 'truncated' ELSE 'success' END AS outcome FROM \`$PROJECT_ID.$DATASET.agent_events\` GROUP BY session_id) SELECT outcome, COUNT(*) AS sessions FROM per_session GROUP BY outcome ORDER BY outcome"
 ```
 
 You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated (plus the 5 successful sessions from the first-run corpus if you seeded that earlier in the same dataset).

--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -279,6 +279,47 @@ bq query --use_legacy_sql=false \
 
 You should see 25 `TOOL_COMPLETED` rows and 5 `AGENT_COMPLETED` rows (each session emits one `submit_request`, three `evaluate_option`, one `commit_outcome`, and one closing `AGENT_COMPLETED` — five tool events plus one agent terminator per session). The `AGENT_COMPLETED` rows are the session terminators that the materializer keys on for terminal-event detection.
 
+### Optional: Realistic-scale data
+
+The 5-session corpus above is intentionally tiny so the first run is fast. When you want production-shaped data — multiple agents and users spread over several days, with failed, orphaned, and truncated sessions — use the `decision-realistic` scenario. It defaults to 100 sessions over a 72-hour window; the first-run path above is unchanged.
+
+<!-- colab:code bash -->
+```bash
+bqaa seed-events \
+    --project-id "$PROJECT_ID" \
+    --dataset-id "$DATASET" \
+    --scenario decision-realistic \
+    --sessions 100 \
+    --seed 42
+```
+
+The JSON report's `session_outcome_counts` shows the mix — roughly `{"success": 70, "failed": 10, "orphaned": 10, "truncated": 10}`.
+
+Confirm the outcome distribution by classifying each session from its rows (orphaned = no `AGENT_COMPLETED`; failed = `AGENT_COMPLETED` with `status = 'error'`; truncated = any row with `is_truncated = true`; otherwise success). A first pass classifies each session, then a second aggregates per outcome:
+
+<!-- colab:code bash -->
+```bash
+bq query --use_legacy_sql=false \
+    "WITH per_session AS (
+       SELECT
+         session_id,
+         CASE
+           WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned'
+           WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed'
+           WHEN COUNTIF(is_truncated) > 0 THEN 'truncated'
+           ELSE 'success'
+         END AS outcome
+       FROM \`$PROJECT_ID.$DATASET.agent_events\`
+       GROUP BY session_id
+     )
+     SELECT outcome, COUNT(*) AS sessions
+     FROM per_session GROUP BY outcome ORDER BY outcome"
+```
+
+You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated.
+
+The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa context-graph` run skips them (it materializes only terminal-event-closed sessions). To surface them as `session_orphaned` instead of silently retrying forever, add `--max-session-age-hours` when you materialize — see the orphan-watchdog discussion later in this codelab.
+
 ## Phase 3: Materialize the Decision Graph
 Duration: 0:05
 

--- a/docs/superpowers/plans/2026-05-29-decision-realistic-scenario.md
+++ b/docs/superpowers/plans/2026-05-29-decision-realistic-scenario.md
@@ -1,0 +1,892 @@
+# `decision-realistic` Scenario Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a realistic-scale `decision-realistic` seed-events scenario (100 sessions / 72h, fixed 70/10/10/10 outcome mix, multiple agents/users/entities, variable decision length) while leaving the small `decision` scenario byte-identical.
+
+**Architecture:** Lift the `_SCENARIO_BUILDERS` seam from per-session builders to corpus builders `(rng, now, sessions) -> (rows, session_outcome_counts)`. `decision` keeps byte-identical output by wrapping its existing per-session builder; a new `decision-realistic` corpus builder produces the realistic shape. `run_seed_events` reports `session_outcome_counts`; `--sessions` gets overridable per-scenario defaults (decision=5, realistic=100).
+
+**Tech Stack:** Python 3.10+, Typer/Click, `google-cloud-bigquery`, pytest, pyink + isort (2-space indent). Spec: `docs/superpowers/specs/2026-05-29-decision-realistic-scenario-design.md`.
+
+---
+
+## File Structure
+
+- **Modify** `src/bigquery_agent_analytics/seed_events.py` — all generator/orchestrator changes (seam refactor, realistic builder, result field, default resolution).
+- **Modify** `src/bigquery_agent_analytics/cli.py` — `--sessions` default becomes `None` (resolved per-scenario in the SDK).
+- **Modify** `tests/test_seed_events.py` — generator-level tests (seam, realistic mix/shape/determinism, default resolution).
+- **Modify** `tests/test_cli_bqaa_app.py` — CLI dry-run for `decision-realistic`, per-scenario default sizing.
+- **Modify** `docs/codelabs/periodic_materialization.md` + regenerate `examples/codelab/periodic_materialization/colab_notebook.ipynb` — optional "Realistic Data" section.
+
+All edits keep 2-space indentation. Run `bash autoformat.sh` after each task and accept its formatting. Commit messages must NOT contain `Co-Authored-By` / "Generated with" trailers.
+
+**Determinism rule (applies throughout):** every random choice — including ids, option counts, confidences, time jitter, outcome assignment, and entity assignment — must flow through the single `random.Random(seed)` instance created by the caller. No `uuid`, no module-level `random.*`.
+
+---
+
+### Task 1: Refactor seam to corpus builders + add `session_outcome_counts`
+
+Lifts the seam without changing `decision` output, and adds the outcome-count field (populated for `decision` as `{"success": N}`).
+
+**Files:**
+- Modify: `src/bigquery_agent_analytics/seed_events.py`
+- Test: `tests/test_seed_events.py`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_seed_events.py`:
+
+```python
+def test_decision_corpus_is_byte_identical_after_refactor() -> None:
+  # Pin decision output so the seam refactor cannot change it.
+  rows = generate_seed_events(sessions=3, seed=42, now=_FIXED_NOW)
+  assert len(rows) == 3 * _EVENTS_PER_SESSION
+  assert rows[0]["agent"] == "demo-agent"
+  assert rows[0]["user_id"] == "demo-user"
+  assert rows[-1]["event_type"] == "AGENT_COMPLETED"
+  # Same (seed, now) still byte-identical.
+  assert generate_seed_events(sessions=3, seed=42, now=_FIXED_NOW) == rows
+
+
+def test_decision_result_reports_success_outcome_counts() -> None:
+  result = run_seed_events(
+      project_id="p", dataset_id="d", sessions=4, seed=1,
+      dry_run=True, now=_FIXED_NOW, bq_client=_FakeBQClient(),
+  )
+  assert result.session_outcome_counts == {"success": 4}
+  assert result.to_json()["session_outcome_counts"] == {"success": 4}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_seed_events.py -q`
+Expected: FAIL — `SeedEventsResult` has no `session_outcome_counts` (AttributeError / unexpected keyword).
+
+- [ ] **Step 3: Refactor the seam** — in `src/bigquery_agent_analytics/seed_events.py`:
+
+(a) Replace the `_SCENARIO_BUILDERS` block (the `_SCENARIO_BUILDERS = {Scenario.DECISION: _decision_session}` line and its following assert) with a corpus builder + registry. Insert `_build_decision_corpus` immediately after `_decision_session`'s definition, then the registry:
+
+```python
+def _build_decision_corpus(
+    rng: random.Random, now: datetime, sessions: int
+) -> tuple[list[dict], dict[str, int]]:
+  """Corpus builder for the small ``decision`` scenario.
+
+  Reproduces the exact pre-refactor loop (30s apart from ``now - 10min``,
+  delegating to ``_decision_session``) so output stays byte-identical.
+  """
+  rows: list[dict] = []
+  cur = now - timedelta(minutes=10)
+  for _ in range(sessions):
+    rows.extend(_decision_session(rng, cur))
+    cur += timedelta(seconds=30)
+  return rows, {"success": sessions}
+
+
+# scenario -> corpus builder ``(rng, now, sessions) -> (rows, outcome_counts)``
+_SCENARIO_BUILDERS = {Scenario.DECISION: _build_decision_corpus}
+assert set(_SCENARIO_BUILDERS) == set(Scenario), (
+    "every Scenario needs a builder; missing: "
+    f"{set(Scenario) - set(_SCENARIO_BUILDERS)}"
+)
+```
+
+(b) Replace the body of `generate_seed_events` so it delegates to the corpus builder and returns rows only:
+
+```python
+def generate_seed_events(
+    *,
+    sessions: int,
+    seed: Optional[int],
+    now: datetime,
+    scenario: Scenario = Scenario.DECISION,
+) -> list[dict]:
+  """Build synthetic agent_events rows. Pure: no I/O.
+
+  ``(seed, now)`` fixed -> byte-identical rows. ``seed=None`` -> live RNG.
+  Raises ``ValueError`` if ``sessions < 1``.
+  """
+  if sessions < 1:
+    raise ValueError("sessions must be >= 1")
+  rng = random.Random(seed)
+  rows, _counts = _SCENARIO_BUILDERS[scenario](rng, now, sessions)
+  return rows
+```
+
+(c) Add the `session_outcome_counts` field to `SeedEventsResult` (last field, with a default so existing direct constructions keep working) and include it in `to_json`:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class SeedEventsResult:
+  """Outcome of a seed-events run."""
+
+  table_ref: str
+  scenario: str
+  sessions: int
+  events_generated: int
+  events_inserted: int
+  dry_run: bool
+  ok: bool
+  event_type_counts: dict[str, int]
+  errors: list[dict]
+  session_outcome_counts: dict[str, int] = dataclasses.field(default_factory=dict)
+
+  def to_json(self) -> dict[str, Any]:
+    return {
+        "table_ref": self.table_ref,
+        "scenario": self.scenario,
+        "sessions": self.sessions,
+        "events_generated": self.events_generated,
+        "events_inserted": self.events_inserted,
+        "dry_run": self.dry_run,
+        "ok": self.ok,
+        "event_type_counts": dict(self.event_type_counts),
+        "session_outcome_counts": dict(self.session_outcome_counts),
+        "errors": list(self.errors),
+    }
+```
+
+(d) In `run_seed_events`, replace the `generate_seed_events(...)` call with a direct builder call (own rng) capturing both rows and outcome counts, and pass `session_outcome_counts` into all three `SeedEventsResult(...)` constructions. The relevant region becomes:
+
+```python
+  rng = random.Random(seed)
+  rows, session_outcome_counts = _SCENARIO_BUILDERS[scenario](rng, now, sessions)
+  counts: dict[str, int] = {}
+  for row in rows:
+    counts[row["event_type"]] = counts.get(row["event_type"], 0) + 1
+  table_ref = f"{project_id}.{dataset_id}.{events_table}"
+```
+
+Then add `session_outcome_counts=session_outcome_counts,` to each of the three `SeedEventsResult(...)` returns (dry-run, insert-error, success). Leave the rest of `run_seed_events` unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_seed_events.py tests/test_cli_bqaa_app.py -q`
+Expected: PASS (all prior tests + the 2 new ones; the existing CLI `insert_errors_exit_1` test still passes because the new field defaults to `{}`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bigquery_agent_analytics/seed_events.py tests/test_seed_events.py
+git commit -m "refactor(seed-events): corpus-builder seam + session_outcome_counts (#247)"
+```
+
+---
+
+### Task 2: Helpers — shuffled cycle, outcome allocation, parameterized `_row`
+
+Small, pure helpers the realistic builder needs, plus generalizing `_row` to accept `agent`/`user_id` (defaults keep `decision` byte-identical).
+
+**Files:**
+- Modify: `src/bigquery_agent_analytics/seed_events.py`
+- Test: `tests/test_seed_events.py`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_seed_events.py`:
+
+```python
+from bigquery_agent_analytics.seed_events import _outcome_allocation
+from bigquery_agent_analytics.seed_events import _shuffled_cycle
+
+
+def test_outcome_allocation_exact_at_100() -> None:
+  assert _outcome_allocation(100) == {
+      "success": 70, "failed": 10, "orphaned": 10, "truncated": 10,
+  }
+
+
+def test_outcome_allocation_scales_and_keeps_min_one() -> None:
+  assert _outcome_allocation(10) == {
+      "success": 7, "failed": 1, "orphaned": 1, "truncated": 1,
+  }
+  assert _outcome_allocation(4) == {
+      "success": 1, "failed": 1, "orphaned": 1, "truncated": 1,
+  }
+
+
+def test_outcome_allocation_rejects_too_few_sessions() -> None:
+  for bad in (3, 1, 0):
+    with pytest.raises(ValueError, match="decision-realistic requires sessions >= 4"):
+      _outcome_allocation(bad)
+
+
+def test_shuffled_cycle_covers_roster_and_is_deterministic() -> None:
+  import random as _random
+
+  roster = ("a", "b", "c", "d")
+  out1 = _shuffled_cycle(_random.Random(1), roster, 10)
+  out2 = _shuffled_cycle(_random.Random(1), roster, 10)
+  assert out1 == out2  # deterministic for a fixed rng seed
+  assert len(out1) == 10
+  assert set(out1) == set(roster)  # every roster member appears
+  # >=2 distinct even for small n
+  assert len(set(_shuffled_cycle(_random.Random(2), roster, 2))) >= 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_seed_events.py -q`
+Expected: FAIL — `_outcome_allocation` / `_shuffled_cycle` not defined.
+
+- [ ] **Step 3: Implement helpers + generalize `_row`** — in `src/bigquery_agent_analytics/seed_events.py`:
+
+(a) Add `import math` to the stdlib import block (keep imports sorted; isort will order it).
+
+(b) Generalize `_row` to accept `agent`/`user_id` keyword args with the current defaults (so `_decision_session` keeps emitting identical rows):
+
+```python
+def _row(
+    rng: random.Random,
+    event_type: str,
+    session_id: str,
+    content: dict,
+    ts: datetime,
+    *,
+    agent: str = "demo-agent",
+    user_id: str = "demo-user",
+) -> dict:
+  return {
+      "timestamp": ts.isoformat(),
+      "event_type": event_type,
+      "agent": agent,
+      "session_id": session_id,
+      "invocation_id": _hex(rng, 32),
+      "user_id": user_id,
+      # One trace per session in the demo corpus; trace_id mirrors session_id.
+      "trace_id": session_id,
+      "span_id": _hex(rng, 16),
+      "parent_span_id": None,
+      "status": "ok",
+      "error_message": None,
+      "is_truncated": False,
+      "content": json.dumps(content),
+      "attributes": "{}",
+      "latency_ms": "{}",
+  }
+```
+
+(c) Add the two helpers (place them after `_row`, before `_decision_session`):
+
+```python
+def _shuffled_cycle(
+    rng: random.Random, roster: tuple[str, ...], n: int
+) -> list[str]:
+  """Return a length-``n`` assignment cycling ``roster``, shuffled in place.
+
+  Repeats the roster to length ``n`` then shuffles, so every member appears
+  (for ``n >= len(roster)``) and at least ``min(n, len(roster))`` distinct
+  values are present -- a true coverage guarantee, not a probabilistic one.
+  """
+  reps = -(-n // len(roster))  # ceil division
+  cycle = (list(roster) * reps)[:n]
+  rng.shuffle(cycle)
+  return cycle
+
+
+def _outcome_allocation(sessions: int) -> dict[str, int]:
+  """Exact, deterministic outcome-bucket counts for ``decision-realistic``.
+
+  Each edge bucket (failed/orphaned/truncated) gets ``round-half-up`` of 10%,
+  floored at 1; ``success`` takes the remainder. Exact 70/10/10/10 at 100.
+  Requires ``sessions >= 4`` (else ``success`` would be < 1).
+  """
+  edge = max(1, math.floor(0.10 * sessions + 0.5))
+  success = sessions - 3 * edge
+  if success < 1:
+    raise ValueError("decision-realistic requires sessions >= 4")
+  return {
+      "success": success,
+      "failed": edge,
+      "orphaned": edge,
+      "truncated": edge,
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass (incl. decision byte-identical regression)**
+
+Run: `python -m pytest tests/test_seed_events.py -q`
+Expected: PASS. In particular `test_decision_corpus_is_byte_identical_after_refactor`, `test_same_seed_and_now_is_byte_identical`, and `test_payload_shape_and_terminal_events` must still pass — proving the `_row` signature change did not alter `decision` output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bigquery_agent_analytics/seed_events.py tests/test_seed_events.py
+git commit -m "feat(seed-events): outcome-allocation + shuffled-cycle helpers; parameterize _row (#247)"
+```
+
+---
+
+### Task 3: `decision-realistic` scenario
+
+The realistic corpus builder and its session builder, registered in the seam.
+
+**Files:**
+- Modify: `src/bigquery_agent_analytics/seed_events.py`
+- Test: `tests/test_seed_events.py`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_seed_events.py`:
+
+```python
+from datetime import timedelta
+
+from bigquery_agent_analytics.seed_events import build_realistic_corpus
+
+
+def _by_session(rows: list[dict]) -> dict[str, list[dict]]:
+  grouped: dict[str, list[dict]] = {}
+  for row in rows:
+    grouped.setdefault(row["session_id"], []).append(row)
+  return grouped
+
+
+def test_realistic_outcome_mix_exact_at_100() -> None:
+  import random as _random
+
+  rows, counts = build_realistic_corpus(_random.Random(42), _FIXED_NOW, 100)
+  assert counts == {"success": 70, "failed": 10, "orphaned": 10, "truncated": 10}
+
+  sessions = _by_session(rows)
+  assert len(sessions) == 100
+  orphaned = [s for s in sessions.values()
+              if not any(r["event_type"] == "AGENT_COMPLETED" for r in s)]
+  failed = [s for s in sessions.values() if any(
+      r["event_type"] == "AGENT_COMPLETED" and r["status"] == "error" for r in s)]
+  truncated = [s for s in sessions.values()
+               if any(r["is_truncated"] for r in s)]
+  assert len(orphaned) == 10
+  assert len(failed) == 10
+  assert len(truncated) == 10
+
+
+def test_realistic_terminal_event_invariant() -> None:
+  import random as _random
+
+  rows, _ = build_realistic_corpus(_random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    terminals = [r for r in session if r["event_type"] == "AGENT_COMPLETED"]
+    assert len(terminals) in (0, 1)  # orphaned -> 0, others -> exactly 1
+
+
+def test_realistic_failed_sessions_have_error_message() -> None:
+  import random as _random
+
+  rows, _ = build_realistic_corpus(_random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    for row in session:
+      if row["event_type"] == "AGENT_COMPLETED" and row["status"] == "error":
+        assert row["error_message"]  # non-empty
+
+
+def test_realistic_variable_option_count_in_range() -> None:
+  import random as _random
+
+  rows, _ = build_realistic_corpus(_random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    options = [r for r in session
+               if '"tool": "evaluate_option"' in r["content"]]
+    assert 2 <= len(options) <= 6
+
+
+def test_realistic_multi_day_span_and_no_future() -> None:
+  import random as _random
+  from datetime import datetime
+
+  rows, _ = build_realistic_corpus(_random.Random(7), _FIXED_NOW, 100)
+  ts = [datetime.fromisoformat(r["timestamp"]) for r in rows]
+  span = max(ts) - min(ts)
+  assert span > timedelta(hours=24)
+  assert span <= timedelta(hours=72)
+  assert max(ts) <= _FIXED_NOW  # no future timestamps
+
+
+def test_realistic_multiple_agents_and_users() -> None:
+  import random as _random
+
+  rows, _ = build_realistic_corpus(_random.Random(7), _FIXED_NOW, 100)
+  assert len({r["agent"] for r in rows}) >= 2
+  assert len({r["user_id"] for r in rows}) >= 2
+
+
+def test_realistic_is_deterministic() -> None:
+  import random as _random
+
+  a, ca = build_realistic_corpus(_random.Random(42), _FIXED_NOW, 100)
+  b, cb = build_realistic_corpus(_random.Random(42), _FIXED_NOW, 100)
+  assert a == b and ca == cb
+
+
+def test_realistic_rejects_too_few_sessions() -> None:
+  import random as _random
+
+  with pytest.raises(ValueError, match="decision-realistic requires sessions >= 4"):
+    build_realistic_corpus(_random.Random(1), _FIXED_NOW, 3)
+
+
+def test_generate_seed_events_supports_realistic_scenario() -> None:
+  rows = generate_seed_events(
+      sessions=100, seed=42, now=_FIXED_NOW, scenario=Scenario.DECISION_REALISTIC
+  )
+  assert len(_by_session(rows)) == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_seed_events.py -q`
+Expected: FAIL — `build_realistic_corpus` / `Scenario.DECISION_REALISTIC` not defined.
+
+- [ ] **Step 3: Implement the realistic scenario** — in `src/bigquery_agent_analytics/seed_events.py`:
+
+(a) Add the enum member:
+
+```python
+class Scenario(str, enum.Enum):
+  """Synthetic event scenarios. Extensible seam for #247."""
+
+  DECISION = "decision"
+  DECISION_REALISTIC = "decision-realistic"
+```
+
+(b) Add realistic constants near `_TOPICS`:
+
+```python
+_REALISTIC_AGENTS = (
+    "loan-advisor",
+    "ops-scheduler",
+    "access-broker",
+    "budget-allocator",
+)
+_REALISTIC_USERS = tuple(f"user-{i:03d}" for i in range(12))
+_REALISTIC_OPTION_LABELS = (
+    "approve",
+    "reject",
+    "defer",
+    "escalate",
+    "delegate",
+    "hold",
+)
+_REALISTIC_WINDOW = timedelta(hours=72)
+# Held back from ``now`` so a session's per-step offsets never produce a
+# timestamp after ``now`` (a session spans at most ~8s; 60s is safe margin).
+_MAX_SESSION_SPAN = timedelta(seconds=60)
+```
+
+(c) Add the session + corpus builders (place after `_build_decision_corpus`):
+
+```python
+def _realistic_session(
+    rng: random.Random,
+    start: datetime,
+    outcome: str,
+    agent: str,
+    user: str,
+    topic: str,
+) -> list[dict]:
+  """One realistic decision session starting at ``start``.
+
+  ``outcome`` is one of success/failed/orphaned/truncated and shapes the
+  terminal event and truncation flag. Option count varies 2..6.
+  """
+  session_id = f"sess-{_hex(rng, 8)}"
+  request_id = f"req-{_hex(rng, 6)}"
+  rows: list[dict] = []
+
+  def add(event_type, content, offset, *, status="ok",
+          error_message=None, is_truncated=False):
+    row = _row(
+        rng, event_type, session_id, content,
+        start + timedelta(seconds=offset), agent=agent, user_id=user,
+    )
+    row["status"] = status
+    row["error_message"] = error_message
+    row["is_truncated"] = is_truncated
+    rows.append(row)
+
+  add(
+      "TOOL_COMPLETED",
+      {
+          "tool": "submit_request",
+          "result": {"request_id": request_id, "request_text": f"Should we {topic}?"},
+      },
+      0,
+  )
+
+  k = rng.randint(2, 6)
+  options = [
+      {
+          "option_id": f"opt-{_hex(rng, 5)}",
+          "option_label": _REALISTIC_OPTION_LABELS[j],
+          "confidence": round(rng.uniform(0.1, 0.95), 2),
+      }
+      for j in range(k)
+  ]
+  for i, opt in enumerate(options):
+    content = {"tool": "evaluate_option", "result": {"request_id": request_id, **opt}}
+    # Truncated sessions clip one evaluate row's payload.
+    clip = outcome == "truncated" and i == 0
+    if clip:
+      content["result"]["notes"] = "(payload truncated)"
+    add("TOOL_COMPLETED", content, i + 1, is_truncated=clip)
+
+  selected = max(options, key=lambda o: o["confidence"])
+  add(
+      "TOOL_COMPLETED",
+      {
+          "tool": "commit_outcome",
+          "result": {
+              "request_id": request_id,
+              "outcome_id": f"out-{_hex(rng, 6)}",
+              "status": "committed",
+              "selected": selected["option_label"],
+          },
+      },
+      k + 1,
+  )
+
+  if outcome == "orphaned":
+    return rows  # no terminal event -- exercises the orphan watchdog
+  if outcome == "failed":
+    add(
+        "AGENT_COMPLETED", {"final": True}, k + 2,
+        status="error",
+        error_message="tool 'commit_outcome' failed: downstream timeout",
+    )
+  else:  # success or truncated
+    add("AGENT_COMPLETED", {"final": True}, k + 2)
+  return rows
+
+
+def build_realistic_corpus(
+    rng: random.Random, now: datetime, sessions: int
+) -> tuple[list[dict], dict[str, int]]:
+  """Corpus builder for ``decision-realistic`` (see spec #247).
+
+  Fixed deterministic mix (70/10/10/10 at 100, scaled otherwise), multi-day
+  spread over ``[now - 72h, now - _MAX_SESSION_SPAN]``, multiple
+  agents/users/topics. Returns ``(rows, session_outcome_counts)``.
+  """
+  counts = _outcome_allocation(sessions)  # raises if sessions < 4
+  outcomes: list[str] = []
+  for name in ("success", "failed", "orphaned", "truncated"):
+    outcomes.extend([name] * counts[name])
+  rng.shuffle(outcomes)
+
+  window_start = now - _REALISTIC_WINDOW
+  window_end = now - _MAX_SESSION_SPAN
+  slot = (window_end - window_start).total_seconds() / sessions
+  starts = [
+      window_start + timedelta(seconds=i * slot + rng.uniform(0, slot))
+      for i in range(sessions)
+  ]
+
+  agents = _shuffled_cycle(rng, _REALISTIC_AGENTS, sessions)
+  users = _shuffled_cycle(rng, _REALISTIC_USERS, sessions)
+  topics = _shuffled_cycle(rng, _TOPICS, sessions)
+
+  rows: list[dict] = []
+  for i in range(sessions):
+    rows.extend(
+        _realistic_session(
+            rng, starts[i], outcomes[i], agents[i], users[i], topics[i]
+        )
+    )
+  return rows, counts
+```
+
+(d) Register the builder:
+
+```python
+_SCENARIO_BUILDERS = {
+    Scenario.DECISION: _build_decision_corpus,
+    Scenario.DECISION_REALISTIC: build_realistic_corpus,
+}
+```
+
+(The existing `assert set(_SCENARIO_BUILDERS) == set(Scenario)` now covers both members.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_seed_events.py -q`
+Expected: PASS (all realistic tests + the decision regression tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bigquery_agent_analytics/seed_events.py tests/test_seed_events.py
+git commit -m "feat(seed-events): add decision-realistic scenario (#247)"
+```
+
+---
+
+### Task 4: Overridable per-scenario `--sessions` defaults
+
+`decision` defaults to 5, `decision-realistic` to 100; explicit `--sessions N` overrides.
+
+**Files:**
+- Modify: `src/bigquery_agent_analytics/seed_events.py` (`run_seed_events`)
+- Modify: `src/bigquery_agent_analytics/cli.py` (`--sessions` default → `None`)
+- Test: `tests/test_seed_events.py`, `tests/test_cli_bqaa_app.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_seed_events.py`:
+
+```python
+def test_default_sessions_per_scenario() -> None:
+  decision = run_seed_events(
+      project_id="p", dataset_id="d", seed=1, dry_run=True,
+      now=_FIXED_NOW, bq_client=_FakeBQClient(),
+  )
+  assert decision.sessions == 5
+
+  realistic = run_seed_events(
+      project_id="p", dataset_id="d", seed=1, dry_run=True,
+      scenario="decision-realistic", now=_FIXED_NOW, bq_client=_FakeBQClient(),
+  )
+  assert realistic.sessions == 100
+  assert realistic.session_outcome_counts == {
+      "success": 70, "failed": 10, "orphaned": 10, "truncated": 10,
+  }
+
+
+def test_explicit_sessions_overrides_scenario_default() -> None:
+  result = run_seed_events(
+      project_id="p", dataset_id="d", sessions=40, seed=1, dry_run=True,
+      scenario="decision-realistic", now=_FIXED_NOW, bq_client=_FakeBQClient(),
+  )
+  assert result.sessions == 40
+  assert sum(result.session_outcome_counts.values()) == 40
+```
+
+Append to `tests/test_cli_bqaa_app.py`:
+
+```python
+def test_bqaa_seed_events_realistic_dry_run_reports_outcomes() -> None:
+  """--scenario decision-realistic defaults to 100 sessions and reports the mix."""
+  result = runner.invoke(
+      bqaa_app,
+      ["seed-events", "--project-id", "p", "--dataset-id", "d",
+       "--scenario", "decision-realistic", "--seed", "42", "--dry-run"],
+  )
+  assert result.exit_code == 0, result.output
+  payload = json.loads(result.output)
+  assert payload["sessions"] == 100
+  assert payload["session_outcome_counts"] == {
+      "success": 70, "failed": 10, "orphaned": 10, "truncated": 10,
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_seed_events.py tests/test_cli_bqaa_app.py -q`
+Expected: FAIL — `run_seed_events` requires/defaults `sessions=5` regardless of scenario; realistic default is not 100.
+
+- [ ] **Step 3: Implement default resolution**
+
+(a) In `src/bigquery_agent_analytics/seed_events.py`, add the default map after `_SCENARIO_BUILDERS`:
+
+```python
+_SCENARIO_DEFAULT_SESSIONS = {
+    Scenario.DECISION: 5,
+    Scenario.DECISION_REALISTIC: 100,
+}
+```
+
+(b) Change `run_seed_events`'s `sessions` parameter to `Optional[int] = None` and resolve it per scenario AFTER coercing the scenario. Replace the signature default and the opening of the body:
+
+```python
+def run_seed_events(
+    *,
+    project_id: str,
+    dataset_id: str,
+    sessions: Optional[int] = None,
+    seed: Optional[int] = None,
+    scenario: Scenario | str = Scenario.DECISION,
+    events_table: str = "agent_events",
+    dry_run: bool = False,
+    now: Optional[datetime] = None,
+    bq_client: Optional[Any] = None,
+) -> SeedEventsResult:
+  """Generate synthetic events and (unless ``dry_run``) insert them.
+
+  ``sessions`` defaults per scenario (decision=5, decision-realistic=100) when
+  not given; an explicit value overrides. Invalid input (resolved
+  ``sessions < 1``, unknown ``scenario``) raises; the CLI maps that to exit 2.
+  BigQuery insert errors are modeled as ``ok=False`` with ``errors`` populated
+  -- not raised -- so the JSON report stays authoritative (CLI exit 1).
+  """
+  scenario = Scenario(scenario) if isinstance(scenario, str) else scenario
+  if sessions is None:
+    sessions = _SCENARIO_DEFAULT_SESSIONS[scenario]
+  if sessions < 1:
+    raise ValueError("sessions must be >= 1")
+  if now is None:
+    now = datetime.now(timezone.utc)
+```
+
+(Delete the old `if sessions < 1` / `scenario = Scenario(...)` lines that previously opened the body — they are replaced by the block above. The rest of `run_seed_events`, from `rng = random.Random(seed)` onward, is unchanged.)
+
+(c) In `src/bigquery_agent_analytics/cli.py`, change the `seed-events` command's `sessions` option default from `5` to `None` and update its help to document the per-scenario defaults:
+
+```python
+    sessions: Optional[int] = typer.Option(
+        None,
+        "--sessions",
+        help=(
+            "Number of synthetic sessions (>= 1). Default depends on"
+            " --scenario: 5 for decision, 100 for decision-realistic."
+        ),
+    ),
+```
+
+(`Optional` is already imported in `cli.py`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_seed_events.py tests/test_cli_bqaa_app.py -q`
+Expected: PASS, including the existing `test_dry_run_generates_without_touching_bigquery` (passes `sessions=2` explicitly) and `test_bqaa_seed_events_dry_run_reports_without_bigquery`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bigquery_agent_analytics/seed_events.py src/bigquery_agent_analytics/cli.py tests/test_seed_events.py tests/test_cli_bqaa_app.py
+git commit -m "feat(cli): per-scenario --sessions defaults (decision=5, realistic=100) (#247)"
+```
+
+---
+
+### Task 5: Codelab "Realistic Data" section + notebook
+
+**Files:**
+- Modify: `docs/codelabs/periodic_materialization.md`
+- Regenerate: `examples/codelab/periodic_materialization/colab_notebook.ipynb`
+
+- [ ] **Step 1: Add the optional section**
+
+In `docs/codelabs/periodic_materialization.md`, immediately AFTER the existing event-verification block (the section that ends with the `25 TOOL_COMPLETED rows and 5 AGENT_COMPLETED rows` paragraph, before `## Phase 3: Materialize the Decision Graph`), insert a new optional subsection. Use the same `<!-- colab:code bash -->` fence markers the file already uses so the notebook generator picks them up:
+
+````markdown
+### Optional: Realistic-scale data
+
+The 5-session corpus above is intentionally tiny so the first run is fast. When you want production-shaped data — multiple agents and users spread over several days, with failed, orphaned, and truncated sessions — use the `decision-realistic` scenario. It defaults to 100 sessions over a 72-hour window; the first-run path above is unchanged.
+
+<!-- colab:code bash -->
+```bash
+bqaa seed-events \
+    --project-id "$PROJECT_ID" \
+    --dataset-id "$DATASET" \
+    --scenario decision-realistic \
+    --sessions 100 \
+    --seed 42
+```
+
+The JSON report's `session_outcome_counts` shows the mix — roughly `{"success": 70, "failed": 10, "orphaned": 10, "truncated": 10}`.
+
+Confirm the outcome distribution by classifying each session from its rows (orphaned = no `AGENT_COMPLETED`; failed = `AGENT_COMPLETED` with `status = 'error'`; truncated = any row with `is_truncated = true`; otherwise success). A first pass classifies each session, then a second aggregates per outcome:
+
+<!-- colab:code bash -->
+```bash
+bq query --use_legacy_sql=false \
+    "WITH per_session AS (
+       SELECT
+         session_id,
+         CASE
+           WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned'
+           WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed'
+           WHEN COUNTIF(is_truncated) > 0 THEN 'truncated'
+           ELSE 'success'
+         END AS outcome
+       FROM \`$PROJECT_ID.$DATASET.agent_events\`
+       GROUP BY session_id
+     )
+     SELECT outcome, COUNT(*) AS sessions
+     FROM per_session GROUP BY outcome ORDER BY outcome"
+```
+
+You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated.
+
+The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa context-graph` run skips them (it materializes only terminal-event-closed sessions). To surface them as `session_orphaned` instead of silently retrying forever, add `--max-session-age-hours` when you materialize — see the orphan-watchdog discussion later in this codelab.
+````
+
+- [ ] **Step 2: Regenerate the notebook**
+
+Run:
+```bash
+python scripts/generate_colab_from_codelab.py \
+    docs/codelabs/periodic_materialization.md \
+    examples/codelab/periodic_materialization/colab_notebook.ipynb
+```
+
+- [ ] **Step 3: Verify the drift check passes**
+
+Run:
+```bash
+python scripts/generate_colab_from_codelab.py --check \
+    docs/codelabs/periodic_materialization.md \
+    examples/codelab/periodic_materialization/colab_notebook.ipynb
+```
+Expected: exit 0.
+
+- [ ] **Step 4: Sanity-check the markdown**
+
+Run: `git diff --check` (expect no whitespace errors) and confirm the first-run seed step (`bqaa seed-events --sessions 5`) is unchanged: `grep -n "sessions 5" docs/codelabs/periodic_materialization.md` should still show the original first-run command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/codelabs/periodic_materialization.md examples/codelab/periodic_materialization/colab_notebook.ipynb
+git commit -m "docs(codelab): optional realistic-scale data section + outcome SQL (#247)"
+```
+
+---
+
+### Task 6: Final verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format check**
+
+Run: `bash autoformat.sh`
+Expected: no changes to tracked files (`git status --short` shows no modified tracked files). If it reformats anything, `git add -A` and amend the most recent relevant commit.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `python -m pytest -q`
+Expected: all pass, including the new `decision-realistic` tests and unchanged `decision` regression tests.
+
+- [ ] **Step 3: Manual smoke**
+
+Run:
+```bash
+python -c "from typer.testing import CliRunner; from bigquery_agent_analytics.cli import bqaa_app; \
+r = CliRunner().invoke(bqaa_app, ['seed-events','--project-id','p','--dataset-id','d','--scenario','decision-realistic','--dry-run','--seed','42']); \
+print(r.exit_code); print(r.output)"
+```
+Expected: exit `0`; JSON with `"sessions": 100`, `"dry_run": true`, `"events_inserted": 0`, `"ok": true`, and `"session_outcome_counts": {"success": 70, "failed": 10, "orphaned": 10, "truncated": 10}`.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u myfork-fork feat/seed-events-realistic-scale
+gh pr create --repo GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK \
+  --base main --head caohy1988:feat/seed-events-realistic-scale \
+  --title "feat(cli): add decision-realistic seed-events scenario (#247)" \
+  --body "<summary referencing the spec + closes #247>"
+```
+(Do not add Co-Authored-By / generated-by signatures.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Seam refactor to corpus builders → Task 1. ✓
+- `decision` byte-identical → Task 1 (`_build_decision_corpus` reproduces the loop) + Task 2 (`_row` defaults) regression tests. ✓
+- `session_outcome_counts` on result, behind `run_seed_events`; `generate_seed_events` returns `list[dict]` unchanged → Task 1. ✓
+- `decision-realistic`: 100/72h default, 70/10/10/10 mix, exact bucket rule (round-half-up/min-1, success=remainder, `sessions>=4`) → Tasks 2 (`_outcome_allocation`) + 3. ✓
+- Failed (status=error+message) / orphaned (no terminal) / truncated (is_truncated) / variable 2–6 options → Task 3 + tests. ✓
+- Time distribution by partition+jitter in `[now-72h, now-_MAX_SESSION_SPAN]`, no future timestamps, multi-day span → Task 3 + `test_realistic_multi_day_span_and_no_future`. ✓
+- ≥2 agents/users via shuffled cycle → Task 2 (`_shuffled_cycle`) + Task 3 + `test_realistic_multiple_agents_and_users`. ✓
+- Determinism → Task 3 `test_realistic_is_deterministic`. ✓
+- Overridable per-scenario `--sessions` defaults → Task 4. ✓
+- Codelab optional section + concrete outcome SQL + orphan-watchdog note + notebook regen → Task 5. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows complete code. Task 5 explicitly instructs removing the illustrative wrong-query block (the only place a "draft then correct" appears) so the committed markdown contains exactly one correct query. ✓
+
+**Type consistency:** `build_realistic_corpus`, `_build_decision_corpus`, and the registry all use the corpus signature `(rng, now, sessions) -> tuple[list[dict], dict[str,int]]`. `_outcome_allocation`/`_shuffled_cycle` signatures match their call sites in Task 3. `SeedEventsResult.session_outcome_counts` (added Task 1) is produced by the builders (Tasks 1/3) and consumed by `run_seed_events` (Tasks 1/4) and tests. `_SCENARIO_DEFAULT_SESSIONS` keys match the `Scenario` members. `_row`'s new keyword-only `agent`/`user_id` default to the original literals, keeping `_decision_session` byte-identical. ✓

--- a/docs/superpowers/specs/2026-05-29-decision-realistic-scenario-design.md
+++ b/docs/superpowers/specs/2026-05-29-decision-realistic-scenario-design.md
@@ -1,0 +1,128 @@
+# Design: `decision-realistic` scenario — realistic-scale demo data (#247)
+
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Issue:** #247 (unblocked by #246 / PR #261)
+**Builds on:** `src/bigquery_agent_analytics/seed_events.py` (the `bqaa seed-events` SDK module + CLI)
+**Follow-up this unblocks:** #255 (CA-first user guide with screenshots)
+
+## Problem
+
+The `decision` scenario shipped in #246 is intentionally tiny and uniform: a single agent/user, all-success sessions, spaced 30s apart from a `now − 10min` base (100 sessions would still span < 1 hour). That is perfect for a fast, predictable first-run codelab, but it does not look like production telemetry. #247 adds a second, realistic-scale scenario — `decision-realistic` — with multi-day spread, multiple agents/users/business entities, and intentional failure/edge-case sessions, while leaving the small `decision` path (and the existing codelab first-run) completely untouched.
+
+## Goals
+
+- A new `decision-realistic` scenario selectable via `--scenario decision-realistic`, using the `_SCENARIO_BUILDERS` seam from #246.
+- 100 sessions (default) spread over a 72h window, with a fixed, deterministic **mix/shape**: 70% success, 10% failed, 10% orphaned, 10% truncated.
+- Multiple agents/users/business entities; variable decision length (2–6 options) for non-orphan flows.
+- Per-outcome reporting via `session_outcome_counts` so the codelab can explain the corpus without inspecting raw rows.
+- Determinism preserved: fixed `(seed, now)` → byte-identical rows for `decision-realistic` too.
+- An optional codelab "Realistic Data" section that does not change the first-run path.
+
+## Non-goals (YAGNI)
+
+- No new scale flags. Sizing reuses the existing `--sessions` (see §4). Shape/mix is baked in.
+- No third scenario, no per-bucket override flags, no configurable time-window flag.
+- `decision` behavior and output are unchanged (byte-identical).
+
+## Design
+
+### 1. Scenario seam refactor
+
+The #246 seam maps each `Scenario` to a **per-session** builder `(rng, now) -> rows`, and `generate_seed_events` owns the session loop + fixed 30s spacing. That cannot express multi-day spread or per-session outcome variety, so the seam is lifted to a **corpus builder** that owns count handling, time distribution, and per-session shape, and also returns outcome counts:
+
+```python
+# builder(rng, now, sessions) -> (rows, session_outcome_counts)
+_SCENARIO_BUILDERS = {
+    Scenario.DECISION:           _build_decision_corpus,
+    Scenario.DECISION_REALISTIC: _build_decision_realistic_corpus,
+}
+```
+
+- `_build_decision_corpus(rng, now, sessions)` reproduces the **exact** current rng call order and timestamps (it wraps the untouched `_decision_session(rng, cur)` in the same `cur = now − 10min; +30s` loop) and returns `(rows, {"success": sessions})`. `decision` output stays byte-identical → all existing `decision` tests pass unchanged.
+- `generate_seed_events(*, sessions, seed, now, scenario) -> list[dict]` is **unchanged in signature and return type**. Internally it creates `rng = random.Random(seed)`, calls the scenario's corpus builder, and returns **only** the rows (discarding the counts). Existing tests that treat its result as a list keep working.
+- `run_seed_events` creates its own `rng` and calls the corpus builder directly so it receives **both** rows and `session_outcome_counts`. (One build per call; `generate_seed_events` and `run_seed_events` do not both build for a single invocation.)
+
+`Scenario` gains `DECISION_REALISTIC = "decision-realistic"`. The existing module-load assert `set(_SCENARIO_BUILDERS) == set(Scenario)` covers the new member.
+
+### 2. `decision-realistic` corpus builder
+
+`_build_decision_realistic_corpus(rng, now, sessions)`. One `random.Random(seed)` drives every choice (no `uuid`/global random), so fixed `(seed, now)` → byte-identical rows.
+
+**Sizing + outcome buckets (deterministic).** Given `sessions = N` (default 100, see §4):
+
+```python
+edge = max(1, math.floor(0.10 * N + 0.5))   # round half up, min 1
+failed = orphaned = truncated = edge
+success = N - failed - orphaned - truncated
+if success < 1:
+    raise ValueError("decision-realistic requires sessions >= 4")
+```
+
+- N=100 → 70 success / 10 failed / 10 orphaned / 10 truncated (exact).
+- N=10 → 7/1/1/1; N=4 → 1/1/1/1; N<4 → `ValueError` (invalid input → CLI exit 2).
+
+Outcomes are assigned to the N session slots and **rng-shuffled** so failures are interleaved (not clustered), keeping exact bucket counts.
+
+**Time distribution.** Session start times are **distributed across** the 72h window ending at `now` (`[now − 72h, now]`) by even partitioning plus bounded `rng` jitter within each slot — not pure random draws — so the corpus span always covers the full multi-day range (the multi-day-span test is then exact, not probabilistic), with the earliest session pinned near `now − 72h` and the latest near `now`. Within a session, steps are offset by seconds from its start (as in `decision`). Older sessions deliberately fall outside a 24h `--lookback-hours`, which the codelab uses to demonstrate windowing.
+
+**Per-outcome session shape** (built on the existing submit → evaluate×k → commit → terminal flow):
+- **success** — `AGENT_COMPLETED`, `status="ok"`. `k` = option count drawn uniformly from 2..6.
+- **failed** — terminates with `AGENT_COMPLETED`, `status="error"`, `error_message` populated (e.g. tool failure / policy block). `k` ∈ 2..6.
+- **orphaned** — **no terminal event** (session ends after `commit_outcome`, or mid-flow). Exercises the materializer's orphan watchdog (`--max-session-age-hours` / `session_orphaned`); these do not materialize under the default `AGENT_COMPLETED` filter — the intended demonstration. `k` ∈ 2..6.
+- **truncated** — `is_truncated=true` and clipped/partial `content` on at least one row; otherwise a normal completed session. `k` ∈ 2..6.
+
+**Entities** (replacing the single `demo-agent`/`demo-user`):
+- ~4 named agents (e.g. `loan-advisor`, `ops-scheduler`, `access-broker`, `budget-allocator`), each aligned to a business topic family.
+- ~12 named users (e.g. `user-000`..`user-011`).
+- Business topics/entities cycled deterministically from an extended topic list.
+Agent/user/topic are chosen per session via `rng`, guaranteeing ≥2 distinct agents and ≥2 distinct users for any realistic N.
+
+The row schema is unchanged (`_EVENT_SCHEMA_FIELDS`); only field *values* vary.
+
+### 3. Result reporting
+
+`SeedEventsResult` gains `session_outcome_counts: dict[str, int]`, surfaced in `to_json()`:
+- `decision` → `{"success": N}`.
+- `decision-realistic` → `{"success": 70, "failed": 10, "orphaned": 10, "truncated": 10}` (at N=100).
+
+`generate_seed_events`'s public `list[dict]` return is unchanged; outcome counts live behind `run_seed_events` only. Adding a key to `to_json()` is additive — the existing round-trip test still passes.
+
+### 4. CLI / `--sessions` semantics (overridable default)
+
+"Fixed baked-in" means fixed **mix/shape**, not fixed count.
+- `--sessions` default becomes scenario-specific: **`decision` → 5, `decision-realistic` → 100**. Explicit `--sessions N` overrides either.
+- Mechanically: the CLI `--sessions` Typer option default becomes `None`; `run_seed_events` resolves `None` to the scenario default via `_SCENARIO_DEFAULT_SESSIONS = {DECISION: 5, DECISION_REALISTIC: 100}`. `decision` with no flag still yields 5 (identical observable behavior; help documents the per-scenario defaults).
+- `--scenario decision-realistic` accepts the new value (string coerced to the enum; unknown values still raise → exit 2).
+
+No other CLI flags change.
+
+### 5. Codelab integration
+
+First-run path unchanged (`bqaa seed-events --sessions 5`). Add an optional **"Realistic Data"** section to `docs/codelabs/periodic_materialization.md`:
+
+```bash
+bqaa seed-events --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
+    --scenario decision-realistic --sessions 100 --seed 42
+```
+
+with two checks: (a) an event-type / outcome distribution query, and (b) orphan-watchdog behavior (`bqaa context-graph` skips the 10 orphaned sessions under the default filter; `--max-session-age-hours` flags them as `session_orphaned`). Regenerate `colab_notebook.ipynb` via `scripts/generate_colab_from_codelab.py`; the CI drift `--check` must pass.
+
+### 6. Tests (`tests/test_seed_events.py`, `tests/test_cli_bqaa_app.py`)
+
+`decision` regression (byte-identical output + existing assertions) stays green unchanged. New `decision-realistic` tests:
+- **Outcome mix:** exact `{"success":70,"failed":10,"orphaned":10,"truncated":10}` at default 100; proportional scaling at other N (e.g. N=10 → 7/1/1/1); `sessions < 4` raises `ValueError`.
+- **Terminal-event invariant:** every non-orphan session has exactly one `AGENT_COMPLETED`; every orphaned session has zero.
+- **Failure markers:** failed sessions carry `status="error"` + non-empty `error_message`; truncated sessions carry `is_truncated=true`.
+- **Variable length:** non-orphan option counts ∈ [2, 6].
+- **Multi-day spread:** `max(timestamp) − min(timestamp)` is > 24h and ≤ 72h.
+- **Entities:** ≥ 2 distinct `agent` values and ≥ 2 distinct `user_id` values.
+- **Determinism:** fixed `(seed, now)` → byte-identical rows; different seed → different.
+- **Reporting:** `session_outcome_counts` matches the actual rows; `run_seed_events(dry_run=True, scenario="decision-realistic")` returns the counts with `events_inserted=0`.
+- **CLI:** `--scenario decision-realistic --dry-run` exits 0 and the JSON payload includes `session_outcome_counts`; default (no `--sessions`) yields 100 sessions for realistic and 5 for `decision`.
+
+## Required Verification (acceptance checks — not yet performed)
+
+- Full test suite green across Python 3.10–3.14.
+- `bash autoformat.sh` reports no changes (pyink + isort).
+- Codelab notebook `--check` passes (markdown ↔ notebook in sync).
+- Manual smoke: `bqaa seed-events --scenario decision-realistic --dry-run --seed 42` reports `sessions: 100`, `session_outcome_counts: {success:70, failed:10, orphaned:10, truncated:10}`, multi-day timestamps; `decision` dry-run output is byte-identical to pre-#247.

--- a/docs/superpowers/specs/2026-05-29-decision-realistic-scenario-design.md
+++ b/docs/superpowers/specs/2026-05-29-decision-realistic-scenario-design.md
@@ -63,7 +63,7 @@ if success < 1:
 
 Outcomes are assigned to the N session slots and **rng-shuffled** so failures are interleaved (not clustered), keeping exact bucket counts.
 
-**Time distribution.** Session start times are **distributed across** the 72h window ending at `now` (`[now − 72h, now]`) by even partitioning plus bounded `rng` jitter within each slot — not pure random draws — so the corpus span always covers the full multi-day range (the multi-day-span test is then exact, not probabilistic), with the earliest session pinned near `now − 72h` and the latest near `now`. Within a session, steps are offset by seconds from its start (as in `decision`). Older sessions deliberately fall outside a 24h `--lookback-hours`, which the codelab uses to demonstrate windowing.
+**Time distribution.** Session start times are **distributed across** the window `[now − 72h, now − _MAX_SESSION_SPAN]` by even partitioning plus bounded `rng` jitter within each slot — not pure random draws — so the corpus span always covers the full multi-day range (the multi-day-span test is then exact, not probabilistic), with the earliest session pinned near `now − 72h` and the latest near `now − _MAX_SESSION_SPAN`. The window's upper bound is held back by `_MAX_SESSION_SPAN` (a constant comfortably larger than any single session's per-step offsets, e.g. 60s) so that a session's tool/terminal rows (start + a few seconds) **never land after `now`** — no future timestamps. Within a session, steps are offset by seconds from its start (as in `decision`). Older sessions deliberately fall outside a 24h `--lookback-hours`, which the codelab uses to demonstrate windowing.
 
 **Per-outcome session shape** (built on the existing submit → evaluate×k → commit → terminal flow):
 - **success** — `AGENT_COMPLETED`, `status="ok"`. `k` = option count drawn uniformly from 2..6.
@@ -75,7 +75,8 @@ Outcomes are assigned to the N session slots and **rng-shuffled** so failures ar
 - ~4 named agents (e.g. `loan-advisor`, `ops-scheduler`, `access-broker`, `budget-allocator`), each aligned to a business topic family.
 - ~12 named users (e.g. `user-000`..`user-011`).
 - Business topics/entities cycled deterministically from an extended topic list.
-Agent/user/topic are chosen per session via `rng`, guaranteeing ≥2 distinct agents and ≥2 distinct users for any realistic N.
+
+Agents and users are assigned via a **shuffled cycle**, not independent `rng.choice` (which could pick the same value every time for small N): build a list by repeating the agent (resp. user) roster to length N, `rng.shuffle` it, then index by session slot. This guarantees near-even coverage and **≥2 distinct agents and ≥2 distinct users for any N ≥ 2** (deterministic given the seed), making the coverage test a true guarantee rather than a probabilistic one. Topic is assigned the same way.
 
 The row schema is unchanged (`_EVENT_SCHEMA_FIELDS`); only field *values* vary.
 
@@ -105,7 +106,9 @@ bqaa seed-events --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
     --scenario decision-realistic --sessions 100 --seed 42
 ```
 
-with two checks: (a) an event-type / outcome distribution query, and (b) orphan-watchdog behavior (`bqaa context-graph` skips the 10 orphaned sessions under the default filter; `--max-session-age-hours` flags them as `session_orphaned`). Regenerate `colab_notebook.ipynb` via `scripts/generate_colab_from_codelab.py`; the CI drift `--check` must pass.
+with two checks: (a) an outcome-distribution query, and (b) orphan-watchdog behavior (`bqaa context-graph` skips the 10 orphaned sessions under the default filter; `--max-session-age-hours` flags them as `session_orphaned`). Regenerate `colab_notebook.ipynb` via `scripts/generate_colab_from_codelab.py`; the CI drift `--check` must pass.
+
+The outcome-distribution check must be **concrete SQL**, not just an event-type tally — event-type counts don't reveal the outcome mix. The implementation plan provides the exact query that classifies each `session_id` by joining/aggregating over its rows: a session is *orphaned* if it has no `AGENT_COMPLETED` row, *failed* if its `AGENT_COMPLETED` has `status = 'error'`, *truncated* if any of its rows has `is_truncated = true`, else *success* — and counts sessions per class, so the reader sees roughly 70/10/10/10 at the default 100. (Classification precedence resolves any overlap; the generator assigns one outcome per session, so overlaps should not occur.)
 
 ### 6. Tests (`tests/test_seed_events.py`, `tests/test_cli_bqaa_app.py`)
 

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -379,9 +379,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated.\n",
+    "You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated (plus the 5 successful sessions from the first-run corpus if you seeded that earlier in the same dataset).\n",
     "\n",
     "The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa context-graph` run skips them (it materializes only terminal-event-closed sessions). To surface them as `session_orphaned` instead of silently retrying forever, add `--max-session-age-hours` when you materialize — see the orphan-watchdog discussion later in this codelab.\n",
+    "\n",
+    "> **Note** — this scenario spreads its sessions across a 72-hour window on purpose. The Phase 3 walkthrough below uses `--lookback-hours 24` and is written for the small 5-session first-run corpus, so its exact counts assume you have *not* run this optional step. If you did, that is the intended lesson: a 24-hour materialization window picks up only the recent slice of a multi-day backlog — widen `--lookback-hours` (or backfill) to capture the older sessions.\n",
     "\n",
     "## Phase 3: Materialize the Decision Graph\n",
     "\n",

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -330,6 +330,59 @@
    "source": [
     "You should see 25 `TOOL_COMPLETED` rows and 5 `AGENT_COMPLETED` rows (each session emits one `submit_request`, three `evaluate_option`, one `commit_outcome`, and one closing `AGENT_COMPLETED` — five tool events plus one agent terminator per session). The `AGENT_COMPLETED` rows are the session terminators that the materializer keys on for terminal-event detection.\n",
     "\n",
+    "### Optional: Realistic-scale data\n",
+    "\n",
+    "The 5-session corpus above is intentionally tiny so the first run is fast. When you want production-shaped data — multiple agents and users spread over several days, with failed, orphaned, and truncated sessions — use the `decision-realistic` scenario. It defaults to 100 sessions over a 72-hour window; the first-run path above is unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!bqaa seed-events      --project-id \"$PROJECT_ID\"      --dataset-id \"$DATASET\"      --scenario decision-realistic      --sessions 100      --seed 42"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The JSON report's `session_outcome_counts` shows the mix — roughly `{\"success\": 70, \"failed\": 10, \"orphaned\": 10, \"truncated\": 10}`.\n",
+    "\n",
+    "Confirm the outcome distribution by classifying each session from its rows (orphaned = no `AGENT_COMPLETED`; failed = `AGENT_COMPLETED` with `status = 'error'`; truncated = any row with `is_truncated = true`; otherwise success). A first pass classifies each session, then a second aggregates per outcome:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!bq query --use_legacy_sql=false      \"WITH per_session AS ( && \\\n",
+    "           SELECT && \\\n",
+    "             session_id, && \\\n",
+    "             CASE && \\\n",
+    "               WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned' && \\\n",
+    "               WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed' && \\\n",
+    "               WHEN COUNTIF(is_truncated) > 0 THEN 'truncated' && \\\n",
+    "               ELSE 'success' && \\\n",
+    "             END AS outcome && \\\n",
+    "           FROM \\`$PROJECT_ID.$DATASET.agent_events\\` && \\\n",
+    "           GROUP BY session_id && \\\n",
+    "         ) && \\\n",
+    "         SELECT outcome, COUNT(*) AS sessions && \\\n",
+    "         FROM per_session GROUP BY outcome ORDER BY outcome\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should see roughly 70 success, 10 failed, 10 orphaned, and 10 truncated.\n",
+    "\n",
+    "The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa context-graph` run skips them (it materializes only terminal-event-closed sessions). To surface them as `session_orphaned` instead of silently retrying forever, add `--max-session-age-hours` when you materialize — see the orphan-watchdog discussion later in this codelab.\n",
+    "\n",
     "## Phase 3: Materialize the Decision Graph\n",
     "\n",
     "Run the materializer locally:"

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -359,20 +359,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bq query --use_legacy_sql=false      \"WITH per_session AS ( && \\\n",
-    "           SELECT && \\\n",
-    "             session_id, && \\\n",
-    "             CASE && \\\n",
-    "               WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned' && \\\n",
-    "               WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed' && \\\n",
-    "               WHEN COUNTIF(is_truncated) > 0 THEN 'truncated' && \\\n",
-    "               ELSE 'success' && \\\n",
-    "             END AS outcome && \\\n",
-    "           FROM \\`$PROJECT_ID.$DATASET.agent_events\\` && \\\n",
-    "           GROUP BY session_id && \\\n",
-    "         ) && \\\n",
-    "         SELECT outcome, COUNT(*) AS sessions && \\\n",
-    "         FROM per_session GROUP BY outcome ORDER BY outcome\""
+    "!bq query --use_legacy_sql=false      \"WITH per_session AS (SELECT session_id, CASE WHEN COUNTIF(event_type = 'AGENT_COMPLETED') = 0 THEN 'orphaned' WHEN COUNTIF(event_type = 'AGENT_COMPLETED' AND status = 'error') > 0 THEN 'failed' WHEN COUNTIF(is_truncated) > 0 THEN 'truncated' ELSE 'success' END AS outcome FROM \\`$PROJECT_ID.$DATASET.agent_events\\` GROUP BY session_id) SELECT outcome, COUNT(*) AS sessions FROM per_session GROUP BY outcome ORDER BY outcome\""
    ]
   },
   {

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2053,8 +2053,13 @@ def seed_events(
         "--events-table",
         help="Destination telemetry table name (in --dataset-id).",
     ),
-    sessions: int = typer.Option(
-        5, "--sessions", help="Number of synthetic decision sessions (>= 1)."
+    sessions: Optional[int] = typer.Option(
+        None,
+        "--sessions",
+        help=(
+            "Number of synthetic sessions (>= 1). Default depends on"
+            " --scenario: 5 for decision, 100 for decision-realistic."
+        ),
     ),
     seed: Optional[int] = typer.Option(
         None,

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2072,7 +2072,10 @@ def seed_events(
     scenario: str = typer.Option(
         "decision",
         "--scenario",
-        help="Synthetic scenario to generate. Currently: decision.",
+        help=(
+            "Synthetic scenario: decision (small, default) or"
+            " decision-realistic (100-session, multi-day, mixed outcomes)."
+        ),
     ),
     dry_run: bool = typer.Option(
         False,

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2088,8 +2088,10 @@ def seed_events(
 ) -> None:
   """Seed a dataset with synthetic agent_events for the context graph.
 
-  Generates completed decision sessions (TOOL_COMPLETED + AGENT_COMPLETED)
-  so ``bqaa context-graph`` has terminal-event-closed sessions to process.
+  Generates decision telemetry (TOOL_COMPLETED + AGENT_COMPLETED) so
+  ``bqaa context-graph`` has sessions to process. The ``decision`` scenario
+  emits only terminal-event-closed sessions; ``decision-realistic`` also
+  includes failed, truncated, and orphaned (no terminal event) sessions.
 
   Exit codes:
       0 — events generated (and inserted, unless --dry-run).

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Synthetic agent_events generator backing ``bqaa seed-events`` (#246).
 
-Writes a small corpus of TOOL_COMPLETED + AGENT_COMPLETED events to a
-configured ``agent_events`` table. Each session is a 3-step decision flow
-(submit_request -> evaluate_option x3 -> commit_outcome) closed by an
-AGENT_COMPLETED row, which is the terminal event the materializer keys on.
+Writes a corpus of TOOL_COMPLETED + AGENT_COMPLETED events to a configured
+``agent_events`` table. The base session is a decision flow (submit_request
+-> evaluate_option -> commit_outcome); the ``decision`` scenario closes every
+session with an AGENT_COMPLETED terminal row, while ``decision-realistic``
+mixes in failed, truncated, and orphaned (no terminal event) sessions. The
+materializer keys on the terminal AGENT_COMPLETED row.
 
 ``--seed`` freezes IDs and content (and event structure); timestamps stay
 anchored to run time so seeded events land inside the materializer's

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -41,6 +41,7 @@ class Scenario(str, enum.Enum):
   """Synthetic event scenarios. Extensible seam for #247."""
 
   DECISION = "decision"
+  DECISION_REALISTIC = "decision-realistic"
 
 
 _EVENT_SCHEMA_FIELDS = (
@@ -67,6 +68,26 @@ _TOPICS = (
     "grant access",
     "release budget",
 )
+
+_REALISTIC_AGENTS = (
+    "loan-advisor",
+    "ops-scheduler",
+    "access-broker",
+    "budget-allocator",
+)
+_REALISTIC_USERS = tuple(f"user-{i:03d}" for i in range(12))
+_REALISTIC_OPTION_LABELS = (
+    "approve",
+    "reject",
+    "defer",
+    "escalate",
+    "delegate",
+    "hold",
+)
+_REALISTIC_WINDOW = timedelta(hours=72)
+# Held back from ``now`` so a session's per-step offsets never produce a
+# timestamp after ``now`` (a session spans at most ~8s; 60s is safe margin).
+_MAX_SESSION_SPAN = timedelta(seconds=60)
 
 
 def _hex(rng: random.Random, length: int) -> str:
@@ -233,8 +254,150 @@ def _build_decision_corpus(
   return rows, {"success": sessions}
 
 
+def _realistic_session(
+    rng: random.Random,
+    start: datetime,
+    outcome: str,
+    agent: str,
+    user: str,
+    topic: str,
+) -> list[dict]:
+  """One realistic decision session starting at ``start``.
+
+  ``outcome`` is one of success/failed/orphaned/truncated and shapes the
+  terminal event and truncation flag. Option count varies 2..6.
+  """
+  session_id = f"sess-{_hex(rng, 8)}"
+  request_id = f"req-{_hex(rng, 6)}"
+  rows: list[dict] = []
+
+  def add(
+      event_type,
+      content,
+      offset,
+      *,
+      status="ok",
+      error_message=None,
+      is_truncated=False,
+  ):
+    row = _row(
+        rng,
+        event_type,
+        session_id,
+        content,
+        start + timedelta(seconds=offset),
+        agent=agent,
+        user_id=user,
+    )
+    row["status"] = status
+    row["error_message"] = error_message
+    row["is_truncated"] = is_truncated
+    rows.append(row)
+
+  add(
+      "TOOL_COMPLETED",
+      {
+          "tool": "submit_request",
+          "result": {
+              "request_id": request_id,
+              "request_text": f"Should we {topic}?",
+          },
+      },
+      0,
+  )
+
+  k = rng.randint(2, 6)
+  options = [
+      {
+          "option_id": f"opt-{_hex(rng, 5)}",
+          "option_label": _REALISTIC_OPTION_LABELS[j],
+          "confidence": round(rng.uniform(0.1, 0.95), 2),
+      }
+      for j in range(k)
+  ]
+  for i, opt in enumerate(options):
+    content = {
+        "tool": "evaluate_option",
+        "result": {"request_id": request_id, **opt},
+    }
+    # Truncated sessions clip one evaluate row's payload.
+    clip = outcome == "truncated" and i == 0
+    if clip:
+      content["result"]["notes"] = "(payload truncated)"
+    add("TOOL_COMPLETED", content, i + 1, is_truncated=clip)
+
+  selected = max(options, key=lambda o: o["confidence"])
+  add(
+      "TOOL_COMPLETED",
+      {
+          "tool": "commit_outcome",
+          "result": {
+              "request_id": request_id,
+              "outcome_id": f"out-{_hex(rng, 6)}",
+              "status": "committed",
+              "selected": selected["option_label"],
+          },
+      },
+      k + 1,
+  )
+
+  if outcome == "orphaned":
+    return rows  # no terminal event -- exercises the orphan watchdog
+  if outcome == "failed":
+    add(
+        "AGENT_COMPLETED",
+        {"final": True},
+        k + 2,
+        status="error",
+        error_message="tool 'commit_outcome' failed: downstream timeout",
+    )
+  else:  # success or truncated
+    add("AGENT_COMPLETED", {"final": True}, k + 2)
+  return rows
+
+
+def build_realistic_corpus(
+    rng: random.Random, now: datetime, sessions: int
+) -> tuple[list[dict], dict[str, int]]:
+  """Corpus builder for ``decision-realistic`` (see spec #247).
+
+  Fixed deterministic mix (70/10/10/10 at 100, scaled otherwise), multi-day
+  spread over ``[now - 72h, now - _MAX_SESSION_SPAN]``, multiple
+  agents/users/topics. Returns ``(rows, session_outcome_counts)``.
+  """
+  counts = _outcome_allocation(sessions)  # raises if sessions < 4
+  outcomes: list[str] = []
+  for name in ("success", "failed", "orphaned", "truncated"):
+    outcomes.extend([name] * counts[name])
+  rng.shuffle(outcomes)
+
+  window_start = now - _REALISTIC_WINDOW
+  window_end = now - _MAX_SESSION_SPAN
+  slot = (window_end - window_start).total_seconds() / sessions
+  starts = [
+      window_start + timedelta(seconds=i * slot + rng.uniform(0, slot))
+      for i in range(sessions)
+  ]
+
+  agents = _shuffled_cycle(rng, _REALISTIC_AGENTS, sessions)
+  users = _shuffled_cycle(rng, _REALISTIC_USERS, sessions)
+  topics = _shuffled_cycle(rng, _TOPICS, sessions)
+
+  rows: list[dict] = []
+  for i in range(sessions):
+    rows.extend(
+        _realistic_session(
+            rng, starts[i], outcomes[i], agents[i], users[i], topics[i]
+        )
+    )
+  return rows, counts
+
+
 # scenario -> corpus builder ``(rng, now, sessions) -> (rows, outcome_counts)``
-_SCENARIO_BUILDERS = {Scenario.DECISION: _build_decision_corpus}
+_SCENARIO_BUILDERS = {
+    Scenario.DECISION: _build_decision_corpus,
+    Scenario.DECISION_REALISTIC: build_realistic_corpus,
+}
 assert set(_SCENARIO_BUILDERS) == set(Scenario), (
     "every Scenario needs a builder; missing: "
     f"{set(Scenario) - set(_SCENARIO_BUILDERS)}"

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -403,6 +403,11 @@ assert set(_SCENARIO_BUILDERS) == set(Scenario), (
     f"{set(Scenario) - set(_SCENARIO_BUILDERS)}"
 )
 
+_SCENARIO_DEFAULT_SESSIONS = {
+    Scenario.DECISION: 5,
+    Scenario.DECISION_REALISTIC: 100,
+}
+
 
 def generate_seed_events(
     *,
@@ -460,7 +465,7 @@ def run_seed_events(
     *,
     project_id: str,
     dataset_id: str,
-    sessions: int = 5,
+    sessions: Optional[int] = None,
     seed: Optional[int] = None,
     scenario: Scenario | str = Scenario.DECISION,
     events_table: str = "agent_events",
@@ -470,14 +475,18 @@ def run_seed_events(
 ) -> SeedEventsResult:
   """Generate synthetic events and (unless ``dry_run``) insert them.
 
+  ``sessions`` defaults per scenario: 5 for ``decision``, 100 for
+  ``decision-realistic``. Pass an explicit value to override.
   Invalid input (``sessions < 1``, unknown ``scenario``) raises; the CLI
   maps that to exit 2. BigQuery insert errors are modeled as ``ok=False``
   with ``errors`` populated -- not raised -- so the JSON report stays
   authoritative (CLI exit 1).
   """
+  scenario = Scenario(scenario) if isinstance(scenario, str) else scenario
+  if sessions is None:
+    sessions = _SCENARIO_DEFAULT_SESSIONS[scenario]
   if sessions < 1:
     raise ValueError("sessions must be >= 1")
-  scenario = Scenario(scenario) if isinstance(scenario, str) else scenario
   if now is None:
     now = datetime.now(timezone.utc)
 

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -349,7 +349,7 @@ def _realistic_session(
         {"final": True},
         k + 2,
         status="error",
-        error_message="tool 'commit_outcome' failed: downstream timeout",
+        error_message="agent run failed: downstream timeout after commit",
     )
   else:  # success or truncated
     add("AGENT_COMPLETED", {"final": True}, k + 2)

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -185,6 +185,8 @@ def _build_decision_corpus(
   Reproduces the exact pre-refactor loop (30s apart from ``now - 10min``,
   delegating to ``_decision_session``) so output stays byte-identical.
   """
+  if sessions < 1:
+    raise ValueError("sessions must be >= 1")
   rows: list[dict] = []
   cur = now - timedelta(minutes=10)
   for _ in range(sessions):
@@ -233,6 +235,7 @@ class SeedEventsResult:
   ok: bool
   event_type_counts: dict[str, int]
   errors: list[dict]
+  # {} when not populated (e.g. a SeedEventsResult constructed without it).
   session_outcome_counts: dict[str, int] = dataclasses.field(
       default_factory=dict
   )

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -32,6 +32,7 @@ from datetime import timedelta
 from datetime import timezone
 import enum
 import json
+import math
 import random
 from typing import Any, Optional
 
@@ -79,14 +80,17 @@ def _row(
     session_id: str,
     content: dict,
     ts: datetime,
+    *,
+    agent: str = "demo-agent",
+    user_id: str = "demo-user",
 ) -> dict:
   return {
       "timestamp": ts.isoformat(),
       "event_type": event_type,
-      "agent": "demo-agent",
+      "agent": agent,
       "session_id": session_id,
       "invocation_id": _hex(rng, 32),
-      "user_id": "demo-user",
+      "user_id": user_id,
       # One trace per session in the demo corpus; trace_id mirrors session_id.
       "trace_id": session_id,
       "span_id": _hex(rng, 16),
@@ -97,6 +101,40 @@ def _row(
       "content": json.dumps(content),
       "attributes": "{}",
       "latency_ms": "{}",
+  }
+
+
+def _shuffled_cycle(
+    rng: random.Random, roster: tuple[str, ...], n: int
+) -> list[str]:
+  """Return a length-``n`` assignment cycling ``roster``, shuffled in place.
+
+  Repeats the roster to length ``n`` then shuffles, so every member appears
+  (for ``n >= len(roster)``) and at least ``min(n, len(roster))`` distinct
+  values are present -- a true coverage guarantee, not a probabilistic one.
+  """
+  reps = -(-n // len(roster))  # ceil division
+  cycle = (list(roster) * reps)[:n]
+  rng.shuffle(cycle)
+  return cycle
+
+
+def _outcome_allocation(sessions: int) -> dict[str, int]:
+  """Exact, deterministic outcome-bucket counts for ``decision-realistic``.
+
+  Each edge bucket (failed/orphaned/truncated) gets ``round-half-up`` of 10%,
+  floored at 1; ``success`` takes the remainder. Exact 70/10/10/10 at 100.
+  Requires ``sessions >= 4`` (else ``success`` would be < 1).
+  """
+  edge = max(1, math.floor(0.10 * sessions + 0.5))
+  success = sessions - 3 * edge
+  if success < 1:
+    raise ValueError("decision-realistic requires sessions >= 4")
+  return {
+      "success": success,
+      "failed": edge,
+      "orphaned": edge,
+      "truncated": edge,
   }
 
 

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -177,7 +177,24 @@ def _decision_session(rng: random.Random, now: datetime) -> list[dict]:
   return rows
 
 
-_SCENARIO_BUILDERS = {Scenario.DECISION: _decision_session}
+def _build_decision_corpus(
+    rng: random.Random, now: datetime, sessions: int
+) -> tuple[list[dict], dict[str, int]]:
+  """Corpus builder for the small ``decision`` scenario.
+
+  Reproduces the exact pre-refactor loop (30s apart from ``now - 10min``,
+  delegating to ``_decision_session``) so output stays byte-identical.
+  """
+  rows: list[dict] = []
+  cur = now - timedelta(minutes=10)
+  for _ in range(sessions):
+    rows.extend(_decision_session(rng, cur))
+    cur += timedelta(seconds=30)
+  return rows, {"success": sessions}
+
+
+# scenario -> corpus builder ``(rng, now, sessions) -> (rows, outcome_counts)``
+_SCENARIO_BUILDERS = {Scenario.DECISION: _build_decision_corpus}
 assert set(_SCENARIO_BUILDERS) == set(Scenario), (
     "every Scenario needs a builder; missing: "
     f"{set(Scenario) - set(_SCENARIO_BUILDERS)}"
@@ -199,12 +216,7 @@ def generate_seed_events(
   if sessions < 1:
     raise ValueError("sessions must be >= 1")
   rng = random.Random(seed)
-  builder = _SCENARIO_BUILDERS[scenario]
-  rows: list[dict] = []
-  cur = now - timedelta(minutes=10)
-  for _ in range(sessions):
-    rows.extend(builder(rng, cur))
-    cur += timedelta(seconds=30)
+  rows, _counts = _SCENARIO_BUILDERS[scenario](rng, now, sessions)
   return rows
 
 
@@ -221,6 +233,9 @@ class SeedEventsResult:
   ok: bool
   event_type_counts: dict[str, int]
   errors: list[dict]
+  session_outcome_counts: dict[str, int] = dataclasses.field(
+      default_factory=dict
+  )
 
   def to_json(self) -> dict[str, Any]:
     return {
@@ -232,6 +247,7 @@ class SeedEventsResult:
         "dry_run": self.dry_run,
         "ok": self.ok,
         "event_type_counts": dict(self.event_type_counts),
+        "session_outcome_counts": dict(self.session_outcome_counts),
         "errors": list(self.errors),
     }
 
@@ -261,8 +277,9 @@ def run_seed_events(
   if now is None:
     now = datetime.now(timezone.utc)
 
-  rows = generate_seed_events(
-      sessions=sessions, seed=seed, now=now, scenario=scenario
+  rng = random.Random(seed)
+  rows, session_outcome_counts = _SCENARIO_BUILDERS[scenario](
+      rng, now, sessions
   )
   counts: dict[str, int] = {}
   for row in rows:
@@ -280,6 +297,7 @@ def run_seed_events(
         ok=True,
         event_type_counts=counts,
         errors=[],
+        session_outcome_counts=session_outcome_counts,
     )
 
   from google.cloud import bigquery
@@ -300,6 +318,7 @@ def run_seed_events(
         ok=False,
         event_type_counts=counts,
         errors=list(errors),
+        session_outcome_counts=session_outcome_counts,
     )
   return SeedEventsResult(
       table_ref=table_ref,
@@ -311,6 +330,7 @@ def run_seed_events(
       ok=True,
       event_type_counts=counts,
       errors=[],
+      session_outcome_counts=session_outcome_counts,
   )
 
 

--- a/src/bigquery_agent_analytics/seed_events.py
+++ b/src/bigquery_agent_analytics/seed_events.py
@@ -407,6 +407,10 @@ _SCENARIO_DEFAULT_SESSIONS = {
     Scenario.DECISION: 5,
     Scenario.DECISION_REALISTIC: 100,
 }
+assert set(_SCENARIO_DEFAULT_SESSIONS) == set(Scenario), (
+    "every Scenario needs a default session count; missing: "
+    f"{set(Scenario) - set(_SCENARIO_DEFAULT_SESSIONS)}"
+)
 
 
 def generate_seed_events(

--- a/tests/test_cli_bqaa_app.py
+++ b/tests/test_cli_bqaa_app.py
@@ -370,3 +370,31 @@ def test_bqaa_seed_events_insert_errors_exit_1(
   )
   assert result.exit_code == 1, result.output
   assert json.loads(result.output)["ok"] is False
+
+
+def test_bqaa_seed_events_realistic_dry_run_reports_outcomes() -> None:
+  """--scenario decision-realistic defaults to 100 sessions and reports the mix."""
+  result = runner.invoke(
+      bqaa_app,
+      [
+          "seed-events",
+          "--project-id",
+          "p",
+          "--dataset-id",
+          "d",
+          "--scenario",
+          "decision-realistic",
+          "--seed",
+          "42",
+          "--dry-run",
+      ],
+  )
+  assert result.exit_code == 0, result.output
+  payload = json.loads(result.output)
+  assert payload["sessions"] == 100
+  assert payload["session_outcome_counts"] == {
+      "success": 70,
+      "failed": 10,
+      "orphaned": 10,
+      "truncated": 10,
+  }

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -324,6 +324,11 @@ def test_realistic_outcome_mix_exact_at_100() -> None:
   assert len(orphaned) == 10
   assert len(failed) == 10
   assert len(truncated) == 10
+  # Truncated is identified solely by is_truncated rows: it must still be a
+  # completed (not failed) session, so this stays distinct from `failed`.
+  for session in truncated:
+    terminals = [r for r in session if r["event_type"] == "AGENT_COMPLETED"]
+    assert len(terminals) == 1 and terminals[0]["status"] == "ok"
 
 
 def test_realistic_terminal_event_invariant() -> None:
@@ -345,7 +350,9 @@ def test_realistic_variable_option_count_in_range() -> None:
   rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
   for session in _by_session(rows).values():
     options = [
-        r for r in session if '"tool": "evaluate_option"' in r["content"]
+        r
+        for r in session
+        if json.loads(r["content"]).get("tool") == "evaluate_option"
     ]
     assert 2 <= len(options) <= 6
 

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 from datetime import datetime
 from datetime import timezone
 import json
+import random
 
 import pytest
 
+from bigquery_agent_analytics.seed_events import _outcome_allocation
+from bigquery_agent_analytics.seed_events import _shuffled_cycle
 from bigquery_agent_analytics.seed_events import generate_seed_events
 from bigquery_agent_analytics.seed_events import run_seed_events
 from bigquery_agent_analytics.seed_events import Scenario
@@ -239,10 +242,6 @@ def test_decision_result_reports_success_outcome_counts() -> None:
   assert result.to_json()["session_outcome_counts"] == {"success": 4}
 
 
-from bigquery_agent_analytics.seed_events import _outcome_allocation
-from bigquery_agent_analytics.seed_events import _shuffled_cycle
-
-
 def test_outcome_allocation_exact_at_100() -> None:
   assert _outcome_allocation(100) == {
       "success": 70,
@@ -276,13 +275,11 @@ def test_outcome_allocation_rejects_too_few_sessions() -> None:
 
 
 def test_shuffled_cycle_covers_roster_and_is_deterministic() -> None:
-  import random as _random
-
   roster = ("a", "b", "c", "d")
-  out1 = _shuffled_cycle(_random.Random(1), roster, 10)
-  out2 = _shuffled_cycle(_random.Random(1), roster, 10)
+  out1 = _shuffled_cycle(random.Random(1), roster, 10)
+  out2 = _shuffled_cycle(random.Random(1), roster, 10)
   assert out1 == out2  # deterministic for a fixed rng seed
   assert len(out1) == 10
   assert set(out1) == set(roster)  # every roster member appears
   # >=2 distinct even for small n
-  assert len(set(_shuffled_cycle(_random.Random(2), roster, 2))) >= 2
+  assert len(set(_shuffled_cycle(random.Random(2), roster, 2))) >= 2

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -393,3 +393,47 @@ def test_generate_seed_events_supports_realistic_scenario() -> None:
       scenario=Scenario.DECISION_REALISTIC,
   )
   assert len(_by_session(rows)) == 100
+
+
+def test_default_sessions_per_scenario() -> None:
+  decision = run_seed_events(
+      project_id="p",
+      dataset_id="d",
+      seed=1,
+      dry_run=True,
+      now=_FIXED_NOW,
+      bq_client=_FakeBQClient(),
+  )
+  assert decision.sessions == 5
+
+  realistic = run_seed_events(
+      project_id="p",
+      dataset_id="d",
+      seed=1,
+      dry_run=True,
+      scenario="decision-realistic",
+      now=_FIXED_NOW,
+      bq_client=_FakeBQClient(),
+  )
+  assert realistic.sessions == 100
+  assert realistic.session_outcome_counts == {
+      "success": 70,
+      "failed": 10,
+      "orphaned": 10,
+      "truncated": 10,
+  }
+
+
+def test_explicit_sessions_overrides_scenario_default() -> None:
+  result = run_seed_events(
+      project_id="p",
+      dataset_id="d",
+      sessions=40,
+      seed=1,
+      dry_run=True,
+      scenario="decision-realistic",
+      now=_FIXED_NOW,
+      bq_client=_FakeBQClient(),
+  )
+  assert result.sessions == 40
+  assert sum(result.session_outcome_counts.values()) == 40

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 import json
 import random
@@ -24,6 +25,7 @@ import pytest
 
 from bigquery_agent_analytics.seed_events import _outcome_allocation
 from bigquery_agent_analytics.seed_events import _shuffled_cycle
+from bigquery_agent_analytics.seed_events import build_realistic_corpus
 from bigquery_agent_analytics.seed_events import generate_seed_events
 from bigquery_agent_analytics.seed_events import run_seed_events
 from bigquery_agent_analytics.seed_events import Scenario
@@ -283,3 +285,104 @@ def test_shuffled_cycle_covers_roster_and_is_deterministic() -> None:
   assert set(out1) == set(roster)  # every roster member appears
   # >=2 distinct even for small n
   assert len(set(_shuffled_cycle(random.Random(2), roster, 2))) >= 2
+
+
+def _by_session(rows: list[dict]) -> dict[str, list[dict]]:
+  grouped: dict[str, list[dict]] = {}
+  for row in rows:
+    grouped.setdefault(row["session_id"], []).append(row)
+  return grouped
+
+
+def test_realistic_outcome_mix_exact_at_100() -> None:
+  rows, counts = build_realistic_corpus(random.Random(42), _FIXED_NOW, 100)
+  assert counts == {
+      "success": 70,
+      "failed": 10,
+      "orphaned": 10,
+      "truncated": 10,
+  }
+
+  sessions = _by_session(rows)
+  assert len(sessions) == 100
+  orphaned = [
+      s
+      for s in sessions.values()
+      if not any(r["event_type"] == "AGENT_COMPLETED" for r in s)
+  ]
+  failed = [
+      s
+      for s in sessions.values()
+      if any(
+          r["event_type"] == "AGENT_COMPLETED" and r["status"] == "error"
+          for r in s
+      )
+  ]
+  truncated = [
+      s for s in sessions.values() if any(r["is_truncated"] for r in s)
+  ]
+  assert len(orphaned) == 10
+  assert len(failed) == 10
+  assert len(truncated) == 10
+
+
+def test_realistic_terminal_event_invariant() -> None:
+  rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    terminals = [r for r in session if r["event_type"] == "AGENT_COMPLETED"]
+    assert len(terminals) in (0, 1)  # orphaned -> 0, others -> exactly 1
+
+
+def test_realistic_failed_sessions_have_error_message() -> None:
+  rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    for row in session:
+      if row["event_type"] == "AGENT_COMPLETED" and row["status"] == "error":
+        assert row["error_message"]  # non-empty
+
+
+def test_realistic_variable_option_count_in_range() -> None:
+  rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
+  for session in _by_session(rows).values():
+    options = [
+        r for r in session if '"tool": "evaluate_option"' in r["content"]
+    ]
+    assert 2 <= len(options) <= 6
+
+
+def test_realistic_multi_day_span_and_no_future() -> None:
+  rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
+  ts = [datetime.fromisoformat(r["timestamp"]) for r in rows]
+  span = max(ts) - min(ts)
+  assert span > timedelta(hours=24)
+  assert span <= timedelta(hours=72)
+  assert max(ts) <= _FIXED_NOW  # no future timestamps
+
+
+def test_realistic_multiple_agents_and_users() -> None:
+  rows, _ = build_realistic_corpus(random.Random(7), _FIXED_NOW, 100)
+  assert len({r["agent"] for r in rows}) >= 2
+  assert len({r["user_id"] for r in rows}) >= 2
+
+
+def test_realistic_is_deterministic() -> None:
+  a, ca = build_realistic_corpus(random.Random(42), _FIXED_NOW, 100)
+  b, cb = build_realistic_corpus(random.Random(42), _FIXED_NOW, 100)
+  assert a == b and ca == cb
+
+
+def test_realistic_rejects_too_few_sessions() -> None:
+  with pytest.raises(
+      ValueError, match="decision-realistic requires sessions >= 4"
+  ):
+    build_realistic_corpus(random.Random(1), _FIXED_NOW, 3)
+
+
+def test_generate_seed_events_supports_realistic_scenario() -> None:
+  rows = generate_seed_events(
+      sessions=100,
+      seed=42,
+      now=_FIXED_NOW,
+      scenario=Scenario.DECISION_REALISTIC,
+  )
+  assert len(_by_session(rows)) == 100

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -208,3 +208,28 @@ def test_to_json_round_trips() -> None:
   assert json.loads(json.dumps(payload)) == payload
   assert payload["ok"] is True
   assert payload["events_inserted"] == 0
+
+
+def test_decision_corpus_is_byte_identical_after_refactor() -> None:
+  # Pin decision output so the seam refactor cannot change it.
+  rows = generate_seed_events(sessions=3, seed=42, now=_FIXED_NOW)
+  assert len(rows) == 3 * _EVENTS_PER_SESSION
+  assert rows[0]["agent"] == "demo-agent"
+  assert rows[0]["user_id"] == "demo-user"
+  assert rows[-1]["event_type"] == "AGENT_COMPLETED"
+  # Same (seed, now) still byte-identical.
+  assert generate_seed_events(sessions=3, seed=42, now=_FIXED_NOW) == rows
+
+
+def test_decision_result_reports_success_outcome_counts() -> None:
+  result = run_seed_events(
+      project_id="p",
+      dataset_id="d",
+      sessions=4,
+      seed=1,
+      dry_run=True,
+      now=_FIXED_NOW,
+      bq_client=_FakeBQClient(),
+  )
+  assert result.session_outcome_counts == {"success": 4}
+  assert result.to_json()["session_outcome_counts"] == {"success": 4}

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -237,3 +237,52 @@ def test_decision_result_reports_success_outcome_counts() -> None:
   )
   assert result.session_outcome_counts == {"success": 4}
   assert result.to_json()["session_outcome_counts"] == {"success": 4}
+
+
+from bigquery_agent_analytics.seed_events import _outcome_allocation
+from bigquery_agent_analytics.seed_events import _shuffled_cycle
+
+
+def test_outcome_allocation_exact_at_100() -> None:
+  assert _outcome_allocation(100) == {
+      "success": 70,
+      "failed": 10,
+      "orphaned": 10,
+      "truncated": 10,
+  }
+
+
+def test_outcome_allocation_scales_and_keeps_min_one() -> None:
+  assert _outcome_allocation(10) == {
+      "success": 7,
+      "failed": 1,
+      "orphaned": 1,
+      "truncated": 1,
+  }
+  assert _outcome_allocation(4) == {
+      "success": 1,
+      "failed": 1,
+      "orphaned": 1,
+      "truncated": 1,
+  }
+
+
+def test_outcome_allocation_rejects_too_few_sessions() -> None:
+  for bad in (3, 1, 0):
+    with pytest.raises(
+        ValueError, match="decision-realistic requires sessions >= 4"
+    ):
+      _outcome_allocation(bad)
+
+
+def test_shuffled_cycle_covers_roster_and_is_deterministic() -> None:
+  import random as _random
+
+  roster = ("a", "b", "c", "d")
+  out1 = _shuffled_cycle(_random.Random(1), roster, 10)
+  out2 = _shuffled_cycle(_random.Random(1), roster, 10)
+  assert out1 == out2  # deterministic for a fixed rng seed
+  assert len(out1) == 10
+  assert set(out1) == set(roster)  # every roster member appears
+  # >=2 distinct even for small n
+  assert len(set(_shuffled_cycle(_random.Random(2), roster, 2))) >= 2

--- a/tests/test_seed_events.py
+++ b/tests/test_seed_events.py
@@ -219,6 +219,10 @@ def test_decision_corpus_is_byte_identical_after_refactor() -> None:
   assert rows[-1]["event_type"] == "AGENT_COMPLETED"
   # Same (seed, now) still byte-identical.
   assert generate_seed_events(sessions=3, seed=42, now=_FIXED_NOW) == rows
+  # Golden values pin the seeded RNG-consumption order: a change to
+  # _decision_session's draw sequence would break these immediately.
+  assert rows[0]["session_id"] == "sess-a3b1799d"
+  assert rows[0]["span_id"] == "bc8960a923b8c1e9"
 
 
 def test_decision_result_reports_success_outcome_counts() -> None:


### PR DESCRIPTION
## Summary

Adds a realistic-scale **`decision-realistic`** seed-events scenario (closes #247, builds on #246 / PR #261). The small `decision` scenario and the codelab first-run path are left untouched; the new scenario produces production-shaped synthetic telemetry for demos and screenshots.

**Closes #247. Tracker: #257.**

```bash
bqaa seed-events \
    --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
    --scenario decision-realistic --seed 42
# 100 sessions over 72h: 70 success / 10 failed / 10 orphaned / 10 truncated,
# multiple agents & users, variable 2-6 option decisions.
```

## What's new

- **Corpus-builder seam refactor.** The `_SCENARIO_BUILDERS` seam is lifted from per-session builders to corpus builders `(rng, now, sessions) -> (rows, session_outcome_counts)`. `decision` stays **byte-identical** (a golden-value test pins the RNG-consumption order); `generate_seed_events` keeps its `list[dict]` contract.
- **`decision-realistic` scenario** (`src/bigquery_agent_analytics/seed_events.py`):
  - Default **100 sessions over a 72-hour window**, exact **70/10/10/10** success/failed/orphaned/truncated mix (deterministic round-half-up/min-1 bucket rule; `sessions >= 4`).
  - **failed** → `AGENT_COMPLETED` with `status="error"` + error message; **orphaned** → no terminal event (exercises the orphan watchdog); **truncated** → `is_truncated=true` clipped payload; **variable 2–6** options per non-orphan flow.
  - Multiple agents/users/business entities, assigned via a **shuffled cycle** that guarantees ≥2 distinct (not probabilistic).
  - **No future timestamps** by construction (session starts bounded by `now - _MAX_SESSION_SPAN`).
  - Fully deterministic for fixed `(seed, now)` — one `random.Random(seed)` drives everything.
- **`session_outcome_counts`** reported via `run_seed_events` / `to_json` (e.g. `{"success":70,"failed":10,"orphaned":10,"truncated":10}`); `{"success":N}` for `decision`.
- **Overridable per-scenario `--sessions` defaults**: `decision`→5, `decision-realistic`→100; explicit `--sessions N` overrides. (CLI default became `None`, resolved per-scenario in `run_seed_events`.) No new flags.
- Module-load completeness asserts guard both `_SCENARIO_BUILDERS` and `_SCENARIO_DEFAULT_SESSIONS` against a future scenario being added without wiring.

## Codelab

First-run path unchanged (`bqaa seed-events --sessions 5`). Added an optional **"Realistic Data"** section with the `decision-realistic` command, a concrete per-session **outcome-classification SQL** (orphaned = no `AGENT_COMPLETED`; failed = `status='error'`; truncated = any `is_truncated`; else success), an orphan-watchdog tie-in, and a note that the 72h spread vs a 24h `--lookback-hours` is the intended windowing lesson. Notebook regenerated from the markdown; CI drift `--check` passes.

## Tests

19 new tests; full suite **3190 passed, 15 skipped**. Highlights: `decision` byte-identical golden-value regression; exact mix at 100 and proportional scaling; terminal-event invariant (orphaned=0, others=1); failure/truncation markers; truncated-vs-failed mutual exclusivity; variable option range; multi-day span + no-future-timestamps; ≥2 agents/users; full determinism; per-scenario `--sessions` defaults + explicit override; CLI realistic dry-run reporting the mix.

## Out of scope (deliberate)

- No new scale flags (sizing reuses `--sessions`); no third scenario.
- `decision` output, internal names, and deploy-shape names unchanged.

## Test plan

- [x] Full suite green (3190 passed, 15 skipped)
- [x] `bash autoformat.sh` clean (pyink + isort)
- [x] Codelab notebook `--check` in sync
- [x] Smoke: `bqaa seed-events --scenario decision-realistic --dry-run --seed 42` → `sessions:100`, `events_inserted:0`, `ok:true`, `session_outcome_counts:{success:70,failed:10,orphaned:10,truncated:10}`
- [ ] CI green on the PR
