### PR TITLE
ci: pin CI runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   format:
     name: Format check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
 
   build:
     name: Build package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [format, test]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Same `ubuntu-latest` pool backlog that stalled the v0.3.4 release (fixed for `release.yml` in #304): CI jobs for PR #305 and the post-merge push run have been queued for an hour while `ubuntu-22.04` jobs in the same org start in seconds. Pin `ci.yml`'s three jobs the same way.

Because `pull_request` workflows execute the PR's own workflow file, **this PR's checks run on the pinned runners and validate the fix themselves** — if they go green quickly, the pin works.

## Test plan
- [x] This PR's own Format check + Test (3.10–3.14) runs are the test: they should start within seconds instead of queueing.