### PR TITLE
feat(otlp): BigQuery writer + projection SQL — envelope v1 to native rows (#316 PR4)

### DIFF
--- a/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/__init__.py
@@ -21,6 +21,8 @@
   (``envelope`` / ``decode``).
 - PR 3: receiver request handling — auth, decode dispatch, Pub/Sub + DLQ
   routing (``receiver``); WSGI entrypoint in ``app``.
+- PR 4: BigQuery writer + projection SQL — envelope v1 to native rows
+  (``writer``), scheduled MERGE + ``bqaa_metrics`` view (``sql``).
 
 See ``docs/otlp_receiver_design.md``.
 """
@@ -58,6 +60,15 @@ from bigquery_agent_analytics_tracing.otlp.schema import METRIC_TABLES
 from bigquery_agent_analytics_tracing.otlp.schema import NATIVE_TABLES
 from bigquery_agent_analytics_tracing.otlp.schema import OTEL_SCHEMA_VERSION
 from bigquery_agent_analytics_tracing.otlp.schema import table_labels
+from bigquery_agent_analytics_tracing.otlp.sql import agent_events_otlp_merge_sql
+from bigquery_agent_analytics_tracing.otlp.sql import bqaa_metrics_view_sql
+from bigquery_agent_analytics_tracing.otlp.sql import CROSSWALK_VERSION
+from bigquery_agent_analytics_tracing.otlp.writer import append_envelope
+from bigquery_agent_analytics_tracing.otlp.writer import BigQueryWriter
+from bigquery_agent_analytics_tracing.otlp.writer import envelope_to_row
+from bigquery_agent_analytics_tracing.otlp.writer import handle_message
+from bigquery_agent_analytics_tracing.otlp.writer import TableWriteError
+from bigquery_agent_analytics_tracing.otlp.writer import target_table
 
 __all__ = [
     # schema (PR 1)
@@ -94,4 +105,14 @@ __all__ = [
     "route_envelopes",
     "handle_export",
     "SIGNAL_PATHS",
+    # writer + projection SQL (PR 4)
+    "BigQueryWriter",
+    "TableWriteError",
+    "envelope_to_row",
+    "target_table",
+    "append_envelope",
+    "handle_message",
+    "agent_events_otlp_merge_sql",
+    "bqaa_metrics_view_sql",
+    "CROSSWALK_VERSION",
 ]

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/consumer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/consumer.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pub/Sub -> BigQuery consumer for envelope v1 (issue #316, PR 4).
+
+Deployable glue: a Pub/Sub subscriber whose callback runs each message through
+``writer.handle_message`` into BigQuery. The append-only BigQuery client and the
+Pub/Sub client are lazy-imported (``receiver`` / core extras); the per-message
+callback is pure and unit-tested. ``ack`` on success, ``nack`` on failure so the
+message redelivers (and ultimately hits the subscription's dead-letter policy).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bigquery_agent_analytics_tracing.otlp import writer
+
+
+class BigQueryAppendWriter:
+  """``writer.BigQueryWriter`` backed by ``insert_rows_json`` (append-only)."""
+
+  def __init__(self, project: str, dataset: str) -> None:
+    from google.cloud import bigquery  # noqa: PLC0415 - optional dependency
+
+    self._client = bigquery.Client(project=project)
+    self._project = project
+    self._dataset = dataset
+
+  def append(self, table: str, row: dict[str, Any]) -> None:
+    table_id = f"{self._project}.{self._dataset}.{table}"
+    errors = self._client.insert_rows_json(table_id, [row])
+    if errors:
+      raise writer.TableWriteError(f"insert into {table} failed: {errors}")
+
+
+def make_callback(
+    bq_writer: writer.BigQueryWriter, *, enable_spans: bool = False
+):
+  """Build a Pub/Sub message callback. Pure — testable with a fake message."""
+
+  def callback(message: Any) -> None:
+    try:
+      writer.handle_message(message.data, bq_writer, enable_spans=enable_spans)
+      message.ack()
+    except Exception:  # noqa: BLE001 - nack -> redelivery / subscription DLQ
+      message.nack()
+
+  return callback
+
+
+def run_subscriber(
+    subscription: str,
+    bq_writer: writer.BigQueryWriter,
+    *,
+    enable_spans: bool = False,
+) -> None:  # pragma: no cover - deployment glue
+  """Block on a Pub/Sub streaming pull, landing messages into BigQuery."""
+  from google.cloud import pubsub_v1  # noqa: PLC0415 - optional dependency
+
+  client = pubsub_v1.SubscriberClient()
+  future = client.subscribe(
+      subscription, callback=make_callback(bq_writer, enable_spans=enable_spans)
+  )
+  future.result()

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/sql.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/sql.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BQAA projection SQL artifacts (issue #316, PR 4).
+
+The read-time dedup views (``projection.dedup_view_sql``, PR 1) feed two
+projection surfaces:
+
+- ``agent_events_otlp`` — a curated table built by a scheduled ``MERGE`` that
+  crosswalks deduped ``otel_logs`` rows into the ``agent_events`` shape. The
+  ``*_dedup`` view already applies newest-write-wins (``ORDER BY ingest_time
+  DESC``), so a replayed/repaired row supersedes the older one before it reaches
+  the projection; the ``MERGE`` upserts on ``idempotency_key``.
+- ``bqaa_metrics`` — a typed view over the five deduped ``otel_metric_*`` tables.
+
+The curated ``agent_events_otlp`` table schema is pinned by
+``projection.agent_events_otlp_columns`` (PR 1).
+"""
+
+from __future__ import annotations
+
+from bigquery_agent_analytics_tracing.otlp import schema as otel_schema
+
+CROSSWALK_VERSION = "1"
+
+# (agent_events column, SQL expression over a deduped otel_logs row).
+# content_parts is intentionally deferred to the raw-body fast-follow.
+_LOG_CROSSWALK: tuple[tuple[str, str], ...] = (
+    ("timestamp", "timestamp"),
+    ("event_type", "COALESCE(event_name, 'otlp.unknown')"),
+    ("agent", "JSON_VALUE(log_attributes, '$.\"agent.name\"')"),
+    ("session_id", "JSON_VALUE(log_attributes, '$.\"session.id\"')"),
+    ("invocation_id", "JSON_VALUE(log_attributes, '$.\"prompt.id\"')"),
+    ("user_id", "JSON_VALUE(resource_attributes, '$.\"user.id\"')"),
+    ("trace_id", "trace_id"),
+    ("span_id", "span_id"),
+    ("parent_span_id", "CAST(NULL AS STRING)"),
+    ("content", "body"),
+    ("attributes", "log_attributes"),
+    ("latency_ms", "CAST(NULL AS JSON)"),
+    ("status", "CAST(NULL AS STRING)"),
+    ("error_message", "CAST(NULL AS STRING)"),
+    ("is_truncated", "FALSE"),
+    ("source_product", "source_product"),
+    ("source_signal", "source_signal"),
+    ("source_event_name", "event_name"),
+    ("crosswalk_version", f"'{CROSSWALK_VERSION}'"),
+    ("idempotency_key", "idempotency_key"),
+)
+
+
+def agent_events_otlp_merge_sql(dataset: str = "${dataset}") -> str:
+  """Scheduled ``MERGE`` that builds ``agent_events_otlp`` from deduped logs.
+
+  Upserts on ``idempotency_key`` so a re-run (or a replayed/repaired row that the
+  dedup view now surfaces as newest) updates the existing projection row rather
+  than duplicating it.
+  """
+  cols = [c for c, _ in _LOG_CROSSWALK]
+  select = ",\n    ".join(f"{expr} AS {col}" for col, expr in _LOG_CROSSWALK)
+  insert_cols = ", ".join(cols)
+  insert_vals = ", ".join(f"S.{c}" for c in cols)
+  update_set = ",\n    ".join(
+      f"{c} = S.{c}" for c in cols if c != "idempotency_key"
+  )
+  return (
+      f"MERGE `{dataset}.agent_events_otlp` T\n"
+      f"USING (\n  SELECT\n    {select}\n"
+      f"  FROM `{dataset}.otel_logs_dedup`\n) S\n"
+      f"ON T.idempotency_key = S.idempotency_key\n"
+      f"WHEN MATCHED THEN UPDATE SET\n    {update_set}\n"
+      f"WHEN NOT MATCHED THEN INSERT ({insert_cols})\n"
+      f"  VALUES ({insert_vals});"
+  )
+
+
+# Per-metric-type projection into the unified bqaa_metrics column shape.
+# (column -> expression); sum/gauge carry a scalar value, the aggregate types
+# carry count + sum.
+_METRIC_PROJECTIONS: dict[str, dict[str, str]] = {
+    "otel_metric_sum": {
+        "temporality": "aggregation_temporality",
+        "value": "value",
+        "count": "CAST(NULL AS INT64)",
+        "sum_value": "CAST(NULL AS FLOAT64)",
+    },
+    "otel_metric_gauge": {
+        "temporality": "CAST(NULL AS INT64)",
+        "value": "value",
+        "count": "CAST(NULL AS INT64)",
+        "sum_value": "CAST(NULL AS FLOAT64)",
+    },
+    "otel_metric_histogram": {
+        "temporality": "aggregation_temporality",
+        "value": "CAST(NULL AS FLOAT64)",
+        "count": "count",
+        "sum_value": "sum",
+    },
+    "otel_metric_exponential_histogram": {
+        "temporality": "aggregation_temporality",
+        "value": "CAST(NULL AS FLOAT64)",
+        "count": "count",
+        "sum_value": "sum",
+    },
+    "otel_metric_summary": {
+        "temporality": "CAST(NULL AS INT64)",
+        "value": "CAST(NULL AS FLOAT64)",
+        "count": "count",
+        "sum_value": "sum",
+    },
+}
+
+
+def bqaa_metrics_view_sql(dataset: str = "${dataset}") -> str:
+  """Typed ``bqaa_metrics`` view UNION-ing the five deduped metric tables."""
+  blocks = []
+  for table in otel_schema.METRIC_TABLES:
+    proj = _METRIC_PROJECTIONS[table]
+    point_kind = table[len("otel_metric_") :]
+    blocks.append(
+        "SELECT\n"
+        "  metric_name, service_name, time_timestamp, unit,\n"
+        f"  '{point_kind}' AS point_kind,\n"
+        f"  {proj['temporality']} AS temporality,\n"
+        f"  {proj['value']} AS value,\n"
+        f"  {proj['count']} AS count,\n"
+        f"  {proj['sum_value']} AS sum_value,\n"
+        "  attributes, source_product, idempotency_key\n"
+        f"FROM `{dataset}.{table}_dedup`"
+    )
+  union = "\nUNION ALL\n".join(blocks)
+  return f"CREATE OR REPLACE VIEW `{dataset}.bqaa_metrics` AS\n{union};"

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
@@ -1,0 +1,312 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Envelope v1 -> native BigQuery rows; append-only writer (issue #316, PR 4).
+
+Consumes the Pub/Sub envelope-v1 messages produced by the receiver (PR 3) and
+maps each to a row for its native table — ``otel_logs``, the five
+``otel_metric_*`` tables, or ``otlp_dead_letter`` (spans gated/deferred). The
+row mapping is pure and table-routing is deterministic, so the whole thing is
+unit-testable with a fake writer; the real BigQuery client is lazy-imported.
+
+Every row preserves the contract fields the dedup views and replay path depend
+on: ``idempotency_key``, ``source_position`` (incl. ``raw_otlp_request_hash``),
+``otel_schema_version``, ``ingest_time``, ``source_product``, ``source_signal``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+import json
+from typing import Any, Protocol
+
+from bigquery_agent_analytics_tracing.otlp import envelope as env
+
+_METRIC_TABLE = {
+    "sum": "otel_metric_sum",
+    "gauge": "otel_metric_gauge",
+    "histogram": "otel_metric_histogram",
+    "exponential_histogram": "otel_metric_exponential_histogram",
+    "summary": "otel_metric_summary",
+}
+
+
+class TableWriteError(Exception):
+  """Envelope could not be mapped/routed to a native table."""
+
+
+class BigQueryWriter(Protocol):
+  """Append rows to a native table (real impl wraps google-cloud-bigquery)."""
+
+  def append(self, table: str, row: dict[str, Any]) -> None:
+    ...
+
+
+def _json(value: Any) -> str | None:
+  """Serialize a JSON column value (matches the package convention)."""
+  if value is None:
+    return None
+  return json.dumps(value, sort_keys=True)
+
+
+def _nanos_to_iso(nanos: Any) -> str | None:
+  """OTLP ``*UnixNano`` (string/int) -> RFC3339 UTC timestamp string."""
+  if nanos in (None, ""):
+    return None
+  seconds = int(nanos) / 1_000_000_000
+  return (
+      datetime.fromtimestamp(seconds, tz=timezone.utc)
+      .isoformat()
+      .replace("+00:00", "Z")
+  )
+
+
+def _num(point: dict[str, Any]) -> float | int | None:
+  if "asDouble" in point:
+    return point["asDouble"]
+  if "asInt" in point:
+    return int(point["asInt"])
+  return None
+
+
+def _int(value: Any) -> int | None:
+  return None if value in (None, "") else int(value)
+
+
+def _int_list(values: Any) -> list[int]:
+  return [int(v) for v in (values or [])]
+
+
+def _receiver_metadata_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  return {
+      "source_product": envelope["source"]["product"],
+      "source_signal": envelope["source"]["signal"],
+      "idempotency_key": envelope["idempotency_key"],
+      "source_position": envelope["source_position"],
+      "ingest_time": envelope["ingest_time"],
+      "raw_preservation": envelope.get("raw_preservation"),
+      "otel_schema_version": envelope.get("otel_schema_version"),
+  }
+
+
+def _exemplars_rows(point: dict[str, Any]) -> list[dict[str, Any]]:
+  rows = []
+  for ex in point.get("exemplars", []) or []:
+    rows.append(
+        {
+            "time_timestamp": _nanos_to_iso(ex.get("timeUnixNano")),
+            "value": _num(ex),
+            "span_id": ex.get("spanId"),
+            "trace_id": ex.get("traceId"),
+            "filtered_attributes": _json(
+                env.otlp_attrs_to_dict(ex.get("filteredAttributes"))
+            ),
+        }
+    )
+  return rows
+
+
+def log_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  record = envelope["record"]
+  resource = envelope["otlp"]["resource_attributes"]
+  scope = envelope["otlp"].get("scope") or {}
+  row = {
+      "timestamp": (
+          _nanos_to_iso(record.get("timeUnixNano"))
+          or _nanos_to_iso(record.get("observedTimeUnixNano"))
+          or envelope["ingest_time"]
+      ),
+      "observed_timestamp": _nanos_to_iso(record.get("observedTimeUnixNano")),
+      "trace_id": record.get("traceId"),
+      "span_id": record.get("spanId"),
+      "trace_flags": _int(record.get("flags")),
+      "severity_text": record.get("severityText"),
+      "severity_number": _int(record.get("severityNumber")),
+      "service_name": resource.get("service.name"),
+      "body": _json(record.get("body")),
+      "resource_attributes": _json(resource),
+      "scope_name": scope.get("name"),
+      "scope_version": scope.get("version"),
+      "scope_attributes": _json(
+          env.otlp_attrs_to_dict(scope.get("attributes"))
+      ),
+      "log_attributes": _json(env.otlp_attrs_to_dict(record.get("attributes"))),
+      "event_name": record.get("eventName"),
+  }
+  row.update(_receiver_metadata_row(envelope))
+  return row
+
+
+def _metric_common_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  record = envelope["record"]
+  point = record["point"]
+  resource = envelope["otlp"]["resource_attributes"]
+  scope = envelope["otlp"].get("scope") or {}
+  row = {
+      "service_name": resource.get("service.name"),
+      "metric_name": record.get("metric_name"),
+      "metric_description": record.get("description"),
+      "unit": record.get("unit"),
+      "start_timestamp": _nanos_to_iso(point.get("startTimeUnixNano")),
+      "time_timestamp": (
+          _nanos_to_iso(point.get("timeUnixNano")) or envelope["ingest_time"]
+      ),
+      "flags": _int(point.get("flags")),
+      "resource_attributes": _json(resource),
+      "scope_name": scope.get("name"),
+      "scope_version": scope.get("version"),
+      "scope_attributes": _json(
+          env.otlp_attrs_to_dict(scope.get("attributes"))
+      ),
+      "attributes": _json(env.otlp_attrs_to_dict(point.get("attributes"))),
+  }
+  row.update(_receiver_metadata_row(envelope))
+  return row
+
+
+def _buckets(buckets: dict[str, Any] | None) -> dict[str, Any]:
+  buckets = buckets or {}
+  return {
+      "offset": _int(buckets.get("offset")),
+      "bucket_counts": _int_list(buckets.get("bucketCounts")),
+  }
+
+
+def metric_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  record = envelope["record"]
+  point = record["point"]
+  kind = record["point_kind"]
+  row = _metric_common_row(envelope)
+  temporality = record.get("aggregation_temporality")
+  if kind in ("sum", "gauge"):
+    row["value"] = _num(point)
+    row["exemplars"] = _exemplars_rows(point)
+    if kind == "sum":
+      row["aggregation_temporality"] = temporality
+      row["is_monotonic"] = record.get("is_monotonic")
+  elif kind == "histogram":
+    row.update(
+        {
+            "count": _int(point.get("count")),
+            "sum": point.get("sum"),
+            "min": point.get("min"),
+            "max": point.get("max"),
+            "bucket_counts": _int_list(point.get("bucketCounts")),
+            "explicit_bounds": list(point.get("explicitBounds") or []),
+            "aggregation_temporality": temporality,
+            "exemplars": _exemplars_rows(point),
+        }
+    )
+  elif kind == "exponential_histogram":
+    row.update(
+        {
+            "count": _int(point.get("count")),
+            "sum": point.get("sum"),
+            "min": point.get("min"),
+            "max": point.get("max"),
+            "scale": _int(point.get("scale")),
+            "zero_count": _int(point.get("zeroCount")),
+            "zero_threshold": point.get("zeroThreshold"),
+            "positive": _buckets(point.get("positive")),
+            "negative": _buckets(point.get("negative")),
+            "aggregation_temporality": temporality,
+            "exemplars": _exemplars_rows(point),
+        }
+    )
+  elif kind == "summary":
+    row.update(
+        {
+            "count": _int(point.get("count")),
+            "sum": point.get("sum"),
+            "quantile_values": [
+                {"quantile": q.get("quantile"), "value": q.get("value")}
+                for q in point.get("quantileValues", []) or []
+            ],
+        }
+    )
+  else:
+    raise TableWriteError(f"unknown metric point_kind {kind!r}")
+  return row
+
+
+def dead_letter_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  parse_error = envelope.get("parse_error") or {}
+  return {
+      "received_at": envelope["ingest_time"],
+      "stage": parse_error.get("stage"),
+      "reason": parse_error.get("reason"),
+      "source_product": envelope["source"]["product"],
+      "source_signal": envelope["source"]["signal"],
+      "idempotency_key": envelope.get("idempotency_key"),
+      "source_position": envelope.get("source_position"),
+      "raw_b64": (envelope.get("raw_preservation") or {}).get("raw_b64"),
+  }
+
+
+def target_table(envelope: dict[str, Any]) -> str:
+  """The native table an envelope lands in."""
+  if envelope.get("delivery", {}).get("dlq"):
+    return "otlp_dead_letter"
+  signal = envelope["source"]["signal"]
+  if signal == "log":
+    return "otel_logs"
+  if signal == "metric":
+    kind = envelope["record"]["point_kind"]
+    if kind not in _METRIC_TABLE:
+      raise TableWriteError(f"unknown metric point_kind {kind!r}")
+    return _METRIC_TABLE[kind]
+  raise TableWriteError(f"no native table for signal {signal!r}")
+
+
+def envelope_to_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  """Map an envelope to its native BigQuery row."""
+  if envelope.get("delivery", {}).get("dlq"):
+    return dead_letter_row(envelope)
+  signal = envelope["source"]["signal"]
+  if signal == "log":
+    return log_row(envelope)
+  if signal == "metric":
+    return metric_row(envelope)
+  raise TableWriteError(f"no row mapping for signal {signal!r}")
+
+
+def append_envelope(
+    envelope: dict[str, Any],
+    writer: BigQueryWriter,
+    *,
+    enable_spans: bool = False,
+) -> str:
+  """Map an envelope to a row and append it to the right native table.
+
+  Returns the target table name. Span envelopes are dropped unless
+  ``enable_spans`` (landing is gated/deferred — design doc).
+  """
+  if envelope["source"]["signal"] == "span" and not enable_spans:
+    return ""  # span landing deferred
+  table = target_table(envelope)
+  writer.append(table, envelope_to_row(envelope))
+  return table
+
+
+def handle_message(
+    data: bytes,
+    writer: BigQueryWriter,
+    *,
+    enable_spans: bool = False,
+) -> str:
+  """Decode one Pub/Sub envelope-v1 message and append it. Returns the table."""
+  envelope = json.loads(data.decode("utf-8"))
+  return append_envelope(envelope, writer, enable_spans=enable_spans)

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -1,0 +1,428 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OTLP BigQuery writer + projection SQL (issue #316, PR 4)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import consumer
+from bigquery_agent_analytics_tracing.otlp import decode
+from bigquery_agent_analytics_tracing.otlp import projection
+from bigquery_agent_analytics_tracing.otlp import sql
+from bigquery_agent_analytics_tracing.otlp import writer
+
+INGEST = "2026-06-30T00:00:00Z"
+
+
+class FakeWriter:
+
+  def __init__(self):
+    self.rows: list[tuple[str, dict]] = []
+
+  def append(self, table: str, row: dict) -> None:
+    self.rows.append((table, row))
+
+
+def _raw(request: dict) -> bytes:
+  return json.dumps(request).encode("utf-8")
+
+
+def _log_envelope():
+  request = {
+      "resourceLogs": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      },
+                      {"key": "user.id", "value": {"stringValue": "u-1"}},
+                  ]
+              },
+              "scopeLogs": [
+                  {
+                      "scope": {"name": "scope", "version": "1.0"},
+                      "logRecords": [
+                          {
+                              "timeUnixNano": "1700000000000000000",
+                              "severityNumber": 9,
+                              "body": {"stringValue": "hello"},
+                              "eventName": "claude_code.user_prompt",
+                              "traceId": "t1",
+                              "spanId": "s1",
+                              "attributes": [
+                                  {
+                                      "key": "session.id",
+                                      "value": {"stringValue": "sess-1"},
+                                  }
+                              ],
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+  return decode.decode_logs_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=INGEST,
+  )[0]
+
+
+_METRIC_BODIES = {
+    "sum": {
+        "aggregationTemporality": 1,
+        "isMonotonic": True,
+        "dataPoints": [{"asDouble": 1.5, "timeUnixNano": "100"}],
+    },
+    "gauge": {"dataPoints": [{"asInt": "7", "timeUnixNano": "100"}]},
+    "histogram": {
+        "aggregationTemporality": 2,
+        "dataPoints": [
+            {
+                "count": "3",
+                "sum": 6.0,
+                "bucketCounts": ["1", "2"],
+                "explicitBounds": [1.0],
+                "timeUnixNano": "100",
+            }
+        ],
+    },
+    "exponentialHistogram": {
+        "aggregationTemporality": 1,
+        "dataPoints": [
+            {
+                "count": "3",
+                "sum": 6.0,
+                "scale": 2,
+                "zeroCount": "0",
+                "positive": {"offset": 0, "bucketCounts": ["1", "2"]},
+                "timeUnixNano": "100",
+            }
+        ],
+    },
+    "summary": {
+        "dataPoints": [
+            {
+                "count": "3",
+                "sum": 6.0,
+                "quantileValues": [{"quantile": 0.5, "value": 2.0}],
+                "timeUnixNano": "100",
+            }
+        ]
+    },
+}
+
+
+def _metric_envelope(otlp_kind):
+  request = {
+      "resourceMetrics": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      }
+                  ]
+              },
+              "scopeMetrics": [
+                  {
+                      "scope": {"name": "scope"},
+                      "metrics": [
+                          {
+                              "name": "m",
+                              "unit": "1",
+                              otlp_kind: _METRIC_BODIES[otlp_kind],
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+  return decode.decode_metrics_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=INGEST,
+  )[0]
+
+
+def _dead_letter_envelope():
+  request = {
+      "resourceMetrics": [
+          {
+              "resource": {"attributes": []},
+              "scopeMetrics": [{"scope": {}, "metrics": [{"name": "bad"}]}],
+          }
+      ]
+  }
+  return decode.decode_metrics_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=INGEST,
+  )[0]
+
+
+# --------------------------------------------------------------------------
+# Logs
+# --------------------------------------------------------------------------
+
+
+def test_log_row_maps_fields_and_converts_timestamp():
+  row = writer.log_row(_log_envelope())
+  assert row["timestamp"] == "2023-11-14T22:13:20Z"  # nanos -> RFC3339
+  assert row["service_name"] == "claude-code"
+  assert row["severity_number"] == 9
+  assert row["trace_id"] == "t1"
+  assert row["event_name"] == "claude_code.user_prompt"
+  assert json.loads(row["body"]) == {"stringValue": "hello"}
+  assert json.loads(row["log_attributes"]) == {"session.id": "sess-1"}
+
+
+# --------------------------------------------------------------------------
+# Contract fields
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "envelope_fn", [_log_envelope, lambda: _metric_envelope("sum")]
+)
+def test_rows_preserve_required_contract_fields(envelope_fn):
+  envelope = envelope_fn()
+  row = writer.envelope_to_row(envelope)
+  for field in (
+      "idempotency_key",
+      "source_position",
+      "otel_schema_version",
+      "ingest_time",
+      "source_product",
+      "source_signal",
+  ):
+    assert row[field] is not None, field
+  assert row["idempotency_key"] == envelope["idempotency_key"]
+  assert row["source_position"]["raw_otlp_request_hash"]  # threaded through
+
+
+# --------------------------------------------------------------------------
+# Metrics — all five types route + carry the right payload
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "otlp_kind,table",
+    [
+        ("sum", "otel_metric_sum"),
+        ("gauge", "otel_metric_gauge"),
+        ("histogram", "otel_metric_histogram"),
+        ("exponentialHistogram", "otel_metric_exponential_histogram"),
+        ("summary", "otel_metric_summary"),
+    ],
+)
+def test_metric_routes_to_its_table(otlp_kind, table):
+  assert writer.target_table(_metric_envelope(otlp_kind)) == table
+
+
+def test_sum_row_has_value_temporality_monotonic():
+  row = writer.metric_row(_metric_envelope("sum"))
+  assert row["value"] == 1.5
+  assert row["aggregation_temporality"] == 1
+  assert row["is_monotonic"] is True
+
+
+def test_gauge_int_value_is_coerced():
+  assert writer.metric_row(_metric_envelope("gauge"))["value"] == 7
+
+
+def test_histogram_row_has_struct_of_array_buckets():
+  row = writer.metric_row(_metric_envelope("histogram"))
+  assert row["count"] == 3
+  assert row["bucket_counts"] == [1, 2]
+  assert row["explicit_bounds"] == [1.0]
+
+
+def test_exponential_histogram_row_has_pos_buckets():
+  row = writer.metric_row(_metric_envelope("exponentialHistogram"))
+  assert row["scale"] == 2
+  assert row["positive"] == {"offset": 0, "bucket_counts": [1, 2]}
+
+
+def test_summary_row_has_quantiles_and_no_exemplars():
+  row = writer.metric_row(_metric_envelope("summary"))
+  assert row["quantile_values"] == [{"quantile": 0.5, "value": 2.0}]
+  assert "exemplars" not in row
+
+
+# --------------------------------------------------------------------------
+# Dead-letter landing
+# --------------------------------------------------------------------------
+
+
+def test_dead_letter_lands_in_dead_letter_table():
+  envelope = _dead_letter_envelope()
+  assert writer.target_table(envelope) == "otlp_dead_letter"
+  row = writer.dead_letter_row(envelope)
+  assert row["stage"] == "otlp_decode"
+  assert row["raw_b64"] is not None
+  assert row["idempotency_key"] is not None
+  assert row["source_position"]["metric_index"] == 0
+
+
+# --------------------------------------------------------------------------
+# append_envelope / handle_message / span gating
+# --------------------------------------------------------------------------
+
+
+def test_append_envelope_routes_through_writer():
+  w = FakeWriter()
+  table = writer.append_envelope(_metric_envelope("gauge"), w)
+  assert table == "otel_metric_gauge"
+  assert w.rows[0][0] == "otel_metric_gauge"
+
+
+def test_handle_message_decodes_and_appends():
+  w = FakeWriter()
+  data = json.dumps(_log_envelope()).encode("utf-8")
+  assert writer.handle_message(data, w) == "otel_logs"
+  assert len(w.rows) == 1
+
+
+def test_span_envelope_is_dropped_unless_enabled():
+  span_env = dict(_log_envelope())
+  span_env["source"] = {"product": "claude_code", "signal": "span"}
+  w = FakeWriter()
+  assert writer.append_envelope(span_env, w) == ""
+  assert w.rows == []
+
+
+# --------------------------------------------------------------------------
+# Replay / idempotency
+# --------------------------------------------------------------------------
+
+
+def test_replay_produces_identical_idempotency_key_in_row():
+  # Same envelope content -> identical idempotency_key in the row, so the dedup
+  # view collapses the replay.
+  a = writer.envelope_to_row(_log_envelope())
+  b = writer.envelope_to_row(_log_envelope())
+  assert a["idempotency_key"] == b["idempotency_key"]
+
+
+# --------------------------------------------------------------------------
+# Projection / dedup SQL
+# --------------------------------------------------------------------------
+
+
+def test_merge_sql_upserts_into_agent_events_otlp_on_idempotency_key():
+  s = sql.agent_events_otlp_merge_sql(dataset="ds")
+  assert "MERGE `ds.agent_events_otlp` T" in s
+  assert "FROM `ds.otel_logs_dedup`" in s
+  assert "ON T.idempotency_key = S.idempotency_key" in s
+  assert "WHEN MATCHED THEN UPDATE SET" in s  # upsert
+  assert "WHEN NOT MATCHED THEN INSERT" in s
+  for col in (
+      "source_product",
+      "source_signal",
+      "source_event_name",
+      "crosswalk_version",
+  ):
+    assert col in s
+
+
+def test_merge_columns_are_within_projection_parity_contract():
+  # Every column the MERGE writes must be a real agent_events_otlp column.
+  import dataclasses
+
+  @dataclasses.dataclass
+  class _F:
+    name: str
+    field_type: str = "STRING"
+    mode: str = "NULLABLE"
+    fields: tuple = ()
+
+  class _BQ:
+
+    def SchemaField(self, name, field_type, mode="NULLABLE", fields=()):  # noqa: N802
+      return _F(name, field_type, mode, tuple(fields))
+
+  projection_cols = {
+      f.name for f in projection.agent_events_otlp_columns(_BQ())
+  }
+  merge_cols = {c for c, _ in sql._LOG_CROSSWALK}
+  assert merge_cols <= projection_cols
+
+
+def test_dedup_view_is_newest_write_wins():
+  s = projection.dedup_view_sql("otel_logs", dataset="ds")
+  assert "PARTITION BY idempotency_key ORDER BY ingest_time DESC" in s
+
+
+def test_bqaa_metrics_view_unions_all_five_metric_tables():
+  s = sql.bqaa_metrics_view_sql(dataset="ds")
+  assert "CREATE OR REPLACE VIEW `ds.bqaa_metrics`" in s
+  for table in (
+      "otel_metric_sum",
+      "otel_metric_gauge",
+      "otel_metric_histogram",
+      "otel_metric_exponential_histogram",
+      "otel_metric_summary",
+  ):
+    assert f"`ds.{table}_dedup`" in s
+  assert s.count("UNION ALL") == 4
+
+
+# --------------------------------------------------------------------------
+# Consumer callback (ack/nack) — no Pub/Sub needed
+# --------------------------------------------------------------------------
+
+
+class _FakeMessage:
+
+  def __init__(self, data):
+    self.data = data
+    self.acked = False
+    self.nacked = False
+
+  def ack(self):
+    self.acked = True
+
+  def nack(self):
+    self.nacked = True
+
+
+def test_consumer_callback_acks_and_writes_on_success():
+  w = FakeWriter()
+  callback = consumer.make_callback(w)
+  msg = _FakeMessage(json.dumps(_log_envelope()).encode("utf-8"))
+  callback(msg)
+  assert msg.acked is True
+  assert w.rows[0][0] == "otel_logs"
+
+
+def test_consumer_callback_nacks_on_failure():
+  w = FakeWriter()
+  callback = consumer.make_callback(w)
+  msg = _FakeMessage(b"not json")
+  callback(msg)
+  assert msg.nacked is True
+  assert w.rows == []


### PR DESCRIPTION
Fourth increment of the **OTel-native OTLP receiver** (#316) — PR 4: the **data-landing path**. Maps the Pub/Sub envelope-v1 messages (from PR 3) into native BigQuery rows and ships the projection SQL. Builds on #323/#325/#326.

Design: [`docs/otlp_receiver_design.md`](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/docs/otlp_receiver_design.md).

### What's here
- **`otlp/writer.py`** — pure envelope→row mapping + deterministic table routing: `otel_logs`, all five `otel_metric_*` tables (per-type payloads — sum `value`+temporality+monotonic, gauge `value`, histogram struct-of-array buckets, exp-histogram pos/neg buckets, summary quantiles), and `otlp_dead_letter`. **Spans gated/deferred.** Every row preserves the contract fields the dedup views + replay depend on (`idempotency_key`, `source_position` incl. `raw_otlp_request_hash`, `otel_schema_version`, `ingest_time`, `source_*`). Nanos→RFC3339, JSON columns serialized, int64-as-string coerced.
- **`otlp/sql.py`** — the scheduled **`MERGE`** into `agent_events_otlp` (upsert on `idempotency_key`, reading the newest-write-wins `otel_logs_dedup` view; crosswalk columns are within the PR-1 projection-parity contract) + the **`bqaa_metrics`** view UNION-ing the five deduped metric tables.
- **`otlp/consumer.py`** — deployable Pub/Sub→BigQuery glue: lazy `BigQueryAppendWriter` (`insert_rows_json`, append-only) + a pure `make_callback` (`ack` on success, `nack`→redelivery / subscription DLQ).

### Scope notes
- **Deployable but locally tested**: the writer + SQL + callback are fully unit-tested with a fake writer; the real BigQuery/Pub/Sub clients are lazy-imported. Terraform/Cloud Run + live e2e is **PR 5**.
- `content_parts` in the `agent_events_otlp` crosswalk is intentionally deferred to the raw-body fast-follow; the projection-parity test still guarantees the MERGE only writes real `agent_events` columns.
- Real ingest uses `insert_rows_json` here; switching to the Storage Write API (as `drain.py` already does for `agent_events`) is a perf fast-follow.

### Verification
- New file: 24 passed — all five metric types, dead-letter landing, contract-field preservation, routing, replay/idempotency (identical key in row), newest-write-wins dedup SQL, projection-parity of MERGE columns, `bqaa_metrics`, and consumer ack/nack. Full producers suite: **185 passed**.
- `isort --check` + `pyink --check` clean.