### PR TITLE
feat(materialize): let run_materialize_window pick the AI.GENERATE model

### DIFF
--- a/examples/migration_v5/periodic_materialization/run_job.py
+++ b/examples/migration_v5/periodic_materialization/run_job.py
@@ -88,6 +88,11 @@ Env vars (all set by the deploy script via
   gaps). ``compiled-only`` skips ``AI.GENERATE`` entirely; any
   span the compiled extractors don't cover surfaces as a typed
   ``empty_extraction`` failure with sample diagnostics.
+* ``BQAA_ENDPOINT`` (default ``gemini-2.5-flash``) — Vertex AI
+  model for the ``ai-fallback`` AI.GENERATE call. Short names
+  resolve to a ``locations/global`` publisher URL, so Gemini 3.x
+  names (e.g. ``gemini-3.5-flash``) work. Ignored under
+  ``compiled-only`` (no AI call is made).
 * ``BQAA_REFERENCE_EXTRACTORS_MODULE`` (default unset, set to
   ``reference_extractor`` by the deploy script in
   compiled-only mode) — dotted module path whose ``EXTRACTORS``
@@ -458,6 +463,11 @@ def main() -> int:
   extraction_mode = (
       os.environ.get("BQAA_EXTRACTION_MODE") or "ai-fallback"
   ).strip()
+  # AI.GENERATE model for the ai-fallback path. Short names resolve to a
+  # locations/global publisher URL inside the SDK, so Gemini 3.x names
+  # (e.g. ``gemini-3.5-flash``) work. Default matches the SDK default so
+  # an unset env var is a no-op. Ignored under ``compiled-only`` (no AI call).
+  endpoint = (os.environ.get("BQAA_ENDPOINT") or "gemini-2.5-flash").strip()
   # Reference module + bundles root. Both default to None;
   # ``compiled-only`` mode requires at least one of them to be set
   # at the SDK boundary (else the manager has no structured
@@ -507,6 +517,7 @@ def main() -> int:
       to_time=to_time_raw,
       state_key_suffix=state_key_suffix,
       extraction_mode=extraction_mode,
+      endpoint=endpoint,
       bundles_root=bundles_root,
       reference_extractors_module=reference_extractors_module,
       max_session_age_hours=max_session_age_hours,
@@ -581,6 +592,7 @@ def main() -> int:
         state_key_suffix=state_key_suffix,
         extraction_mode=extraction_mode,
         max_session_age_hours=max_session_age_hours,
+        endpoint=endpoint,
     )
 
     if property_graph_name:

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1996,6 +1996,18 @@ def materialize_window(
             "mode."
         ),
     ),
+    endpoint: str = typer.Option(
+        "gemini-2.5-flash",
+        "--endpoint",
+        help=(
+            "Vertex AI model for the AI.GENERATE extraction "
+            "fallback (used in 'ai-fallback' mode). Short names "
+            "resolve to a locations/global publisher URL, so "
+            "Gemini 3.x models such as 'gemini-3.5-flash' work "
+            "here. Ignored under --extraction-mode=compiled-only "
+            "(no AI call is made)."
+        ),
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -2063,6 +2075,7 @@ def materialize_window(
         extraction_mode=extraction_mode,
         state_key_suffix=state_key_suffix,
         max_session_age_hours=max_session_age_hours,
+        endpoint=endpoint,
     )
     typer.echo(format_output(result.to_json(), fmt))
     if not result.ok:

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1335,6 +1335,7 @@ def run_materialize_window(
     state_key_suffix: Optional[str] = None,
     extraction_mode: str = EXTRACTION_MODE_AI_FALLBACK,
     max_session_age_hours: Optional[float] = None,
+    endpoint: str = "gemini-2.5-flash",
 ) -> MaterializeWindowResult:
   """The end-to-end run.
 
@@ -1427,6 +1428,12 @@ def run_materialize_window(
       (backfill runs scan a fixed historical window where the
       "what's still in-flight?" question is undefined).
       ``None`` (default) disables the watchdog.
+    endpoint: Vertex AI model for the ``AI.GENERATE`` extraction
+      fallback (``ai-fallback`` / ``ai-only`` modes). Resolved to a
+      ``locations/global`` publisher URL, so Gemini 3.x names such as
+      ``gemini-3.5-flash`` work here. Defaults to ``gemini-2.5-flash``.
+      Ignored when extraction is fully served by compiled/reference
+      extractors (no AI fallback is invoked).
   """
   # Orphan-watchdog validation. Like the numeric guardrails below,
   # a typo at the boundary (``--max-session-age-hours=-1`` or ``0``)
@@ -1865,6 +1872,7 @@ def run_materialize_window(
       outcome_callback=outcomes_cb,
       table_id=events_table,
       expected_fingerprint=compile_bundle_fingerprint,
+      endpoint=endpoint,
   )
 
   # Materialize per session so a single-session failure doesn't
@@ -2235,6 +2243,7 @@ def _build_manager(
     outcome_callback: Callable[[str, Any], None],
     table_id: str,
     expected_fingerprint: Optional[str] = None,
+    endpoint: str = "gemini-2.5-flash",
 ) -> Any:
   """Construct the OntologyGraphManager — with compiled bundles
   wired when ``bundles_root`` is set, otherwise the plain
@@ -2284,6 +2293,7 @@ def _build_manager(
         bq_client=bq_client,
         table_id=table_id,
         extractors=extractors,
+        endpoint=endpoint,
     )
 
   if reference_extractors_module is None:
@@ -2345,6 +2355,7 @@ def _build_manager(
       bq_client=bq_client,
       table_id=table_id,
       on_outcome=outcome_callback,
+      endpoint=endpoint,
   )
 
 

--- a/tests/test_cli_context_graph_input_modes.py
+++ b/tests/test_cli_context_graph_input_modes.py
@@ -23,6 +23,8 @@ wiring exits non-zero.
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 import typer
 from typer.testing import CliRunner
@@ -90,3 +92,46 @@ def test_cli_exits_nonzero_when_both_modes() -> None:
       _BASE + ["--property-graph", "g.sql", "--ontology", "o.yaml"],
   )
   assert result.exit_code != 0
+
+
+# --------------------------------------------------------------------------- #
+# --endpoint forwarding: the operator's AI.GENERATE model selection must reach
+# run_materialize_window, else `bqaa context-graph` users stay pinned to the
+# SDK default regardless of --endpoint.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResult:
+  ok = True
+
+  def to_json(self):
+    return {}
+
+
+def _invoke_capturing_endpoint(extra_args):
+  captured: dict = {}
+
+  def _fake_run(**kwargs):
+    captured.update(kwargs)
+    return _FakeResult()
+
+  with mock.patch(
+      "bigquery_agent_analytics.materialize_window.run_materialize_window",
+      _fake_run,
+  ):
+    result = runner.invoke(
+        bqaa_app, _BASE + ["--property-graph", "g.sql"] + extra_args
+    )
+  assert result.exit_code == 0, result.output
+  return captured["endpoint"]
+
+
+def test_cli_endpoint_forwarded() -> None:
+  assert (
+      _invoke_capturing_endpoint(["--endpoint", "gemini-3.5-flash"])
+      == "gemini-3.5-flash"
+  )
+
+
+def test_cli_endpoint_defaults_to_gemini_25_flash() -> None:
+  assert _invoke_capturing_endpoint([]) == "gemini-2.5-flash"

--- a/tests/test_materialize_window.py
+++ b/tests/test_materialize_window.py
@@ -801,6 +801,65 @@ class TestEventsTableThreading:
     assert captured["table_id"] == "custom_events"
 
 
+class TestEndpointThreading:
+  """``endpoint=`` must reach the AI.GENERATE model selection.
+
+  The materializer's ``AI.GENERATE`` model is set when the manager is
+  built (``from_ontology_binding(endpoint=...)``). Before this was
+  threaded, ``run_materialize_window`` had no way to pick the model —
+  every run used the ``gemini-2.5-flash`` default regardless of caller
+  intent. These tests pin the full chain
+  ``run_materialize_window -> _build_manager -> from_ontology_binding``
+  by leaving ``_build_manager`` real and capturing at the factory."""
+
+  def _run_capturing_endpoint(self, fixture_paths, **extra):
+    ontology_yaml, binding_yaml = fixture_paths
+    now = _dt.datetime(2026, 5, 15, 14, 0, tzinfo=_dt.timezone.utc)
+    client = _stub_bq_client([])
+    captured: dict[str, str] = {}
+
+    def _factory(**kwargs):
+      captured["endpoint"] = kwargs.get("endpoint")
+      return mock.Mock(spec=["spec", "extract_graph"])
+
+    with (
+        mock.patch(
+            "bigquery_agent_analytics.ontology_graph."
+            "OntologyGraphManager.from_ontology_binding",
+            side_effect=_factory,
+        ),
+        mock.patch(
+            "bigquery_agent_analytics.ontology_materializer.OntologyMaterializer"
+        ),
+    ):
+      mw.run_materialize_window(
+          project_id="test-proj",
+          dataset_id="test_ds",
+          ontology_path=str(ontology_yaml),
+          binding_path=str(binding_yaml),
+          lookback_hours=6.0,
+          validate_binding=False,
+          bq_client=client,
+          run_started_at=now,
+          **extra,
+      )
+    return captured["endpoint"]
+
+  def test_endpoint_reaches_ai_generate_factory(self, fixture_paths):
+    """An explicit ``endpoint`` reaches
+    ``from_ontology_binding(endpoint=...)`` through the real
+    ``_build_manager`` (no mock on the forwarder)."""
+    assert (
+        self._run_capturing_endpoint(fixture_paths, endpoint="gemini-3.5-flash")
+        == "gemini-3.5-flash"
+    )
+
+  def test_endpoint_defaults_to_gemini_25_flash(self, fixture_paths):
+    """Omitting ``endpoint`` preserves the prior default — this
+    change must not move the model for existing callers."""
+    assert self._run_capturing_endpoint(fixture_paths) == "gemini-2.5-flash"
+
+
 class TestCheckpointCarryForward:
 
   def test_failure_carries_forward_prior_checkpoint(self, fixture_paths):

--- a/tests/test_run_job_property_graph.py
+++ b/tests/test_run_job_property_graph.py
@@ -185,3 +185,22 @@ def test_explicit_mode_unchanged(monkeypatch) -> None:
   assert "property_graph_path" not in kwargs
   assert retargets == [("proj", "graph_ds")]
   assert kwargs["dataset_id"] == "events_ds"
+
+
+def test_endpoint_env_forwarded(monkeypatch) -> None:
+  # BQAA_ENDPOINT must reach run_materialize_window so scheduled deploys can
+  # pick the AI.GENERATE model (e.g. gemini-3.5-flash). Without this the cron
+  # path is pinned to the SDK default regardless of operator intent.
+  rc, kwargs, _ = _drive(
+      monkeypatch, {**_BASE_ENV, "BQAA_ENDPOINT": "gemini-3.5-flash"}
+  )
+  assert rc == 0
+  assert kwargs["endpoint"] == "gemini-3.5-flash"
+
+
+def test_endpoint_defaults_when_env_unset(monkeypatch) -> None:
+  # Unset BQAA_ENDPOINT keeps the SDK default — no behavior change for
+  # existing deploys.
+  rc, kwargs, _ = _drive(monkeypatch, _BASE_ENV)  # no BQAA_ENDPOINT
+  assert rc == 0
+  assert kwargs["endpoint"] == "gemini-2.5-flash"


### PR DESCRIPTION
Let callers and operators choose the AI.GENERATE model for context-graph materialization, across all three surfaces (Python API, CLI, scheduled deploy).

## Why

The `AI.GENERATE` extraction fallback was pinned to the `gemini-2.5-flash` default with no way to select the model. `_resolve_endpoint` already builds a `locations/global` publisher URL, so Gemini 3.x names (e.g. `gemini-3.5-flash`) resolve correctly — the only missing piece was a parameter to set it, plumbed through every entry point operators actually use.

## What

**Commit 1 — Python API:**
- `run_materialize_window(..., endpoint="gemini-2.5-flash")` — new keyword, default unchanged.
- Forwarded to `_build_manager`, which passes it to both manager factories (`from_ontology_binding`, `from_bundles_root`).

**Commit 2 — operator paths (addresses review P2):**
- `bqaa context-graph --endpoint` (default `gemini-2.5-flash`) → forwarded to `run_materialize_window`.
- `run_job.py` reads `BQAA_ENDPOINT` (default `gemini-2.5-flash`) → forwarded through `common_kwargs`; documented in the env header and the startup log line.

**No behavior change for existing callers** — omitting the param / env / flag keeps `gemini-2.5-flash`. Short names resolve to `locations/global`, so `gemini-3.5-flash` works on all three paths.

## Tests

- `tests/test_materialize_window.py::TestEndpointThreading` — endpoint reaches `from_ontology_binding` through the **real** `_build_manager` (not mocked) + unchanged default.
- `tests/test_cli_context_graph_input_modes.py` — `--endpoint` forwarding + default.
- `tests/test_run_job_property_graph.py` — `BQAA_ENDPOINT` forwarding + default.

183 passed across the touched suites.

## Validation (live, real ADK agent + plugin)

Two end-to-end runs on a live project, agent and `AI.GENERATE` both on `gemini-3.5-flash` (Vertex `global` location):

- **Codelab decision graph (DDL-only / `--property-graph`):** `ok=true`, 4/4 sessions; GQL traversal returned real request→option→outcome traces.
- **Explicit MAKO graph (`ontology.yaml` + `binding.yaml` + reference extractor):** `ok=true`, 3/3 sessions, full 11-entity / 12-relationship hub (89 rows). GQL reward loop returned real `reward_value` floats (0.90 / 0.88 / 0.85) from the agent's `compute_reward`.

The Vertex 404 some users may hit on `gemini-3.5-flash` is a location issue, not access: Gemini 3.x lives in the `global` location, which `_resolve_endpoint` already targets.