### PR TITLE
fix(otlp): dataset write grant via GA access list — add-iam-policy-binding requires allowlisting

### DIFF
--- a/deploy/otlp_receiver/Dockerfile
+++ b/deploy/otlp_receiver/Dockerfile
@@ -21,8 +21,10 @@ RUN pip install --no-cache-dir "/src/producers[receiver]"
 ENV PORT=8080
 
 # Default role: OTLP receiver. Consumer role overrides CMD to:
-#   gunicorn --factory --bind :$PORT \
-#     bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env
-CMD exec gunicorn --factory --bind ":${PORT}" --workers 2 --threads 8 \
+#   gunicorn --bind :$PORT \
+#     'bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env()'
+# gunicorn calls factories via the 'module:callable()' syntax; '--factory'
+# is a uvicorn flag and makes the container exit 2 on startup.
+CMD exec gunicorn --bind ":${PORT}" --workers 2 --threads 8 \
     --access-logfile - \
-    bigquery_agent_analytics_tracing.otlp.app:make_app
+    'bigquery_agent_analytics_tracing.otlp.app:make_app()'

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/app.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/app.py
@@ -14,9 +14,10 @@
 
 """WSGI entrypoint for the OTLP receiver on Cloud Run (issue #316, PR 3).
 
-Deploy with gunicorn using the app factory::
+Deploy with gunicorn using the factory-call syntax (``--factory`` is a
+uvicorn flag; gunicorn calls factories via ``module:callable()``)::
 
-    gunicorn --factory bigquery_agent_analytics_tracing.otlp.app:make_app
+    gunicorn 'bigquery_agent_analytics_tracing.otlp.app:make_app()'
 
 Config comes from environment variables; the real Pub/Sub publisher is
 lazy-constructed (needs the ``receiver`` extra). The request logic lives in

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -563,8 +563,10 @@ def run_bootstrap(
           consumer_sa,
           "--command",
           "gunicorn",
-          "--args",
-          _CONSUMER_GUNICORN_ARGS,
+          # Single-token --args=... form: gcloud argparse treats a
+          # space-separated value that begins with '-' as another flag
+          # ("--args: expected one argument").
+          f"--args={_CONSUMER_GUNICORN_ARGS}",
           "--set-env-vars",
           f"BQAA_PROJECT={s.project},BQAA_DATASET={s.dataset},"
           f"BQAA_OTLP_ENABLE_TRACES={spans}",

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -436,7 +436,7 @@ def run_bootstrap(
           "roles/pubsub.publisher",
       ]
   )
-  # jobUser needs project scope (query jobs), but dataEditor is scoped to
+  # jobUser needs project scope (query jobs), but write access is scoped to
   # the target dataset: a project-wide grant would let a compromised
   # consumer SA modify every dataset in the project.
   runner.run(
@@ -451,16 +451,19 @@ def run_bootstrap(
           "roles/bigquery.jobUser",
       ]
   )
+  # Dataset-scoped write access via GA BigQuery DCL, piped over the same
+  # bq query stdin path the DDL uses. The obvious alternatives both fail
+  # live: `bq add-iam-policy-binding --dataset` needs an allowlisted
+  # preview API ("This feature requires allowlisting"), and `bq update
+  # --source /dev/stdin` rejects stdin ("Source path is not a file" — bq
+  # requires a regular file). GRANT is idempotent, so re-runs converge.
   runner.run(
-      [
-          "bq",
-          f"--project_id={s.project}",
-          "add-iam-policy-binding",
-          "--dataset",
-          f"--member=serviceAccount:{consumer_sa}",
-          "--role=roles/bigquery.dataEditor",
-          f"{s.project}:{s.dataset}",
-      ]
+      [*bq, "query", "--use_legacy_sql=false"],
+      input_text=(
+          "GRANT `roles/bigquery.dataEditor` ON SCHEMA"
+          f" `{s.project}.{s.dataset}`"
+          f' TO "serviceAccount:{consumer_sa}";'
+      ),
   )
   runner.run(
       [

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import pathlib
+import re
 import secrets as _secrets
 import shlex
 import subprocess
@@ -69,9 +70,12 @@ _APIS = (
     "iam.googleapis.com",
 )
 
+# gunicorn calls app factories via the 'module:callable()' syntax;
+# '--factory' is a uvicorn flag and makes the container exit 2 on startup
+# (hit live during the #324 e2e — first real Cloud Run deploy).
 _CONSUMER_GUNICORN_ARGS = (
-    "--factory,--bind,0.0.0.0:8080,--workers,2,--threads,8,"
-    "bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env"
+    "--bind,0.0.0.0:8080,--workers,2,--threads,8,"
+    "bigquery_agent_analytics_tracing.otlp.consumer:make_push_app_from_env()"
 )
 
 
@@ -187,6 +191,14 @@ class BootstrapSettings:
     # Reuse the PR 1 tier validation (privacy/signals/replay ack) so the
     # gate can't drift between `config` and `bootstrap`.
     self._spec("<pending-deploy>")
+    # Both feed backtick-quoted SQL identifiers (DDL, the DCL GRANT, the
+    # scheduled MERGE) run under admin credentials: a backtick-bearing
+    # value breaks out of the quoting and appends arbitrary SQL. Same
+    # validation as VerifySettings.
+    if not re.fullmatch(r"[a-z0-9.:-]+", self.project, re.IGNORECASE):
+      raise ValueError(f"invalid GCP project id {self.project!r}")
+    if not re.fullmatch(r"\w+", self.dataset, re.ASCII):
+      raise ValueError(f"invalid BigQuery dataset id {self.dataset!r}")
     if not self.sources:
       raise ValueError(
           "at least one telemetry source is required; expected one of"

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -161,9 +161,15 @@ def test_consumer_gunicorn_args_use_factory_call_syntax(tmp_path):
   # gunicorn >= 20.1 calls factories via the 'module:callable()' syntax.
   r = FakeRunner()
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
-  consumer = " ".join(r.find("run deploy", "consumer")[0][0])
+  argv = r.find("run deploy", "consumer")[0][0]
+  consumer = " ".join(argv)
   assert "--factory" not in consumer
-  assert "make_push_app_from_env()" in consumer
+  # gcloud argparse treats a space-separated --args value that begins with
+  # '-' as another flag ("--args: expected one argument"); it must be the
+  # single-token --args=... form.
+  [args_token] = [a for a in argv if a.startswith("--args")]
+  assert args_token.startswith("--args=--bind")
+  assert args_token.endswith("make_push_app_from_env()")
 
 
 def test_bootstrap_default_signals_keep_traces_off(tmp_path):

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -125,7 +125,12 @@ def test_bootstrap_runs_the_full_deploy_sequence(tmp_path):
 def test_bootstrap_creates_schema_from_ddl_module(tmp_path):
   r = FakeRunner()
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
-  [(argv, ddl_sql)] = r.find("bq", "query", "--use_legacy_sql=false")
+  ddl_calls = [
+      inp
+      for _, inp in r.find("bq", "query", "--use_legacy_sql=false")
+      if inp and "CREATE TABLE" in inp
+  ]
+  [ddl_sql] = ddl_calls
   assert "CREATE TABLE IF NOT EXISTS `agent_analytics.otel_logs`" in ddl_sql
   assert "otel_spans" not in ddl_sql  # spans gated off by default
 
@@ -137,7 +142,11 @@ def test_bootstrap_traces_signal_enables_spans_everywhere(tmp_path):
       r,
       echo=lambda *_: None,
   )
-  [(_, ddl_sql)] = r.find("bq", "query", "--use_legacy_sql=false")
+  [ddl_sql] = [
+      inp
+      for _, inp in r.find("bq", "query", "--use_legacy_sql=false")
+      if inp and "CREATE TABLE" in inp
+  ]
   assert "otel_spans" in ddl_sql
   receiver = " ".join(r.find("run deploy", "receiver")[0][0])
   consumer = " ".join(r.find("run deploy", "consumer")[0][0])
@@ -291,24 +300,31 @@ def test_bootstrap_creates_dlq_retention_subscription(tmp_path):
 
 
 def test_bootstrap_scopes_data_editor_to_the_dataset(tmp_path):
-  # jobUser needs project scope, but dataEditor must be dataset-scoped: a
+  # jobUser needs project scope, but write access must be dataset-scoped: a
   # project-wide grant lets a compromised consumer SA modify every dataset
-  # in the project.
+  # in the project. The GA mechanism is a WRITER entry in the dataset access
+  # list — `bq add-iam-policy-binding --dataset` requires allowlisting and
+  # fails on normal projects (hit live during the #324 e2e).
   r = FakeRunner()
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
   sa = "bqaa-otlp-consumer@my-proj.iam.gserviceaccount.com"
-  # No project-level dataEditor grant.
+  # No project-level dataEditor grant, no allowlisted preview API.
   assert not r.find("gcloud projects add-iam-policy-binding", "dataEditor")
+  assert not r.find("add-iam-policy-binding", "--dataset")
   # jobUser stays project-level.
   [(job_argv, _)] = r.find("gcloud projects add-iam-policy-binding", "jobUser")
   assert f"serviceAccount:{sa}" in " ".join(job_argv)
-  # dataEditor lands on the dataset via bq add-iam-policy-binding.
-  [(argv, _)] = r.find("add-iam-policy-binding", "dataEditor")
-  joined = " ".join(argv)
-  assert joined.startswith("bq ")
-  assert "--dataset" in argv
-  assert f"--member=serviceAccount:{sa}" in argv
-  assert "my-proj:agent_analytics" in argv
+  # dataEditor lands via GA BigQuery DCL (GRANT is idempotent), piped over
+  # the same bq query stdin path the DDL uses ('bq update --source
+  # /dev/stdin' fails too: bq requires a regular file, stdin is a pipe).
+  [grant_sql] = [
+      inp
+      for _, inp in r.find("bq", "query", "--use_legacy_sql=false")
+      if inp and inp.lstrip().startswith("GRANT")
+  ]
+  assert "`roles/bigquery.dataEditor`" in grant_sql
+  assert "ON SCHEMA `my-proj.agent_analytics`" in grant_sql
+  assert f'"serviceAccount:{sa}"' in grant_sql
 
 
 def test_bootstrap_dlq_subscription_failure_is_not_swallowed(tmp_path):

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -154,6 +154,18 @@ def test_bootstrap_traces_signal_enables_spans_everywhere(tmp_path):
   assert "BQAA_OTLP_ENABLE_TRACES=1" in consumer
 
 
+def test_consumer_gunicorn_args_use_factory_call_syntax(tmp_path):
+  # '--factory' is a uvicorn flag, not gunicorn: the consumer container
+  # exits 2 on startup with "unrecognized arguments: --factory" (hit live
+  # during the #324 e2e — first real Cloud Run deploy of this image).
+  # gunicorn >= 20.1 calls factories via the 'module:callable()' syntax.
+  r = FakeRunner()
+  bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
+  consumer = " ".join(r.find("run deploy", "consumer")[0][0])
+  assert "--factory" not in consumer
+  assert "make_push_app_from_env()" in consumer
+
+
 def test_bootstrap_default_signals_keep_traces_off(tmp_path):
   r = FakeRunner()
   bootstrap.run_bootstrap(_settings(tmp_path), r, echo=lambda *_: None)
@@ -359,6 +371,23 @@ def test_find_merge_config_survives_garbage_listing():
       )
       is None
   )
+
+
+def test_bootstrap_rejects_non_identifier_project_and_dataset(tmp_path):
+  # project/dataset feed backtick-quoted SQL identifiers (DDL, the DCL
+  # GRANT, the scheduled MERGE) run under admin credentials: a
+  # backtick-bearing value breaks out of the quoting and appends SQL.
+  import pytest
+
+  with pytest.raises(ValueError, match="dataset"):
+    _settings(tmp_path, dataset="ds` ; DROP TABLE x;--")
+  with pytest.raises(ValueError, match="project"):
+    _settings(tmp_path, project="p`.hax")
+  # Legitimate ids pass, incl. legacy domain-scoped projects.
+  ok = _settings(
+      tmp_path, project="domain.com:my-proj-1", dataset="agent_analytics_2"
+  )
+  assert ok.dataset == "agent_analytics_2"
 
 
 def test_bootstrap_rejects_unknown_or_empty_sources(tmp_path):


### PR DESCRIPTION
Found live during the #324 end-to-end admin flow (first real `bqaa-otel bootstrap --execute` against a fresh dataset), in **two rounds** — each surfaced with the exact failing command + bq's stderr by the #331 failure-visibility hardening:

1. `bq add-iam-policy-binding --dataset` (the #331 review approach) fails on normal projects: **"This feature requires allowlisting"** — the flag exists in bq 2.1.28's CLI but the backing dataset-IAM API is an allowlisted preview.
2. The dataset access-list patch via `bq update --source /dev/stdin` also fails: **"Source path is not a file: /dev/stdin"** — bq requires a regular file; subprocess stdin is a pipe.

**Fix**: GA BigQuery DCL, piped over the same `bq query` stdin path the DDL bundle already uses successfully:

```sql
GRANT `roles/bigquery.dataEditor` ON SCHEMA `project.dataset` TO "serviceAccount:<consumer-sa>";
```

GRANT is idempotent (re-runs converge), `jobUser` stays project-scoped, still no project-wide `dataEditor`.

TDD: the dataset-grant test asserts the GRANT statement (role, schema, service account) and that **neither** failing CLI surface is invoked; DDL-content tests disambiguate the two `bq query` calls by stdin content. Full producers suite: 302 passed; pyink/isort clean. The #324 e2e resumes from this fix and its live evidence will land on the issue.