### PR TITLE
docs(codelab): add one-row corpus preview query (#257)

### DIFF
--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -269,6 +269,16 @@ bqaa seed-events \
 
 The command prints a JSON report. For 5 sessions you should see `"events_generated": 30`, `"events_inserted": 30`, and `"ok": true`.
 
+Preview the corpus at a glance — how many sessions, how many events, and the time range they span — in one row:
+
+<!-- colab:code bash -->
+```bash
+bq query --use_legacy_sql=false \
+    "SELECT COUNT(DISTINCT session_id) AS sessions, COUNT(*) AS events, MIN(timestamp) AS earliest_event, MAX(timestamp) AS latest_event FROM \`$PROJECT_ID.$DATASET.agent_events\`"
+```
+
+For the default 5-session run this shows 5 sessions and 30 events spanning a few minutes. (Seed the realistic scenario below and the same query reports ~100 sessions across roughly three days.)
+
 Verify the events landed:
 
 <!-- colab:code bash -->

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -312,6 +312,24 @@
    "source": [
     "The command prints a JSON report. For 5 sessions you should see `\"events_generated\": 30`, `\"events_inserted\": 30`, and `\"ok\": true`.\n",
     "\n",
+    "Preview the corpus at a glance — how many sessions, how many events, and the time range they span — in one row:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!bq query --use_legacy_sql=false      \"SELECT COUNT(DISTINCT session_id) AS sessions, COUNT(*) AS events, MIN(timestamp) AS earliest_event, MAX(timestamp) AS latest_event FROM \\`$PROJECT_ID.$DATASET.agent_events\\`\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the default 5-session run this shows 5 sessions and 30 events spanning a few minutes. (Seed the realistic scenario below and the same query reports ~100 sessions across roughly three days.)\n",
+    "\n",
     "Verify the events landed:"
    ]
   },


### PR DESCRIPTION
## Summary

Adds the one remaining Colab checklist item from #257: a small **preview query** after the seed step that shows **sessions, total events, and the time range** in a single readable row.

```sql
SELECT COUNT(DISTINCT session_id) AS sessions, COUNT(*) AS events,
       MIN(timestamp) AS earliest_event, MAX(timestamp) AS latest_event
FROM `$PROJECT_ID.$DATASET.agent_events`
```

For the default 5-session run it shows 5 sessions / 30 events over a few minutes; with the realistic scenario it shows ~100 sessions over ~3 days.

SQL is single-line so the generated Colab cell is valid (the generator joins multi-line bash with `&&`). Notebook regenerated; drift `--check` passes.

Closes the last open Colab-specific item tracked in #257.

## Test plan

- [x] Notebook regenerated; `--check` in sync
- [x] Preview cell is a single valid `bq query` (no `&&` mangling)
- [x] `git diff --check` clean