### PR TITLE
feat(deploy): expose AI.GENERATE endpoint on the scheduled deploy + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ renames, and the migration-v5 compiled-extractor path.
   graph dataset). Explicit `--ontology`/`--binding` is preserved as the advanced
   override (descriptions, inheritance, derived properties, renames, the
   migration-v5 compiled extractor).
+- **Selectable `AI.GENERATE` extraction model**
+  ([#298](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/298))
+  — choose the model for the `ai-fallback` extraction across every surface:
+  `run_materialize_window(endpoint=...)` (Python API), `bqaa context-graph
+  --endpoint` (CLI), and `BQAA_ENDPOINT` for the scheduled `run_job.py` deploy.
+  Short names resolve to the Vertex `locations/global` publisher URL, so Gemini
+  3.x models such as `gemini-3.5-flash` work. Defaults to `gemini-2.5-flash`
+  everywhere, so existing callers are unaffected; ignored under
+  `--extraction-mode=compiled-only` (no AI call is made).
 
 ### Fixed
 

--- a/docs/guides/scheduled-context-graph-deploy.md
+++ b/docs/guides/scheduled-context-graph-deploy.md
@@ -101,6 +101,10 @@ Expect a JSON report with `"mode": "property-graph"` and
 `"sessions_materialized" > 0`. This is the cheapest way to confirm the
 placeholder + split-dataset wiring before deploying.
 
+To validate a specific `AI.GENERATE` model here too, add
+`BQAA_ENDPOINT="gemini-3.5-flash"` to the env block above — the same knob the
+deploy wires from `--endpoint` (bash) / `endpoint` (Terraform).
+
 ## 3. Deploy on a schedule
 
 Pick one path. The **bash** deploy builds its own image inline (Cloud
@@ -126,6 +130,20 @@ source, pre-creates the graph dataset, sets up least-privilege service accounts
 and wires the Cloud Scheduler trigger. (`--property-graph` is incompatible with
 `--extraction-mode=compiled-only`, which the script rejects at the boundary.)
 
+To pick the `AI.GENERATE` extraction model — e.g. a Gemini 3.x model — add
+`--endpoint`; it's wired as `BQAA_ENDPOINT` on the Job. Default is unset, so the
+runtime keeps its `gemini-2.5-flash` default:
+
+```bash
+./examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh \
+  --project "$PROJECT_ID" --region us-central1 \
+  --events-dataset "$EVENTS_DS" --graph-dataset "$GRAPH_DS" \
+  --schedule "0 */6 * * *" \
+  --property-graph property_graph.sql \
+  --endpoint gemini-3.5-flash \
+  --smoke
+```
+
 ### Option B — Terraform
 
 Terraform takes a published image as input, so build one first with
@@ -148,7 +166,12 @@ events_dataset_id = "agent_analytics"
 graph_dataset_id  = "agent_decisions_graph"
 schedule          = "0 */6 * * *"
 property_graph    = true
+# endpoint        = "gemini-3.5-flash"   # optional: AI.GENERATE model (BQAA_ENDPOINT)
 ```
+
+Set `endpoint` to pick the `AI.GENERATE` model (e.g. a Gemini 3.x model); it
+wires `BQAA_ENDPOINT` on the Job. Leave it at its `""` default to keep the
+runtime's `gemini-2.5-flash`.
 
 ```bash
 cd examples/migration_v5/periodic_materialization/terraform
@@ -183,6 +206,18 @@ The Cloud Logging entry per run is structured JSON; the key fields are
 
 Then query the graph itself — the materialized decision traces are GQL-queryable
 exactly as in [Phase 4 of the codelab](../codelabs/periodic_materialization.md).
+
+## Troubleshooting
+
+**`404 NOT_FOUND ... Publisher Model ... was not found or your project does not
+have access to it`** when you set `--endpoint` / `BQAA_ENDPOINT` to a Gemini 3.x
+model. This is almost always a *location* mismatch, not an access problem:
+Gemini 3.x models on Vertex AI are served from the **`global`** location, and
+the SDK already resolves a short model name (`gemini-3.5-flash`) to a
+`locations/global` publisher URL. If you still hit a 404, pass the model name
+exactly as published for Vertex AI's `global` endpoint (a regional name like a
+`us-central1`-only model will 404), and confirm the model is enabled for your
+project. The runtime's default `gemini-2.5-flash` works without any of this.
 
 ## When to use explicit `--ontology` / `--binding` instead
 

--- a/examples/migration_v5/periodic_materialization/README.md
+++ b/examples/migration_v5/periodic_materialization/README.md
@@ -306,6 +306,13 @@ Requirements / limits:
 * Not compatible with `--extraction-mode=compiled-only` (no reference
   extractors are staged in derived mode); the deploy rejects that combination.
 
+**Pick the `AI.GENERATE` model.** Add `--endpoint MODEL` to choose the
+extraction model; it wires `BQAA_ENDPOINT` on the Job. Default is unset, so the
+runtime keeps its `gemini-2.5-flash` default. Short names resolve to the Vertex
+`locations/global` publisher URL, so Gemini 3.x models such as
+`gemini-3.5-flash` work. Ignored under `--extraction-mode=compiled-only` (no AI
+call is made). Applies to both the schema-derived and explicit paths (#298).
+
 **Advanced — explicit ontology + binding.** Omit `--property-graph` to keep the
 default MAKO path: descriptions for AI prompting, entity inheritance, derived
 properties, column renames, and the hand-authored compiled extractor. That is

--- a/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/migration_v5/periodic_materialization/deploy_cloud_run_job.sh
@@ -102,6 +102,7 @@ JOB_NAME="bqaa-periodic-materialization"
 SMOKE=false
 EXTRACTION_MODE="ai-fallback"
 PROPERTY_GRAPH=""
+ENDPOINT=""
 MAX_SESSION_AGE_HOURS=""
 # Production posture by default: split runtime + scheduler-caller
 # SAs (issue #182). ``--single-sa`` is the escape hatch for
@@ -157,6 +158,13 @@ Optional:
                                table_ddl.sql must sit next to it. Use for
                                rename-free graphs; not compatible with
                                --extraction-mode=compiled-only.
+  --endpoint MODEL             Vertex AI model for the AI.GENERATE extraction
+                               fallback, wired as BQAA_ENDPOINT on the Job.
+                               Short names resolve to the locations/global
+                               publisher URL, so Gemini 3.x models (e.g.
+                               gemini-3.5-flash) work. Default unset → the
+                               runtime's gemini-2.5-flash. Ignored under
+                               --extraction-mode=compiled-only (no AI call).
   --max-session-age-hours N    Enable the orphan-session watchdog (issue
                                #180). When set, each cron pass additionally
                                scans for sessions whose first event is
@@ -224,6 +232,7 @@ while [[ $# -gt 0 ]]; do
     --smoke)           SMOKE=true; shift ;;
     --extraction-mode) require_arg "$1" "${2-}"; EXTRACTION_MODE="$2"; shift 2 ;;
     --property-graph)  require_arg "$1" "${2-}"; PROPERTY_GRAPH="$2"; shift 2 ;;
+    --endpoint)        require_arg "$1" "${2-}"; ENDPOINT="$2"; shift 2 ;;
     --max-session-age-hours)
                        require_arg "$1" "${2-}"; MAX_SESSION_AGE_HOURS="$2"; shift 2 ;;
     --single-sa)       SINGLE_SA=true; shift ;;
@@ -729,6 +738,12 @@ fi
 # property graph instead of the explicit ontology/binding pair (#286).
 if [[ -n "$PROPERTY_GRAPH" ]]; then
   ENV_VARS+=("BQAA_PROPERTY_GRAPH=property_graph.sql")
+fi
+# AI.GENERATE model selection (#298). Only wired when the operator opts in via
+# ``--endpoint``; default deploys leave it unset so the runtime keeps its own
+# gemini-2.5-flash default. No-op under compiled-only (run_job ignores it).
+if [[ -n "$ENDPOINT" ]]; then
+  ENV_VARS+=("BQAA_ENDPOINT=${ENDPOINT}")
 fi
 # Orphan-session watchdog (issue #180). Only wired when the
 # operator explicitly opts in via ``--max-session-age-hours``;

--- a/examples/migration_v5/periodic_materialization/terraform/README.md
+++ b/examples/migration_v5/periodic_materialization/terraform/README.md
@@ -11,7 +11,7 @@ Resolves [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-
 | Graph dataset | `google_bigquery_dataset` | §1 — `bq mk` (pre-create so the runtime SA never needs `bigquery.datasets.create`) |
 | Runtime SA + scheduler-caller SA | `google_service_account` ×2 | §2 — `_ensure_sa` (split by default; `single_sa = true` collapses to one) |
 | Project + dataset IAM grants | `google_project_iam_member`, `google_bigquery_dataset_iam_member` | §3 — `_retry_iam gcloud projects add-iam-policy-binding` and the dataset-level grant block. Terraform's dependency graph handles the IAM-propagation race declaratively (the `depends_on` on the Cloud Run Job resource ensures grants land before the first invocation) |
-| Cloud Run v2 Job | `google_cloud_run_v2_job` | §4 — `gcloud run jobs deploy`. Same env-var set the bash deploy wires (`BQAA_PROJECT_ID`, `BQAA_EVENTS_DATASET_ID`, `BQAA_GRAPH_DATASET_ID`, `BQAA_LOCATION`, `BQAA_LOOKBACK_HOURS`, `BQAA_OVERLAP_MINUTES`, `BQAA_EXTRACTION_MODE`, `BQAA_MAX_RETRIES`, conditionally `BQAA_MAX_SESSIONS`, `BQAA_MAX_SESSION_AGE_HOURS`, `BQAA_REFERENCE_EXTRACTORS_MODULE`, and `BQAA_PROPERTY_GRAPH` when `property_graph = true`) |
+| Cloud Run v2 Job | `google_cloud_run_v2_job` | §4 — `gcloud run jobs deploy`. Same env-var set the bash deploy wires (`BQAA_PROJECT_ID`, `BQAA_EVENTS_DATASET_ID`, `BQAA_GRAPH_DATASET_ID`, `BQAA_LOCATION`, `BQAA_LOOKBACK_HOURS`, `BQAA_OVERLAP_MINUTES`, `BQAA_EXTRACTION_MODE`, `BQAA_MAX_RETRIES`, conditionally `BQAA_MAX_SESSIONS`, `BQAA_MAX_SESSION_AGE_HOURS`, `BQAA_REFERENCE_EXTRACTORS_MODULE`, `BQAA_PROPERTY_GRAPH` when `property_graph = true`, and `BQAA_ENDPOINT` when `endpoint != ""`) |
 | `roles/run.invoker` on the job → scheduler SA | `google_cloud_run_v2_job_iam_member` | §5 — `_retry_iam gcloud run jobs add-iam-policy-binding` |
 | Cloud Scheduler trigger | `google_cloud_scheduler_job` | §6 — `gcloud scheduler jobs create http` with `--oauth-service-account-email` pointing at the scheduler SA |
 
@@ -88,6 +88,7 @@ image_uri          = "us-central1-docker.pkg.dev/my-project/bqaa/periodic-materi
 # Optional overrides — defaults match the bash deploy
 # property_graph        = false   # true → schema-derived mode (see below)
 # extraction_mode       = "ai-fallback"
+# endpoint              = ""       # AI.GENERATE model (BQAA_ENDPOINT); e.g. "gemini-3.5-flash"
 # max_retries           = 2
 # max_session_age_hours = 24
 # single_sa             = false
@@ -180,6 +181,7 @@ Optional (defaults match `deploy_cloud_run_job.sh`):
 * `location` — `"US"`
 * `job_name` — `"bqaa-periodic-materialization"`
 * `extraction_mode` — `"ai-fallback"`
+* `endpoint` — `""` (AI.GENERATE model; wires `BQAA_ENDPOINT` when non-empty, e.g. `"gemini-3.5-flash"`; `""` → runtime default `gemini-2.5-flash`)
 * `max_retries` — `2`
 * `max_session_age_hours` — `null` (watchdog disabled)
 * `single_sa` — `false` (split-SA default)

--- a/examples/migration_v5/periodic_materialization/terraform/main.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/main.tf
@@ -72,6 +72,13 @@ locals {
     var.property_graph ? {
       BQAA_PROPERTY_GRAPH = "property_graph.sql"
     } : {},
+    # AI.GENERATE model selection (#298). Empty string (default) leaves
+    # BQAA_ENDPOINT unset so the runtime keeps its own gemini-2.5-flash
+    # default; a value wires the env var. Mirrors the bash deploy's
+    # ``--endpoint`` → ``BQAA_ENDPOINT`` wiring. No-op under compiled-only.
+    var.endpoint == "" ? {} : {
+      BQAA_ENDPOINT = var.endpoint
+    },
   )
 }
 

--- a/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
+++ b/examples/migration_v5/periodic_materialization/terraform/terraform.tfvars.example
@@ -19,6 +19,8 @@ image_uri         = "us-central1-docker.pkg.dev/your-project/bqaa/periodic-mater
 #                                         #        build the image with build_image.sh --property-graph;
 #                                         #        not compatible with extraction_mode = "compiled-only"
 # extraction_mode       = "ai-fallback"   # or "compiled-only"
+# endpoint              = ""               # AI.GENERATE model (BQAA_ENDPOINT); e.g. "gemini-3.5-flash";
+#                                         #        "" → runtime default gemini-2.5-flash
 # max_retries           = 2
 # max_session_age_hours = 24              # null → orphan watchdog disabled
 # single_sa             = false           # true → combined bqaa-periodic-sa identity

--- a/examples/migration_v5/periodic_materialization/terraform/variables.tf
+++ b/examples/migration_v5/periodic_materialization/terraform/variables.tf
@@ -80,6 +80,12 @@ variable "property_graph" {
   default     = false
 }
 
+variable "endpoint" {
+  description = "AI.GENERATE model selection (#298). Vertex AI model for the ``ai-fallback`` extraction call, wired as ``BQAA_ENDPOINT`` on the Job. Short names resolve to the ``locations/global`` publisher URL, so Gemini 3.x models (e.g. ``gemini-3.5-flash``) work. Empty string (default) leaves ``BQAA_ENDPOINT`` unset so the runtime keeps its own ``gemini-2.5-flash`` default. Ignored under ``extraction_mode = \"compiled-only\"`` (no AI call is made)."
+  type        = string
+  default     = ""
+}
+
 variable "max_retries" {
   description = "Cloud Run Job retry count on failure. The orchestrator's session-level idempotency + append-only state table make additional retries safe. Default 2 matches the deploy script post-#183 (production posture: silently absorb transient BQ slot pressure / rate-limit noise instead of paging on-call)."
   type        = number

--- a/tests/test_deploy_property_graph_mode.py
+++ b/tests/test_deploy_property_graph_mode.py
@@ -159,3 +159,13 @@ def test_build_image_property_graph_staging_contract() -> None:
   # Terraform-built images can't bake hardcoded artifacts either.
   assert "grep -qF '${PROJECT_ID}'" in text
   assert "grep -qF '${DATASET}'" in text
+
+
+def test_deploy_script_endpoint_wiring() -> None:
+  # --endpoint MODEL must wire BQAA_ENDPOINT on the Job, and only when set
+  # (unset leaves the runtime's gemini-2.5-flash default in place) — so an
+  # operator can pick Gemini 3.x on the scheduled path, not just locally.
+  text = _DEPLOY.read_text()
+  assert "--endpoint)" in text
+  assert '[[ -n "$ENDPOINT" ]]' in text
+  assert 'ENV_VARS+=("BQAA_ENDPOINT=${ENDPOINT}")' in text

--- a/tests/test_terraform_property_graph_mode.py
+++ b/tests/test_terraform_property_graph_mode.py
@@ -64,6 +64,18 @@ def test_tfvars_example_documents_property_graph() -> None:
   assert "property_graph" in _TFVARS
 
 
+def test_endpoint_variable_declared() -> None:
+  assert 'variable "endpoint"' in _VARS
+  assert "type        = string" in _VARS
+
+
+def test_endpoint_env_wired_conditionally() -> None:
+  # BQAA_ENDPOINT is set only when var.endpoint is non-empty — mirrors the
+  # bash deploy's `[[ -n "$ENDPOINT" ]]` guard so the two surfaces don't drift.
+  assert 'var.endpoint == "" ?' in _MAIN
+  assert "BQAA_ENDPOINT = var.endpoint" in _MAIN
+
+
 @pytest.mark.skipif(
     shutil.which("terraform") is None, reason="terraform binary not available"
 )


### PR DESCRIPTION
Completes the operator path for the AI.GENERATE endpoint knob introduced in #298, plus the release/runbook hygiene that the #298 review called out.

## The gap this closes

#298 wired `BQAA_ENDPOINT` into `run_job.py`, but the deploy wrappers that *set* the Job's env did not forward it — `deploy_cloud_run_job.sh` built a fixed `ENV_VARS` set and Terraform had no `endpoint` variable. So an operator using the bash or Terraform deploy could not pick a Gemini 3.x model through the deploy interface (only via the local `run_job.py` validate step, the one-off CLI, or a manual `gcloud run jobs update`). A runbook example would have been misleading without this.

## What

- **`deploy_cloud_run_job.sh`** — `--endpoint MODEL` appends `BQAA_ENDPOINT` to the Job env, only when set (unset keeps the runtime's `gemini-2.5-flash`). Documented in `--help`.
- **Terraform** — new `endpoint` string variable (default `""`); merged into `env_vars` only when non-empty, mirroring the bash guard so the two surfaces stay in lockstep. Documented in `terraform.tfvars.example`.
- **`docs/guides/scheduled-context-graph-deploy.md`** — Gemini 3.x examples on the local validate step, the bash deploy, and Terraform; plus a **Troubleshooting** note for the Vertex `404 ... Publisher Model not found` (Gemini 3.x is served from the `global` location, which the SDK already targets).
- **CHANGELOG** — folds the endpoint knob into `[0.3.3]` (0.3.3 is not yet on PyPI — latest published is 0.3.2 — so it ships as part of that release rather than a separate patch).

## Tests

- `test_deploy_property_graph_mode.py::test_deploy_script_endpoint_wiring` — `--endpoint` arg + conditional `BQAA_ENDPOINT` append.
- `test_terraform_property_graph_mode.py` — `endpoint` variable declared + conditional env wiring.

`terraform fmt -check` clean, `shellcheck -S error` clean, `bash -n` clean. 32 passed across the deploy / Terraform / run_job / CLI suites.

Follows #298 (Python API + CLI + `run_job.py` endpoint) and #296 (this runbook).