### PR TITLE
feat: --graph mode — materialize from the deployed property graph via INFORMATION_SCHEMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-06-10
+
+### Release highlights
+
+Consume the graph you already deployed. `bqaa context-graph --graph <name>`
+reads your property graph's definition back from BigQuery's
+`INFORMATION_SCHEMA.PROPERTY_GRAPHS` and derives the ontology + binding from
+it plus the live table schemas — no SQL file is passed to (or staged for) the
+materializer. You deploy the graph with standard `bq` DDL once; from then on
+the deployed graph is the single source of truth, so what you query with GQL
+and what gets materialized can never drift apart. The docs (codelab, blog,
+scheduled-deploy runbook, guides) now teach this flow exclusively.
+
+### Added
+
+- **Deployed-graph (`--graph`) materialization mode** — point the
+  materializer at a property graph that already exists in BigQuery instead of
+  a local DDL file. Available on every surface: `bqaa context-graph --graph`
+  (CLI; accepts a bare name resolved in `--dataset-id`, or qualified
+  `dataset.graph` / `project.dataset.graph`),
+  `run_materialize_window(graph=...)` (Python API), `BQAA_GRAPH` (scheduled
+  `run_job.py`), `deploy_cloud_run_job.sh --graph`, and the Terraform
+  module's `graph` variable. The SDK fetches the normalized `CREATE PROPERTY
+  GRAPH` statement from the dataset-qualified
+  `INFORMATION_SCHEMA.PROPERTY_GRAPHS` view and feeds the existing
+  schema-derive pipeline; a missing graph fails with an error that lists the
+  graphs the dataset does contain. In deployed-graph deploys nothing is
+  staged into the image and the entity-table bootstrap is skipped (the
+  graph's existence proves its node/edge tables exist). Mutually exclusive
+  with `--property-graph` and `--ontology`/`--binding`; incompatible with
+  `--extraction-mode=compiled-only` (no reference extractors are staged in
+  derived mode).
+
+### Changed
+
+- **Docs teach only the deployed-graph flow.** The codelab (+ regenerated
+  Colab notebook), blog post, scheduled Context Graph deploy runbook, the
+  Conversational Analytics-first guide, and the example READMEs now apply the
+  table DDL + `CREATE PROPERTY GRAPH` to BigQuery as the one-time deploy step
+  and materialize with `--graph` / `BQAA_GRAPH` / `graph =`. The file-based
+  `--property-graph` mode from 0.3.3 keeps working for existing scripts and
+  images but is no longer documented; prefer `--graph`.
+
 ## [0.3.3] - 2026-06-08
 
 ### Release highlights

--- a/docs/blog/periodic_materialization.md
+++ b/docs/blog/periodic_materialization.md
@@ -67,7 +67,7 @@ bqaa seed-events \
 
 ### Step 2: Define the context graph
 
-Declare the graph shape once, in standard SQL. This models the decision flow: requests, the options each request weighed, the committed outcome, and the edges that connect them.
+Declare the graph shape once, in standard SQL, and run it in BigQuery. This models the decision flow: requests, the options each request weighed, the committed outcome, and the edges that connect them. The deployed graph becomes the single source of truth — the materializer in the next step reads this definition back from BigQuery's `INFORMATION_SCHEMA.PROPERTY_GRAPHS`.
 
 ```sql
 CREATE OR REPLACE PROPERTY GRAPH agent_analytics.agent_decisions_graph
@@ -98,12 +98,12 @@ CREATE OR REPLACE PROPERTY GRAPH agent_analytics.agent_decisions_graph
 
 ### Step 3: Extract context graph from agent traces
 
-A single command reads the raw `agent_events` and populates the graph tables. It derives what to extract directly from the property graph you defined in Step 2: `bqaa context-graph` reads that `CREATE PROPERTY GRAPH` definition and the schemas of the tables it references, so the property-graph schema is the only thing you author — no separate ontology or binding file. For local development, run the materializer once:
+A single command reads the raw `agent_events` and populates the graph tables. It derives what to extract directly from the graph you deployed in Step 2: `bqaa context-graph` reads the `CREATE PROPERTY GRAPH` definition back from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` along with the schemas of the tables it references, so the property-graph schema is the only thing you author — no SQL file handed to the materializer, no separate ontology or binding file. For local development, run the materializer once:
 
 ```bash
 bqaa context-graph \
     --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
-    --property-graph property_graph.sql \
+    --graph agent_decisions_graph \
     --lookback-hours 24
 ```
 

--- a/docs/codelabs/periodic_materialization.md
+++ b/docs/codelabs/periodic_materialization.md
@@ -188,7 +188,7 @@ Duration: 02:00
 
 The codelab needs just two ready-to-use artifacts: the **table DDL** (the physical graph tables) and the **property-graph schema** (`CREATE PROPERTY GRAPH`). You do not author either yourself; the codelab uses them as-is, and the [README in the artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/codelab/periodic_materialization/README.md) explains how to adapt them for your own decision domain.
 
-The property-graph schema is the single source of truth for *what* the graph contains. `bqaa context-graph` reads it (plus your table schemas) to figure out which entities and relationships to extract and where to write them — so you do **not** need to write a separate ontology or binding file.
+The property-graph schema is the single source of truth for *what* the graph contains. You apply it to BigQuery once; from then on the **deployed graph itself is the contract**: `bqaa context-graph` reads the graph's definition back from BigQuery's `INFORMATION_SCHEMA.PROPERTY_GRAPHS` (plus your table schemas) to figure out which entities and relationships to extract and where to write them — so you do **not** need to write a separate ontology or binding file, and no SQL file is ever passed to the materializer.
 
 This codelab is self-contained: the cell below writes the two artifacts into a working directory, so there is nothing to download. They are the same files shipped in [`examples/codelab/periodic_materialization/`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization).
 
@@ -299,7 +299,7 @@ DecisionRequest --[evaluatesOption]--> DecisionOption
 `DecisionRequest` is the question the agent received. `DecisionOption` is one alternative the agent considered. `DecisionOutcome` records the committed choice and the rationale.
 
 > aside positive
-> **Advanced: bring your own ontology + binding.** Schema-derived mode covers the common case. When you need finer control — human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames — author an explicit `ontology.yaml` + `binding.yaml` and pass `--ontology`/`--binding` instead of `--property-graph`. The [artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization) ships both files as a starting point.
+> **Advanced: bring your own ontology + binding.** Schema-derived mode covers the common case. When you need finer control — human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames — author an explicit `ontology.yaml` + `binding.yaml` and pass `--ontology`/`--binding` instead of `--graph`. The [artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization) ships both files as a starting point.
 
 ## Apply the property graph schema
 
@@ -316,7 +316,7 @@ envsubst < property_graph.sql | bq query --use_legacy_sql=false
 
 You should see five `CREATE TABLE` results and one `CREATE PROPERTY GRAPH` result. The DDL is idempotent; you can re-run it safely.
 
-That is the only schema work you do. Because `bqaa context-graph` derives what to extract from this property graph, there is no separate binding file to render — the `${PROJECT_ID}` / `${DATASET}` markers in `property_graph.sql` are resolved for you from `--project-id` / `--dataset-id` when you materialize.
+That is the only schema work you do — and the only time the SQL files are used. BigQuery now records your graph's definition, and `bqaa context-graph` reads it back from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` by name, so there is no separate binding file to render and no SQL file to pass to the materializer. What you query with GQL and what gets materialized can never drift apart: they are the same deployed graph.
 
 ## Generate sample agent events
 
@@ -406,7 +406,7 @@ The 10 orphaned sessions never emitted `AGENT_COMPLETED`, so the default `bqaa c
 
 Duration: 05:00
 
-`bqaa context-graph` reads the raw `agent_events`, then **derives what to extract directly from your property graph**: it reads the `CREATE PROPERTY GRAPH` definition you applied in *Apply the property graph schema* and the schemas of the tables it references, works out the entities, relationships, and column types, and populates the graph tables. Point it at `property_graph.sql` with `--property-graph` — no separate ontology or binding file required.
+`bqaa context-graph` reads the raw `agent_events`, then **derives what to extract directly from your deployed graph**: it reads the `CREATE PROPERTY GRAPH` definition you applied in *Apply the property graph schema* back from BigQuery's `INFORMATION_SCHEMA.PROPERTY_GRAPHS`, joins it with the schemas of the tables it references, works out the entities, relationships, and column types, and populates the graph tables. Point it at the deployed graph by name with `--graph` — no SQL file, no separate ontology or binding file.
 
 **Run the materializer** locally:
 
@@ -415,7 +415,7 @@ Duration: 05:00
 bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
-    --property-graph ~/bqaa-codelab/property_graph.sql \
+    --graph agent_decisions_graph \
     --lookback-hours 24 \
     --format json
 ```
@@ -577,7 +577,7 @@ TO=$(date -u -d "8 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
 bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
-    --property-graph ~/bqaa-codelab/property_graph.sql \
+    --graph agent_decisions_graph \
     --lookback-hours 1 \
     --backfill --from "$FROM" --to "$TO" \
     --state-key-suffix codelab_backfill_demo \
@@ -592,10 +592,10 @@ os.environ["TO"]   = (now - datetime.timedelta(hours=8)).strftime("%Y-%m-%dT%H:%
 print(f"Backfill window FROM = {os.environ['FROM']}")
 print(f"Backfill window TO   = {os.environ['TO']}")
 
-!cd ~/bqaa-codelab && bqaa context-graph \
+!bqaa context-graph \
     --project-id "$PROJECT_ID" \
     --dataset-id "$DATASET" \
-    --property-graph property_graph.sql \
+    --graph agent_decisions_graph \
     --lookback-hours 1 \
     --backfill --from "$FROM" --to "$TO" \
     --state-key-suffix codelab_backfill_demo \
@@ -639,7 +639,7 @@ The local run you completed in *Materialize the decision graph* uses default beh
 * **Bound the per-run batch size** (`--max-sessions`). Useful when an upstream event spike threatens to overwhelm a single scan.
 
 > aside positive
-> **From "run this once" to "run this every six hours":** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. Follow the [scheduled Context Graph deploy runbook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/guides/scheduled-context-graph-deploy.md) to take *this* `--property-graph` graph to a scheduled deploy with the same one-artifact flow, or the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/context_graph/periodic_materialization) for the full IAM matrix and the explicit-ontology/binding path.
+> **From "run this once" to "run this every six hours":** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. Follow the [scheduled Context Graph deploy runbook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/guides/scheduled-context-graph-deploy.md) to take *this* deployed graph to a scheduled deploy with the same `--graph` flow, or the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/context_graph/periodic_materialization) for the full IAM matrix and the explicit-ontology/binding path.
 
 ## Clean up
 
@@ -667,7 +667,7 @@ Duration: 02:00
 
 Congratulations! You've turned raw agent event logs into a queryable Context Graph in BigQuery and traced a single decision end-to-end, with no external graph database or ETL pipeline.
 
-The same pattern applies wherever an agent makes consequential decisions: credit underwriting, prior authorization, marketing budget moves, procurement, customer service, and internal IT. To build your own decision graph, copy the codelab artifacts as a starting point and adapt the two declarative files (table DDL + the `CREATE PROPERTY GRAPH` schema) to your domain — `bqaa context-graph --property-graph` derives the rest. Reach for an explicit `ontology.yaml` + `binding.yaml` only when you need descriptions, inheritance, derived properties, or column renames.
+The same pattern applies wherever an agent makes consequential decisions: credit underwriting, prior authorization, marketing budget moves, procurement, customer service, and internal IT. To build your own decision graph, copy the codelab artifacts as a starting point, adapt the two declarative files (table DDL + the `CREATE PROPERTY GRAPH` schema) to your domain, and apply them to BigQuery — `bqaa context-graph --graph` reads the deployed graph and derives the rest. Reach for an explicit `ontology.yaml` + `binding.yaml` only when you need descriptions, inheritance, derived properties, or column renames.
 
 #### What you've learned
 

--- a/docs/guides/conversational-analytics-first.md
+++ b/docs/guides/conversational-analytics-first.md
@@ -36,8 +36,8 @@ an audit artifact.
 already followed the
 [Periodic Materialization codelab](../codelabs/periodic_materialization.md)
 through materialization, so that your project has: the dataset created, the
-graph-table DDL applied, and the `agent_decisions_graph` property graph defined
-(`property_graph.sql`). That setup is about ten minutes and is not repeated
+graph-table DDL applied, and the `agent_decisions_graph` property graph
+deployed to BigQuery. That setup is about ten minutes and is not repeated
 here.
 
 With the codelab setup in place, the only two commands specific to this guide
@@ -52,11 +52,13 @@ bqaa seed-events \
     --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
     --scenario decision-realistic --seed 42
 
-# 2. Materialize the decision graph from the events. --lookback-hours 80
-#    covers the corpus's 72-hour spread so every completed session is captured.
+# 2. Materialize the decision graph from the events. The materializer reads
+#    the deployed graph's definition back from INFORMATION_SCHEMA.PROPERTY_GRAPHS.
+#    --lookback-hours 80 covers the corpus's 72-hour spread so every completed
+#    session is captured.
 bqaa context-graph \
     --project-id "$PROJECT_ID" --dataset-id "$DATASET" \
-    --property-graph property_graph.sql \
+    --graph agent_decisions_graph \
     --lookback-hours 80
 ```
 

--- a/docs/guides/scheduled-context-graph-deploy.md
+++ b/docs/guides/scheduled-context-graph-deploy.md
@@ -1,10 +1,13 @@
-# Deploy a Context Graph on a schedule — one artifact
+# Deploy a Context Graph on a schedule — consume the deployed graph
 
 This runbook takes the [Periodic Materialization codelab](../codelabs/periodic_materialization.md)
 graph from a local run to a **hands-off scheduled production deploy**, using the
-schema-derived (`--property-graph`) flow: you ship one `property_graph.sql` (plus
-its companion `table_ddl.sql`) and the Cloud Run Job derives the ontology +
-binding from it — no hand-written `ontology.yaml` / `binding.yaml`.
+deployed-graph (`--graph`) flow: you create the property graph in BigQuery once
+(standard `bq` DDL), and the Cloud Run Job reads the graph's definition back
+from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` on every run and derives the
+ontology + binding from it — no hand-written `ontology.yaml` / `binding.yaml`,
+and no SQL file shipped in the image. The deployed graph is the single source
+of truth: what you query with GQL is exactly what the job materializes.
 
 It's the rename-free / common path. For richer graphs (descriptions to steer the
 AI prompt, entity inheritance, derived properties, column renames, or a
@@ -12,14 +15,15 @@ compiled extractor) keep the explicit `--ontology` / `--binding` path in the
 [context-graph deploy README](../../examples/context_graph/periodic_materialization/README.md),
 which is also the deep reference for IAM, scheduling, monitoring, and teardown.
 
-> Requires `bigquery-agent-analytics >= 0.3.3`.
+> Requires `bigquery-agent-analytics >= 0.3.4`.
 
 ## The shape
 
 ```
 agent_events                run_job.py (Cloud Run Job, every N hrs):
-(your EVENTS dataset)  ───►   1. apply table_ddl.sql  → graph tables exist
-   read-only                  2. derive ontology+binding from property_graph.sql
+(your EVENTS dataset)  ───►   1. read graph DDL from INFORMATION_SCHEMA
+   read-only                     .PROPERTY_GRAPHS (your GRAPH dataset)
+                              2. derive ontology+binding from it
                               3. materialize sessions  → node/edge tables
                                                           (your GRAPH dataset)
                                           │
@@ -29,17 +33,16 @@ agent_events                run_job.py (Cloud Run Job, every N hrs):
 ```
 
 Two datasets, two lifecycles: **events** is read-only (your agents write it);
-**graph** is writable (the job creates the tables, the materialized graph, and
-the state table). `bqaa context-graph --property-graph` resolves the
-`${PROJECT_ID}` / `${DATASET}` placeholders so everything lands in the graph
-dataset while events stay read-only.
+**graph** is writable (you create the tables + the property graph once; the job
+writes the materialized rows and the state table). You deploy the graph schema
+yourself in step 1; from then on the job only ever *reads* the definition.
 
 ## 0. Prerequisites
 
 ```bash
 export PROJECT_ID="your-project"
-export EVENTS_DS="agent_analytics"     # read-only: holds agent_events
-export GRAPH_DS="agent_decisions_graph"  # writable: holds the materialized graph
+export EVENTS_DS="agent_analytics"   # read-only: holds agent_events
+export GRAPH_DS="decision_graph"     # writable: holds the materialized graph
 
 gcloud services enable \
   bigquery.googleapis.com run.googleapis.com cloudscheduler.googleapis.com \
@@ -47,7 +50,7 @@ gcloud services enable \
   aiplatform.googleapis.com --project="$PROJECT_ID"
 ```
 
-`aiplatform.googleapis.com` is needed because schema-derived mode uses
+`aiplatform.googleapis.com` is needed because deployed-graph mode uses
 `AI.GENERATE` extraction (`ai-fallback`). The deploy script grants the runtime
 service account `roles/aiplatform.user` automatically in that mode.
 
@@ -60,46 +63,54 @@ bqaa seed-events --project-id "$PROJECT_ID" --dataset-id "$EVENTS_DS" \
     --scenario decision --sessions 5
 ```
 
-## 1. Your two artifacts
+## 1. Deploy your graph to BigQuery
 
-Schema-derived mode needs exactly two **placeholdered** files. The codelab ships
-both, ready to adapt:
+This is the only schema work you do, and you do it once. The codelab ships
+both DDL files, ready to adapt to your own decision domain:
 
 ```bash
 cp examples/codelab/periodic_materialization/property_graph.sql .
 cp examples/codelab/periodic_materialization/table_ddl.sql .
+
+bq --location=US mk --dataset "$PROJECT_ID:$GRAPH_DS" 2>/dev/null || true
+
+# The files are placeholdered for envsubst; the graph lives in the GRAPH
+# dataset, so render ${DATASET} as $GRAPH_DS. Tables first — CREATE PROPERTY
+# GRAPH rejects references to tables that do not exist yet.
+DATASET="$GRAPH_DS" envsubst < table_ddl.sql      | bq query --use_legacy_sql=false
+DATASET="$GRAPH_DS" envsubst < property_graph.sql | bq query --use_legacy_sql=false
 ```
 
-Both must use `${PROJECT_ID}` / `${DATASET}` (not hardcoded references) — the
-deploy refuses hardcoded artifacts so the scheduled job can never derive against
-the wrong dataset, and `table_ddl.sql` must sit next to `property_graph.sql`.
+BigQuery now records the graph's definition; everything downstream consumes it
+by name (`agent_decisions_graph`) via `INFORMATION_SCHEMA.PROPERTY_GRAPHS`.
+Confirm it's there:
+
+```bash
+bq query --use_legacy_sql=false \
+ "SELECT property_graph_name FROM \`$PROJECT_ID.$GRAPH_DS\`.INFORMATION_SCHEMA.PROPERTY_GRAPHS"
+# → agent_decisions_graph
+```
 
 ## 2. Validate locally before you pay for Cloud Run
 
 Run the job's runtime entrypoint on your laptop against the real datasets — same
-code path the Cloud Run Job runs, no container:
+code path the Cloud Run Job runs, no container, nothing staged:
 
 ```bash
-pip install -e .   # or: pip install 'bigquery-agent-analytics>=0.3.3'
-
-# Stage the runtime + your two artifacts together (mirrors what the deploy
-# script bundles into the image).
-mkdir -p /tmp/cg-deploy && cp \
-  examples/context_graph/periodic_materialization/run_job.py \
-  property_graph.sql table_ddl.sql /tmp/cg-deploy/
+pip install -e .   # or: pip install 'bigquery-agent-analytics>=0.3.4'
 
 BQAA_PROJECT_ID="$PROJECT_ID" \
 BQAA_EVENTS_DATASET_ID="$EVENTS_DS" \
 BQAA_GRAPH_DATASET_ID="$GRAPH_DS" \
-BQAA_PROPERTY_GRAPH="property_graph.sql" \
+BQAA_GRAPH="agent_decisions_graph" \
 BQAA_LOOKBACK_HOURS="72" \
 BQAA_LOCATION="US" \
-python /tmp/cg-deploy/run_job.py
+python examples/context_graph/periodic_materialization/run_job.py
 ```
 
-Expect a JSON report with `"mode": "property-graph"` and
+Expect a JSON report with `"mode": "deployed-graph"` and
 `"sessions_materialized" > 0`. This is the cheapest way to confirm the
-placeholder + split-dataset wiring before deploying.
+graph lookup + split-dataset wiring before deploying.
 
 To validate a specific `AI.GENERATE` model here too, add
 `BQAA_ENDPOINT="gemini-3.5-flash"` to the env block above — the same knob the
@@ -119,15 +130,15 @@ first.
   --project "$PROJECT_ID" --region us-central1 \
   --events-dataset "$EVENTS_DS" --graph-dataset "$GRAPH_DS" \
   --schedule "0 */6 * * *" \
-  --property-graph property_graph.sql \
+  --graph agent_decisions_graph \
   --smoke
 ```
 
 `--smoke` runs the job once after deploy and tails the logs, so you find out
 *now* whether it works. The script builds + publishes the image from local
 source, pre-creates the graph dataset, sets up least-privilege service accounts
-+ IAM, deploys the Cloud Run Job with `BQAA_PROPERTY_GRAPH=property_graph.sql`,
-and wires the Cloud Scheduler trigger. (`--property-graph` is incompatible with
++ IAM, deploys the Cloud Run Job with `BQAA_GRAPH=agent_decisions_graph`,
+and wires the Cloud Scheduler trigger. (`--graph` is incompatible with
 `--extraction-mode=compiled-only`, which the script rejects at the boundary.)
 
 To pick the `AI.GENERATE` extraction model — e.g. a Gemini 3.x model — add
@@ -139,21 +150,20 @@ runtime keeps its `gemini-2.5-flash` default:
   --project "$PROJECT_ID" --region us-central1 \
   --events-dataset "$EVENTS_DS" --graph-dataset "$GRAPH_DS" \
   --schedule "0 */6 * * *" \
-  --property-graph property_graph.sql \
+  --graph agent_decisions_graph \
   --endpoint gemini-3.5-flash \
   --smoke
 ```
 
 ### Option B — Terraform
 
-Terraform takes a published image as input, so build one first with
-`build_image.sh --property-graph` (it stages `property_graph.sql` + the sibling
-`table_ddl.sql` instead of `ontology.yaml`/`binding.yaml`/`reference_extractor.py`):
+Terraform takes a published image as input, so build one first. Deployed-graph
+mode needs nothing staged beyond the runtime, so the default build works as-is:
 
 ```bash
 IMAGE_URI="$(./examples/context_graph/periodic_materialization/build_image.sh \
-  --project "$PROJECT_ID" --repo bqaa --create-repo \
-  --property-graph property_graph.sql)"     # → REGION-docker.pkg.dev/.../...:<tag>
+  --project "$PROJECT_ID" --repo bqaa --create-repo)"
+  # → REGION-docker.pkg.dev/.../...:<tag>
 ```
 
 Then point Terraform at it:
@@ -163,9 +173,9 @@ Then point Terraform at it:
 project_id        = "your-project"
 region            = "us-central1"
 events_dataset_id = "agent_analytics"
-graph_dataset_id  = "agent_decisions_graph"
+graph_dataset_id  = "decision_graph"
 schedule          = "0 */6 * * *"
-property_graph    = true
+graph             = "agent_decisions_graph"
 # endpoint        = "gemini-3.5-flash"   # optional: AI.GENERATE model (BQAA_ENDPOINT)
 ```
 
@@ -179,7 +189,7 @@ terraform init
 terraform apply -var "image_uri=$IMAGE_URI"
 ```
 
-`property_graph = true` sets `BQAA_PROPERTY_GRAPH` on the Job; a plan-time
+`graph = "agent_decisions_graph"` sets `BQAA_GRAPH` on the Job; a plan-time
 precondition rejects it together with `extraction_mode = "compiled-only"`.
 
 ## 4. Verify
@@ -200,7 +210,7 @@ bq query --use_legacy_sql=false \
 ```
 
 The Cloud Logging entry per run is structured JSON; the key fields are
-`mode = "property-graph"`, `sessions_materialized`, `sessions_failed`, and
+`mode = "deployed-graph"`, `sessions_materialized`, `sessions_failed`, and
 `ok`. Wire a Cloud Monitoring alert on `ok = false` (see the
 [deploy README](../../examples/context_graph/periodic_materialization/README.md#cloud-monitoring-alerts)).
 
@@ -208,6 +218,15 @@ Then query the graph itself — the materialized decision traces are GQL-queryab
 exactly as in [Phase 4 of the codelab](../codelabs/periodic_materialization.md).
 
 ## Troubleshooting
+
+**`Property graph ... not found in ... (INFORMATION_SCHEMA.PROPERTY_GRAPHS)`**
+— the job looked for `BQAA_GRAPH` in the graph dataset and didn't find it. The
+error lists the graphs that *do* exist there. Usual causes: step 1 was applied
+to a different dataset than `BQAA_GRAPH_DATASET_ID`, or the `CREATE PROPERTY
+GRAPH` statement failed (its tables didn't exist yet). Re-run step 1 and
+confirm with the `INFORMATION_SCHEMA.PROPERTY_GRAPHS` query shown there. If
+your graph lives in a *different* dataset on purpose, pass a qualified name:
+`--graph other_dataset.agent_decisions_graph`.
 
 **`404 NOT_FOUND ... Publisher Model ... was not found or your project does not
 have access to it`** when you set `--endpoint` / `BQAA_ENDPOINT` to a Gemini 3.x
@@ -221,8 +240,8 @@ project. The runtime's default `gemini-2.5-flash` works without any of this.
 
 ## When to use explicit `--ontology` / `--binding` instead
 
-Schema-derived mode covers rename-free graphs with AI extraction. Reach for the
-explicit pair (omit `--property-graph`; the deploy bundles `ontology.yaml` +
+Deployed-graph mode covers rename-free graphs with AI extraction. Reach for the
+explicit pair (omit `--graph`; the deploy bundles `ontology.yaml` +
 `binding.yaml`) when you need: human-readable descriptions to steer the
 `AI.GENERATE` prompt, entity inheritance, derived (computed) properties, column
 renames, or a deterministic compiled extractor (`--extraction-mode=compiled-only`).

--- a/examples/codelab/periodic_materialization/README.md
+++ b/examples/codelab/periodic_materialization/README.md
@@ -6,9 +6,9 @@ These are the artifacts the *Trace AI Agent Decisions with BigQuery Property Gra
 
 | File | Purpose |
 |---|---|
-| `property_graph.sql` | Property-graph DDL. Stitches the node and edge tables into a queryable BigQuery property graph. **This is the single source of truth `bqaa context-graph --property-graph` derives the materialization spec from.** |
+| `property_graph.sql` | Property-graph DDL. Stitches the node and edge tables into a queryable BigQuery property graph. **You apply this to BigQuery once; the deployed graph is then the single source of truth `bqaa context-graph --graph` derives the materialization spec from** (read back via `INFORMATION_SCHEMA.PROPERTY_GRAPHS`). |
 | `table_ddl.sql` | Node and edge table DDL. The materializer writes into these tables every run. |
-| `ontology.yaml` | **Optional override.** Names the entities and relationships; used by the materializer to construct the `AI.GENERATE` extraction prompt. Only needed when you pass `--ontology`/`--binding` instead of `--property-graph`. |
+| `ontology.yaml` | **Optional override.** Names the entities and relationships; used by the materializer to construct the `AI.GENERATE` extraction prompt. Only needed when you pass `--ontology`/`--binding` instead of `--graph`. |
 | `binding.yaml` | **Optional override.** Maps ontology entities to physical BigQuery tables and columns. Must be rendered with `envsubst` before use. Pairs with `ontology.yaml`. |
 | `seed_events.py` | Thin compatibility shim over the maintained `bqaa seed-events` command (SDK module `bigquery_agent_analytics.seed_events`). Writes a small corpus of completed decision sessions so the materializer has something to process. |
 
@@ -18,11 +18,11 @@ These are the artifacts the *Trace AI Agent Decisions with BigQuery Property Gra
 2. `envsubst < table_ddl.sql | bq query --use_legacy_sql=false` creates the node and edge tables.
 3. `envsubst < property_graph.sql | bq query --use_legacy_sql=false` creates the property graph.
 4. `bqaa seed-events --project-id "$PROJECT_ID" --dataset-id "$DATASET" --sessions 5` populates `agent_events` (the bundled `seed_events.py` remains as a compatibility shim if you are running from the downloaded kit).
-5. `bqaa context-graph --project-id "$PROJECT_ID" --dataset-id "$DATASET" --property-graph property_graph.sql --lookback-hours 24` materializes the graph. It derives the entities, relationships, and column types from `property_graph.sql` plus the table schemas — no ontology or binding file required, and the `${PROJECT_ID}` / `${DATASET}` markers are resolved from `--project-id` / `--dataset-id`.
+5. `bqaa context-graph --project-id "$PROJECT_ID" --dataset-id "$DATASET" --graph agent_decisions_graph --lookback-hours 24` materializes the graph. It reads the deployed graph's definition back from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` and derives the entities, relationships, and column types from it plus the table schemas — no SQL file passed to the materializer, no ontology or binding file required.
 
 ### Advanced: explicit ontology + binding
 
-`ontology.yaml` and `binding.yaml` are kept here for when you outgrow schema-derived mode — when you need human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames. Render the binding (`envsubst < binding.yaml > binding.rendered.yaml`) and pass `--ontology ontology.yaml --binding binding.rendered.yaml` in place of `--property-graph`.
+`ontology.yaml` and `binding.yaml` are kept here for when you outgrow schema-derived mode — when you need human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames. Render the binding (`envsubst < binding.yaml > binding.rendered.yaml`) and pass `--ontology ontology.yaml --binding binding.rendered.yaml` in place of `--graph`.
 
 ## Domain model
 
@@ -37,7 +37,7 @@ DecisionRequest --[evaluatesOption]--> DecisionOption
 
 ## Adapting these for your domain
 
-For a production deployment you author your own versions of just **two** files describing your decision domain; `bqaa context-graph --property-graph` derives the rest:
+For a production deployment you author your own versions of just **two** files describing your decision domain, apply them to BigQuery, and `bqaa context-graph --graph` derives the rest from the deployed graph:
 
 * `property_graph.sql` — `CREATE OR REPLACE PROPERTY GRAPH ... NODE TABLES (...) EDGE TABLES (... SOURCE KEY (...) REFERENCES ... LABEL ...)`.
 * `table_ddl.sql` — `CREATE TABLE IF NOT EXISTS` for each node and edge table, with the SDK metadata columns `session_id` and `extracted_at` included on every bound table.

--- a/examples/codelab/periodic_materialization/colab_notebook.ipynb
+++ b/examples/codelab/periodic_materialization/colab_notebook.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "The codelab needs just two ready-to-use artifacts: the **table DDL** (the physical graph tables) and the **property-graph schema** (`CREATE PROPERTY GRAPH`). You do not author either yourself; the codelab uses them as-is, and the [README in the artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/codelab/periodic_materialization/README.md) explains how to adapt them for your own decision domain.\n",
     "\n",
-    "The property-graph schema is the single source of truth for *what* the graph contains. `bqaa context-graph` reads it (plus your table schemas) to figure out which entities and relationships to extract and where to write them — so you do **not** need to write a separate ontology or binding file.\n",
+    "The property-graph schema is the single source of truth for *what* the graph contains. You apply it to BigQuery once; from then on the **deployed graph itself is the contract**: `bqaa context-graph` reads the graph's definition back from BigQuery's `INFORMATION_SCHEMA.PROPERTY_GRAPHS` (plus your table schemas) to figure out which entities and relationships to extract and where to write them — so you do **not** need to write a separate ontology or binding file, and no SQL file is ever passed to the materializer.\n",
     "\n",
     "This codelab is self-contained: the cell below writes the two artifacts into a working directory, so there is nothing to download. They are the same files shipped in [`examples/codelab/periodic_materialization/`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization)."
    ]
@@ -327,7 +327,7 @@
     "\n",
     "`DecisionRequest` is the question the agent received. `DecisionOption` is one alternative the agent considered. `DecisionOutcome` records the committed choice and the rationale.\n",
     "\n",
-    "> **Advanced: bring your own ontology + binding.** Schema-derived mode covers the common case. When you need finer control — human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames — author an explicit `ontology.yaml` + `binding.yaml` and pass `--ontology`/`--binding` instead of `--property-graph`. The [artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization) ships both files as a starting point.\n",
+    "> **Advanced: bring your own ontology + binding.** Schema-derived mode covers the common case. When you need finer control — human-readable descriptions to steer the AI extraction prompt, entity inheritance, derived (computed) properties, or column renames — author an explicit `ontology.yaml` + `binding.yaml` and pass `--ontology`/`--binding` instead of `--graph`. The [artifacts folder](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/codelab/periodic_materialization) ships both files as a starting point.\n",
     "\n",
     "## Apply the property graph schema\n",
     "\n",
@@ -352,7 +352,7 @@
    "source": [
     "You should see five `CREATE TABLE` results and one `CREATE PROPERTY GRAPH` result. The DDL is idempotent; you can re-run it safely.\n",
     "\n",
-    "That is the only schema work you do. Because `bqaa context-graph` derives what to extract from this property graph, there is no separate binding file to render — the `${PROJECT_ID}` / `${DATASET}` markers in `property_graph.sql` are resolved for you from `--project-id` / `--dataset-id` when you materialize.\n",
+    "That is the only schema work you do — and the only time the SQL files are used. BigQuery now records your graph's definition, and `bqaa context-graph` reads it back from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` by name, so there is no separate binding file to render and no SQL file to pass to the materializer. What you query with GQL and what gets materialized can never drift apart: they are the same deployed graph.\n",
     "\n",
     "## Generate sample agent events\n",
     "\n",
@@ -472,7 +472,7 @@
     "## Materialize the decision graph\n",
     "\n",
     "\n",
-    "`bqaa context-graph` reads the raw `agent_events`, then **derives what to extract directly from your property graph**: it reads the `CREATE PROPERTY GRAPH` definition you applied in *Apply the property graph schema* and the schemas of the tables it references, works out the entities, relationships, and column types, and populates the graph tables. Point it at `property_graph.sql` with `--property-graph` — no separate ontology or binding file required.\n",
+    "`bqaa context-graph` reads the raw `agent_events`, then **derives what to extract directly from your deployed graph**: it reads the `CREATE PROPERTY GRAPH` definition you applied in *Apply the property graph schema* back from BigQuery's `INFORMATION_SCHEMA.PROPERTY_GRAPHS`, joins it with the schemas of the tables it references, works out the entities, relationships, and column types, and populates the graph tables. Point it at the deployed graph by name with `--graph` — no SQL file, no separate ontology or binding file.\n",
     "\n",
     "**Run the materializer** locally:"
    ]
@@ -483,7 +483,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!bqaa context-graph      --project-id \"$PROJECT_ID\"      --dataset-id \"$DATASET\"      --property-graph ~/bqaa-codelab/property_graph.sql      --lookback-hours 24      --format json"
+    "!bqaa context-graph      --project-id \"$PROJECT_ID\"      --dataset-id \"$DATASET\"      --graph agent_decisions_graph      --lookback-hours 24      --format json"
    ]
   },
   {
@@ -658,10 +658,10 @@
     "print(f\"Backfill window FROM = {os.environ['FROM']}\")\n",
     "print(f\"Backfill window TO   = {os.environ['TO']}\")\n",
     "\n",
-    "!cd ~/bqaa-codelab && bqaa context-graph \\\n",
+    "!bqaa context-graph \\\n",
     "    --project-id \"$PROJECT_ID\" \\\n",
     "    --dataset-id \"$DATASET\" \\\n",
-    "    --property-graph property_graph.sql \\\n",
+    "    --graph agent_decisions_graph \\\n",
     "    --lookback-hours 1 \\\n",
     "    --backfill --from \"$FROM\" --to \"$TO\" \\\n",
     "    --state-key-suffix codelab_backfill_demo \\\n",
@@ -712,7 +712,7 @@
     "* **Replay a past window** (`--backfill --from / --to`). You exercised this in *Replay a past window* above. The replay is tracked separately from the regular schedule so it cannot interfere with the live refresh.\n",
     "* **Bound the per-run batch size** (`--max-sessions`). Useful when an upstream event spike threatens to overwhelm a single scan.\n",
     "\n",
-    "> **From \"run this once\" to \"run this every six hours\":** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. Follow the [scheduled Context Graph deploy runbook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/guides/scheduled-context-graph-deploy.md) to take *this* `--property-graph` graph to a scheduled deploy with the same one-artifact flow, or the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/context_graph/periodic_materialization) for the full IAM matrix and the explicit-ontology/binding path.\n",
+    "> **From \"run this once\" to \"run this every six hours\":** The SDK ships a deploy script and a Terraform module that wrap `bqaa context-graph` as a Cloud Run Job triggered by Cloud Scheduler, with least-privilege service accounts and the IAM grants the job needs. Follow the [scheduled Context Graph deploy runbook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/guides/scheduled-context-graph-deploy.md) to take *this* deployed graph to a scheduled deploy with the same `--graph` flow, or the [periodic-materialization deployment guide](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/examples/context_graph/periodic_materialization) for the full IAM matrix and the explicit-ontology/binding path.\n",
     "\n",
     "## Clean up\n",
     "\n",
@@ -743,7 +743,7 @@
     "\n",
     "Congratulations! You've turned raw agent event logs into a queryable Context Graph in BigQuery and traced a single decision end-to-end, with no external graph database or ETL pipeline.\n",
     "\n",
-    "The same pattern applies wherever an agent makes consequential decisions: credit underwriting, prior authorization, marketing budget moves, procurement, customer service, and internal IT. To build your own decision graph, copy the codelab artifacts as a starting point and adapt the two declarative files (table DDL + the `CREATE PROPERTY GRAPH` schema) to your domain — `bqaa context-graph --property-graph` derives the rest. Reach for an explicit `ontology.yaml` + `binding.yaml` only when you need descriptions, inheritance, derived properties, or column renames.\n",
+    "The same pattern applies wherever an agent makes consequential decisions: credit underwriting, prior authorization, marketing budget moves, procurement, customer service, and internal IT. To build your own decision graph, copy the codelab artifacts as a starting point, adapt the two declarative files (table DDL + the `CREATE PROPERTY GRAPH` schema) to your domain, and apply them to BigQuery — `bqaa context-graph --graph` reads the deployed graph and derives the rest. Reach for an explicit `ontology.yaml` + `binding.yaml` only when you need descriptions, inheritance, derived properties, or column renames.\n",
     "\n",
     "#### What you've learned\n",
     "\n",

--- a/examples/context_graph/README.md
+++ b/examples/context_graph/README.md
@@ -57,25 +57,29 @@ bq query --use_legacy_sql=false < table_ddl.sql
 bq query --use_legacy_sql=false < property_graph.sql
 ```
 
-Both files are idempotent — re-running them is safe.
+Both files are idempotent — re-running them is safe. This is the only time
+the SQL files are used: from here on the **deployed graph in BigQuery is the
+single source of truth**.
 
 ### Materialize the graph from agent events
 
 `bqaa context-graph` reads raw `agent_events` rows (written by the BigQuery
 Agent Analytics Plugin), derives the entities and relationships to extract
-**directly from your property graph**, and populates the node and edge tables:
+**directly from your deployed graph** — it reads the graph's definition back
+from `INFORMATION_SCHEMA.PROPERTY_GRAPHS` — and populates the node and edge
+tables:
 
 ```bash
 bqaa context-graph \
     --project-id your-project \
     --dataset-id your_dataset \
-    --property-graph property_graph.sql \
+    --graph mako_demo_graph \
     --lookback-hours 24 \
     --format json
 ```
 
-That single `--property-graph` flag is the whole configuration — no separate
-ontology or binding file is needed on this path.
+That single `--graph` flag is the whole configuration — no SQL file handed to
+the materializer, no separate ontology or binding file on this path.
 
 ### Query it
 
@@ -118,8 +122,9 @@ The flow:
    Deploys the Cloud Run Job, creates the runtime service account with narrow
    IAM (events-READ, graph-WRITE), wires the Cloud Scheduler trigger, and runs
    `--smoke` to verify in one shot. The deploy script's
-   `--property-graph property_graph.sql` mode derives everything from your
-   placeholdered property graph at run time — no checked-in files to edit.
+   `--graph <name>` mode derives everything from your deployed graph at run
+   time (via `INFORMATION_SCHEMA.PROPERTY_GRAPHS`) — nothing staged, no
+   checked-in files to edit.
 
 4. **Verify** — Cloud Logging shows the JSON report on every run
    (`jsonPayload.ok`, `sessions_materialized`, `rows_materialized`, per-table
@@ -163,7 +168,7 @@ above covers the common case; reach for an explicit `ontology.yaml` +
 `binding.yaml` only when you need finer control — human-readable descriptions
 that steer the AI extraction prompt, entity inheritance, derived (computed)
 properties, or column renames. You then pass `--ontology`/`--binding` to
-`bqaa context-graph` instead of `--property-graph`.
+`bqaa context-graph` instead of `--graph`.
 
 The artifact pipeline that turns an OWL TTL into binding + DDL +
 property-graph SQL is **ontology-agnostic** — see `ontology_artifacts.py` —
@@ -386,18 +391,18 @@ PYTHONPATH=src python examples/context_graph/export_events_jsonl.py --help
 ### Deploying the explicit-ontology graph on a schedule
 
 The periodic-materialization deploy also supports this path: bundle the
-checked-in `binding.yaml` / `ontology.yaml` / `table_ddl.sql` instead of a
-placeholdered property graph. Running it against a different `OntologyConfig`
+checked-in `binding.yaml` / `ontology.yaml` / `table_ddl.sql` instead of
+pointing at a deployed graph. Running it against a different `OntologyConfig`
 means regenerating those snapshots for your config first
 (`mako_artifacts.py` / `ontology_artifacts.py`) and pointing the deploy at the
-new files. The rename-free `--property-graph` mode described above remains the
+new files. The rename-free `--graph` mode described above remains the
 common path.
 
 ## Related
 
 - [`periodic_materialization/`](./periodic_materialization/) — production deployment: Cloud Run Job + Cloud Scheduler, IAM matrix, alerting.
 - [Periodic Materialization codelab](../../docs/codelabs/periodic_materialization.md) — guided end-to-end walkthrough.
-- [Scheduled deploy runbook](../../docs/guides/scheduled-context-graph-deploy.md) — take a `--property-graph` graph to a scheduled deploy.
+- [Scheduled deploy runbook](../../docs/guides/scheduled-context-graph-deploy.md) — take a deployed graph to a scheduled `--graph` deploy.
 - [`examples/decision_lineage_demo/`](../decision_lineage_demo/) — reference pattern for ADK agent + BigQuery Agent Analytics plugin wiring.
 - [Rollout guide](../../docs/extractor_compilation_rollout_guide.md) — extractor compilation pipeline reference.
 - [Ontology runtime reader](../../docs/ontology_runtime_reader.md) — runtime reader API.

--- a/examples/context_graph/periodic_materialization/README.md
+++ b/examples/context_graph/periodic_materialization/README.md
@@ -194,12 +194,12 @@ before paying for a deploy:
 pip install -e .
 #
 # (b) Pinned from PyPI — once you're on a stable SDK version.
-#     0.3.3 adds schema-derived (``--property-graph``) deploy
-#     parity on top of the 0.3.2 context-graph production track
-#     (compiled-only deploy, backfill, orphan watchdog,
-#     Terraform module, split SAs, ``--max-retries``). Use this
-#     for unmodified production use.
-pip install 'bigquery-agent-analytics>=0.3.3'
+#     0.3.4 adds the deployed-graph (``--graph`` / ``BQAA_GRAPH``)
+#     mode: the runtime derives the spec from the property graph
+#     you already created in BigQuery, read back via
+#     INFORMATION_SCHEMA.PROPERTY_GRAPHS. Use this for unmodified
+#     production use.
+pip install 'bigquery-agent-analytics>=0.3.4'
 
 # Either way, install the example's ancillary deps:
 pip install -r examples/context_graph/periodic_materialization/requirements.txt
@@ -273,11 +273,13 @@ the logs, so you find out *now* whether the deploy actually
 works — not when the first scheduled fire happens six hours
 later.
 
-### Schema-derived deploy (`--property-graph`)
+### Deployed-graph deploy (`--graph`)
 
 The deploy above bundles the MAKO `ontology.yaml` + `binding.yaml`. For a
-**rename-free, codelab-style graph** you can skip those entirely and deploy
-from just a property graph — the same one-artifact flow the
+**rename-free, codelab-style graph** you can skip those entirely: deploy your
+graph to BigQuery once (apply your table DDL, then your `CREATE PROPERTY
+GRAPH`, with `bq query`), and point the job at it by name — the same
+deployed-graph flow the
 [codelab](../../../docs/codelabs/periodic_materialization.md) uses locally:
 
 ```bash
@@ -287,22 +289,24 @@ from just a property graph — the same one-artifact flow the
   --events-dataset your_events_dataset \
   --graph-dataset your_graph_dataset \
   --schedule "0 */6 * * *" \
-  --property-graph path/to/property_graph.sql
+  --graph your_graph_name
 ```
 
-`--property-graph` points at a `CREATE PROPERTY GRAPH` `.sql`; a placeholdered
-(`${PROJECT_ID}` / `${DATASET}`) `table_ddl.sql` must sit **next to it**. The
-deploy stages both (no `ontology.yaml`/`binding.yaml`), sets
-`BQAA_PROPERTY_GRAPH=property_graph.sql`, and the runtime derives the ontology +
-binding from the property graph + your live table schemas at run time (#286).
-Events stay read-only in your events dataset; the graph tables, schema lookup,
+`--graph` names a property graph that already exists in BigQuery (bare name
+resolved in `--graph-dataset`, or `dataset.graph` / `project.dataset.graph`).
+The deploy stages nothing — it sets `BQAA_GRAPH` on the Job, and on every run
+the runtime reads the graph's definition back from
+`INFORMATION_SCHEMA.PROPERTY_GRAPHS` and derives the ontology + binding from
+it plus your live table schemas. The deployed graph is the single source of
+truth: what you query with GQL is exactly what the job materializes. Events
+stay read-only in your events dataset; the schema lookup, materialized rows,
 and the state table all target the graph dataset.
 
 Requirements / limits:
 
-* Both files must be **placeholdered** (`${PROJECT_ID}` / `${DATASET}`) — the
-  deploy refuses hardcoded references so the job can never derive against the
-  wrong dataset.
+* The graph (and therefore its node/edge tables) must exist before the first
+  run — apply your DDL with `bq query` first. A missing graph fails the run
+  with an error that lists the graphs the dataset does contain.
 * Not compatible with `--extraction-mode=compiled-only` (no reference
   extractors are staged in derived mode); the deploy rejects that combination.
 
@@ -311,12 +315,12 @@ extraction model; it wires `BQAA_ENDPOINT` on the Job. Default is unset, so the
 runtime keeps its `gemini-2.5-flash` default. Short names resolve to the Vertex
 `locations/global` publisher URL, so Gemini 3.x models such as
 `gemini-3.5-flash` work. Ignored under `--extraction-mode=compiled-only` (no AI
-call is made). Applies to both the schema-derived and explicit paths (#298).
+call is made). Applies to both the deployed-graph and explicit paths (#298).
 
-**Advanced — explicit ontology + binding.** Omit `--property-graph` to keep the
+**Advanced — explicit ontology + binding.** Omit `--graph` to keep the
 default MAKO path: descriptions for AI prompting, entity inheritance, derived
 properties, column renames, and the hand-authored compiled extractor. That is
-the right path for context graph and any graph that outgrows schema-derived mode.
+the right path for context graph and any graph that outgrows derived mode.
 
 The script:
 

--- a/examples/context_graph/periodic_materialization/deploy_cloud_run_job.sh
+++ b/examples/context_graph/periodic_materialization/deploy_cloud_run_job.sh
@@ -101,6 +101,7 @@ MAX_SESSIONS=""
 JOB_NAME="bqaa-periodic-materialization"
 SMOKE=false
 EXTRACTION_MODE="ai-fallback"
+GRAPH=""
 PROPERTY_GRAPH=""
 ENDPOINT=""
 MAX_SESSION_AGE_HOURS=""
@@ -150,14 +151,26 @@ Optional:
                                roles/aiplatform.user grant and idempotently
                                removes any pre-existing grant from a prior
                                ai-fallback deploy of the same SA.
-  --property-graph PATH        Schema-derived mode (#286): derive the
-                               ontology + binding from this CREATE PROPERTY
-                               GRAPH .sql file plus the table schemas, instead
-                               of staging ontology.yaml/binding.yaml. A
-                               placeholdered (\${PROJECT_ID}/\${DATASET})
-                               table_ddl.sql must sit next to it. Use for
-                               rename-free graphs; not compatible with
+  --graph NAME                 Deployed-graph mode (recommended): NAME is a
+                               property graph you already created in BigQuery
+                               (bare name resolved in --graph-dataset, or
+                               dataset.graph / project.dataset.graph). The
+                               runtime reads the graph's DDL back from
+                               INFORMATION_SCHEMA.PROPERTY_GRAPHS and derives
+                               the ontology + binding from it plus the live
+                               table schemas — nothing is staged; the deployed
+                               graph is the single source of truth. Apply your
+                               table DDL + CREATE PROPERTY GRAPH with bq
+                               before deploying. Not compatible with
                                --extraction-mode=compiled-only.
+  --property-graph PATH        Legacy file-based schema-derived mode (#286):
+                               derive the ontology + binding from this CREATE
+                               PROPERTY GRAPH .sql file plus the table
+                               schemas, instead of staging
+                               ontology.yaml/binding.yaml. A placeholdered
+                               (\${PROJECT_ID}/\${DATASET}) table_ddl.sql must
+                               sit next to it. Prefer --graph. Not compatible
+                               with --extraction-mode=compiled-only.
   --endpoint MODEL             Vertex AI model for the AI.GENERATE extraction
                                fallback, wired as BQAA_ENDPOINT on the Job.
                                Short names resolve to the locations/global
@@ -231,6 +244,7 @@ while [[ $# -gt 0 ]]; do
     --job-name)        require_arg "$1" "${2-}"; JOB_NAME="$2"; shift 2 ;;
     --smoke)           SMOKE=true; shift ;;
     --extraction-mode) require_arg "$1" "${2-}"; EXTRACTION_MODE="$2"; shift 2 ;;
+    --graph)           require_arg "$1" "${2-}"; GRAPH="$2"; shift 2 ;;
     --property-graph)  require_arg "$1" "${2-}"; PROPERTY_GRAPH="$2"; shift 2 ;;
     --endpoint)        require_arg "$1" "${2-}"; ENDPOINT="$2"; shift 2 ;;
     --max-session-age-hours)
@@ -272,11 +286,24 @@ case "$EXTRACTION_MODE" in
     ;;
 esac
 
-# Spec input mode (#286). ``--property-graph`` selects schema-derived
-# mode: the ontology + binding are derived from the property graph + the
-# table schemas, so no ``ontology.yaml`` / ``binding.yaml`` is staged.
-# Unset = the explicit context-graph ontology+binding (compiled-extractor)
-# path. Exactly one mode is in effect.
+# Spec input mode. ``--graph`` (recommended) selects deployed-graph mode:
+# the runtime reads the customer's already-deployed property graph back from
+# ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` and derives the ontology + binding
+# from it — nothing is staged. ``--property-graph`` (legacy) selects the
+# file-based schema-derived mode. Unset (both) = the explicit context-graph
+# ontology+binding (compiled-extractor) path. Exactly one mode is in effect.
+if [[ -n "$GRAPH" && -n "$PROPERTY_GRAPH" ]]; then
+  echo "Error: --graph and --property-graph are mutually exclusive; pass exactly one spec input mode." >&2
+  exit 1
+fi
+if [[ -n "$GRAPH" ]]; then
+  # Deployed-graph mode has no reference extractors staged, so compiled-only
+  # would empty_extract at runtime — reject it at the deploy boundary.
+  if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
+    echo "Error: --graph (deployed-graph mode) does not support --extraction-mode=compiled-only: no reference extractors are staged in derived mode. Use 'ai-fallback', or deploy the explicit ontology/binding path." >&2
+    exit 1
+  fi
+fi
 TABLE_DDL_SRC=""
 if [[ -n "$PROPERTY_GRAPH" ]]; then
   # Derived mode has no reference extractors staged, so compiled-only
@@ -644,7 +671,12 @@ STAGING="$(mktemp -d -t bqaa-cloud-run-job-XXXXXXXX)"
 
 echo "==> staging at $STAGING"
 cp "${SCRIPT_DIR}/run_job.py" "$STAGING/"
-if [[ -n "$PROPERTY_GRAPH" ]]; then
+if [[ -n "$GRAPH" ]]; then
+  # Deployed-graph mode: nothing to stage. The runtime reads the customer's
+  # deployed graph back from INFORMATION_SCHEMA.PROPERTY_GRAPHS; the graph's
+  # existence proves its node/edge tables exist, so no table DDL ships either.
+  :
+elif [[ -n "$PROPERTY_GRAPH" ]]; then
   # Schema-derived mode: stage only the property graph + its companion
   # table DDL. The runtime derives ontology + binding from them, so no
   # ontology.yaml / binding.yaml / reference_extractor.py is needed.
@@ -734,8 +766,13 @@ fi
 if [[ "$EXTRACTION_MODE" == "compiled-only" ]]; then
   ENV_VARS+=("BQAA_REFERENCE_EXTRACTORS_MODULE=reference_extractor")
 fi
-# Schema-derived mode: tell the runtime to derive the spec from the staged
-# property graph instead of the explicit ontology/binding pair (#286).
+# Deployed-graph mode: tell the runtime to derive the spec from the
+# customer's already-deployed property graph (INFORMATION_SCHEMA lookup).
+if [[ -n "$GRAPH" ]]; then
+  ENV_VARS+=("BQAA_GRAPH=${GRAPH}")
+fi
+# Schema-derived mode (legacy): tell the runtime to derive the spec from the
+# staged property graph instead of the explicit ontology/binding pair (#286).
 if [[ -n "$PROPERTY_GRAPH" ]]; then
   ENV_VARS+=("BQAA_PROPERTY_GRAPH=property_graph.sql")
 fi

--- a/examples/context_graph/periodic_materialization/run_job.py
+++ b/examples/context_graph/periodic_materialization/run_job.py
@@ -47,14 +47,25 @@ Env vars (all set by the deploy script via
   ``agent_events``.
 * ``BQAA_GRAPH_DATASET_ID`` (required) — target dataset for
   the materialized graph (entity + relationship tables).
-* ``BQAA_PROPERTY_GRAPH`` (default unset) — when set to a staged
-  ``CREATE PROPERTY GRAPH`` ``.sql`` filename (e.g.
-  ``property_graph.sql``), runs in schema-derived mode (#286): the
-  ontology + binding are derived from the property graph + table
-  schemas, so no ``ontology.yaml`` / ``binding.yaml`` is staged and no
-  binding retargeting happens. Use placeholdered (``${PROJECT_ID}`` /
-  ``${DATASET}``), rename-free graphs. Unset ⇒ explicit ontology +
-  binding (the advanced / compiled-extractor path).
+* ``BQAA_GRAPH`` (default unset) — the name of a property graph the
+  customer already deployed to BigQuery (bare name resolved in
+  ``BQAA_GRAPH_DATASET_ID``, or ``dataset.graph`` /
+  ``project.dataset.graph``). The runtime reads the graph's DDL back
+  from ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` and derives the
+  ontology + binding from it plus the live table schemas — the
+  deployed graph is the single source of truth, nothing is staged,
+  and no table bootstrap runs (the graph's existence proves its
+  node/edge tables exist). Mutually exclusive with
+  ``BQAA_PROPERTY_GRAPH``.
+* ``BQAA_PROPERTY_GRAPH`` (default unset; legacy) — when set to a
+  staged ``CREATE PROPERTY GRAPH`` ``.sql`` filename (e.g.
+  ``property_graph.sql``), runs in file-based schema-derived mode
+  (#286): the ontology + binding are derived from the staged file +
+  table schemas, so no ``ontology.yaml`` / ``binding.yaml`` is staged
+  and no binding retargeting happens. Use placeholdered
+  (``${PROJECT_ID}`` / ``${DATASET}``), rename-free graphs. Prefer
+  ``BQAA_GRAPH``. Unset (both) ⇒ explicit ontology + binding (the
+  advanced / compiled-extractor path).
 * ``BQAA_LOCATION`` (default ``US``) — BigQuery location;
   must match both datasets.
 * ``BQAA_LOOKBACK_HOURS`` (default ``6``) — scan window size.
@@ -480,13 +491,30 @@ def main() -> int:
       os.environ.get("BQAA_REFERENCE_EXTRACTORS_MODULE") or None
   )
   bundles_root = os.environ.get("BQAA_BUNDLES_ROOT") or None
-  # Spec input mode. ``BQAA_PROPERTY_GRAPH`` (a staged ``*.sql`` filename)
-  # selects schema-derived mode (#277/#286): the ontology + binding are derived
-  # from the property graph + table schemas, so no ``ontology.yaml`` /
-  # ``binding.yaml`` is staged and no binding retargeting happens. When unset,
-  # the wrapper uses the explicit ontology + binding (the context-graph /
+  # Spec input mode, in precedence order. ``BQAA_GRAPH`` (a deployed
+  # property-graph name) selects deployed-graph mode: the runtime reads the
+  # graph's DDL back from ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` and derives
+  # the ontology + binding from it — nothing staged, no table bootstrap.
+  # ``BQAA_PROPERTY_GRAPH`` (a staged ``*.sql`` filename; legacy) selects
+  # file-based schema-derived mode (#277/#286). When both are unset, the
+  # wrapper uses the explicit ontology + binding (the context-graph /
   # compiled-extractor advanced path). Exactly one mode is in effect.
+  graph = os.environ.get("BQAA_GRAPH") or None
   property_graph_name = os.environ.get("BQAA_PROPERTY_GRAPH") or None
+  if graph and property_graph_name:
+    print(
+        json.dumps(
+            {
+                "severity": "ERROR",
+                "message": (
+                    "BQAA_GRAPH and BQAA_PROPERTY_GRAPH are mutually"
+                    " exclusive; set exactly one spec input mode."
+                ),
+            }
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(2)
   # Orphan-session watchdog (issue #180). Unset means disabled —
   # mirrors the CLI flag. ``_optional_env_float`` raises ``exit 2``
   # on a non-numeric value at the boundary, and the materializer's
@@ -518,6 +546,7 @@ def main() -> int:
       state_key_suffix=state_key_suffix,
       extraction_mode=extraction_mode,
       endpoint=endpoint,
+      graph=graph,
       bundles_root=bundles_root,
       reference_extractors_module=reference_extractors_module,
       max_session_age_hours=max_session_age_hours,
@@ -552,14 +581,25 @@ def main() -> int:
     )
 
     # 2. Bootstrap entity tables. Idempotent — no-op after first run.
-    ddl_count = _bootstrap_entity_tables(
-        bq_client, project_id, graph_dataset_id
-    )
-    _emit(
-        "INFO",
-        message="entity-table DDL applied",
-        statements=ddl_count,
-    )
+    # Skipped in deployed-graph (``BQAA_GRAPH``) mode: the customer's
+    # ``CREATE PROPERTY GRAPH`` can only have succeeded if its node/edge
+    # tables already exist, and the staged demo ``table_ddl.sql`` would not
+    # match their graph anyway.
+    if graph:
+      _emit(
+          "INFO",
+          message="entity-table bootstrap skipped (deployed-graph mode)",
+          graph=graph,
+      )
+    else:
+      ddl_count = _bootstrap_entity_tables(
+          bq_client, project_id, graph_dataset_id
+      )
+      _emit(
+          "INFO",
+          message="entity-table DDL applied",
+          statements=ddl_count,
+      )
 
     # 3. Run the orchestrator. Reads events from
     # ``BQAA_EVENTS_DATASET_ID``; writes entities/relationships AND the
@@ -595,7 +635,24 @@ def main() -> int:
         endpoint=endpoint,
     )
 
-    if property_graph_name:
+    if graph:
+      # Deployed-graph mode: the runtime reads the graph's DDL back from
+      # ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` in the graph dataset and
+      # derives the ontology + binding from it + the live table schemas.
+      # Nothing is staged; the deployed graph is the single source of truth.
+      _emit(
+          "INFO",
+          message="spec input mode",
+          mode="deployed-graph",
+          graph=graph,
+      )
+      result = mw.run_materialize_window(
+          graph=graph,
+          graph_project_id=project_id,
+          graph_dataset_id=graph_dataset_id,
+          **common_kwargs,
+      )
+    elif property_graph_name:
       # Schema-derived mode (#286): no ontology/binding, no binding retarget.
       # ``graph_*`` target the writable graph dataset for placeholder
       # resolution, INFORMATION_SCHEMA lookup, and writes; events stay

--- a/examples/context_graph/periodic_materialization/terraform/README.md
+++ b/examples/context_graph/periodic_materialization/terraform/README.md
@@ -11,7 +11,7 @@ Resolves [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-
 | Graph dataset | `google_bigquery_dataset` | §1 — `bq mk` (pre-create so the runtime SA never needs `bigquery.datasets.create`) |
 | Runtime SA + scheduler-caller SA | `google_service_account` ×2 | §2 — `_ensure_sa` (split by default; `single_sa = true` collapses to one) |
 | Project + dataset IAM grants | `google_project_iam_member`, `google_bigquery_dataset_iam_member` | §3 — `_retry_iam gcloud projects add-iam-policy-binding` and the dataset-level grant block. Terraform's dependency graph handles the IAM-propagation race declaratively (the `depends_on` on the Cloud Run Job resource ensures grants land before the first invocation) |
-| Cloud Run v2 Job | `google_cloud_run_v2_job` | §4 — `gcloud run jobs deploy`. Same env-var set the bash deploy wires (`BQAA_PROJECT_ID`, `BQAA_EVENTS_DATASET_ID`, `BQAA_GRAPH_DATASET_ID`, `BQAA_LOCATION`, `BQAA_LOOKBACK_HOURS`, `BQAA_OVERLAP_MINUTES`, `BQAA_EXTRACTION_MODE`, `BQAA_MAX_RETRIES`, conditionally `BQAA_MAX_SESSIONS`, `BQAA_MAX_SESSION_AGE_HOURS`, `BQAA_REFERENCE_EXTRACTORS_MODULE`, `BQAA_PROPERTY_GRAPH` when `property_graph = true`, and `BQAA_ENDPOINT` when `endpoint != ""`) |
+| Cloud Run v2 Job | `google_cloud_run_v2_job` | §4 — `gcloud run jobs deploy`. Same env-var set the bash deploy wires (`BQAA_PROJECT_ID`, `BQAA_EVENTS_DATASET_ID`, `BQAA_GRAPH_DATASET_ID`, `BQAA_LOCATION`, `BQAA_LOOKBACK_HOURS`, `BQAA_OVERLAP_MINUTES`, `BQAA_EXTRACTION_MODE`, `BQAA_MAX_RETRIES`, conditionally `BQAA_MAX_SESSIONS`, `BQAA_MAX_SESSION_AGE_HOURS`, `BQAA_REFERENCE_EXTRACTORS_MODULE`, `BQAA_GRAPH` when `graph != ""`, `BQAA_PROPERTY_GRAPH` when `property_graph = true` (legacy), and `BQAA_ENDPOINT` when `endpoint != ""`) |
 | `roles/run.invoker` on the job → scheduler SA | `google_cloud_run_v2_job_iam_member` | §5 — `_retry_iam gcloud run jobs add-iam-policy-binding` |
 | Cloud Scheduler trigger | `google_cloud_scheduler_job` | §6 — `gcloud scheduler jobs create http` with `--oauth-service-account-email` pointing at the scheduler SA |
 
@@ -19,7 +19,7 @@ Resolves [#186](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-
 
 **Container image build + publish.** The bash deploy builds the image from local sources via Cloud Buildpacks (`gcloud run jobs deploy --source $STAGING`), assembling a staging directory with `run_job.py` + `reference_extractor.py` + the demo artifacts + the vendored SDK source + `Procfile` + `requirements.txt` before invoking the build. That staging step is non-trivial — pointing `gcloud builds submit` directly at the `periodic_materialization/` directory would build an image that's missing the SDK source, the demo artifacts, and the Procfile.
 
-The module takes the **published** image URI as the required `image_uri` variable. To produce a Terraform-compatible image, use the bundled [`../build_image.sh`](../build_image.sh) helper — it stages the exact layout `deploy_cloud_run_job.sh` produces in its temp dir, then runs `gcloud builds submit` against that staging dir. Same image contents either way; Terraform just consumes the publish artifact instead of doing the build inline. For schema-derived deploys (`property_graph = true`), build the image with `build_image.sh --property-graph path/to/property_graph.sql` so the placeholdered `property_graph.sql` + `table_ddl.sql` are staged instead of `ontology.yaml`/`binding.yaml`.
+The module takes the **published** image URI as the required `image_uri` variable. To produce a Terraform-compatible image, use the bundled [`../build_image.sh`](../build_image.sh) helper — it stages the exact layout `deploy_cloud_run_job.sh` produces in its temp dir, then runs `gcloud builds submit` against that staging dir. Same image contents either way; Terraform just consumes the publish artifact instead of doing the build inline. Deployed-graph deploys (`graph = "<name>"`) use the default image as-is — nothing graph-specific is staged. (Legacy file-based deploys with `property_graph = true` build the image with `build_image.sh --property-graph path/to/property_graph.sql` so the placeholdered `property_graph.sql` + `table_ddl.sql` are staged instead of `ontology.yaml`/`binding.yaml`.)
 
 ```bash
 # From the repo root.
@@ -86,7 +86,7 @@ graph_dataset_id   = "context_graph"
 schedule           = "0 */6 * * *"
 image_uri          = "us-central1-docker.pkg.dev/my-project/bqaa/periodic-materialization:v1"
 # Optional overrides — defaults match the bash deploy
-# property_graph        = false   # true → schema-derived mode (see below)
+# graph                 = ""      # deployed-graph mode (see below)
 # extraction_mode       = "ai-fallback"
 # endpoint              = ""       # AI.GENERATE model (BQAA_ENDPOINT); e.g. "gemini-3.5-flash"
 # max_retries           = 2
@@ -95,20 +95,22 @@ image_uri          = "us-central1-docker.pkg.dev/my-project/bqaa/periodic-materi
 # location              = "US"
 ```
 
-#### Schema-derived mode (`property_graph = true`)
+#### Deployed-graph mode (`graph = "<name>"`)
 
 For a **rename-free, codelab-style graph** you can skip the explicit
-`ontology.yaml` / `binding.yaml` and derive the spec from a property graph (the
-[#286](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/286)
-one-artifact flow). Set `property_graph = true` and build the image with
-`build_image.sh --property-graph path/to/property_graph.sql` (a placeholdered
-`${PROJECT_ID}` / `${DATASET}` `table_ddl.sql` must sit next to it). The module
-then sets `BQAA_PROPERTY_GRAPH=property_graph.sql` on the Job so the runtime
-derives the ontology + binding from the property graph + your live table
-schemas. `property_graph = true` is rejected at plan time with
-`extraction_mode = "compiled-only"` (no reference extractors are staged in
-derived mode). Leave `property_graph = false` (default) for the explicit MAKO /
-compiled-extractor path.
+`ontology.yaml` / `binding.yaml` and derive the spec from the property graph
+you already created in BigQuery. Apply your table DDL + `CREATE PROPERTY
+GRAPH` with `bq query` first, then set `graph` to the deployed graph's name
+(bare name resolved in the graph dataset, or `dataset.graph` /
+`project.dataset.graph`). The module sets `BQAA_GRAPH` on the Job so the
+runtime reads the graph's definition back from
+`INFORMATION_SCHEMA.PROPERTY_GRAPHS` on every run and derives the ontology +
+binding from it plus your live table schemas — nothing graph-specific is
+staged in the image, so the default `build_image.sh` image works as-is.
+`graph` is rejected at plan time with `extraction_mode = "compiled-only"` (no
+reference extractors are staged in derived mode) and with `property_graph =
+true` (legacy file-based mode; prefer `graph`). Leave `graph = ""` (default)
+for the explicit MAKO / compiled-extractor path.
 
 ### 2. Init + plan + apply
 

--- a/examples/context_graph/periodic_materialization/terraform/main.tf
+++ b/examples/context_graph/periodic_materialization/terraform/main.tf
@@ -66,9 +66,16 @@ locals {
     var.extraction_mode == "compiled-only" ? {
       BQAA_REFERENCE_EXTRACTORS_MODULE = "reference_extractor"
     } : {},
-    # Schema-derived mode (#286): tell the runtime to derive the spec from the
-    # staged ``property_graph.sql`` instead of the explicit ontology/binding
-    # pair. Mirrors the bash deploy's ``BQAA_PROPERTY_GRAPH`` wiring.
+    # Deployed-graph mode: tell the runtime to derive the spec from the
+    # customer's already-deployed property graph (INFORMATION_SCHEMA lookup).
+    # Mirrors the bash deploy's ``--graph`` → ``BQAA_GRAPH`` wiring.
+    var.graph == "" ? {} : {
+      BQAA_GRAPH = var.graph
+    },
+    # Schema-derived mode (#286, legacy): tell the runtime to derive the spec
+    # from the staged ``property_graph.sql`` instead of the explicit
+    # ontology/binding pair. Mirrors the bash deploy's ``BQAA_PROPERTY_GRAPH``
+    # wiring.
     var.property_graph ? {
       BQAA_PROPERTY_GRAPH = "property_graph.sql"
     } : {},
@@ -281,13 +288,21 @@ resource "google_cloud_run_v2_job" "periodic" {
     }
   }
 
-  # Schema-derived mode has no reference extractors staged, so
+  # Schema-derived modes have no reference extractors staged, so
   # ``compiled-only`` would empty_extract at runtime. Reject the
-  # combination at plan time, mirroring the bash deploy's boundary check.
+  # combinations at plan time, mirroring the bash deploy's boundary checks.
   lifecycle {
     precondition {
       condition     = !(var.property_graph && var.extraction_mode == "compiled-only")
       error_message = "property_graph = true (schema-derived mode) does not support extraction_mode = \"compiled-only\": no reference extractors are staged in derived mode. Use \"ai-fallback\", or the explicit ontology/binding path."
+    }
+    precondition {
+      condition     = !(var.graph != "" && var.extraction_mode == "compiled-only")
+      error_message = "graph (deployed-graph mode) does not support extraction_mode = \"compiled-only\": no reference extractors are staged in derived mode. Use \"ai-fallback\", or the explicit ontology/binding path."
+    }
+    precondition {
+      condition     = !(var.graph != "" && var.property_graph)
+      error_message = "graph and property_graph are mutually exclusive; set exactly one spec input mode."
     }
   }
 

--- a/examples/context_graph/periodic_materialization/terraform/terraform.tfvars.example
+++ b/examples/context_graph/periodic_materialization/terraform/terraform.tfvars.example
@@ -15,7 +15,12 @@ image_uri         = "us-central1-docker.pkg.dev/your-project/bqaa/periodic-mater
 # Optional overrides (commented = use the default)
 # location              = "US"
 # job_name              = "bqaa-periodic-materialization"
-# property_graph        = false           # true → schema-derived mode (no ontology/binding);
+# graph                 = ""              # deployed-graph mode (recommended): name of a property
+#                                         #        graph you already created in BigQuery (BQAA_GRAPH);
+#                                         #        the runtime reads its DDL from
+#                                         #        INFORMATION_SCHEMA.PROPERTY_GRAPHS — nothing staged;
+#                                         #        not compatible with extraction_mode = "compiled-only"
+# property_graph        = false           # legacy file-based schema-derived mode (prefer graph);
 #                                         #        build the image with build_image.sh --property-graph;
 #                                         #        not compatible with extraction_mode = "compiled-only"
 # extraction_mode       = "ai-fallback"   # or "compiled-only"

--- a/examples/context_graph/periodic_materialization/terraform/variables.tf
+++ b/examples/context_graph/periodic_materialization/terraform/variables.tf
@@ -74,8 +74,14 @@ variable "extraction_mode" {
   }
 }
 
+variable "graph" {
+  description = "Deployed-graph mode (recommended). The name of a property graph you already created in BigQuery (bare name resolved in the graph dataset, or ``dataset.graph`` / ``project.dataset.graph``). The runtime reads the graph's DDL back from ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` and derives the ontology + binding from it plus the live table schemas (the module sets ``BQAA_GRAPH``) — nothing is staged in the image; the deployed graph is the single source of truth. Apply your table DDL + ``CREATE PROPERTY GRAPH`` with ``bq`` before ``terraform apply``. Not compatible with ``extraction_mode = \"compiled-only\"`` (no reference extractors are staged in derived mode), and mutually exclusive with ``property_graph``. Empty string (default) disables the mode."
+  type        = string
+  default     = ""
+}
+
 variable "property_graph" {
-  description = "Schema-derived mode (#286). When ``true``, the runtime derives the ontology + binding from a staged ``property_graph.sql`` + the table schemas instead of an explicit ``ontology.yaml`` / ``binding.yaml`` pair (the module sets ``BQAA_PROPERTY_GRAPH=property_graph.sql``). The published image must be built with ``build_image.sh --property-graph`` so the placeholdered (``$${PROJECT_ID}`` / ``$${DATASET}``) ``property_graph.sql`` + ``table_ddl.sql`` are staged. Use for rename-free graphs; not compatible with ``extraction_mode = \"compiled-only\"`` (no reference extractors are staged in derived mode). ``false`` (default) = explicit ontology + binding (the context-graph / compiled-extractor path)."
+  description = "Legacy file-based schema-derived mode (#286); prefer ``graph``. When ``true``, the runtime derives the ontology + binding from a staged ``property_graph.sql`` + the table schemas instead of an explicit ``ontology.yaml`` / ``binding.yaml`` pair (the module sets ``BQAA_PROPERTY_GRAPH=property_graph.sql``). The published image must be built with ``build_image.sh --property-graph`` so the placeholdered (``$${PROJECT_ID}`` / ``$${DATASET}``) ``property_graph.sql`` + ``table_ddl.sql`` are staged. Use for rename-free graphs; not compatible with ``extraction_mode = \"compiled-only\"`` (no reference extractors are staged in derived mode). ``false`` (default) = explicit ontology + binding (the context-graph / compiled-extractor path)."
   type        = bool
   default     = false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigquery-agent-analytics"
-version = "0.3.3"
+version = "0.3.4"
 description = "SDK for analyzing and evaluating agent traces stored in BigQuery."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1771,25 +1771,30 @@ def _validate_context_graph_input_mode(
     ontology_path: Optional[str],
     binding_path: Optional[str],
     property_graph_path: Optional[str],
+    graph: Optional[str] = None,
 ) -> None:
   """Enforce exactly one input mode for the graph-refresh command.
 
-  Exactly one of (``--ontology`` + ``--binding``) or ``--property-graph`` must
-  be supplied. Raises ``typer.BadParameter`` (rendered as a usage error)
-  otherwise. Kept as a pure helper so the rule is unit-tested directly rather
-  than through brittle assertions on rendered CLI output.
+  Exactly one of ``--graph``, ``--property-graph``, or (``--ontology`` +
+  ``--binding``) must be supplied. Raises ``typer.BadParameter`` (rendered as
+  a usage error) otherwise. Kept as a pure helper so the rule is unit-tested
+  directly rather than through brittle assertions on rendered CLI output.
   """
   has_separated = ontology_path is not None or binding_path is not None
-  if property_graph_path is not None and has_separated:
+  modes_supplied = sum(
+      [graph is not None, property_graph_path is not None, has_separated]
+  )
+  if modes_supplied > 1:
     raise typer.BadParameter(
-        "Use either --property-graph or --ontology/--binding, not both."
+        "Use exactly one of --graph, --property-graph, or"
+        " --ontology/--binding."
     )
-  if property_graph_path is None and (
-      ontology_path is None or binding_path is None
+  if modes_supplied == 0 or (
+      has_separated and (ontology_path is None or binding_path is None)
   ):
     raise typer.BadParameter(
-        "Provide --property-graph PATH, or both --ontology PATH and"
-        " --binding PATH."
+        "Provide --graph NAME, --property-graph PATH, or both --ontology PATH"
+        " and --binding PATH."
     )
 
 
@@ -1822,6 +1827,19 @@ def materialize_window(
             " and binding from the graph definition + table schemas, so no"
             " hand-written ontology.yaml/binding.yaml is needed. Mutually"
             " exclusive with --ontology/--binding."
+        ),
+    ),
+    graph: Optional[str] = typer.Option(
+        None,
+        "--graph",
+        help=(
+            "Name of a property graph already deployed to BigQuery (bare"
+            " name, dataset.graph, or project.dataset.graph; bare names"
+            " resolve in --dataset-id). Reads the graph's DDL back from"
+            " INFORMATION_SCHEMA.PROPERTY_GRAPHS and derives the ontology and"
+            " binding from it + the live table schemas — the deployed graph"
+            " is the single source of truth. Mutually exclusive with"
+            " --property-graph and --ontology/--binding."
         ),
     ),
     events_table: str = typer.Option(
@@ -2033,9 +2051,9 @@ def materialize_window(
           programming bug).
   """
   # Validate the input mode before any work: exactly one of
-  # (--ontology + --binding) or (--property-graph).
+  # --graph, --property-graph, or (--ontology + --binding).
   _validate_context_graph_input_mode(
-      ontology_path, binding_path, property_graph_path
+      ontology_path, binding_path, property_graph_path, graph
   )
 
   try:
@@ -2056,6 +2074,7 @@ def materialize_window(
         ontology_path=ontology_path,
         binding_path=binding_path,
         property_graph_path=property_graph_path,
+        graph=graph,
         events_table=events_table,
         lookback_hours=lookback_hours,
         overlap_minutes=overlap_minutes,

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -1811,7 +1811,8 @@ def materialize_window(
         "--ontology",
         help=(
             "Path to ontology YAML file. Use with --binding, or omit both and"
-            " pass --property-graph to derive them from the graph DDL."
+            " pass --graph to derive them from the property graph you already"
+            " deployed to BigQuery."
         ),
     ),
     binding_path: Optional[str] = typer.Option(

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1247,6 +1247,32 @@ def _state_table_defaults(
   return (graph_project_id or project_id, graph_dataset_id or dataset_id)
 
 
+def _normalize_graph_target(
+    graph: str,
+    project_id: str,
+    dataset_id: str,
+    graph_project_id: Optional[str],
+    graph_dataset_id: Optional[str],
+) -> tuple[str, str, str]:
+  """Resolve a (possibly qualified) ``graph`` ref into the graph target.
+
+  Returns ``(graph_project_id, graph_dataset_id, bare_graph_name)``. A
+  qualified reference (``dataset.graph`` / ``project.dataset.graph``) is the
+  most specific signal, so its parts become the effective graph target — the
+  state table, the binding target, and the ``INFORMATION_SCHEMA`` lookups all
+  follow the graph's own dataset, never a (possibly read-only) events
+  dataset. A bare name keeps the explicit ``graph_*`` args (falling back to
+  the events ``project_id`` / ``dataset_id``, the single-dataset shape).
+  """
+  from .property_graph_spec import split_graph_ref
+
+  return split_graph_ref(
+      graph,
+      default_project=graph_project_id or project_id,
+      default_dataset=graph_dataset_id or dataset_id,
+  )
+
+
 def _resolve_ontology_binding(
     *,
     ontology_path: Optional[str],
@@ -1392,7 +1418,12 @@ def run_materialize_window(
       ``graph_project_id``, defaulting to ``dataset_id`` / ``project_id``) and
       derives the ontology + binding from it plus the live table schemas, so
       the deployed graph is the single source of truth and no local SQL file
-      is consumed. Mutually exclusive with the other input modes.
+      is consumed. A *qualified* reference sets the effective graph target:
+      its dataset/project become the ``graph_dataset_id`` /
+      ``graph_project_id`` defaults, so the state table and the binding
+      target follow the graph's own dataset rather than a (possibly
+      read-only) events ``dataset_id``. Mutually exclusive with the other
+      input modes.
     graph_project_id, graph_dataset_id: For schema-derived mode, the project /
       dataset that holds the graph tables and receives the materialized graph
       (``${PROJECT_ID}`` / ``${DATASET}`` placeholder resolution, schema lookup,
@@ -1638,6 +1669,14 @@ def run_materialize_window(
   run_id = generate_run_id()
 
   client = bq_client or bigquery.Client(project=project_id, location=location)
+
+  # Normalize a qualified ``graph`` reference BEFORE anything derives a
+  # graph target from it (state-table defaults, binding target, schema
+  # lookups).
+  if graph is not None:
+    graph_project_id, graph_dataset_id, graph = _normalize_graph_target(
+        graph, project_id, dataset_id, graph_project_id, graph_dataset_id
+    )
 
   # Resolve identifiers + qualified refs.
   events_table_ref = validated_table_ref(project_id, dataset_id, events_table)

--- a/src/bigquery_agent_analytics/materialize_window.py
+++ b/src/bigquery_agent_analytics/materialize_window.py
@@ -1257,34 +1257,68 @@ def _resolve_ontology_binding(
     bq_client: Any,
     graph_project_id: Optional[str] = None,
     graph_dataset_id: Optional[str] = None,
+    graph: Optional[str] = None,
 ):
-  """Resolve the ``(Ontology, Binding)`` pair from one of two input modes.
+  """Resolve the ``(Ontology, Binding)`` pair from one of three input modes.
 
   * Explicit YAML: ``ontology_path`` + ``binding_path`` together.
-  * Schema-derived: ``property_graph_path`` (a ``CREATE PROPERTY GRAPH`` DDL
-    file) -- parse it, read column types from ``INFORMATION_SCHEMA.COLUMNS``
-    via ``bq_client``, and synthesise the pair in memory (#277). No
-    hand-written ontology/binding required.
+  * Schema-derived from the deployed graph: ``graph`` (the name of a property
+    graph the user already created in BigQuery) -- read its normalized
+    ``CREATE PROPERTY GRAPH`` DDL back from
+    ``INFORMATION_SCHEMA.PROPERTY_GRAPHS``, then derive as below. The deployed
+    graph is the single source of truth; no local SQL file is consumed.
+  * Schema-derived from a local file: ``property_graph_path`` (a ``CREATE
+    PROPERTY GRAPH`` DDL file) -- parse it, read column types from
+    ``INFORMATION_SCHEMA.COLUMNS`` via ``bq_client``, and synthesise the pair
+    in memory (#277). No hand-written ontology/binding required.
 
   ``graph_project_id`` / ``graph_dataset_id`` target the derived graph (its
   ``${PROJECT_ID}`` / ``${DATASET}`` placeholder resolution, schema lookup, and
   binding target) at a project/dataset distinct from the events ``project_id`` /
   ``dataset_id``. They default to ``project_id`` / ``dataset_id`` (single-dataset
   shape, e.g. the codelab). A two-dataset deploy -- a read-only events dataset
-  and a separate graph dataset -- sets them to the graph dataset.
+  and a separate graph dataset -- sets them to the graph dataset. In ``graph``
+  mode they also locate the ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` lookup
+  (unless ``graph`` itself is dataset- or project-qualified).
 
-  Exactly one mode must be supplied; both or neither raises ``ValueError``.
-  This is the single seam the orchestrator uses to obtain its spec, so both
+  Exactly one mode must be supplied; anything else raises ``ValueError``.
+  This is the single seam the orchestrator uses to obtain its spec, so all
   input modes converge here onto the same downstream ``resolve()`` path.
   """
   from bigquery_ontology import load_binding
   from bigquery_ontology import load_ontology
 
+  modes_supplied = sum(
+      [
+          graph is not None,
+          property_graph_path is not None,
+          ontology_path is not None or binding_path is not None,
+      ]
+  )
+  if modes_supplied > 1:
+    raise ValueError(
+        "Provide exactly one of --graph, --property-graph, or"
+        " --ontology/--binding."
+    )
+
+  if graph is not None:
+    from .property_graph_spec import derive_ontology_binding_from_ddl
+    from .property_graph_spec import fetch_property_graph_ddl
+
+    ddl_text = fetch_property_graph_ddl(
+        bq_client,
+        project_id=graph_project_id or project_id,
+        dataset_id=graph_dataset_id or dataset_id,
+        graph_name=graph,
+    )
+    return derive_ontology_binding_from_ddl(
+        ddl_text,
+        project_id=graph_project_id or project_id,
+        dataset_id=graph_dataset_id or dataset_id,
+        bq_client=bq_client,
+    )
+
   if property_graph_path is not None:
-    if ontology_path is not None or binding_path is not None:
-      raise ValueError(
-          "Provide either --property-graph or --ontology/--binding, not both."
-      )
     from .property_graph_spec import derive_ontology_binding_from_ddl
 
     ddl_text = pathlib.Path(property_graph_path).read_text(encoding="utf-8")
@@ -1297,8 +1331,8 @@ def _resolve_ontology_binding(
 
   if ontology_path is None or binding_path is None:
     raise ValueError(
-        "Provide --property-graph PATH, or both --ontology PATH and"
-        " --binding PATH."
+        "Provide --graph NAME, --property-graph PATH, or both"
+        " --ontology PATH and --binding PATH."
     )
   ontology_obj = load_ontology(ontology_path)
   binding_obj = load_binding(binding_path, ontology=ontology_obj)
@@ -1312,6 +1346,7 @@ def run_materialize_window(
     ontology_path: Optional[str] = None,
     binding_path: Optional[str] = None,
     property_graph_path: Optional[str] = None,
+    graph: Optional[str] = None,
     graph_project_id: Optional[str] = None,
     graph_dataset_id: Optional[str] = None,
     events_table: str = "agent_events",
@@ -1350,6 +1385,14 @@ def run_materialize_window(
       schema-derived input mode; the ontology + binding are synthesised from
       the graph definition and live table schemas. Mutually exclusive with
       ``ontology_path`` / ``binding_path``; exactly one mode must be supplied.
+    graph: Name of a property graph the user already deployed to BigQuery --
+      a bare name, ``dataset.graph``, or ``project.dataset.graph``. The
+      orchestrator reads the graph's normalized DDL back from
+      ``INFORMATION_SCHEMA.PROPERTY_GRAPHS`` (in ``graph_dataset_id`` /
+      ``graph_project_id``, defaulting to ``dataset_id`` / ``project_id``) and
+      derives the ontology + binding from it plus the live table schemas, so
+      the deployed graph is the single source of truth and no local SQL file
+      is consumed. Mutually exclusive with the other input modes.
     graph_project_id, graph_dataset_id: For schema-derived mode, the project /
       dataset that holds the graph tables and receives the materialized graph
       (``${PROJECT_ID}`` / ``${DATASET}`` placeholder resolution, schema lookup,
@@ -1613,15 +1656,17 @@ def run_materialize_window(
   )
   state_table_ref = f"{state_project}.{state_dataset}.{state_table_local}"
 
-  # Resolve the ontology + binding from one of two input modes (see
-  # _resolve_ontology_binding): explicit YAML, or schema-derived from a
-  # CREATE PROPERTY GRAPH DDL.
+  # Resolve the ontology + binding from one of three input modes (see
+  # _resolve_ontology_binding): explicit YAML, schema-derived from the
+  # deployed graph (INFORMATION_SCHEMA.PROPERTY_GRAPHS), or schema-derived
+  # from a local CREATE PROPERTY GRAPH DDL file.
   from bigquery_ontology._fingerprint import fingerprint_model
 
   ontology_obj, binding_obj = _resolve_ontology_binding(
       ontology_path=ontology_path,
       binding_path=binding_path,
       property_graph_path=property_graph_path,
+      graph=graph,
       project_id=project_id,
       dataset_id=dataset_id,
       graph_project_id=graph_project_id,

--- a/src/bigquery_agent_analytics/property_graph_spec.py
+++ b/src/bigquery_agent_analytics/property_graph_spec.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Derive an ontology + binding from a property-graph DDL file.
+"""Derive an ontology + binding from property-graph DDL.
 
 The capstone of GitHub issue #277, Option A: turn the ``CREATE PROPERTY GRAPH``
 DDL the user already authors (the query surface) into the in-memory
 ``Ontology`` + ``Binding`` the materializer needs -- so ``bqaa context-graph``
 no longer requires hand-written ``ontology.yaml`` / ``binding.yaml``.
+
+The DDL text can come from two sources:
+
+* A local ``.sql`` file (``--property-graph``), possibly placeholdered for
+  ``envsubst`` (``${PROJECT_ID}`` / ``${DATASET}``).
+* The graph the user already deployed to BigQuery (``--graph``):
+  :func:`fetch_property_graph_ddl` reads the normalized ``CREATE PROPERTY
+  GRAPH`` statement back from ``INFORMATION_SCHEMA.PROPERTY_GRAPHS``, making
+  the deployed graph itself the single source of truth.
 
 This ties together the three offline building blocks in ``bigquery_ontology``:
 
@@ -59,6 +68,107 @@ def resolve_placeholders(text: str, mapping: Mapping[str, str]) -> str:
     return mapping.get(match.group(1), match.group(0))
 
   return _PLACEHOLDER_RE.sub(_replace, text)
+
+
+class PropertyGraphLookupError(ValueError):
+  """A deployed property graph could not be resolved in INFORMATION_SCHEMA."""
+
+
+def split_graph_ref(
+    graph_ref: str,
+    *,
+    default_project: str,
+    default_dataset: str,
+) -> tuple[str, str, str]:
+  """Split a graph reference into ``(project, dataset, graph_name)``.
+
+  Accepts a bare graph name, ``dataset.graph``, or ``project.dataset.graph``;
+  missing qualifiers fall back to ``default_project`` / ``default_dataset``.
+  """
+  parts = graph_ref.split(".")
+  if len(parts) == 3:
+    project, dataset, name = parts
+  elif len(parts) == 2:
+    project, (dataset, name) = default_project, parts
+  elif len(parts) == 1:
+    project, dataset, name = default_project, default_dataset, parts[0]
+  else:
+    raise PropertyGraphLookupError(
+        f"Cannot parse graph reference {graph_ref!r}: expected 1-3"
+        " dot-separated parts (graph, dataset.graph, or"
+        " project.dataset.graph)."
+    )
+  if not all((project, dataset, name)):
+    raise PropertyGraphLookupError(
+        f"Graph reference {graph_ref!r} is not fully qualified and no"
+        " default project/dataset is available."
+    )
+  return project, dataset, name
+
+
+def fetch_property_graph_ddl(
+    bq_client: Any,
+    *,
+    project_id: str,
+    dataset_id: str,
+    graph_name: str,
+) -> str:
+  """Fetch a deployed graph's DDL from ``INFORMATION_SCHEMA.PROPERTY_GRAPHS``.
+
+  Args:
+    bq_client: A ``google.cloud.bigquery.Client``.
+    project_id: Default project for unqualified ``graph_name`` references.
+    dataset_id: Default dataset for unqualified ``graph_name`` references.
+    graph_name: The deployed graph -- a bare name, ``dataset.graph``, or
+      ``project.dataset.graph``.
+
+  Returns:
+    The normalized ``CREATE PROPERTY GRAPH`` statement BigQuery recorded for
+    the graph. Fully qualified, placeholder-free -- ready for
+    :func:`derive_ontology_binding_from_ddl`.
+
+  Raises:
+    PropertyGraphLookupError: The graph does not exist in the target dataset;
+      the message lists the graphs that do.
+  """
+  from google.cloud import bigquery
+
+  project, dataset, name = split_graph_ref(
+      graph_name, default_project=project_id, default_dataset=dataset_id
+  )
+  sql = (
+      "SELECT ddl\n"
+      f"FROM `{project}.{dataset}`.INFORMATION_SCHEMA.PROPERTY_GRAPHS\n"
+      "WHERE property_graph_name = @graph_name"
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("graph_name", "STRING", name)
+      ]
+  )
+  rows = list(bq_client.query(sql, job_config=job_config).result())
+  if rows:
+    return rows[0]["ddl"]
+
+  available_sql = (
+      "SELECT property_graph_name\n"
+      f"FROM `{project}.{dataset}`.INFORMATION_SCHEMA.PROPERTY_GRAPHS\n"
+      "ORDER BY property_graph_name"
+  )
+  available = [
+      row["property_graph_name"]
+      for row in bq_client.query(available_sql).result()
+  ]
+  hint = (
+      f" Graphs in that dataset: {', '.join(available)}."
+      if available
+      else " The dataset has no property graphs; apply your CREATE PROPERTY"
+      " GRAPH DDL first."
+  )
+  raise PropertyGraphLookupError(
+      f"Property graph `{name}` not found in `{project}.{dataset}`"
+      " (INFORMATION_SCHEMA.PROPERTY_GRAPHS)." + hint
+  )
 
 
 def derive_ontology_binding_from_ddl(

--- a/tests/test_cli_context_graph_input_modes.py
+++ b/tests/test_cli_context_graph_input_modes.py
@@ -38,12 +38,12 @@ from bigquery_agent_analytics.cli import bqaa_app
 
 
 def test_rejects_both_modes() -> None:
-  with pytest.raises(typer.BadParameter, match="not both"):
+  with pytest.raises(typer.BadParameter, match="exactly one"):
     _validate_context_graph_input_mode("o.yaml", "b.yaml", "g.sql")
 
 
 def test_rejects_neither_mode() -> None:
-  with pytest.raises(typer.BadParameter, match="Provide --property-graph"):
+  with pytest.raises(typer.BadParameter, match="Provide --graph"):
     _validate_context_graph_input_mode(None, None, None)
 
 
@@ -53,7 +53,7 @@ def test_rejects_ontology_without_binding() -> None:
 
 
 def test_rejects_property_graph_with_partial_separated() -> None:
-  with pytest.raises(typer.BadParameter, match="not both"):
+  with pytest.raises(typer.BadParameter, match="exactly one"):
     _validate_context_graph_input_mode("o.yaml", None, "g.sql")
 
 
@@ -63,6 +63,20 @@ def test_accepts_separated_mode() -> None:
 
 def test_accepts_property_graph_mode() -> None:
   _validate_context_graph_input_mode(None, None, "g.sql")  # no raise
+
+
+def test_accepts_graph_mode() -> None:
+  _validate_context_graph_input_mode(None, None, None, "my_graph")  # no raise
+
+
+def test_rejects_graph_with_property_graph() -> None:
+  with pytest.raises(typer.BadParameter, match="exactly one"):
+    _validate_context_graph_input_mode(None, None, "g.sql", "my_graph")
+
+
+def test_rejects_graph_with_separated() -> None:
+  with pytest.raises(typer.BadParameter, match="exactly one"):
+    _validate_context_graph_input_mode("o.yaml", "b.yaml", None, "my_graph")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_deploy_graph_mode.py
+++ b/tests/test_deploy_graph_mode.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployed-graph (``--graph`` / ``BQAA_GRAPH``) mode: deploy + Terraform wiring.
+
+Static + shell tests mirroring ``test_deploy_property_graph_mode.py`` /
+``test_terraform_property_graph_mode.py``: boundary rejections run the script
+directly (the validation fires before any gcloud call); the staging and env
+contracts are pinned by asserting on the script / module text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+_DEPLOY_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "context_graph"
+    / "periodic_materialization"
+)
+_DEPLOY = _DEPLOY_DIR / "deploy_cloud_run_job.sh"
+_DEPLOY_TEXT = _DEPLOY.read_text()
+_RUN_JOB_TEXT = (_DEPLOY_DIR / "run_job.py").read_text()
+
+_TF_DIR = _DEPLOY_DIR / "terraform"
+_TF_MAIN = (_TF_DIR / "main.tf").read_text()
+_TF_VARS = (_TF_DIR / "variables.tf").read_text()
+_TFVARS_EXAMPLE = (_TF_DIR / "terraform.tfvars.example").read_text()
+
+_REQUIRED = [
+    "--project",
+    "p",
+    "--region",
+    "us-central1",
+    "--events-dataset",
+    "e",
+    "--graph-dataset",
+    "g",
+    "--schedule",
+    "0 */6 * * *",
+]
+
+
+def _run_deploy(args):
+  return subprocess.run(
+      ["bash", str(_DEPLOY), *_REQUIRED, *args],
+      capture_output=True,
+      text=True,
+      timeout=60,
+  )
+
+
+# --------------------------------------------------------------------------- #
+# Deploy script boundary rejections
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_rejects_graph_with_compiled_only() -> None:
+  result = _run_deploy(
+      ["--graph", "agent_decisions_graph", "--extraction-mode", "compiled-only"]
+  )
+  assert result.returncode != 0
+  assert "compiled-only" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_rejects_graph_with_property_graph(tmp_path) -> None:
+  (tmp_path / "property_graph.sql").write_text("x")
+  (tmp_path / "table_ddl.sql").write_text("x")
+  result = _run_deploy(
+      [
+          "--graph",
+          "agent_decisions_graph",
+          "--property-graph",
+          str(tmp_path / "property_graph.sql"),
+      ]
+  )
+  assert result.returncode != 0
+  assert "mutually exclusive" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_graph_requires_value() -> None:
+  result = _run_deploy(["--graph"])
+  assert result.returncode != 0
+
+
+# --------------------------------------------------------------------------- #
+# Deploy script wiring contracts (text pins)
+# --------------------------------------------------------------------------- #
+
+
+def test_deploy_wires_bqaa_graph_env() -> None:
+  assert 'ENV_VARS+=("BQAA_GRAPH=${GRAPH}")' in _DEPLOY_TEXT
+
+
+def test_deploy_graph_mode_stages_nothing() -> None:
+  # The graph-mode staging branch ships only run_job.py: no property_graph.sql,
+  # no table_ddl.sql, no ontology/binding artifacts.
+  graph_branch = _DEPLOY_TEXT.split('if [[ -n "$GRAPH" ]]; then', 2)[2].split(
+      "elif"
+  )[0]
+  assert "cp" not in graph_branch
+
+
+def test_deploy_help_documents_graph_flag() -> None:
+  assert "--graph NAME" in _DEPLOY_TEXT
+  assert "INFORMATION_SCHEMA.PROPERTY_GRAPHS" in _DEPLOY_TEXT
+
+
+# --------------------------------------------------------------------------- #
+# run_job.py wiring contracts (text pins)
+# --------------------------------------------------------------------------- #
+
+
+def test_run_job_reads_bqaa_graph() -> None:
+  assert 'os.environ.get("BQAA_GRAPH")' in _RUN_JOB_TEXT
+
+
+def test_run_job_rejects_both_modes() -> None:
+  assert "mutually" in _RUN_JOB_TEXT
+
+
+def test_run_job_skips_bootstrap_in_graph_mode() -> None:
+  assert "entity-table bootstrap skipped (deployed-graph mode)" in _RUN_JOB_TEXT
+
+
+# --------------------------------------------------------------------------- #
+# Terraform module wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_tf_graph_variable_declared() -> None:
+  assert 'variable "graph"' in _TF_VARS
+  graph_block = _TF_VARS.split('variable "graph"')[1].split("variable ")[0]
+  assert "type        = string" in graph_block
+  assert 'default     = ""' in graph_block
+
+
+def test_tf_env_var_wired_conditionally() -> None:
+  # BQAA_GRAPH is merged only when var.graph is non-empty.
+  assert 'var.graph == "" ? {} : {' in _TF_MAIN
+  assert "BQAA_GRAPH = var.graph" in _TF_MAIN
+
+
+def test_tf_compiled_only_precondition() -> None:
+  assert (
+      '!(var.graph != "" && var.extraction_mode == "compiled-only")' in _TF_MAIN
+  )
+
+
+def test_tf_mutual_exclusion_precondition() -> None:
+  assert '!(var.graph != "" && var.property_graph)' in _TF_MAIN
+
+
+def test_tfvars_example_documents_graph() -> None:
+  assert "graph " in _TFVARS_EXAMPLE
+  assert "deployed-graph mode" in _TFVARS_EXAMPLE

--- a/tests/test_property_graph_spec.py
+++ b/tests/test_property_graph_spec.py
@@ -183,7 +183,7 @@ def test_orchestrator_resolves_via_property_graph(tmp_path) -> None:
 def test_orchestrator_rejects_both_modes() -> None:
   from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
 
-  with pytest.raises(ValueError, match="not both"):
+  with pytest.raises(ValueError, match="exactly one"):
     _resolve_ontology_binding(
         ontology_path="o.yaml",
         binding_path="b.yaml",
@@ -197,7 +197,7 @@ def test_orchestrator_rejects_both_modes() -> None:
 def test_orchestrator_rejects_neither_mode() -> None:
   from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
 
-  with pytest.raises(ValueError, match="Provide --property-graph"):
+  with pytest.raises(ValueError, match="Provide --graph"):
     _resolve_ontology_binding(
         ontology_path=None,
         binding_path=None,
@@ -281,3 +281,254 @@ def test_state_table_defaults_to_events_in_single_dataset() -> None:
   from bigquery_agent_analytics.materialize_window import _state_table_defaults
 
   assert _state_table_defaults("p", "d", None, None) == ("p", "d")
+
+
+# --------------------------------------------------------------------------- #
+# Deployed-graph mode: fetch the DDL from INFORMATION_SCHEMA.PROPERTY_GRAPHS
+# --------------------------------------------------------------------------- #
+
+# Captured live from BigQuery (test-project-0728-467323, 2026-06): the
+# normalized ``ddl`` column INFORMATION_SCHEMA.PROPERTY_GRAPHS returns for the
+# codelab graph, genericized to project ``p`` / dataset ``d``. Shape pins the
+# parser against the normalized form: plain ``CREATE PROPERTY GRAPH`` (no
+# ``OR REPLACE``), newline-heavy layout, ``KEY (a,b)`` without spaces, edge
+# PROPERTIES that include the SDK metadata columns, trailing semicolon.
+_INFOSCHEMA_DDL = """CREATE PROPERTY GRAPH `p.d.agent_decisions_graph`
+NODE TABLES (
+`p.d.decision_request` AS decision_request
+KEY (request_id)
+LABEL DecisionRequest PROPERTIES (request_id, request_text, requested_at),
+
+`p.d.decision_option` AS decision_option
+KEY (option_id)
+LABEL DecisionOption PROPERTIES (option_id, option_label, confidence))
+
+EDGE TABLES (
+`p.d.evaluates_option` AS evaluates_option
+KEY (request_id,option_id)
+SOURCE KEY (request_id)
+  REFERENCES decision_request (request_id)
+DESTINATION KEY (option_id)
+  REFERENCES decision_option (option_id)
+LABEL evaluatesOption PROPERTIES (request_id, option_id, session_id, extracted_at));
+"""
+
+_SCHEMAS_WITH_METADATA = {
+    "decision_request": _SCHEMAS["decision_request"]
+    + [
+        {"column_name": "session_id", "data_type": "STRING"},
+        {"column_name": "extracted_at", "data_type": "TIMESTAMP"},
+    ],
+    "decision_option": _SCHEMAS["decision_option"]
+    + [
+        {"column_name": "session_id", "data_type": "STRING"},
+        {"column_name": "extracted_at", "data_type": "TIMESTAMP"},
+    ],
+    "evaluates_option": _SCHEMAS["evaluates_option"]
+    + [
+        {"column_name": "session_id", "data_type": "STRING"},
+        {"column_name": "extracted_at", "data_type": "TIMESTAMP"},
+    ],
+}
+
+
+class _FakeGraphClient:
+  """Dispatches on the query's parameter name.
+
+  ``graph_name`` -> INFORMATION_SCHEMA.PROPERTY_GRAPHS lookup;
+  ``table_name`` -> INFORMATION_SCHEMA.COLUMNS lookup; a parameter-less query
+  is the available-graphs listing used for not-found error messages. Records
+  every SQL string for assertions.
+  """
+
+  def __init__(self, graphs, schemas):
+    self._graphs = graphs  # {graph_name: ddl}
+    self._schemas = schemas
+    self.queries = []
+
+  def query(self, sql, job_config=None):
+    self.queries.append(sql)
+    if job_config is None:
+      return _FakeJob(
+          [{"property_graph_name": name} for name in sorted(self._graphs)]
+      )
+    param = job_config.query_parameters[0]
+    if param.name == "graph_name":
+      ddl = self._graphs.get(param.value)
+      return _FakeJob([{"ddl": ddl}] if ddl is not None else [])
+    return _FakeJob(self._schemas.get(param.value, []))
+
+
+def test_split_graph_ref_qualification() -> None:
+  from bigquery_agent_analytics.property_graph_spec import split_graph_ref
+
+  assert split_graph_ref("g", default_project="p", default_dataset="d") == (
+      "p",
+      "d",
+      "g",
+  )
+  assert split_graph_ref(
+      "ds2.g", default_project="p", default_dataset="d"
+  ) == ("p", "ds2", "g")
+  assert split_graph_ref(
+      "p2.ds2.g", default_project="p", default_dataset="d"
+  ) == ("p2", "ds2", "g")
+
+
+def test_split_graph_ref_rejects_too_many_parts() -> None:
+  from bigquery_agent_analytics.property_graph_spec import (
+      PropertyGraphLookupError,
+      split_graph_ref,
+  )
+
+  with pytest.raises(PropertyGraphLookupError, match="1-3"):
+    split_graph_ref("a.b.c.d", default_project="p", default_dataset="d")
+
+
+def test_fetch_property_graph_ddl_happy_path() -> None:
+  from bigquery_agent_analytics.property_graph_spec import (
+      fetch_property_graph_ddl,
+  )
+
+  client = _FakeGraphClient(
+      {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
+  )
+  ddl = fetch_property_graph_ddl(
+      client,
+      project_id="p",
+      dataset_id="d",
+      graph_name="agent_decisions_graph",
+  )
+  assert ddl == _INFOSCHEMA_DDL
+  # The lookup is dataset-qualified (no region qualifier needed).
+  assert "`p.d`.INFORMATION_SCHEMA.PROPERTY_GRAPHS" in client.queries[0]
+
+
+def test_fetch_property_graph_ddl_qualified_name_overrides_defaults() -> None:
+  from bigquery_agent_analytics.property_graph_spec import (
+      fetch_property_graph_ddl,
+  )
+
+  client = _FakeGraphClient(
+      {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
+  )
+  fetch_property_graph_ddl(
+      client,
+      project_id="p",
+      dataset_id="d",
+      graph_name="p2.graph_ds.agent_decisions_graph",
+  )
+  assert "`p2.graph_ds`.INFORMATION_SCHEMA.PROPERTY_GRAPHS" in (
+      client.queries[0]
+  )
+
+
+def test_fetch_property_graph_ddl_not_found_lists_available() -> None:
+  from bigquery_agent_analytics.property_graph_spec import (
+      PropertyGraphLookupError,
+      fetch_property_graph_ddl,
+  )
+
+  client = _FakeGraphClient(
+      {"other_graph": "CREATE PROPERTY GRAPH ..."}, _SCHEMAS_WITH_METADATA
+  )
+  with pytest.raises(PropertyGraphLookupError) as exc_info:
+    fetch_property_graph_ddl(
+        client, project_id="p", dataset_id="d", graph_name="missing_graph"
+    )
+  assert "missing_graph" in str(exc_info.value)
+  assert "other_graph" in str(exc_info.value)
+
+
+def test_fetch_property_graph_ddl_not_found_empty_dataset() -> None:
+  from bigquery_agent_analytics.property_graph_spec import (
+      PropertyGraphLookupError,
+      fetch_property_graph_ddl,
+  )
+
+  client = _FakeGraphClient({}, _SCHEMAS_WITH_METADATA)
+  with pytest.raises(
+      PropertyGraphLookupError, match="no property graphs"
+  ):
+    fetch_property_graph_ddl(
+        client, project_id="p", dataset_id="d", graph_name="missing_graph"
+    )
+
+
+def test_orchestrator_resolves_via_deployed_graph() -> None:
+  # End-to-end: --graph mode fetches the normalized INFORMATION_SCHEMA DDL
+  # and derives the same ontology + binding the file path would. The fixture
+  # is the live-captured normalized form, so this also pins parser tolerance
+  # for that shape (KEY without spaces, metadata columns in edge PROPERTIES,
+  # no OR REPLACE).
+  from bigquery_agent_analytics.materialize_window import (
+      _resolve_ontology_binding,
+  )
+
+  client = _FakeGraphClient(
+      {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
+  )
+  ontology, binding = _resolve_ontology_binding(
+      ontology_path=None,
+      binding_path=None,
+      property_graph_path=None,
+      graph="agent_decisions_graph",
+      project_id="p",
+      dataset_id="d",
+      bq_client=client,
+  )
+  assert ontology.ontology == "agent_decisions_graph"
+  assert {e.name for e in ontology.entities} == {
+      "DecisionRequest",
+      "DecisionOption",
+  }
+  assert [r.name for r in ontology.relationships] == ["evaluatesOption"]
+  request_binding = next(
+      e for e in binding.entities if e.name == "DecisionRequest"
+  )
+  assert request_binding.source == "p.d.decision_request"
+
+
+def test_orchestrator_graph_mode_uses_graph_dataset_for_lookup() -> None:
+  # Split-dataset deploy: the deployed graph lives in the graph dataset, so
+  # the INFORMATION_SCHEMA lookup must target graph_dataset_id, not the
+  # events dataset.
+  from bigquery_agent_analytics.materialize_window import (
+      _resolve_ontology_binding,
+  )
+
+  graph_ddl = _INFOSCHEMA_DDL.replace("`p.d.", "`p.graph_ds.")
+  client = _FakeGraphClient(
+      {"agent_decisions_graph": graph_ddl}, _SCHEMAS_WITH_METADATA
+  )
+  _, binding = _resolve_ontology_binding(
+      ontology_path=None,
+      binding_path=None,
+      property_graph_path=None,
+      graph="agent_decisions_graph",
+      project_id="p",
+      dataset_id="events_ds",
+      graph_dataset_id="graph_ds",
+      bq_client=client,
+  )
+  assert "`p.graph_ds`.INFORMATION_SCHEMA.PROPERTY_GRAPHS" in (
+      client.queries[0]
+  )
+  assert binding.target.dataset == "graph_ds"
+
+
+def test_orchestrator_rejects_graph_with_other_modes() -> None:
+  from bigquery_agent_analytics.materialize_window import (
+      _resolve_ontology_binding,
+  )
+
+  with pytest.raises(ValueError, match="exactly one"):
+    _resolve_ontology_binding(
+        ontology_path=None,
+        binding_path=None,
+        property_graph_path="g.sql",
+        graph="agent_decisions_graph",
+        project_id="p",
+        dataset_id="d",
+        bq_client=_FakeClient({}),
+    )

--- a/tests/test_property_graph_spec.py
+++ b/tests/test_property_graph_spec.py
@@ -367,28 +367,26 @@ def test_split_graph_ref_qualification() -> None:
       "d",
       "g",
   )
-  assert split_graph_ref(
-      "ds2.g", default_project="p", default_dataset="d"
-  ) == ("p", "ds2", "g")
+  assert split_graph_ref("ds2.g", default_project="p", default_dataset="d") == (
+      "p",
+      "ds2",
+      "g",
+  )
   assert split_graph_ref(
       "p2.ds2.g", default_project="p", default_dataset="d"
   ) == ("p2", "ds2", "g")
 
 
 def test_split_graph_ref_rejects_too_many_parts() -> None:
-  from bigquery_agent_analytics.property_graph_spec import (
-      PropertyGraphLookupError,
-      split_graph_ref,
-  )
+  from bigquery_agent_analytics.property_graph_spec import PropertyGraphLookupError
+  from bigquery_agent_analytics.property_graph_spec import split_graph_ref
 
   with pytest.raises(PropertyGraphLookupError, match="1-3"):
     split_graph_ref("a.b.c.d", default_project="p", default_dataset="d")
 
 
 def test_fetch_property_graph_ddl_happy_path() -> None:
-  from bigquery_agent_analytics.property_graph_spec import (
-      fetch_property_graph_ddl,
-  )
+  from bigquery_agent_analytics.property_graph_spec import fetch_property_graph_ddl
 
   client = _FakeGraphClient(
       {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
@@ -405,9 +403,7 @@ def test_fetch_property_graph_ddl_happy_path() -> None:
 
 
 def test_fetch_property_graph_ddl_qualified_name_overrides_defaults() -> None:
-  from bigquery_agent_analytics.property_graph_spec import (
-      fetch_property_graph_ddl,
-  )
+  from bigquery_agent_analytics.property_graph_spec import fetch_property_graph_ddl
 
   client = _FakeGraphClient(
       {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
@@ -424,10 +420,8 @@ def test_fetch_property_graph_ddl_qualified_name_overrides_defaults() -> None:
 
 
 def test_fetch_property_graph_ddl_not_found_lists_available() -> None:
-  from bigquery_agent_analytics.property_graph_spec import (
-      PropertyGraphLookupError,
-      fetch_property_graph_ddl,
-  )
+  from bigquery_agent_analytics.property_graph_spec import fetch_property_graph_ddl
+  from bigquery_agent_analytics.property_graph_spec import PropertyGraphLookupError
 
   client = _FakeGraphClient(
       {"other_graph": "CREATE PROPERTY GRAPH ..."}, _SCHEMAS_WITH_METADATA
@@ -441,15 +435,11 @@ def test_fetch_property_graph_ddl_not_found_lists_available() -> None:
 
 
 def test_fetch_property_graph_ddl_not_found_empty_dataset() -> None:
-  from bigquery_agent_analytics.property_graph_spec import (
-      PropertyGraphLookupError,
-      fetch_property_graph_ddl,
-  )
+  from bigquery_agent_analytics.property_graph_spec import fetch_property_graph_ddl
+  from bigquery_agent_analytics.property_graph_spec import PropertyGraphLookupError
 
   client = _FakeGraphClient({}, _SCHEMAS_WITH_METADATA)
-  with pytest.raises(
-      PropertyGraphLookupError, match="no property graphs"
-  ):
+  with pytest.raises(PropertyGraphLookupError, match="no property graphs"):
     fetch_property_graph_ddl(
         client, project_id="p", dataset_id="d", graph_name="missing_graph"
     )
@@ -461,9 +451,7 @@ def test_orchestrator_resolves_via_deployed_graph() -> None:
   # is the live-captured normalized form, so this also pins parser tolerance
   # for that shape (KEY without spaces, metadata columns in edge PROPERTIES,
   # no OR REPLACE).
-  from bigquery_agent_analytics.materialize_window import (
-      _resolve_ontology_binding,
-  )
+  from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
 
   client = _FakeGraphClient(
       {"agent_decisions_graph": _INFOSCHEMA_DDL}, _SCHEMAS_WITH_METADATA
@@ -493,9 +481,7 @@ def test_orchestrator_graph_mode_uses_graph_dataset_for_lookup() -> None:
   # Split-dataset deploy: the deployed graph lives in the graph dataset, so
   # the INFORMATION_SCHEMA lookup must target graph_dataset_id, not the
   # events dataset.
-  from bigquery_agent_analytics.materialize_window import (
-      _resolve_ontology_binding,
-  )
+  from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
 
   graph_ddl = _INFOSCHEMA_DDL.replace("`p.d.", "`p.graph_ds.")
   client = _FakeGraphClient(
@@ -518,9 +504,7 @@ def test_orchestrator_graph_mode_uses_graph_dataset_for_lookup() -> None:
 
 
 def test_orchestrator_rejects_graph_with_other_modes() -> None:
-  from bigquery_agent_analytics.materialize_window import (
-      _resolve_ontology_binding,
-  )
+  from bigquery_agent_analytics.materialize_window import _resolve_ontology_binding
 
   with pytest.raises(ValueError, match="exactly one"):
     _resolve_ontology_binding(

--- a/tests/test_property_graph_spec.py
+++ b/tests/test_property_graph_spec.py
@@ -516,3 +516,43 @@ def test_orchestrator_rejects_graph_with_other_modes() -> None:
         dataset_id="d",
         bq_client=_FakeClient({}),
     )
+
+
+def test_normalize_graph_target_qualified_ref_sets_graph_target() -> None:
+  # P2 from PR review: a qualified --graph ref must drive the WHOLE graph
+  # target (state table, binding target), not just the INFORMATION_SCHEMA
+  # lookup — otherwise a CLI user with a read-only events dataset writes
+  # state into it.
+  from bigquery_agent_analytics.materialize_window import _normalize_graph_target
+  from bigquery_agent_analytics.materialize_window import _state_table_defaults
+
+  gp, gd, name = _normalize_graph_target(
+      "p2.graph_ds.my_graph", "events-proj", "events_ds", None, None
+  )
+  assert (gp, gd, name) == ("p2", "graph_ds", "my_graph")
+  # The state table then follows the graph's own dataset.
+  assert _state_table_defaults("events-proj", "events_ds", gp, gd) == (
+      "p2",
+      "graph_ds",
+  )
+
+  # dataset.graph: project falls back to the events project.
+  gp, gd, name = _normalize_graph_target(
+      "graph_ds.my_graph", "events-proj", "events_ds", None, None
+  )
+  assert (gp, gd, name) == ("events-proj", "graph_ds", "my_graph")
+
+
+def test_normalize_graph_target_bare_name_keeps_explicit_args() -> None:
+  from bigquery_agent_analytics.materialize_window import _normalize_graph_target
+
+  # Bare name + explicit graph_* args (the run_job split-dataset shape).
+  assert _normalize_graph_target(
+      "my_graph", "events-proj", "events_ds", "gproj", "gds"
+  ) == ("gproj", "gds", "my_graph")
+  # Bare name, single-dataset shape: falls back to the events target.
+  assert _normalize_graph_target("my_graph", "p", "d", None, None) == (
+      "p",
+      "d",
+      "my_graph",
+  )


### PR DESCRIPTION
## Summary

Users deploy their property graph to BigQuery with standard DDL; the materializer now consumes that **deployed graph** directly. `bqaa context-graph --graph <name>` reads the graph's normalized `CREATE PROPERTY GRAPH` statement back from the dataset-qualified `INFORMATION_SCHEMA.PROPERTY_GRAPHS` view and feeds the existing schema-derive pipeline — no graph-DDL file is passed to (or staged for) the materializer. The deployed graph is the single source of truth: what you query with GQL is exactly what gets materialized.

**SDK (`feat(materialize)`)**
- `fetch_property_graph_ddl()` + `split_graph_ref()` in `property_graph_spec.py`; a missing graph raises `PropertyGraphLookupError` listing the graphs the dataset *does* contain.
- Third spec input mode threaded through `_resolve_ontology_binding` / `run_materialize_window(graph=...)` / `bqaa context-graph --graph` (bare name resolved in `--dataset-id`, or `dataset.graph` / `project.dataset.graph`; split-dataset deploys resolve in the graph dataset).
- Exactly-one-of validation across `--graph` | `--property-graph` | `--ontology`/`--binding`.

**Scheduled deploy (`feat(deploy)`)**
- `run_job.py`: `BQAA_GRAPH` env; skips artifact staging and the entity-table bootstrap (the graph's existence proves its node/edge tables exist).
- `deploy_cloud_run_job.sh --graph` and Terraform `graph` variable; nothing staged in the image; boundary rejections for `--property-graph` combos and `compiled-only` mirrored in bash + plan-time preconditions.

**Docs (`docs`)**
- Codelab (+ regenerated Colab notebook), blog, scheduled-deploy runbook, CA-first guide, and the example READMEs now teach only the deployed-graph flow: apply `table_ddl.sql` + `property_graph.sql` with `bq query` once, then materialize with `--graph`. The file-based `--property-graph` mode keeps working for existing scripts/images but is no longer documented.

**Release (`chore(release)`)**: CHANGELOG `[0.3.4]` + version bump (additive, backward-compatible).

## Test plan
- [x] Full suite: 3327 passed, 15 skipped (includes 18 new tests: fetch/qualified-name/not-found, end-to-end derive from a **live-captured** normalized `INFORMATION_SCHEMA` ddl fixture, CLI mode matrix, deploy + Terraform wiring).
- [x] Colab notebook regenerated and `--check` clean; `shellcheck` 0 errors; `terraform fmt -check` clean.
- [x] **Live E2E** on the canonical test project: scratch dataset → `bq` apply table DDL + property graph → `bqaa seed-events --sessions 5` → `bqaa context-graph --graph agent_decisions_graph` → `ok: true`, 5/5 sessions, `rows_materialized` = 5/15/5 nodes + 15/5 edges → GQL traversal returns the documented 15 distinct rows. Scratch dataset dropped.
- [x] Grep gate: no `--property-graph` / `BQAA_PROPERTY_GRAPH` left in docs or example READMEs except explicitly-marked legacy notes.