### PR TITLE
feat(otlp): bqaa-otel verify + smoke — deployment health checks (#324 PR3)

### DIFF
--- a/deploy/otlp_receiver/README.md
+++ b/deploy/otlp_receiver/README.md
@@ -108,11 +108,21 @@ traces (`otel.trace_exporter`) are observability only.
 ## Verify
 
 ```bash
+# Read-only health checks: endpoint reachability + auth enforcement,
+# table/view existence, recent rows, dead-letter health.
+BQAA_OTLP_TOKEN=<token> PYTHONPATH=producers/src python3 -m \
+  bigquery_agent_analytics_tracing.otlp.cli verify \
+  --endpoint <url> --project <proj> --dataset <dataset>
+
+# Add --smoke to also send synthetic OTLP logs+metrics and follow them into
+# the native tables, dedup views, and the agent_events_otlp projection.
+```
+
+The full pytest e2e (same payloads as `--smoke`, plus protobuf-path and
+dead-letter round-trips) remains available:
+
+```bash
 BQAA_OTLP_ENDPOINT=<url> BQAA_OTLP_TOKEN=<token> \
   BQAA_PROJECT=<proj> BQAA_DATASET=<dataset> \
   python -m pytest producers/tests/test_otlp_e2e.py -v
 ```
-
-The smoke test sends OTLP logs + metrics, confirms rows in the native tables,
-`*_dedup` views, `agent_events_otlp`, and `bqaa_metrics`, and that a malformed
-request lands in `otlp_dead_letter` with a replayable `raw_b64`.

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -370,9 +370,18 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     return 2
   # The bearer token rides on every request: plain http to a remote host
   # would send it cleartext. Loopback stays allowed for local harnesses.
-  # Schemes are case-insensitive (HTTP:// must not bypass the guard).
-  split = urllib.parse.urlsplit(args.endpoint)
-  host = split.hostname or ""
+  # Schemes are case-insensitive (HTTP:// must not bypass the guard), and
+  # urlsplit itself raises on malformed bracketed IPv6 ('http://[::1').
+  try:
+    split = urllib.parse.urlsplit(args.endpoint)
+    host = split.hostname or ""
+  except ValueError as exc:
+    print(
+        f"bqaa-otel: error: --endpoint {args.endpoint!r} is not a valid"
+        f" URL ({exc}) — expected e.g. https://<receiver>.run.app",
+        file=sys.stderr,
+    )
+    return 2
   scheme = split.scheme.lower()
   if scheme not in ("http", "https"):
     print(

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -23,12 +23,14 @@ smoke (PR 3) lands next in the stack.
 from __future__ import annotations
 
 import argparse
+import os
 import pathlib
 import subprocess
 import sys
 
 from . import bootstrap as bootstrap_mod
 from . import config_artifacts
+from . import verify as verify_mod
 
 
 def _parse_kv(pairs: str) -> dict[str, str]:
@@ -199,6 +201,46 @@ def _build_parser() -> argparse.ArgumentParser:
       action="store_true",
       help="Apply the plan (default: print the commands and exit).",
   )
+
+  ver = sub.add_parser(
+      "verify",
+      help=(
+          "Check a deployment: endpoint reachability + auth enforcement,"
+          " table/view existence, recent rows, dead-letter health."
+          " --smoke additionally sends synthetic OTLP logs+metrics and"
+          " follows them into BigQuery and the projection."
+      ),
+  )
+  ver.add_argument("--endpoint", required=True, help="Receiver base URL.")
+  ver.add_argument(
+      "--token",
+      default=None,
+      help="Bearer token (default: the BQAA_OTLP_TOKEN env var).",
+  )
+  ver.add_argument("--project", required=True, help="GCP project id.")
+  ver.add_argument("--dataset", required=True, help="BigQuery dataset id.")
+  ver.add_argument(
+      "--signals",
+      default="logs,metrics",
+      help="Signal tier the deployment was bootstrapped with.",
+  )
+  ver.add_argument(
+      "--recent-hours",
+      type=int,
+      default=24,
+      help="Freshness window for recent-row / dead-letter checks.",
+  )
+  ver.add_argument(
+      "--smoke",
+      action="store_true",
+      help="Also exercise the write path with synthetic telemetry.",
+  )
+  ver.add_argument(
+      "--timeout",
+      type=float,
+      default=150,
+      help="Seconds to wait for smoke rows to land.",
+  )
   return parser
 
 
@@ -312,12 +354,63 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
   return 0
 
 
+def _cmd_verify(args: argparse.Namespace) -> int:
+  token = args.token or os.environ.get("BQAA_OTLP_TOKEN", "")
+  if not token:
+    print(
+        "bqaa-otel: error: no bearer token — pass --token or set"
+        " BQAA_OTLP_TOKEN",
+        file=sys.stderr,
+    )
+    return 2
+  settings = verify_mod.VerifySettings(
+      endpoint=args.endpoint,
+      token=token,
+      project=args.project,
+      dataset=args.dataset,
+      signals=tuple(s for s in args.signals.split(",") if s),
+      recent_hours=args.recent_hours,
+  )
+  query_rows = verify_mod.make_query_rows(args.project)
+  results = verify_mod.run_verify(
+      settings,
+      http_post=verify_mod.default_http_post,
+      query_rows=query_rows,
+  )
+  if args.smoke:
+    results += verify_mod.run_smoke(
+        settings,
+        http_post=verify_mod.default_http_post,
+        query_rows=query_rows,
+        timeout_s=args.timeout,
+    )
+
+  failures = 0
+  for r in results:
+    if r.ok:
+      status = "OK  "
+    elif r.warning:
+      status = "WARN"
+    else:
+      status = "FAIL"
+      failures += 1
+    print(f"{status}  {r.name}: {r.detail}")
+  print()
+  if failures:
+    print(f"{failures} check(s) failed.")
+    return 1
+  print("All checks passed.")
+  return 0
+
+
 def main(argv: list[str] | None = None) -> int:
   args = _build_parser().parse_args(argv)
   if args.command == "config":
     return _cmd_config(args)
   if args.command == "bootstrap":
     return _cmd_bootstrap(args)
+  if args.command == "verify":
+    return _cmd_verify(args)
   raise AssertionError(f"unhandled command {args.command!r}")
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -370,8 +370,10 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     return 2
   # The bearer token rides on every request: plain http to a remote host
   # would send it cleartext. Loopback stays allowed for local harnesses.
-  host = urllib.parse.urlsplit(args.endpoint).hostname or ""
-  if args.endpoint.startswith("http://") and host not in (
+  # Schemes are case-insensitive (HTTP:// must not bypass the guard).
+  split = urllib.parse.urlsplit(args.endpoint)
+  host = split.hostname or ""
+  if split.scheme.lower() == "http" and host not in (
       "localhost",
       "127.0.0.1",
       "::1",

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -16,8 +16,8 @@
 
 ``config`` (PR 1) generates deployable telemetry-source artifacts from an
 already-deployed receiver's coordinates; ``bootstrap`` (PR 2) deploys the
-full pipeline (plan mode by default, ``--execute`` applies). ``verify`` /
-smoke (PR 3) lands next in the stack.
+full pipeline (plan mode by default, ``--execute`` applies); ``verify``
+(PR 3) checks a deployment read-only, or end-to-end with ``--smoke``.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import urllib.parse
 
 from . import bootstrap as bootstrap_mod
 from . import config_artifacts
@@ -215,7 +216,11 @@ def _build_parser() -> argparse.ArgumentParser:
   ver.add_argument(
       "--token",
       default=None,
-      help="Bearer token (default: the BQAA_OTLP_TOKEN env var).",
+      help=(
+          "Bearer token. Prefer the BQAA_OTLP_TOKEN env var (the default):"
+          " a token on the command line is visible in shell history and"
+          " process listings."
+      ),
   )
   ver.add_argument("--project", required=True, help="GCP project id.")
   ver.add_argument("--dataset", required=True, help="BigQuery dataset id.")
@@ -239,7 +244,7 @@ def _build_parser() -> argparse.ArgumentParser:
       "--timeout",
       type=float,
       default=150,
-      help="Seconds to wait for smoke rows to land.",
+      help="Total seconds to wait for all smoke rows to land (one budget).",
   )
   return parser
 
@@ -363,14 +368,32 @@ def _cmd_verify(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
     return 2
-  settings = verify_mod.VerifySettings(
-      endpoint=args.endpoint,
-      token=token,
-      project=args.project,
-      dataset=args.dataset,
-      signals=tuple(s for s in args.signals.split(",") if s),
-      recent_hours=args.recent_hours,
-  )
+  # The bearer token rides on every request: plain http to a remote host
+  # would send it cleartext. Loopback stays allowed for local harnesses.
+  host = urllib.parse.urlsplit(args.endpoint).hostname or ""
+  if args.endpoint.startswith("http://") and host not in (
+      "localhost",
+      "127.0.0.1",
+      "::1",
+  ):
+    print(
+        "bqaa-otel: error: refusing to send the bearer token over plain"
+        f" http to {host!r} — use an https endpoint (http is allowed for"
+        " localhost only).",
+        file=sys.stderr,
+    )
+    return 2
+  try:
+    settings = verify_mod.VerifySettings(
+        endpoint=args.endpoint,
+        token=token,
+        project=args.project,
+        dataset=args.dataset,
+        signals=tuple(s for s in args.signals.split(",") if s),
+        recent_hours=args.recent_hours,
+    )
+  except ValueError as exc:
+    return _report_settings_error(exc)
   query_rows = verify_mod.make_query_rows(args.project)
   results = verify_mod.run_verify(
       settings,

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -373,7 +373,15 @@ def _cmd_verify(args: argparse.Namespace) -> int:
   # Schemes are case-insensitive (HTTP:// must not bypass the guard).
   split = urllib.parse.urlsplit(args.endpoint)
   host = split.hostname or ""
-  if split.scheme.lower() == "http" and host not in (
+  scheme = split.scheme.lower()
+  if scheme not in ("http", "https"):
+    print(
+        f"bqaa-otel: error: --endpoint {args.endpoint!r} is not an http(s)"
+        " URL — expected e.g. https://<receiver>.run.app",
+        file=sys.stderr,
+    )
+    return 2
+  if scheme == "http" and host not in (
       "localhost",
       "127.0.0.1",
       "::1",

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -516,23 +516,34 @@ def default_http_post(url: str, body: bytes, headers: dict) -> tuple[int, str]:
   connection refused, TLS, timeout) return status 0 with the error text —
   the one condition a reachability check must report gracefully.
   """
-  request = urllib.request.Request(url, data=body, headers=headers)
   try:
+    # Request() itself raises ValueError on malformed/schemeless URLs, so
+    # it lives inside the guard to keep the never-raises contract.
+    request = urllib.request.Request(url, data=body, headers=headers)
     with _NO_REDIRECT_OPENER.open(request, timeout=_HTTP_TIMEOUT_S) as resp:
       return resp.status, resp.read().decode("utf-8", "replace")
   except urllib.error.HTTPError as exc:
     return exc.code, exc.read().decode("utf-8", "replace")
-  except (urllib.error.URLError, OSError) as exc:
+  except (urllib.error.URLError, OSError, ValueError) as exc:
     return 0, str(exc)
 
 
 def make_query_rows(project: str) -> QueryRows:
-  """A QueryRows backed by google-cloud-bigquery."""
-  from google.cloud import bigquery
+  """A QueryRows backed by google-cloud-bigquery.
 
-  client = bigquery.Client(project=project)
+  The client is constructed lazily on first use so factory-time failures
+  (missing ADC, import problems) surface through the guarded per-check
+  calls as ``query failed: ...`` rows instead of crashing the CLI before
+  the first check runs.
+  """
+  client = None
 
   def query_rows(query: str) -> list:
+    nonlocal client
+    if client is None:
+      from google.cloud import bigquery
+
+      client = bigquery.Client(project=project)
     return [tuple(row) for row in client.query(query).result()]
 
   return query_rows

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -33,14 +33,29 @@ import dataclasses
 import json
 import time
 from typing import Any, Callable
+import urllib.error
+import urllib.request
 import uuid
 
+from . import config_artifacts
 from . import sql as otel_sql
 
-# (status, body) for a POST; body is bytes, headers a plain dict.
+# (status, body) for a POST; body is bytes, headers a plain dict. Status 0
+# means the transport itself failed (unreachable/DNS/TLS/timeout).
 HttpPost = Callable[[str, bytes, dict], tuple[int, str]]
 # Rows for a query, as sequences indexable like bigquery Row tuples.
 QueryRows = Callable[[str], list]
+
+_POLL_INTERVAL_S = 5
+_HTTP_TIMEOUT_S = 30
+# Each table's real timestamp column: bqaa_metrics is a VIEW that projects
+# time_timestamp (no ingest_time), and otlp_dead_letter keys on received_at.
+# Querying the wrong column crashes against every healthy deployment.
+_TIMESTAMP_COLUMNS = {
+    "otel_logs": "ingest_time",
+    "bqaa_metrics": "time_timestamp",
+    "otlp_dead_letter": "received_at",
+}
 
 _NATIVE_TABLES = (
     "otel_logs",
@@ -71,6 +86,15 @@ class VerifySettings:
   signals: tuple[str, ...] = ("logs", "metrics")
   recent_hours: int = 24
 
+  def __post_init__(self):
+    # Same tier gate as config/bootstrap: a typo like 'traces'->'trace'
+    # would silently drop the otel_spans existence expectations.
+    if frozenset(self.signals) not in config_artifacts.SIGNAL_TIERS:
+      raise ValueError(
+          f"unsupported signal tier {','.join(self.signals)!r}; expected"
+          " 'logs,metrics' or 'logs,metrics,traces'"
+      )
+
   @property
   def qualified(self) -> str:
     return f"{self.project}.{self.dataset}"
@@ -95,6 +119,34 @@ def _empty_logs_body() -> bytes:
   return json.dumps({"resourceLogs": []}).encode("utf-8")
 
 
+def _recent_count_check(
+    settings: VerifySettings,
+    query_rows: QueryRows,
+    table: str,
+    *,
+    name: str,
+    ok_fn: Callable[[int], bool],
+    detail_fn: Callable[[int], str],
+) -> CheckResult:
+  """COUNT rows in the freshness window; a query error is a failed check.
+
+  A count the deployment considers unhealthy is reported as a warning
+  (advisory), never a hard failure — a fresh deployment has no rows and a
+  busy one may have dead letters worth inspecting.
+  """
+  column = _TIMESTAMP_COLUMNS[table]
+  try:
+    count = query_rows(
+        f"SELECT COUNT(*) FROM `{settings.qualified}.{table}` WHERE"
+        f" {column} > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL"
+        f" {settings.recent_hours} HOUR)"
+    )[0][0]
+  except Exception as exc:  # noqa: BLE001 - report, never crash the report
+    return CheckResult(name=name, ok=False, detail=f"query failed: {exc}")
+  ok = ok_fn(count)
+  return CheckResult(name=name, ok=ok, detail=detail_fn(count), warning=not ok)
+
+
 def run_verify(
     settings: VerifySettings,
     *,
@@ -106,16 +158,21 @@ def run_verify(
   logs_url = settings.endpoint.rstrip("/") + "/v1/logs"
 
   # 1. Reachability + auth enforcement: an unauthenticated request must be
-  # rejected, an authenticated empty request must be accepted.
-  status, _ = http_post(logs_url, _empty_logs_body(), {})
+  # rejected, an authenticated empty request must be accepted. Status 0
+  # means the transport itself failed (unreachable/DNS/TLS/timeout).
+  status, detail_body = http_post(logs_url, _empty_logs_body(), {})
   results.append(
       CheckResult(
           name="endpoint auth enforced",
           ok=status == 401,
-          detail=f"unauthenticated POST {logs_url} -> {status} (want 401)",
+          detail=(
+              f"unreachable: {detail_body}"
+              if status == 0
+              else f"unauthenticated POST {logs_url} -> {status} (want 401)"
+          ),
       )
   )
-  status, body = http_post(
+  status, detail_body = http_post(
       logs_url,
       _empty_logs_body(),
       {
@@ -127,18 +184,36 @@ def run_verify(
       CheckResult(
           name="endpoint reachable",
           ok=status == 200,
-          detail=f"authenticated POST {logs_url} -> {status} (want 200)",
+          detail=(
+              f"unreachable: {detail_body}"
+              if status == 0
+              # A decode-only probe: 200 proves auth + decode, not the
+              # Pub/Sub publish path (use --smoke for end-to-end proof).
+              else f"authenticated POST {logs_url} -> {status} (want 200;"
+              " decode-only probe — use --smoke for the full path)"
+          ),
       )
   )
 
-  # 2. Table/view existence.
-  existing = {
-      row[0]
-      for row in query_rows(
-          "SELECT table_name FROM"
-          f" `{settings.qualified}.INFORMATION_SCHEMA.TABLES`"
-      )
-  }
+  # 2. Table/view existence. A failing query here (dataset missing,
+  # permission denied) is exactly what this check must REPORT, not crash on.
+  try:
+    existing = {
+        row[0]
+        for row in query_rows(
+            "SELECT table_name FROM"
+            f" `{settings.qualified}.INFORMATION_SCHEMA.TABLES`"
+        )
+    }
+  except Exception as exc:  # noqa: BLE001 - report, never crash the report
+    results.append(
+        CheckResult(
+            name="tables and views exist",
+            ok=False,
+            detail=f"query failed: {exc}",
+        )
+    )
+    return results  # every later check needs the listing
   missing = [t for t in _expected_tables(settings) if t not in existing]
   results.append(
       CheckResult(
@@ -154,37 +229,33 @@ def run_verify(
   for table in ("otel_logs", "bqaa_metrics"):
     if table in missing:
       continue
-    count = query_rows(
-        f"SELECT COUNT(*) FROM `{settings.qualified}.{table}` WHERE"
-        " ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL"
-        f" {settings.recent_hours} HOUR)"
-    )[0][0]
     results.append(
-        CheckResult(
+        _recent_count_check(
+            settings,
+            query_rows,
+            table,
             name=f"recent rows in {table}",
-            ok=count > 0,
-            detail=f"{count} rows in the last {settings.recent_hours}h",
-            warning=count == 0,
+            ok_fn=lambda count: count > 0,
+            detail_fn=lambda count: (
+                f"{count} rows in the last {settings.recent_hours}h"
+            ),
         )
     )
 
   # 4. Dead-letter health: rows here mean malformed/failed deliveries.
   if "otlp_dead_letter" not in missing:
-    dead = query_rows(
-        f"SELECT COUNT(*) FROM `{settings.qualified}.otlp_dead_letter`"
-        " WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL"
-        f" {settings.recent_hours} HOUR)"
-    )[0][0]
     results.append(
-        CheckResult(
+        _recent_count_check(
+            settings,
+            query_rows,
+            "otlp_dead_letter",
             name="dead-letter health",
-            ok=dead == 0,
-            detail=(
-                f"{dead} dead-lettered records in the last"
+            ok_fn=lambda count: count == 0,
+            detail_fn=lambda count: (
+                f"{count} dead-lettered records in the last"
                 f" {settings.recent_hours}h"
-                + ("" if dead == 0 else " — inspect otlp_dead_letter.raw_b64")
+                + ("" if count == 0 else " — inspect otlp_dead_letter.raw_b64")
             ),
-            warning=dead > 0,
         )
     )
   return results
@@ -265,6 +336,19 @@ def synthetic_gauge_payload(run_id: str, now_nanos: int) -> dict:
   }
 
 
+def _send_counts(body: str) -> tuple[int, int]:
+  """(published, dead_lettered) from a receiver response body.
+
+  Unparseable/absent counts read as healthy (-1, 0): only an explicit
+  dead-letter or zero-published report fails the send check.
+  """
+  try:
+    parsed = json.loads(body)
+    return int(parsed.get("published", -1)), int(parsed.get("dead_lettered", 0))
+  except (ValueError, TypeError, AttributeError):
+    return -1, 0
+
+
 def run_smoke(
     settings: VerifySettings,
     *,
@@ -290,23 +374,34 @@ def run_smoke(
     status, body = http_post(
         base + path, json.dumps(payload).encode("utf-8"), headers
     )
+    # The receiver returns 200 with dead_lettered>0 for per-record decode
+    # failures; accepting that would burn the whole polling budget before
+    # failing with no diagnostic.
+    published, dead = _send_counts(body)
+    ok = status == 200 and dead == 0 and published != 0
     results.append(
         CheckResult(
             name=f"smoke send {path}",
-            ok=status == 200,
-            detail=f"POST {path} -> {status}",
+            ok=ok,
+            detail=(
+                f"POST {path} -> {status}"
+                + ("" if ok else f" (published={published}, dead={dead})")
+            ),
         )
     )
   if any(not r.ok for r in results):
     return results
 
+  # One shared deadline for every landing check: --timeout bounds the whole
+  # wait phase, not each check separately.
+  deadline = time.monotonic() + timeout_s
+
   def _wait_count(query: str) -> int:
-    deadline = time.monotonic() + timeout_s
     while True:
       count = query_rows(query)[0][0]
       if count or time.monotonic() >= deadline:
         return count
-      sleep(5)
+      sleep(_POLL_INTERVAL_S)
 
   run_filter = f"JSON_VALUE(log_attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
   checks = (
@@ -340,12 +435,24 @@ def run_smoke(
 
   if landed:
     # Run the projection MERGE now (scheduled every 15 min in prod) and
-    # verify the smoke event projected with the product event name.
-    query_rows(otel_sql.agent_events_otlp_merge_sql(settings.qualified))
-    rows = query_rows(
-        f"SELECT event_type FROM `{settings.qualified}.agent_events_otlp`"
-        f" WHERE JSON_VALUE(attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
-    )
+    # verify the smoke event projected with the product event name. The
+    # MERGE upserts on idempotency_key, so racing the scheduled run is
+    # data-safe; a serialization error surfaces as a failed check.
+    try:
+      query_rows(otel_sql.agent_events_otlp_merge_sql(settings.qualified))
+      rows = query_rows(
+          f"SELECT event_type FROM `{settings.qualified}.agent_events_otlp`"
+          f" WHERE JSON_VALUE(attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
+      )
+    except Exception as exc:  # noqa: BLE001 - report, never crash the report
+      results.append(
+          CheckResult(
+              name="smoke event projected into agent_events_otlp",
+              ok=False,
+              detail=f"query failed: {exc}",
+          )
+      )
+      return results
     ok = bool(rows) and rows[0][0] == "claude_code.user_prompt"
     results.append(
         CheckResult(
@@ -377,17 +484,37 @@ def run_smoke(
 # --------------------------------------------------------------------------
 
 
-def default_http_post(url: str, body: bytes, headers: dict) -> tuple[int, str]:
-  """POST via urllib; returns (status, body) without raising on 4xx/5xx."""
-  import urllib.error
-  import urllib.request
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+  """Never follow redirects.
 
+  urllib would otherwise resend the Authorization header to the redirect
+  target (token exfiltration on a compromised/typo'd endpoint) and convert
+  the POST to a GET that dead-letters on the receiver. A 3xx surfaces as
+  its status code instead.
+  """
+
+  def redirect_request(self, *args, **kwargs):
+    return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def default_http_post(url: str, body: bytes, headers: dict) -> tuple[int, str]:
+  """POST via urllib; (status, body), never raises.
+
+  4xx/5xx/3xx return their status code; transport failures (DNS,
+  connection refused, TLS, timeout) return status 0 with the error text —
+  the one condition a reachability check must report gracefully.
+  """
   request = urllib.request.Request(url, data=body, headers=headers)
   try:
-    with urllib.request.urlopen(request, timeout=30) as response:
-      return response.status, response.read().decode("utf-8", "replace")
+    with _NO_REDIRECT_OPENER.open(request, timeout=_HTTP_TIMEOUT_S) as resp:
+      return resp.status, resp.read().decode("utf-8", "replace")
   except urllib.error.HTTPError as exc:
     return exc.code, exc.read().decode("utf-8", "replace")
+  except (urllib.error.URLError, OSError) as exc:
+    return 0, str(exc)
 
 
 def make_query_rows(project: str) -> QueryRows:

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -423,7 +423,16 @@ def run_smoke(
   )
   landed = True
   for name, query in checks:
-    count = _wait_count(query)
+    # A missing table / permission error while polling must become a failed
+    # check, not a traceback that also hides the earlier results.
+    try:
+      count = _wait_count(query)
+    except Exception as exc:  # noqa: BLE001 - report, never crash the report
+      results.append(
+          CheckResult(name=name, ok=False, detail=f"query failed: {exc}")
+      )
+      landed = False
+      continue
     results.append(
         CheckResult(
             name=name,

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -1,0 +1,402 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``bqaa-otel verify`` / smoke — deployment health checks (#324 PR3).
+
+``run_verify`` is strictly read-only: endpoint reachability + bearer-token
+enforcement, table/view existence, recent-row freshness, and dead-letter
+health. ``run_smoke`` additionally exercises the write path with synthetic
+OTLP logs + metrics and follows them through the native tables, the dedup
+views, and the ``agent_events_otlp`` projection (running the scheduled
+MERGE once, exactly as the live e2e test does — the payload builders here
+are shared with it).
+
+I/O is injected (``http_post``, ``query_rows``) so every check is
+unit-testable; the CLI wires urllib + google-cloud-bigquery in
+:func:`default_http_post` / :func:`default_query_rows`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from typing import Any, Callable
+import uuid
+
+from . import sql as otel_sql
+
+# (status, body) for a POST; body is bytes, headers a plain dict.
+HttpPost = Callable[[str, bytes, dict], tuple[int, str]]
+# Rows for a query, as sequences indexable like bigquery Row tuples.
+QueryRows = Callable[[str], list]
+
+_NATIVE_TABLES = (
+    "otel_logs",
+    "otel_metric_sum",
+    "otel_metric_gauge",
+    "otel_metric_histogram",
+    "otel_metric_exponential_histogram",
+    "otel_metric_summary",
+    "otlp_dead_letter",
+)
+_VIEWS = (
+    "otel_logs_dedup",
+    "otel_metric_sum_dedup",
+    "otel_metric_gauge_dedup",
+    "otel_metric_histogram_dedup",
+    "otel_metric_exponential_histogram_dedup",
+    "otel_metric_summary_dedup",
+    "bqaa_metrics",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifySettings:
+  endpoint: str
+  token: str
+  project: str
+  dataset: str
+  signals: tuple[str, ...] = ("logs", "metrics")
+  recent_hours: int = 24
+
+  @property
+  def qualified(self) -> str:
+    return f"{self.project}.{self.dataset}"
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckResult:
+  name: str
+  ok: bool
+  detail: str
+  warning: bool = False  # advisory: never fails the run
+
+
+def _expected_tables(settings: VerifySettings) -> tuple[str, ...]:
+  expected = _NATIVE_TABLES + ("agent_events_otlp",) + _VIEWS
+  if "traces" in settings.signals:
+    expected += ("otel_spans", "otel_spans_dedup")
+  return expected
+
+
+def _empty_logs_body() -> bytes:
+  return json.dumps({"resourceLogs": []}).encode("utf-8")
+
+
+def run_verify(
+    settings: VerifySettings,
+    *,
+    http_post: HttpPost,
+    query_rows: QueryRows,
+) -> list[CheckResult]:
+  """Read-only deployment checks; warnings never fail the run."""
+  results: list[CheckResult] = []
+  logs_url = settings.endpoint.rstrip("/") + "/v1/logs"
+
+  # 1. Reachability + auth enforcement: an unauthenticated request must be
+  # rejected, an authenticated empty request must be accepted.
+  status, _ = http_post(logs_url, _empty_logs_body(), {})
+  results.append(
+      CheckResult(
+          name="endpoint auth enforced",
+          ok=status == 401,
+          detail=f"unauthenticated POST {logs_url} -> {status} (want 401)",
+      )
+  )
+  status, body = http_post(
+      logs_url,
+      _empty_logs_body(),
+      {
+          "Authorization": f"Bearer {settings.token}",
+          "Content-Type": "application/json",
+      },
+  )
+  results.append(
+      CheckResult(
+          name="endpoint reachable",
+          ok=status == 200,
+          detail=f"authenticated POST {logs_url} -> {status} (want 200)",
+      )
+  )
+
+  # 2. Table/view existence.
+  existing = {
+      row[0]
+      for row in query_rows(
+          "SELECT table_name FROM"
+          f" `{settings.qualified}.INFORMATION_SCHEMA.TABLES`"
+      )
+  }
+  missing = [t for t in _expected_tables(settings) if t not in existing]
+  results.append(
+      CheckResult(
+          name="tables and views exist",
+          ok=not missing,
+          detail=(
+              "all present" if not missing else f"missing: {', '.join(missing)}"
+          ),
+      )
+  )
+
+  # 3. Recent rows (freshness): informational — a fresh deployment has none.
+  for table in ("otel_logs", "bqaa_metrics"):
+    if table in missing:
+      continue
+    count = query_rows(
+        f"SELECT COUNT(*) FROM `{settings.qualified}.{table}` WHERE"
+        " ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL"
+        f" {settings.recent_hours} HOUR)"
+    )[0][0]
+    results.append(
+        CheckResult(
+            name=f"recent rows in {table}",
+            ok=count > 0,
+            detail=f"{count} rows in the last {settings.recent_hours}h",
+            warning=count == 0,
+        )
+    )
+
+  # 4. Dead-letter health: rows here mean malformed/failed deliveries.
+  if "otlp_dead_letter" not in missing:
+    dead = query_rows(
+        f"SELECT COUNT(*) FROM `{settings.qualified}.otlp_dead_letter`"
+        " WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL"
+        f" {settings.recent_hours} HOUR)"
+    )[0][0]
+    results.append(
+        CheckResult(
+            name="dead-letter health",
+            ok=dead == 0,
+            detail=(
+                f"{dead} dead-lettered records in the last"
+                f" {settings.recent_hours}h"
+                + ("" if dead == 0 else " — inspect otlp_dead_letter.raw_b64")
+            ),
+            warning=dead > 0,
+        )
+    )
+  return results
+
+
+# --------------------------------------------------------------------------
+# Synthetic payloads (shared with producers/tests/test_otlp_e2e.py)
+# --------------------------------------------------------------------------
+
+
+def synthetic_logs_payload(run_id: str, now_nanos: int) -> dict:
+  """One OTLP/JSON log record tagged with ``bqaa.run_id`` for tracking."""
+  return {
+      "resourceLogs": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      },
+                  ]
+              },
+              "scopeLogs": [
+                  {
+                      "scope": {"name": "bqaa-smoke"},
+                      "logRecords": [
+                          {
+                              "timeUnixNano": str(now_nanos),
+                              "body": {"stringValue": "bqaa smoke"},
+                              "eventName": "claude_code.user_prompt",
+                              "attributes": [
+                                  {
+                                      "key": "bqaa.run_id",
+                                      "value": {"stringValue": run_id},
+                                  },
+                                  {
+                                      "key": "session.id",
+                                      "value": {"stringValue": run_id},
+                                  },
+                              ],
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+
+
+def synthetic_gauge_payload(run_id: str, now_nanos: int) -> dict:
+  """One OTLP/JSON gauge point named after the run id."""
+  return {
+      "resourceMetrics": [
+          {
+              "resource": {"attributes": []},
+              "scopeMetrics": [
+                  {
+                      "scope": {"name": "bqaa-smoke"},
+                      "metrics": [
+                          {
+                              "name": f"bqaa_e2e_{run_id}",
+                              "unit": "1",
+                              "gauge": {
+                                  "dataPoints": [
+                                      {
+                                          "asDouble": 1.0,
+                                          "timeUnixNano": str(now_nanos),
+                                      }
+                                  ]
+                              },
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+
+
+def run_smoke(
+    settings: VerifySettings,
+    *,
+    http_post: HttpPost,
+    query_rows: QueryRows,
+    sleep: Callable[[float], None] = time.sleep,
+    timeout_s: float = 150,
+) -> list[CheckResult]:
+  """Send synthetic logs+metrics and follow them into BigQuery."""
+  results: list[CheckResult] = []
+  run_id = uuid.uuid4().hex
+  now_nanos = int(time.time() * 1e9)
+  headers = {
+      "Authorization": f"Bearer {settings.token}",
+      "Content-Type": "application/json",
+  }
+  base = settings.endpoint.rstrip("/")
+
+  for path, payload in (
+      ("/v1/logs", synthetic_logs_payload(run_id, now_nanos)),
+      ("/v1/metrics", synthetic_gauge_payload(run_id, now_nanos)),
+  ):
+    status, body = http_post(
+        base + path, json.dumps(payload).encode("utf-8"), headers
+    )
+    results.append(
+        CheckResult(
+            name=f"smoke send {path}",
+            ok=status == 200,
+            detail=f"POST {path} -> {status}",
+        )
+    )
+  if any(not r.ok for r in results):
+    return results
+
+  def _wait_count(query: str) -> int:
+    deadline = time.monotonic() + timeout_s
+    while True:
+      count = query_rows(query)[0][0]
+      if count or time.monotonic() >= deadline:
+        return count
+      sleep(5)
+
+  run_filter = f"JSON_VALUE(log_attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
+  checks = (
+      (
+          "smoke row in otel_logs",
+          f"SELECT COUNT(*) FROM `{settings.qualified}.otel_logs`"
+          f" WHERE {run_filter}",
+      ),
+      (
+          "smoke point in otel_metric_gauge",
+          f"SELECT COUNT(*) FROM `{settings.qualified}.otel_metric_gauge`"
+          f" WHERE metric_name = 'bqaa_e2e_{run_id}'",
+      ),
+      (
+          "smoke point in bqaa_metrics view",
+          f"SELECT COUNT(*) FROM `{settings.qualified}.bqaa_metrics`"
+          f" WHERE metric_name = 'bqaa_e2e_{run_id}'",
+      ),
+  )
+  landed = True
+  for name, query in checks:
+    count = _wait_count(query)
+    results.append(
+        CheckResult(
+            name=name,
+            ok=count >= 1,
+            detail=f"{count} rows (waited up to {timeout_s:.0f}s)",
+        )
+    )
+    landed = landed and count >= 1
+
+  if landed:
+    # Run the projection MERGE now (scheduled every 15 min in prod) and
+    # verify the smoke event projected with the product event name.
+    query_rows(otel_sql.agent_events_otlp_merge_sql(settings.qualified))
+    rows = query_rows(
+        f"SELECT event_type FROM `{settings.qualified}.agent_events_otlp`"
+        f" WHERE JSON_VALUE(attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
+    )
+    ok = bool(rows) and rows[0][0] == "claude_code.user_prompt"
+    results.append(
+        CheckResult(
+            name="smoke event projected into agent_events_otlp",
+            ok=ok,
+            detail=(
+                f"event_type={rows[0][0]!r}" if rows else "no projected row"
+            ),
+        )
+    )
+
+  if "traces" in settings.signals:
+    results.append(
+        CheckResult(
+            name="traces smoke",
+            ok=False,
+            warning=True,
+            detail=(
+                "span landing is not implemented yet (#324 traces tier,"
+                " final PR of the stack) — otel_spans receives no rows"
+            ),
+        )
+    )
+  return results
+
+
+# --------------------------------------------------------------------------
+# Default I/O implementations (used by the CLI)
+# --------------------------------------------------------------------------
+
+
+def default_http_post(url: str, body: bytes, headers: dict) -> tuple[int, str]:
+  """POST via urllib; returns (status, body) without raising on 4xx/5xx."""
+  import urllib.error
+  import urllib.request
+
+  request = urllib.request.Request(url, data=body, headers=headers)
+  try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+      return response.status, response.read().decode("utf-8", "replace")
+  except urllib.error.HTTPError as exc:
+    return exc.code, exc.read().decode("utf-8", "replace")
+
+
+def make_query_rows(project: str) -> QueryRows:
+  """A QueryRows backed by google-cloud-bigquery."""
+  from google.cloud import bigquery
+
+  client = bigquery.Client(project=project)
+
+  def query_rows(query: str) -> list:
+    return [tuple(row) for row in client.query(query).result()]
+
+  return query_rows

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 import time
 from typing import Any, Callable
 import urllib.error
@@ -94,6 +95,14 @@ class VerifySettings:
           f"unsupported signal tier {','.join(self.signals)!r}; expected"
           " 'logs,metrics' or 'logs,metrics,traces'"
       )
+    # Both feed backtick-quoted SQL identifiers (settings.qualified): a
+    # backtick-bearing value would break out of the quoting and append
+    # arbitrary SQL. Allow dots/colons/hyphens in project ids (legacy
+    # domain-scoped projects); dataset ids are word characters only.
+    if not re.fullmatch(r"[a-z0-9.:-]+", self.project, re.IGNORECASE):
+      raise ValueError(f"invalid GCP project id {self.project!r}")
+    if not re.fullmatch(r"\w+", self.dataset, re.ASCII):
+      raise ValueError(f"invalid BigQuery dataset id {self.dataset!r}")
 
   @property
   def qualified(self) -> str:

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -426,6 +426,24 @@ def test_verify_rejects_plain_http_for_remote_hosts(monkeypatch, capsys):
   assert "https" in capsys.readouterr().err.lower()
 
 
+def test_verify_rejects_mixed_case_http_scheme(monkeypatch, capsys):
+  # URL schemes are case-insensitive: HTTP:// must not bypass the guard.
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "HTTP://receiver.example.com",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+      ]
+  )
+  assert rc == 2
+  assert "https" in capsys.readouterr().err.lower()
+
+
 def test_verify_allows_http_for_localhost(monkeypatch):
   from bigquery_agent_analytics_tracing.otlp import verify
 

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -393,3 +393,114 @@ def test_verify_token_falls_back_to_env(monkeypatch):
   )
   assert rc == 0
   assert seen["token"] == "env-tok"
+
+
+# --------------------------------------------------------------------------
+# verify hardening (#332 full review)
+# --------------------------------------------------------------------------
+
+
+def test_verify_missing_token_exits_two(monkeypatch, capsys):
+  monkeypatch.delenv("BQAA_OTLP_TOKEN", raising=False)
+  rc = _run(
+      ["verify", "--endpoint", "https://r", "--project", "p", "--dataset", "d"]
+  )
+  assert rc == 2
+  assert "token" in capsys.readouterr().err.lower()
+
+
+def test_verify_rejects_plain_http_for_remote_hosts(monkeypatch, capsys):
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "http://receiver.example.com",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+      ]
+  )
+  assert rc == 2
+  assert "https" in capsys.readouterr().err.lower()
+
+
+def test_verify_allows_http_for_localhost(monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  monkeypatch.setattr(verify, "run_verify", lambda *a, **k: _fake_results())
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "http://127.0.0.1:9999",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+      ]
+  )
+  assert rc == 0
+
+
+def test_verify_invalid_signals_exit_two(monkeypatch, capsys):
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "https://r",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+          "--signals",
+          "logs,metrics,trace",
+      ]
+  )
+  assert rc == 2
+  assert "signal" in capsys.readouterr().err.lower()
+
+
+def test_verify_plumbs_settings_and_timeout(monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  seen = {}
+
+  def record_verify(settings, **kw):
+    seen["settings"] = settings
+    return _fake_results()
+
+  def record_smoke(settings, **kw):
+    seen["timeout_s"] = kw.get("timeout_s")
+    return _fake_results()
+
+  monkeypatch.setattr(verify, "run_verify", record_verify)
+  monkeypatch.setattr(verify, "run_smoke", record_smoke)
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "https://r",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+          "--signals",
+          "logs,metrics,traces",
+          "--recent-hours",
+          "6",
+          "--timeout",
+          "9",
+          "--smoke",
+      ]
+  )
+  assert rc == 0
+  assert seen["settings"].signals == ("logs", "metrics", "traces")
+  assert seen["settings"].recent_hours == 6
+  assert seen["timeout_s"] == 9

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -522,3 +522,20 @@ def test_verify_plumbs_settings_and_timeout(monkeypatch):
   assert seen["settings"].signals == ("logs", "metrics", "traces")
   assert seen["settings"].recent_hours == 6
   assert seen["timeout_s"] == 9
+
+
+def test_verify_rejects_schemeless_endpoint(monkeypatch, capsys):
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "receiver.example.com",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+      ]
+  )
+  assert rc == 2
+  assert "http" in capsys.readouterr().err.lower()

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -539,3 +539,12 @@ def test_verify_rejects_schemeless_endpoint(monkeypatch, capsys):
   )
   assert rc == 2
   assert "http" in capsys.readouterr().err.lower()
+
+
+def test_verify_malformed_ipv6_endpoint_exits_cleanly(monkeypatch, capsys):
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
+  rc = _run(
+      ["verify", "--endpoint", "http://[::1", "--project", "p", "--dataset", "d"]
+  )
+  assert rc == 2
+  assert "endpoint" in capsys.readouterr().err.lower()

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -544,7 +544,15 @@ def test_verify_rejects_schemeless_endpoint(monkeypatch, capsys):
 def test_verify_malformed_ipv6_endpoint_exits_cleanly(monkeypatch, capsys):
   monkeypatch.setenv("BQAA_OTLP_TOKEN", "tok")
   rc = _run(
-      ["verify", "--endpoint", "http://[::1", "--project", "p", "--dataset", "d"]
+      [
+          "verify",
+          "--endpoint",
+          "http://[::1",
+          "--project",
+          "p",
+          "--dataset",
+          "d",
+      ]
   )
   assert rc == 2
   assert "endpoint" in capsys.readouterr().err.lower()

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -278,3 +278,118 @@ def test_bootstrap_rejects_bogus_source(capsys):
   rc = _run(["bootstrap", "--project", "p", "--source", "cursor"])
   assert rc == 2
   assert "source" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# verify subcommand (PR3)
+# --------------------------------------------------------------------------
+
+
+def _fake_results(*, fail=False, warn=False):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  results = [verify.CheckResult("endpoint reachable", True, "200")]
+  if warn:
+    results.append(
+        verify.CheckResult("recent rows in otel_logs", False, "0", True)
+    )
+  if fail:
+    results.append(verify.CheckResult("tables and views exist", False, "gone"))
+  return results
+
+
+def test_verify_green_exits_zero(capsys, monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  monkeypatch.setattr(
+      verify, "run_verify", lambda *a, **k: _fake_results(warn=True)
+  )
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "https://r",
+          "--token",
+          "tok",
+          "--project",
+          "p",
+          "--dataset",
+          "ds",
+      ]
+  )
+  assert rc == 0
+  out = capsys.readouterr().out
+  assert "OK" in out and "WARN" in out
+
+
+def test_verify_failure_exits_nonzero(capsys, monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  monkeypatch.setattr(
+      verify, "run_verify", lambda *a, **k: _fake_results(fail=True)
+  )
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "https://r",
+          "--token",
+          "tok",
+          "--project",
+          "p",
+          "--dataset",
+          "ds",
+      ]
+  )
+  assert rc == 1
+  assert "FAIL" in capsys.readouterr().out
+
+
+def test_verify_smoke_flag_also_runs_smoke(monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  called = {}
+  monkeypatch.setattr(verify, "run_verify", lambda *a, **k: _fake_results())
+  monkeypatch.setattr(
+      verify,
+      "run_smoke",
+      lambda *a, **k: called.setdefault("smoke", True) and _fake_results(),
+  )
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  rc = _run(
+      [
+          "verify",
+          "--endpoint",
+          "https://r",
+          "--token",
+          "tok",
+          "--project",
+          "p",
+          "--dataset",
+          "ds",
+          "--smoke",
+      ]
+  )
+  assert rc == 0
+  assert called.get("smoke")
+
+
+def test_verify_token_falls_back_to_env(monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import verify
+
+  seen = {}
+
+  def _record(settings, **kw):
+    seen["token"] = settings.token
+    return _fake_results()
+
+  monkeypatch.setattr(verify, "run_verify", _record)
+  monkeypatch.setattr(verify, "make_query_rows", lambda project: lambda q: [])
+  monkeypatch.setenv("BQAA_OTLP_TOKEN", "env-tok")
+  rc = _run(
+      ["verify", "--endpoint", "https://r", "--project", "p", "--dataset", "ds"]
+  )
+  assert rc == 0
+  assert seen["token"] == "env-tok"

--- a/producers/tests/test_otlp_e2e.py
+++ b/producers/tests/test_otlp_e2e.py
@@ -36,6 +36,7 @@ import uuid
 import pytest
 
 from bigquery_agent_analytics_tracing.otlp import sql as otel_sql
+from bigquery_agent_analytics_tracing.otlp import verify as otel_verify
 
 ENDPOINT = os.environ.get("BQAA_OTLP_ENDPOINT")
 TOKEN = os.environ.get("BQAA_OTLP_TOKEN")
@@ -83,71 +84,12 @@ def _wait_count(query: str, timeout=150) -> int:
 def test_logs_and_metrics_land_and_project():
   run_id = uuid.uuid4().hex
 
-  logs = {
-      "resourceLogs": [
-          {
-              "resource": {
-                  "attributes": [
-                      {
-                          "key": "service.name",
-                          "value": {"stringValue": "claude-code"},
-                      },
-                  ]
-              },
-              "scopeLogs": [
-                  {
-                      "scope": {"name": "e2e"},
-                      "logRecords": [
-                          {
-                              "timeUnixNano": str(int(time.time() * 1e9)),
-                              "body": {"stringValue": "e2e"},
-                              "eventName": "claude_code.user_prompt",
-                              "attributes": [
-                                  {
-                                      "key": "bqaa.run_id",
-                                      "value": {"stringValue": run_id},
-                                  },
-                                  {
-                                      "key": "session.id",
-                                      "value": {"stringValue": run_id},
-                                  },
-                              ],
-                          }
-                      ],
-                  }
-              ],
-          }
-      ]
-  }
+  # Payload builders are shared with `bqaa-otel verify --smoke` (#324 PR3)
+  # so the CLI smoke and this live e2e exercise the identical shapes.
+  now_nanos = int(time.time() * 1e9)
+  logs = otel_verify.synthetic_logs_payload(run_id, now_nanos)
   metric_name = f"bqaa_e2e_{run_id}"
-  metrics = {
-      "resourceMetrics": [
-          {
-              "resource": {"attributes": []},
-              "scopeMetrics": [
-                  {
-                      "scope": {"name": "e2e"},
-                      "metrics": [
-                          {
-                              "name": metric_name,
-                              "unit": "1",
-                              "gauge": {
-                                  "dataPoints": [
-                                      {
-                                          "asDouble": 1.0,
-                                          "timeUnixNano": str(
-                                              int(time.time() * 1e9)
-                                          ),
-                                      }
-                                  ]
-                              },
-                          }
-                      ],
-                  }
-              ],
-          }
-      ]
-  }
+  metrics = otel_verify.synthetic_gauge_payload(run_id, now_nanos)
   assert _post("/v1/logs", logs).status_code == 200
   assert _post("/v1/metrics", metrics).status_code == 200
 

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -54,28 +54,38 @@ _ALL_TABLES = [
 class FakeHttp:
   """(status, body) per (path, authed?); records posts."""
 
-  def __init__(self, unauthed_status=401, authed_status=200):
+  def __init__(
+      self,
+      unauthed_status=401,
+      authed_status=200,
+      authed_body='{"published": 1, "dead_lettered": 0}',
+  ):
     self.unauthed_status = unauthed_status
     self.authed_status = authed_status
+    self.authed_body = authed_body
     self.posts = []  # (url, body, headers)
 
   def __call__(self, url, body, headers):
     self.posts.append((url, body, headers))
     if "Authorization" in headers:
-      return self.authed_status, "{}"
+      return self.authed_status, self.authed_body
     return self.unauthed_status, "unauthorized"
 
 
 class FakeBQ:
   """Answers queries by substring; records them."""
 
-  def __init__(self, tables=None, counts=None):
+  def __init__(self, tables=None, counts=None, raising=()):
     self.tables = _ALL_TABLES if tables is None else tables
     self.counts = counts or {}
+    self.raising = tuple(raising)  # substrings whose queries raise
     self.queries = []
 
   def __call__(self, query):
     self.queries.append(query)
+    for needle in self.raising:
+      if needle in query:
+        raise RuntimeError(f"boom: {needle}")
     if "INFORMATION_SCHEMA.TABLES" in query:
       return list(self.tables)
     for needle, value in self.counts.items():
@@ -188,7 +198,7 @@ def test_smoke_sends_logs_and_metrics_and_verifies_projection():
   original = bq.__call__
 
   def with_projection(query):
-    if "agent_events_otlp" in query and "event_type" in query:
+    if query.lstrip().startswith("SELECT") and "agent_events_otlp" in query:
       bq.queries.append(query)
       return [("claude_code.user_prompt",)]
     return original(query)
@@ -248,3 +258,226 @@ def test_synthetic_payload_builders_shape():
   metric = metrics["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
   assert metric["name"] == "bqaa_e2e_runid123"
   assert json.dumps(logs) and json.dumps(metrics)  # JSON-serializable
+
+
+# --------------------------------------------------------------------------
+# #332 full-review hardening
+# --------------------------------------------------------------------------
+
+
+def test_verify_freshness_uses_each_tables_real_timestamp_column():
+  # bqaa_metrics is a VIEW without ingest_time (it projects time_timestamp),
+  # and otlp_dead_letter keys on received_at — querying ingest_time on either
+  # crashes verify against every healthy deployment.
+  bq = FakeBQ(counts={"otel_logs": 1, "bqaa_metrics": 1})
+  verify.run_verify(
+      verify.VerifySettings(**_SETTINGS), http_post=FakeHttp(), query_rows=bq
+  )
+  logs_q = [q for q in bq.queries if ".otel_logs`" in q][0]
+  assert "ingest_time" in logs_q
+  metrics_q = [q for q in bq.queries if ".bqaa_metrics`" in q][0]
+  assert "time_timestamp" in metrics_q
+  assert "ingest_time" not in metrics_q
+  dlq_q = [q for q in bq.queries if ".otlp_dead_letter`" in q][0]
+  assert "received_at" in dlq_q
+  assert "ingest_time" not in dlq_q
+
+
+def test_verify_flags_unreachable_endpoint_as_failure():
+  # status 0 is the "transport failed" convention from default_http_post.
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=lambda url, body, headers: (0, "connection refused"),
+      query_rows=FakeBQ(),
+  )
+  assert any(
+      "reachable" in r.name or "auth" in r.name for r in _failures(results)
+  )
+
+
+def test_verify_flags_authed_non_200_as_failure():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(authed_status=503),
+      query_rows=FakeBQ(),
+  )
+  assert any("reachable" in r.name for r in _failures(results))
+
+
+def test_verify_survives_missing_dataset_instead_of_crashing():
+  # A missing dataset (NotFound on INFORMATION_SCHEMA) is exactly what the
+  # existence check should REPORT, not crash on.
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(raising=("INFORMATION_SCHEMA",)),
+  )
+  bad = [r for r in results if "exist" in r.name]
+  assert bad and not bad[0].ok and "boom" in bad[0].detail
+
+
+def test_verify_survives_failing_count_query():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(raising=(".otel_logs`",)),
+  )
+  recent = [r for r in results if "otel_logs" in r.name]
+  assert recent and not recent[0].ok and "boom" in recent[0].detail
+
+
+def test_verify_skips_counts_for_missing_tables():
+  bq = FakeBQ(tables=[])
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS), http_post=FakeHttp(), query_rows=bq
+  )
+  assert not any("recent" in r.name or "dead" in r.name for r in results)
+  assert not any("COUNT(*)" in q for q in bq.queries)
+
+
+def test_verify_settings_reject_invalid_signal_tier():
+  import pytest
+
+  with pytest.raises(ValueError, match="signal"):
+    verify.VerifySettings(**_SETTINGS, signals=("logs", "metrics", "trace"))
+  with pytest.raises(ValueError, match="signal"):
+    verify.VerifySettings(**_SETTINGS, signals=("logs",))
+
+
+def test_smoke_send_failure_short_circuits_bigquery():
+  bq = FakeBQ()
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(authed_status=500),
+      query_rows=bq,
+      sleep=lambda _: None,
+  )
+  assert _failures(results)
+  assert bq.queries == []
+
+
+def test_smoke_detects_its_own_record_being_dead_lettered():
+  # The receiver returns 200 with dead_lettered>0 for per-record decode
+  # failures; accepting that would burn the whole polling budget before
+  # failing with no diagnostic.
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(authed_body='{"published": 0, "dead_lettered": 1}'),
+      query_rows=FakeBQ(),
+      sleep=lambda _: None,
+      timeout_s=0,
+  )
+  send = [r for r in results if "send" in r.name]
+  assert send and all(not r.ok for r in send)
+  assert any("dead" in r.detail for r in send)
+
+
+def test_smoke_projection_mismatch_is_a_failure():
+  counts = {"otel_logs": 1, "otel_metric_gauge": 1, "bqaa_metrics": 1}
+
+  def wrong_event(query):
+    if query.lstrip().startswith("SELECT") and "agent_events_otlp" in query:
+      return [("other.event",)]
+    return FakeBQ(counts=counts)(query)
+
+  def no_row(query):
+    if query.lstrip().startswith("SELECT") and "agent_events_otlp" in query:
+      return []
+    return FakeBQ(counts=counts)(query)
+
+  for query_rows in (wrong_event, no_row):
+    results = verify.run_smoke(
+        verify.VerifySettings(**_SETTINGS),
+        http_post=FakeHttp(),
+        query_rows=query_rows,
+        sleep=lambda _: None,
+    )
+    projected = [r for r in results if "projected" in r.name]
+    assert projected and not projected[0].ok and not projected[0].warning
+
+
+def test_smoke_retries_until_rows_land():
+  calls = {"n": 0}
+  sleeps = []
+
+  def eventually(query):
+    if "COUNT(*)" in query and ".otel_logs`" in query:
+      calls["n"] += 1
+      return [(1 if calls["n"] >= 2 else 0,)]
+    return FakeBQ(counts={"otel_metric_gauge": 1, "bqaa_metrics": 1})(query)
+
+  def fake_projection(query):
+    if query.lstrip().startswith("SELECT") and "agent_events_otlp" in query:
+      return [("claude_code.user_prompt",)]
+    return eventually(query)
+
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=fake_projection,
+      sleep=sleeps.append,
+      timeout_s=60,
+  )
+  assert not _failures(results)
+  assert calls["n"] == 2
+  assert sleeps and sleeps[0] == 5
+
+
+def test_smoke_survives_failing_merge_or_projection_query():
+  counts = {"otel_logs": 1, "otel_metric_gauge": 1, "bqaa_metrics": 1}
+
+  def merge_boom(query):
+    if query.lstrip().startswith("MERGE"):
+      raise RuntimeError("concurrent update")
+    return FakeBQ(counts=counts)(query)
+
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=merge_boom,
+      sleep=lambda _: None,
+  )
+  projected = [r for r in results if "projected" in r.name]
+  assert projected and not projected[0].ok
+  assert "concurrent update" in projected[0].detail
+
+
+def test_default_http_post_reports_unreachable_as_status_zero():
+  status, detail = verify.default_http_post(
+      "http://127.0.0.1:1/v1/logs", b"{}", {}
+  )
+  assert status == 0
+  assert detail
+
+
+def test_default_http_post_does_not_follow_redirects():
+  # A redirect would resend the Authorization header to another host and
+  # convert the POST to a GET that dead-letters on the receiver; redirects
+  # must surface as a status, never be followed.
+  assert hasattr(verify, "_NO_REDIRECT_OPENER")
+  handler = verify._NoRedirect()
+  assert (
+      handler.redirect_request(None, None, 303, "See Other", {}, "https://x")
+      is None
+  )
+
+
+def test_make_query_rows_converts_rows_to_tuples(monkeypatch):
+  class FakeJob:
+
+    def result(self):
+      return [[1, "a"], [2, "b"]]
+
+  class FakeClient:
+
+    def __init__(self, project):
+      assert project == "my-proj"
+
+    def query(self, query):
+      return FakeJob()
+
+  import google.cloud.bigquery as bigquery
+
+  monkeypatch.setattr(bigquery, "Client", FakeClient)
+  rows = verify.make_query_rows("my-proj")("SELECT 1")
+  assert rows == [(1, "a"), (2, "b")]

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``bqaa-otel verify`` / smoke (#324 PR3).
+
+``run_verify`` is read-only (reachability, auth enforcement, table/view
+existence, recent rows, DLQ health). ``run_smoke`` additionally injects
+synthetic OTLP logs+metrics and follows them through the native tables and
+the ``agent_events_otlp`` projection — the same path the live e2e test
+drives, via shared payload builders.
+"""
+
+import json
+
+from bigquery_agent_analytics_tracing.otlp import verify
+
+_SETTINGS = dict(
+    endpoint="https://recv.example.run.app",
+    token="tok",
+    project="my-proj",
+    dataset="ds",
+)
+
+_ALL_TABLES = [
+    ("otel_logs",),
+    ("otel_metric_sum",),
+    ("otel_metric_gauge",),
+    ("otel_metric_histogram",),
+    ("otel_metric_exponential_histogram",),
+    ("otel_metric_summary",),
+    ("otlp_dead_letter",),
+    ("agent_events_otlp",),
+    ("otel_logs_dedup",),
+    ("otel_metric_sum_dedup",),
+    ("otel_metric_gauge_dedup",),
+    ("otel_metric_histogram_dedup",),
+    ("otel_metric_exponential_histogram_dedup",),
+    ("otel_metric_summary_dedup",),
+    ("bqaa_metrics",),
+]
+
+
+class FakeHttp:
+  """(status, body) per (path, authed?); records posts."""
+
+  def __init__(self, unauthed_status=401, authed_status=200):
+    self.unauthed_status = unauthed_status
+    self.authed_status = authed_status
+    self.posts = []  # (url, body, headers)
+
+  def __call__(self, url, body, headers):
+    self.posts.append((url, body, headers))
+    if "Authorization" in headers:
+      return self.authed_status, "{}"
+    return self.unauthed_status, "unauthorized"
+
+
+class FakeBQ:
+  """Answers queries by substring; records them."""
+
+  def __init__(self, tables=None, counts=None):
+    self.tables = _ALL_TABLES if tables is None else tables
+    self.counts = counts or {}
+    self.queries = []
+
+  def __call__(self, query):
+    self.queries.append(query)
+    if "INFORMATION_SCHEMA.TABLES" in query:
+      return list(self.tables)
+    for needle, value in self.counts.items():
+      if needle in query:
+        return [(value,)]
+    return [(0,)]
+
+
+def _failures(results):
+  return [r for r in results if not r.ok and not r.warning]
+
+
+# --------------------------------------------------------------------------
+# verify (read-only)
+# --------------------------------------------------------------------------
+
+
+def test_verify_all_green():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(counts={"otel_logs": 5}),
+  )
+  assert results and not _failures(results)
+
+
+def test_verify_flags_unreachable_or_open_endpoint():
+  # 200 without auth means the receiver is not enforcing the bearer token.
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(unauthed_status=200),
+      query_rows=FakeBQ(),
+  )
+  assert any("auth" in r.name for r in _failures(results))
+
+
+def test_verify_flags_missing_tables():
+  tables = [t for t in _ALL_TABLES if t != ("agent_events_otlp",)]
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(tables=tables),
+  )
+  bad = _failures(results)
+  assert any("agent_events_otlp" in r.detail for r in bad)
+
+
+def test_verify_does_not_require_otel_spans_unless_traces():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(),  # no otel_spans in _ALL_TABLES
+  )
+  assert not any("otel_spans" in r.detail for r in _failures(results))
+  traces = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS, signals=("logs", "metrics", "traces")),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(),
+  )
+  assert any("otel_spans" in r.detail for r in _failures(traces))
+
+
+def test_verify_zero_recent_rows_is_warning_not_failure():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(counts={}),  # all counts 0
+  )
+  recent = [r for r in results if "recent" in r.name]
+  assert recent and all(r.warning and not r.ok for r in recent)
+  assert not _failures(results)
+
+
+def test_verify_recent_dead_letters_is_warning():
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(counts={"otlp_dead_letter": 3, "otel_logs": 5}),
+  )
+  dlq = [r for r in results if "dead" in r.name]
+  assert dlq and dlq[0].warning and "3" in dlq[0].detail
+  assert not _failures(results)
+
+
+def test_verify_is_read_only():
+  bq = FakeBQ(counts={"otel_logs": 1})
+  http = FakeHttp()
+  verify.run_verify(
+      verify.VerifySettings(**_SETTINGS), http_post=http, query_rows=bq
+  )
+  assert not any("MERGE" in q or "INSERT" in q for q in bq.queries)
+  # Probe posts carry an empty logs request, never synthetic events.
+  assert not any(b"user_prompt" in body for _, body, _ in http.posts)
+
+
+# --------------------------------------------------------------------------
+# smoke (write path)
+# --------------------------------------------------------------------------
+
+
+def test_smoke_sends_logs_and_metrics_and_verifies_projection():
+  bq = FakeBQ(
+      counts={
+          "otel_logs": 1,
+          "otel_metric_gauge": 1,
+          "bqaa_metrics": 1,
+      }
+  )
+  # Distinguish the projection query: it selects event_type.
+  original = bq.__call__
+
+  def with_projection(query):
+    if "agent_events_otlp" in query and "event_type" in query:
+      bq.queries.append(query)
+      return [("claude_code.user_prompt",)]
+    return original(query)
+
+  http = FakeHttp()
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=http,
+      query_rows=with_projection,
+      sleep=lambda _: None,
+  )
+  assert not _failures(results)
+  paths = [url for url, _, _ in http.posts]
+  assert any(url.endswith("/v1/logs") for url in paths)
+  assert any(url.endswith("/v1/metrics") for url in paths)
+  # The scheduled MERGE is exercised so the projection is verified now.
+  assert any("MERGE" in q for q in bq.queries)
+
+
+def test_smoke_fails_when_rows_never_land():
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(counts={}),
+      sleep=lambda _: None,
+      timeout_s=0,
+  )
+  assert _failures(results)
+
+
+def test_smoke_traces_tier_reports_pending_span_landing():
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS, signals=("logs", "metrics", "traces")),
+      http_post=FakeHttp(),
+      query_rows=FakeBQ(
+          counts={"otel_logs": 1, "otel_metric_gauge": 1, "bqaa_metrics": 1}
+      ),
+      sleep=lambda _: None,
+  )
+  traces = [r for r in results if "traces" in r.name]
+  assert traces and traces[0].warning
+  assert "span" in traces[0].detail.lower()
+
+
+# --------------------------------------------------------------------------
+# shared payload builders (also used by the live e2e test)
+# --------------------------------------------------------------------------
+
+
+def test_synthetic_payload_builders_shape():
+  logs = verify.synthetic_logs_payload("runid123", now_nanos=42)
+  record = logs["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+  assert record["eventName"] == "claude_code.user_prompt"
+  attrs = {a["key"]: a["value"]["stringValue"] for a in record["attributes"]}
+  assert attrs["bqaa.run_id"] == "runid123"
+  metrics = verify.synthetic_gauge_payload("runid123", now_nanos=42)
+  metric = metrics["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+  assert metric["name"] == "bqaa_e2e_runid123"
+  assert json.dumps(logs) and json.dumps(metrics)  # JSON-serializable

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -536,3 +536,24 @@ def test_default_http_post_never_raises_on_malformed_url():
   )
   assert status == 0
   assert detail
+
+
+def test_verify_settings_reject_non_identifier_project_and_dataset():
+  # project/dataset are interpolated into backtick-quoted SQL identifiers;
+  # a backtick-bearing value breaks out of the quoting and appends SQL.
+  import pytest
+
+  bad = dict(_SETTINGS)
+  bad["dataset"] = "ds` WHERE 1=1; DROP TABLE x;--"
+  with pytest.raises(ValueError, match="dataset"):
+    verify.VerifySettings(**bad)
+  bad = dict(_SETTINGS)
+  bad["project"] = "p`.hax"
+  with pytest.raises(ValueError, match="project"):
+    verify.VerifySettings(**bad)
+  # Legitimate ids still pass: underscores, digits, hyphens/dots/colons
+  # (legacy domain-scoped projects).
+  ok = dict(_SETTINGS)
+  ok["project"] = "domain.com:my-proj-1"
+  ok["dataset"] = "agent_analytics_2"
+  assert verify.VerifySettings(**ok).qualified

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -481,3 +481,25 @@ def test_make_query_rows_converts_rows_to_tuples(monkeypatch):
   monkeypatch.setattr(bigquery, "Client", FakeClient)
   rows = verify.make_query_rows("my-proj")("SELECT 1")
   assert rows == [(1, "a"), (2, "b")]
+
+
+def test_smoke_survives_failing_landing_query():
+  # A missing table / permission error while polling for landed rows must
+  # become a failed check, not a traceback that also hides earlier results.
+  def landing_boom(query):
+    if "COUNT(*)" in query and ".otel_logs`" in query:
+      raise RuntimeError("permission denied")
+    return FakeBQ(counts={"otel_metric_gauge": 1, "bqaa_metrics": 1})(query)
+
+  results = verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=landing_boom,
+      sleep=lambda _: None,
+      timeout_s=0,
+  )
+  logs_check = [r for r in results if "otel_logs" in r.name]
+  assert logs_check and not logs_check[0].ok
+  assert "permission denied" in logs_check[0].detail
+  # The projection step must not run when a landing check failed.
+  assert not any("projected" in r.name for r in results)

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -503,3 +503,36 @@ def test_smoke_survives_failing_landing_query():
   assert "permission denied" in logs_check[0].detail
   # The projection step must not run when a landing check failed.
   assert not any("projected" in r.name for r in results)
+
+
+def test_make_query_rows_is_lazy_so_credential_errors_become_check_failures(
+    monkeypatch,
+):
+  # Missing ADC / client construction failure must surface through the
+  # guarded per-check calls ("query failed: ..."), not crash the CLI
+  # before the first check runs.
+  import google.cloud.bigquery as bigquery
+
+  def boom(project):
+    raise RuntimeError("Could not automatically determine credentials")
+
+  monkeypatch.setattr(bigquery, "Client", boom)
+  query_rows = verify.make_query_rows("p")  # must NOT raise here
+  results = verify.run_verify(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=FakeHttp(),
+      query_rows=query_rows,
+  )
+  exist = [r for r in results if "exist" in r.name]
+  assert exist and not exist[0].ok
+  assert "credentials" in exist[0].detail
+
+
+def test_default_http_post_never_raises_on_malformed_url():
+  # Docstring contract: (status, body), never raises — including a
+  # schemeless endpoint that makes urllib's Request constructor throw.
+  status, detail = verify.default_http_post(
+      "receiver.example.com/v1/logs", b"{}", {}
+  )
+  assert status == 0
+  assert detail


### PR DESCRIPTION
**Rebased on main** (#330, #331 merged); the diff is now this PR only.

Third increment of [#324](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/324): the `bqaa otel verify` acceptance criterion.

## verify (read-only)

```bash
BQAA_OTLP_TOKEN=<token> bqaa-otel verify --endpoint <url> --project <proj> --dataset <ds> [--smoke]
```

Checks: unauthenticated POST must get **401** (auth enforcement — a 200 fails the check as an open endpoint), authenticated empty POST must get 200 (reachability), all expected tables/views exist via `INFORMATION_SCHEMA.TABLES` (`otel_spans` only required when `--signals` includes traces), recent-row freshness, and dead-letter counts. Zero recent rows and recent dead letters are **warnings** — a fresh deployment passes. Exit 1 only on hard failures.

## --smoke (write path)

Sends synthetic OTLP logs + a gauge (payload builders **shared with `test_otlp_e2e.py`**, which now imports them — the CLI smoke and the live e2e exercise identical shapes), waits for rows in `otel_logs`/`otel_metric_gauge`/`bqaa_metrics`, then runs the scheduled MERGE once and asserts the event projects into `agent_events_otlp` as `claude_code.user_prompt`. The traces tier reports span landing as pending (PR4 of the stack).

## Design

I/O is injected (`http_post`, `query_rows`) so all checks are unit-testable without GCP; the CLI wires urllib + google-cloud-bigquery defaults lazily. `run_verify` is provably read-only (test asserts no MERGE/INSERT queries and no synthetic events posted).

## Testing

- 15 new unit tests across `test_otlp_verify.py` and `test_otlp_cli.py` (auth-not-enforced detection, missing-table detection, warning semantics, read-only guarantee, smoke landing/projection/timeout, traces gating, CLI exit codes, BQAA_OTLP_TOKEN fallback).
- Full producers suite: 255 passed, 3 skipped; pyink + isort clean.