### PR TITLE
docs(guide): CA-first guide uses --property-graph (issue #277 docs sweep)

### DIFF
--- a/docs/guides/conversational-analytics-first.md
+++ b/docs/guides/conversational-analytics-first.md
@@ -36,10 +36,9 @@ an audit artifact.
 already followed the
 [Periodic Materialization codelab](../codelabs/periodic_materialization.md)
 through materialization, so that your project has: the dataset created, the
-`ontology.yaml` / `binding.yaml` bundle in place with the binding rendered
-(`envsubst < binding.yaml > binding.rendered.yaml`), the graph-table DDL
-applied, and the `agent_decisions_graph` property graph defined. That setup is
-about ten minutes and is not repeated here.
+graph-table DDL applied, and the `agent_decisions_graph` property graph defined
+(`property_graph.sql`). That setup is about ten minutes and is not repeated
+here.
 
 With the codelab setup in place, the only two commands specific to this guide
 produce a realistic corpus and materialize it:
@@ -57,7 +56,7 @@ bqaa seed-events \
 #    covers the corpus's 72-hour spread so every completed session is captured.
 bqaa context-graph \
     --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
-    --ontology ontology.yaml --binding binding.rendered.yaml \
+    --property-graph property_graph.sql \
     --lookback-hours 80
 ```
 


### PR DESCRIPTION
Final docs sweep for the #277 one-artifact flow (after #285 merged).

The Conversational-Analytics-first guide is part of the same periodic-materialization codelab story (it links to the codelab and reuses its dataset), but still told readers to keep an `ontology.yaml`/`binding.yaml` bundle, render the binding, and materialize with `--ontology`/`--binding`. This aligns it with the codelab:

- **Prerequisite** is now just the property graph (`property_graph.sql`) — dropped the "ontology.yaml/binding.yaml bundle with the binding rendered" requirement.
- **Materialize** step uses `bqaa context-graph --property-graph property_graph.sql`.

## Sweep result

I grepped all of `docs/` and `examples/` for `ontology.yaml` / `binding.yaml` / `--ontology` / `--binding` / `binding.rendered`. After this fix, every remaining mention is correctly scoped:

- the **advanced-override** notes in the codelab, blog, and artifacts README (intentional);
- the **`bigquery_ontology` toolchain docs** (`gm` CLI, binding-validation, scaffold, compilation, OWL import) — these are inherently about *authoring* ontologies/bindings;
- the **OWL-derived migration/lineage production paths** (`examples/migration_v5`, `examples/decision_lineage_demo`) — advanced flows where the ontology/binding are generated from TTL.

No reader-facing place still implies `ontology.yaml`/`binding.yaml` are required for the common path. Docs-only; no code change.