### PR TITLE
feat(otlp): receiver service — auth, decode dispatch, Pub/Sub+DLQ routing (#316 PR3)

### DIFF
--- a/producers/pyproject.toml
+++ b/producers/pyproject.toml
@@ -53,6 +53,11 @@ openai-agents = [
 claude-sdk = [
   "claude-agent-sdk>=0.1.0",
 ]
+receiver = [
+  "google-cloud-pubsub>=2.18.0",
+  "opentelemetry-proto>=1.20.0",
+  "gunicorn>=21.0",
+]
 dev = [
   "pytest>=7.0",
   "pytest-asyncio>=0.21",

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
@@ -19,6 +19,8 @@
 - PR 2: OTLP decode + envelope library — decoded OTLP logs/metrics to envelope
   v1, ``source_position``, per-signal idempotency, dead-letter envelopes
   (``envelope`` / ``decode``).
+- PR 3: receiver request handling — auth, decode dispatch, Pub/Sub + DLQ
+  routing (``receiver``); WSGI entrypoint in ``app``.
 
 See ``docs/otlp_receiver_design.md``.
 """
@@ -43,6 +45,15 @@ from bigquery_agent_analytics_tracing.otlp.projection import agent_events_otlp_c
 from bigquery_agent_analytics_tracing.otlp.projection import DEDUP_TABLES
 from bigquery_agent_analytics_tracing.otlp.projection import dedup_view_sql
 from bigquery_agent_analytics_tracing.otlp.projection import missing_agent_events_columns
+from bigquery_agent_analytics_tracing.otlp.receiver import authenticate
+from bigquery_agent_analytics_tracing.otlp.receiver import decode_body
+from bigquery_agent_analytics_tracing.otlp.receiver import DecodeError
+from bigquery_agent_analytics_tracing.otlp.receiver import handle_export
+from bigquery_agent_analytics_tracing.otlp.receiver import Publisher
+from bigquery_agent_analytics_tracing.otlp.receiver import ReceiverConfig
+from bigquery_agent_analytics_tracing.otlp.receiver import ReceiverResult
+from bigquery_agent_analytics_tracing.otlp.receiver import route_envelopes
+from bigquery_agent_analytics_tracing.otlp.receiver import SIGNAL_PATHS
 from bigquery_agent_analytics_tracing.otlp.schema import METRIC_TABLES
 from bigquery_agent_analytics_tracing.otlp.schema import NATIVE_TABLES
 from bigquery_agent_analytics_tracing.otlp.schema import OTEL_SCHEMA_VERSION
@@ -73,4 +84,14 @@ __all__ = [
     "dead_letter_key",
     "decode_logs_request",
     "decode_metrics_request",
+    # receiver (PR 3)
+    "ReceiverConfig",
+    "ReceiverResult",
+    "Publisher",
+    "DecodeError",
+    "authenticate",
+    "decode_body",
+    "route_envelopes",
+    "handle_export",
+    "SIGNAL_PATHS",
 ]

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/app.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/app.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WSGI entrypoint for the OTLP receiver on Cloud Run (issue #316, PR 3).
+
+Deploy with gunicorn using the app factory::
+
+    gunicorn --factory bigquery_agent_analytics_tracing.otlp.app:make_app
+
+Config comes from environment variables; the real Pub/Sub publisher is
+lazy-constructed (needs the ``receiver`` extra). The request logic lives in
+``receiver.py`` and is fully unit-tested without a server or network.
+"""
+
+from __future__ import annotations
+
+import http.client
+import os
+from typing import Any, Callable, Iterable
+
+from bigquery_agent_analytics_tracing import _utils
+from bigquery_agent_analytics_tracing.otlp import receiver
+
+
+class PubSubPublisher:
+  """``receiver.Publisher`` backed by google-cloud-pubsub (lazy import)."""
+
+  def __init__(self) -> None:
+    from google.cloud import pubsub_v1  # noqa: PLC0415 - optional dependency
+
+    self._client = pubsub_v1.PublisherClient()
+
+  def publish(self, topic: str, message: bytes) -> None:
+    self._client.publish(topic, message).result()
+
+
+def config_from_env() -> receiver.ReceiverConfig:
+  return receiver.ReceiverConfig(
+      expected_token=os.environ["BQAA_OTLP_TOKEN"],
+      main_topic=os.environ["BQAA_OTLP_MAIN_TOPIC"],
+      dlq_topic=os.environ["BQAA_OTLP_DLQ_TOPIC"],
+      enable_traces=os.environ.get("BQAA_OTLP_ENABLE_TRACES", "0") == "1",
+      source_product=os.environ.get("BQAA_OTLP_SOURCE_PRODUCT", "claude_code"),
+  )
+
+
+def make_app(
+    config: receiver.ReceiverConfig | None = None,
+    publisher: receiver.Publisher | None = None,
+) -> Callable[[dict[str, Any], Callable], Iterable[bytes]]:
+  """Build the WSGI app. Tests pass an explicit config + fake publisher."""
+  config = config or config_from_env()
+  publisher = publisher or PubSubPublisher()
+
+  def app(environ: dict[str, Any], start_response: Callable) -> Iterable[bytes]:
+    path = environ.get("PATH_INFO", "")
+    if path == "/healthz":
+      start_response("200 OK", [("Content-Type", "text/plain")])
+      return [b"ok"]
+
+    try:
+      length = int(environ.get("CONTENT_LENGTH") or 0)
+    except ValueError:
+      length = 0
+    body = environ["wsgi.input"].read(length) if length else b""
+
+    result = receiver.handle_export(
+        path=path,
+        body=body,
+        content_type=environ.get("CONTENT_TYPE"),
+        auth_header=environ.get("HTTP_AUTHORIZATION"),
+        ingest_time=_utils.iso_timestamp(),
+        config=config,
+        publisher=publisher,
+    )
+
+    reason = http.client.responses.get(result.status, "")
+    start_response(
+        f"{result.status} {reason}", [("Content-Type", "application/json")]
+    )
+    return [
+        receiver._encode(
+            {
+                "status": result.status,
+                "published": result.published,
+                "dead_lettered": result.dead_lettered,
+                "message": result.message,
+            }
+        )
+    ]
+
+  return app

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/envelope.py
@@ -244,7 +244,12 @@ def dead_letter_key(
   """
   if source_position is not None:
     return _sha([source_position.canonical(), stage])
-  return _sha([raw_otlp_request_hash or "", stage])
+  if not raw_otlp_request_hash:
+    raise ValueError(
+        "dead_letter_key requires source_position or raw_otlp_request_hash; a"
+        " stage-only key would collapse unrelated whole-request failures"
+    )
+  return _sha([raw_otlp_request_hash, stage])
 
 
 def dead_letter_envelope(

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
@@ -159,20 +159,41 @@ def handle_export(
   signal = SIGNAL_PATHS.get(path)
   if signal is None:
     return ReceiverResult(404, message=f"unknown path {path!r}")
+
+  # Authenticate every known OTLP endpoint *before* any gate or decode, so auth
+  # failures are always 401 and the trace gate state never leaks to
+  # unauthenticated callers.
+  if not authenticate(auth_header, config.expected_token):
+    return ReceiverResult(401, message="unauthenticated")
+
   if signal == "trace":
     if not config.enable_traces:
       return ReceiverResult(404, message="traces not enabled")
     # Receiver wiring exists behind the flag, but span landing is deferred to
     # the trace work (design doc); accept-but-not-implemented.
     return ReceiverResult(501, message="trace landing not implemented")
-  if not authenticate(auth_header, config.expected_token):
-    return ReceiverResult(401, message="unauthenticated")
 
+  # Decode the body AND walk its structure under one guard: any malformed
+  # request — bad bytes (DecodeError) or valid JSON with the wrong OTLP shape
+  # (e.g. ``{"resourceLogs":[null]}`` raising inside the decode library) —
+  # becomes a keyed, replayable whole-request dead letter, never a 500.
   try:
     request = decode_body(signal, content_type, body)
-  except DecodeError as exc:
-    # Whole-request failure: one dead letter, keyed from request hash + stage
-    # (raw_otlp_request_hash always set so the key never collapses).
+    if signal == "log":
+      envelopes = decode.decode_logs_request(
+          request,
+          source_product=config.source_product,
+          raw_request=body,
+          ingest_time=ingest_time,
+      )
+    else:
+      envelopes = decode.decode_metrics_request(
+          request,
+          source_product=config.source_product,
+          raw_request=body,
+          ingest_time=ingest_time,
+      )
+  except Exception as exc:  # noqa: BLE001 - malformed request -> dead letter
     dead_letter = env.dead_letter_envelope(
         source_product=config.source_product,
         source_signal=signal,
@@ -183,21 +204,9 @@ def handle_export(
         raw_otlp_request_hash=env.request_hash(body),
     )
     publisher.publish(config.dlq_topic, _encode(dead_letter))
-    return ReceiverResult(400, dead_lettered=1, message="otlp decode failed")
+    return ReceiverResult(
+        400, dead_lettered=1, message="malformed otlp request"
+    )
 
-  if signal == "log":
-    envelopes = decode.decode_logs_request(
-        request,
-        source_product=config.source_product,
-        raw_request=body,
-        ingest_time=ingest_time,
-    )
-  else:
-    envelopes = decode.decode_metrics_request(
-        request,
-        source_product=config.source_product,
-        raw_request=body,
-        ingest_time=ingest_time,
-    )
   published, dead = route_envelopes(envelopes, publisher, config)
   return ReceiverResult(200, published=published, dead_lettered=dead)

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTLP receiver request handling (issue #316, PR 3).
+
+The transport-agnostic core: authenticate, decode an OTLP export body, run it
+through the PR-2 decode library, and route the resulting envelopes to the main
+Pub/Sub topic (success) or the DLQ topic (dead letters). The HTTP/WSGI
+entrypoint (``app.py``) and the real Pub/Sub publisher wrap this; tests drive it
+directly with local fixtures and a fake publisher — no network needed.
+
+The original request bytes (``body``) are threaded into the decode layer so
+dead-letter envelopes carry a replayable payload and a reproducible request
+hash (the PR-2 contract). Whole-request failures (bad auth aside) are
+dead-lettered with ``raw_otlp_request_hash`` always set, so the dead-letter key
+never collapses (see ``envelope.dead_letter_key``).
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+import hmac
+import json
+from typing import Any, Protocol
+
+from bigquery_agent_analytics_tracing.otlp import decode
+from bigquery_agent_analytics_tracing.otlp import envelope as env
+
+# OTLP HTTP path -> signal name.
+SIGNAL_PATHS = {
+    "/v1/logs": "log",
+    "/v1/metrics": "metric",
+    "/v1/traces": "trace",
+}
+
+
+class Publisher(Protocol):
+  """Minimal publish interface (real impl wraps google-cloud-pubsub)."""
+
+  def publish(self, topic: str, message: bytes) -> None:
+    ...
+
+
+class DecodeError(Exception):
+  """OTLP body could not be decoded into a request dict."""
+
+
+@dataclass
+class ReceiverConfig:
+  expected_token: str
+  main_topic: str
+  dlq_topic: str
+  enable_traces: bool = False  # signal-tier gate (#324)
+  source_product: str = "claude_code"
+
+
+@dataclass
+class ReceiverResult:
+  status: int
+  published: int = 0
+  dead_lettered: int = 0
+  message: str = ""
+
+
+def authenticate(auth_header: str | None, expected_token: str) -> bool:
+  """Constant-time bearer-token check."""
+  prefix = "Bearer "
+  if not auth_header or not auth_header.startswith(prefix):
+    return False
+  return hmac.compare_digest(auth_header[len(prefix) :], expected_token)
+
+
+def decode_body(
+    signal: str, content_type: str | None, body: bytes
+) -> dict[str, Any]:
+  """Decode an OTLP export body into the decoded request dict.
+
+  OTLP/HTTP protobuf (the recommended enterprise default) via
+  ``opentelemetry-proto`` (lazy-imported), or OTLP/HTTP JSON via ``json``.
+  Raises ``DecodeError`` on failure.
+  """
+  content = (content_type or "").split(";")[0].strip().lower()
+  if content in ("application/json", ""):
+    try:
+      return json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+      raise DecodeError(f"invalid OTLP/JSON body: {exc!r}") from exc
+  if content == "application/x-protobuf":
+    return _decode_protobuf(signal, body)
+  raise DecodeError(f"unsupported content-type {content_type!r}")
+
+
+def _decode_protobuf(signal: str, body: bytes) -> dict[str, Any]:
+  try:
+    from google.protobuf.json_format import MessageToDict
+
+    if signal == "log":
+      from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest as Request
+    elif signal == "metric":
+      from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest as Request
+    else:
+      raise DecodeError(f"protobuf decode unsupported for signal {signal!r}")
+  except ImportError as exc:
+    raise DecodeError(
+        "OTLP/protobuf needs the 'receiver' extra (opentelemetry-proto)"
+    ) from exc
+  message = Request()
+  try:
+    message.ParseFromString(body)
+  except Exception as exc:  # noqa: BLE001
+    raise DecodeError(f"invalid OTLP/protobuf body: {exc!r}") from exc
+  return MessageToDict(message, preserving_proto_field_name=False)
+
+
+def _encode(envelope: dict[str, Any]) -> bytes:
+  return json.dumps(envelope, separators=(",", ":")).encode("utf-8")
+
+
+def route_envelopes(
+    envelopes: list[dict[str, Any]],
+    publisher: Publisher,
+    config: ReceiverConfig,
+) -> tuple[int, int]:
+  """Publish each envelope to the main topic, or the DLQ if it is a dead letter."""
+  published = dead = 0
+  for envelope in envelopes:
+    if envelope.get("delivery", {}).get("dlq"):
+      publisher.publish(config.dlq_topic, _encode(envelope))
+      dead += 1
+    else:
+      publisher.publish(config.main_topic, _encode(envelope))
+      published += 1
+  return published, dead
+
+
+def handle_export(
+    *,
+    path: str,
+    body: bytes,
+    content_type: str | None,
+    auth_header: str | None,
+    ingest_time: str,
+    config: ReceiverConfig,
+    publisher: Publisher,
+) -> ReceiverResult:
+  """Authenticate, decode, and route one OTLP export request."""
+  signal = SIGNAL_PATHS.get(path)
+  if signal is None:
+    return ReceiverResult(404, message=f"unknown path {path!r}")
+  if signal == "trace":
+    if not config.enable_traces:
+      return ReceiverResult(404, message="traces not enabled")
+    # Receiver wiring exists behind the flag, but span landing is deferred to
+    # the trace work (design doc); accept-but-not-implemented.
+    return ReceiverResult(501, message="trace landing not implemented")
+  if not authenticate(auth_header, config.expected_token):
+    return ReceiverResult(401, message="unauthenticated")
+
+  try:
+    request = decode_body(signal, content_type, body)
+  except DecodeError as exc:
+    # Whole-request failure: one dead letter, keyed from request hash + stage
+    # (raw_otlp_request_hash always set so the key never collapses).
+    dead_letter = env.dead_letter_envelope(
+        source_product=config.source_product,
+        source_signal=signal,
+        stage="otlp_decode",
+        reason=repr(exc),
+        raw_b64=base64.b64encode(body).decode("ascii"),
+        received_at=ingest_time,
+        raw_otlp_request_hash=env.request_hash(body),
+    )
+    publisher.publish(config.dlq_topic, _encode(dead_letter))
+    return ReceiverResult(400, dead_lettered=1, message="otlp decode failed")
+
+  if signal == "log":
+    envelopes = decode.decode_logs_request(
+        request,
+        source_product=config.source_product,
+        raw_request=body,
+        ingest_time=ingest_time,
+    )
+  else:
+    envelopes = decode.decode_metrics_request(
+        request,
+        source_product=config.source_product,
+        raw_request=body,
+        ingest_time=ingest_time,
+    )
+  published, dead = route_envelopes(envelopes, publisher, config)
+  return ReceiverResult(200, published=published, dead_lettered=dead)

--- a/producers/tests/test_otlp_receiver.py
+++ b/producers/tests/test_otlp_receiver.py
@@ -186,6 +186,19 @@ def test_undecodable_body_is_dead_lettered_with_keyed_replayable_payload():
   assert base64.b64decode(dl["raw_preservation"]["raw_b64"]) == body
 
 
+def test_valid_json_with_wrong_otlp_shape_is_dead_lettered_not_500():
+  # Valid JSON, malformed OTLP structure: the decode library raises inside the
+  # receiver's guard; it must dead-letter (keyed + replayable), never crash.
+  body = json.dumps({"resourceLogs": [None]}).encode("utf-8")
+  result, pub = _call("/v1/logs", body)
+  assert result.status == 400
+  assert result.dead_lettered == 1
+  dl = pub.to("proj/dlq")[0]
+  assert dl["parse_error"]["stage"] == "otlp_decode"
+  assert dl["idempotency_key"] is not None
+  assert base64.b64decode(dl["raw_preservation"]["raw_b64"]) == body
+
+
 # --------------------------------------------------------------------------
 # Traces signal-tier gate (#324)
 # --------------------------------------------------------------------------
@@ -201,6 +214,20 @@ def test_traces_path_is_501_when_enabled_landing_deferred():
   result, pub = _call("/v1/traces", b"{}", config=_config(enable_traces=True))
   assert result.status == 501
   assert pub.calls == []
+
+
+def test_traces_requires_auth_before_revealing_gate_state():
+  # Unauthenticated callers must get 401 on /v1/traces regardless of the gate,
+  # so 404-vs-501 never leaks to them.
+  for enabled in (False, True):
+    result, pub = _call(
+        "/v1/traces",
+        b"{}",
+        token="wrong",
+        config=_config(enable_traces=enabled),
+    )
+    assert result.status == 401
+    assert pub.calls == []
 
 
 # --------------------------------------------------------------------------

--- a/producers/tests/test_otlp_receiver.py
+++ b/producers/tests/test_otlp_receiver.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OTLP receiver request handling (issue #316, PR 3)."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import app as otlp_app
+from bigquery_agent_analytics_tracing.otlp import envelope as env
+from bigquery_agent_analytics_tracing.otlp import receiver
+
+INGEST = "2026-06-29T00:00:00Z"
+TOKEN = "secret-token"
+
+
+class FakePublisher:
+
+  def __init__(self):
+    self.calls: list[tuple[str, dict]] = []
+
+  def publish(self, topic: str, message: bytes) -> None:
+    self.calls.append((topic, json.loads(message)))
+
+  def to(self, topic: str) -> list[dict]:
+    return [msg for t, msg in self.calls if t == topic]
+
+
+def _config(enable_traces=False):
+  return receiver.ReceiverConfig(
+      expected_token=TOKEN,
+      main_topic="proj/main",
+      dlq_topic="proj/dlq",
+      enable_traces=enable_traces,
+  )
+
+
+def _logs_body():
+  request = {
+      "resourceLogs": [
+          {
+              "resource": {"attributes": []},
+              "scopeLogs": [
+                  {
+                      "scope": {"name": "s", "version": "1"},
+                      "logRecords": [
+                          {"timeUnixNano": "100", "body": {"stringValue": "hi"}}
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+  return json.dumps(request).encode("utf-8")
+
+
+def _metrics_body(metrics):
+  request = {
+      "resourceMetrics": [
+          {
+              "resource": {"attributes": []},
+              "scopeMetrics": [{"scope": {"name": "s"}, "metrics": metrics}],
+          }
+      ]
+  }
+  return json.dumps(request).encode("utf-8")
+
+
+_GOOD_GAUGE = {
+    "name": "g",
+    "gauge": {"dataPoints": [{"asDouble": 1.0, "timeUnixNano": "100"}]},
+}
+
+
+def _call(
+    path,
+    body,
+    *,
+    token=TOKEN,
+    content_type="application/json",
+    config=None,
+    publisher=None,
+):
+  config = config or _config()
+  publisher = publisher or FakePublisher()
+  auth = f"Bearer {token}" if token is not None else None
+  result = receiver.handle_export(
+      path=path,
+      body=body,
+      content_type=content_type,
+      auth_header=auth,
+      ingest_time=INGEST,
+      config=config,
+      publisher=publisher,
+  )
+  return result, publisher
+
+
+# --------------------------------------------------------------------------
+# Auth
+# --------------------------------------------------------------------------
+
+
+def test_authenticate_accepts_correct_bearer_only():
+  assert receiver.authenticate(f"Bearer {TOKEN}", TOKEN) is True
+  assert receiver.authenticate("Bearer wrong", TOKEN) is False
+  assert receiver.authenticate(TOKEN, TOKEN) is False  # missing "Bearer "
+  assert receiver.authenticate(None, TOKEN) is False
+
+
+def test_unauthenticated_request_is_rejected_without_publishing():
+  result, pub = _call("/v1/logs", _logs_body(), token="wrong")
+  assert result.status == 401
+  assert pub.calls == []
+
+
+# --------------------------------------------------------------------------
+# Routing
+# --------------------------------------------------------------------------
+
+
+def test_valid_logs_export_publishes_to_main_topic():
+  result, pub = _call("/v1/logs", _logs_body())
+  assert result.status == 200
+  assert result.published == 1
+  assert result.dead_lettered == 0
+  assert len(pub.to("proj/main")) == 1
+  assert pub.to("proj/main")[0]["source"]["signal"] == "log"
+
+
+def test_valid_metrics_export_publishes_to_main_topic():
+  result, pub = _call("/v1/metrics", _metrics_body([_GOOD_GAUGE]))
+  assert result.status == 200
+  assert result.published == 1
+  assert pub.to("proj/main")[0]["record"]["point_kind"] == "gauge"
+
+
+def test_unknown_path_is_404():
+  result, pub = _call("/v1/nope", _logs_body())
+  assert result.status == 404
+  assert pub.calls == []
+
+
+def test_bad_metric_routes_to_dlq_while_good_one_goes_to_main():
+  body = _metrics_body([{"name": "bad"}, _GOOD_GAUGE])
+  result, pub = _call("/v1/metrics", body)
+  assert result.status == 200
+  assert result.published == 1
+  assert result.dead_lettered == 1
+  assert len(pub.to("proj/main")) == 1
+  assert len(pub.to("proj/dlq")) == 1
+  assert pub.to("proj/dlq")[0]["delivery"]["dlq"] is True
+
+
+# --------------------------------------------------------------------------
+# Whole-request failure -> DLQ, keyed + replayable
+# --------------------------------------------------------------------------
+
+
+def test_undecodable_body_is_dead_lettered_with_keyed_replayable_payload():
+  body = b"this is not OTLP json"
+  result, pub = _call("/v1/logs", body)
+  assert result.status == 400
+  assert result.dead_lettered == 1
+  dl = pub.to("proj/dlq")[0]
+  assert dl["parse_error"]["stage"] == "otlp_decode"
+  assert dl["source_position"] is None  # whole-request failure
+  assert dl["idempotency_key"] is not None  # keyed from request hash + stage
+  # raw_b64 round-trips to the original body (replayable).
+  assert base64.b64decode(dl["raw_preservation"]["raw_b64"]) == body
+
+
+# --------------------------------------------------------------------------
+# Traces signal-tier gate (#324)
+# --------------------------------------------------------------------------
+
+
+def test_traces_path_is_404_when_disabled():
+  result, pub = _call("/v1/traces", b"{}")
+  assert result.status == 404
+  assert pub.calls == []
+
+
+def test_traces_path_is_501_when_enabled_landing_deferred():
+  result, pub = _call("/v1/traces", b"{}", config=_config(enable_traces=True))
+  assert result.status == 501
+  assert pub.calls == []
+
+
+# --------------------------------------------------------------------------
+# decode_body + guard + route_envelopes units
+# --------------------------------------------------------------------------
+
+
+def test_decode_body_rejects_unsupported_content_type():
+  with pytest.raises(receiver.DecodeError):
+    receiver.decode_body("log", "text/csv", b"a,b,c")
+
+
+def test_dead_letter_key_guard_rejects_stage_only():
+  # The receiver always passes a request hash; a stage-only key would collapse
+  # unrelated whole-request failures, so it is forbidden.
+  with pytest.raises(ValueError):
+    env.dead_letter_key("otlp_decode", None, None)
+
+
+def test_route_envelopes_splits_main_and_dlq():
+  pub = FakePublisher()
+  envelopes = [
+      {"delivery": {"dlq": False}},
+      {"delivery": {"dlq": True}},
+      {"delivery": {"dlq": False}},
+  ]
+  published, dead = receiver.route_envelopes(envelopes, pub, _config())
+  assert (published, dead) == (2, 1)
+  assert len(pub.to("proj/main")) == 2
+  assert len(pub.to("proj/dlq")) == 1
+
+
+# --------------------------------------------------------------------------
+# WSGI entrypoint (app.py) — no pubsub/proto deps needed (injected fake)
+# --------------------------------------------------------------------------
+
+
+def _wsgi_call(
+    application, path, body=b"", auth=None, content_type="application/json"
+):
+  environ = {
+      "PATH_INFO": path,
+      "REQUEST_METHOD": "POST",
+      "CONTENT_LENGTH": str(len(body)),
+      "CONTENT_TYPE": content_type,
+      "wsgi.input": io.BytesIO(body),
+  }
+  if auth is not None:
+    environ["HTTP_AUTHORIZATION"] = auth
+  captured: dict = {}
+
+  def start_response(status, headers):
+    captured["status"] = status
+
+  out = b"".join(application(environ, start_response))
+  return captured["status"], out
+
+
+def test_wsgi_healthz_returns_ok():
+  application = otlp_app.make_app(config=_config(), publisher=FakePublisher())
+  status, out = _wsgi_call(application, "/healthz")
+  assert status.startswith("200")
+  assert out == b"ok"
+
+
+def test_wsgi_logs_export_routes_through_the_app():
+  pub = FakePublisher()
+  application = otlp_app.make_app(config=_config(), publisher=pub)
+  status, out = _wsgi_call(
+      application, "/v1/logs", _logs_body(), auth=f"Bearer {TOKEN}"
+  )
+  assert status.startswith("200")
+  assert json.loads(out)["published"] == 1
+  assert len(pub.to("proj/main")) == 1
+
+
+def test_wsgi_unauthenticated_is_401():
+  application = otlp_app.make_app(config=_config(), publisher=FakePublisher())
+  status, _ = _wsgi_call(
+      application, "/v1/logs", _logs_body(), auth="Bearer nope"
+  )
+  assert status.startswith("401")


### PR DESCRIPTION
Third increment of the **OTel-native OTLP receiver** (#316) — PR 3: the request-handling **service**, tying PR 1 (schema) and PR 2 (decode/envelope) to Pub/Sub. Builds on #323 + #325.

Design: [`docs/otlp_receiver_design.md`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/otlp_receiver_design.md).

### What's here
- **`otlp/receiver.py`** — transport-agnostic core. Constant-time bearer auth; `decode_body` dispatch (OTLP/HTTP **protobuf** via lazy `opentelemetry-proto`, or JSON); `handle_export` authenticates → decodes → routes envelopes to the **main** topic (success) or **DLQ** (dead letters). The original request **bytes** are threaded into the PR-2 decode layer, so dead letters stay replayable + keyed; whole-request decode failures dead-letter with `raw_otlp_request_hash` always set. `/v1/traces` is **signal-tier gated** (#324): `404` when disabled, `501` (wired, landing deferred) when enabled.
- **`otlp/app.py`** — WSGI entrypoint for Cloud Run (`gunicorn --factory bigquery_agent_analytics_tracing.otlp.app:make_app`); env-driven config + lazy `google-cloud-pubsub` publisher. All logic stays in `receiver.py`.
- **`otlp/envelope.py`** — **PR #325 review hardening**: `dead_letter_key` now raises `ValueError` when neither `source_position` nor `raw_otlp_request_hash` is provided (a stage-only key would collapse unrelated whole-request failures). The receiver always passes the request hash.
- **`pyproject.toml`** — new optional `receiver` extra (`google-cloud-pubsub`, `opentelemetry-proto`, `gunicorn`).

### Scope notes
- **Deployable but locally tested.** The core + all 15 tests need none of the optional deps — they use a fake publisher and JSON fixtures. The real Pub/Sub client and protobuf decode are lazy-imported behind the `receiver` extra. Terraform/Cloud Run wiring + live e2e is PR 5.
- Auth failures return `401` (not dead-lettered); malformed-but-authenticated requests dead-letter.

### Verification
- New file: 15 passed (auth accept/reject, logs/metrics routing, per-record DLQ split, undecodable-body DLQ that is keyed + replayable, traces gating, the key guard, and the WSGI app end-to-end). Full producers suite: **159 passed**, no regressions.
- `isort --check` + `pyink --check` clean (as `producers-ci.yml` runs them).