### PR TITLE
ci(release): pin runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     name: Build package
     if: startsWith(github.event.release.tag_name, 'v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +64,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: pypi
     permissions:
       id-token: write
@@ -80,7 +80,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: testpypi
     permissions:
       id-token: write


### PR DESCRIPTION
The ubuntu-latest hosted-runner pool is backlogged (the v0.3.4 release job queued 20+ minutes across three run attempts) while ubuntu-22.04 jobs in the same org are picked up in seconds. Pin the release workflow's jobs so publishing is not hostage to the rolling-alias pool.

Unblocks re-issuing the v0.3.4 release: the release workflow executes from the tag's commit, so the tag will be recreated on top of this fix.