### PR TITLE
fix(deploy): run_job table-DDL bootstrap mis-split on comment semicolons (found by --property-graph smoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Schema-derived (`--property-graph`) materialization, local → production**
+  (local: [#277](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/277)
+  via [#278](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/278)–[#281](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/281),
+  [#285](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/285),
+  [#287](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/287);
+  deploy: [#286](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/286)
+  via [#288](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/288)–[#292](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/292))
+  — `bqaa context-graph --property-graph property_graph.sql` derives the ontology
+  + binding from the property graph + live table schemas, so no hand-written
+  `ontology.yaml` / `binding.yaml` is needed for rename-free graphs. Scheduled
+  production reaches parity: the Cloud Run deploy script, image builder,
+  `run_job.py` (`BQAA_PROPERTY_GRAPH`), and the Terraform module all accept the
+  one-artifact flow (placeholdered `property_graph.sql` + sibling
+  `table_ddl.sql`), with a split read-only-events / writable-graph contract
+  (events read-only; graph tables + `_bqaa_materialization_state` land in the
+  graph dataset). Explicit `--ontology`/`--binding` is preserved as the advanced
+  override (descriptions, inheritance, derived properties, renames, the
+  migration-v5 compiled extractor).
+
+### Fixed
+
+- **`run_job.py` table-DDL bootstrap mis-split on comment semicolons**
+  ([#286](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/286))
+  — `_bootstrap_entity_tables` split the DDL on `;` without stripping `--`
+  comments, so a comment containing `;` (e.g. the codelab `table_ddl.sql`'s
+  "materializer fills automatically; they are required") produced a
+  comment-only fragment BigQuery rejected with "Unexpected end of statement".
+  Now strips line comments before splitting. Found by a live `--property-graph`
+  deploy smoke.
+
 ## [0.3.2] - 2026-05-22
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`run_job.py` table-DDL bootstrap mis-split on comment semicolons**
+- **`run_job.py` table-DDL bootstrap mis-split on statement boundaries**
   ([#286](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/286))
-  — `_bootstrap_entity_tables` split the DDL on `;` without stripping `--`
-  comments, so a comment containing `;` (e.g. the codelab `table_ddl.sql`'s
-  "materializer fills automatically; they are required") produced a
-  comment-only fragment BigQuery rejected with "Unexpected end of statement".
-  Now strips line comments before splitting. Found by a live `--property-graph`
-  deploy smoke.
+  — `_bootstrap_entity_tables` split the DDL on `;` without accounting for
+  comments or quoting, so a `;` inside a `--` comment (e.g. the codelab
+  `table_ddl.sql`'s "materializer fills automatically; they are required")
+  produced a comment-only fragment BigQuery rejected with "Unexpected end of
+  statement" — and a `;` or `--` inside a string literal
+  (`OPTIONS(description="has; semicolon")`, `DEFAULT 'a;b'`) or a backtick
+  identifier could corrupt a customer's DDL. Replaced with a quote- and
+  comment-aware splitter: it strips `--` line comments and `/* */` block
+  comments and splits on `;` only at the top level (never inside `'`, `"`, or
+  `` ` `` quoting). Found by a live `--property-graph` deploy smoke.
 
 ## [0.3.2] - 2026-05-22
 

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -127,7 +127,6 @@ import datetime as _dt
 import json
 import os
 import pathlib
-import re
 import sys
 import tempfile
 from typing import Any, Optional
@@ -298,15 +297,58 @@ def _bootstrap_entity_tables(
 def _split_sql_statements(ddl_text: str) -> list[str]:
   """Split a multi-statement DDL script into individual statements.
 
-  Strips ``--`` line comments first, because comment prose can contain ``;``
-  (e.g. ``materializer fills automatically; they are required``) and a naive
-  ``split(";")`` would otherwise produce a comment-only fragment that BigQuery
-  rejects with "Unexpected end of statement". The committed table DDL uses no
-  string literals or quoted identifiers containing ``--`` or ``;``, so
-  line-comment stripping is safe here. Empty fragments are dropped.
+  A quote- and comment-aware scanner: it removes ``--`` line comments and
+  ``/* */`` block comments and splits on ``;`` only at the top level -- never
+  inside a single-quoted string, double-quoted string, or backtick-quoted
+  identifier. A naive ``split(";")`` corrupts otherwise-valid BigQuery DDL such
+  as a comment containing ``;`` (which yields a fragment BigQuery rejects with
+  "Unexpected end of statement"), ``OPTIONS(description="has; semicolon")``,
+  ``DEFAULT 'a;b'``, or a quoted ``--``. Empty fragments are dropped.
   """
-  without_comments = re.sub(r"--[^\n]*", "", ddl_text)
-  return [s.strip() for s in without_comments.split(";") if s.strip()]
+  statements: list[str] = []
+  buf: list[str] = []
+  quote: Optional[str] = None  # "'", '"', or "`" while inside a quoted span
+  i, n = 0, len(ddl_text)
+  while i < n:
+    ch = ddl_text[i]
+    if quote is not None:
+      buf.append(ch)
+      if ch == "\\" and i + 1 < n:  # escaped char inside the quote
+        buf.append(ddl_text[i + 1])
+        i += 2
+        continue
+      if ch == quote:
+        quote = None
+      i += 1
+      continue
+    # Outside any quote: comments and the statement separator are structural.
+    if ch == "-" and i + 1 < n and ddl_text[i + 1] == "-":
+      newline = ddl_text.find("\n", i)
+      i = n if newline == -1 else newline  # keep the newline as whitespace
+      continue
+    if ch == "/" and i + 1 < n and ddl_text[i + 1] == "*":
+      close = ddl_text.find("*/", i + 2)
+      i = n if close == -1 else close + 2
+      buf.append(" ")  # don't glue the tokens the comment separated
+      continue
+    if ch in ("'", '"', "`"):
+      quote = ch
+      buf.append(ch)
+      i += 1
+      continue
+    if ch == ";":
+      stmt = "".join(buf).strip()
+      if stmt:
+        statements.append(stmt)
+      buf = []
+      i += 1
+      continue
+    buf.append(ch)
+    i += 1
+  tail = "".join(buf).strip()
+  if tail:
+    statements.append(tail)
+  return statements
 
 
 def _ensure_graph_dataset(

--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -127,6 +127,7 @@ import datetime as _dt
 import json
 import os
 import pathlib
+import re
 import sys
 import tempfile
 from typing import Any, Optional
@@ -288,12 +289,24 @@ def _bootstrap_entity_tables(
       .replace("${DATASET}", graph_dataset_id)
   )
   count = 0
-  for stmt in ddl_text.strip().split(";"):
-    stmt = stmt.strip()
-    if stmt:
-      bq_client.query(stmt).result()
-      count += 1
+  for stmt in _split_sql_statements(ddl_text):
+    bq_client.query(stmt).result()
+    count += 1
   return count
+
+
+def _split_sql_statements(ddl_text: str) -> list[str]:
+  """Split a multi-statement DDL script into individual statements.
+
+  Strips ``--`` line comments first, because comment prose can contain ``;``
+  (e.g. ``materializer fills automatically; they are required``) and a naive
+  ``split(";")`` would otherwise produce a comment-only fragment that BigQuery
+  rejects with "Unexpected end of statement". The committed table DDL uses no
+  string literals or quoted identifiers containing ``--`` or ``;``, so
+  line-comment stripping is safe here. Empty fragments are dropped.
+  """
+  without_comments = re.sub(r"--[^\n]*", "", ddl_text)
+  return [s.strip() for s in without_comments.split(";") if s.strip()]
 
 
 def _ensure_graph_dataset(

--- a/tests/test_run_job_property_graph.py
+++ b/tests/test_run_job_property_graph.py
@@ -122,6 +122,40 @@ def test_split_sql_statements_handles_semicolon_in_comments() -> None:
   assert all(";" not in s for s in stmts)
 
 
+def test_split_sql_statements_is_quote_aware() -> None:
+  # Semicolons / -- inside string literals, OPTIONS descriptions, and
+  # backtick identifiers must NOT split the statement or be stripped.
+  run_job = _load_run_job()
+  ddl = (
+      "CREATE TABLE `p.d.a` (\n"
+      '  id STRING OPTIONS(description="has; a semicolon and -- dashes"),\n'
+      "  note STRING DEFAULT 'x;y'\n"
+      ");\n"
+      "CREATE TABLE `p.d.b` (id STRING);\n"
+  )
+  stmts = run_job._split_sql_statements(ddl)
+  assert len(stmts) == 2
+  # The in-string semicolons and dashes survive intact in the first statement.
+  assert 'description="has; a semicolon and -- dashes"' in stmts[0]
+  assert "DEFAULT 'x;y'" in stmts[0]
+  assert stmts[1] == "CREATE TABLE `p.d.b` (id STRING)"
+
+
+def test_split_sql_statements_handles_block_comments_and_escapes() -> None:
+  run_job = _load_run_job()
+  ddl = (
+      "CREATE TABLE `p.d.a` /* inline; comment */ (\n"
+      "  s STRING DEFAULT 'a\\';b'\n"  # escaped quote then ; inside the string
+      ");\n"
+      "CREATE TABLE `p.d.b` (id STRING)"
+  )
+  stmts = run_job._split_sql_statements(ddl)
+  assert len(stmts) == 2
+  assert "/* inline; comment */" not in stmts[0]  # block comment removed
+  assert "DEFAULT 'a\\';b'" in stmts[0]  # in-string ; preserved
+  assert stmts[1] == "CREATE TABLE `p.d.b` (id STRING)"
+
+
 def test_property_graph_mode(monkeypatch) -> None:
   rc, kwargs, retargets = _drive(
       monkeypatch, {**_BASE_ENV, "BQAA_PROPERTY_GRAPH": "property_graph.sql"}

--- a/tests/test_run_job_property_graph.py
+++ b/tests/test_run_job_property_graph.py
@@ -93,6 +93,35 @@ _BASE_ENV = {
 }
 
 
+def _load_run_job():
+  spec = importlib.util.spec_from_file_location("_run_job_split", _RUN_JOB)
+  run_job = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(run_job)
+  return run_job
+
+
+def test_split_sql_statements_handles_semicolon_in_comments() -> None:
+  # Regression: the codelab table_ddl.sql comment "fills automatically; they
+  # are required" has a ';' inside a comment. A naive split(';') turns that
+  # into a comment-only fragment BigQuery rejects ("Unexpected end of
+  # statement"). The splitter must strip comments first.
+  run_job = _load_run_job()
+  ddl = (
+      "-- ``session_id`` are SDK metadata columns the\n"
+      "-- materializer fills automatically; they are required on every\n"
+      "-- bound table.\n"
+      "--\n"
+      "-- Apply with:\n"
+      "--   envsubst < table_ddl.sql | bq query\n"
+      "CREATE TABLE IF NOT EXISTS `p.d.a` (id STRING);\n"
+      "CREATE TABLE IF NOT EXISTS `p.d.b` (id STRING);\n"
+  )
+  stmts = run_job._split_sql_statements(ddl)
+  assert len(stmts) == 2
+  assert all(s.startswith("CREATE TABLE IF NOT EXISTS") for s in stmts)
+  assert all(";" not in s for s in stmts)
+
+
 def test_property_graph_mode(monkeypatch) -> None:
   rc, kwargs, retargets = _drive(
       monkeypatch, {**_BASE_ENV, "BQAA_PROPERTY_GRAPH": "property_graph.sql"}


### PR DESCRIPTION
Found by the **live `--property-graph` deploy smoke** run after #292 merged (the deploy-parity arc, #286). Bugfix + CHANGELOG.

## The bug

`run_job.py::_bootstrap_entity_tables` applies the table DDL by splitting on `;` and running each fragment. It split **without stripping `--` comments**, so a comment that contains `;` — e.g. the codelab `table_ddl.sql`'s `-- materializer fills automatically; they are required` — became a **comment-only fragment** that BigQuery rejects with `Syntax error: Unexpected end of statement`. The graph-table bootstrap then failed for *any* `--property-graph` deploy using codelab-style artifacts (the placeholdered ones the new mode requires).

```
{"severity":"ERROR","message":"unexpected error...","error_type":"BadRequest",
 "error":"400 Syntax error: Unexpected end of statement at [5:36]..."}
```

## The fix

`_split_sql_statements()` is a **quote- and comment-aware** scanner: it removes `--` line comments and `/* */` block comments and splits on `;` **only at the top level** — never inside single quotes, double quotes, or backtick identifiers (honoring backslash escapes). This is safe both for the codelab comment-with-`;` case and for customer DDL with `;`/`--` inside `OPTIONS(description=...)`, `DEFAULT` string literals, or quoted identifiers. Regression tests cover all of these.

## Live smoke (post-fix) — clean end-to-end

`run_job.py` in property-graph mode, scratch **split** datasets on a real project:

- `spec mode = property-graph`, `BQAA_PROPERTY_GRAPH=property_graph.sql` — no ontology/binding staged ✓
- table DDL applied: **5 statements** (bootstrap fixed) ✓
- **5/5 sessions materialized, 0 failed**; `DecisionRequest 5 / DecisionOption 15 / DecisionOutcome 5` + edges ✓
- graph tables **and** `_bqaa_materialization_state` in the **graph** dataset ✓
- **events dataset read-only** (only `agent_events`) ✓

## CHANGELOG

Added the `Unreleased` entry for the schema-derived (`--property-graph`) local→production materialization (#277 + #286 chains) and this fix.

25 tests pass across the `run_job` / deploy-script / Terraform / derive suites. Refs #286.

