### PR TITLE
feat(otlp): OTLP decode + envelope library (#316 PR2)

### DIFF
--- a/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
@@ -12,15 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OTel-native OTLP receiver storage layer for BQAA (issue #316).
+"""OTel-native OTLP receiver storage + decode layer for BQAA (issue #316).
 
-PR 1 of the receiver: the BigQuery schema package — native ``otel_*`` tables as
-source of truth, BQAA ``agent_events_otlp`` projection contract, and read-time
-dedup views. See ``docs/otlp_receiver_design.md``.
+- PR 1: BigQuery schema package — native ``otel_*`` tables, ``agent_events_otlp``
+  projection contract, read-time dedup views (``schema`` / ``projection``).
+- PR 2: OTLP decode + envelope library — decoded OTLP logs/metrics to envelope
+  v1, ``source_position``, per-signal idempotency, dead-letter envelopes
+  (``envelope`` / ``decode``).
+
+See ``docs/otlp_receiver_design.md``.
 """
 
 from __future__ import annotations
 
+from bigquery_agent_analytics_tracing.otlp.decode import decode_logs_request
+from bigquery_agent_analytics_tracing.otlp.decode import decode_metrics_request
+from bigquery_agent_analytics_tracing.otlp.envelope import canonical_json
+from bigquery_agent_analytics_tracing.otlp.envelope import dead_letter_envelope
+from bigquery_agent_analytics_tracing.otlp.envelope import ENVELOPE_VERSION
+from bigquery_agent_analytics_tracing.otlp.envelope import log_idempotency_key
+from bigquery_agent_analytics_tracing.otlp.envelope import make_envelope
+from bigquery_agent_analytics_tracing.otlp.envelope import metric_idempotency_key
+from bigquery_agent_analytics_tracing.otlp.envelope import otlp_attrs_to_dict
+from bigquery_agent_analytics_tracing.otlp.envelope import raw_preservation
+from bigquery_agent_analytics_tracing.otlp.envelope import request_hash
+from bigquery_agent_analytics_tracing.otlp.envelope import SourcePosition
+from bigquery_agent_analytics_tracing.otlp.envelope import span_idempotency_key
 from bigquery_agent_analytics_tracing.otlp.projection import agent_events_otlp_columns
 from bigquery_agent_analytics_tracing.otlp.projection import DEDUP_TABLES
 from bigquery_agent_analytics_tracing.otlp.projection import dedup_view_sql
@@ -31,6 +48,7 @@ from bigquery_agent_analytics_tracing.otlp.schema import OTEL_SCHEMA_VERSION
 from bigquery_agent_analytics_tracing.otlp.schema import table_labels
 
 __all__ = [
+    # schema (PR 1)
     "OTEL_SCHEMA_VERSION",
     "NATIVE_TABLES",
     "METRIC_TABLES",
@@ -39,4 +57,18 @@ __all__ = [
     "missing_agent_events_columns",
     "dedup_view_sql",
     "DEDUP_TABLES",
+    # envelope + decode (PR 2)
+    "ENVELOPE_VERSION",
+    "SourcePosition",
+    "request_hash",
+    "canonical_json",
+    "otlp_attrs_to_dict",
+    "log_idempotency_key",
+    "metric_idempotency_key",
+    "span_idempotency_key",
+    "raw_preservation",
+    "make_envelope",
+    "dead_letter_envelope",
+    "decode_logs_request",
+    "decode_metrics_request",
 ]

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
@@ -29,6 +29,7 @@ from bigquery_agent_analytics_tracing.otlp.decode import decode_logs_request
 from bigquery_agent_analytics_tracing.otlp.decode import decode_metrics_request
 from bigquery_agent_analytics_tracing.otlp.envelope import canonical_json
 from bigquery_agent_analytics_tracing.otlp.envelope import dead_letter_envelope
+from bigquery_agent_analytics_tracing.otlp.envelope import dead_letter_key
 from bigquery_agent_analytics_tracing.otlp.envelope import ENVELOPE_VERSION
 from bigquery_agent_analytics_tracing.otlp.envelope import log_idempotency_key
 from bigquery_agent_analytics_tracing.otlp.envelope import make_envelope
@@ -69,6 +70,7 @@ __all__ = [
     "raw_preservation",
     "make_envelope",
     "dead_letter_envelope",
+    "dead_letter_key",
     "decode_logs_request",
     "decode_metrics_request",
 ]

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decode OTLP logs/metrics requests into envelope-v1 messages (#316, PR 2).
+
+Input is the **decoded** OTLP JSON structure (``ExportLogsServiceRequest`` /
+``ExportMetricsServiceRequest`` as camelCase dicts — what ``protobuf -> dict``
+yields at the receiver edge). One envelope is emitted per log record / metric
+data point. A record that cannot be decoded becomes a dead-letter envelope
+(``parse_error`` populated) rather than aborting the batch, so one bad record
+never drops a whole request.
+
+Spans are intentionally out of scope for PR 2 (trace-gated; see the design doc).
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from bigquery_agent_analytics_tracing.otlp import envelope as env
+
+# OTLP metric ``oneof data`` member names, mapped to the snake_case point kind
+# used by the native ``otel_metric_*`` tables.
+_METRIC_KINDS = {
+    "sum": "sum",
+    "gauge": "gauge",
+    "histogram": "histogram",
+    "exponentialHistogram": "exponential_histogram",
+    "summary": "summary",
+}
+
+
+def _b64_canonical(obj: Any) -> str:
+  """Base64 of the canonical JSON of a (sub)record — for dead-letter payloads."""
+  return base64.b64encode(env.canonical_json(obj).encode("utf-8")).decode(
+      "ascii"
+  )
+
+
+def _metric_kind(metric: dict[str, Any]) -> str | None:
+  """The OTLP ``oneof`` member present on a metric, or ``None`` if unrecognized."""
+  for member in _METRIC_KINDS:
+    if member in metric:
+      return member
+  return None
+
+
+def decode_logs_request(
+    request: dict[str, Any],
+    *,
+    source_product: str,
+    raw_request_hash: str,
+    ingest_time: str,
+) -> list[dict[str, Any]]:
+  """Decode an ``ExportLogsServiceRequest`` dict into log envelopes."""
+  envelopes: list[dict[str, Any]] = []
+  for i, resource_logs in enumerate(request.get("resourceLogs", [])):
+    resource_attrs = env.otlp_attrs_to_dict(
+        resource_logs.get("resource", {}).get("attributes")
+    )
+    for j, scope_logs in enumerate(resource_logs.get("scopeLogs", [])):
+      scope = scope_logs.get("scope", {})
+      for k, record in enumerate(scope_logs.get("logRecords", [])):
+        position = env.SourcePosition(raw_request_hash, i, j, record_index=k)
+        try:
+          key = env.log_idempotency_key(record, resource_attrs, scope, position)
+          envelopes.append(
+              env.make_envelope(
+                  source_product=source_product,
+                  source_signal="log",
+                  record=record,
+                  resource_attributes=resource_attrs,
+                  scope=scope,
+                  source_position=position,
+                  idempotency_key=key,
+                  ingest_time=ingest_time,
+              )
+          )
+        except Exception as exc:  # noqa: BLE001 - malformed -> dead letter
+          envelopes.append(
+              env.dead_letter_envelope(
+                  source_product=source_product,
+                  source_signal="log",
+                  stage="otlp_decode",
+                  reason=repr(exc),
+                  raw_b64=_b64_canonical(record),
+                  received_at=ingest_time,
+                  source_position=position,
+              )
+          )
+  return envelopes
+
+
+def _metric_record(
+    metric: dict[str, Any],
+    kind: str,
+    body: dict[str, Any],
+    point: dict[str, Any],
+) -> dict[str, Any]:
+  """Decoded record payload for one metric data point."""
+  return {
+      "metric_name": metric.get("name"),
+      "description": metric.get("description"),
+      "unit": metric.get("unit"),
+      "point_kind": _METRIC_KINDS[kind],
+      "aggregation_temporality": body.get("aggregationTemporality"),
+      "is_monotonic": body.get("isMonotonic"),
+      "point": point,
+  }
+
+
+def decode_metrics_request(
+    request: dict[str, Any],
+    *,
+    source_product: str,
+    raw_request_hash: str,
+    ingest_time: str,
+) -> list[dict[str, Any]]:
+  """Decode an ``ExportMetricsServiceRequest`` dict into metric envelopes.
+
+  Handles all five OTLP point types (Sum/Gauge/Histogram/ExponentialHistogram/
+  Summary). A metric with no recognized type yields a single dead-letter.
+  """
+  envelopes: list[dict[str, Any]] = []
+  for i, resource_metrics in enumerate(request.get("resourceMetrics", [])):
+    resource_attrs = env.otlp_attrs_to_dict(
+        resource_metrics.get("resource", {}).get("attributes")
+    )
+    for j, scope_metrics in enumerate(resource_metrics.get("scopeMetrics", [])):
+      scope = scope_metrics.get("scope", {})
+      for m, metric in enumerate(scope_metrics.get("metrics", [])):
+        kind = _metric_kind(metric)
+        if kind is None:
+          envelopes.append(
+              env.dead_letter_envelope(
+                  source_product=source_product,
+                  source_signal="metric",
+                  stage="otlp_decode",
+                  reason=(
+                      f"metric {metric.get('name')!r} has no recognized point"
+                      " type"
+                  ),
+                  raw_b64=_b64_canonical(metric),
+                  received_at=ingest_time,
+                  source_position=env.SourcePosition(
+                      raw_request_hash, i, j, metric_index=m
+                  ),
+              )
+          )
+          continue
+        body = metric.get(kind, {})
+        temporality = body.get("aggregationTemporality")
+        for p, point in enumerate(body.get("dataPoints", [])):
+          position = env.SourcePosition(
+              raw_request_hash, i, j, metric_index=m, data_point_index=p
+          )
+          try:
+            key = env.metric_idempotency_key(
+                point,
+                metric.get("name", ""),
+                temporality,
+                resource_attrs,
+                scope,
+                position,
+            )
+            envelopes.append(
+                env.make_envelope(
+                    source_product=source_product,
+                    source_signal="metric",
+                    record=_metric_record(metric, kind, body, point),
+                    resource_attributes=resource_attrs,
+                    scope=scope,
+                    source_position=position,
+                    idempotency_key=key,
+                    ingest_time=ingest_time,
+                )
+            )
+          except Exception as exc:  # noqa: BLE001 - malformed -> dead letter
+            envelopes.append(
+                env.dead_letter_envelope(
+                    source_product=source_product,
+                    source_signal="metric",
+                    stage="otlp_decode",
+                    reason=repr(exc),
+                    raw_b64=_b64_canonical(point),
+                    received_at=ingest_time,
+                    source_position=position,
+                )
+            )
+  return envelopes

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
@@ -42,13 +42,6 @@ _METRIC_KINDS = {
 }
 
 
-def _b64_canonical(obj: Any) -> str:
-  """Base64 of the canonical JSON of a (sub)record — for dead-letter payloads."""
-  return base64.b64encode(env.canonical_json(obj).encode("utf-8")).decode(
-      "ascii"
-  )
-
-
 def _metric_kind(metric: dict[str, Any]) -> str | None:
   """The OTLP ``oneof`` member present on a metric, or ``None`` if unrecognized."""
   for member in _METRIC_KINDS:
@@ -61,10 +54,17 @@ def decode_logs_request(
     request: dict[str, Any],
     *,
     source_product: str,
-    raw_request_hash: str,
+    raw_request: bytes,
     ingest_time: str,
 ) -> list[dict[str, Any]]:
-  """Decode an ``ExportLogsServiceRequest`` dict into log envelopes."""
+  """Decode an ``ExportLogsServiceRequest`` into log envelopes.
+
+  ``request`` is the decoded dict; ``raw_request`` is the original wire payload
+  (protobuf or OTLP/HTTP JSON bytes), which is the source of both
+  ``raw_otlp_request_hash`` and the **replayable** dead-letter ``raw_b64``.
+  """
+  raw_hash = env.request_hash(raw_request)
+  raw_b64 = base64.b64encode(raw_request).decode("ascii")
   envelopes: list[dict[str, Any]] = []
   for i, resource_logs in enumerate(request.get("resourceLogs", [])):
     resource_attrs = env.otlp_attrs_to_dict(
@@ -73,7 +73,7 @@ def decode_logs_request(
     for j, scope_logs in enumerate(resource_logs.get("scopeLogs", [])):
       scope = scope_logs.get("scope", {})
       for k, record in enumerate(scope_logs.get("logRecords", [])):
-        position = env.SourcePosition(raw_request_hash, i, j, record_index=k)
+        position = env.SourcePosition(raw_hash, i, j, record_index=k)
         try:
           key = env.log_idempotency_key(record, resource_attrs, scope, position)
           envelopes.append(
@@ -95,9 +95,10 @@ def decode_logs_request(
                   source_signal="log",
                   stage="otlp_decode",
                   reason=repr(exc),
-                  raw_b64=_b64_canonical(record),
+                  raw_b64=raw_b64,
                   received_at=ingest_time,
                   source_position=position,
+                  raw_otlp_request_hash=raw_hash,
               )
           )
   return envelopes
@@ -125,14 +126,17 @@ def decode_metrics_request(
     request: dict[str, Any],
     *,
     source_product: str,
-    raw_request_hash: str,
+    raw_request: bytes,
     ingest_time: str,
 ) -> list[dict[str, Any]]:
-  """Decode an ``ExportMetricsServiceRequest`` dict into metric envelopes.
+  """Decode an ``ExportMetricsServiceRequest`` into metric envelopes.
 
   Handles all five OTLP point types (Sum/Gauge/Histogram/ExponentialHistogram/
   Summary). A metric with no recognized type yields a single dead-letter.
+  ``raw_request`` is the original wire payload (see ``decode_logs_request``).
   """
+  raw_hash = env.request_hash(raw_request)
+  raw_b64 = base64.b64encode(raw_request).decode("ascii")
   envelopes: list[dict[str, Any]] = []
   for i, resource_metrics in enumerate(request.get("resourceMetrics", [])):
     resource_attrs = env.otlp_attrs_to_dict(
@@ -152,11 +156,12 @@ def decode_metrics_request(
                       f"metric {metric.get('name')!r} has no recognized point"
                       " type"
                   ),
-                  raw_b64=_b64_canonical(metric),
+                  raw_b64=raw_b64,
                   received_at=ingest_time,
                   source_position=env.SourcePosition(
-                      raw_request_hash, i, j, metric_index=m
+                      raw_hash, i, j, metric_index=m
                   ),
+                  raw_otlp_request_hash=raw_hash,
               )
           )
           continue
@@ -164,7 +169,7 @@ def decode_metrics_request(
         temporality = body.get("aggregationTemporality")
         for p, point in enumerate(body.get("dataPoints", [])):
           position = env.SourcePosition(
-              raw_request_hash, i, j, metric_index=m, data_point_index=p
+              raw_hash, i, j, metric_index=m, data_point_index=p
           )
           try:
             key = env.metric_idempotency_key(
@@ -194,9 +199,10 @@ def decode_metrics_request(
                     source_signal="metric",
                     stage="otlp_decode",
                     reason=repr(exc),
-                    raw_b64=_b64_canonical(point),
+                    raw_b64=raw_b64,
                     received_at=ingest_time,
                     source_position=position,
+                    raw_otlp_request_hash=raw_hash,
                 )
             )
   return envelopes

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
@@ -229,6 +229,24 @@ def make_envelope(
   }
 
 
+def dead_letter_key(
+    stage: str,
+    source_position: SourcePosition | None = None,
+    raw_otlp_request_hash: str | None = None,
+) -> str:
+  """Deterministic key for a dead-letter / replay row.
+
+  Decode failed, so there is no canonical record *content* to hash. Key from
+  ``source_position`` (which carries the original request hash + indices) where
+  decode got that far; otherwise from ``raw_otlp_request_hash + stage`` for
+  whole-request failures (auth, undecodable request). This lets DLQ rows be
+  deduped and lets a replay worker recognize a re-failed message.
+  """
+  if source_position is not None:
+    return _sha([source_position.canonical(), stage])
+  return _sha([raw_otlp_request_hash or "", stage])
+
+
 def dead_letter_envelope(
     *,
     source_product: str,
@@ -238,16 +256,22 @@ def dead_letter_envelope(
     raw_b64: str | None,
     received_at: str,
     source_position: SourcePosition | None = None,
+    raw_otlp_request_hash: str | None = None,
 ) -> dict[str, Any]:
   """Envelope for a record that could not be decoded/written.
 
   Routed to ``otlp_dead_letter`` + the DLQ topic, never to the analytics tables.
-  ``source_position`` is carried where decode got far enough; a whole-request
-  failure leaves it ``None`` (keyed downstream from request hash + stage).
+  ``raw_b64`` must be the **replayable** original OTLP request payload (so a
+  replay worker can republish it to ``/v1/logs`` / ``/v1/metrics``), not a
+  re-serialized subrecord. ``source_position`` is carried where decode got far
+  enough; a whole-request failure leaves it ``None`` and keys from
+  ``raw_otlp_request_hash + stage``.
   """
   return {
       "envelope_version": ENVELOPE_VERSION,
-      "idempotency_key": None,
+      "idempotency_key": dead_letter_key(
+          stage, source_position, raw_otlp_request_hash
+      ),
       "ingest_time": received_at,
       "source": {"product": source_product, "signal": source_signal},
       "source_position": (

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pub/Sub envelope v1 construction + per-signal idempotency (issue #316, PR 2).
+
+Pure functions over the **decoded** OTLP JSON structure (camelCase, as produced
+by ``protobuf -> dict`` at the receiver edge) — no network, no BigQuery, no
+protobuf dependency — so the whole library is unit-testable with synthetic
+fixtures. See ``docs/otlp_receiver_design.md`` §4 for the envelope and key
+contract.
+
+Idempotency keys are ``SHA256`` hex over a canonicalized payload. They include
+``source_position`` (the stable, replay-invariant position of a record within
+its OTLP request) so two legitimately identical records/points in the same
+request do not collapse, while a retried/replayed request reproduces the key
+exactly. ``ingest_time`` is deliberately **not** part of any key.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any
+
+from bigquery_agent_analytics_tracing.otlp import schema as otel_schema
+
+ENVELOPE_VERSION = "1"
+
+# Point payload keys that are NOT part of a metric point's "value" (they are
+# hashed separately, or are not identity-bearing).
+_NON_VALUE_POINT_KEYS = frozenset(
+    {"attributes", "startTimeUnixNano", "timeUnixNano"}
+)
+
+
+def canonical_json(value: Any) -> str:
+  """Stable JSON encoding for hashing (sorted keys, no insignificant space)."""
+  return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def request_hash(raw: bytes) -> str:
+  """SHA256 hex of the original OTLP request bytes (feeds ``source_position``)."""
+  return hashlib.sha256(raw).hexdigest()
+
+
+def _anyvalue(value: Any) -> Any:
+  """Extract a Python value from an OTLP ``AnyValue`` JSON object."""
+  if not isinstance(value, dict):
+    return value
+  if "stringValue" in value:
+    return value["stringValue"]
+  if "boolValue" in value:
+    return value["boolValue"]
+  if "intValue" in value:
+    return int(value["intValue"])  # OTLP JSON encodes int64 as a string
+  if "doubleValue" in value:
+    return value["doubleValue"]
+  if "bytesValue" in value:
+    return value["bytesValue"]
+  if "arrayValue" in value:
+    return [_anyvalue(v) for v in value["arrayValue"].get("values", [])]
+  if "kvlistValue" in value:
+    return otlp_attrs_to_dict(value["kvlistValue"].get("values", []))
+  return None
+
+
+def otlp_attrs_to_dict(attributes: Any) -> dict[str, Any]:
+  """OTLP ``KeyValue`` list -> ``{key: value}`` dict."""
+  result: dict[str, Any] = {}
+  for kv in attributes or []:
+    result[kv["key"]] = _anyvalue(kv.get("value", {}))
+  return result
+
+
+@dataclass(frozen=True)
+class SourcePosition:
+  """Stable, replay-invariant position of a record within its OTLP request."""
+
+  raw_otlp_request_hash: str
+  resource_index: int
+  scope_index: int
+  record_index: int | None = None  # log record index (logs)
+  metric_index: int | None = None  # metric index (metrics)
+  data_point_index: int | None = None  # data point index (metrics)
+
+  def as_dict(self) -> dict[str, Any]:
+    return {
+        "raw_otlp_request_hash": self.raw_otlp_request_hash,
+        "resource_index": self.resource_index,
+        "scope_index": self.scope_index,
+        "record_index": self.record_index,
+        "metric_index": self.metric_index,
+        "data_point_index": self.data_point_index,
+    }
+
+  def canonical(self) -> str:
+    return canonical_json(self.as_dict())
+
+
+def _sha(parts: list[str]) -> str:
+  return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def _scope_id(scope: dict[str, Any] | None) -> str:
+  scope = scope or {}
+  return f"{scope.get('name', '')}@{scope.get('version', '')}"
+
+
+def log_idempotency_key(
+    record: dict[str, Any],
+    resource_attributes: dict[str, Any],
+    scope: dict[str, Any] | None,
+    source_position: SourcePosition,
+) -> str:
+  """SHA256 key for a log record (design §4.1)."""
+  return _sha(
+      [
+          canonical_json(resource_attributes),
+          _scope_id(scope),
+          str(
+              record.get("observedTimeUnixNano")
+              or record.get("timeUnixNano")
+              or ""
+          ),
+          str(record.get("severityNumber", "")),
+          canonical_json(record.get("body")),
+          canonical_json(otlp_attrs_to_dict(record.get("attributes"))),
+          source_position.canonical(),
+      ]
+  )
+
+
+def metric_idempotency_key(
+    point: dict[str, Any],
+    metric_name: str,
+    temporality: Any,
+    resource_attributes: dict[str, Any],
+    scope: dict[str, Any] | None,
+    source_position: SourcePosition,
+) -> str:
+  """SHA256 key for a metric data point of any of the five types (design §4.1).
+
+  The "value" component is the whole point payload minus the separately-hashed
+  attributes/timestamps, so it works uniformly for Sum/Gauge (``asDouble`` /
+  ``asInt``), Histogram/ExponentialHistogram (buckets), and Summary (quantiles).
+  """
+  value = {k: v for k, v in point.items() if k not in _NON_VALUE_POINT_KEYS}
+  return _sha(
+      [
+          canonical_json(resource_attributes),
+          _scope_id(scope),
+          metric_name,
+          canonical_json(otlp_attrs_to_dict(point.get("attributes"))),
+          str(point.get("startTimeUnixNano", "")),
+          str(point.get("timeUnixNano", "")),
+          str(temporality or ""),
+          canonical_json(value),
+          source_position.canonical(),
+      ]
+  )
+
+
+def span_idempotency_key(trace_id: str, span_id: str) -> str:
+  """Spans have a natural key — no hash needed."""
+  return f"{trace_id}{span_id}"
+
+
+def raw_preservation(
+    policy: str = "decoded_only", raw: bytes | None = None
+) -> dict[str, Any]:
+  """Build the ``raw_preservation`` block.
+
+  ``decoded_only`` keeps no raw bytes; ``decoded_plus_raw`` base64-encodes the
+  original record bytes for replay/debug.
+  """
+  if policy == "decoded_only":
+    return {"policy": "decoded_only", "raw_b64": None}
+  if policy == "decoded_plus_raw":
+    encoded = base64.b64encode(raw).decode("ascii") if raw is not None else None
+    return {"policy": "decoded_plus_raw", "raw_b64": encoded}
+  raise ValueError(f"unknown raw-preservation policy {policy!r}")
+
+
+def make_envelope(
+    *,
+    source_product: str,
+    source_signal: str,
+    record: dict[str, Any],
+    resource_attributes: dict[str, Any],
+    scope: dict[str, Any] | None,
+    source_position: SourcePosition,
+    idempotency_key: str,
+    ingest_time: str,
+    raw_preservation_block: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  """Assemble a successful envelope v1 message for one record/point."""
+  return {
+      "envelope_version": ENVELOPE_VERSION,
+      "otel_schema_version": otel_schema.OTEL_SCHEMA_VERSION,
+      "idempotency_key": idempotency_key,
+      "ingest_time": ingest_time,
+      "source": {"product": source_product, "signal": source_signal},
+      "source_position": source_position.as_dict(),
+      "otlp": {
+          "resource_attributes": resource_attributes,
+          "scope": scope or {},
+      },
+      "record": record,
+      "raw_preservation": (
+          raw_preservation_block
+          if raw_preservation_block is not None
+          else {"policy": "decoded_only", "raw_b64": None}
+      ),
+      "parse_error": None,
+      "delivery": {"attempt": 1, "dlq": False},
+  }
+
+
+def dead_letter_envelope(
+    *,
+    source_product: str,
+    source_signal: str,
+    stage: str,
+    reason: str,
+    raw_b64: str | None,
+    received_at: str,
+    source_position: SourcePosition | None = None,
+) -> dict[str, Any]:
+  """Envelope for a record that could not be decoded/written.
+
+  Routed to ``otlp_dead_letter`` + the DLQ topic, never to the analytics tables.
+  ``source_position`` is carried where decode got far enough; a whole-request
+  failure leaves it ``None`` (keyed downstream from request hash + stage).
+  """
+  return {
+      "envelope_version": ENVELOPE_VERSION,
+      "idempotency_key": None,
+      "ingest_time": received_at,
+      "source": {"product": source_product, "signal": source_signal},
+      "source_position": (
+          source_position.as_dict() if source_position is not None else None
+      ),
+      "record": None,
+      "raw_preservation": {"policy": "raw_only", "raw_b64": raw_b64},
+      "parse_error": {"stage": stage, "reason": reason, "raw_b64": raw_b64},
+      "delivery": {"attempt": 1, "dlq": True},
+  }

--- a/producers/tests/test_otlp_decode.py
+++ b/producers/tests/test_otlp_decode.py
@@ -17,14 +17,37 @@
 from __future__ import annotations
 
 import base64
+import json
 
 import pytest
 
 from bigquery_agent_analytics_tracing.otlp import decode
 from bigquery_agent_analytics_tracing.otlp import envelope as env
 
-HASH = "req-hash-abc"
 INGEST = "2026-06-29T00:00:00Z"
+
+
+def _raw(request: dict) -> bytes:
+  """Original wire payload for a request (OTLP/HTTP JSON bytes here)."""
+  return json.dumps(request).encode("utf-8")
+
+
+def _decode_logs(request, ingest_time=INGEST):
+  return decode.decode_logs_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=ingest_time,
+  )
+
+
+def _decode_metrics(request, ingest_time=INGEST):
+  return decode.decode_metrics_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=ingest_time,
+  )
 
 
 def _logs_request(log_records):
@@ -145,18 +168,16 @@ _METRIC_BODIES = {
 
 
 def test_decode_one_log_record_into_one_envelope():
-  envs = decode.decode_logs_request(
-      _logs_request([_A_LOG]),
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )
+  req = _logs_request([_A_LOG])
+  envs = _decode_logs(req)
   assert len(envs) == 1
   e = envs[0]
   assert e["envelope_version"] == "1"
   assert e["otel_schema_version"] == env.otel_schema.OTEL_SCHEMA_VERSION
   assert e["source"] == {"product": "claude_code", "signal": "log"}
-  assert e["source_position"]["raw_otlp_request_hash"] == HASH
+  assert e["source_position"]["raw_otlp_request_hash"] == env.request_hash(
+      _raw(req)
+  )
   assert e["source_position"]["record_index"] == 0
   assert e["otlp"]["resource_attributes"] == {"service.name": "claude-code"}
   assert len(e["idempotency_key"]) == 64  # sha256 hex
@@ -179,12 +200,7 @@ def test_decode_one_log_record_into_one_envelope():
     ],
 )
 def test_decode_each_metric_point_type(kind, expected_point_kind):
-  envs = decode.decode_metrics_request(
-      _metrics_request(kind, _METRIC_BODIES[kind]),
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )
+  envs = _decode_metrics(_metrics_request(kind, _METRIC_BODIES[kind]))
   assert len(envs) == 1
   e = envs[0]
   assert e["source"]["signal"] == "metric"
@@ -195,12 +211,7 @@ def test_decode_each_metric_point_type(kind, expected_point_kind):
 
 
 def test_sum_preserves_temporality_and_monotonicity_in_record():
-  e = decode.decode_metrics_request(
-      _metrics_request("sum", _METRIC_BODIES["sum"]),
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )[0]
+  e = _decode_metrics(_metrics_request("sum", _METRIC_BODIES["sum"]))[0]
   assert e["record"]["aggregation_temporality"] == 1
   assert e["record"]["is_monotonic"] is True
 
@@ -212,47 +223,27 @@ def test_sum_preserves_temporality_and_monotonicity_in_record():
 
 def test_idempotency_key_is_stable_across_decodes():
   req = _logs_request([_A_LOG])
-  k1 = decode.decode_logs_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )[0]["idempotency_key"]
-  k2 = decode.decode_logs_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )[0]["idempotency_key"]
-  assert k1 == k2
+  assert (
+      _decode_logs(req)[0]["idempotency_key"]
+      == _decode_logs(req)[0]["idempotency_key"]
+  )
 
 
 def test_idempotency_key_ignores_ingest_time_so_replay_collapses():
   req = _logs_request([_A_LOG])
-  k1 = decode.decode_logs_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time="2026-06-29T00:00:00Z",
-  )[0]["idempotency_key"]
-  k2 = decode.decode_logs_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time="2026-06-29T11:11:11Z",  # later replay
-  )[0]["idempotency_key"]
+  k1 = _decode_logs(req, ingest_time="2026-06-29T00:00:00Z")[0][
+      "idempotency_key"
+  ]
+  k2 = _decode_logs(req, ingest_time="2026-06-29T11:11:11Z")[0][
+      "idempotency_key"
+  ]
   assert k1 == k2
 
 
 def test_two_identical_records_in_one_request_get_distinct_keys():
   # Same content twice -> source_position.record_index distinguishes them, so
   # the dedup view will not collapse two legitimate records.
-  envs = decode.decode_logs_request(
-      _logs_request([dict(_A_LOG), dict(_A_LOG)]),
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )
+  envs = _decode_logs(_logs_request([dict(_A_LOG), dict(_A_LOG)]))
   assert len(envs) == 2
   assert envs[0]["idempotency_key"] != envs[1]["idempotency_key"]
   assert envs[0]["source_position"]["record_index"] == 0
@@ -266,28 +257,19 @@ def test_distinct_data_points_get_distinct_keys():
           {"asDouble": 1.0, "timeUnixNano": "100"},  # identical value
       ]
   }
-  envs = decode.decode_metrics_request(
-      _metrics_request("gauge", body),
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )
+  envs = _decode_metrics(_metrics_request("gauge", body))
   assert len(envs) == 2
   assert envs[0]["idempotency_key"] != envs[1]["idempotency_key"]
 
 
 # --------------------------------------------------------------------------
-# Malformed -> dead letter
+# Malformed -> dead letter (replayable + keyed, per #316 contract)
 # --------------------------------------------------------------------------
 
 
 def test_metric_with_unrecognized_type_becomes_dead_letter():
-  req = _metrics_request("notARealType", {"dataPoints": []}, name="bad")
-  envs = decode.decode_metrics_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
+  envs = _decode_metrics(
+      _metrics_request("notARealType", {"dataPoints": []}, name="bad")
   )
   assert len(envs) == 1
   e = envs[0]
@@ -295,6 +277,38 @@ def test_metric_with_unrecognized_type_becomes_dead_letter():
   assert e["delivery"]["dlq"] is True
   assert e["parse_error"]["stage"] == "otlp_decode"
   assert e["source_position"]["metric_index"] == 0
+
+
+def test_dead_letter_raw_b64_is_the_replayable_original_request():
+  req = _metrics_request("notARealType", {"dataPoints": []}, name="bad")
+  e = _decode_metrics(req)[0]
+  # raw_b64 round-trips to the ORIGINAL request bytes (republishable to
+  # /v1/metrics), not a re-serialized subrecord.
+  assert base64.b64decode(e["raw_preservation"]["raw_b64"]) == _raw(req)
+  assert base64.b64decode(e["parse_error"]["raw_b64"]) == _raw(req)
+  # and the request hash is reproducible from that payload.
+  assert e["source_position"]["raw_otlp_request_hash"] == env.request_hash(
+      _raw(req)
+  )
+
+
+def test_dead_letter_is_keyed_from_source_position():
+  req = _metrics_request("notARealType", {"dataPoints": []}, name="bad")
+  e = _decode_metrics(req)[0]
+  raw_hash = env.request_hash(_raw(req))
+  expected = env.dead_letter_key(
+      "otlp_decode", env.SourcePosition(raw_hash, 0, 0, metric_index=0)
+  )
+  assert e["idempotency_key"] == expected
+  assert e["idempotency_key"] is not None
+
+
+def test_dead_letter_key_falls_back_to_request_hash_and_stage():
+  # Whole-request failure (no source_position): key from request hash + stage.
+  k_auth = env.dead_letter_key("auth", None, "req-hash")
+  k_decode = env.dead_letter_key("otlp_decode", None, "req-hash")
+  assert len(k_auth) == 64
+  assert k_auth != k_decode  # stage participates in the key
 
 
 def test_one_bad_metric_does_not_drop_the_good_one():
@@ -314,12 +328,7 @@ def test_one_bad_metric_does_not_drop_the_good_one():
           }
       ]
   }
-  envs = decode.decode_metrics_request(
-      req,
-      source_product="claude_code",
-      raw_request_hash=HASH,
-      ingest_time=INGEST,
-  )
+  envs = _decode_metrics(req)
   assert len(envs) == 2
   assert envs[0]["parse_error"]["stage"] == "otlp_decode"
   assert envs[1]["record"]["metric_name"] == "good"

--- a/producers/tests/test_otlp_decode.py
+++ b/producers/tests/test_otlp_decode.py
@@ -1,0 +1,357 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OTLP decode + envelope library (issue #316, PR 2)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import decode
+from bigquery_agent_analytics_tracing.otlp import envelope as env
+
+HASH = "req-hash-abc"
+INGEST = "2026-06-29T00:00:00Z"
+
+
+def _logs_request(log_records):
+  return {
+      "resourceLogs": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      }
+                  ]
+              },
+              "scopeLogs": [
+                  {
+                      "scope": {
+                          "name": "com.anthropic.claude_code",
+                          "version": "1.0",
+                      },
+                      "logRecords": log_records,
+                  }
+              ],
+          }
+      ]
+  }
+
+
+_A_LOG = {
+    "timeUnixNano": "1700000000000000000",
+    "observedTimeUnixNano": "1700000000000000001",
+    "severityNumber": 9,
+    "severityText": "INFO",
+    "body": {"stringValue": "hello"},
+    "attributes": [
+        {
+            "key": "event.name",
+            "value": {"stringValue": "claude_code.user_prompt"},
+        }
+    ],
+}
+
+
+def _metrics_request(kind, body, name="m"):
+  return {
+      "resourceMetrics": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      }
+                  ]
+              },
+              "scopeMetrics": [
+                  {
+                      "scope": {
+                          "name": "com.anthropic.claude_code",
+                          "version": "1.0",
+                      },
+                      "metrics": [{"name": name, "unit": "1", kind: body}],
+                  }
+              ],
+          }
+      ]
+  }
+
+
+_METRIC_BODIES = {
+    "sum": {
+        "aggregationTemporality": 1,
+        "isMonotonic": True,
+        "dataPoints": [{"asDouble": 1.5, "timeUnixNano": "100"}],
+    },
+    "gauge": {"dataPoints": [{"asDouble": 2.0, "timeUnixNano": "100"}]},
+    "histogram": {
+        "aggregationTemporality": 2,
+        "dataPoints": [
+            {
+                "count": "3",
+                "sum": 6.0,
+                "bucketCounts": ["1", "2"],
+                "explicitBounds": [1.0],
+                "timeUnixNano": "100",
+            }
+        ],
+    },
+    "exponentialHistogram": {
+        "aggregationTemporality": 1,
+        "dataPoints": [
+            {
+                "scale": 2,
+                "zeroCount": "0",
+                "count": "3",
+                "sum": 6.0,
+                "positive": {"offset": 0, "bucketCounts": ["1", "2"]},
+                "timeUnixNano": "100",
+            }
+        ],
+    },
+    "summary": {
+        "dataPoints": [
+            {
+                "count": "3",
+                "sum": 6.0,
+                "quantileValues": [{"quantile": 0.5, "value": 2.0}],
+                "timeUnixNano": "100",
+            }
+        ]
+    },
+}
+
+
+# --------------------------------------------------------------------------
+# Logs
+# --------------------------------------------------------------------------
+
+
+def test_decode_one_log_record_into_one_envelope():
+  envs = decode.decode_logs_request(
+      _logs_request([_A_LOG]),
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 1
+  e = envs[0]
+  assert e["envelope_version"] == "1"
+  assert e["otel_schema_version"] == env.otel_schema.OTEL_SCHEMA_VERSION
+  assert e["source"] == {"product": "claude_code", "signal": "log"}
+  assert e["source_position"]["raw_otlp_request_hash"] == HASH
+  assert e["source_position"]["record_index"] == 0
+  assert e["otlp"]["resource_attributes"] == {"service.name": "claude-code"}
+  assert len(e["idempotency_key"]) == 64  # sha256 hex
+  assert e["parse_error"] is None
+
+
+# --------------------------------------------------------------------------
+# Metrics — all five point types
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind,expected_point_kind",
+    [
+        ("sum", "sum"),
+        ("gauge", "gauge"),
+        ("histogram", "histogram"),
+        ("exponentialHistogram", "exponential_histogram"),
+        ("summary", "summary"),
+    ],
+)
+def test_decode_each_metric_point_type(kind, expected_point_kind):
+  envs = decode.decode_metrics_request(
+      _metrics_request(kind, _METRIC_BODIES[kind]),
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 1
+  e = envs[0]
+  assert e["source"]["signal"] == "metric"
+  assert e["record"]["point_kind"] == expected_point_kind
+  assert e["source_position"]["metric_index"] == 0
+  assert e["source_position"]["data_point_index"] == 0
+  assert len(e["idempotency_key"]) == 64
+
+
+def test_sum_preserves_temporality_and_monotonicity_in_record():
+  e = decode.decode_metrics_request(
+      _metrics_request("sum", _METRIC_BODIES["sum"]),
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )[0]
+  assert e["record"]["aggregation_temporality"] == 1
+  assert e["record"]["is_monotonic"] is True
+
+
+# --------------------------------------------------------------------------
+# Idempotency
+# --------------------------------------------------------------------------
+
+
+def test_idempotency_key_is_stable_across_decodes():
+  req = _logs_request([_A_LOG])
+  k1 = decode.decode_logs_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )[0]["idempotency_key"]
+  k2 = decode.decode_logs_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )[0]["idempotency_key"]
+  assert k1 == k2
+
+
+def test_idempotency_key_ignores_ingest_time_so_replay_collapses():
+  req = _logs_request([_A_LOG])
+  k1 = decode.decode_logs_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time="2026-06-29T00:00:00Z",
+  )[0]["idempotency_key"]
+  k2 = decode.decode_logs_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time="2026-06-29T11:11:11Z",  # later replay
+  )[0]["idempotency_key"]
+  assert k1 == k2
+
+
+def test_two_identical_records_in_one_request_get_distinct_keys():
+  # Same content twice -> source_position.record_index distinguishes them, so
+  # the dedup view will not collapse two legitimate records.
+  envs = decode.decode_logs_request(
+      _logs_request([dict(_A_LOG), dict(_A_LOG)]),
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 2
+  assert envs[0]["idempotency_key"] != envs[1]["idempotency_key"]
+  assert envs[0]["source_position"]["record_index"] == 0
+  assert envs[1]["source_position"]["record_index"] == 1
+
+
+def test_distinct_data_points_get_distinct_keys():
+  body = {
+      "dataPoints": [
+          {"asDouble": 1.0, "timeUnixNano": "100"},
+          {"asDouble": 1.0, "timeUnixNano": "100"},  # identical value
+      ]
+  }
+  envs = decode.decode_metrics_request(
+      _metrics_request("gauge", body),
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 2
+  assert envs[0]["idempotency_key"] != envs[1]["idempotency_key"]
+
+
+# --------------------------------------------------------------------------
+# Malformed -> dead letter
+# --------------------------------------------------------------------------
+
+
+def test_metric_with_unrecognized_type_becomes_dead_letter():
+  req = _metrics_request("notARealType", {"dataPoints": []}, name="bad")
+  envs = decode.decode_metrics_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 1
+  e = envs[0]
+  assert e["record"] is None
+  assert e["delivery"]["dlq"] is True
+  assert e["parse_error"]["stage"] == "otlp_decode"
+  assert e["source_position"]["metric_index"] == 0
+
+
+def test_one_bad_metric_does_not_drop_the_good_one():
+  req = {
+      "resourceMetrics": [
+          {
+              "resource": {"attributes": []},
+              "scopeMetrics": [
+                  {
+                      "scope": {},
+                      "metrics": [
+                          {"name": "bad"},  # no recognized point type
+                          {"name": "good", "gauge": _METRIC_BODIES["gauge"]},
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+  envs = decode.decode_metrics_request(
+      req,
+      source_product="claude_code",
+      raw_request_hash=HASH,
+      ingest_time=INGEST,
+  )
+  assert len(envs) == 2
+  assert envs[0]["parse_error"]["stage"] == "otlp_decode"
+  assert envs[1]["record"]["metric_name"] == "good"
+
+
+# --------------------------------------------------------------------------
+# Helpers: attributes, raw preservation, keys, request hash
+# --------------------------------------------------------------------------
+
+
+def test_otlp_attrs_to_dict_extracts_typed_anyvalues():
+  attrs = [
+      {"key": "s", "value": {"stringValue": "x"}},
+      {"key": "n", "value": {"intValue": "42"}},
+      {"key": "b", "value": {"boolValue": True}},
+  ]
+  assert env.otlp_attrs_to_dict(attrs) == {"s": "x", "n": 42, "b": True}
+
+
+def test_raw_preservation_modes():
+  assert env.raw_preservation() == {"policy": "decoded_only", "raw_b64": None}
+  rp = env.raw_preservation("decoded_plus_raw", b"abc")
+  assert rp["policy"] == "decoded_plus_raw"
+  assert base64.b64decode(rp["raw_b64"]) == b"abc"
+  with pytest.raises(ValueError):
+    env.raw_preservation("bogus")
+
+
+def test_span_idempotency_key_is_natural():
+  assert env.span_idempotency_key("trace1", "span1") == "trace1span1"
+
+
+def test_request_hash_is_deterministic_sha256():
+  assert env.request_hash(b"abc") == env.request_hash(b"abc")
+  assert len(env.request_hash(b"abc")) == 64


### PR DESCRIPTION
Second increment of the **OTel-native OTLP receiver** (#316) — PR 2 of the receiver PR plan: the pure **decode + envelope** library. Builds directly on PR 1's schema package (#323).

Design: [`docs/otlp_receiver_design.md`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/otlp_receiver_design.md) §4.

### What's here
- **`otlp/envelope.py`** — `SourcePosition`; `canonical_json`; SHA256 **per-signal idempotency keys** (logs = content + `source_position`; metrics = value + `source_position`; spans = natural `trace_id||span_id`), with `ingest_time` deliberately **excluded** so retry/replay reproduces the key; OTLP `AnyValue`/attribute decoding; raw-body preservation policy; `make_envelope` / `dead_letter_envelope` (envelope v1).
- **`otlp/decode.py`** — `decode_logs_request` / `decode_metrics_request` walk the decoded OTLP JSON tree, compute the `source_position` indices, handle **all five metric point types** (sum/gauge/histogram/exponential_histogram/summary), and route malformed records to **dead-letter envelopes** without dropping the rest of the batch.

### Scope notes
- **Pure logic** — operates on the *decoded* OTLP JSON structure (camelCase dicts, what `protobuf → dict` yields at the receiver edge). No network, BigQuery, or protobuf dependency, so it's fully unit-testable. The protobuf wire-decode + transport are PR 3 (receiver service); the BigQuery writer is PR 4.
- Spans are intentionally out of scope here (trace-gated).

### Verification
- New file: 17 passed (incl. all five metric types parametrized). Full producers suite: **141 passed**, no regressions.
- `isort --check` and `pyink --check` clean (as `producers-ci.yml` runs them).

Key properties covered by tests: idempotency keys are **stable across decodes** and **invariant to `ingest_time`** (replay collapses), two **identical records in one request get distinct keys** via `source_position` (no false collapse in the dedup views), and **one bad record doesn't drop the batch**.