### PR TITLE
feat(deploy): run_job.py --property-graph mode for scheduled materialization (issue #286, PR 2)

### DIFF
--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -47,6 +47,14 @@ Env vars (all set by the deploy script via
   ``agent_events``.
 * ``BQAA_GRAPH_DATASET_ID`` (required) — target dataset for
   the materialized graph (entity + relationship tables).
+* ``BQAA_PROPERTY_GRAPH`` (default unset) — when set to a staged
+  ``CREATE PROPERTY GRAPH`` ``.sql`` filename (e.g.
+  ``property_graph.sql``), runs in schema-derived mode (#286): the
+  ontology + binding are derived from the property graph + table
+  schemas, so no ``ontology.yaml`` / ``binding.yaml`` is staged and no
+  binding retargeting happens. Use placeholdered (``${PROJECT_ID}`` /
+  ``${DATASET}``), rename-free graphs. Unset ⇒ explicit ontology +
+  binding (the advanced / compiled-extractor path).
 * ``BQAA_LOCATION`` (default ``US``) — BigQuery location;
   must match both datasets.
 * ``BQAA_LOOKBACK_HOURS`` (default ``6``) — scan window size.
@@ -266,13 +274,18 @@ def _bootstrap_entity_tables(
   silently fails on every run. Bootstrapping at startup means
   the customer doesn't need a separate one-time setup step.
   """
+  # Retarget the table DDL to the customer's graph dataset. Two artifact
+  # styles are supported: the migration-v5 snapshot hard-codes the canonical
+  # ``project.dataset`` prefix; the property-graph (codelab-style) artifacts use
+  # ``${PROJECT_ID}`` / ``${DATASET}`` placeholders. Resolve both so either
+  # style lands in ``{project}.{graph_dataset}`` -- which is also where the
+  # derive path reads INFORMATION_SCHEMA from.
   ddl_text = (
       _find_artifact("table_ddl.sql")
       .read_text()
-      .replace(
-          _CANONICAL_PREFIX,
-          f"{project_id}.{graph_dataset_id}",
-      )
+      .replace(_CANONICAL_PREFIX, f"{project_id}.{graph_dataset_id}")
+      .replace("${PROJECT_ID}", project_id)
+      .replace("${DATASET}", graph_dataset_id)
   )
   count = 0
   for stmt in ddl_text.strip().split(";"):
@@ -402,6 +415,13 @@ def main() -> int:
       os.environ.get("BQAA_REFERENCE_EXTRACTORS_MODULE") or None
   )
   bundles_root = os.environ.get("BQAA_BUNDLES_ROOT") or None
+  # Spec input mode. ``BQAA_PROPERTY_GRAPH`` (a staged ``*.sql`` filename)
+  # selects schema-derived mode (#277/#286): the ontology + binding are derived
+  # from the property graph + table schemas, so no ``ontology.yaml`` /
+  # ``binding.yaml`` is staged and no binding retargeting happens. When unset,
+  # the wrapper uses the explicit ontology + binding (the migration-v5 /
+  # compiled-extractor advanced path). Exactly one mode is in effect.
+  property_graph_name = os.environ.get("BQAA_PROPERTY_GRAPH") or None
   # Orphan-session watchdog (issue #180). Unset means disabled —
   # mirrors the CLI flag. ``_optional_env_float`` raises ``exit 2``
   # on a non-numeric value at the boundary, and the materializer's
@@ -475,18 +495,11 @@ def main() -> int:
         statements=ddl_count,
     )
 
-    # 3. Retarget binding to the customer's graph dataset.
-    binding_path = _retarget_binding(project_id, graph_dataset_id)
-
-    # 4. Run the orchestrator. Reads events from
-    # ``BQAA_EVENTS_DATASET_ID``; writes entities/relationships
-    # AND the state/checkpoint table into
-    # ``BQAA_GRAPH_DATASET_ID`` per the retargeted binding.
-    # The state-table arg is fully-qualified
-    # (``project.dataset.table``) so it ignores the
-    # orchestrator's default-dataset fallback (which would point
-    # at the read-only events dataset). This keeps the source
-    # dataset truly read-only per the README contract.
+    # 3. Run the orchestrator. Reads events from
+    # ``BQAA_EVENTS_DATASET_ID``; writes entities/relationships AND the
+    # state/checkpoint table into ``BQAA_GRAPH_DATASET_ID``. The
+    # state-table arg is fully-qualified (``project.dataset.table``) so the
+    # read-only events dataset is never written, per the README contract.
     state_table_ref = (
         f"{project_id}.{graph_dataset_id}._bqaa_materialization_state"
     )
@@ -496,11 +509,9 @@ def main() -> int:
     parsed_from = mw._parse_backfill_timestamp("BQAA_FROM", from_time_raw)
     parsed_to = mw._parse_backfill_timestamp("BQAA_TO", to_time_raw)
 
-    result = mw.run_materialize_window(
+    common_kwargs = dict(
         project_id=project_id,
         dataset_id=events_dataset_id,
-        ontology_path=str(_find_artifact("ontology.yaml")),
-        binding_path=str(binding_path),
         lookback_hours=lookback_hours,
         overlap_minutes=overlap_minutes,
         max_sessions=max_sessions,
@@ -514,10 +525,40 @@ def main() -> int:
         to_time=parsed_to,
         state_key_suffix=state_key_suffix,
         extraction_mode=extraction_mode,
-        bundles_root=bundles_root,
-        reference_extractors_module=reference_extractors_module,
         max_session_age_hours=max_session_age_hours,
     )
+
+    if property_graph_name:
+      # Schema-derived mode (#286): no ontology/binding, no binding retarget.
+      # ``graph_*`` target the writable graph dataset for placeholder
+      # resolution, INFORMATION_SCHEMA lookup, and writes; events stay
+      # read-only in ``events_dataset_id``. ``property_graph.sql`` is staged
+      # with ``${PROJECT_ID}`` / ``${DATASET}`` placeholders that the
+      # materializer resolves from ``project_id`` / ``graph_dataset_id``.
+      _emit(
+          "INFO",
+          message="spec input mode",
+          mode="property-graph",
+          property_graph=property_graph_name,
+      )
+      result = mw.run_materialize_window(
+          property_graph_path=str(_find_artifact(property_graph_name)),
+          graph_project_id=project_id,
+          graph_dataset_id=graph_dataset_id,
+          **common_kwargs,
+      )
+    else:
+      # Explicit ontology + binding (advanced; migration-v5 compiled path).
+      # Retarget the committed binding to the customer's graph dataset.
+      _emit("INFO", message="spec input mode", mode="explicit")
+      binding_path = _retarget_binding(project_id, graph_dataset_id)
+      result = mw.run_materialize_window(
+          ontology_path=str(_find_artifact("ontology.yaml")),
+          binding_path=str(binding_path),
+          bundles_root=bundles_root,
+          reference_extractors_module=reference_extractors_module,
+          **common_kwargs,
+      )
 
     # Structured JSON report for Cloud Logging. Cloud Logging
     # filters / metrics can pivot on the keys here directly

--- a/tests/test_run_job_property_graph.py
+++ b/tests/test_run_job_property_graph.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime wrapper tests for the Cloud Run Job's spec input modes (issue #286).
+
+Loads ``examples/migration_v5/periodic_materialization/run_job.py`` and drives
+``main()`` with BigQuery, dataset bootstrap, and the orchestrator all faked, so
+we can assert how each mode calls ``run_materialize_window`` without touching
+BigQuery.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_RUN_JOB = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "examples"
+    / "migration_v5"
+    / "periodic_materialization"
+    / "run_job.py"
+)
+
+
+class _FakeResult:
+  ok = True
+
+  def to_json(self):
+    return {}
+
+
+def _drive(monkeypatch, env):
+  """Run ``run_job.main()`` with all I/O faked; return (rc, mw_kwargs, retargets)."""
+  spec = importlib.util.spec_from_file_location("_run_job_under_test", _RUN_JOB)
+  run_job = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(run_job)
+
+  import google.cloud.bigquery as bq
+
+  import bigquery_agent_analytics.materialize_window as mw
+
+  captured: dict = {}
+
+  def _fake_run(**kwargs):
+    captured.update(kwargs)
+    return _FakeResult()
+
+  monkeypatch.setattr(mw, "run_materialize_window", _fake_run)
+  monkeypatch.setattr(bq, "Client", lambda *a, **k: object())
+  monkeypatch.setattr(run_job, "_ensure_graph_dataset", lambda *a, **k: False)
+  monkeypatch.setattr(run_job, "_bootstrap_entity_tables", lambda *a, **k: 0)
+  retargets: list = []
+  monkeypatch.setattr(
+      run_job,
+      "_retarget_binding",
+      lambda project_id, graph_dataset_id: retargets.append(
+          (project_id, graph_dataset_id)
+      )
+      or pathlib.Path("/tmp/binding.retargeted.yaml"),
+  )
+  monkeypatch.setattr(
+      run_job, "_find_artifact", lambda name: pathlib.Path("/staged") / name
+  )
+
+  for key in ("BQAA_PROPERTY_GRAPH",):
+    monkeypatch.delenv(key, raising=False)
+  for key, value in env.items():
+    monkeypatch.setenv(key, value)
+
+  rc = run_job.main()
+  return rc, captured, retargets
+
+
+_BASE_ENV = {
+    "BQAA_PROJECT_ID": "proj",
+    "BQAA_EVENTS_DATASET_ID": "events_ds",
+    "BQAA_GRAPH_DATASET_ID": "graph_ds",
+    "BQAA_LOOKBACK_HOURS": "6",
+}
+
+
+def test_property_graph_mode(monkeypatch) -> None:
+  rc, kwargs, retargets = _drive(
+      monkeypatch, {**_BASE_ENV, "BQAA_PROPERTY_GRAPH": "property_graph.sql"}
+  )
+  assert rc == 0
+  # Derives from the staged property graph; no ontology/binding, no retarget.
+  assert kwargs["property_graph_path"].endswith("property_graph.sql")
+  assert "ontology_path" not in kwargs
+  assert "binding_path" not in kwargs
+  assert retargets == []
+  # Events stay read-only in events_ds; the graph targets graph_ds.
+  assert kwargs["dataset_id"] == "events_ds"
+  assert kwargs["graph_project_id"] == "proj"
+  assert kwargs["graph_dataset_id"] == "graph_ds"
+  # State table is the writable graph dataset.
+  assert kwargs["state_table"] == "proj.graph_ds._bqaa_materialization_state"
+
+
+def test_explicit_mode_unchanged(monkeypatch) -> None:
+  rc, kwargs, retargets = _drive(
+      monkeypatch, _BASE_ENV
+  )  # no BQAA_PROPERTY_GRAPH
+  assert rc == 0
+  # Explicit ontology + binding, with the binding retargeted to the graph ds.
+  assert kwargs["ontology_path"].endswith("ontology.yaml")
+  assert kwargs["binding_path"].endswith("binding.retargeted.yaml")
+  assert "property_graph_path" not in kwargs
+  assert retargets == [("proj", "graph_ds")]
+  assert kwargs["dataset_id"] == "events_ds"


### PR DESCRIPTION
**PR 2 for #286** — teaches the Cloud Run Job **runtime wrapper** (`run_job.py`) to materialize in schema-derived mode. Built on the #288 split-dataset enabler; branched **unstacked** off fresh `main`.

## What changes

- **New env var `BQAA_PROPERTY_GRAPH`** — when set to a staged `CREATE PROPERTY GRAPH` `.sql` filename (e.g. `property_graph.sql`), the wrapper runs in schema-derived mode: ontology + binding are derived from the property graph + table schemas, so **no `ontology.yaml`/`binding.yaml` is staged and no binding retargeting happens**. Unset ⇒ the explicit ontology+binding path (migration-v5 / compiled extractor), unchanged.
- **Split-dataset wiring (the #288 contract):** the property-graph branch calls `run_materialize_window(property_graph_path=…, graph_project_id=project_id, graph_dataset_id=graph_dataset_id, …)`. Events stay **read-only** in `BQAA_EVENTS_DATASET_ID`; schema lookup, materialized tables, and the state table all target the **writable** `BQAA_GRAPH_DATASET_ID`. The `${PROJECT_ID}`/`${DATASET}` placeholders in `property_graph.sql` are resolved by the materializer from `project_id`/`graph_dataset_id`.
- **Table bootstrap handles placeholdered artifacts.** `_bootstrap_entity_tables` now resolves `${PROJECT_ID}`/`${DATASET}` (in addition to the existing canonical-prefix rewrite), so the codelab-style placeholdered `table_ddl.sql` is retargeted to the graph dataset before the first run. This is a **hard prerequisite**: derive mode reads `INFORMATION_SCHEMA` and can't create the tables itself.
- **No rewriter** (per the agreed simplification): property-graph mode just requires placeholdered, rename-free artifacts and reuses existing `${}` resolution. `reference_extractors_module`/`bundles_root` are passed **only** in the explicit branch (compiled extraction stays an explicit-mode concern).

## Tests

`tests/test_run_job_property_graph.py` loads `run_job.py` and drives `main()` with BigQuery, dataset bootstrap, and the orchestrator all faked:
- **property-graph mode** → `run_materialize_window` called with `property_graph_path` + `graph_project_id`/`graph_dataset_id`, **no** `ontology_path`/`binding_path`, **no** `_retarget_binding`; `dataset_id` stays the events dataset; state table is the graph dataset.
- **explicit mode** (no `BQAA_PROPERTY_GRAPH`) → ontology + binding paths + a binding retarget to the graph dataset; unchanged.

171 tests pass across the runtime + materializer + derive + CLI suites.

## Scope / next

Runtime wrapper only. **PR 3**: `deploy_cloud_run_job.sh` + `build_image.sh` — add `--property-graph` mode, stage `property_graph.sql` (+ placeholdered `table_ddl.sql`), set `BQAA_PROPERTY_GRAPH`, and validate exactly-one-mode at the deploy boundary. Then Terraform (PR 4) and docs (PR 5).

Refs #286. Depends on #288 (merged).
