### PR TITLE
chore(release): 0.3.3 — schema-derived (--property-graph) Context Graph, local → production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-08
+
+### Release highlights
+
+Schema-derived Context Graph materialization, end to end. `bqaa context-graph
+--property-graph property_graph.sql` now derives the ontology + binding from the
+property graph plus live table schemas, so rename-free graphs need no
+hand-written `ontology.yaml` / `binding.yaml` — and the same one-artifact flow
+reaches the scheduled production path (Cloud Run deploy script, image builder,
+`run_job.py`, and the Terraform module), with a split read-only-events /
+writable-graph dataset contract. Explicit `--ontology` / `--binding` is retained
+as the advanced override for descriptions, inheritance, derived properties,
+renames, and the migration-v5 compiled-extractor path.
+
 ### Added
 
 - **Schema-derived (`--property-graph`) materialization, local → production**

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -194,11 +194,12 @@ before paying for a deploy:
 pip install -e .
 #
 # (b) Pinned from PyPI — once you're on a stable SDK version.
-#     0.3.2 is the migration-v5 production-track release
+#     0.3.3 adds schema-derived (``--property-graph``) deploy
+#     parity on top of the 0.3.2 migration-v5 production track
 #     (compiled-only deploy, backfill, orphan watchdog,
 #     Terraform module, split SAs, ``--max-retries``). Use this
 #     for unmodified production use.
-pip install 'bigquery-agent-analytics>=0.3.2'
+pip install 'bigquery-agent-analytics>=0.3.3'
 
 # Either way, install the example's ancillary deps:
 pip install -r examples/migration_v5/periodic_materialization/requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigquery-agent-analytics"
-version = "0.3.2"
+version = "0.3.3"
 description = "SDK for analyzing and evaluating agent traces stored in BigQuery."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **0.3.3**, packaging the schema-derived (`--property-graph`) Context Graph work now that it's complete and live-smoke-validated.

## What's in 0.3.3

- **Local** ([#277](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/277)): `bqaa context-graph --property-graph property_graph.sql` derives the ontology + binding from the property graph + live table schemas — no hand-written `ontology.yaml`/`binding.yaml` for rename-free graphs (#278–#281, #285, #287).
- **Production** ([#286](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/286)): the same one-artifact flow on the scheduled path — deploy script, image builder, `run_job.py` (`BQAA_PROPERTY_GRAPH`), and Terraform — with a split read-only-events / writable-graph dataset contract (#288–#292).
- **Fix** (#294): quote/comment-aware table-DDL bootstrap splitter (found by a live `--property-graph` deploy smoke).

Explicit `--ontology`/`--binding` is retained as the advanced override (descriptions, inheritance, derived properties, renames, migration-v5 compiled extractor).

## Changes

- `pyproject.toml`: `0.3.2` → `0.3.3`.
- `CHANGELOG.md`: `[Unreleased]` → dated `[0.3.3]` with a release-highlights summary.
- migration-v5 deploy README: PyPI pin `>=0.3.2` → `>=0.3.3` (the documented `--property-graph` deploy path requires 0.3.3) + a note on what 0.3.3 adds.

Patch bump (continues the 0.3.x migration-v5 production track); backward-compatible — `--property-graph` is additive, the explicit YAML path is unchanged.