### PR TITLE
feat(ontology): synthesize ontology+binding from a property graph (issue #277, PR 3)

### DIFF
--- a/src/bigquery_ontology/graph_to_spec.py
+++ b/src/bigquery_ontology/graph_to_spec.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthesise an in-memory ontology + binding from a property graph.
+
+Building block 3 of deriving a materialization spec from the property graph
+alone (GitHub issue #277). Given the types-free
+:class:`~bigquery_ontology.graph_ddl_parser.ParsedPropertyGraph` (PR 1) and the
+:class:`~bigquery_ontology.graph_schema_join.GraphColumnTypes` recovered from
+the table schemas (PR 2), this module produces the upstream
+:class:`~bigquery_ontology.ontology_models.Ontology` and
+:class:`~bigquery_ontology.binding_models.Binding` objects that the SDK's
+existing ``resolve()`` already consumes -- so nothing downstream changes.
+
+Mapping rules
+-------------
+
+* **Entity** = one node table; its name is the node ``LABEL``. The node alias
+  (the DDL-local table handle) is used only to wire edges (``REFERENCES``).
+* **Relationship** = one edge table; its name is the edge ``LABEL``; its
+  endpoints are the entity names of the referenced node aliases.
+* **Property types** come from the joined table schema (PR 2), never from a
+  hand-written ``type:`` field.
+* **Primary key** = the node ``KEY`` columns, mapped to their property names; a
+  key column without a stored property gets a passthrough property.
+* **SDK metadata columns** (``session_id`` / ``extracted_at``) are stripped from
+  properties and keys -- the resolver re-injects them as ``metadata_columns``.
+* **Derived ``(expr) AS name`` properties are skipped**: they have no physical
+  column to read or write and ``resolve()`` rejects ``expr`` for
+  materialization. (Keep an explicit ontology/binding if you need them.)
+
+Limitations (raise rather than guess; provide an explicit ontology/binding for
+these): multi-label nodes (label inheritance) are not synthesised, and free-text
+descriptions/synonyms are not recoverable from the DDL or schema. Descriptions
+are absent in derived mode (best paired with ``--extraction-mode=compiled-only``,
+where they are unused).
+
+Scope (per #277): produce the Ontology + Binding. Wiring this into the CLI
+(``bqaa context-graph --property-graph ...``) is PR 4.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .binding_models import Backend
+from .binding_models import BigQueryTarget
+from .binding_models import Binding
+from .binding_models import EntityBinding
+from .binding_models import PropertyBinding
+from .binding_models import RelationshipBinding
+from .graph_ddl_parser import ParsedEdgeTable
+from .graph_ddl_parser import ParsedNodeTable
+from .graph_ddl_parser import ParsedPropertyGraph
+from .graph_schema_join import GraphColumnTypes
+from .ontology_models import Entity
+from .ontology_models import Keys
+from .ontology_models import Ontology
+from .ontology_models import Property
+from .ontology_models import Relationship
+
+__all__ = [
+    "GraphSpecSynthesisError",
+    "derive_ontology_binding",
+]
+
+_DEFAULT_METADATA_COLUMNS = ("session_id", "extracted_at")
+
+
+class GraphSpecSynthesisError(ValueError):
+  """Raised when a property graph cannot be turned into an ontology+binding."""
+
+
+def _single_label(alias: str, labels: Sequence[str], kind: str) -> str:
+  """Return the sole label, or fail: multi-label is not synthesised."""
+  if len(labels) != 1:
+    raise GraphSpecSynthesisError(
+        f"{kind} {alias!r} has {len(labels)} labels {list(labels)}; "
+        "schema-derived mode supports exactly one label per table. Provide an "
+        "explicit ontology/binding to model label inheritance."
+    )
+  return labels[0]
+
+
+def _build_entity(
+    node: ParsedNodeTable,
+    entity_name: str,
+    column_types: dict,
+    metadata: frozenset,
+) -> tuple[Entity, EntityBinding]:
+  """Build the Entity + EntityBinding for one node table."""
+  # Stored, non-metadata properties (derived properties have column=None).
+  column_to_name: dict[str, str] = {}
+  ordered: list[tuple[str, str]] = []  # (property_name, column)
+  for prop in node.properties:
+    if prop.column is None or prop.column in metadata:
+      continue
+    column_to_name[prop.column] = prop.name
+    ordered.append((prop.name, prop.column))
+
+  # Every non-metadata key column must be a property; synthesise a passthrough
+  # for any key column that is not already a stored property.
+  key_columns = [c for c in node.key_columns if c not in metadata]
+  if not key_columns:
+    raise GraphSpecSynthesisError(
+        f"Node {node.alias!r} has no non-metadata KEY column to use as a "
+        "primary key."
+    )
+  for column in key_columns:
+    if column not in column_to_name:
+      column_to_name[column] = column
+      ordered.append((column, column))
+
+  properties: list[Property] = []
+  property_bindings: list[PropertyBinding] = []
+  for name, column in ordered:
+    if column not in column_types:
+      # resolve_graph_column_types types every referenced column, so this only
+      # fires if a caller passes mismatched parsed-graph / types objects.
+      raise GraphSpecSynthesisError(
+          f"Node {node.alias!r} column {column!r} has no resolved type; the "
+          "parsed graph and the column types do not match."
+      )
+    properties.append(Property(name=name, type=column_types[column]))
+    property_bindings.append(PropertyBinding(name=name, column=column))
+
+  primary = [column_to_name[c] for c in key_columns]
+  entity = Entity(
+      name=entity_name,
+      keys=Keys(primary=primary),
+      properties=properties,
+  )
+  entity_binding = EntityBinding(
+      name=entity_name, source=node.source, properties=property_bindings
+  )
+  return entity, entity_binding
+
+
+def _build_relationship(
+    edge: ParsedEdgeTable,
+    rel_name: str,
+    from_entity: str,
+    to_entity: str,
+    column_types: dict,
+    metadata: frozenset,
+) -> tuple[Relationship, RelationshipBinding]:
+  """Build the Relationship + RelationshipBinding for one edge table."""
+  properties: list[Property] = []
+  property_bindings: list[PropertyBinding] = []
+  for prop in edge.properties:
+    if prop.column is None or prop.column in metadata:
+      continue
+    if prop.column not in column_types:
+      raise GraphSpecSynthesisError(
+          f"Edge {edge.alias!r} column {prop.column!r} has no resolved type; "
+          "the parsed graph and the column types do not match."
+      )
+    properties.append(Property(name=prop.name, type=column_types[prop.column]))
+    property_bindings.append(
+        PropertyBinding(name=prop.name, column=prop.column)
+    )
+
+  from_columns = [c for c in edge.source_key_columns if c not in metadata]
+  to_columns = [c for c in edge.dest_key_columns if c not in metadata]
+  if not from_columns or not to_columns:
+    raise GraphSpecSynthesisError(
+        f"Edge {edge.alias!r} has no non-metadata SOURCE/DESTINATION key "
+        "columns to bind its endpoints."
+    )
+
+  relationship = Relationship(
+      name=rel_name, from_=from_entity, to=to_entity, properties=properties
+  )
+  relationship_binding = RelationshipBinding(
+      name=rel_name,
+      source=edge.source,
+      from_columns=list(from_columns),
+      to_columns=list(to_columns),
+      properties=property_bindings,
+  )
+  return relationship, relationship_binding
+
+
+def derive_ontology_binding(
+    graph: ParsedPropertyGraph,
+    column_types: GraphColumnTypes,
+    *,
+    project: str,
+    dataset: str,
+    binding_name: Optional[str] = None,
+    metadata_columns: Sequence[str] = _DEFAULT_METADATA_COLUMNS,
+) -> tuple[Ontology, Binding]:
+  """Synthesise an ``Ontology`` + ``Binding`` from a parsed graph and its types.
+
+  Args:
+    graph: The parsed property graph (see :mod:`graph_ddl_parser`).
+    column_types: Resolved column types (see :mod:`graph_schema_join`).
+    project: BigQuery project for the binding target.
+    dataset: BigQuery dataset for the binding target.
+    binding_name: Name for the binding document (defaults to
+      ``"<graph>_binding"``).
+    metadata_columns: SDK runtime columns to strip from properties/keys; the
+      resolver re-injects them. Defaults to ``("session_id", "extracted_at")``.
+
+  Returns:
+    ``(ontology, binding)`` -- validated upstream models ready for the SDK's
+    ``resolve(ontology, binding)``.
+
+  Raises:
+    GraphSpecSynthesisError: For graphs outside the synthesisable subset
+      (multi-label nodes, missing primary key, dangling edge endpoints, or a
+      parsed-graph / column-types mismatch).
+  """
+  metadata = frozenset(metadata_columns)
+
+  alias_to_entity: dict[str, str] = {}
+  entities: list[Entity] = []
+  entity_bindings: list[EntityBinding] = []
+  for node in graph.nodes:
+    entity_name = _single_label(node.alias, node.labels, "Node")
+    if node.alias in alias_to_entity:
+      raise GraphSpecSynthesisError(
+          f"Duplicate node alias {node.alias!r} in the property graph."
+      )
+    types = column_types.node(node.alias).column_types
+    entity, entity_binding = _build_entity(
+        node, entity_name, dict(types), metadata
+    )
+    alias_to_entity[node.alias] = entity_name
+    entities.append(entity)
+    entity_bindings.append(entity_binding)
+
+  relationships: list[Relationship] = []
+  relationship_bindings: list[RelationshipBinding] = []
+  for edge in graph.edges:
+    rel_name = _single_label(edge.alias, edge.labels, "Edge")
+    if edge.source_ref_alias not in alias_to_entity:
+      raise GraphSpecSynthesisError(
+          f"Edge {edge.alias!r} SOURCE references unknown node alias "
+          f"{edge.source_ref_alias!r}."
+      )
+    if edge.dest_ref_alias not in alias_to_entity:
+      raise GraphSpecSynthesisError(
+          f"Edge {edge.alias!r} DESTINATION references unknown node alias "
+          f"{edge.dest_ref_alias!r}."
+      )
+    types = column_types.edge(edge.alias).column_types
+    relationship, relationship_binding = _build_relationship(
+        edge,
+        rel_name,
+        alias_to_entity[edge.source_ref_alias],
+        alias_to_entity[edge.dest_ref_alias],
+        dict(types),
+        metadata,
+    )
+    relationships.append(relationship)
+    relationship_bindings.append(relationship_binding)
+
+  ontology = Ontology(
+      ontology=graph.name, entities=entities, relationships=relationships
+  )
+  binding = Binding(
+      binding=binding_name or f"{graph.name}_binding",
+      ontology=graph.name,
+      target=BigQueryTarget(
+          backend=Backend.BIGQUERY, project=project, dataset=dataset
+      ),
+      entities=entity_bindings,
+      relationships=relationship_bindings,
+  )
+  return ontology, binding

--- a/src/bigquery_ontology/graph_to_spec.py
+++ b/src/bigquery_ontology/graph_to_spec.py
@@ -98,8 +98,13 @@ def _build_entity(
     entity_name: str,
     column_types: dict,
     metadata: frozenset,
-) -> tuple[Entity, EntityBinding]:
-  """Build the Entity + EntityBinding for one node table."""
+) -> tuple[Entity, EntityBinding, dict[str, str]]:
+  """Build the Entity + EntityBinding for one node table.
+
+  Also returns the node's ``{column -> property_name}`` map, which edges use to
+  translate their ``REFERENCES`` physical PK columns into endpoint property
+  names.
+  """
   # Stored, non-metadata properties (derived properties have column=None).
   column_to_name: dict[str, str] = {}
   ordered: list[tuple[str, str]] = []  # (property_name, column)
@@ -144,7 +149,50 @@ def _build_entity(
   entity_binding = EntityBinding(
       name=entity_name, source=node.source, properties=property_bindings
   )
-  return entity, entity_binding
+  return entity, entity_binding, column_to_name
+
+
+def _endpoint_column_refs(
+    edge_alias: str,
+    side: str,
+    fk_columns: tuple[str, ...],
+    ref_columns: tuple[str, ...],
+    target_column_to_name: dict[str, str],
+    metadata: frozenset,
+) -> list[dict[str, str]]:
+  """Build explicit ``{edge_fk_column: endpoint_pk_property}`` ColumnRefs.
+
+  The property graph's ``SOURCE/DESTINATION KEY (fk...) REFERENCES Node
+  (pk...)`` clause pairs each edge FK column with a specific physical PK column
+  of the endpoint, positionally. We preserve that pairing as dict-shape
+  ColumnRefs rather than a bare column list: a bare list is interpreted by the
+  resolver positionally against the endpoint's PK *declaration* order, which
+  silently mismatches whenever the REFERENCES order differs from the KEY order
+  (composite-key permutation) or the PK column is a renamed property.
+  Metadata columns (e.g. ``session_id``) are dropped as paired entries.
+  """
+  if len(fk_columns) != len(ref_columns):
+    raise GraphSpecSynthesisError(
+        f"Edge {edge_alias!r} {side} KEY has {len(fk_columns)} columns but its"
+        f" REFERENCES has {len(ref_columns)}; they must pair one-to-one."
+    )
+  refs: list[dict[str, str]] = []
+  for fk_column, ref_column in zip(fk_columns, ref_columns):
+    if fk_column in metadata or ref_column in metadata:
+      continue
+    target_property = target_column_to_name.get(ref_column)
+    if target_property is None:
+      raise GraphSpecSynthesisError(
+          f"Edge {edge_alias!r} {side} REFERENCES column {ref_column!r}, which"
+          " is not a key property of the referenced entity."
+      )
+    refs.append({fk_column: target_property})
+  if not refs:
+    raise GraphSpecSynthesisError(
+        f"Edge {edge_alias!r} has no non-metadata {side} key columns to bind"
+        " its endpoint."
+    )
+  return refs
 
 
 def _build_relationship(
@@ -152,6 +200,8 @@ def _build_relationship(
     rel_name: str,
     from_entity: str,
     to_entity: str,
+    from_column_to_name: dict[str, str],
+    to_column_to_name: dict[str, str],
     column_types: dict,
     metadata: frozenset,
 ) -> tuple[Relationship, RelationshipBinding]:
@@ -171,13 +221,22 @@ def _build_relationship(
         PropertyBinding(name=prop.name, column=prop.column)
     )
 
-  from_columns = [c for c in edge.source_key_columns if c not in metadata]
-  to_columns = [c for c in edge.dest_key_columns if c not in metadata]
-  if not from_columns or not to_columns:
-    raise GraphSpecSynthesisError(
-        f"Edge {edge.alias!r} has no non-metadata SOURCE/DESTINATION key "
-        "columns to bind its endpoints."
-    )
+  from_columns = _endpoint_column_refs(
+      edge.alias,
+      "SOURCE",
+      edge.source_key_columns,
+      edge.source_ref_columns,
+      from_column_to_name,
+      metadata,
+  )
+  to_columns = _endpoint_column_refs(
+      edge.alias,
+      "DESTINATION",
+      edge.dest_key_columns,
+      edge.dest_ref_columns,
+      to_column_to_name,
+      metadata,
+  )
 
   relationship = Relationship(
       name=rel_name, from_=from_entity, to=to_entity, properties=properties
@@ -185,8 +244,8 @@ def _build_relationship(
   relationship_binding = RelationshipBinding(
       name=rel_name,
       source=edge.source,
-      from_columns=list(from_columns),
-      to_columns=list(to_columns),
+      from_columns=from_columns,
+      to_columns=to_columns,
       properties=property_bindings,
   )
   return relationship, relationship_binding
@@ -219,12 +278,15 @@ def derive_ontology_binding(
 
   Raises:
     GraphSpecSynthesisError: For graphs outside the synthesisable subset
-      (multi-label nodes, missing primary key, dangling edge endpoints, or a
-      parsed-graph / column-types mismatch).
+      (multi-label nodes, duplicate entity/relationship labels, missing primary
+      key, dangling edge endpoints, mismatched SOURCE/DESTINATION key vs.
+      REFERENCES arity, or a parsed-graph / column-types mismatch).
   """
   metadata = frozenset(metadata_columns)
 
   alias_to_entity: dict[str, str] = {}
+  alias_to_column_name: dict[str, dict[str, str]] = {}
+  entity_names: set[str] = set()
   entities: list[Entity] = []
   entity_bindings: list[EntityBinding] = []
   for node in graph.nodes:
@@ -233,18 +295,33 @@ def derive_ontology_binding(
       raise GraphSpecSynthesisError(
           f"Duplicate node alias {node.alias!r} in the property graph."
       )
+    if entity_name in entity_names:
+      raise GraphSpecSynthesisError(
+          f"Duplicate entity name {entity_name!r}: two node tables share the"
+          " LABEL. Give them distinct labels or provide an explicit"
+          " ontology/binding."
+      )
     types = column_types.node(node.alias).column_types
-    entity, entity_binding = _build_entity(
+    entity, entity_binding, column_to_name = _build_entity(
         node, entity_name, dict(types), metadata
     )
     alias_to_entity[node.alias] = entity_name
+    alias_to_column_name[node.alias] = column_to_name
+    entity_names.add(entity_name)
     entities.append(entity)
     entity_bindings.append(entity_binding)
 
+  relationship_names: set[str] = set()
   relationships: list[Relationship] = []
   relationship_bindings: list[RelationshipBinding] = []
   for edge in graph.edges:
     rel_name = _single_label(edge.alias, edge.labels, "Edge")
+    if rel_name in relationship_names:
+      raise GraphSpecSynthesisError(
+          f"Duplicate relationship name {rel_name!r}: two edge tables share the"
+          " LABEL. Give them distinct labels or provide an explicit"
+          " ontology/binding."
+      )
     if edge.source_ref_alias not in alias_to_entity:
       raise GraphSpecSynthesisError(
           f"Edge {edge.alias!r} SOURCE references unknown node alias "
@@ -261,9 +338,12 @@ def derive_ontology_binding(
         rel_name,
         alias_to_entity[edge.source_ref_alias],
         alias_to_entity[edge.dest_ref_alias],
+        alias_to_column_name[edge.source_ref_alias],
+        alias_to_column_name[edge.dest_ref_alias],
         dict(types),
         metadata,
     )
+    relationship_names.add(rel_name)
     relationships.append(relationship)
     relationship_bindings.append(relationship_binding)
 

--- a/tests/test_graph_to_spec.py
+++ b/tests/test_graph_to_spec.py
@@ -130,9 +130,9 @@ def test_relationship_endpoints_resolve_aliases_to_entity_names() -> None:
   assert rel.to == "DecisionOption"
 
   rel_binding = binding.relationships[0]
-  # FK columns stripped of session_id.
-  assert rel_binding.from_columns == ["request_id"]
-  assert rel_binding.to_columns == ["option_id"]
+  # Explicit FK -> endpoint-PK-property mapping (session_id pair stripped).
+  assert rel_binding.from_columns == [{"request_id": "request_id"}]
+  assert rel_binding.to_columns == [{"option_id": "option_id"}]
 
 
 def test_binding_target_and_sources() -> None:
@@ -200,6 +200,82 @@ def test_derived_property_is_skipped() -> None:
   assert "full_name" not in names  # derived -> skipped
   assert names == {"person_id"}
   assert all(p.expr is None for p in ontology.entities[0].properties)
+
+
+def test_composite_pk_permutation_maps_fk_to_correct_property() -> None:
+  # REFERENCES order differs from the node KEY declaration order. A bare
+  # positional column list would mismatch; explicit dict-shape refs must pair
+  # each edge FK to the PK property the DDL actually references.
+  ddl = """
+  CREATE PROPERTY GRAPH g
+    NODE TABLES (
+      raw.thing AS Thing
+        KEY (pk_a, pk_b)
+        LABEL Thing PROPERTIES (pk_a AS key_a, pk_b AS key_b),
+      raw.other AS Other
+        KEY (oid)
+        LABEL Other PROPERTIES (oid)
+    )
+    EDGE TABLES (
+      raw.rel AS rel
+        KEY (fk_b, fk_a, o_fk)
+        SOURCE KEY (fk_b, fk_a) REFERENCES Thing (pk_b, pk_a)
+        DESTINATION KEY (o_fk) REFERENCES Other (oid)
+        LABEL Rel
+    )
+  """
+  schemas = {
+      "raw.thing": {"pk_a": "STRING", "pk_b": "INT64"},
+      "raw.other": {"oid": "STRING"},
+      "raw.rel": {"fk_a": "STRING", "fk_b": "INT64", "o_fk": "STRING"},
+  }
+  _, binding = _derive(ddl, schemas)
+  rel = binding.relationships[0]
+  # fk_b references pk_b (property key_b); fk_a references pk_a (property key_a).
+  # NOT the positional (fk_b -> key_a) a bare list would have produced.
+  assert rel.from_columns == [{"fk_b": "key_b"}, {"fk_a": "key_a"}]
+  assert rel.to_columns == [{"o_fk": "oid"}]
+
+
+def test_duplicate_node_label_raises() -> None:
+  ddl = """
+  CREATE PROPERTY GRAPH g
+    NODE TABLES (
+      raw.a AS a KEY (id) LABEL Dup PROPERTIES (id),
+      raw.b AS b KEY (id) LABEL Dup PROPERTIES (id)
+    )
+  """
+  schemas = {"raw.a": {"id": "STRING"}, "raw.b": {"id": "STRING"}}
+  with pytest.raises(GraphSpecSynthesisError, match="Duplicate entity name"):
+    _derive(ddl, schemas)
+
+
+def test_duplicate_edge_label_raises() -> None:
+  ddl = """
+  CREATE PROPERTY GRAPH g
+    NODE TABLES (
+      raw.a AS A KEY (id) LABEL A PROPERTIES (id),
+      raw.b AS B KEY (id) LABEL B PROPERTIES (id)
+    )
+    EDGE TABLES (
+      raw.e1 AS e1 KEY (x, y)
+        SOURCE KEY (x) REFERENCES A (id)
+        DESTINATION KEY (y) REFERENCES B (id) LABEL Dup,
+      raw.e2 AS e2 KEY (x, y)
+        SOURCE KEY (x) REFERENCES A (id)
+        DESTINATION KEY (y) REFERENCES B (id) LABEL Dup
+    )
+  """
+  schemas = {
+      "raw.a": {"id": "STRING"},
+      "raw.b": {"id": "STRING"},
+      "raw.e1": {"x": "STRING", "y": "STRING"},
+      "raw.e2": {"x": "STRING", "y": "STRING"},
+  }
+  with pytest.raises(
+      GraphSpecSynthesisError, match="Duplicate relationship name"
+  ):
+    _derive(ddl, schemas)
 
 
 def test_multi_label_node_raises() -> None:

--- a/tests/test_graph_to_spec.py
+++ b/tests/test_graph_to_spec.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ontology+binding synthesis from a property graph (issue #277, PR 3).
+
+Pure, offline: the parsed graph and column types are built in-process. The
+final test feeds the synthesised pair through the SDK's real ``resolve()`` to
+prove the output is materialization-ready (the whole point of #277).
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import pytest
+
+from bigquery_ontology.graph_ddl_parser import parse_property_graph_ddl
+from bigquery_ontology.graph_schema_join import resolve_graph_column_types
+from bigquery_ontology.graph_to_spec import derive_ontology_binding
+from bigquery_ontology.graph_to_spec import GraphSpecSynthesisError
+from bigquery_ontology.ontology_models import PropertyType
+
+
+class _FakeProvider:
+
+  def __init__(self, schemas: Mapping[str, Mapping[str, str]]) -> None:
+    self._schemas = schemas
+
+  def column_types(self, table_ref: str) -> Mapping[str, str]:
+    return self._schemas[table_ref]
+
+
+def _derive(ddl: str, schemas, *, project="p", dataset="d"):
+  graph = parse_property_graph_ddl(ddl)
+  types = resolve_graph_column_types(graph, _FakeProvider(schemas))
+  return derive_ontology_binding(graph, types, project=project, dataset=dataset)
+
+
+# A concrete (no ${...}) codelab-shaped graph in the SDK transpiler style:
+# entity name == LABEL, snake-case table aliases, session_id in KEY/PROPERTIES.
+_DDL = """
+CREATE OR REPLACE PROPERTY GRAPH p.d.agent_decisions_graph
+  NODE TABLES (
+    p.d.decision_request AS decision_request
+      KEY (request_id, session_id)
+      LABEL DecisionRequest
+      PROPERTIES (request_id, request_text, requested_at, session_id, extracted_at),
+    p.d.decision_option AS decision_option
+      KEY (option_id, session_id)
+      LABEL DecisionOption
+      PROPERTIES (option_id, option_label, confidence, session_id, extracted_at)
+  )
+  EDGE TABLES (
+    p.d.evaluates_option AS evaluates_option
+      KEY (request_id, option_id, session_id)
+      SOURCE KEY (request_id, session_id) REFERENCES decision_request (request_id, session_id)
+      DESTINATION KEY (option_id, session_id) REFERENCES decision_option (option_id, session_id)
+      LABEL evaluatesOption
+      PROPERTIES (extracted_at)
+  )
+"""
+
+_SCHEMAS = {
+    "p.d.decision_request": {
+        "request_id": "STRING",
+        "request_text": "STRING",
+        "requested_at": "TIMESTAMP",
+        "session_id": "STRING",
+        "extracted_at": "TIMESTAMP",
+    },
+    "p.d.decision_option": {
+        "option_id": "STRING",
+        "option_label": "STRING",
+        "confidence": "FLOAT64",
+        "session_id": "STRING",
+        "extracted_at": "TIMESTAMP",
+    },
+    "p.d.evaluates_option": {
+        "request_id": "STRING",
+        "option_id": "STRING",
+        "session_id": "STRING",
+        "extracted_at": "TIMESTAMP",
+    },
+}
+
+
+def test_entity_name_is_label_and_types_come_from_schema() -> None:
+  ontology, _ = _derive(_DDL, _SCHEMAS)
+  assert ontology.ontology == "agent_decisions_graph"
+  names = {e.name for e in ontology.entities}
+  assert names == {"DecisionRequest", "DecisionOption"}  # LABELs, not aliases
+
+  request = next(e for e in ontology.entities if e.name == "DecisionRequest")
+  prop_types = {p.name: p.type for p in request.properties}
+  # session_id / extracted_at metadata stripped; types recovered from schema.
+  assert prop_types == {
+      "request_id": PropertyType.STRING,
+      "request_text": PropertyType.STRING,
+      "requested_at": PropertyType.TIMESTAMP,
+  }
+  option = next(e for e in ontology.entities if e.name == "DecisionOption")
+  assert {p.name: p.type for p in option.properties}["confidence"] == (
+      PropertyType.DOUBLE
+  )
+
+
+def test_primary_key_strips_metadata_and_maps_to_property_names() -> None:
+  ontology, _ = _derive(_DDL, _SCHEMAS)
+  request = next(e for e in ontology.entities if e.name == "DecisionRequest")
+  # KEY was (request_id, session_id); session_id stripped.
+  assert request.keys.primary == ["request_id"]
+
+
+def test_relationship_endpoints_resolve_aliases_to_entity_names() -> None:
+  ontology, binding = _derive(_DDL, _SCHEMAS)
+  assert [r.name for r in ontology.relationships] == ["evaluatesOption"]
+  rel = ontology.relationships[0]
+  assert rel.from_ == "DecisionRequest"  # alias decision_request -> LABEL
+  assert rel.to == "DecisionOption"
+
+  rel_binding = binding.relationships[0]
+  # FK columns stripped of session_id.
+  assert rel_binding.from_columns == ["request_id"]
+  assert rel_binding.to_columns == ["option_id"]
+
+
+def test_binding_target_and_sources() -> None:
+  _, binding = _derive(_DDL, _SCHEMAS, project="proj", dataset="ds")
+  assert binding.ontology == "agent_decisions_graph"
+  assert binding.binding == "agent_decisions_graph_binding"
+  assert binding.target.project == "proj"
+  assert binding.target.dataset == "ds"
+  account = next(e for e in binding.entities if e.name == "DecisionRequest")
+  assert account.source == "p.d.decision_request"
+  cols = {pb.name: pb.column for pb in account.properties}
+  assert cols == {
+      "request_id": "request_id",
+      "request_text": "request_text",
+      "requested_at": "requested_at",
+  }
+
+
+def test_renamed_property_and_passthrough_key() -> None:
+  # A renamed property (acct_id AS account_id) and a KEY column that is not a
+  # stored property (it gets a passthrough property so the PK is bindable).
+  ddl = """
+  CREATE PROPERTY GRAPH g
+    NODE TABLES (
+      raw.accounts AS Account
+        KEY (acct_id)
+        LABEL Account PROPERTIES (acct_id AS account_id, balance)
+    )
+  """
+  schemas = {"raw.accounts": {"acct_id": "STRING", "balance": "NUMERIC"}}
+  ontology, binding = _derive(ddl, schemas)
+  account = ontology.entities[0]
+  prop_types = {p.name: p.type for p in account.properties}
+  assert prop_types == {
+      "account_id": PropertyType.STRING,
+      "balance": PropertyType.NUMERIC,
+  }
+  # PK column acct_id maps to property name account_id.
+  assert account.keys.primary == ["account_id"]
+  cols = {pb.name: pb.column for pb in binding.entities[0].properties}
+  assert cols == {"account_id": "acct_id", "balance": "balance"}
+
+
+def test_derived_property_is_skipped() -> None:
+  ddl = """
+  CREATE PROPERTY GRAPH g
+    NODE TABLES (
+      raw.persons AS Person
+        KEY (person_id)
+        LABEL Person PROPERTIES (
+          person_id,
+          (first || ' ' || last) AS full_name
+        )
+    )
+  """
+  schemas = {
+      "raw.persons": {
+          "person_id": "STRING",
+          "first": "STRING",
+          "last": "STRING",
+      }
+  }
+  ontology, binding = _derive(ddl, schemas)
+  names = {p.name for p in ontology.entities[0].properties}
+  assert "full_name" not in names  # derived -> skipped
+  assert names == {"person_id"}
+  assert all(p.expr is None for p in ontology.entities[0].properties)
+
+
+def test_multi_label_node_raises() -> None:
+  ddl = (
+      "CREATE PROPERTY GRAPH g NODE TABLES ("
+      " t AS N KEY (id) LABEL Child LABEL Parent PROPERTIES (id))"
+  )
+  schemas = {"t": {"id": "STRING"}}
+  with pytest.raises(GraphSpecSynthesisError, match="labels"):
+    _derive(ddl, schemas)
+
+
+def test_synthesised_pair_resolves_for_materialization() -> None:
+  # The end-to-end goal: the synthesised ontology+binding must be consumable by
+  # the SDK's real resolver, exactly like a hand-written pair would be.
+  resolve = pytest.importorskip(
+      "bigquery_agent_analytics.resolved_spec"
+  ).resolve
+  ontology, binding = _derive(_DDL, _SCHEMAS)
+  resolved = resolve(ontology, binding)
+
+  assert resolved.name == "agent_decisions_graph"
+  entity = next(e for e in resolved.entities if e.name == "DecisionRequest")
+  assert entity.key_columns == ("request_id",)
+  # The resolver re-injects the SDK metadata columns we stripped.
+  assert entity.metadata_columns == ("session_id", "extracted_at")
+  rel = next(r for r in resolved.relationships if r.name == "evaluatesOption")
+  assert rel.from_entity == "DecisionRequest"
+  assert rel.to_entity == "DecisionOption"


### PR DESCRIPTION
**PR 3 of 4** for **issue #277, Option A**. Branched off fresh `main` after #279 (PR 2) merged — **not stacked**.

## What this PR adds

The keystone of deriving a materialization spec from the property graph alone: `bigquery_ontology.graph_to_spec.derive_ontology_binding()`. It combines the parsed graph (PR 1) with the schema-recovered column types (PR 2) into the upstream **`Ontology` + `Binding`** objects that the SDK's existing **`resolve()`** already consumes — so nothing downstream changes.

```
ParsedPropertyGraph + GraphColumnTypes  ->  derive_ontology_binding()  ->  (Ontology, Binding)  ->  resolve()  ->  materializer
```

## Mapping rules

- **Entity** = one node table; name is the node `LABEL`. The alias is used only to wire edge `REFERENCES`.
- **Relationship** = one edge table; name is the edge `LABEL`; endpoints resolved from referenced node alias → entity name.
- **Property types** come from the joined table schema (PR 2), never a hand-written `type:` field.
- **Primary key** = node `KEY` columns mapped to property names; a key column with no stored property gets a **passthrough** property so the PK stays bindable.
- **SDK metadata columns** (`session_id` / `extracted_at`) are stripped from properties, keys, and edge FK columns — the resolver re-injects them as `metadata_columns`.
- **Derived `(expr) AS name` properties are skipped** (no physical column; `resolve()` rejects `expr` for materialization).

## Limitations (raise, don't guess)

Multi-label nodes (label inheritance), missing primary key, and dangling edge endpoints raise `GraphSpecSynthesisError` — keep an explicit ontology/binding for those. Descriptions/synonyms aren't recoverable from DDL+schema; derived mode pairs best with `--extraction-mode=compiled-only`, where descriptions are unused.

## Tests

`tests/test_graph_to_spec.py` — 11 offline tests: entity name = LABEL + types from schema, metadata-stripped primary key mapped to property names, relationship endpoint resolution + FK stripping, binding target/sources, renamed property + passthrough key, derived-property skipping, multi-label rejection, and — the payoff — an **end-to-end test that feeds the synthesised pair through the SDK's real `resolve()`** and asserts the materializer spec (key columns, re-injected `session_id`/`extracted_at`, relationship endpoints). Full ontology + derive suite (384 tests) green; pyink/isort clean.

## Scope / what's next

Produces the `(Ontology, Binding)` pair. **PR 4** wires it into the CLI: `bqaa context-graph --property-graph property_graph.sql …` (deriving from the parsed graph + live `BigQuerySchemaProvider`), keeping `--ontology`/`--binding` as overrides. Imported by nothing yet → zero behavior change.

