### PR TITLE
fix(otlp): enum-name normalization for INTEGER columns + valid Codex TOML template

### DIFF
--- a/producers/src/bigquery_agent_analytics_tracing/otlp/config_artifacts.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/config_artifacts.py
@@ -134,20 +134,23 @@ def codex_config_toml(spec: BootstrapSpec) -> str:
         "# no supported raw request/response body path, so prompt capture",
         "# stays off.",
     ]
+  exporter = (
+      "{ otlp-http = { "
+      f'endpoint = "{spec.endpoint}/v1/logs", protocol = "binary", '
+      'headers = { "Authorization" = "Bearer ${BQAA_OTLP_TOKEN}" } } }'
+  )
   lines += [
       "[otel]",
       'environment = "prod"',
-      'exporter = "otlp-http"',
+      "# Inline-table exporter shape verified against real codex 0.142.5",
+      "# (#317 e2e); the string+section form is invalid TOML.",
+      f"exporter = {exporter}",
       '# PENDING #317: metrics_exporter/trace_exporter stay "none" until the',
-      "# version-specific Codex config shape is pinned and verified.",
+      "# version-pinned fixtures land (shapes verified live, same inline",
+      "# form with /v1/metrics and /v1/traces endpoints).",
       'metrics_exporter = "none"',
       'trace_exporter = "none"',
       "log_user_prompt = false",
-      "",
-      '[otel.exporter."otlp-http"]',
-      f'endpoint = "{spec.endpoint}/v1/logs"',
-      'protocol = "binary"',
-      'headers = { "Authorization" = "Bearer ${BQAA_OTLP_TOKEN}" }',
   ]
   return "\n".join(lines) + "\n"
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/writer.py
@@ -119,6 +119,38 @@ def _enum_name(value: Any, names: dict[int, str]) -> str | None:
   return str(value)
 
 
+# The reverse direction, for INTEGER columns: protobuf MessageToDict emits
+# enum NAMES ("SEVERITY_NUMBER_INFO", "AGGREGATION_TEMPORALITY_DELTA") where
+# OTLP/JSON carries ints. Found live in the #317 e2e: every real metric
+# export and every Codex log envelope dead-lettered on these two fields.
+_SEVERITY_NUMBER_VALUES = {"SEVERITY_NUMBER_UNSPECIFIED": 0} | {
+    f"SEVERITY_NUMBER_{level}{n if n > 1 else ''}": base + n - 1
+    for base, level in (
+        (1, "TRACE"),
+        (5, "DEBUG"),
+        (9, "INFO"),
+        (13, "WARN"),
+        (17, "ERROR"),
+        (21, "FATAL"),
+    )
+    for n in (1, 2, 3, 4)
+}
+_AGGREGATION_TEMPORALITY_VALUES = {
+    "AGGREGATION_TEMPORALITY_UNSPECIFIED": 0,
+    "AGGREGATION_TEMPORALITY_DELTA": 1,
+    "AGGREGATION_TEMPORALITY_CUMULATIVE": 2,
+}
+
+
+def _enum_int(value: Any, values: dict[str, int]) -> int | None:
+  """Int for an INTEGER column from either enum encoding; never raises."""
+  if value in (None, ""):
+    return None
+  if isinstance(value, int) or (isinstance(value, str) and value.isdigit()):
+    return int(value)
+  return values.get(str(value))
+
+
 def _receiver_metadata_row(envelope: dict[str, Any]) -> dict[str, Any]:
   return {
       "source_product": envelope["source"]["product"],
@@ -163,7 +195,9 @@ def log_row(envelope: dict[str, Any]) -> dict[str, Any]:
       "span_id": record.get("spanId"),
       "trace_flags": _int(record.get("flags")),
       "severity_text": record.get("severityText"),
-      "severity_number": _int(record.get("severityNumber")),
+      "severity_number": _enum_int(
+          record.get("severityNumber"), _SEVERITY_NUMBER_VALUES
+      ),
       "service_name": resource.get("service.name"),
       "body": _json(record.get("body")),
       "resource_attributes": _json(resource),
@@ -274,7 +308,9 @@ def metric_row(envelope: dict[str, Any]) -> dict[str, Any]:
   point = record["point"]
   kind = record["point_kind"]
   row = _metric_common_row(envelope)
-  temporality = record.get("aggregation_temporality")
+  temporality = _enum_int(
+      record.get("aggregation_temporality"), _AGGREGATION_TEMPORALITY_VALUES
+  )
   if kind in ("sum", "gauge"):
     row["value"] = _num(point)
     row["exemplars"] = _exemplars_rows(point)

--- a/producers/tests/test_otlp_config_artifacts.py
+++ b/producers/tests/test_otlp_config_artifacts.py
@@ -164,7 +164,10 @@ def test_codex_config_is_valid_toml_in_the_verified_shape():
   # The old template mixed 'exporter = "otlp-http"' (string) with an
   # [otel.exporter."otlp-http"] table — invalid TOML that never parsed.
   # The verified shape (real codex 0.142.5, #317 e2e) is the inline table.
-  import tomllib
+  try:
+    import tomllib
+  except ImportError:  # Python < 3.11 — the dev extra ships tomli
+    import tomli as tomllib
 
   toml = ca.codex_config_toml(_spec())
   parsed = tomllib.loads(toml)
@@ -183,7 +186,10 @@ def test_codex_config_is_valid_toml_in_the_verified_shape():
 def test_codex_metrics_stay_gated_pending_317():
   # Metrics stay off with a pointer at the gate even when metrics is a
   # selected signal — the config shape is verified per Codex version in #317.
-  import tomllib
+  try:
+    import tomllib
+  except ImportError:  # Python < 3.11 — the dev extra ships tomli
+    import tomli as tomllib
 
   toml = ca.codex_config_toml(_spec(signals=("logs", "metrics")))
   assert tomllib.loads(toml)["otel"]["metrics_exporter"] == "none"

--- a/producers/tests/test_otlp_config_artifacts.py
+++ b/producers/tests/test_otlp_config_artifacts.py
@@ -160,22 +160,33 @@ def test_claude_resource_attributes_rendered_as_kv_pairs():
 # --------------------------------------------------------------------------
 
 
-def test_codex_baseline_matches_issue_324_contract():
+def test_codex_config_is_valid_toml_in_the_verified_shape():
+  # The old template mixed 'exporter = "otlp-http"' (string) with an
+  # [otel.exporter."otlp-http"] table — invalid TOML that never parsed.
+  # The verified shape (real codex 0.142.5, #317 e2e) is the inline table.
+  import tomllib
+
   toml = ca.codex_config_toml(_spec())
-  assert 'exporter = "otlp-http"' in toml
-  assert 'metrics_exporter = "none"' in toml  # gated on #317
-  assert 'trace_exporter = "none"' in toml
-  assert "log_user_prompt = false" in toml
-  assert f'endpoint = "{_ENDPOINT}/v1/logs"' in toml
-  assert 'protocol = "binary"' in toml
-  assert '"Authorization" = "Bearer ${BQAA_OTLP_TOKEN}"' in toml
+  parsed = tomllib.loads(toml)
+  otel = parsed["otel"]
+  assert otel["exporter"]["otlp-http"]["endpoint"] == f"{_ENDPOINT}/v1/logs"
+  assert otel["exporter"]["otlp-http"]["protocol"] == "binary"
+  assert (
+      otel["exporter"]["otlp-http"]["headers"]["Authorization"]
+      == "Bearer ${BQAA_OTLP_TOKEN}"
+  )
+  assert otel["metrics_exporter"] == "none"  # gated on #317 fixtures PR
+  assert otel["trace_exporter"] == "none"
+  assert otel["log_user_prompt"] is False
 
 
 def test_codex_metrics_stay_gated_pending_317():
   # Metrics stay off with a pointer at the gate even when metrics is a
   # selected signal — the config shape is verified per Codex version in #317.
+  import tomllib
+
   toml = ca.codex_config_toml(_spec(signals=("logs", "metrics")))
-  assert 'metrics_exporter = "none"' in toml
+  assert tomllib.loads(toml)["otel"]["metrics_exporter"] == "none"
   assert "#317" in toml
 
 

--- a/producers/tests/test_otlp_writer.py
+++ b/producers/tests/test_otlp_writer.py
@@ -625,3 +625,42 @@ def test_span_envelope_dropped_without_traces_tier():
   w = FakeWriter()
   assert writer.append_envelope(_span_envelope(), w) == ""
   assert w.rows == []
+
+
+# --------------------------------------------------------------------------
+# Enum-name normalization (#317 live e2e: real protobuf exports DLQ'd)
+# --------------------------------------------------------------------------
+
+
+def test_log_severity_number_accepts_protobuf_enum_names():
+  # Codex sends severityNumber as the enum NAME ("SEVERITY_NUMBER_INFO");
+  # _int() crashed on it and every real Codex log envelope dead-lettered.
+  envelope = _log_envelope()
+  envelope["record"]["severityNumber"] = "SEVERITY_NUMBER_INFO"
+  assert writer.log_row(envelope)["severity_number"] == 9
+  envelope["record"]["severityNumber"] = "SEVERITY_NUMBER_ERROR"
+  assert writer.log_row(envelope)["severity_number"] == 17
+  envelope["record"]["severityNumber"] = 13  # int passthrough
+  assert writer.log_row(envelope)["severity_number"] == 13
+  envelope["record"]["severityNumber"] = "SEVERITY_NUMBER_SOMETHING_NEW"
+  assert writer.log_row(envelope)["severity_number"] is None  # never crash
+
+
+def test_metric_temporality_accepts_protobuf_enum_names():
+  # Real Claude Code metric exports carry aggregationTemporality as
+  # "AGGREGATION_TEMPORALITY_DELTA"; the column is INTEGER, so every real
+  # metric row failed the BigQuery insert and dead-lettered — synthetic
+  # test payloads used ints and masked it.
+  envelope = _metric_envelope("sum")
+  envelope["record"][
+      "aggregation_temporality"
+  ] = "AGGREGATION_TEMPORALITY_DELTA"
+  assert writer.metric_row(envelope)["aggregation_temporality"] == 1
+  envelope["record"][
+      "aggregation_temporality"
+  ] = "AGGREGATION_TEMPORALITY_CUMULATIVE"
+  assert writer.metric_row(envelope)["aggregation_temporality"] == 2
+  envelope["record"]["aggregation_temporality"] = 2  # int passthrough
+  assert writer.metric_row(envelope)["aggregation_temporality"] == 2
+  envelope["record"]["aggregation_temporality"] = None
+  assert writer.metric_row(envelope)["aggregation_temporality"] is None


### PR DESCRIPTION
Three bugs found live during #317 verification against the receiver deployed by the #324 e2e — all invisible to synthetic tests, all observable only because the DLQ retention subscription (#331 review) preserved the failing envelopes:

1. **Every real metric export has been silently dead-lettering.** Protobuf `MessageToDict` emits `aggregationTemporality` as the enum NAME (`"AGGREGATION_TEMPORALITY_DELTA"`) while the `aggregation_temporality` column is INTEGER — BigQuery rejects the insert ("Cannot convert value to integer"), the consumer 500s, and after 5 attempts the envelope lands in the transport DLQ. This explains the `bqaa_metrics: 0 rows` WARN in the #324 evidence: real Claude Code metrics were failing, not empty. Synthetic smoke payloads used ints and masked it.
2. **Every real Codex log envelope crashed the writer**: Codex 0.142.5 sends `severityNumber` as `"SEVERITY_NUMBER_INFO"` and `_int()` raised `ValueError`. Claude Code omits the field, so Claude logs always landed.
3. **The generated `codex.config.toml` has been invalid TOML since #330**: `exporter = "otlp-http"` (string) conflicts with the `[otel.exporter."otlp-http"]` table — `tomllib` fails with "Cannot overwrite a value", so no admin could ever have used the generated file. The substring-based test never parsed it. Rewritten in the **inline-table shape verified against real codex 0.142.5** (`exporter = { otlp-http = { endpoint, protocol, headers } }`); metrics/traces stay `"none"`-gated pending the #317 fixtures PR (their shapes are also verified live, same form).

## Fix

`_enum_int` — the reverse of #333's `_enum_name`, for INTEGER columns: int/digit passthrough, full `SEVERITY_NUMBER_*` (0–24) and `AGGREGATION_TEMPORALITY_*` name maps, unknown names → NULL instead of a crash. Applied to `log_row.severity_number` and metric-row temporality.

## Verification

- TDD: 4 new/updated tests watched fail first; full producers suite **323 passed**; pyink/isort clean.
- **Regression-proven against real production payloads**: the actual dead-lettered metric envelope now maps temporality → 1 and inserts cleanly into real BigQuery; all 19 captured real Codex log envelopes build rows (severity → 9) with `event.name` attributes intact for the crosswalk.
- Follow-up on the live deployment (after merge): redeploy consumer, replay the DLQ, and run the Codex e2e — evidence lands on #317.