### PR TITLE
fix(otlp): crosswalk reads Claude event.name + identity from log attributes (live-e2e finding)

### DIFF
--- a/producers/src/bigquery_agent_analytics_tracing/otlp/sql.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/sql.py
@@ -36,13 +36,27 @@ CROSSWALK_VERSION = "1"
 
 # (agent_events column, SQL expression over a deduped otel_logs row).
 # content_parts is intentionally deferred to the raw-body fast-follow.
+#
+# Product convention (validated against a real Claude Code session, PR 5 e2e):
+# Claude Code carries the event name in the ``event.name`` *log attribute* (and
+# the body), not the OTLP ``LogRecord.event_name`` field, and puts identity
+# (``user.id``, ``session.id``, ``prompt.id``) in *log* attributes rather than
+# resource attributes. The crosswalk therefore prefers the log-attribute value
+# and falls back to the OTLP field / resource attribute.
+_EVENT_NAME = (
+    "COALESCE(JSON_VALUE(log_attributes, '$.\"event.name\"'), event_name)"
+)
 _LOG_CROSSWALK: tuple[tuple[str, str], ...] = (
     ("timestamp", "timestamp"),
-    ("event_type", "COALESCE(event_name, 'otlp.unknown')"),
+    ("event_type", f"COALESCE({_EVENT_NAME}, 'otlp.unknown')"),
     ("agent", "JSON_VALUE(log_attributes, '$.\"agent.name\"')"),
     ("session_id", "JSON_VALUE(log_attributes, '$.\"session.id\"')"),
     ("invocation_id", "JSON_VALUE(log_attributes, '$.\"prompt.id\"')"),
-    ("user_id", "JSON_VALUE(resource_attributes, '$.\"user.id\"')"),
+    (
+        "user_id",
+        "COALESCE(JSON_VALUE(log_attributes, '$.\"user.id\"'),"
+        " JSON_VALUE(resource_attributes, '$.\"user.id\"'))",
+    ),
     ("trace_id", "trace_id"),
     ("span_id", "span_id"),
     ("parent_span_id", "CAST(NULL AS STRING)"),
@@ -54,7 +68,7 @@ _LOG_CROSSWALK: tuple[tuple[str, str], ...] = (
     ("is_truncated", "FALSE"),
     ("source_product", "source_product"),
     ("source_signal", "source_signal"),
-    ("source_event_name", "event_name"),
+    ("source_event_name", _EVENT_NAME),
     ("crosswalk_version", f"'{CROSSWALK_VERSION}'"),
     ("idempotency_key", "idempotency_key"),
 )

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -354,9 +354,19 @@ def test_merge_sql_upserts_into_agent_events_otlp_on_idempotency_key():
 def test_merge_crosswalk_reads_claude_event_name_and_identity_conventions():
   # Validated against a real Claude Code session (PR 5 e2e): the event name and
   # identity live in the log attributes, not the OTLP field / resource attrs.
+  # Pin the full expression-to-column bindings so a regression in any one
+  # column (e.g. event_type falling back to the bare OTLP field) fails even
+  # while the snippet survives elsewhere in the MERGE.
   s = sql.agent_events_otlp_merge_sql(dataset="ds")
-  assert "JSON_VALUE(log_attributes, '$.\"event.name\"')" in s
-  assert "JSON_VALUE(log_attributes, '$.\"user.id\"')" in s
+  event_name = (
+      "COALESCE(JSON_VALUE(log_attributes, '$.\"event.name\"'), event_name)"
+  )
+  assert f"COALESCE({event_name}, 'otlp.unknown') AS event_type" in s
+  assert f"{event_name} AS source_event_name" in s
+  assert (
+      "COALESCE(JSON_VALUE(log_attributes, '$.\"user.id\"'),"
+      " JSON_VALUE(resource_attributes, '$.\"user.id\"')) AS user_id" in s
+  )
 
 
 def test_merge_columns_are_within_projection_parity_contract():

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -351,6 +351,14 @@ def test_merge_sql_upserts_into_agent_events_otlp_on_idempotency_key():
     assert col in s
 
 
+def test_merge_crosswalk_reads_claude_event_name_and_identity_conventions():
+  # Validated against a real Claude Code session (PR 5 e2e): the event name and
+  # identity live in the log attributes, not the OTLP field / resource attrs.
+  s = sql.agent_events_otlp_merge_sql(dataset="ds")
+  assert "JSON_VALUE(log_attributes, '$.\"event.name\"')" in s
+  assert "JSON_VALUE(log_attributes, '$.\"user.id\"')" in s
+
+
 def test_merge_columns_are_within_projection_parity_contract():
   # Every column the MERGE writes must be a real agent_events_otlp column.
   import dataclasses


### PR DESCRIPTION
Found while running the **PR-5 live e2e for real** — a headless `claude -p` session exporting OTLP into BigQuery through the actual receiver/decode/writer code (local harness fusing receiver+consumer, writing to a real dataset).

### The finding
Claude Code's real telemetry doesn't match the synthetic fixtures on two conventions:
- The **event name** is in the `event.name` **log attribute** (and the `body`, e.g. `claude_code.user_prompt`), **not** the OTLP `LogRecord.event_name` field.
- **Identity** (`user.id`, `session.id`, `prompt.id`) is in **log** attributes, not resource attributes.

So the `agent_events_otlp` crosswalk — which read the OTLP `event_name` field and `user.id` from *resource* attributes — projected **every real Claude event as `event_type='otlp.unknown'` with a null `user_id`**:

```
event_type    | n  | with_user | with_session
otlp.unknown  | 26 | 0         | 26
```

(`session_id` already worked because the crosswalk reads it from log attributes.)

### The fix
The crosswalk now prefers the log-attribute value, falling back to the OTLP field / resource attribute:
- `event_type` / `source_event_name` ← `COALESCE(JSON_VALUE(log_attributes,'$."event.name"'), event_name)`
- `user_id` ← `COALESCE(JSON_VALUE(log_attributes,'$."user.id"'), JSON_VALUE(resource_attributes,'$."user.id"'))`

Re-running the MERGE on the **same real rows** reprojects all 26 correctly:

```
hook_registered 12 | plugin_loaded 8 | hook_execution_complete/start 4 |
user_prompt 1 | mcp_server_connection 1   — all with_user = with_session = n
```

### Notes
- **Native `otel_logs` already preserved everything faithfully** — nothing was lost; only the BQAA projection needed the product convention. This is exactly the split the design intends (native = raw OTLP; projection = product knowledge).
- Regression test added (`test_merge_crosswalk_reads_claude_event_name_and_identity_conventions`). Producers suite green; pyink + isort clean.
- This is Claude-specific convention; #317 will add the analogous Codex conventions when verifying Codex telemetry against the deployed receiver.