### PR TITLE
docs: note idempotent retry for transient materialize insert failures (#255)

### DIFF
--- a/docs/guides/conversational-analytics-first.md
+++ b/docs/guides/conversational-analytics-first.md
@@ -76,6 +76,10 @@ materialized into the graph (an agent that never finished has no committed
 outcome). That is intentional, and it is one of the things CA can surface for
 you below.
 
+> If a materialization run reports a transient BigQuery streaming-buffer insert
+> failure, re-run `bqaa context-graph`. The materializer is idempotent and
+> retries the same session window safely.
+
 ### Point Conversational Analytics at the graph
 
 In the Google Cloud console, open **Conversational Analytics**, create a data


### PR DESCRIPTION
## Summary

One-line troubleshooting note in the Conversational Analytics-first guide: if `bqaa context-graph` reports a transient BigQuery streaming-buffer insert failure, re-run it — the materializer is idempotent and retries the same session window safely.

Observed while staging the guide's demo graph: 1 of 90 sessions dropped an outcome row to a streaming-buffer insert failure; re-running heals it. Scoped to the guide's setup section only (not duplicated in the codelab).

Follow-up to #255 / #264.

## Test plan

- [x] `git diff --check` clean
- [x] Single-file docs change, no code/notebook impact