### PR TITLE
feat(otlp): traces tier — span decode, otel_spans landing, traces smoke (#324 PR4)

### DIFF
--- a/deploy/otlp_receiver/README.md
+++ b/deploy/otlp_receiver/README.md
@@ -36,8 +36,9 @@ writes the ready-to-distribute Claude Code / Codex config artifacts
 `bqaa-otel config --help` for generating artifacts against an existing
 deployment).
 
-- **Endpoints:** `<url>/v1/logs`, `<url>/v1/metrics` (`/v1/traces` is gated —
-  set `ENABLE_SPANS=1` to wire it; span landing is deferred).
+- **Endpoints:** `<url>/v1/logs`, `<url>/v1/metrics`, and — when the
+  deployment's signal tier includes traces (`--signals logs,metrics,traces`
+  / `ENABLE_SPANS=1`) — `<url>/v1/traces`, landing spans in `otel_spans`.
 - **Auth:** bearer token — `Authorization: Bearer <token>`. The receiver rejects
   unauthenticated requests with `401`.
 - **Protocol:** OTLP/HTTP `http/protobuf` is the recommended enterprise default.

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
@@ -21,7 +21,8 @@ data point. A record that cannot be decoded becomes a dead-letter envelope
 (``parse_error`` populated) rather than aborting the batch, so one bad record
 never drops a whole request.
 
-Spans are intentionally out of scope for PR 2 (trace-gated; see the design doc).
+Spans (``ExportTraceServiceRequest``) joined in #324 PR 4; landing stays
+gated behind the traces signal tier (``BQAA_OTLP_ENABLE_TRACES``).
 """
 
 from __future__ import annotations
@@ -93,6 +94,63 @@ def decode_logs_request(
               env.dead_letter_envelope(
                   source_product=source_product,
                   source_signal="log",
+                  stage="otlp_decode",
+                  reason=repr(exc),
+                  raw_b64=raw_b64,
+                  received_at=ingest_time,
+                  source_position=position,
+                  raw_otlp_request_hash=raw_hash,
+              )
+          )
+  return envelopes
+
+
+def decode_traces_request(
+    request: dict[str, Any],
+    *,
+    source_product: str,
+    raw_request: bytes,
+    ingest_time: str,
+) -> list[dict[str, Any]]:
+  """Decode an ``ExportTraceServiceRequest`` into span envelopes.
+
+  Spans carry a natural idempotency key (``trace_id + span_id``); a span
+  missing that identity becomes a dead letter. ``raw_request`` is the
+  original wire payload (see ``decode_logs_request``).
+  """
+  raw_hash = env.request_hash(raw_request)
+  raw_b64 = base64.b64encode(raw_request).decode("ascii")
+  envelopes: list[dict[str, Any]] = []
+  for i, resource_spans in enumerate(request.get("resourceSpans", [])):
+    resource_attrs = env.otlp_attrs_to_dict(
+        resource_spans.get("resource", {}).get("attributes")
+    )
+    for j, scope_spans in enumerate(resource_spans.get("scopeSpans", [])):
+      scope = scope_spans.get("scope", {})
+      for k, span in enumerate(scope_spans.get("spans", [])):
+        position = env.SourcePosition(raw_hash, i, j, record_index=k)
+        try:
+          trace_id = span.get("traceId") or ""
+          span_id = span.get("spanId") or ""
+          if not trace_id or not span_id:
+            raise ValueError("span missing traceId/spanId identity")
+          envelopes.append(
+              env.make_envelope(
+                  source_product=source_product,
+                  source_signal="span",
+                  record=span,
+                  resource_attributes=resource_attrs,
+                  scope=scope,
+                  source_position=position,
+                  idempotency_key=env.span_idempotency_key(trace_id, span_id),
+                  ingest_time=ingest_time,
+              )
+          )
+        except Exception as exc:  # noqa: BLE001 - malformed -> dead letter
+          envelopes.append(
+              env.dead_letter_envelope(
+                  source_product=source_product,
+                  source_signal="span",
                   stage="otlp_decode",
                   reason=repr(exc),
                   raw_b64=raw_b64,

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/decode.py
@@ -28,6 +28,7 @@ gated behind the traces signal tier (``BQAA_OTLP_ENABLE_TRACES``).
 from __future__ import annotations
 
 import base64
+import binascii
 from typing import Any
 
 from bigquery_agent_analytics_tracing.otlp import envelope as env
@@ -105,6 +106,49 @@ def decode_logs_request(
   return envelopes
 
 
+def _canonical_hex_id(value: Any, nbytes: int) -> Any:
+  """Normalize a trace/span id to canonical lowercase hex.
+
+  OTLP/JSON carries ids as hex, but ``MessageToDict`` on the protobuf path
+  base64-encodes ``bytes`` fields — without normalization the same span
+  gets two different idempotency keys and the ``trace_id`` cluster column
+  mixes encodings across transports. Unrecognized shapes pass through
+  untouched (identity validation happens downstream).
+  """
+  if not value or not isinstance(value, str):
+    return value
+  if len(value) == nbytes * 2:
+    try:
+      bytes.fromhex(value)
+      return value.lower()
+    except ValueError:
+      pass
+  try:
+    raw = base64.b64decode(value, validate=True)
+    if len(raw) == nbytes:
+      return raw.hex()
+  except (ValueError, binascii.Error):
+    pass
+  return value
+
+
+def _normalize_span_ids(span: dict[str, Any]) -> dict[str, Any]:
+  span = dict(span)
+  for key, nbytes in (("traceId", 16), ("spanId", 8), ("parentSpanId", 8)):
+    if key in span:
+      span[key] = _canonical_hex_id(span[key], nbytes)
+  if span.get("links"):
+    span["links"] = [
+        {
+            **link,
+            "traceId": _canonical_hex_id(link.get("traceId"), 16),
+            "spanId": _canonical_hex_id(link.get("spanId"), 8),
+        }
+        for link in span["links"]
+    ]
+  return span
+
+
 def decode_traces_request(
     request: dict[str, Any],
     *,
@@ -114,9 +158,10 @@ def decode_traces_request(
 ) -> list[dict[str, Any]]:
   """Decode an ``ExportTraceServiceRequest`` into span envelopes.
 
-  Spans carry a natural idempotency key (``trace_id + span_id``); a span
-  missing that identity becomes a dead letter. ``raw_request`` is the
-  original wire payload (see ``decode_logs_request``).
+  Spans carry a natural idempotency key (``trace_id + span_id``, normalized
+  to canonical lowercase hex — see ``_canonical_hex_id``); a span missing
+  that identity becomes a dead letter. ``raw_request`` is the original wire
+  payload (see ``decode_logs_request``).
   """
   raw_hash = env.request_hash(raw_request)
   raw_b64 = base64.b64encode(raw_request).decode("ascii")
@@ -130,6 +175,7 @@ def decode_traces_request(
       for k, span in enumerate(scope_spans.get("spans", [])):
         position = env.SourcePosition(raw_hash, i, j, record_index=k)
         try:
+          span = _normalize_span_ids(span)
           trace_id = span.get("traceId") or ""
           span_id = span.get("spanId") or ""
           if not trace_id or not span_id:

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
@@ -208,7 +208,9 @@ def handle_export(
   except Exception as exc:  # noqa: BLE001 - malformed request -> dead letter
     dead_letter = env.dead_letter_envelope(
         source_product=config.source_product,
-        source_signal=signal,
+        # Success envelopes and per-span dead letters use "span"; the
+        # whole-request path must match or DLQ triage filters miss one side.
+        source_signal="span" if signal == "trace" else signal,
         stage="otlp_decode",
         reason=repr(exc),
         raw_b64=base64.b64encode(body).decode("ascii"),

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/receiver.py
@@ -110,6 +110,8 @@ def _decode_protobuf(signal: str, body: bytes) -> dict[str, Any]:
       from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest as Request
     elif signal == "metric":
       from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest as Request
+    elif signal == "trace":
+      from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest as Request
     else:
       raise DecodeError(f"protobuf decode unsupported for signal {signal!r}")
   except ImportError as exc:
@@ -171,12 +173,10 @@ def handle_export(
   if not authenticate(auth_header, config.expected_token):
     return ReceiverResult(401, message="unauthenticated")
 
-  if signal == "trace":
-    if not config.enable_traces:
-      return ReceiverResult(404, message="traces not enabled")
-    # Receiver wiring exists behind the flag, but span landing is deferred to
-    # the trace work (design doc); accept-but-not-implemented.
-    return ReceiverResult(501, message="trace landing not implemented")
+  # The traces signal tier gates the whole path (issue #324); the consumer
+  # additionally drops span envelopes unless its own flag is set.
+  if signal == "trace" and not config.enable_traces:
+    return ReceiverResult(404, message="traces not enabled")
 
   # Decode the body AND walk its structure under one guard: any malformed
   # request — bad bytes (DecodeError) or valid JSON with the wrong OTLP shape
@@ -186,6 +186,13 @@ def handle_export(
     request = decode_body(signal, content_type, body)
     if signal == "log":
       envelopes = decode.decode_logs_request(
+          request,
+          source_product=config.source_product,
+          raw_request=body,
+          ingest_time=ingest_time,
+      )
+    elif signal == "trace":
+      envelopes = decode.decode_traces_request(
           request,
           source_product=config.source_product,
           raw_request=body,

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -358,6 +358,48 @@ def _send_counts(body: str) -> tuple[int, int]:
     return -1, 0
 
 
+def synthetic_span_payload(run_id: str, now_nanos: int) -> dict:
+  """One OTLP/JSON span tagged with ``bqaa.run_id`` (traces signal tier)."""
+  return {
+      "resourceSpans": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      },
+                  ]
+              },
+              "scopeSpans": [
+                  {
+                      "scope": {"name": "bqaa-smoke"},
+                      "spans": [
+                          {
+                              # Spans key on trace_id+span_id; derive both
+                              # from the run id so replays collapse.
+                              "traceId": run_id.ljust(32, "0")[:32],
+                              "spanId": run_id.ljust(16, "0")[:16],
+                              "name": "bqaa_smoke_span",
+                              "kind": "SPAN_KIND_INTERNAL",
+                              "startTimeUnixNano": str(now_nanos),
+                              "endTimeUnixNano": str(now_nanos),
+                              "status": {"code": "STATUS_CODE_OK"},
+                              "attributes": [
+                                  {
+                                      "key": "bqaa.run_id",
+                                      "value": {"stringValue": run_id},
+                                  },
+                              ],
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+
+
 def run_smoke(
     settings: VerifySettings,
     *,
@@ -376,10 +418,13 @@ def run_smoke(
   }
   base = settings.endpoint.rstrip("/")
 
-  for path, payload in (
+  sends = [
       ("/v1/logs", synthetic_logs_payload(run_id, now_nanos)),
       ("/v1/metrics", synthetic_gauge_payload(run_id, now_nanos)),
-  ):
+  ]
+  if "traces" in settings.signals:
+    sends.append(("/v1/traces", synthetic_span_payload(run_id, now_nanos)))
+  for path, payload in sends:
     status, body = http_post(
         base + path, json.dumps(payload).encode("utf-8"), headers
     )
@@ -413,7 +458,7 @@ def run_smoke(
       sleep(_POLL_INTERVAL_S)
 
   run_filter = f"JSON_VALUE(log_attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
-  checks = (
+  checks = [
       (
           "smoke row in otel_logs",
           f"SELECT COUNT(*) FROM `{settings.qualified}.otel_logs`"
@@ -429,7 +474,15 @@ def run_smoke(
           f"SELECT COUNT(*) FROM `{settings.qualified}.bqaa_metrics`"
           f" WHERE metric_name = 'bqaa_e2e_{run_id}'",
       ),
-  )
+  ]
+  if "traces" in settings.signals:
+    checks.append(
+        (
+            "smoke span in otel_spans",
+            f"SELECT COUNT(*) FROM `{settings.qualified}.otel_spans` WHERE"
+            f" JSON_VALUE(span_attributes, '$.\"bqaa.run_id\"') = '{run_id}'",
+        )
+    )
   landed = True
   for name, query in checks:
     # A missing table / permission error while polling must become a failed
@@ -482,18 +535,6 @@ def run_smoke(
         )
     )
 
-  if "traces" in settings.signals:
-    results.append(
-        CheckResult(
-            name="traces smoke",
-            ok=False,
-            warning=True,
-            detail=(
-                "span landing is not implemented yet (#324 traces tier,"
-                " final PR of the stack) — otel_spans receives no rows"
-            ),
-        )
-    )
   return results
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/verify.py
@@ -17,7 +17,8 @@
 ``run_verify`` is strictly read-only: endpoint reachability + bearer-token
 enforcement, table/view existence, recent-row freshness, and dead-letter
 health. ``run_smoke`` additionally exercises the write path with synthetic
-OTLP logs + metrics and follows them through the native tables, the dedup
+OTLP logs + metrics (and a span when the deployment's signal tier includes
+traces) and follows them through the native tables, the dedup
 views, and the ``agent_events_otlp`` projection (running the scheduled
 MERGE once, exactly as the live e2e test does — the payload builders here
 are shared with it).

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
@@ -15,8 +15,8 @@
 """Envelope v1 -> native BigQuery rows; append-only writer (issue #316, PR 4).
 
 Consumes the Pub/Sub envelope-v1 messages produced by the receiver (PR 3) and
-maps each to a row for its native table — ``otel_logs``, the five
-``otel_metric_*`` tables, or ``otlp_dead_letter`` (spans gated/deferred). The
+maps each to a row for its native table — ``otel_logs``, ``otel_spans``
+(traces signal tier), the five ``otel_metric_*`` tables, or ``otlp_dead_letter``. The
 row mapping is pure and table-routing is deterministic, so the whole thing is
 unit-testable with a fake writer; the real BigQuery client is lazy-imported.
 
@@ -88,6 +88,35 @@ def _int(value: Any) -> int | None:
 
 def _int_list(values: Any) -> list[int]:
   return [int(v) for v in (values or [])]
+
+
+def _str(value: Any) -> str | None:
+  return None if value is None else str(value)
+
+
+# OTLP/JSON encodes enums as ints while protobuf MessageToDict emits names;
+# both must land the same canonical STRING or filters silently miss rows.
+_SPAN_KIND_NAMES = {
+    0: "SPAN_KIND_UNSPECIFIED",
+    1: "SPAN_KIND_INTERNAL",
+    2: "SPAN_KIND_SERVER",
+    3: "SPAN_KIND_CLIENT",
+    4: "SPAN_KIND_PRODUCER",
+    5: "SPAN_KIND_CONSUMER",
+}
+_STATUS_CODE_NAMES = {
+    0: "STATUS_CODE_UNSET",
+    1: "STATUS_CODE_OK",
+    2: "STATUS_CODE_ERROR",
+}
+
+
+def _enum_name(value: Any, names: dict[int, str]) -> str | None:
+  if value is None:
+    return None
+  if isinstance(value, int) or (isinstance(value, str) and value.isdigit()):
+    return names.get(int(value), str(value))
+  return str(value)
 
 
 def _receiver_metadata_row(envelope: dict[str, Any]) -> dict[str, Any]:
@@ -166,11 +195,9 @@ def span_row(envelope: dict[str, Any]) -> dict[str, Any]:
       "parent_span_id": record.get("parentSpanId"),
       "trace_state": record.get("traceState"),
       "span_name": record.get("name"),
-      # kind/status.code arrive as enum names via protobuf MessageToDict but
-      # may be bare ints on the raw JSON path; the column is STRING either way.
-      "span_kind": _str(record.get("kind")),
+      "span_kind": _enum_name(record.get("kind"), _SPAN_KIND_NAMES),
       "service_name": resource.get("service.name"),
-      "status_code": _str(status.get("code")),
+      "status_code": _enum_name(status.get("code"), _STATUS_CODE_NAMES),
       "status_message": status.get("message"),
       "resource_attributes": _json(resource),
       "scope_name": scope.get("name"),
@@ -205,10 +232,6 @@ def span_row(envelope: dict[str, Any]) -> dict[str, Any]:
   }
   row.update(_receiver_metadata_row(envelope))
   return row
-
-
-def _str(value: Any) -> str | None:
-  return None if value is None else str(value)
 
 
 def _metric_common_row(envelope: dict[str, Any]) -> dict[str, Any]:
@@ -357,7 +380,7 @@ def append_envelope(
   """Map an envelope to a row and append it to the right native table.
 
   Returns the target table name. Span envelopes are dropped unless
-  ``enable_spans`` (landing is gated/deferred — design doc).
+  ``enable_spans`` (the traces signal tier, BQAA_OTLP_ENABLE_TRACES).
   """
   if envelope["source"]["signal"] == "span" and not enable_spans:
     return ""  # span landing deferred

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
@@ -150,6 +150,67 @@ def log_row(envelope: dict[str, Any]) -> dict[str, Any]:
   return row
 
 
+def span_row(envelope: dict[str, Any]) -> dict[str, Any]:
+  record = envelope["record"]
+  resource = envelope["otlp"]["resource_attributes"]
+  scope = envelope["otlp"].get("scope") or {}
+  status = record.get("status") or {}
+  row = {
+      "timestamp": (
+          _nanos_to_iso(record.get("startTimeUnixNano"))
+          or envelope["ingest_time"]
+      ),
+      "end_timestamp": _nanos_to_iso(record.get("endTimeUnixNano")),
+      "trace_id": record.get("traceId"),
+      "span_id": record.get("spanId"),
+      "parent_span_id": record.get("parentSpanId"),
+      "trace_state": record.get("traceState"),
+      "span_name": record.get("name"),
+      # kind/status.code arrive as enum names via protobuf MessageToDict but
+      # may be bare ints on the raw JSON path; the column is STRING either way.
+      "span_kind": _str(record.get("kind")),
+      "service_name": resource.get("service.name"),
+      "status_code": _str(status.get("code")),
+      "status_message": status.get("message"),
+      "resource_attributes": _json(resource),
+      "scope_name": scope.get("name"),
+      "scope_version": scope.get("version"),
+      "scope_attributes": _json(
+          env.otlp_attrs_to_dict(scope.get("attributes"))
+      ),
+      "span_attributes": _json(
+          env.otlp_attrs_to_dict(record.get("attributes"))
+      ),
+      "events": [
+          {
+              "timestamp": _nanos_to_iso(event.get("timeUnixNano")),
+              "name": event.get("name"),
+              "attributes": _json(
+                  env.otlp_attrs_to_dict(event.get("attributes"))
+              ),
+          }
+          for event in record.get("events", []) or []
+      ],
+      "links": [
+          {
+              "trace_id": link.get("traceId"),
+              "span_id": link.get("spanId"),
+              "trace_state": link.get("traceState"),
+              "attributes": _json(
+                  env.otlp_attrs_to_dict(link.get("attributes"))
+              ),
+          }
+          for link in record.get("links", []) or []
+      ],
+  }
+  row.update(_receiver_metadata_row(envelope))
+  return row
+
+
+def _str(value: Any) -> str | None:
+  return None if value is None else str(value)
+
+
 def _metric_common_row(envelope: dict[str, Any]) -> dict[str, Any]:
   record = envelope["record"]
   point = record["point"]
@@ -268,6 +329,8 @@ def target_table(envelope: dict[str, Any]) -> str:
     if kind not in _METRIC_TABLE:
       raise TableWriteError(f"unknown metric point_kind {kind!r}")
     return _METRIC_TABLE[kind]
+  if signal == "span":
+    return "otel_spans"
   raise TableWriteError(f"no native table for signal {signal!r}")
 
 
@@ -280,6 +343,8 @@ def envelope_to_row(envelope: dict[str, Any]) -> dict[str, Any]:
     return log_row(envelope)
   if signal == "metric":
     return metric_row(envelope)
+  if signal == "span":
+    return span_row(envelope)
   raise TableWriteError(f"no row mapping for signal {signal!r}")
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
@@ -383,7 +383,7 @@ def append_envelope(
   ``enable_spans`` (the traces signal tier, BQAA_OTLP_ENABLE_TRACES).
   """
   if envelope["source"]["signal"] == "span" and not enable_spans:
-    return ""  # span landing deferred
+    return ""  # traces tier disabled on this consumer
   table = target_table(envelope)
   writer.append(table, envelope_to_row(envelope))
   return table

--- a/producers/tests/test_otlp_decode.py
+++ b/producers/tests/test_otlp_decode.py
@@ -452,3 +452,45 @@ def test_two_spans_get_distinct_keys_and_positions():
       envelopes[0]["source_position"]["record_index"]
       != envelopes[1]["source_position"]["record_index"]
   )
+
+
+def test_protobuf_base64_ids_normalize_to_canonical_hex():
+  # MessageToDict base64-encodes bytes fields, while OTLP/JSON carries hex:
+  # without normalization the same span gets two different idempotency keys
+  # and the trace_id cluster column mixes encodings across transports.
+  import base64
+
+  trace_hex = "0123456789abcdef0123456789abcdef"
+  span_hex = "0123456789abcdef"
+  parent_hex = "fedcba9876543210"
+  b64 = lambda h: base64.b64encode(bytes.fromhex(h)).decode("ascii")
+  span = _span(
+      traceId=b64(trace_hex),
+      spanId=b64(span_hex),
+      parentSpanId=b64(parent_hex),
+      links=[
+          {
+              "traceId": b64(trace_hex),
+              "spanId": b64(parent_hex),
+          }
+      ],
+  )
+  [envelope] = _decode_traces(_traces_request([span]))
+  record = envelope["record"]
+  assert record["traceId"] == trace_hex
+  assert record["spanId"] == span_hex
+  assert record["parentSpanId"] == parent_hex
+  assert record["links"][0]["traceId"] == trace_hex
+  assert record["links"][0]["spanId"] == parent_hex
+  assert envelope["idempotency_key"] == trace_hex + span_hex
+
+
+def test_hex_ids_are_lowercased_for_stable_keys():
+  span = _span(
+      traceId="0123456789ABCDEF0123456789ABCDEF", spanId="0123456789ABCDEF"
+  )
+  [envelope] = _decode_traces(_traces_request([span]))
+  assert envelope["record"]["traceId"] == "0123456789abcdef0123456789abcdef"
+  assert envelope["idempotency_key"] == (
+      "0123456789abcdef0123456789abcdef" + "0123456789abcdef"
+  )

--- a/producers/tests/test_otlp_decode.py
+++ b/producers/tests/test_otlp_decode.py
@@ -364,3 +364,91 @@ def test_span_idempotency_key_is_natural():
 def test_request_hash_is_deterministic_sha256():
   assert env.request_hash(b"abc") == env.request_hash(b"abc")
   assert len(env.request_hash(b"abc")) == 64
+
+
+# --------------------------------------------------------------------------
+# Traces (#324 PR4 — span landing)
+# --------------------------------------------------------------------------
+
+
+def _decode_traces(request, ingest_time=INGEST):
+  return decode.decode_traces_request(
+      request,
+      source_product="claude_code",
+      raw_request=_raw(request),
+      ingest_time=ingest_time,
+  )
+
+
+def _traces_request(spans):
+  return {
+      "resourceSpans": [
+          {
+              "resource": {
+                  "attributes": [
+                      {
+                          "key": "service.name",
+                          "value": {"stringValue": "claude-code"},
+                      }
+                  ]
+              },
+              "scopeSpans": [
+                  {"scope": {"name": "s", "version": "1"}, "spans": spans}
+              ],
+          }
+      ]
+  }
+
+
+def _span(**overrides):
+  span = {
+      "traceId": "0123456789abcdef0123456789abcdef",
+      "spanId": "0123456789abcdef",
+      "name": "tool_use",
+      "kind": "SPAN_KIND_INTERNAL",
+      "startTimeUnixNano": "1000000000",
+      "endTimeUnixNano": "2000000000",
+      "status": {"code": "STATUS_CODE_OK"},
+      "attributes": [{"key": "tool.name", "value": {"stringValue": "Bash"}}],
+  }
+  span.update(overrides)
+  return span
+
+
+def test_decode_one_span_into_one_envelope():
+  envelopes = _decode_traces(_traces_request([_span()]))
+  assert len(envelopes) == 1
+  e = envelopes[0]
+  assert e["source"]["signal"] == "span"
+  assert e["parse_error"] is None
+  assert e["record"]["name"] == "tool_use"
+  assert e["otlp"]["resource_attributes"]["service.name"] == "claude-code"
+  # Spans have a natural idempotency key: trace_id + span_id.
+  assert e["idempotency_key"] == env.span_idempotency_key(
+      "0123456789abcdef0123456789abcdef", "0123456789abcdef"
+  )
+
+
+def test_span_key_is_replay_invariant():
+  request = _traces_request([_span()])
+  a = _decode_traces(request, ingest_time="2026-06-29T00:00:00Z")[0]
+  b = _decode_traces(request, ingest_time="2026-06-30T09:09:09Z")[0]
+  assert a["idempotency_key"] == b["idempotency_key"]
+
+
+def test_span_missing_identity_becomes_dead_letter():
+  envelopes = _decode_traces(_traces_request([_span(spanId="")]))
+  assert len(envelopes) == 1
+  assert envelopes[0]["delivery"]["dlq"] is True
+  assert envelopes[0]["parse_error"]["stage"] == "otlp_decode"
+
+
+def test_two_spans_get_distinct_keys_and_positions():
+  spans = [_span(), _span(spanId="fedcba9876543210")]
+  envelopes = _decode_traces(_traces_request(spans))
+  assert len(envelopes) == 2
+  assert envelopes[0]["idempotency_key"] != envelopes[1]["idempotency_key"]
+  assert (
+      envelopes[0]["source_position"]["record_index"]
+      != envelopes[1]["source_position"]["record_index"]
+  )

--- a/producers/tests/test_otlp_e2e.py
+++ b/producers/tests/test_otlp_e2e.py
@@ -198,3 +198,32 @@ def test_malformed_request_lands_in_dead_letter_with_replayable_body():
       return  # replayable original payload present
     time.sleep(5)
   pytest.fail("malformed request did not reach otlp_dead_letter with raw_b64")
+
+
+TRACES_ENABLED = os.environ.get("BQAA_OTLP_ENABLE_TRACES") == "1"
+
+
+@pytest.mark.skipif(
+    not TRACES_ENABLED,
+    reason="traces e2e needs a deployment with BQAA_OTLP_ENABLE_TRACES=1",
+)
+def test_spans_land_in_otel_spans():
+  # Traces signal tier (#324 PR4): synthetic span -> receiver -> otel_spans.
+  run_id = uuid.uuid4().hex
+  payload = otel_verify.synthetic_span_payload(run_id, int(time.time() * 1e9))
+  assert _post("/v1/traces", payload).status_code == 200
+  assert (
+      _wait_count(
+          f"SELECT COUNT(*) FROM `{_QUALIFIED}.otel_spans` WHERE"
+          f" JSON_VALUE(span_attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
+      )
+      >= 1
+  )
+  # Read-time dedup view surfaces it too.
+  assert (
+      _rows(
+          f"SELECT COUNT(*) FROM `{_QUALIFIED}.otel_spans_dedup` WHERE"
+          f" JSON_VALUE(span_attributes, '$.\"bqaa.run_id\"') = '{run_id}'"
+      )[0][0]
+      >= 1
+  )

--- a/producers/tests/test_otlp_receiver.py
+++ b/producers/tests/test_otlp_receiver.py
@@ -214,15 +214,41 @@ def test_traces_path_is_404_when_disabled():
   assert pub.calls == []
 
 
-def test_traces_path_is_501_when_enabled_landing_deferred():
-  result, pub = _call("/v1/traces", b"{}", config=_config(enable_traces=True))
-  assert result.status == 501
-  assert pub.calls == []
+def test_traces_path_decodes_and_publishes_spans_when_enabled():
+  request = {
+      "resourceSpans": [
+          {
+              "resource": {"attributes": []},
+              "scopeSpans": [
+                  {
+                      "scope": {"name": "s", "version": "1"},
+                      "spans": [
+                          {
+                              "traceId": "0123456789abcdef0123456789abcdef",
+                              "spanId": "0123456789abcdef",
+                              "name": "tool_use",
+                              "startTimeUnixNano": "1000000000",
+                          }
+                      ],
+                  }
+              ],
+          }
+      ]
+  }
+  result, pub = _call(
+      "/v1/traces",
+      json.dumps(request).encode("utf-8"),
+      config=_config(enable_traces=True),
+  )
+  assert result.status == 200
+  [envelope] = pub.to("proj/main")
+  assert envelope["source"]["signal"] == "span"
+  assert envelope["record"]["name"] == "tool_use"
 
 
 def test_traces_requires_auth_before_revealing_gate_state():
   # Unauthenticated callers must get 401 on /v1/traces regardless of the gate,
-  # so 404-vs-501 never leaks to them.
+  # so 404-vs-200 never leaks to them.
   for enabled in (False, True):
     result, pub = _call(
         "/v1/traces",

--- a/producers/tests/test_otlp_receiver.py
+++ b/producers/tests/test_otlp_receiver.py
@@ -341,3 +341,66 @@ def test_wsgi_unauthenticated_is_401():
       application, "/v1/logs", _logs_body(), auth="Bearer nope"
   )
   assert status.startswith("401")
+
+
+def test_trace_whole_request_dead_letter_uses_span_signal():
+  # Per-span dead letters and success envelopes use source_signal="span";
+  # the whole-request path must match or DLQ triage filters miss one side.
+  result, pub = _call(
+      "/v1/traces", b"not otlp", config=_config(enable_traces=True)
+  )
+  assert result.status == 400
+  [dl] = pub.to("proj/main")
+  assert dl["source"]["signal"] == "span"
+
+
+def test_empty_resource_spans_is_200_published_zero():
+  result, pub = _call(
+      "/v1/traces",
+      json.dumps({"resourceSpans": []}).encode("utf-8"),
+      config=_config(enable_traces=True),
+  )
+  assert result.status == 200
+  assert result.published == 0
+  assert pub.calls == []
+
+
+def test_protobuf_trace_export_decodes_and_normalizes_ids():
+  trace_service_pb2 = pytest.importorskip(
+      "opentelemetry.proto.collector.trace.v1.trace_service_pb2"
+  )
+  from opentelemetry.proto.trace.v1 import trace_pb2
+
+  trace_hex = "0123456789abcdef0123456789abcdef"
+  span_hex = "0123456789abcdef"
+  request = trace_service_pb2.ExportTraceServiceRequest(
+      resource_spans=[
+          trace_pb2.ResourceSpans(
+              scope_spans=[
+                  trace_pb2.ScopeSpans(
+                      spans=[
+                          trace_pb2.Span(
+                              trace_id=bytes.fromhex(trace_hex),
+                              span_id=bytes.fromhex(span_hex),
+                              name="tool_use",
+                              kind=trace_pb2.Span.SPAN_KIND_INTERNAL,
+                              start_time_unix_nano=1_000_000_000,
+                          )
+                      ]
+                  )
+              ]
+          )
+      ]
+  )
+  result, pub = _call(
+      "/v1/traces",
+      request.SerializeToString(),
+      content_type="application/x-protobuf",
+      config=_config(enable_traces=True),
+  )
+  assert result.status == 200
+  [envelope] = pub.to("proj/main")
+  # base64 bytes from MessageToDict must be normalized to canonical hex.
+  assert envelope["record"]["traceId"] == trace_hex
+  assert envelope["record"]["spanId"] == span_hex
+  assert envelope["idempotency_key"] == trace_hex + span_hex

--- a/producers/tests/test_otlp_verify.py
+++ b/producers/tests/test_otlp_verify.py
@@ -229,18 +229,46 @@ def test_smoke_fails_when_rows_never_land():
   assert _failures(results)
 
 
-def test_smoke_traces_tier_reports_pending_span_landing():
+def test_smoke_traces_tier_sends_spans_and_verifies_otel_spans():
+  http = FakeHttp()
   results = verify.run_smoke(
       verify.VerifySettings(**_SETTINGS, signals=("logs", "metrics", "traces")),
-      http_post=FakeHttp(),
+      http_post=http,
+      query_rows=FakeBQ(
+          counts={
+              "otel_logs": 1,
+              "otel_metric_gauge": 1,
+              "bqaa_metrics": 1,
+              "otel_spans": 1,
+          }
+      ),
+      sleep=lambda _: None,
+  )
+  assert any(url.endswith("/v1/traces") for url, _, _ in http.posts)
+  spans = [r for r in results if "otel_spans" in r.name]
+  assert spans and spans[0].ok and not spans[0].warning
+
+
+def test_smoke_default_tier_does_not_send_traces():
+  http = FakeHttp()
+  verify.run_smoke(
+      verify.VerifySettings(**_SETTINGS),
+      http_post=http,
       query_rows=FakeBQ(
           counts={"otel_logs": 1, "otel_metric_gauge": 1, "bqaa_metrics": 1}
       ),
       sleep=lambda _: None,
   )
-  traces = [r for r in results if "traces" in r.name]
-  assert traces and traces[0].warning
-  assert "span" in traces[0].detail.lower()
+  assert not any(url.endswith("/v1/traces") for url, _, _ in http.posts)
+
+
+def test_synthetic_span_payload_shape():
+  payload = verify.synthetic_span_payload("runid123", now_nanos=42)
+  span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+  assert span["name"] == "bqaa_smoke_span"
+  attrs = {a["key"]: a["value"]["stringValue"] for a in span["attributes"]}
+  assert attrs["bqaa.run_id"] == "runid123"
+  assert len(span["traceId"]) == 32 and len(span["spanId"]) == 16
 
 
 # --------------------------------------------------------------------------

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -496,3 +496,100 @@ def test_push_app_healthz_serves_port():
   )
   assert status.startswith("200")
   assert out == b"ok"
+
+
+# --------------------------------------------------------------------------
+# Spans (#324 PR4 — otel_spans landing)
+# --------------------------------------------------------------------------
+
+
+def _span_envelope():
+  return {
+      "envelope_version": "1",
+      "otel_schema_version": "1",
+      "idempotency_key": "0123456789abcdef0123456789abcdef0123456789abcdef",
+      "ingest_time": "2026-06-29T00:00:00Z",
+      "source": {"product": "claude_code", "signal": "span"},
+      "source_position": {
+          "raw_otlp_request_hash": "h",
+          "resource_index": 0,
+          "scope_index": 0,
+          "record_index": 0,
+          "metric_index": None,
+          "data_point_index": None,
+      },
+      "otlp": {
+          "resource_attributes": {"service.name": "claude-code"},
+          "scope": {"name": "s", "version": "1"},
+      },
+      "record": {
+          "traceId": "0123456789abcdef0123456789abcdef",
+          "spanId": "0123456789abcdef",
+          "parentSpanId": "aaaabbbbccccdddd",
+          "traceState": "k=v",
+          "name": "tool_use",
+          "kind": "SPAN_KIND_INTERNAL",
+          "startTimeUnixNano": "1000000000",
+          "endTimeUnixNano": "2000000000",
+          "status": {"code": "STATUS_CODE_OK", "message": "fine"},
+          "attributes": [
+              {"key": "tool.name", "value": {"stringValue": "Bash"}}
+          ],
+          "events": [
+              {
+                  "timeUnixNano": "1500000000",
+                  "name": "retry",
+                  "attributes": [{"key": "n", "value": {"intValue": "1"}}],
+              }
+          ],
+          "links": [
+              {
+                  "traceId": "ffff0000ffff0000ffff0000ffff0000",
+                  "spanId": "ffff0000ffff0000",
+                  "traceState": "",
+                  "attributes": [],
+              }
+          ],
+      },
+      "raw_preservation": {"policy": "decoded_only", "raw_b64": None},
+      "parse_error": None,
+      "delivery": {"attempt": 1, "dlq": False},
+  }
+
+
+def test_span_row_maps_the_otel_spans_schema():
+  row = writer.span_row(_span_envelope())
+  assert row["timestamp"] == "1970-01-01T00:00:01Z"
+  assert row["end_timestamp"] == "1970-01-01T00:00:02Z"
+  assert row["trace_id"] == "0123456789abcdef0123456789abcdef"
+  assert row["span_id"] == "0123456789abcdef"
+  assert row["parent_span_id"] == "aaaabbbbccccdddd"
+  assert row["trace_state"] == "k=v"
+  assert row["span_name"] == "tool_use"
+  assert row["span_kind"] == "SPAN_KIND_INTERNAL"
+  assert row["service_name"] == "claude-code"
+  assert row["status_code"] == "STATUS_CODE_OK"
+  assert row["status_message"] == "fine"
+  assert json.loads(row["span_attributes"]) == {"tool.name": "Bash"}
+  assert row["events"][0]["name"] == "retry"
+  assert row["events"][0]["timestamp"] == "1970-01-01T00:00:01.500000Z"
+  assert row["links"][0]["trace_id"] == "ffff0000ffff0000ffff0000ffff0000"
+  assert row["scope_name"] == "s"
+  # Receiver metadata rides along like every native table.
+  assert row["source_signal"] == "span"
+  assert row["idempotency_key"]
+
+
+def test_span_envelope_lands_in_otel_spans_when_enabled():
+  w = FakeWriter()
+  assert writer.append_envelope(_span_envelope(), w, enable_spans=True) == (
+      "otel_spans"
+  )
+  assert w.rows[0][0] == "otel_spans"
+
+
+def test_span_defaults_missing_start_time_to_ingest_time():
+  envelope = _span_envelope()
+  del envelope["record"]["startTimeUnixNano"]
+  row = writer.span_row(envelope)
+  assert row["timestamp"] == "2026-06-29T00:00:00Z"

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -593,3 +593,35 @@ def test_span_defaults_missing_start_time_to_ingest_time():
   del envelope["record"]["startTimeUnixNano"]
   row = writer.span_row(envelope)
   assert row["timestamp"] == "2026-06-29T00:00:00Z"
+
+
+def test_span_kind_and_status_ints_normalize_to_enum_names():
+  # OTLP/JSON encodes enums as ints; protobuf MessageToDict emits names.
+  # Both must land the same canonical STRING or filters silently miss rows.
+  envelope = _span_envelope()
+  envelope["record"]["kind"] = 2
+  envelope["record"]["status"] = {"code": 1}
+  row = writer.span_row(envelope)
+  assert row["span_kind"] == "SPAN_KIND_SERVER"
+  assert row["status_code"] == "STATUS_CODE_OK"
+  envelope["record"]["kind"] = 99  # unknown: passthrough, never crash
+  assert writer.span_row(envelope)["span_kind"] == "99"
+
+
+def test_minimal_span_row_defaults():
+  envelope = _span_envelope()
+  for key in ("kind", "status", "endTimeUnixNano", "events", "links"):
+    envelope["record"].pop(key, None)
+  envelope["otlp"]["scope"] = None
+  row = writer.span_row(envelope)
+  assert row["span_kind"] is None
+  assert row["status_code"] is None
+  assert row["end_timestamp"] is None
+  assert row["events"] == [] and row["links"] == []
+  assert row["scope_name"] is None
+
+
+def test_span_envelope_dropped_without_traces_tier():
+  w = FakeWriter()
+  assert writer.append_envelope(_span_envelope(), w) == ""
+  assert w.rows == []


### PR DESCRIPTION
**Rebased on main** (#330, #331, #332 merged); the diff is now this PR only. The traces smoke inherits all of #332's verify hardening (guarded queries, dead-letter-aware sends, shared timeout budget).

Final increment of [#324](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/324): the `logs,metrics,traces` signal tier becomes real end to end. Before this PR the receiver only opened the `/v1/traces` route (accept-but-501) — there was no span decode, no row mapping, and `target_table` raised for span envelopes.

## What this adds

- **decode**: `decode_traces_request` — `ExportTraceServiceRequest` → span envelopes with the natural `trace_id+span_id` idempotency key (replay-invariant by construction). A span missing that identity dead-letters individually, same per-record semantics as logs/metrics.
- **receiver**: `/v1/traces` decodes and publishes span envelopes when the tier is enabled; the protobuf path wires `ExportTraceServiceRequest`. Auth-before-gate and 404-when-disabled behavior unchanged (tests kept).
- **writer**: `span_row` maps the full `otel_spans` schema — start/end timestamps, identity (trace/span/parent), `span_name`/`span_kind`, `service_name`, status, resource/scope/span attributes as JSON, repeated `events`/`links`, receiver metadata. The consumer-side `enable_spans` gate still drops spans when the tier is off.
- **verify**: `bqaa-otel verify --smoke` on a traces-tier deployment now sends a synthetic span and verifies `otel_spans` rows — replacing PR3's pending warning. `synthetic_span_payload` joins the shared builders.
- **e2e**: skip-guarded live traces test (`BQAA_OTLP_ENABLE_TRACES=1`) covering `otel_spans` and its dedup view.

With this, every #324 acceptance criterion that was gated on span landing is implementable: the traces smoke test exists at both the CLI (`verify --smoke`) and pytest e2e levels.

## Testing

- TDD throughout: 13 new/updated unit tests across decode (identity key, replay invariance, dead-letter, positions), writer (schema mapping incl. events/links timestamps, gate), receiver (decode+publish when enabled), verify (span smoke sent + checked, default tier sends no traces).
- Full producers suite: 264 passed, 4 skipped; pyink + isort clean.
- Drove the full pipeline locally without cloud: receiver 200 → envelope → consumer writer lands `otel_spans` (correct name/service/timestamps/status/key); gated-off run drops the span and writes nothing.