### PR TITLE
feat(otlp): bqaa-otel bootstrap — plan/execute deploy orchestration (#324 PR2)

### DIFF
--- a/deploy/otlp_receiver/README.md
+++ b/deploy/otlp_receiver/README.md
@@ -13,15 +13,28 @@ Claude Code / Codex --OTLP--> Cloud Run receiver --> Pub/Sub --> consumer --> Bi
 ## Deploy
 
 ```bash
-PROJECT=my-proj DATASET=agent_analytics REGION=us-central1 \
-  bash deploy/otlp_receiver/setup.sh
+# Print the plan (runs nothing):
+PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \
+  bootstrap --project my-proj --dataset agent_analytics --region us-central1
+
+# Apply it:
+PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \
+  bootstrap --project my-proj --dataset agent_analytics --region us-central1 --execute
 ```
 
+(`bqaa-otel bootstrap ...` once the producers package is installed;
+`setup.sh` is a thin wrapper over the same command with the historical
+env-var interface: `PROJECT=my-proj bash deploy/otlp_receiver/setup.sh`.)
+
 This creates: the native tables + `*_dedup` views + `agent_events_otlp` +
-`bqaa_metrics` (DDL generated from the schema package via `gen_schema_sql.py`),
-Pub/Sub topics/subscription + DLQ, a Secret Manager bearer token, the Cloud Run
-receiver + consumer, and the scheduled `MERGE`. It prints the receiver URL and
-how to read the token.
+`bqaa_metrics` (DDL generated from the schema package; `gen_schema_sql.py`
+prints the same bundle standalone), Pub/Sub topics/subscription + DLQ, a
+Secret Manager bearer token, the Cloud Run receiver + consumer, and the
+scheduled `MERGE`. It prints the receiver URL, how to read the token, and
+writes the ready-to-distribute Claude Code / Codex config artifacts
+(`--source claude-code,codex --signals ... --privacy ...` — see
+`bqaa-otel config --help` for generating artifacts against an existing
+deployment).
 
 - **Endpoints:** `<url>/v1/logs`, `<url>/v1/metrics` (`/v1/traces` is gated —
   set `ENABLE_SPANS=1` to wire it; span landing is deferred).

--- a/deploy/otlp_receiver/setup.sh
+++ b/deploy/otlp_receiver/setup.sh
@@ -3,13 +3,10 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 #
-# Deploy the OTel-native OTLP receiver (issue #316, PR 5): BigQuery schema +
-# views, Pub/Sub topics + a push subscription with DLQ, a Secret Manager bearer
-# token, dedicated least-privilege service accounts, the Cloud Run receiver +
-# push-consumer, and the scheduled MERGE into agent_events_otlp.
-#
-# Prereqs: gcloud + bq authenticated, a billing-enabled project, and Docker (for
-# `gcloud builds submit`). Run from the repository root.
+# Thin wrapper: the deploy sequence now lives in `bqaa-otel bootstrap`
+# (producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py, issue
+# #324) so the shell path and the CLI can't drift. Same env-var interface as
+# before; run from the repository root.
 #
 #   PROJECT=my-proj DATASET=agent_analytics REGION=us-central1 BQ_LOCATION=US \
 #     bash deploy/otlp_receiver/setup.sh
@@ -22,149 +19,11 @@ BQ_LOCATION="${BQ_LOCATION:-US}"          # BigQuery dataset + scheduled-query l
 ENABLE_SPANS="${ENABLE_SPANS:-0}"         # 1 to create/land otel_spans
 SOURCE_PRODUCT="${SOURCE_PRODUCT:-claude_code}"
 
-AR_REPO="${AR_REPO:-bqaa}"
-MAIN_TOPIC="${MAIN_TOPIC:-bqaa-otlp}"
-DLQ_TOPIC="${DLQ_TOPIC:-bqaa-otlp-dlq}"
-SUBSCRIPTION="${SUBSCRIPTION:-bqaa-otlp-sub}"
-SECRET="${SECRET:-bqaa-otlp-token}"
-IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT}/${AR_REPO}/otlp-receiver:latest}"
-RECEIVER_SVC="${RECEIVER_SVC:-bqaa-otlp-receiver}"
-CONSUMER_SVC="${CONSUMER_SVC:-bqaa-otlp-consumer}"
-HERE="$(cd "$(dirname "$0")" && pwd)"
+SIGNALS="logs,metrics"
+[ "$ENABLE_SPANS" = "1" ] && SIGNALS="logs,metrics,traces"
 
-RECEIVER_SA="bqaa-otlp-receiver@${PROJECT}.iam.gserviceaccount.com"
-CONSUMER_SA="bqaa-otlp-consumer@${PROJECT}.iam.gserviceaccount.com"
-PUSH_SA="bqaa-otlp-push@${PROJECT}.iam.gserviceaccount.com"
-PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
-PUBSUB_AGENT="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
-
-echo "==> Enabling APIs"
-gcloud services enable --project "$PROJECT" \
-  run.googleapis.com pubsub.googleapis.com bigquery.googleapis.com \
-  bigquerydatatransfer.googleapis.com secretmanager.googleapis.com \
-  cloudbuild.googleapis.com artifactregistry.googleapis.com iam.googleapis.com
-
-echo "==> Ensuring Artifact Registry repo '${AR_REPO}' exists"
-gcloud artifacts repositories describe "$AR_REPO" --project "$PROJECT" \
-  --location "$REGION" >/dev/null 2>&1 || \
-gcloud artifacts repositories create "$AR_REPO" --project "$PROJECT" \
-  --location "$REGION" --repository-format=docker
-
-echo "==> Creating BigQuery dataset (${BQ_LOCATION}) + native schema"
-bq --project_id="$PROJECT" --location="$BQ_LOCATION" mk -f --dataset \
-  "${PROJECT}:${DATASET}" >/dev/null
-SPANS_FLAG=""; [ "$ENABLE_SPANS" = "1" ] && SPANS_FLAG="--enable-spans"
-PYTHONPATH=producers/src python3 "${HERE}/gen_schema_sql.py" "$DATASET" $SPANS_FLAG \
-  | bq --project_id="$PROJECT" --location="$BQ_LOCATION" query --use_legacy_sql=false
-
-echo "==> Creating the bearer token secret"
-if ! gcloud secrets describe "$SECRET" --project "$PROJECT" >/dev/null 2>&1; then
-  openssl rand -hex 32 | gcloud secrets create "$SECRET" --project "$PROJECT" \
-    --replication-policy=automatic --data-file=-
-fi
-
-echo "==> Creating service accounts"
-for sa in bqaa-otlp-receiver bqaa-otlp-consumer bqaa-otlp-push; do
-  gcloud iam service-accounts describe "${sa}@${PROJECT}.iam.gserviceaccount.com" \
-    --project "$PROJECT" >/dev/null 2>&1 || \
-  gcloud iam service-accounts create "$sa" --project "$PROJECT"
-done
-
-echo "==> Creating Pub/Sub topics"
-gcloud pubsub topics create "$MAIN_TOPIC" --project "$PROJECT" 2>/dev/null || true
-gcloud pubsub topics create "$DLQ_TOPIC" --project "$PROJECT" 2>/dev/null || true
-
-echo "==> Granting least-privilege IAM"
-# Receiver: read the token secret + publish to the main ingest topic. (Parse/
-# decode dead letters travel the main topic with delivery.dlq=true and are
-# written to otlp_dead_letter by the consumer; the receiver never publishes to
-# the transport DLQ topic.)
-gcloud secrets add-iam-policy-binding "$SECRET" --project "$PROJECT" \
-  --member "serviceAccount:${RECEIVER_SA}" \
-  --role roles/secretmanager.secretAccessor >/dev/null
-gcloud pubsub topics add-iam-policy-binding "$MAIN_TOPIC" --project "$PROJECT" \
-  --member "serviceAccount:${RECEIVER_SA}" --role roles/pubsub.publisher >/dev/null
-# Consumer: write BigQuery.
-gcloud projects add-iam-policy-binding "$PROJECT" \
-  --member "serviceAccount:${CONSUMER_SA}" --role roles/bigquery.dataEditor >/dev/null
-gcloud projects add-iam-policy-binding "$PROJECT" \
-  --member "serviceAccount:${CONSUMER_SA}" --role roles/bigquery.jobUser >/dev/null
-# Pub/Sub service agent: mint OIDC tokens for the push endpoint + publish to the
-# transport DLQ (the subscriber grant is added after the subscription exists).
-gcloud pubsub topics add-iam-policy-binding "$DLQ_TOPIC" --project "$PROJECT" \
-  --member "serviceAccount:${PUBSUB_AGENT}" --role roles/pubsub.publisher >/dev/null
-gcloud iam service-accounts add-iam-policy-binding "$PUSH_SA" --project "$PROJECT" \
-  --member "serviceAccount:${PUBSUB_AGENT}" \
-  --role roles/iam.serviceAccountTokenCreator >/dev/null
-
-echo "==> Building image"
-gcloud builds submit --project "$PROJECT" --config=/dev/stdin . <<EOF
-steps:
-- name: gcr.io/cloud-builders/docker
-  args: ['build','-f','deploy/otlp_receiver/Dockerfile','-t','${IMAGE}','.']
-images: ['${IMAGE}']
-EOF
-
-MAIN_TOPIC_PATH="projects/${PROJECT}/topics/${MAIN_TOPIC}"
-
-echo "==> Deploying the OTLP receiver (Cloud Run)"
-gcloud run deploy "$RECEIVER_SVC" --project "$PROJECT" --region "$REGION" \
-  --image "$IMAGE" --allow-unauthenticated --service-account "$RECEIVER_SA" \
-  --set-secrets "BQAA_OTLP_TOKEN=${SECRET}:latest" \
-  --set-env-vars "BQAA_OTLP_MAIN_TOPIC=${MAIN_TOPIC_PATH},BQAA_OTLP_SOURCE_PRODUCT=${SOURCE_PRODUCT},BQAA_OTLP_ENABLE_TRACES=${ENABLE_SPANS}"
-
-echo "==> Deploying the Pub/Sub push consumer (Cloud Run HTTP service)"
-gcloud run deploy "$CONSUMER_SVC" --project "$PROJECT" --region "$REGION" \
-  --image "$IMAGE" --no-allow-unauthenticated --service-account "$CONSUMER_SA" \
-  --command gunicorn \
-  --args "--factory,--bind,0.0.0.0:8080,--workers,2,--threads,8,bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env" \
-  --set-env-vars "BQAA_PROJECT=${PROJECT},BQAA_DATASET=${DATASET},BQAA_OTLP_ENABLE_TRACES=${ENABLE_SPANS}"
-
-CONSUMER_URL="$(gcloud run services describe "$CONSUMER_SVC" --project "$PROJECT" \
-  --region "$REGION" --format='value(status.url)')"
-gcloud run services add-iam-policy-binding "$CONSUMER_SVC" --project "$PROJECT" \
-  --region "$REGION" --member "serviceAccount:${PUSH_SA}" \
-  --role roles/run.invoker >/dev/null
-
-echo "==> Creating the push subscription (OIDC) with DLQ"
-gcloud pubsub subscriptions create "$SUBSCRIPTION" --project "$PROJECT" \
-  --topic "$MAIN_TOPIC" --push-endpoint "${CONSUMER_URL}/" \
-  --push-auth-service-account "$PUSH_SA" \
-  --dead-letter-topic "$DLQ_TOPIC" --max-delivery-attempts 5 \
-  --ack-deadline 60 2>/dev/null || \
-gcloud pubsub subscriptions update "$SUBSCRIPTION" --project "$PROJECT" \
-  --push-endpoint "${CONSUMER_URL}/" --push-auth-service-account "$PUSH_SA"
-
-# Dead-letter forwarding needs the Pub/Sub service agent to acknowledge on the
-# source subscription in addition to publishing to the DLQ topic.
-gcloud pubsub subscriptions add-iam-policy-binding "$SUBSCRIPTION" --project "$PROJECT" \
-  --member "serviceAccount:${PUBSUB_AGENT}" --role roles/pubsub.subscriber >/dev/null
-
-echo "==> Registering the scheduled MERGE into agent_events_otlp (every 15 min)"
-PYTHONPATH=producers/src python3 "${HERE}/gen_schema_sql.py" "$DATASET" --merge-only \
-  > /tmp/agent_events_otlp_merge.sql
-if bq --project_id="$PROJECT" --location="$BQ_LOCATION" ls --transfer_config \
-     --format=json 2>/dev/null | grep -q '"displayName": "bqaa_agent_events_otlp_merge"'; then
-  echo "  scheduled query already exists — update it in the BigQuery console if needed"
-else
-  bq --project_id="$PROJECT" --location="$BQ_LOCATION" mk --transfer_config \
-    --data_source=scheduled_query --display_name="bqaa_agent_events_otlp_merge" \
-    --schedule="every 15 minutes" \
-    --params="$(python3 -c 'import json;print(json.dumps({"query":open("/tmp/agent_events_otlp_merge.sql").read()}))')"
-fi
-
-RECEIVER_URL="$(gcloud run services describe "$RECEIVER_SVC" --project "$PROJECT" \
-  --region "$REGION" --format='value(status.url)')"
-
-cat <<EOF
-
-==> Done. Receiver: ${RECEIVER_URL}
-    Endpoints: ${RECEIVER_URL}/v1/logs , ${RECEIVER_URL}/v1/metrics
-    Bearer token: gcloud secrets versions access latest --secret=${SECRET} --project ${PROJECT}
-
-Next: configure Claude Code / Codex to export to this endpoint (see README.md),
-then run the smoke test:
-    BQAA_OTLP_ENDPOINT=${RECEIVER_URL} BQAA_OTLP_TOKEN=<token> \\
-      BQAA_PROJECT=${PROJECT} BQAA_DATASET=${DATASET} \\
-      python -m pytest producers/tests/test_otlp_e2e.py -v
-EOF
+PYTHONPATH="producers/src${PYTHONPATH:+:$PYTHONPATH}" exec python3 -m \
+  bigquery_agent_analytics_tracing.otlp.cli bootstrap \
+  --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
+  --bq-location "$BQ_LOCATION" --signals "$SIGNALS" \
+  --source-product "$SOURCE_PRODUCT" --execute

--- a/deploy/otlp_receiver/setup.sh
+++ b/deploy/otlp_receiver/setup.sh
@@ -5,12 +5,26 @@
 #
 # Thin wrapper: the deploy sequence now lives in `bqaa-otel bootstrap`
 # (producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py, issue
-# #324) so the shell path and the CLI can't drift. Same env-var interface as
-# before; run from the repository root.
+# #324) so the shell path and the CLI can't drift. The documented env-var
+# interface (PROJECT/DATASET/REGION/BQ_LOCATION/ENABLE_SPANS/SOURCE_PRODUCT)
+# is preserved; the old resource-name overrides (AR_REPO, MAIN_TOPIC, ...)
+# are fixed constants in bootstrap.py now and are rejected below rather than
+# silently ignored. Run from the repository root.
 #
 #   PROJECT=my-proj DATASET=agent_analytics REGION=us-central1 BQ_LOCATION=US \
 #     bash deploy/otlp_receiver/setup.sh
 set -euo pipefail
+
+# Fail fast instead of deploying duplicate parallel infra under default names
+# for anyone who customized these in the pre-#324 script.
+for dropped in AR_REPO MAIN_TOPIC DLQ_TOPIC SUBSCRIPTION SECRET IMAGE \
+    RECEIVER_SVC CONSUMER_SVC; do
+  if eval "[ -n \"\${$dropped:-}\" ]"; then
+    echo "ERROR: $dropped is no longer configurable (fixed constant in" \
+      "bqaa-otel bootstrap); unset it to proceed." >&2
+    exit 1
+  fi
+done
 
 PROJECT="${PROJECT:?set PROJECT}"
 DATASET="${DATASET:-agent_analytics}"

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -1,0 +1,618 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``bqaa-otel bootstrap`` — the #324 admin deploy orchestration.
+
+Absorbs ``deploy/otlp_receiver/setup.sh`` (which now delegates here so the
+deploy sequence has one source of truth): BigQuery schema + views generated
+straight from the ``ddl``/``sql`` modules, Pub/Sub topics + OIDC push
+subscription with DLQ, Secret Manager bearer token, least-privilege service
+accounts, the Cloud Run receiver + consumer, the scheduled ``MERGE``, and —
+new versus the shell script — the PR 1 config artifacts rendered against the
+real deployed endpoint.
+
+Commands run through an injectable runner so the sequence is unit-testable
+and so plan mode (the CLI default) renders every command without executing
+anything. The bearer token is never embedded in generated artifacts; the
+summary prints the ``gcloud secrets versions access`` command instead.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+import secrets as _secrets
+import subprocess
+from typing import Any, Callable, Protocol
+
+from . import config_artifacts
+from . import ddl
+from . import sql
+
+AR_REPO = "bqaa"
+MAIN_TOPIC = "bqaa-otlp"
+DLQ_TOPIC = "bqaa-otlp-dlq"
+SUBSCRIPTION = "bqaa-otlp-sub"
+SECRET = "bqaa-otlp-token"
+RECEIVER_SVC = "bqaa-otlp-receiver"
+CONSUMER_SVC = "bqaa-otlp-consumer"
+MERGE_DISPLAY_NAME = "bqaa_agent_events_otlp_merge"
+
+_APIS = (
+    "run.googleapis.com",
+    "pubsub.googleapis.com",
+    "bigquery.googleapis.com",
+    "bigquerydatatransfer.googleapis.com",
+    "secretmanager.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+)
+
+_CONSUMER_GUNICORN_ARGS = (
+    "--factory,--bind,0.0.0.0:8080,--workers,2,--threads,8,"
+    "bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env"
+)
+
+
+class Runner(Protocol):
+  """Executes one external command; see :class:`SubprocessRunner`."""
+
+  def run(self, argv: list[str], input_text: str | None = None) -> str:
+    """Run to completion; return stdout. Raises on failure."""
+
+  def try_run(
+      self, argv: list[str], input_text: str | None = None
+  ) -> str | None:
+    """Run; return stdout, or ``None`` on failure (probe / idempotent)."""
+
+
+class SubprocessRunner:
+  """Real runner: gcloud/bq via subprocess, echoing each command."""
+
+  def __init__(self, echo: Callable[..., None] = print):
+    self._echo = echo
+
+  def run(self, argv: list[str], input_text: str | None = None) -> str:
+    self._echo(f"$ {' '.join(argv)}")
+    return subprocess.run(
+        argv,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+  def try_run(
+      self, argv: list[str], input_text: str | None = None
+  ) -> str | None:
+    try:
+      return self.run(argv, input_text)
+    except subprocess.CalledProcessError:
+      return None
+
+
+class _PlanRunner:
+  """Records the would-run commands; existence probes take the create path."""
+
+  _PLACEHOLDERS = (
+      ("projects describe", "<project-number>"),
+      (RECEIVER_SVC, "<receiver-url>"),
+      (CONSUMER_SVC, "<consumer-url>"),
+      ("secrets versions access", "<token>"),
+  )
+
+  def __init__(self):
+    self.commands: list[tuple[tuple[str, ...], str | None]] = []
+
+  def _canned(self, argv: list[str]) -> str:
+    joined = " ".join(argv)
+    for needle, placeholder in self._PLACEHOLDERS:
+      if needle in joined:
+        return placeholder
+    return ""
+
+  def run(self, argv: list[str], input_text: str | None = None) -> str:
+    self.commands.append((tuple(argv), input_text))
+    return self._canned(argv)
+
+  def try_run(
+      self, argv: list[str], input_text: str | None = None
+  ) -> str | None:
+    joined = " ".join(argv)
+    if "describe" in joined or "--transfer_config" in joined:
+      return None  # probe: assume the resource is missing → show creates
+    self.commands.append((tuple(argv), input_text))
+    return self._canned(argv)
+
+
+@dataclasses.dataclass(frozen=True)
+class BootstrapSettings:
+  """Validated admin inputs for one bootstrap run."""
+
+  project: str
+  dataset: str = "agent_analytics"
+  region: str = "us-central1"
+  bq_location: str = "US"
+  signals: tuple[str, ...] = ("logs", "metrics")
+  privacy: str = "baseline"
+  sources: tuple[str, ...] = ("claude-code",)
+  source_product: str = "claude_code"
+  resource_attributes: dict[str, str] | None = None
+  acknowledge_content_logging: bool = False
+  out_dir: pathlib.Path = pathlib.Path(".")
+
+  def __post_init__(self):
+    # Reuse the PR 1 tier validation (privacy/signals/replay ack) so the
+    # gate can't drift between `config` and `bootstrap`.
+    self._spec("<pending-deploy>")
+    for source in self.sources:
+      if source not in config_artifacts.SOURCES:
+        raise ValueError(
+            f"unknown source {source!r}; expected one of"
+            f" {config_artifacts.SOURCES}"
+        )
+
+  def _spec(self, endpoint: str) -> config_artifacts.BootstrapSpec:
+    return config_artifacts.BootstrapSpec(
+        endpoint=endpoint,
+        signals=self.signals,
+        privacy=self.privacy,
+        resource_attributes=self.resource_attributes,
+        acknowledge_content_logging=self.acknowledge_content_logging,
+    )
+
+  @property
+  def enable_spans(self) -> bool:
+    return "traces" in self.signals
+
+
+@dataclasses.dataclass(frozen=True)
+class BootstrapResult:
+  receiver_url: str
+  consumer_url: str
+  artifact_paths: tuple[pathlib.Path, ...]
+
+
+def _image(s: BootstrapSettings) -> str:
+  return f"{s.region}-docker.pkg.dev/{s.project}/{AR_REPO}/otlp-receiver:latest"
+
+
+def run_bootstrap(
+    settings: BootstrapSettings,
+    runner: Runner,
+    *,
+    echo: Callable[..., None] = print,
+    write_file: Callable[[pathlib.Path, str], None] | None = None,
+) -> BootstrapResult:
+  """Execute the full deploy sequence (setup.sh parity + config artifacts)."""
+  s = settings
+  proj = ["--project", s.project]
+  spans = "1" if s.enable_spans else "0"
+
+  if write_file is None:
+
+    def write_file(path: pathlib.Path, content: str) -> None:
+      path.parent.mkdir(parents=True, exist_ok=True)
+      path.write_text(content)
+
+  receiver_sa = f"{RECEIVER_SVC}@{s.project}.iam.gserviceaccount.com"
+  consumer_sa = f"{CONSUMER_SVC}@{s.project}.iam.gserviceaccount.com"
+  push_sa = f"bqaa-otlp-push@{s.project}.iam.gserviceaccount.com"
+
+  echo("==> Enabling APIs")
+  runner.run(["gcloud", "services", "enable", *proj, *_APIS])
+
+  echo(f"==> Ensuring Artifact Registry repo {AR_REPO!r} exists")
+  if (
+      runner.try_run(
+          [
+              "gcloud",
+              "artifacts",
+              "repositories",
+              "describe",
+              AR_REPO,
+              *proj,
+              "--location",
+              s.region,
+          ]
+      )
+      is None
+  ):
+    runner.run(
+        [
+            "gcloud",
+            "artifacts",
+            "repositories",
+            "create",
+            AR_REPO,
+            *proj,
+            "--location",
+            s.region,
+            "--repository-format=docker",
+        ]
+    )
+
+  echo(f"==> Creating BigQuery dataset ({s.bq_location}) + native schema")
+  bq = ["bq", f"--project_id={s.project}", f"--location={s.bq_location}"]
+  runner.run([*bq, "mk", "-f", "--dataset", f"{s.project}:{s.dataset}"])
+  runner.run(
+      [*bq, "query", "--use_legacy_sql=false"],
+      input_text=ddl.create_all_sql(s.dataset, enable_spans=s.enable_spans),
+  )
+
+  echo("==> Creating the bearer token secret")
+  if runner.try_run(["gcloud", "secrets", "describe", SECRET, *proj]) is None:
+    runner.run(
+        [
+            "gcloud",
+            "secrets",
+            "create",
+            SECRET,
+            *proj,
+            "--replication-policy=automatic",
+            "--data-file=-",
+        ],
+        input_text=_secrets.token_hex(32),
+    )
+
+  echo("==> Creating service accounts")
+  for sa_id in (RECEIVER_SVC, CONSUMER_SVC, "bqaa-otlp-push"):
+    if (
+        runner.try_run(
+            [
+                "gcloud",
+                "iam",
+                "service-accounts",
+                "describe",
+                f"{sa_id}@{s.project}.iam.gserviceaccount.com",
+                *proj,
+            ]
+        )
+        is None
+    ):
+      runner.run(["gcloud", "iam", "service-accounts", "create", sa_id, *proj])
+
+  echo("==> Creating Pub/Sub topics")
+  for topic in (MAIN_TOPIC, DLQ_TOPIC):
+    runner.try_run(["gcloud", "pubsub", "topics", "create", topic, *proj])
+
+  echo("==> Granting least-privilege IAM")
+  project_number = runner.run(
+      [
+          "gcloud",
+          "projects",
+          "describe",
+          s.project,
+          "--format=value(projectNumber)",
+      ]
+  )
+  pubsub_agent = (
+      f"service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  )
+  runner.run(
+      [
+          "gcloud",
+          "secrets",
+          "add-iam-policy-binding",
+          SECRET,
+          *proj,
+          "--member",
+          f"serviceAccount:{receiver_sa}",
+          "--role",
+          "roles/secretmanager.secretAccessor",
+      ]
+  )
+  runner.run(
+      [
+          "gcloud",
+          "pubsub",
+          "topics",
+          "add-iam-policy-binding",
+          MAIN_TOPIC,
+          *proj,
+          "--member",
+          f"serviceAccount:{receiver_sa}",
+          "--role",
+          "roles/pubsub.publisher",
+      ]
+  )
+  for role in ("roles/bigquery.dataEditor", "roles/bigquery.jobUser"):
+    runner.run(
+        [
+            "gcloud",
+            "projects",
+            "add-iam-policy-binding",
+            s.project,
+            "--member",
+            f"serviceAccount:{consumer_sa}",
+            "--role",
+            role,
+        ]
+    )
+  runner.run(
+      [
+          "gcloud",
+          "pubsub",
+          "topics",
+          "add-iam-policy-binding",
+          DLQ_TOPIC,
+          *proj,
+          "--member",
+          f"serviceAccount:{pubsub_agent}",
+          "--role",
+          "roles/pubsub.publisher",
+      ]
+  )
+  runner.run(
+      [
+          "gcloud",
+          "iam",
+          "service-accounts",
+          "add-iam-policy-binding",
+          push_sa,
+          *proj,
+          "--member",
+          f"serviceAccount:{pubsub_agent}",
+          "--role",
+          "roles/iam.serviceAccountTokenCreator",
+      ]
+  )
+
+  echo("==> Building image")
+  image = _image(s)
+  build_config = (
+      "steps:\n"
+      "- name: gcr.io/cloud-builders/docker\n"
+      f"  args: ['build','-f','deploy/otlp_receiver/Dockerfile',"
+      f"'-t','{image}','.']\n"
+      f"images: ['{image}']\n"
+  )
+  runner.run(
+      ["gcloud", "builds", "submit", *proj, "--config=/dev/stdin", "."],
+      input_text=build_config,
+  )
+
+  main_topic_path = f"projects/{s.project}/topics/{MAIN_TOPIC}"
+
+  echo("==> Deploying the OTLP receiver (Cloud Run)")
+  runner.run(
+      [
+          "gcloud",
+          "run",
+          "deploy",
+          RECEIVER_SVC,
+          *proj,
+          "--region",
+          s.region,
+          "--image",
+          image,
+          "--allow-unauthenticated",
+          "--service-account",
+          receiver_sa,
+          "--set-secrets",
+          f"BQAA_OTLP_TOKEN={SECRET}:latest",
+          "--set-env-vars",
+          f"BQAA_OTLP_MAIN_TOPIC={main_topic_path},"
+          f"BQAA_OTLP_SOURCE_PRODUCT={s.source_product},"
+          f"BQAA_OTLP_ENABLE_TRACES={spans}",
+      ]
+  )
+
+  echo("==> Deploying the Pub/Sub push consumer (Cloud Run HTTP service)")
+  runner.run(
+      [
+          "gcloud",
+          "run",
+          "deploy",
+          CONSUMER_SVC,
+          *proj,
+          "--region",
+          s.region,
+          "--image",
+          image,
+          "--no-allow-unauthenticated",
+          "--service-account",
+          consumer_sa,
+          "--command",
+          "gunicorn",
+          "--args",
+          _CONSUMER_GUNICORN_ARGS,
+          "--set-env-vars",
+          f"BQAA_PROJECT={s.project},BQAA_DATASET={s.dataset},"
+          f"BQAA_OTLP_ENABLE_TRACES={spans}",
+      ]
+  )
+
+  consumer_url = runner.run(
+      [
+          "gcloud",
+          "run",
+          "services",
+          "describe",
+          CONSUMER_SVC,
+          *proj,
+          "--region",
+          s.region,
+          "--format=value(status.url)",
+      ]
+  )
+  runner.run(
+      [
+          "gcloud",
+          "run",
+          "services",
+          "add-iam-policy-binding",
+          CONSUMER_SVC,
+          *proj,
+          "--region",
+          s.region,
+          "--member",
+          f"serviceAccount:{push_sa}",
+          "--role",
+          "roles/run.invoker",
+      ]
+  )
+
+  echo("==> Creating the push subscription (OIDC) with DLQ")
+  if (
+      runner.try_run(
+          [
+              "gcloud",
+              "pubsub",
+              "subscriptions",
+              "create",
+              SUBSCRIPTION,
+              *proj,
+              "--topic",
+              MAIN_TOPIC,
+              "--push-endpoint",
+              f"{consumer_url}/",
+              "--push-auth-service-account",
+              push_sa,
+              "--dead-letter-topic",
+              DLQ_TOPIC,
+              "--max-delivery-attempts",
+              "5",
+              "--ack-deadline",
+              "60",
+          ]
+      )
+      is None
+  ):
+    runner.run(
+        [
+            "gcloud",
+            "pubsub",
+            "subscriptions",
+            "update",
+            SUBSCRIPTION,
+            *proj,
+            "--push-endpoint",
+            f"{consumer_url}/",
+            "--push-auth-service-account",
+            push_sa,
+        ]
+    )
+  runner.run(
+      [
+          "gcloud",
+          "pubsub",
+          "subscriptions",
+          "add-iam-policy-binding",
+          SUBSCRIPTION,
+          *proj,
+          "--member",
+          f"serviceAccount:{pubsub_agent}",
+          "--role",
+          "roles/pubsub.subscriber",
+      ]
+  )
+
+  echo("==> Registering the scheduled MERGE into agent_events_otlp")
+  existing = runner.try_run([*bq, "ls", "--transfer_config", "--format=json"])
+  if existing is None or MERGE_DISPLAY_NAME not in existing:
+    merge_sql = sql.agent_events_otlp_merge_sql(dataset=s.dataset)
+    runner.run(
+        [
+            *bq,
+            "mk",
+            "--transfer_config",
+            "--data_source=scheduled_query",
+            f"--display_name={MERGE_DISPLAY_NAME}",
+            "--schedule=every 15 minutes",
+            f"--params={json.dumps({'query': merge_sql})}",
+        ]
+    )
+  else:
+    echo("  scheduled query already exists — leaving it unchanged")
+
+  receiver_url = runner.run(
+      [
+          "gcloud",
+          "run",
+          "services",
+          "describe",
+          RECEIVER_SVC,
+          *proj,
+          "--region",
+          s.region,
+          "--format=value(status.url)",
+      ]
+  )
+
+  echo("==> Generating telemetry-source config artifacts")
+  artifacts = config_artifacts.render_artifacts(
+      s._spec(receiver_url), sources=s.sources
+  )
+  paths = []
+  for filename, content in artifacts.items():
+    path = s.out_dir / filename
+    write_file(path, content)
+    paths.append(path)
+    echo(f"  wrote {path}")
+
+  echo("")
+  echo(f"==> Done. Receiver: {receiver_url}")
+  echo(f"    Endpoints: {receiver_url}/v1/logs , {receiver_url}/v1/metrics")
+  echo(
+      "    Bearer token (fill it into the artifacts; never committed):"
+      f" gcloud secrets versions access latest --secret={SECRET}"
+      f" --project {s.project}"
+  )
+  echo("")
+  echo("Next: distribute the generated config artifacts, then smoke-test:")
+  echo(
+      f"    BQAA_OTLP_ENDPOINT={receiver_url} BQAA_OTLP_TOKEN=<token>"
+      f" BQAA_PROJECT={s.project} BQAA_DATASET={s.dataset}"
+      " python -m pytest producers/tests/test_otlp_e2e.py -v"
+  )
+  return BootstrapResult(
+      receiver_url=receiver_url,
+      consumer_url=consumer_url,
+      artifact_paths=tuple(paths),
+  )
+
+
+def render_plan(settings: BootstrapSettings) -> str:
+  """The commands ``--execute`` would run, without running anything."""
+  planner = _PlanRunner()
+  run_bootstrap(
+      settings,
+      planner,
+      echo=lambda *_: None,
+      write_file=lambda *_: None,
+  )
+  lines = [
+      "bqaa-otel bootstrap plan (nothing has been executed).",
+      "Values captured at run time are shown as <placeholders>.",
+      "",
+  ]
+  for argv, input_text in planner.commands:
+    lines.append("  $ " + " ".join(_display_arg(a) for a in argv))
+    if input_text is not None:
+      summary = f"{len(input_text.splitlines())} lines"
+      lines.append(f"      [stdin: {summary}]")
+  lines += [
+      "",
+      "Re-run with --execute to apply.",
+  ]
+  return "\n".join(lines)
+
+
+def _display_arg(arg: str) -> str:
+  if len(arg) > 100:
+    return arg[:97] + "..."
+  return arg

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -556,8 +556,19 @@ def run_bootstrap(
   echo("==> Registering the scheduled MERGE into agent_events_otlp")
   merge_sql = sql.agent_events_otlp_merge_sql(dataset=s.dataset)
   params = json.dumps({"query": merge_sql})
+  # bq requires --transfer_location (the dataset location) for
+  # `ls --transfer_config`; without it the listing always fails and the
+  # convergence path would silently never trigger.
   existing_name = _find_merge_config(
-      runner.try_run([*bq, "ls", "--transfer_config", "--format=json"]),
+      runner.try_run(
+          [
+              *bq,
+              "ls",
+              "--transfer_config",
+              f"--transfer_location={s.bq_location}",
+              "--format=json",
+          ]
+      ),
       s.dataset,
   )
   if existing_name:

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -34,8 +34,9 @@ import dataclasses
 import json
 import pathlib
 import secrets as _secrets
+import shlex
 import subprocess
-from typing import Any, Callable, Protocol
+from typing import Callable, Protocol
 
 from . import config_artifacts
 from . import ddl
@@ -45,10 +46,17 @@ AR_REPO = "bqaa"
 MAIN_TOPIC = "bqaa-otlp"
 DLQ_TOPIC = "bqaa-otlp-dlq"
 SUBSCRIPTION = "bqaa-otlp-sub"
+# Retention subscription on the DLQ topic: Pub/Sub only retains messages for
+# subscriptions that exist at publish time, so without this every dead letter
+# forwarded after max delivery attempts would be permanently discarded.
+DLQ_SUBSCRIPTION = "bqaa-otlp-dlq-sub"
+DLQ_RETENTION = "7d"
 SECRET = "bqaa-otlp-token"
 RECEIVER_SVC = "bqaa-otlp-receiver"
 CONSUMER_SVC = "bqaa-otlp-consumer"
 MERGE_DISPLAY_NAME = "bqaa_agent_events_otlp_merge"
+MAX_DELIVERY_ATTEMPTS = "5"
+ACK_DEADLINE_SECONDS = "60"
 
 _APIS = (
     "run.googleapis.com",
@@ -79,6 +87,21 @@ class Runner(Protocol):
     """Run; return stdout, or ``None`` on failure (probe / idempotent)."""
 
 
+def _hardened_argv(argv: list[str]) -> list[str]:
+  """Make gcloud/bq non-interactive.
+
+  Output is captured, so an interactive prompt would be invisible while the
+  child blocks on the tty — the deploy would hang forever mid-sequence.
+  ``--quiet`` (gcloud) and ``--headless`` (bq, global flag: goes before the
+  command) turn prompts into fast visible failures instead.
+  """
+  if argv[0] == "gcloud" and "--quiet" not in argv:
+    return [*argv, "--quiet"]
+  if argv[0] == "bq" and "--headless" not in argv:
+    return [argv[0], "--headless", *argv[1:]]
+  return argv
+
+
 class SubprocessRunner:
   """Real runner: gcloud/bq via subprocess, echoing each command."""
 
@@ -86,13 +109,20 @@ class SubprocessRunner:
     self._echo = echo
 
   def run(self, argv: list[str], input_text: str | None = None) -> str:
-    self._echo(f"$ {' '.join(argv)}")
+    argv = _hardened_argv(argv)
+    self._echo(f"$ {shlex.join(argv)}")
+    # stdin is never the tty: a prompting child must see EOF, not hang.
+    stdin_kwargs = (
+        {"input": input_text}
+        if input_text is not None
+        else {"stdin": subprocess.DEVNULL}
+    )
     return subprocess.run(
         argv,
-        input=input_text,
         capture_output=True,
         text=True,
         check=True,
+        **stdin_kwargs,
     ).stdout.strip()
 
   def try_run(
@@ -111,7 +141,6 @@ class _PlanRunner:
       ("projects describe", "<project-number>"),
       (RECEIVER_SVC, "<receiver-url>"),
       (CONSUMER_SVC, "<consumer-url>"),
-      ("secrets versions access", "<token>"),
   )
 
   def __init__(self):
@@ -158,6 +187,11 @@ class BootstrapSettings:
     # Reuse the PR 1 tier validation (privacy/signals/replay ack) so the
     # gate can't drift between `config` and `bootstrap`.
     self._spec("<pending-deploy>")
+    if not self.sources:
+      raise ValueError(
+          "at least one telemetry source is required; expected one of"
+          f" {config_artifacts.SOURCES}"
+      )
     for source in self.sources:
       if source not in config_artifacts.SOURCES:
         raise ValueError(
@@ -277,7 +311,7 @@ def run_bootstrap(
       input_text=ddl.create_all_sql(s.dataset, enable_spans=s.enable_spans),
   )
 
-  echo("==> Creating the bearer token secret")
+  echo("==> Ensuring the bearer token secret exists")
   if runner.try_run(["gcloud", "secrets", "describe", SECRET, *proj]) is None:
     runner.run(
         [
@@ -292,7 +326,7 @@ def run_bootstrap(
         input_text=_secrets.token_hex(32),
     )
 
-  echo("==> Creating service accounts")
+  echo("==> Ensuring service accounts exist")
   for sa_id in (RECEIVER_SVC, CONSUMER_SVC, "bqaa-otlp-push"):
     if (
         runner.try_run(
@@ -309,9 +343,27 @@ def run_bootstrap(
     ):
       runner.run(["gcloud", "iam", "service-accounts", "create", sa_id, *proj])
 
-  echo("==> Creating Pub/Sub topics")
+  echo("==> Ensuring Pub/Sub topics + DLQ retention subscription exist")
   for topic in (MAIN_TOPIC, DLQ_TOPIC):
     runner.try_run(["gcloud", "pubsub", "topics", "create", topic, *proj])
+  # Retain dead letters so they can be inspected and replayed; a topic with
+  # no subscription silently discards everything published to it.
+  runner.try_run(
+      [
+          "gcloud",
+          "pubsub",
+          "subscriptions",
+          "create",
+          DLQ_SUBSCRIPTION,
+          *proj,
+          "--topic",
+          DLQ_TOPIC,
+          "--message-retention-duration",
+          DLQ_RETENTION,
+          "--expiration-period",
+          "never",
+      ]
+  )
 
   echo("==> Granting least-privilege IAM")
   project_number = runner.run(
@@ -490,7 +542,21 @@ def run_bootstrap(
       ]
   )
 
-  echo("==> Creating the push subscription (OIDC) with DLQ")
+  echo("==> Ensuring the push subscription (OIDC) with DLQ")
+  # One shared flag list for create AND the repair/update path, so the
+  # settings structurally cannot drift apart.
+  push_flags = [
+      "--push-endpoint",
+      f"{consumer_url}/",
+      "--push-auth-service-account",
+      push_sa,
+      "--dead-letter-topic",
+      DLQ_TOPIC,
+      "--max-delivery-attempts",
+      MAX_DELIVERY_ATTEMPTS,
+      "--ack-deadline",
+      ACK_DEADLINE_SECONDS,
+  ]
   if (
       runner.try_run(
           [
@@ -502,22 +568,11 @@ def run_bootstrap(
               *proj,
               "--topic",
               MAIN_TOPIC,
-              "--push-endpoint",
-              f"{consumer_url}/",
-              "--push-auth-service-account",
-              push_sa,
-              "--dead-letter-topic",
-              DLQ_TOPIC,
-              "--max-delivery-attempts",
-              "5",
-              "--ack-deadline",
-              "60",
+              *push_flags,
           ]
       )
       is None
   ):
-    # Repair path: converge every setting the create path applies, so a
-    # drifted or pre-DLQ subscription is brought back to spec.
     runner.run(
         [
             "gcloud",
@@ -526,16 +581,7 @@ def run_bootstrap(
             "update",
             SUBSCRIPTION,
             *proj,
-            "--push-endpoint",
-            f"{consumer_url}/",
-            "--push-auth-service-account",
-            push_sa,
-            "--dead-letter-topic",
-            DLQ_TOPIC,
-            "--max-delivery-attempts",
-            "5",
-            "--ack-deadline",
-            "60",
+            *push_flags,
         ]
     )
   runner.run(
@@ -556,11 +602,12 @@ def run_bootstrap(
   echo("==> Registering the scheduled MERGE into agent_events_otlp")
   merge_sql = sql.agent_events_otlp_merge_sql(dataset=s.dataset)
   params = json.dumps({"query": merge_sql})
-  # bq requires --transfer_location (the dataset location) for
-  # `ls --transfer_config`; without it the listing always fails and the
-  # convergence path would silently never trigger.
+  # The listing is a hard `run`, not `try_run`: "can't list" is NOT "doesn't
+  # exist". DTS display names are not unique, so treating a transient listing
+  # failure as absence would mint a duplicate scheduled MERGE on every flaky
+  # re-run. bq requires --transfer_location (the dataset location) here.
   existing_name = _find_merge_config(
-      runner.try_run(
+      runner.run(
           [
               *bq,
               "ls",
@@ -571,6 +618,12 @@ def run_bootstrap(
       ),
       s.dataset,
   )
+  # --service_account_name pins the transfer config to the consumer SA
+  # (which already holds the BigQuery roles). Without it DTS runs the MERGE
+  # on the invoking admin's personal OAuth — the projection job silently
+  # dies when that admin loses access or leaves. The admin needs
+  # iam.serviceAccounts.actAs on the consumer SA for this call.
+  dts_sa = f"--service_account_name={consumer_sa}"
   if existing_name:
     # Converge: refresh the SQL so re-runs after crosswalk/MERGE changes
     # never leave a stale scheduled query behind.
@@ -580,6 +633,7 @@ def run_bootstrap(
             "update",
             "--transfer_config",
             f"--params={params}",
+            dts_sa,
             existing_name,
         ]
     )
@@ -594,6 +648,7 @@ def run_bootstrap(
             # Dataset-specific so several datasets in one project/location
             # each keep their own projection job.
             f"--display_name={MERGE_DISPLAY_NAME}_{s.dataset}",
+            dts_sa,
             "--schedule=every 15 minutes",
             f"--params={params}",
         ]
@@ -673,6 +728,7 @@ def render_plan(settings: BootstrapSettings) -> str:
 
 
 def _display_arg(arg: str) -> str:
+  """Shell-quoted (so a copied plan line runs unchanged), long args elided."""
   if len(arg) > 100:
-    return arg[:97] + "..."
-  return arg
+    return shlex.quote(arg[:97]) + "...[truncated]"
+  return shlex.quote(arg)

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -190,6 +190,30 @@ def _image(s: BootstrapSettings) -> str:
   return f"{s.region}-docker.pkg.dev/{s.project}/{AR_REPO}/otlp-receiver:latest"
 
 
+def _find_merge_config(listing: str | None, dataset: str) -> str | None:
+  """Resource name of this dataset's scheduled-MERGE config, if one exists.
+
+  Matches either the dataset-specific display name or a legacy
+  ``bqaa_agent_events_otlp_merge`` config whose query targets this dataset
+  (pre-#331 deployments used the unsuffixed name for every dataset).
+  """
+  if not listing:
+    return None
+  try:
+    configs = json.loads(listing)
+  except ValueError:
+    return None
+  for config in configs:
+    display = config.get("displayName", "")
+    query = (config.get("params") or {}).get("query", "")
+    if display == f"{MERGE_DISPLAY_NAME}_{dataset}" or (
+        display == MERGE_DISPLAY_NAME
+        and f"`{dataset}.agent_events_otlp`" in query
+    ):
+      return config.get("name")
+  return None
+
+
 def run_bootstrap(
     settings: BootstrapSettings,
     runner: Runner,
@@ -492,6 +516,8 @@ def run_bootstrap(
       )
       is None
   ):
+    # Repair path: converge every setting the create path applies, so a
+    # drifted or pre-DLQ subscription is brought back to spec.
     runner.run(
         [
             "gcloud",
@@ -504,6 +530,12 @@ def run_bootstrap(
             f"{consumer_url}/",
             "--push-auth-service-account",
             push_sa,
+            "--dead-letter-topic",
+            DLQ_TOPIC,
+            "--max-delivery-attempts",
+            "5",
+            "--ack-deadline",
+            "60",
         ]
     )
   runner.run(
@@ -522,22 +554,39 @@ def run_bootstrap(
   )
 
   echo("==> Registering the scheduled MERGE into agent_events_otlp")
-  existing = runner.try_run([*bq, "ls", "--transfer_config", "--format=json"])
-  if existing is None or MERGE_DISPLAY_NAME not in existing:
-    merge_sql = sql.agent_events_otlp_merge_sql(dataset=s.dataset)
+  merge_sql = sql.agent_events_otlp_merge_sql(dataset=s.dataset)
+  params = json.dumps({"query": merge_sql})
+  existing_name = _find_merge_config(
+      runner.try_run([*bq, "ls", "--transfer_config", "--format=json"]),
+      s.dataset,
+  )
+  if existing_name:
+    # Converge: refresh the SQL so re-runs after crosswalk/MERGE changes
+    # never leave a stale scheduled query behind.
+    runner.run(
+        [
+            *bq,
+            "update",
+            "--transfer_config",
+            f"--params={params}",
+            existing_name,
+        ]
+    )
+    echo("  scheduled query already exists — SQL refreshed")
+  else:
     runner.run(
         [
             *bq,
             "mk",
             "--transfer_config",
             "--data_source=scheduled_query",
-            f"--display_name={MERGE_DISPLAY_NAME}",
+            # Dataset-specific so several datasets in one project/location
+            # each keep their own projection job.
+            f"--display_name={MERGE_DISPLAY_NAME}_{s.dataset}",
             "--schedule=every 15 minutes",
-            f"--params={json.dumps({'query': merge_sql})}",
+            f"--params={params}",
         ]
     )
-  else:
-    echo("  scheduled query already exists — leaving it unchanged")
 
   receiver_url = runner.run(
       [

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -347,23 +347,54 @@ def run_bootstrap(
   for topic in (MAIN_TOPIC, DLQ_TOPIC):
     runner.try_run(["gcloud", "pubsub", "topics", "create", topic, *proj])
   # Retain dead letters so they can be inspected and replayed; a topic with
-  # no subscription silently discards everything published to it.
-  runner.try_run(
-      [
-          "gcloud",
-          "pubsub",
-          "subscriptions",
-          "create",
-          DLQ_SUBSCRIPTION,
-          *proj,
-          "--topic",
-          DLQ_TOPIC,
-          "--message-retention-duration",
-          DLQ_RETENTION,
-          "--expiration-period",
-          "never",
-      ]
-  )
+  # no subscription silently discards everything published to it. Hard
+  # `run` on the mutation: a swallowed failure here would report success
+  # while dead letters keep evaporating.
+  dlq_retention_flags = [
+      "--message-retention-duration",
+      DLQ_RETENTION,
+      "--expiration-period",
+      "never",
+  ]
+  if (
+      runner.try_run(
+          [
+              "gcloud",
+              "pubsub",
+              "subscriptions",
+              "describe",
+              DLQ_SUBSCRIPTION,
+              *proj,
+          ]
+      )
+      is None
+  ):
+    runner.run(
+        [
+            "gcloud",
+            "pubsub",
+            "subscriptions",
+            "create",
+            DLQ_SUBSCRIPTION,
+            *proj,
+            "--topic",
+            DLQ_TOPIC,
+            *dlq_retention_flags,
+        ]
+    )
+  else:
+    # Converge retention/expiration on a pre-existing subscription.
+    runner.run(
+        [
+            "gcloud",
+            "pubsub",
+            "subscriptions",
+            "update",
+            DLQ_SUBSCRIPTION,
+            *proj,
+            *dlq_retention_flags,
+        ]
+    )
 
   echo("==> Granting least-privilege IAM")
   project_number = runner.run(
@@ -405,19 +436,32 @@ def run_bootstrap(
           "roles/pubsub.publisher",
       ]
   )
-  for role in ("roles/bigquery.dataEditor", "roles/bigquery.jobUser"):
-    runner.run(
-        [
-            "gcloud",
-            "projects",
-            "add-iam-policy-binding",
-            s.project,
-            "--member",
-            f"serviceAccount:{consumer_sa}",
-            "--role",
-            role,
-        ]
-    )
+  # jobUser needs project scope (query jobs), but dataEditor is scoped to
+  # the target dataset: a project-wide grant would let a compromised
+  # consumer SA modify every dataset in the project.
+  runner.run(
+      [
+          "gcloud",
+          "projects",
+          "add-iam-policy-binding",
+          s.project,
+          "--member",
+          f"serviceAccount:{consumer_sa}",
+          "--role",
+          "roles/bigquery.jobUser",
+      ]
+  )
+  runner.run(
+      [
+          "bq",
+          f"--project_id={s.project}",
+          "add-iam-policy-binding",
+          "--dataset",
+          f"--member=serviceAccount:{consumer_sa}",
+          "--role=roles/bigquery.dataEditor",
+          f"{s.project}:{s.dataset}",
+      ]
+  )
   runner.run(
       [
           "gcloud",
@@ -633,6 +677,10 @@ def run_bootstrap(
             "update",
             "--transfer_config",
             f"--params={params}",
+            # bq forwards service_account_name on update only when
+            # update_credentials is set (bq 2.1.28 frontend/command_update);
+            # without it the config silently keeps its old credential.
+            "--update_credentials",
             dts_sa,
             existing_name,
         ]

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -25,6 +25,7 @@ import argparse
 import pathlib
 import sys
 
+from . import bootstrap as bootstrap_mod
 from . import config_artifacts
 
 
@@ -117,6 +118,83 @@ def _build_parser() -> argparse.ArgumentParser:
       default=pathlib.Path("."),
       help="Directory to write artifacts into (default: current directory).",
   )
+
+  boot = sub.add_parser(
+      "bootstrap",
+      help=(
+          "Deploy the full OTel->BigQuery pipeline: schema + views, Pub/Sub"
+          " + DLQ, bearer-token secret, Cloud Run receiver + consumer,"
+          " scheduled MERGE, and telemetry-source config artifacts. Default"
+          " is plan mode; pass --execute to apply."
+      ),
+  )
+  boot.add_argument("--project", required=True, help="GCP project id.")
+  boot.add_argument(
+      "--dataset", default="agent_analytics", help="BigQuery dataset id."
+  )
+  boot.add_argument(
+      "--region", default="us-central1", help="Cloud Run / Artifact Registry"
+  )
+  boot.add_argument(
+      "--bq-location", default="US", help="BigQuery dataset location."
+  )
+  boot.add_argument(
+      "--source",
+      default="claude-code",
+      help=(
+          "Comma-separated telemetry sources:"
+          f" {','.join(config_artifacts.SOURCES)}"
+      ),
+  )
+  boot.add_argument(
+      "--signals",
+      default="logs,metrics",
+      help="Signal tier: 'logs,metrics' (default) or 'logs,metrics,traces'.",
+  )
+  boot.add_argument(
+      "--privacy",
+      default="baseline",
+      choices=config_artifacts.PRIVACY_TIERS,
+      help=(
+          "Privacy tier. 'baseline' (default) captures no prompt/tool"
+          " content; 'replay' requires --i-understand-content-logging."
+      ),
+  )
+  boot.add_argument(
+      "--source-product",
+      default="claude_code",
+      help=(
+          "source_product stamped on ingested rows by the receiver"
+          " (BQAA_OTLP_SOURCE_PRODUCT)."
+      ),
+  )
+  boot.add_argument(
+      "--resource-attributes",
+      type=_parse_kv,
+      default=None,
+      metavar="K=V[,K=V...]",
+      help="OTEL_RESOURCE_ATTRIBUTES to stamp, e.g. department=engineering.",
+  )
+  boot.add_argument(
+      "--i-understand-content-logging",
+      action="store_true",
+      dest="ack_content_logging",
+      help=(
+          "Required with --privacy replay: acknowledges prompt text (which"
+          " can contain full conversation history) will be exported."
+      ),
+  )
+  boot.add_argument(
+      "--out",
+      type=pathlib.Path,
+      default=pathlib.Path("."),
+      help="Directory to write config artifacts into after the deploy.",
+  )
+  boot.add_argument(
+      "--execute",
+      action="store_true",
+      help="Apply the plan (default: print the commands and exit).",
+  )
   return parser
 
 
@@ -175,10 +253,46 @@ def _cmd_config(args: argparse.Namespace) -> int:
   return 0
 
 
+def _cmd_bootstrap(args: argparse.Namespace) -> int:
+  try:
+    settings = bootstrap_mod.BootstrapSettings(
+        project=args.project,
+        dataset=args.dataset,
+        region=args.region,
+        bq_location=args.bq_location,
+        signals=tuple(s for s in args.signals.split(",") if s),
+        privacy=args.privacy,
+        sources=tuple(s for s in args.source.split(",") if s),
+        source_product=args.source_product,
+        resource_attributes=args.resource_attributes,
+        acknowledge_content_logging=args.ack_content_logging,
+        out_dir=args.out,
+    )
+  except ValueError as exc:
+    print(f"bqaa-otel: error: {exc}", file=sys.stderr)
+    if "acknowledge_content_logging" in str(exc):
+      print(
+          "bqaa-otel: --privacy replay exports prompt text; pass"
+          " --i-understand-content-logging only if that is acceptable"
+          " in your environment.",
+          file=sys.stderr,
+      )
+    return 2
+
+  if not args.execute:
+    print(bootstrap_mod.render_plan(settings))
+    return 0
+
+  bootstrap_mod.run_bootstrap(settings, bootstrap_mod.SubprocessRunner())
+  return 0
+
+
 def main(argv: list[str] | None = None) -> int:
   args = _build_parser().parse_args(argv)
   if args.command == "config":
     return _cmd_config(args)
+  if args.command == "bootstrap":
+    return _cmd_bootstrap(args)
   raise AssertionError(f"unhandled command {args.command!r}")
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -14,15 +14,17 @@
 
 """``bqaa-otel`` — enterprise admin CLI for OTel -> BigQuery (issue #324).
 
-PR 1 ships ``config`` (generate deployable telemetry-source artifacts from
-an already-deployed receiver's coordinates). ``bootstrap`` (infra
-orchestration, PR 2) and ``verify`` / smoke (PR 3) land next in the stack.
+``config`` (PR 1) generates deployable telemetry-source artifacts from an
+already-deployed receiver's coordinates; ``bootstrap`` (PR 2) deploys the
+full pipeline (plan mode by default, ``--execute`` applies). ``verify`` /
+smoke (PR 3) lands next in the stack.
 """
 
 from __future__ import annotations
 
 import argparse
 import pathlib
+import subprocess
 import sys
 
 from . import bootstrap as bootstrap_mod
@@ -133,7 +135,9 @@ def _build_parser() -> argparse.ArgumentParser:
       "--dataset", default="agent_analytics", help="BigQuery dataset id."
   )
   boot.add_argument(
-      "--region", default="us-central1", help="Cloud Run / Artifact Registry"
+      "--region",
+      default="us-central1",
+      help="Cloud Run / Artifact Registry region.",
   )
   boot.add_argument(
       "--bq-location", default="US", help="BigQuery dataset location."
@@ -198,6 +202,19 @@ def _build_parser() -> argparse.ArgumentParser:
   return parser
 
 
+def _report_settings_error(exc: ValueError) -> int:
+  """Print a tier/settings ValueError (shared by config and bootstrap)."""
+  print(f"bqaa-otel: error: {exc}", file=sys.stderr)
+  if "acknowledge_content_logging" in str(exc):
+    print(
+        "bqaa-otel: --privacy replay exports prompt text; pass"
+        " --i-understand-content-logging only if that is acceptable"
+        " in your environment.",
+        file=sys.stderr,
+    )
+  return 2
+
+
 def _cmd_config(args: argparse.Namespace) -> int:
   try:
     spec = config_artifacts.BootstrapSpec(
@@ -212,15 +229,7 @@ def _cmd_config(args: argparse.Namespace) -> int:
         spec, sources=tuple(s for s in args.source.split(",") if s)
     )
   except ValueError as exc:
-    print(f"bqaa-otel: error: {exc}", file=sys.stderr)
-    if "acknowledge_content_logging" in str(exc):
-      print(
-          "bqaa-otel: --privacy replay exports prompt text; pass"
-          " --i-understand-content-logging only if that is acceptable"
-          " in your environment.",
-          file=sys.stderr,
-      )
-    return 2
+    return _report_settings_error(exc)
 
   if spec.privacy == "replay":
     print(
@@ -269,21 +278,37 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
         out_dir=args.out,
     )
   except ValueError as exc:
-    print(f"bqaa-otel: error: {exc}", file=sys.stderr)
-    if "acknowledge_content_logging" in str(exc):
-      print(
-          "bqaa-otel: --privacy replay exports prompt text; pass"
-          " --i-understand-content-logging only if that is acceptable"
-          " in your environment.",
-          file=sys.stderr,
-      )
-    return 2
+    return _report_settings_error(exc)
 
   if not args.execute:
     print(bootstrap_mod.render_plan(settings))
     return 0
 
-  bootstrap_mod.run_bootstrap(settings, bootstrap_mod.SubprocessRunner())
+  # The Cloud Build step uploads the *current directory* as the build
+  # context; refuse to mutate anything unless we are at the repo root.
+  if not pathlib.Path("deploy/otlp_receiver/Dockerfile").is_file():
+    print(
+        "bqaa-otel: error: deploy/otlp_receiver/Dockerfile not found —"
+        " run --execute from the repository root (the Cloud Build step"
+        " uploads the current directory as the build context).",
+        file=sys.stderr,
+    )
+    return 2
+
+  try:
+    bootstrap_mod.run_bootstrap(settings, bootstrap_mod.SubprocessRunner())
+  except subprocess.CalledProcessError as exc:
+    cmd = exc.cmd if isinstance(exc.cmd, str) else " ".join(exc.cmd)
+    print(f"bqaa-otel: deploy step failed: {cmd}", file=sys.stderr)
+    for stream in (exc.stderr, exc.stdout):
+      if stream and stream.strip():
+        print(stream.strip(), file=sys.stderr)
+    print(
+        "bqaa-otel: fix the underlying error and re-run — every step is"
+        " idempotent/convergent, so a re-run resumes safely.",
+        file=sys.stderr,
+    )
+    return 1
   return 0
 
 

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -196,7 +196,7 @@ def test_bootstrap_refreshes_stale_merge_sql_instead_of_skipping(tmp_path):
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
   # Real bq rejects `ls --transfer_config` without --transfer_location; a
   # failing listing would silently take the create path forever.
-  [(ls_argv, _)] = r.find("--transfer_config", "ls")
+  [(ls_argv, _)] = r.find("--transfer_config", " ls ")
   assert "--transfer_location=US" in ls_argv
   assert not r.find("--transfer_config", "mk")
   [(argv, _)] = r.find("--transfer_config", "update")
@@ -272,6 +272,10 @@ def test_scheduled_merge_update_also_pins_service_account(tmp_path):
   [(argv, _)] = r.find("--transfer_config", "update")
   sa = "bqaa-otlp-consumer@my-proj.iam.gserviceaccount.com"
   assert f"--service_account_name={sa}" in argv
+  # bq only forwards service_account_name on update when update_credentials
+  # is set (checked in bq 2.1.28 source) — without it the existing config
+  # silently keeps the old admin OAuth credential.
+  assert "--update_credentials" in argv
 
 
 def test_bootstrap_creates_dlq_retention_subscription(tmp_path):
@@ -282,6 +286,51 @@ def test_bootstrap_creates_dlq_retention_subscription(tmp_path):
   [(argv, _)] = r.find("subscriptions create", "bqaa-otlp-dlq-sub")
   joined = " ".join(argv)
   assert "--topic bqaa-otlp-dlq" in joined
+  assert "--message-retention-duration" in joined
+  assert "--expiration-period never" in joined
+
+
+def test_bootstrap_scopes_data_editor_to_the_dataset(tmp_path):
+  # jobUser needs project scope, but dataEditor must be dataset-scoped: a
+  # project-wide grant lets a compromised consumer SA modify every dataset
+  # in the project.
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  sa = "bqaa-otlp-consumer@my-proj.iam.gserviceaccount.com"
+  # No project-level dataEditor grant.
+  assert not r.find("gcloud projects add-iam-policy-binding", "dataEditor")
+  # jobUser stays project-level.
+  [(job_argv, _)] = r.find("gcloud projects add-iam-policy-binding", "jobUser")
+  assert f"serviceAccount:{sa}" in " ".join(job_argv)
+  # dataEditor lands on the dataset via bq add-iam-policy-binding.
+  [(argv, _)] = r.find("add-iam-policy-binding", "dataEditor")
+  joined = " ".join(argv)
+  assert joined.startswith("bq ")
+  assert "--dataset" in argv
+  assert f"--member=serviceAccount:{sa}" in argv
+  assert "my-proj:agent_analytics" in argv
+
+
+def test_bootstrap_dlq_subscription_failure_is_not_swallowed(tmp_path):
+  # A DLQ retention subscription that fails to create must abort the run:
+  # silently continuing reports success while dead letters keep evaporating.
+  import subprocess
+
+  import pytest
+
+  r = FakeRunner(failing=("bqaa-otlp-dlq-sub",))
+  with pytest.raises(subprocess.CalledProcessError):
+    bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+
+
+def test_bootstrap_converges_existing_dlq_subscription(tmp_path):
+  # An existing DLQ subscription gets its retention/expiration converged
+  # rather than skipped (it may predate the retention settings).
+  r = FakeRunner(existing=("subscriptions describe bqaa-otlp-dlq-sub",))
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  assert not r.find("subscriptions create", "bqaa-otlp-dlq-sub")
+  [(argv, _)] = r.find("subscriptions update", "bqaa-otlp-dlq-sub")
+  joined = " ".join(argv)
   assert "--message-retention-duration" in joined
   assert "--expiration-period never" in joined
 
@@ -308,9 +357,9 @@ def test_bootstrap_rejects_unknown_or_empty_sources(tmp_path):
 def test_bootstrap_repairs_existing_subscription_with_dlq_flags(tmp_path):
   # An existing (possibly drifted / pre-DLQ) subscription must be updated
   # with the same DLQ + deadline settings the create path uses.
-  r = FakeRunner(failing=("subscriptions create",))
+  r = FakeRunner(failing=("subscriptions create bqaa-otlp-sub ",))
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
-  [(argv, _)] = r.find("subscriptions update")
+  [(argv, _)] = r.find("subscriptions update", "bqaa-otlp-sub ")
   joined = " ".join(argv)
   assert "--push-endpoint" in joined
   assert "--push-auth-service-account" in joined

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -189,6 +189,10 @@ def test_bootstrap_refreshes_stale_merge_sql_instead_of_skipping(tmp_path):
   )
   r = FakeRunner(transfer_listing=listing)
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  # Real bq rejects `ls --transfer_config` without --transfer_location; a
+  # failing listing would silently take the create path forever.
+  [(ls_argv, _)] = r.find("--transfer_config", "ls")
+  assert "--transfer_location=US" in ls_argv
   assert not r.find("--transfer_config", "mk")
   [(argv, _)] = r.find("--transfer_config", "update")
   joined = " ".join(argv)

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -47,12 +47,17 @@ class FakeRunner:
       return (
           _RECEIVER_URL if bootstrap.RECEIVER_SVC in joined else _CONSUMER_URL
       )
-    if "secrets versions access" in joined:
-      return "tok-from-secret"
     return ""
 
   def run(self, argv, input_text=None):
+    import subprocess
+
     self.calls.append((tuple(argv), input_text))
+    joined = " ".join(argv)
+    if any(f in joined for f in self.failing):
+      raise subprocess.CalledProcessError(1, list(argv), stderr="boom")
+    if "--transfer_config" in joined and "ls" in argv:
+      return self.transfer_listing or ""
     return self._canned(argv)
 
   def try_run(self, argv, input_text=None):
@@ -156,7 +161,7 @@ def test_bootstrap_existing_secret_is_not_recreated(tmp_path):
 def test_bootstrap_subscription_has_dlq_and_oidc_push(tmp_path):
   r = FakeRunner()
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
-  sub = " ".join(r.find("subscriptions create")[0][0])
+  sub = " ".join(r.find("subscriptions create", "bqaa-otlp-sub ")[0][0])
   assert "--dead-letter-topic bqaa-otlp-dlq" in sub
   assert f"--push-endpoint {_CONSUMER_URL}/" in sub
   assert "--push-auth-service-account" in sub
@@ -224,6 +229,80 @@ def test_bootstrap_second_dataset_gets_its_own_merge(tmp_path):
   joined = " ".join(argv)
   assert "MERGE `ds2.agent_events_otlp`" in joined
   assert "ds2" in [a for a in argv if "--display_name" in a][0]
+
+
+def test_bootstrap_listing_failure_aborts_instead_of_duplicating(tmp_path):
+  # "Can't list" is not "doesn't exist": a transient bq ls failure must abort
+  # (visible error), never take the create path — DTS display names are not
+  # unique, so blind mk mints a duplicate scheduled MERGE on every flaky run.
+  import subprocess
+
+  import pytest
+
+  r = FakeRunner(failing=("--transfer_config",))
+  with pytest.raises(subprocess.CalledProcessError):
+    bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  assert not r.find("--transfer_config", "mk")
+
+
+def test_scheduled_merge_runs_as_consumer_service_account(tmp_path):
+  # Without --service_account_name, DTS pins the transfer config to the
+  # invoking admin's personal OAuth — the projection job dies when they leave.
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, _)] = r.find("--transfer_config", "mk")
+  sa = "bqaa-otlp-consumer@my-proj.iam.gserviceaccount.com"
+  assert f"--service_account_name={sa}" in argv
+
+
+def test_scheduled_merge_update_also_pins_service_account(tmp_path):
+  listing = json.dumps(
+      [
+          {
+              "name": "projects/1/locations/us/transferConfigs/42",
+              "displayName": "bqaa_agent_events_otlp_merge",
+              "params": {
+                  "query": "MERGE `agent_analytics.agent_events_otlp` T"
+              },
+          }
+      ]
+  )
+  r = FakeRunner(transfer_listing=listing)
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, _)] = r.find("--transfer_config", "update")
+  sa = "bqaa-otlp-consumer@my-proj.iam.gserviceaccount.com"
+  assert f"--service_account_name={sa}" in argv
+
+
+def test_bootstrap_creates_dlq_retention_subscription(tmp_path):
+  # Pub/Sub discards messages published to a topic with no subscription: the
+  # DLQ topic needs a retention subscription or dead letters evaporate.
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, _)] = r.find("subscriptions create", "bqaa-otlp-dlq-sub")
+  joined = " ".join(argv)
+  assert "--topic bqaa-otlp-dlq" in joined
+  assert "--message-retention-duration" in joined
+  assert "--expiration-period never" in joined
+
+
+def test_find_merge_config_survives_garbage_listing():
+  assert bootstrap._find_merge_config("not json at all", "ds") is None
+  assert (
+      bootstrap._find_merge_config(
+          json.dumps([{"displayName": "x", "params": None}]), "ds"
+      )
+      is None
+  )
+
+
+def test_bootstrap_rejects_unknown_or_empty_sources(tmp_path):
+  import pytest
+
+  with pytest.raises(ValueError, match="source"):
+    _settings(tmp_path, sources=("cursor",))
+  with pytest.raises(ValueError, match="source"):
+    _settings(tmp_path, sources=())
 
 
 def test_bootstrap_repairs_existing_subscription_with_dlq_flags(tmp_path):
@@ -294,4 +373,49 @@ def test_render_plan_lists_commands_without_running(tmp_path):
 
 def test_render_plan_marks_capture_placeholders(tmp_path):
   plan = bootstrap.render_plan(_settings(tmp_path))
-  assert "<receiver-url>" in plan or "status.url" in plan
+  # Captured values that feed later commands render as placeholders.
+  assert "<consumer-url>" in plan
+  assert "<project-number>" in plan
+  # Args with spaces are shell-quoted so a copied plan line runs unchanged.
+  assert "'--schedule=every 15 minutes'" in plan
+
+
+# --------------------------------------------------------------------------
+# SubprocessRunner (the only code that touches real subprocesses)
+# --------------------------------------------------------------------------
+
+
+def test_subprocess_runner_returns_stripped_stdout_and_raises():
+  import subprocess
+
+  import pytest
+
+  r = bootstrap.SubprocessRunner(echo=lambda *_: None)
+  assert r.run(["python3", "-c", "print(' hi ')"]) == "hi"
+  with pytest.raises(subprocess.CalledProcessError):
+    r.run(["python3", "-c", "import sys; sys.exit(3)"])
+  assert r.try_run(["python3", "-c", "import sys; sys.exit(3)"]) is None
+
+
+def test_subprocess_runner_never_inherits_the_tty():
+  # A command that prompts must see EOF (devnull), not block on stdin while
+  # its prompt is invisible in the captured pipe.
+  r = bootstrap.SubprocessRunner(echo=lambda *_: None)
+  out = r.run(["python3", "-c", "import sys; print(repr(sys.stdin.read()))"])
+  assert out == "''"
+
+
+def test_hardened_argv_makes_clis_non_interactive():
+  assert bootstrap._hardened_argv(["gcloud", "x", "y"]) == [
+      "gcloud",
+      "x",
+      "y",
+      "--quiet",
+  ]
+  assert bootstrap._hardened_argv(["bq", "--project_id=p", "ls"]) == [
+      "bq",
+      "--headless",
+      "--project_id=p",
+      "ls",
+  ]
+  assert bootstrap._hardened_argv(["docker", "ps"]) == ["docker", "ps"]

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -33,8 +33,10 @@ _CONSUMER_URL = "https://bqaa-otlp-consumer-x.run.app"
 class FakeRunner:
   """Records every command; answers describe/access with canned output."""
 
-  def __init__(self, existing=()):
+  def __init__(self, existing=(), transfer_listing=None, failing=()):
     self.existing = set(existing)  # resource kinds whose describe succeeds
+    self.transfer_listing = transfer_listing  # bq ls --transfer_config JSON
+    self.failing = tuple(failing)  # substrings whose try_run fails
     self.calls = []  # (argv tuple, input_text)
 
   def _canned(self, argv):
@@ -56,6 +58,10 @@ class FakeRunner:
   def try_run(self, argv, input_text=None):
     self.calls.append((tuple(argv), input_text))
     joined = " ".join(argv)
+    if any(f in joined for f in self.failing):
+      return None
+    if "--transfer_config" in joined and "ls" in argv:
+      return self.transfer_listing
     if "describe" in joined or " ls " in f" {joined} ":
       for kind in self.existing:
         if kind in joined:
@@ -163,6 +169,71 @@ def test_bootstrap_registers_scheduled_merge(tmp_path):
   joined = " ".join(argv)
   assert "scheduled_query" in joined
   assert "MERGE `agent_analytics.agent_events_otlp`" in joined
+  # Display name is dataset-specific so multiple datasets can coexist.
+  assert "agent_analytics" in [a for a in argv if "--display_name" in a][0]
+
+
+def test_bootstrap_refreshes_stale_merge_sql_instead_of_skipping(tmp_path):
+  # Re-running bootstrap after a crosswalk/MERGE change must converge the
+  # scheduled query to the current SQL, not leave the stale version.
+  listing = json.dumps(
+      [
+          {
+              "name": "projects/1/locations/us/transferConfigs/42",
+              "displayName": "bqaa_agent_events_otlp_merge",
+              "params": {
+                  "query": "MERGE `agent_analytics.agent_events_otlp` T -- OLD"
+              },
+          }
+      ]
+  )
+  r = FakeRunner(transfer_listing=listing)
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  assert not r.find("--transfer_config", "mk")
+  [(argv, _)] = r.find("--transfer_config", "update")
+  joined = " ".join(argv)
+  assert "projects/1/locations/us/transferConfigs/42" in joined
+  assert "MERGE `agent_analytics.agent_events_otlp`" in joined
+  assert "-- OLD" not in joined
+
+
+def test_bootstrap_second_dataset_gets_its_own_merge(tmp_path):
+  # A transfer config for another dataset must not swallow this dataset's
+  # projection job.
+  listing = json.dumps(
+      [
+          {
+              "name": "projects/1/locations/us/transferConfigs/42",
+              "displayName": "bqaa_agent_events_otlp_merge",
+              "params": {
+                  "query": "MERGE `agent_analytics.agent_events_otlp` T"
+              },
+          }
+      ]
+  )
+  r = FakeRunner(transfer_listing=listing)
+  bootstrap.run_bootstrap(
+      _settings(tmp_path, dataset="ds2"), r, echo=lambda *_: None
+  )
+  assert not r.find("--transfer_config", "update")
+  [(argv, _)] = r.find("--transfer_config", "mk")
+  joined = " ".join(argv)
+  assert "MERGE `ds2.agent_events_otlp`" in joined
+  assert "ds2" in [a for a in argv if "--display_name" in a][0]
+
+
+def test_bootstrap_repairs_existing_subscription_with_dlq_flags(tmp_path):
+  # An existing (possibly drifted / pre-DLQ) subscription must be updated
+  # with the same DLQ + deadline settings the create path uses.
+  r = FakeRunner(failing=("subscriptions create",))
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, _)] = r.find("subscriptions update")
+  joined = " ".join(argv)
+  assert "--push-endpoint" in joined
+  assert "--push-auth-service-account" in joined
+  assert "--dead-letter-topic bqaa-otlp-dlq" in joined
+  assert "--max-delivery-attempts 5" in joined
+  assert "--ack-deadline 60" in joined
 
 
 def test_bootstrap_writes_artifacts_with_deployed_endpoint(tmp_path):

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``bqaa-otel bootstrap`` orchestration (#324 PR2).
+
+The orchestration absorbs ``deploy/otlp_receiver/setup.sh``: same gcloud/bq
+sequence, but driven through an injectable runner so the steps are testable
+without GCP and so plan mode (the default) can render the commands without
+executing anything.
+"""
+
+import json
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+_RECEIVER_URL = "https://bqaa-otlp-receiver-x.run.app"
+_CONSUMER_URL = "https://bqaa-otlp-consumer-x.run.app"
+
+
+class FakeRunner:
+  """Records every command; answers describe/access with canned output."""
+
+  def __init__(self, existing=()):
+    self.existing = set(existing)  # resource kinds whose describe succeeds
+    self.calls = []  # (argv tuple, input_text)
+
+  def _canned(self, argv):
+    joined = " ".join(argv)
+    if "projects describe" in joined:
+      return "123456"
+    if "run services describe" in joined:
+      return (
+          _RECEIVER_URL if bootstrap.RECEIVER_SVC in joined else _CONSUMER_URL
+      )
+    if "secrets versions access" in joined:
+      return "tok-from-secret"
+    return ""
+
+  def run(self, argv, input_text=None):
+    self.calls.append((tuple(argv), input_text))
+    return self._canned(argv)
+
+  def try_run(self, argv, input_text=None):
+    self.calls.append((tuple(argv), input_text))
+    joined = " ".join(argv)
+    if "describe" in joined or " ls " in f" {joined} ":
+      for kind in self.existing:
+        if kind in joined:
+          return self._canned(argv)
+      return None
+    return self._canned(argv)
+
+  # -- assertion helpers ---------------------------------------------------
+
+  def joined(self):
+    return [" ".join(argv) for argv, _ in self.calls]
+
+  def find(self, *needles):
+    return [
+        (argv, inp)
+        for argv, inp in self.calls
+        if all(n in " ".join(argv) for n in needles)
+    ]
+
+
+def _settings(tmp_path, **kw):
+  defaults = dict(
+      project="my-proj",
+      dataset="agent_analytics",
+      region="us-central1",
+      bq_location="US",
+      out_dir=tmp_path / "artifacts",
+  )
+  defaults.update(kw)
+  return bootstrap.BootstrapSettings(**defaults)
+
+
+# --------------------------------------------------------------------------
+# Execute: the setup.sh sequence
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_runs_the_full_deploy_sequence(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  joined = r.joined()
+  for expected in (
+      "gcloud services enable",
+      "bq --project_id=my-proj --location=US mk -f --dataset",
+      "gcloud secrets create",
+      "gcloud pubsub topics create bqaa-otlp",
+      "gcloud pubsub topics create bqaa-otlp-dlq",
+      "gcloud builds submit",
+      "gcloud run deploy bqaa-otlp-receiver",
+      "gcloud run deploy bqaa-otlp-consumer",
+      "gcloud pubsub subscriptions create bqaa-otlp-sub",
+  ):
+    assert any(expected in c for c in joined), f"missing: {expected}"
+
+
+def test_bootstrap_creates_schema_from_ddl_module(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, ddl_sql)] = r.find("bq", "query", "--use_legacy_sql=false")
+  assert "CREATE TABLE IF NOT EXISTS `agent_analytics.otel_logs`" in ddl_sql
+  assert "otel_spans" not in ddl_sql  # spans gated off by default
+
+
+def test_bootstrap_traces_signal_enables_spans_everywhere(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(
+      _settings(tmp_path, signals=("logs", "metrics", "traces")),
+      r,
+      echo=lambda *_: None,
+  )
+  [(_, ddl_sql)] = r.find("bq", "query", "--use_legacy_sql=false")
+  assert "otel_spans" in ddl_sql
+  receiver = " ".join(r.find("run deploy", "receiver")[0][0])
+  consumer = " ".join(r.find("run deploy", "consumer")[0][0])
+  assert "BQAA_OTLP_ENABLE_TRACES=1" in receiver
+  assert "BQAA_OTLP_ENABLE_TRACES=1" in consumer
+
+
+def test_bootstrap_default_signals_keep_traces_off(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  receiver = " ".join(r.find("run deploy", "receiver")[0][0])
+  assert "BQAA_OTLP_ENABLE_TRACES=0" in receiver
+
+
+def test_bootstrap_existing_secret_is_not_recreated(tmp_path):
+  r = FakeRunner(existing=("secrets describe bqaa-otlp-token",))
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  assert not r.find("secrets", "create")
+
+
+def test_bootstrap_subscription_has_dlq_and_oidc_push(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  sub = " ".join(r.find("subscriptions create")[0][0])
+  assert "--dead-letter-topic bqaa-otlp-dlq" in sub
+  assert f"--push-endpoint {_CONSUMER_URL}/" in sub
+  assert "--push-auth-service-account" in sub
+
+
+def test_bootstrap_registers_scheduled_merge(tmp_path):
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  [(argv, _)] = r.find("--transfer_config", "mk")
+  joined = " ".join(argv)
+  assert "scheduled_query" in joined
+  assert "MERGE `agent_analytics.agent_events_otlp`" in joined
+
+
+def test_bootstrap_writes_artifacts_with_deployed_endpoint(tmp_path):
+  r = FakeRunner()
+  result = bootstrap.run_bootstrap(
+      _settings(tmp_path, sources=("claude-code", "codex")),
+      r,
+      echo=lambda *_: None,
+  )
+  assert result.receiver_url == _RECEIVER_URL
+  env = json.loads(
+      (tmp_path / "artifacts" / "claude-code.managed-settings.json").read_text()
+  )["env"]
+  assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == _RECEIVER_URL
+  # The bearer token is NOT embedded by default — artifacts are meant to be
+  # committed/distributed; the summary points at the secret instead.
+  assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "Authorization=Bearer <token>"
+  assert (tmp_path / "artifacts" / "codex.config.toml").exists()
+
+
+def test_bootstrap_summary_prints_endpoints_token_and_smoke(tmp_path):
+  lines = []
+  bootstrap.run_bootstrap(
+      _settings(tmp_path),
+      FakeRunner(),
+      echo=lambda *a: lines.append(" ".join(map(str, a))),
+  )
+  text = "\n".join(lines)
+  assert f"{_RECEIVER_URL}/v1/logs" in text
+  assert (
+      "gcloud secrets versions access latest --secret=bqaa-otlp-token" in text
+  )
+  assert "test_otlp_e2e.py" in text
+
+
+def test_bootstrap_replay_requires_acknowledgement(tmp_path):
+  with pytest.raises(ValueError, match="acknowledge_content_logging"):
+    _settings(tmp_path, privacy="replay")
+
+
+# --------------------------------------------------------------------------
+# Plan mode (the default)
+# --------------------------------------------------------------------------
+
+
+def test_render_plan_lists_commands_without_running(tmp_path):
+  plan = bootstrap.render_plan(_settings(tmp_path))
+  assert "gcloud run deploy bqaa-otlp-receiver" in plan
+  assert "gcloud pubsub subscriptions create" in plan
+  assert "--execute" in plan  # tells the admin how to apply
+  # Long DDL/MERGE bodies are summarized, not dumped.
+  assert "CREATE TABLE IF NOT EXISTS" not in plan
+
+
+def test_render_plan_marks_capture_placeholders(tmp_path):
+  plan = bootstrap.render_plan(_settings(tmp_path))
+  assert "<receiver-url>" in plan or "status.url" in plan

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -188,8 +188,12 @@ def test_bootstrap_default_is_plan_mode(tmp_path, capsys, monkeypatch):
 
 
 def test_bootstrap_execute_invokes_run_bootstrap(tmp_path, monkeypatch):
+  import pathlib as _pathlib
+
   from bigquery_agent_analytics_tracing.otlp import bootstrap
 
+  # --execute refuses to run outside the repo root (Cloud Build context).
+  monkeypatch.chdir(_pathlib.Path(bootstrap.__file__).parents[4])
   seen = {}
 
   def _fake_run_bootstrap(settings, runner, **kw):
@@ -231,3 +235,46 @@ def test_bootstrap_replay_requires_ack_flag(capsys):
   )
   assert rc != 0
   assert "--i-understand-content-logging" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# bootstrap failure modes (#331 full review)
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_execute_surfaces_failed_step_stderr(monkeypatch, capsys):
+  import subprocess
+
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+  def _boom(*a, **k):
+    raise subprocess.CalledProcessError(
+        1, ["gcloud", "run", "deploy"], stderr="PERMISSION_DENIED: nope"
+    )
+
+  monkeypatch.setattr(bootstrap, "run_bootstrap", _boom)
+  monkeypatch.setattr("pathlib.Path.is_file", lambda self: True)
+  rc = _run(["bootstrap", "--project", "p", "--execute"])
+  assert rc == 1
+  err = capsys.readouterr().err
+  assert "gcloud run deploy" in err
+  assert "PERMISSION_DENIED: nope" in err
+
+
+def test_bootstrap_execute_requires_repo_root(monkeypatch, tmp_path, capsys):
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+  def _never(*a, **k):
+    raise AssertionError("must not deploy without the Dockerfile present")
+
+  monkeypatch.setattr(bootstrap, "run_bootstrap", _never)
+  monkeypatch.chdir(tmp_path)  # no deploy/otlp_receiver/Dockerfile here
+  rc = _run(["bootstrap", "--project", "p", "--execute"])
+  assert rc == 2
+  assert "repository root" in capsys.readouterr().err
+
+
+def test_bootstrap_rejects_bogus_source(capsys):
+  rc = _run(["bootstrap", "--project", "p", "--source", "cursor"])
+  assert rc == 2
+  assert "source" in capsys.readouterr().err

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -158,3 +158,76 @@ def test_console_script_is_registered():
   assert (
       scripts["bqaa-otel"] == "bigquery_agent_analytics_tracing.otlp.cli:main"
   )
+
+
+# --------------------------------------------------------------------------
+# bootstrap subcommand (PR2)
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_default_is_plan_mode(tmp_path, capsys, monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+  def _boom(*a, **k):
+    raise AssertionError("plan mode must not execute")
+
+  monkeypatch.setattr(bootstrap.SubprocessRunner, "run", _boom)
+  rc = _run(
+      [
+          "bootstrap",
+          "--project",
+          "my-proj",
+          "--out",
+          str(tmp_path),
+      ]
+  )
+  assert rc == 0
+  out = capsys.readouterr().out
+  assert "--execute" in out
+  assert "gcloud run deploy bqaa-otlp-receiver" in out
+
+
+def test_bootstrap_execute_invokes_run_bootstrap(tmp_path, monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+  seen = {}
+
+  def _fake_run_bootstrap(settings, runner, **kw):
+    seen["settings"] = settings
+    seen["runner"] = runner
+    return bootstrap.BootstrapResult("https://r", "https://c", ())
+
+  monkeypatch.setattr(bootstrap, "run_bootstrap", _fake_run_bootstrap)
+  rc = _run(
+      [
+          "bootstrap",
+          "--project",
+          "my-proj",
+          "--dataset",
+          "ds1",
+          "--signals",
+          "logs,metrics,traces",
+          "--out",
+          str(tmp_path),
+          "--execute",
+      ]
+  )
+  assert rc == 0
+  assert seen["settings"].project == "my-proj"
+  assert seen["settings"].dataset == "ds1"
+  assert seen["settings"].enable_spans is True
+  assert isinstance(seen["runner"], bootstrap.SubprocessRunner)
+
+
+def test_bootstrap_replay_requires_ack_flag(capsys):
+  rc = _run(
+      [
+          "bootstrap",
+          "--project",
+          "my-proj",
+          "--privacy",
+          "replay",
+      ]
+  )
+  assert rc != 0
+  assert "--i-understand-content-logging" in capsys.readouterr().err


### PR DESCRIPTION
**Rebased on main** (#330 merged); the diff is now this PR only.

Second increment of [#324](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/324): `bqaa-otel bootstrap` absorbs `deploy/otlp_receiver/setup.sh` so the deploy sequence has one source of truth. `setup.sh` becomes a thin wrapper preserving the historical env-var interface (`PROJECT=... bash deploy/otlp_receiver/setup.sh`).

## Plan mode is the default

```bash
bqaa-otel bootstrap --project my-proj                # prints every command, runs nothing
bqaa-otel bootstrap --project my-proj --execute      # applies
```

The plan lists the exact gcloud/bq commands with `<placeholders>` for run-time captures (receiver URL, project number) and summarizes stdin payloads (DDL shows a line count; the generated token is never displayed).

## What execute does (setup.sh parity + more)

Same sequence as the shell script — APIs, Artifact Registry, dataset + native-schema DDL, bearer-token secret, least-privilege SAs, topics + IAM, Cloud Build image, receiver/consumer Cloud Run deploys, OIDC push subscription with DLQ, scheduled MERGE — with these changes:

- DDL and MERGE SQL come **straight from the `ddl`/`sql` modules** (no `gen_schema_sql.py` subprocess; that script remains as a standalone utility).
- After deploy it renders the **PR1 config artifacts against the real receiver URL** (Claude managed-settings JSON, Codex TOML, MDM guidance) and prints the exact next admin action + smoke-test command.
- The bearer token is **never embedded** in generated artifacts; the summary prints the `gcloud secrets versions access` command instead.
- `--signals logs,metrics,traces` creates `otel_spans` DDL and sets `BQAA_OTLP_ENABLE_TRACES=1` on both services (span *landing* remains PR4 of the stack).
- Tier validation (privacy/signals/replay ack) is **reused from PR1's `BootstrapSpec`**, so the `config` and `bootstrap` gates cannot drift.

## Testing

- 15 new unit tests: the deploy sequence via a recording `FakeRunner` (command families, DDL content + spans gating, secret idempotency, DLQ/OIDC subscription shape, scheduled-MERGE registration, artifact endpoint/token assertions, summary), plan-mode rendering, CLI plan-vs-execute dispatch and the replay ack gate.
- Full producers suite: 240 passed, 3 skipped; pyink + isort clean; `bash -n setup.sh` clean.
- Drove the real plan mode: byte-for-byte the setup.sh command sequence, token stdin summarized not shown.