### PR TITLE
feat(materialize): derive mode can target a separate graph dataset (issue #286 enabler)

### DIFF
--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1238,6 +1238,8 @@ def _resolve_ontology_binding(
     project_id: str,
     dataset_id: str,
     bq_client: Any,
+    graph_project_id: Optional[str] = None,
+    graph_dataset_id: Optional[str] = None,
 ):
   """Resolve the ``(Ontology, Binding)`` pair from one of two input modes.
 
@@ -1246,6 +1248,13 @@ def _resolve_ontology_binding(
     file) -- parse it, read column types from ``INFORMATION_SCHEMA.COLUMNS``
     via ``bq_client``, and synthesise the pair in memory (#277). No
     hand-written ontology/binding required.
+
+  ``graph_project_id`` / ``graph_dataset_id`` target the derived graph (its
+  ``${PROJECT_ID}`` / ``${DATASET}`` placeholder resolution, schema lookup, and
+  binding target) at a project/dataset distinct from the events ``project_id`` /
+  ``dataset_id``. They default to ``project_id`` / ``dataset_id`` (single-dataset
+  shape, e.g. the codelab). A two-dataset deploy -- a read-only events dataset
+  and a separate graph dataset -- sets them to the graph dataset.
 
   Exactly one mode must be supplied; both or neither raises ``ValueError``.
   This is the single seam the orchestrator uses to obtain its spec, so both
@@ -1264,8 +1273,8 @@ def _resolve_ontology_binding(
     ddl_text = pathlib.Path(property_graph_path).read_text(encoding="utf-8")
     return derive_ontology_binding_from_ddl(
         ddl_text,
-        project_id=project_id,
-        dataset_id=dataset_id,
+        project_id=graph_project_id or project_id,
+        dataset_id=graph_dataset_id or dataset_id,
         bq_client=bq_client,
     )
 
@@ -1286,6 +1295,8 @@ def run_materialize_window(
     ontology_path: Optional[str] = None,
     binding_path: Optional[str] = None,
     property_graph_path: Optional[str] = None,
+    graph_project_id: Optional[str] = None,
+    graph_dataset_id: Optional[str] = None,
     events_table: str = "agent_events",
     lookback_hours: float,
     overlap_minutes: float = DEFAULT_OVERLAP_MINUTES,
@@ -1321,6 +1332,13 @@ def run_materialize_window(
       schema-derived input mode; the ontology + binding are synthesised from
       the graph definition and live table schemas. Mutually exclusive with
       ``ontology_path`` / ``binding_path``; exactly one mode must be supplied.
+    graph_project_id, graph_dataset_id: For schema-derived mode, the project /
+      dataset that holds the graph tables and receives the materialized graph
+      (``${PROJECT_ID}`` / ``${DATASET}`` placeholder resolution, schema lookup,
+      and binding target). Default to ``project_id`` / ``dataset_id`` (the
+      single-dataset shape). A two-dataset deploy -- a read-only events dataset
+      (``dataset_id``) and a separate graph dataset -- sets these to the graph
+      dataset so events are still read from ``dataset_id``.
     events_table: Source telemetry table name (relative to
       ``--dataset-id``).
     lookback_hours: Window size. The discovery query lower bound
@@ -1574,6 +1592,8 @@ def run_materialize_window(
       property_graph_path=property_graph_path,
       project_id=project_id,
       dataset_id=dataset_id,
+      graph_project_id=graph_project_id,
+      graph_dataset_id=graph_dataset_id,
       bq_client=client,
   )
   ontology_fp = fingerprint_model(ontology_obj)

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1230,6 +1230,23 @@ def _parse_backfill_timestamp(
 # ------------------------------------------------------------------ #
 
 
+def _state_table_defaults(
+    project_id: str,
+    dataset_id: str,
+    graph_project_id: Optional[str],
+    graph_dataset_id: Optional[str],
+) -> tuple[str, str]:
+  """Default project/dataset for the state table.
+
+  Follows the graph target when split-dataset mode is in use
+  (``graph_dataset_id`` / ``graph_project_id`` set), so the per-run
+  checkpoint is never written into a read-only events dataset. Defaults to
+  ``project_id`` / ``dataset_id`` otherwise (single-dataset shape). An explicit
+  ``state_table`` always overrides these defaults.
+  """
+  return (graph_project_id or project_id, graph_dataset_id or dataset_id)
+
+
 def _resolve_ontology_binding(
     *,
     ontology_path: Optional[str],
@@ -1574,10 +1591,18 @@ def run_materialize_window(
 
   # Resolve identifiers + qualified refs.
   events_table_ref = validated_table_ref(project_id, dataset_id, events_table)
+  # The state/checkpoint table is written every run, so it must live in a
+  # WRITABLE dataset. In split-dataset mode (graph_dataset_id set, e.g. a
+  # read-only events dataset + a separate graph dataset) it defaults to the
+  # graph target, never the events dataset. An explicit --state-table still
+  # wins. Single-dataset callers are unchanged (graph_* default to events).
+  state_default_project, state_default_dataset = _state_table_defaults(
+      project_id, dataset_id, graph_project_id, graph_dataset_id
+  )
   state_project, state_dataset, state_table_local = parse_state_table_ref(
       state_table or DEFAULT_STATE_TABLE_NAME,
-      default_project=project_id,
-      default_dataset=dataset_id,
+      default_project=state_default_project,
+      default_dataset=state_default_dataset,
   )
   state_table_ref = f"{state_project}.{state_dataset}.{state_table_local}"
 

--- a/tests/test_property_graph_spec.py
+++ b/tests/test_property_graph_spec.py
@@ -253,3 +253,31 @@ def test_orchestrator_graph_dataset_defaults_to_events_dataset(
   )
   assert binding.target.project == "p"
   assert binding.target.dataset == "d"
+
+
+def test_state_table_defaults_to_graph_dataset_in_split_mode() -> None:
+  # The per-run checkpoint must land in the WRITABLE graph dataset, never the
+  # read-only events dataset, when split-dataset mode is in use and no explicit
+  # state_table is given.
+  from bigquery_agent_analytics.materialize_window import _state_table_defaults
+  from bigquery_agent_analytics.materialize_window import DEFAULT_STATE_TABLE_NAME
+  from bigquery_agent_analytics.materialize_window import parse_state_table_ref
+
+  proj, ds = _state_table_defaults(
+      "events-proj", "events_ds", "graph-proj", "graph_ds"
+  )
+  assert (proj, ds) == ("graph-proj", "graph_ds")
+
+  # End-to-end: with no explicit state_table, the ref resolves to the graph
+  # dataset (not the events dataset).
+  state_proj, state_ds, state_name = parse_state_table_ref(
+      DEFAULT_STATE_TABLE_NAME, default_project=proj, default_dataset=ds
+  )
+  assert (state_proj, state_ds) == ("graph-proj", "graph_ds")
+  assert state_name == DEFAULT_STATE_TABLE_NAME
+
+
+def test_state_table_defaults_to_events_in_single_dataset() -> None:
+  from bigquery_agent_analytics.materialize_window import _state_table_defaults
+
+  assert _state_table_defaults("p", "d", None, None) == ("p", "d")

--- a/tests/test_property_graph_spec.py
+++ b/tests/test_property_graph_spec.py
@@ -206,3 +206,50 @@ def test_orchestrator_rejects_neither_mode() -> None:
         dataset_id="d",
         bq_client=_FakeClient({}),
     )
+
+
+def test_orchestrator_separate_graph_dataset(tmp_path) -> None:
+  # Two-dataset deploy: events live in one dataset, the graph in another.
+  # The derived binding must target the GRAPH dataset (graph_*), while the
+  # events dataset_id is left for the orchestrator's event read.
+  from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
+
+  ddl_file = tmp_path / "property_graph.sql"
+  ddl_file.write_text(_DDL, encoding="utf-8")  # uses ${PROJECT_ID}.${DATASET}
+
+  _, binding = _resolve_ontology_binding(
+      ontology_path=None,
+      binding_path=None,
+      property_graph_path=str(ddl_file),
+      project_id="events-proj",
+      dataset_id="events_ds",
+      graph_project_id="graph-proj",
+      graph_dataset_id="graph_ds",
+      bq_client=_FakeClient(_SCHEMAS),
+  )
+  # Binding target + sources resolve to the GRAPH dataset, not events.
+  assert binding.target.project == "graph-proj"
+  assert binding.target.dataset == "graph_ds"
+  request = next(e for e in binding.entities if e.name == "DecisionRequest")
+  assert request.source == "graph-proj.graph_ds.decision_request"
+
+
+def test_orchestrator_graph_dataset_defaults_to_events_dataset(
+    tmp_path,
+) -> None:
+  # Single-dataset shape (codelab/CLI): omitting graph_* targets dataset_id.
+  from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
+
+  ddl_file = tmp_path / "property_graph.sql"
+  ddl_file.write_text(_DDL, encoding="utf-8")
+
+  _, binding = _resolve_ontology_binding(
+      ontology_path=None,
+      binding_path=None,
+      property_graph_path=str(ddl_file),
+      project_id="p",
+      dataset_id="d",
+      bq_client=_FakeClient(_SCHEMAS),
+  )
+  assert binding.target.project == "p"
+  assert binding.target.dataset == "d"


### PR DESCRIPTION
**PR 1 for #286** (scheduled-deploy parity for `--property-graph`). This is the SDK **enabler** the deploy wiring needs; the deploy-script / `run_job.py` / Terraform / docs changes follow in subsequent PRs.

## Why this is needed (a real finding while scoping #286)

Derive mode (`--property-graph`) used a single `dataset_id` for **both**:
- the **events** read (`{project}.{dataset_id}.agent_events`), and
- the **derived graph target** — `${PROJECT_ID}`/`${DATASET}` resolution in `property_graph.sql`, the `INFORMATION_SCHEMA.COLUMNS` lookup, and the synthesized binding's target.

That's fine for the codelab's single-dataset shape. But the production Cloud Run wrapper (`examples/migration_v5/periodic_materialization/run_job.py`) deliberately uses a **read-only events dataset** and a **separate graph dataset** (the README's read-only-source contract; today it decouples them by *retargeting* `binding.yaml`). With one `dataset_id`, a naive `--property-graph` deploy would read schema from — and write the graph into — the **events** dataset. So deploy parity can't just pass `property_graph_path`; it needs to target the graph dataset separately.

## Change

Add optional `graph_project_id` / `graph_dataset_id` to `run_materialize_window` (and the `_resolve_ontology_binding` seam). In schema-derived mode they target the derived graph's project/dataset; they **default to `project_id` / `dataset_id`**, so single-dataset callers (codelab, the `bqaa context-graph` CLI) are completely unchanged. Events are still read from `dataset_id`.

`run_job.py` (a later PR) will set `graph_dataset_id` = the graph dataset so events stay read-only and the graph lands in the right place.

## Tests

- `test_orchestrator_separate_graph_dataset`: with `graph_*` set, the derived binding target **and** sources resolve to the graph dataset (`graph-proj.graph_ds.*`), not the events dataset.
- `test_orchestrator_graph_dataset_defaults_to_events_dataset`: omitting `graph_*` targets `dataset_id` (single-dataset unchanged).

167 tests pass across the materializer + derive + CLI suites; backward-compatible (new params default to current behavior). Called by nothing new yet — pure enabler.

Refs #286.
