### PR TITLE
docs+scripts(demo): hero-story runbook, SQL pack, live-validated scripts (#344 PR1+PR2)

### DIFF
--- a/demo/hero_story/OPERATOR.md
+++ b/demo/hero_story/OPERATOR.md
@@ -1,0 +1,100 @@
+# Operator track: fresh-project install
+
+The presenter track ([README.md](README.md)) assumes this has already been
+done once, rehearsed, and left standing. This file is the full path from an
+empty GCP project to demo-ready.
+
+## The clock, precisely
+
+**≤30 minutes total, of which Cloud Build is ~10,** measured from
+`preflight.sh` green to `verify --smoke` green. The clock **excludes** the
+prerequisites below — install/auth failures are preflight findings, not
+runbook time.
+
+## Prerequisites (outside the clock)
+
+| Requirement | Check | Notes |
+|---|---|---|
+| gcloud CLI, authenticated | `gcloud auth list` | Owner/Editor-equivalent on the target project |
+| bq CLI | `bq version` | Ships with gcloud SDK |
+| Billing enabled on project | `gcloud billing projects describe $PROJECT` | Cloud Build/Run refuse without it |
+| Org policy allows `allUsers` invoker on Cloud Run | org-policy check in preflight | The receiver is bearer-token-authenticated at the app layer but publicly routable |
+| BQAA producers package | `pip install "<repo>/producers[receiver]"` or `PYTHONPATH=producers/src` from a checkout | Provides `bqaa-otel` |
+| Claude Code CLI, authenticated | `claude --version` + an interactive login done once | Session hangs without auth |
+| Codex CLI ≥ 0.142.5, authenticated | `codex --version`; `~/.codex/auth.json` exists | Config shapes are version-pinned; see #317 |
+| Region choice | default `us-central1` | Cloud Run + Artifact Registry region; BigQuery location default `US` |
+
+Run `scripts/preflight.sh` — it verifies all of the above in under two
+minutes with actionable messages. **Do not start the clock until it is
+green.**
+
+## Install (inside the clock)
+
+```bash
+export PROJECT=<your-project> DATASET=bqaa_hero_demo_$(date +%Y%m%d)
+scripts/preflight.sh "$PROJECT" "$DATASET"
+
+# Plan first (prints every command, mutates nothing), then execute:
+bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" \
+  --signals logs,metrics,traces --source claude-code,codex \
+  --out demo/hero_story/evidence/artifacts
+bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" \
+  --signals logs,metrics,traces --source claude-code,codex \
+  --out demo/hero_story/evidence/artifacts --execute
+```
+
+Every step is idempotent/convergent: if a step fails, the error output shows
+the exact command and its stderr — fix the cause and re-run the same
+command; it resumes.
+
+Then install the generated artifacts:
+
+- **Claude Code**: paste `claude-code.managed-settings.json` into the Claude
+  admin console (Owner/Primary Owner; there is no admin API), or distribute
+  via MDM (`claude-code.endpoint-managed.md`). For a laptop-only demo, the
+  session script applies the same env vars directly.
+- **Codex**: fill the literal bearer token into `codex.config.toml`
+  (`gcloud secrets versions access latest --secret=bqaa-otlp-token`) and
+  install as user-level `~/.codex/config.toml` (the demo scripts use an
+  isolated `CODEX_HOME` instead of touching your real config). Codex does
+  **not** expand `${ENV}` references in config headers — the file holds the
+  literal secret; never commit it.
+
+## Timing expectations
+
+| Step | Time |
+|---|---|
+| preflight | < 2 min |
+| bootstrap: APIs, dataset+DDL, secret, SAs, topics, IAM | ~3 min |
+| bootstrap: Cloud Build image | ~8–10 min |
+| bootstrap: Cloud Run deploys, subscription, DTS, artifacts | ~2 min |
+| sessions + flush (`run_sessions.sh`) | ~4 min |
+| `verify --smoke` | ~1–2 min |
+
+## Troubleshooting (each of these happened in real runs)
+
+| Symptom | Cause / fix |
+|---|---|
+| A `bq`/`gcloud` step fails with its stderr shown | Fix the stated cause; re-run bootstrap (convergent) |
+| `verify --smoke` metric checks pass but product metric queries are empty | Metric counters flush on a cadence; the session script pins `OTEL_METRIC_EXPORT_INTERVAL` and waits — do not shorten the waits |
+| Codex session hangs | stdin must be closed (`< /dev/null`), use `--skip-git-repo-check` outside a repo, and ensure `auth.json` exists in `CODEX_HOME` |
+| Codex 401s at the receiver | The literal token was not filled into `config.toml` (env refs are not expanded) |
+| Rows stamped with the wrong product | The `x-bqaa-source-product` header is missing from that exporter's config |
+| Dead letters > 0 | Inspect `otlp_dead_letter.raw_b64` (replayable); the DLQ retention subscription keeps transport-level failures |
+
+## Teardown
+
+`scripts/teardown.sh` — dry-run by default, `--confirm` to delete; consumes
+the resource inventory written at bootstrap time
+(`evidence/demo_resources.json`) and removes only allowlisted demo
+resources, then verifies the DTS scheduled MERGE is gone and the dataset no
+longer exists. The dataset contains real telemetry: tear down promptly for
+throwaway projects.
+
+## Version capture
+
+`run_sessions.sh` records into `evidence/`: BQAA commit, `gcloud`/`bq`
+versions, `claude --version`, `codex --version`, project/dataset/region,
+signal + privacy tiers, and the `DEMO_RUN_ID`. Codex OTel behavior is
+version-sensitive (#317) — the evidence must say what it was recorded
+against.

--- a/demo/hero_story/README.md
+++ b/demo/hero_story/README.md
@@ -81,8 +81,9 @@ query next are real product telemetry.* Keep the two separate.
 ## Act 3 — The payoff (5 minutes)
 
 Run the SQL pack in order — each file opens with the leadership question it
-answers and every query filters on this run's `demo_run_id`, so the numbers
-on screen are from the sessions the audience just watched:
+answers. Logs/metrics/spans queries filter on this run's `demo_run_id`, so
+those numbers are from the sessions the audience just watched; dead-letter
+health rows (in `00`/`05`) are deliberately deployment-scoped:
 
 ```bash
 scripts/run_queries.sh $DEMO_RUN_ID   # writes results to evidence/

--- a/demo/hero_story/README.md
+++ b/demo/hero_story/README.md
@@ -1,0 +1,124 @@
+# Hero demo: Claude Code + Codex telemetry → BigQuery, in your own project
+
+## The demo contract
+
+| | |
+|---|---|
+| **Audience** | Platform admin running it + engineering director watching |
+| **Promise** | In one sitting: real Claude Code **and** Codex telemetry landing in one customer-owned BigQuery schema, with privacy controls demonstrated and a clean teardown |
+| **Success screen** | `bqaa-otel verify --smoke` all green **plus** one BigQuery result showing `source_product IN ('claude_code', 'codex')` across logs, metrics, and spans |
+| **Clock** | Presenter track: ~12 min against an existing deployment. Fresh install: ≤30 min ([OPERATOR.md](OPERATOR.md)) — Cloud Build accounts for ~10 of them |
+
+**The accurate one-liner:** one command deploys the collector and the
+warehouse surface into the customer's own GCP project; two generated
+artifacts then enable the sources (Claude Code managed settings, Codex
+`config.toml`). Telemetry never touches infrastructure the customer does not
+own.
+
+```
+Claude Code / Codex --OTLP--> Cloud Run receiver --> Pub/Sub --> consumer --> BigQuery
+        (developer laptops)          └────────── customer-owned GCP project ──────────┘
+```
+
+Presenter prerequisites: a deployment already bootstrapped by
+[OPERATOR.md](OPERATOR.md), `scripts/preflight.sh` green, and one rehearsal.
+Never present a first run.
+
+---
+
+## Act 1 — The problem (1 minute)
+
+> "We rolled out Claude Code and Codex to our engineers. Today we cannot
+> answer: who uses them, what they cost, which teams get value, or what the
+> agents actually did. Each vendor has a dashboard; we have no unified,
+> queryable record in **our** warehouse — and security wants proof about
+> what leaves developer machines."
+
+That is the whole setup. Do not oversell; the next ten minutes are the
+argument.
+
+## Act 2 — The magic moment (5 minutes)
+
+**Beat 1 — the pipeline exists because of one command.** Show (do not
+re-run) the command that built everything in this project:
+
+```bash
+bqaa-otel bootstrap --project $PROJECT --dataset $DATASET \
+  --signals logs,metrics,traces --source claude-code,codex --execute
+```
+
+Point at what it created: native OTel tables + dedup views + the BQAA
+projection, an authenticated Cloud Run receiver, Pub/Sub with a retained
+dead-letter queue, a scheduled projection MERGE — and the two config
+artifacts, generated against the real endpoint.
+
+**Beat 2 — privacy is a flag, not a promise.** Show the baseline artifact
+(no prompt text, no tool content), then run the refusal live:
+
+```bash
+bqaa-otel config --endpoint $URL --source claude-code --privacy replay
+# bqaa-otel: error: ... requires acknowledge_content_logging
+# (exit code 2 — content capture is impossible to enable by accident)
+```
+
+**Beat 3 — real sessions.** Run the scripted sessions (both products, fixed
+`demo_run_id`, deterministic prompts — see `scripts/run_sessions.sh`):
+
+```bash
+scripts/run_sessions.sh   # prints DEMO_RUN_ID=<id>; keep it for Act 3
+```
+
+While they flush (~1 min), run the pipeline proof:
+
+```bash
+BQAA_OTLP_TOKEN=... bqaa-otel verify --smoke --signals logs,metrics,traces \
+  --endpoint $URL --project $PROJECT --dataset $DATASET
+```
+
+Say explicitly: *the smoke rows prove the pipeline; the session rows we
+query next are real product telemetry.* Keep the two separate.
+
+## Act 3 — The payoff (5 minutes)
+
+Run the SQL pack in order — each file opens with the leadership question it
+answers and every query filters on this run's `demo_run_id`, so the numbers
+on screen are from the sessions the audience just watched:
+
+```bash
+scripts/run_queries.sh $DEMO_RUN_ID   # writes results to evidence/
+```
+
+| Query | The question on the slide |
+|---|---|
+| `sql/00_health_and_freshness.sql` | Is the pipeline healthy *right now*? |
+| `sql/01_adoption_by_product.sql` | Who is using Claude Code vs Codex? |
+| `sql/02_token_usage_and_estimated_cost_by_team.sql` | Where is usage going, and what does it roughly cost? *(tokens are measured; dollars are an estimate from the rates CTE)* |
+| `sql/03_event_mix_and_workflow.sql` | What are the agents actually doing? |
+| `sql/04_latency_from_spans.sql` | How fast — p50/p95 from real spans, per product |
+| `sql/05_governance_privacy_dlq.sql` | Is privacy holding and is ingestion clean? *(searches for the exact scripted prompt string across content-bearing columns; returns a status row)* |
+| `sql/06_raw_native_escape_hatch.sql` | When a product ships a new event tomorrow, do we lose it? *(no — preserved natively, queryable before any code changes)* |
+
+Close on the success screen: the verify output plus the
+both-products-one-schema result. Then hand over `one_pager.md`, regenerated
+from this run — that is the artifact that gets forwarded.
+
+---
+
+## After the demo
+
+- Regenerate the forwardable summary: `evidence/` outputs → `one_pager.md`
+  (aggregates and hashes only — see redaction rules in
+  `evidence/template.md`).
+- Tear down if this was a throwaway project: `scripts/teardown.sh`
+  (dry-run by default; the dataset contains real telemetry).
+
+## What this demo deliberately does not claim
+
+- **Not replay.** Traces are span structure and timing, not transcripts.
+  Codex documents no raw request/response body path; Claude raw-body capture
+  exists only behind the explicit replay acknowledgement.
+- **Not vendor pricing.** Token counts are measured; dollar figures are
+  estimates from an editable rates table with a visible as-of date.
+- **Scoped privacy claim.** Baseline proves prompt content is not written
+  into this telemetry warehouse by this configuration — it is not a claim
+  about other channels.

--- a/demo/hero_story/README.md
+++ b/demo/hero_story/README.md
@@ -95,7 +95,7 @@ scripts/run_queries.sh $DEMO_RUN_ID   # writes results to evidence/
 | `sql/02_token_usage_and_estimated_cost_by_team.sql` | Where is usage going, and what does it roughly cost? *(tokens are measured; dollars are an estimate from the rates CTE)* |
 | `sql/03_event_mix_and_workflow.sql` | What are the agents actually doing? |
 | `sql/04_latency_from_spans.sql` | How fast — p50/p95 from real spans, per product |
-| `sql/05_governance_privacy_dlq.sql` | Is privacy holding and is ingestion clean? *(searches for the exact scripted prompt string across content-bearing columns; returns a status row)* |
+| `sql/05_governance_privacy_dlq.sql` | Is privacy holding and is ingestion clean? *(exact scripted-prompt search returning status rows; note: privacy checks are run-scoped, dead-letter health is deliberately deployment-scoped)* |
 | `sql/06_raw_native_escape_hatch.sql` | When a product ships a new event tomorrow, do we lose it? *(no — preserved natively, queryable before any code changes)* |
 
 Close on the success screen: the verify output plus the

--- a/demo/hero_story/evidence/.gitignore
+++ b/demo/hero_story/evidence/.gitignore
@@ -1,0 +1,6 @@
+# Runtime evidence must never be committed: it contains bearer tokens (codex
+# config copies), personal identifiers, and raw outputs. Only the template
+# is tracked.
+*
+!.gitignore
+!template.md

--- a/demo/hero_story/evidence/template.md
+++ b/demo/hero_story/evidence/template.md
@@ -1,0 +1,49 @@
+# Demo run evidence — `DEMO_RUN_ID: <run_id>`
+
+Copy this file per run; `scripts/run_sessions.sh` and `run_queries.sh`
+fill most fields. This is the raw record behind `one_pager.md`.
+
+## Redaction rules (enforced before anything leaves the team)
+
+Screenshots and pasted outputs must contain **none** of the following:
+
+- bearer tokens (any `Authorization` header content)
+- personal emails or raw `user_id` values — use the SHA256 hashes the SQL
+  pack already emits
+- raw prompt or response text
+- the full receiver URL when shared outside the org (show
+  `https://bqaa-otlp-receiver-…run.app`)
+
+## Versions (Codex OTel behavior is version-sensitive — #317)
+
+| Component | Value |
+|---|---|
+| BQAA commit | `<git rev-parse --short HEAD>` |
+| `bqaa-otel` invocation mode | installed package / `PYTHONPATH=producers/src` |
+| gcloud | `<gcloud version | head -1>` |
+| bq | `<bq version>` |
+| Claude Code | `<claude --version>` |
+| Codex | `<codex --version>` (minimum verified: 0.142.5) |
+
+## Run parameters
+
+| Parameter | Value |
+|---|---|
+| project / dataset / region | |
+| signals tier | logs,metrics,traces |
+| privacy tier | baseline |
+| `DEMO_RUN_ID` (= `env` resource attribute) | |
+| session start / end (UTC) | |
+
+## Captured outputs
+
+- [ ] `preflight.txt` — all checks green
+- [ ] `bootstrap_plan.txt` — the plan-mode command listing (no secrets)
+- [ ] `verify_smoke.txt` — all checks green (pipeline proof)
+- [ ] `sql/NN_*.csv` — one result per pack query, this run id only
+- [ ] `replay_refusal.txt` — the exit-2 privacy gate capture
+- [ ] `demo_resources.json` — resource inventory (feeds teardown)
+
+## Notes / anomalies
+
+<!-- anything surprising, with links to issues filed -->

--- a/demo/hero_story/one_pager.md
+++ b/demo/hero_story/one_pager.md
@@ -1,0 +1,44 @@
+# AI coding telemetry, in our own warehouse — demo summary
+
+<!-- Regenerate per run from evidence/; aggregates and hashes only (see
+     evidence/template.md redaction rules). Fields marked <…> are filled
+     by scripts/run_queries.sh from this run's SQL outputs. -->
+
+**What we showed.** Claude Code and Codex telemetry from real developer
+sessions, landing in a BigQuery dataset **we own**, queryable with plain
+SQL, with privacy enforced by configuration.
+
+**Architecture (one line).** Developer machines export OpenTelemetry →
+an authenticated Cloud Run receiver → Pub/Sub (with a retained dead-letter
+queue) → BigQuery — every component inside our own GCP project; no
+third-party analytics service in the path.
+
+**How much work it was.** One command deployed the pipeline
+(`bqaa-otel bootstrap … --execute`); two generated config artifacts enabled
+the sources. Fresh-project install: ≤30 minutes including the container
+build.
+
+## Numbers from this run (`DEMO_RUN_ID: <run_id>`, window: <n>h)
+
+| Question | Result |
+|---|---|
+| Products reporting | `claude_code`, `codex` — one schema, provenance-tagged |
+| Sessions / conversations | <claude_sessions> Claude, <codex_conversations> Codex |
+| Distinct users (hashed) | <distinct_users_hashed> |
+| Tokens (measured) | <total_tokens> — est. $<est_cost_usd> *(estimate; editable rates, as-of <rate_as_of>)* |
+| Agent latency | <span_name> p95 = <p95_ms> ms (from real spans) |
+| Prompt content in warehouse | **PASS — none found** (exact-string scan of all content-bearing columns; baseline tier) |
+| Replay without explicit acknowledgement | **Refused** (exit 2 — content capture cannot be enabled by accident) |
+| Dead letters | <dead_letter_count> (transport DLQ retained + replayable) |
+
+## Why it matters
+
+- **Adoption & ROI**: usage and token spend per team, per product, in SQL —
+  joinable with everything else in the warehouse.
+- **Governance**: privacy tiers are configuration with an explicit
+  acknowledgement gate; the telemetry itself proves what was (not) captured.
+- **Future-proof**: new event types a vendor ships tomorrow are preserved
+  natively and queryable before any code changes.
+
+**Versions**: Claude Code <claude_version>, Codex <codex_version>
+(verified ≥ 0.142.5), BQAA <bqaa_commit>. Full record: `evidence/`.

--- a/demo/hero_story/scripts/demo_prompts.sh
+++ b/demo/hero_story/scripts/demo_prompts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Single source of truth for the scripted demo prompts.
+# sql/05_governance_privacy_dlq.sql searches for BOTH strings VERBATIM as
+# the privacy proof — any change here flows to run_sessions.sh and
+# run_queries.sh automatically because both source this file.
+#
+# The Claude prompt is deliberately non-trivial: the response must take
+# long enough that in-session metric/span export intervals elapse
+# (Claude's shutdown flush is unreliable in very short sessions).
+export CLAUDE_PROMPT="Explain in about 150 words why unified telemetry matters for platform teams, covering adoption, cost attribution, and incident response."
+export CODEX_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams (codex)."

--- a/demo/hero_story/scripts/preflight.sh
+++ b/demo/hero_story/scripts/preflight.sh
@@ -6,9 +6,21 @@ set -uo pipefail
 PROJECT="${1:?usage: preflight.sh <project> [dataset]}"
 DATASET="${2:-}"
 
-PASS=0; FAIL=0
+PASS=0; FAIL=0; WARN=0
 ok()   { printf 'OK    %s\n' "$1"; PASS=$((PASS+1)); }
 bad()  { printf 'FAIL  %s\n      fix: %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf 'WARN  %s\n      note: %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+# Same identifier rules as the product CLI (BootstrapSettings/VerifySettings):
+# these values are interpolated into SQL identifiers by the demo scripts.
+python3 -c "
+import re, sys
+project, dataset = sys.argv[1], sys.argv[2]
+if not re.fullmatch(r'[a-z0-9.:-]+', project, re.IGNORECASE):
+    sys.exit('FAIL  invalid GCP project id %r' % project)
+if not re.fullmatch(r'\\w+', dataset, re.ASCII):
+    sys.exit('FAIL  invalid BigQuery dataset id %r' % dataset)
+" "$PROJECT" "${DATASET:-placeholder_ds}" || exit 1
 
 # --- local CLIs -------------------------------------------------------------
 command -v gcloud >/dev/null && ok "gcloud present ($(gcloud version 2>/dev/null | head -1))" \
@@ -48,20 +60,51 @@ BILLING=$(gcloud billing projects describe "$PROJECT" --format='value(billingEna
 [ "$BILLING" = "True" ] && ok "billing enabled" \
   || bad "billing not enabled (or not visible)" "link a billing account; Cloud Build/Run refuse without it"
 
-# --- permissions (best effort, via the Resource Manager API) -----------------
-# (gcloud has no test-iam-permissions subcommand for projects; use the REST
-# call — it returns exactly the subset of tested permissions the caller has.)
-PERMS=$(curl -s -X POST \
+# --- permissions (via the Resource Manager API) -------------------------------
+# (gcloud has no test-iam-permissions subcommand for projects; the REST call
+# returns exactly the subset of tested permissions the caller holds.)
+# This list mirrors what bootstrap ACTUALLY does — creates AND the
+# setIamPolicy/actAs/DTS surface where real runs have failed mid-deploy.
+REQUIRED_PERMS="run.services.create run.services.setIamPolicy pubsub.topics.create pubsub.subscriptions.create bigquery.datasets.create bigquery.jobs.create bigquery.transfers.update secretmanager.secrets.create secretmanager.secrets.setIamPolicy cloudbuild.builds.create iam.serviceAccounts.create iam.serviceAccounts.setIamPolicy iam.serviceAccounts.actAs resourcemanager.projects.setIamPolicy"
+PERM_RESULT=$(curl -s -X POST \
   -H "Authorization: Bearer $(gcloud auth print-access-token 2>/dev/null)" \
   -H "Content-Type: application/json" \
   "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT}:testIamPermissions" \
-  -d '{"permissions":["run.services.create","pubsub.topics.create","bigquery.datasets.create","secretmanager.secrets.create","cloudbuild.builds.create"]}' \
-  | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("permissions", [])))' 2>/dev/null)
-if [ "${PERMS:-0}" -ge 5 ]; then
-  ok "deploy permissions present (run/pubsub/bq/secret/cloudbuild)"
+  -d "{\"permissions\":[$(echo "$REQUIRED_PERMS" | tr ' ' '\n' | sed 's/.*/"&"/' | paste -sd, -)]}" \
+  | REQUIRED="$REQUIRED_PERMS" python3 -c '
+import json, os, sys
+granted = set(json.load(sys.stdin).get("permissions", []))
+required = os.environ["REQUIRED"].split()
+missing = [p for p in required if p not in granted]
+counts = str(len(required) - len(missing)) + "/" + str(len(required))
+print(counts + "|" + ",".join(missing))' 2>/dev/null)
+PERM_COUNTS="${PERM_RESULT%%|*}"
+PERM_MISSING="${PERM_RESULT#*|}"
+if [ -n "$PERM_RESULT" ] && [ -z "$PERM_MISSING" ]; then
+  ok "deploy permissions present (${PERM_COUNTS}: create + setIamPolicy/actAs/DTS surface)"
 else
-  bad "missing some deploy permissions (${PERMS:-0}/5 granted)" \
-      "need roles covering Cloud Run, Pub/Sub, BigQuery, Secret Manager, Cloud Build"
+  bad "missing deploy permissions (${PERM_COUNTS:-0/14}): ${PERM_MISSING:-could not query}" \
+      "grant roles covering these before starting the clock"
+fi
+
+# --- org policy: can Cloud Run be invoked by allUsers? ------------------------
+# The receiver deploys --allow-unauthenticated (bearer auth at the app
+# layer). Domain-restricted sharing (iam.allowedPolicyMemberDomains) blocks
+# the allUsers grant and the deploy fails ~12 minutes in, at Cloud Run.
+ORG_POLICY=$(gcloud resource-manager org-policies describe \
+  constraints/iam.allowedPolicyMemberDomains --project "$PROJECT" \
+  --effective --format=json 2>/dev/null)
+if [ -z "$ORG_POLICY" ]; then
+  warn "org policy iam.allowedPolicyMemberDomains not readable" \
+       "cannot verify allUsers is permitted; if domain-restricted sharing is enforced, the Cloud Run deploy fails ~12 min in"
+elif printf '%s' "$ORG_POLICY" | python3 -c '
+import json, sys
+p = json.load(sys.stdin).get("listPolicy", {})
+sys.exit(1 if (p.get("allowedValues") or p.get("allValues") == "DENY") else 0)' 2>/dev/null; then
+  ok "org policy permits allUsers member grants (Cloud Run --allow-unauthenticated will work)"
+else
+  bad "domain-restricted sharing is enforced (iam.allowedPolicyMemberDomains)" \
+      "the receiver needs an allUsers invoker grant; get a policy exception or use a project where it is allowed"
 fi
 
 # --- dataset state (avoid demoing into a dirty dataset) ----------------------
@@ -74,6 +117,6 @@ if [ -n "$DATASET" ]; then
 fi
 
 echo
-echo "${PASS} ok, ${FAIL} failed"
+echo "${PASS} ok, ${WARN} warnings, ${FAIL} failed"
 [ "$FAIL" -eq 0 ] || { echo "Preflight FAILED — do not start the demo clock."; exit 1; }
 echo "Preflight green — safe to bootstrap/present."

--- a/demo/hero_story/scripts/preflight.sh
+++ b/demo/hero_story/scripts/preflight.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Preflight for the hero demo: fail in <2 minutes with actionable messages,
+# BEFORE anything mutates. Read-only. Usage: preflight.sh <project> [dataset]
+set -uo pipefail
+
+PROJECT="${1:?usage: preflight.sh <project> [dataset]}"
+DATASET="${2:-}"
+
+PASS=0; FAIL=0
+ok()   { printf 'OK    %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf 'FAIL  %s\n      fix: %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+# --- local CLIs -------------------------------------------------------------
+command -v gcloud >/dev/null && ok "gcloud present ($(gcloud version 2>/dev/null | head -1))" \
+  || bad "gcloud missing" "install the Google Cloud SDK"
+command -v bq >/dev/null && ok "bq present ($(bq version 2>/dev/null | head -1))" \
+  || bad "bq missing" "ships with the Google Cloud SDK"
+command -v python3 >/dev/null && ok "python3 present" || bad "python3 missing" "install Python 3.10+"
+python3 -c "import bigquery_agent_analytics_tracing.otlp.cli" 2>/dev/null \
+  && ok "bqaa-otel importable" \
+  || bad "bqaa-otel not importable" "pip install 'producers[receiver]' or export PYTHONPATH=producers/src"
+
+# Product CLIs: a missing/unauthenticated CLI stalls the demo harder than a
+# missing GCP role (sessions hang waiting for login).
+if command -v claude >/dev/null; then
+  ok "claude CLI present ($(claude --version 2>/dev/null | head -1))"
+else
+  bad "claude CLI missing" "install Claude Code and log in once interactively"
+fi
+if command -v codex >/dev/null; then
+  CODEX_V=$(codex --version 2>/dev/null | head -1)
+  ok "codex CLI present (${CODEX_V})"
+  [ -f "${CODEX_HOME:-$HOME/.codex}/auth.json" ] \
+    && ok "codex auth.json present" \
+    || bad "codex not authenticated" "run codex once interactively to create auth.json"
+else
+  bad "codex CLI missing" "install Codex >= 0.142.5 (config shapes are version-pinned)"
+fi
+
+# --- GCP auth / project / billing -------------------------------------------
+ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -1)
+[ -n "$ACCOUNT" ] && ok "gcloud authenticated as ${ACCOUNT}" \
+  || bad "no active gcloud account" "gcloud auth login && gcloud auth application-default login"
+gcloud projects describe "$PROJECT" --format='value(projectId)' >/dev/null 2>&1 \
+  && ok "project ${PROJECT} accessible" \
+  || bad "project ${PROJECT} not accessible" "check the id and your permissions"
+BILLING=$(gcloud billing projects describe "$PROJECT" --format='value(billingEnabled)' 2>/dev/null)
+[ "$BILLING" = "True" ] && ok "billing enabled" \
+  || bad "billing not enabled (or not visible)" "link a billing account; Cloud Build/Run refuse without it"
+
+# --- permissions (best effort, via the Resource Manager API) -----------------
+# (gcloud has no test-iam-permissions subcommand for projects; use the REST
+# call — it returns exactly the subset of tested permissions the caller has.)
+PERMS=$(curl -s -X POST \
+  -H "Authorization: Bearer $(gcloud auth print-access-token 2>/dev/null)" \
+  -H "Content-Type: application/json" \
+  "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT}:testIamPermissions" \
+  -d '{"permissions":["run.services.create","pubsub.topics.create","bigquery.datasets.create","secretmanager.secrets.create","cloudbuild.builds.create"]}' \
+  | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("permissions", [])))' 2>/dev/null)
+if [ "${PERMS:-0}" -ge 5 ]; then
+  ok "deploy permissions present (run/pubsub/bq/secret/cloudbuild)"
+else
+  bad "missing some deploy permissions (${PERMS:-0}/5 granted)" \
+      "need roles covering Cloud Run, Pub/Sub, BigQuery, Secret Manager, Cloud Build"
+fi
+
+# --- dataset state (avoid demoing into a dirty dataset) ----------------------
+if [ -n "$DATASET" ]; then
+  if bq --project_id="$PROJECT" --headless show --dataset "${PROJECT}:${DATASET}" >/dev/null 2>&1; then
+    ok "dataset ${DATASET} exists (bootstrap will converge; use a fresh name for a clean-slate demo)"
+  else
+    ok "dataset ${DATASET} does not exist yet (bootstrap will create it)"
+  fi
+fi
+
+echo
+echo "${PASS} ok, ${FAIL} failed"
+[ "$FAIL" -eq 0 ] || { echo "Preflight FAILED — do not start the demo clock."; exit 1; }
+echo "Preflight green — safe to bootstrap/present."

--- a/demo/hero_story/scripts/preflight.sh
+++ b/demo/hero_story/scripts/preflight.sh
@@ -65,7 +65,7 @@ BILLING=$(gcloud billing projects describe "$PROJECT" --format='value(billingEna
 # returns exactly the subset of tested permissions the caller holds.)
 # This list mirrors what bootstrap ACTUALLY does — creates AND the
 # setIamPolicy/actAs/DTS surface where real runs have failed mid-deploy.
-REQUIRED_PERMS="run.services.create run.services.setIamPolicy pubsub.topics.create pubsub.subscriptions.create bigquery.datasets.create bigquery.jobs.create bigquery.transfers.update secretmanager.secrets.create secretmanager.secrets.setIamPolicy cloudbuild.builds.create iam.serviceAccounts.create iam.serviceAccounts.setIamPolicy iam.serviceAccounts.actAs resourcemanager.projects.setIamPolicy"
+REQUIRED_PERMS="serviceusage.services.enable artifactregistry.repositories.create run.services.create run.services.setIamPolicy pubsub.topics.create pubsub.topics.setIamPolicy pubsub.subscriptions.create pubsub.subscriptions.update pubsub.subscriptions.setIamPolicy bigquery.datasets.create bigquery.jobs.create bigquery.transfers.update secretmanager.secrets.create secretmanager.versions.add secretmanager.secrets.setIamPolicy cloudbuild.builds.create iam.serviceAccounts.create iam.serviceAccounts.setIamPolicy iam.serviceAccounts.actAs resourcemanager.projects.setIamPolicy"
 PERM_RESULT=$(curl -s -X POST \
   -H "Authorization: Bearer $(gcloud auth print-access-token 2>/dev/null)" \
   -H "Content-Type: application/json" \

--- a/demo/hero_story/scripts/run_queries.sh
+++ b/demo/hero_story/scripts/run_queries.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Execute the leadership SQL pack for one demo run; print each result and
+# write CSVs to evidence/sql/. Requires the run id (argument or the file
+# persisted by run_sessions.sh) so stale rows can never pad the numbers.
+#
+# Usage: PROJECT=<proj> DATASET=<ds> run_queries.sh [DEMO_RUN_ID] [WINDOW_HOURS]
+set -euo pipefail
+
+PROJECT="${PROJECT:?set PROJECT}"
+DATASET="${DATASET:?set DATASET}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
+RUN_ID="${1:-$(cat "$EVIDENCE_DIR/DEMO_RUN_ID" 2>/dev/null || true)}"
+WINDOW="${2:-24}"
+[ -n "$RUN_ID" ] || { echo "usage: run_queries.sh <DEMO_RUN_ID> — none given and evidence/DEMO_RUN_ID missing"; exit 2; }
+
+# The exact scripted prompt (sql/05 searches for it verbatim); keep in sync
+# with run_sessions.sh.
+SCRIPTED_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."
+
+mkdir -p "$EVIDENCE_DIR/sql"
+echo "SQL pack for DEMO_RUN_ID=$RUN_ID (window ${WINDOW}h)"
+
+# Refresh the projection first: the scheduled MERGE runs every 15 minutes,
+# so a demo querying right after its sessions would otherwise find an empty
+# event-mix (03). Same idempotent MERGE verify --smoke runs; safe to race.
+echo "refreshing agent_events_otlp projection (idempotent MERGE)..."
+python3 - "$PROJECT" "$DATASET" << 'MERGE_EOF'
+import sys
+from bigquery_agent_analytics_tracing.otlp import sql
+from google.cloud import bigquery
+project, dataset = sys.argv[1], sys.argv[2]
+bigquery.Client(project=project).query(
+    sql.agent_events_otlp_merge_sql(f"{project}.{dataset}")
+).result()
+print("projection refreshed")
+MERGE_EOF
+FAILED=0
+for f in "$HERE"/sql/*.sql; do
+  name=$(basename "$f" .sql)
+  PARAMS=(--parameter="demo_run_id::${RUN_ID}" --parameter="window_hours:INT64:${WINDOW}")
+  case "$name" in 05_*) PARAMS+=(--parameter="scripted_prompt::${SCRIPTED_PROMPT}");; esac
+  echo; echo "=== $name ==="
+  if sed "s/\${dataset}/${PROJECT}.${DATASET}/g" "$f" \
+      | bq query --project_id="$PROJECT" --headless --use_legacy_sql=false \
+          --format=csv "${PARAMS[@]}" > "$EVIDENCE_DIR/sql/${name}.csv" 2> "$EVIDENCE_DIR/sql/${name}.err"; then
+    column -s, -t < "$EVIDENCE_DIR/sql/${name}.csv" | head -12
+    rm -f "$EVIDENCE_DIR/sql/${name}.err"
+  else
+    echo "QUERY FAILED — $EVIDENCE_DIR/sql/${name}.err:"; head -3 "$EVIDENCE_DIR/sql/${name}.err"
+    FAILED=1
+  fi
+done
+echo
+[ "$FAILED" -eq 0 ] && echo "All queries succeeded; CSVs in evidence/sql/." || { echo "Some queries failed."; exit 1; }

--- a/demo/hero_story/scripts/run_queries.sh
+++ b/demo/hero_story/scripts/run_queries.sh
@@ -28,9 +28,9 @@ if not re.fullmatch(r'\\w+', run_id, re.ASCII):
 " "$PROJECT" "$DATASET" "$RUN_ID" || exit 2
 
 
-# The exact scripted prompt (sql/05 searches for it verbatim); keep in sync
-# with run_sessions.sh.
-SCRIPTED_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."
+# The exact scripted prompts live in ONE place (sourced, never duplicated):
+# sql/05 searches for BOTH verbatim as the privacy proof.
+source "$(dirname "$0")/demo_prompts.sh"
 
 mkdir -p "$EVIDENCE_DIR/sql"
 echo "SQL pack for DEMO_RUN_ID=$RUN_ID (window ${WINDOW}h)"
@@ -53,7 +53,10 @@ FAILED=0
 for f in "$HERE"/sql/*.sql; do
   name=$(basename "$f" .sql)
   PARAMS=(--parameter="demo_run_id::${RUN_ID}" --parameter="window_hours:INT64:${WINDOW}")
-  case "$name" in 05_*) PARAMS+=(--parameter="scripted_prompt::${SCRIPTED_PROMPT}");; esac
+  case "$name" in 05_*) PARAMS+=(
+      --parameter="scripted_prompt_claude::${CLAUDE_PROMPT}"
+      --parameter="scripted_prompt_codex::${CODEX_PROMPT}"
+  );; esac
   echo; echo "=== $name ==="
   if sed "s/\${dataset}/${PROJECT}.${DATASET}/g" "$f" \
       | bq query --project_id="$PROJECT" --headless --use_legacy_sql=false \

--- a/demo/hero_story/scripts/run_queries.sh
+++ b/demo/hero_story/scripts/run_queries.sh
@@ -14,6 +14,20 @@ RUN_ID="${1:-$(cat "$EVIDENCE_DIR/DEMO_RUN_ID" 2>/dev/null || true)}"
 WINDOW="${2:-24}"
 [ -n "$RUN_ID" ] || { echo "usage: run_queries.sh <DEMO_RUN_ID> — none given and evidence/DEMO_RUN_ID missing"; exit 2; }
 
+# Same identifier rules as the product CLI: these values are interpolated
+# into BigQuery SQL identifiers below.
+python3 -c "
+import re, sys
+project, dataset, run_id = sys.argv[1], sys.argv[2], sys.argv[3]
+if not re.fullmatch(r'[a-z0-9.:-]+', project, re.IGNORECASE):
+    sys.exit('invalid GCP project id %r' % project)
+if not re.fullmatch(r'\\w+', dataset, re.ASCII):
+    sys.exit('invalid BigQuery dataset id %r' % dataset)
+if not re.fullmatch(r'\\w+', run_id, re.ASCII):
+    sys.exit('invalid DEMO_RUN_ID %r (word characters only)' % run_id)
+" "$PROJECT" "$DATASET" "$RUN_ID" || exit 2
+
+
 # The exact scripted prompt (sql/05 searches for it verbatim); keep in sync
 # with run_sessions.sh.
 SCRIPTED_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."

--- a/demo/hero_story/scripts/run_sessions.sh
+++ b/demo/hero_story/scripts/run_sessions.sh
@@ -31,13 +31,9 @@ if not re.fullmatch(r'\\w+', run_id, re.ASCII):
     sys.exit('invalid DEMO_RUN_ID %r (word characters only)' % run_id)
 " "$PROJECT" "$DATASET" "$DEMO_RUN_ID" || exit 2
 
-# The exact scripted prompts — sql/05 searches for these strings verbatim.
-# Deliberately non-trivial: the response must take long enough that at least
-# one in-session metric/span export interval elapses — Claude's shutdown
-# flush in very short sessions is unreliable (observed live), so the demo
-# must not depend on it.
-CLAUDE_PROMPT="Explain in about 150 words why unified telemetry matters for platform teams, covering adoption, cost attribution, and incident response."
-CODEX_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams (codex)."
+# The exact scripted prompts live in ONE place — sql/05 searches for them
+# verbatim, so run_sessions.sh and run_queries.sh must never drift apart.
+source "$(dirname "$0")/demo_prompts.sh"
 
 mkdir -p "$EVIDENCE_DIR"
 TOKEN=$(gcloud secrets versions access latest --secret=bqaa-otlp-token --project "$PROJECT")

--- a/demo/hero_story/scripts/run_sessions.sh
+++ b/demo/hero_story/scripts/run_sessions.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Deterministic demo sessions: one real Claude Code and one real Codex
+# session, both tagged with a fresh DEMO_RUN_ID (carried as the `env`
+# resource attribute — the query boundary for the whole SQL pack), with a
+# landing assertion so Act 3 never opens on an empty dashboard.
+#
+# Usage:
+#   PROJECT=<proj> DATASET=<ds> ENDPOINT=<receiver-url> run_sessions.sh
+# Optional: DEMO_RUN_ID (default: generated), EVIDENCE_DIR, TEAM, COST_CENTER
+set -euo pipefail
+
+PROJECT="${PROJECT:?set PROJECT}"
+DATASET="${DATASET:?set DATASET}"
+ENDPOINT="${ENDPOINT:?set ENDPOINT (receiver base URL)}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
+DEMO_RUN_ID="${DEMO_RUN_ID:-hero$(date +%Y%m%d%H%M%S)}"
+TEAM="${TEAM:-platform}"
+COST_CENTER="${COST_CENTER:-demo-001}"
+# The exact scripted prompts — sql/05 searches for these strings verbatim.
+CLAUDE_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."
+CODEX_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams (codex)."
+
+mkdir -p "$EVIDENCE_DIR"
+TOKEN=$(gcloud secrets versions access latest --secret=bqaa-otlp-token --project "$PROJECT")
+
+# ---- version capture (Codex OTel behavior is version-sensitive, #317) ------
+{
+  echo "DEMO_RUN_ID: $DEMO_RUN_ID"
+  echo "timestamp_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "project: $PROJECT | dataset: $DATASET"
+  echo "bqaa_commit: $(git -C "$HERE/../.." rev-parse --short HEAD 2>/dev/null || echo 'installed-package')"
+  echo "gcloud: $(gcloud version 2>/dev/null | head -1)"
+  echo "bq: $(bq version 2>/dev/null | head -1)"
+  echo "claude: $(claude --version 2>/dev/null | head -1)"
+  echo "codex: $(codex --version 2>/dev/null | head -1)"
+  echo "signals: logs,metrics,traces | privacy: baseline"
+  echo "scripted_prompt_claude: $CLAUDE_PROMPT"
+  echo "scripted_prompt_codex: $CODEX_PROMPT"
+} > "$EVIDENCE_DIR/versions.txt"
+
+# ---- privacy beat capture: the replay refusal (expected exit 2) ------------
+set +e
+python3 -m bigquery_agent_analytics_tracing.otlp.cli config \
+  --endpoint "$ENDPOINT" --source claude-code --privacy replay \
+  --out "$EVIDENCE_DIR/should-not-exist" > /dev/null 2> "$EVIDENCE_DIR/replay_refusal.txt"
+REFUSAL_RC=$?
+set -e
+if [ "$REFUSAL_RC" -ne 2 ]; then
+  echo "ERROR: replay refusal returned rc=$REFUSAL_RC (expected 2)"; exit 1
+fi
+echo "privacy gate captured (exit 2) -> evidence/replay_refusal.txt"
+
+# ---- Claude Code session (env vars == generated managed settings) ----------
+echo "==> Claude Code session (baseline privacy, traces tier)"
+(
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_LOGS_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp OTEL_TRACES_EXPORTER=otlp
+  export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+  export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+  export OTEL_EXPORTER_OTLP_ENDPOINT="$ENDPOINT"
+  export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TOKEN},x-bqaa-source-product=claude_code"
+  export OTEL_RESOURCE_ATTRIBUTES="env=${DEMO_RUN_ID},department=${TEAM},cost_center=${COST_CENTER}"
+  export OTEL_LOGS_EXPORT_INTERVAL=2000 OTEL_METRIC_EXPORT_INTERVAL=5000
+  cd "$EVIDENCE_DIR"
+  claude -p "$CLAUDE_PROMPT" --model haiku < /dev/null 2>&1 | tail -1
+  sleep 10  # let the exporters flush the final batch — do not shorten
+)
+
+# ---- Codex session (generated artifact + run-id environment override) ------
+echo "==> Codex session (isolated CODEX_HOME; your real ~/.codex is untouched)"
+CODEX_DEMO_HOME="$EVIDENCE_DIR/codex_home"
+mkdir -p "$CODEX_DEMO_HOME"
+cp "${CODEX_HOME:-$HOME/.codex}/auth.json" "$CODEX_DEMO_HOME/"
+# Start from the bootstrap-generated artifact: fill the token, then carry the
+# run id in `environment` (codex cannot set arbitrary resource attributes;
+# `environment` lands as the `env` resource attribute — the query boundary).
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-$EVIDENCE_DIR/artifacts}"
+if [ ! -f "$ARTIFACTS_DIR/codex.config.toml" ]; then
+  echo "ERROR: $ARTIFACTS_DIR/codex.config.toml not found."
+  echo "  Generate it first (either of):"
+  echo "    bqaa-otel bootstrap ... --out $ARTIFACTS_DIR --execute"
+  echo "    bqaa-otel config --endpoint $ENDPOINT --source claude-code,codex \\"
+  echo "      --signals logs,metrics,traces --out $ARTIFACTS_DIR"
+  exit 1
+fi
+sed -e "s/<token>/${TOKEN}/g" \
+    -e "s/environment = \"prod\"/environment = \"${DEMO_RUN_ID}\"/" \
+    "$ARTIFACTS_DIR/codex.config.toml" > "$CODEX_DEMO_HOME/config.toml"
+(
+  cd "$EVIDENCE_DIR"
+  CODEX_HOME="$CODEX_DEMO_HOME" codex exec --skip-git-repo-check -s read-only \
+    "$CODEX_PROMPT" < /dev/null 2>&1 | tail -1
+  sleep 10
+)
+
+# ---- landing assertion: never open Act 3 on an empty dashboard -------------
+echo "==> Waiting for rows to land (logs, tokens, spans; up to ~4 min)"
+QUALIFIED="${PROJECT}.${DATASET}"
+check() { bq query --project_id="$PROJECT" --headless --use_legacy_sql=false --format=csv "$1" 2>/dev/null | tail -1; }
+for i in $(seq 1 16); do
+  LOGS=$(check "SELECT COUNT(*) FROM \`${QUALIFIED}.otel_logs_dedup\` WHERE JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'")
+  SPANS=$(check "SELECT COUNT(*) FROM \`${QUALIFIED}.otel_spans_dedup\` WHERE JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'")
+  TOKENS=$(check "SELECT CAST(COALESCE(SUM(t),0) AS INT64) FROM (
+      SELECT CAST(value AS FLOAT64) AS t FROM \`${QUALIFIED}.otel_metric_sum_dedup\` WHERE metric_name='claude_code.token.usage' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'
+      UNION ALL SELECT \`sum\` FROM \`${QUALIFIED}.otel_metric_histogram_dedup\` WHERE metric_name='codex.turn.token_usage' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}')")
+  echo "  poll $i: logs=${LOGS:-0} spans=${SPANS:-0} tokens=${TOKENS:-0}"
+  if [ "${LOGS:-0}" -gt 0 ] && [ "${SPANS:-0}" -gt 0 ] && [ "${TOKENS:-0}" -gt 0 ]; then
+    break
+  fi
+  sleep 15
+done
+if [ "${LOGS:-0}" -eq 0 ] || [ "${SPANS:-0}" -eq 0 ] || [ "${TOKENS:-0}" -eq 0 ]; then
+  echo "ERROR: rows did not land (logs=${LOGS:-0} spans=${SPANS:-0} tokens=${TOKENS:-0}) — do not proceed to Act 3"
+  exit 1
+fi
+
+echo "$DEMO_RUN_ID" > "$EVIDENCE_DIR/DEMO_RUN_ID"
+echo
+echo "DEMO_RUN_ID=$DEMO_RUN_ID   (persisted to evidence/DEMO_RUN_ID)"
+echo "Next: scripts/run_queries.sh"

--- a/demo/hero_story/scripts/run_sessions.sh
+++ b/demo/hero_story/scripts/run_sessions.sh
@@ -17,6 +17,20 @@ EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
 DEMO_RUN_ID="${DEMO_RUN_ID:-hero$(date +%Y%m%d%H%M%S)}"
 TEAM="${TEAM:-platform}"
 COST_CENTER="${COST_CENTER:-demo-001}"
+
+# Same identifier rules as the product CLI: these values are interpolated
+# into BigQuery SQL identifiers below.
+python3 -c "
+import re, sys
+project, dataset, run_id = sys.argv[1], sys.argv[2], sys.argv[3]
+if not re.fullmatch(r'[a-z0-9.:-]+', project, re.IGNORECASE):
+    sys.exit('invalid GCP project id %r' % project)
+if not re.fullmatch(r'\\w+', dataset, re.ASCII):
+    sys.exit('invalid BigQuery dataset id %r' % dataset)
+if not re.fullmatch(r'\\w+', run_id, re.ASCII):
+    sys.exit('invalid DEMO_RUN_ID %r (word characters only)' % run_id)
+" "$PROJECT" "$DATASET" "$DEMO_RUN_ID" || exit 2
+
 # The exact scripted prompts — sql/05 searches for these strings verbatim.
 CLAUDE_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."
 CODEX_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams (codex)."

--- a/demo/hero_story/scripts/run_sessions.sh
+++ b/demo/hero_story/scripts/run_sessions.sh
@@ -32,7 +32,11 @@ if not re.fullmatch(r'\\w+', run_id, re.ASCII):
 " "$PROJECT" "$DATASET" "$DEMO_RUN_ID" || exit 2
 
 # The exact scripted prompts — sql/05 searches for these strings verbatim.
-CLAUDE_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams."
+# Deliberately non-trivial: the response must take long enough that at least
+# one in-session metric/span export interval elapses — Claude's shutdown
+# flush in very short sessions is unreliable (observed live), so the demo
+# must not depend on it.
+CLAUDE_PROMPT="Explain in about 150 words why unified telemetry matters for platform teams, covering adoption, cost attribution, and incident response."
 CODEX_PROMPT="Summarize in one sentence why unified telemetry matters for platform teams (codex)."
 
 mkdir -p "$EVIDENCE_DIR"
@@ -75,11 +79,30 @@ echo "==> Claude Code session (baseline privacy, traces tier)"
   export OTEL_EXPORTER_OTLP_ENDPOINT="$ENDPOINT"
   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TOKEN},x-bqaa-source-product=claude_code"
   export OTEL_RESOURCE_ATTRIBUTES="env=${DEMO_RUN_ID},department=${TEAM},cost_center=${COST_CENTER}"
-  export OTEL_LOGS_EXPORT_INTERVAL=2000 OTEL_METRIC_EXPORT_INTERVAL=5000
+  # Short intervals so exports fire DURING the session, not only at the
+  # unreliable shutdown flush; OTEL_BSP_SCHEDULE_DELAY covers spans.
+  export OTEL_LOGS_EXPORT_INTERVAL=2000 OTEL_METRIC_EXPORT_INTERVAL=2000
+  export OTEL_BSP_SCHEDULE_DELAY=2000
   cd "$EVIDENCE_DIR"
   claude -p "$CLAUDE_PROMPT" --model haiku < /dev/null 2>&1 | tail -1
   sleep 10  # let the exporters flush the final batch — do not shorten
 )
+claude_session() {  # reused by the mid-poll top-up below
+  (
+    export CLAUDE_CODE_ENABLE_TELEMETRY=1
+    export OTEL_LOGS_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp OTEL_TRACES_EXPORTER=otlp
+    export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+    export OTEL_EXPORTER_OTLP_ENDPOINT="$ENDPOINT"
+    export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TOKEN},x-bqaa-source-product=claude_code"
+    export OTEL_RESOURCE_ATTRIBUTES="env=${DEMO_RUN_ID},department=${TEAM},cost_center=${COST_CENTER}"
+    export OTEL_LOGS_EXPORT_INTERVAL=2000 OTEL_METRIC_EXPORT_INTERVAL=2000
+    export OTEL_BSP_SCHEDULE_DELAY=2000
+    cd "$EVIDENCE_DIR"
+    claude -p "$CLAUDE_PROMPT" --model haiku < /dev/null 2>&1 | tail -1
+    sleep 10
+  )
+}
 
 # ---- Codex session (generated artifact + run-id environment override) ------
 echo "==> Codex session (isolated CODEX_HOME; your real ~/.codex is untouched)"
@@ -109,23 +132,54 @@ sed -e "s/<token>/${TOKEN}/g" \
 )
 
 # ---- landing assertion: never open Act 3 on an empty dashboard -------------
-echo "==> Waiting for rows to land (logs, tokens, spans; up to ~4 min)"
+# PER-PRODUCT gates: the demo's promise is BOTH products in one schema, so
+# an aggregate check that one product could satisfy alone is not enough.
+echo "==> Waiting for BOTH products to land (logs, spans, tokens; up to ~4 min)"
 QUALIFIED="${PROJECT}.${DATASET}"
-check() { bq query --project_id="$PROJECT" --headless --use_legacy_sql=false --format=csv "$1" 2>/dev/null | tail -1; }
+product_stats() {  # -> "logs,spans,tokens" for one source_product
+  bq query --project_id="$PROJECT" --headless --use_legacy_sql=false --format=csv "
+    SELECT
+      (SELECT COUNT(*) FROM \`${QUALIFIED}.otel_logs_dedup\`
+        WHERE source_product='$1' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'),
+      (SELECT COUNT(*) FROM \`${QUALIFIED}.otel_spans_dedup\`
+        WHERE source_product='$1' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'),
+      (SELECT CAST(COALESCE(SUM(t),0) AS INT64) FROM (
+        SELECT CAST(value AS FLOAT64) AS t FROM \`${QUALIFIED}.otel_metric_sum_dedup\`
+          WHERE metric_name='claude_code.token.usage' AND source_product='$1'
+            AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'
+        UNION ALL
+        SELECT \`sum\` FROM \`${QUALIFIED}.otel_metric_histogram_dedup\`
+          WHERE metric_name='codex.turn.token_usage' AND source_product='$1'
+            AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'))" \
+    2>/dev/null | tail -1
+}
+ALL_GREEN=0
 for i in $(seq 1 16); do
-  LOGS=$(check "SELECT COUNT(*) FROM \`${QUALIFIED}.otel_logs_dedup\` WHERE JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'")
-  SPANS=$(check "SELECT COUNT(*) FROM \`${QUALIFIED}.otel_spans_dedup\` WHERE JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'")
-  TOKENS=$(check "SELECT CAST(COALESCE(SUM(t),0) AS INT64) FROM (
-      SELECT CAST(value AS FLOAT64) AS t FROM \`${QUALIFIED}.otel_metric_sum_dedup\` WHERE metric_name='claude_code.token.usage' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}'
-      UNION ALL SELECT \`sum\` FROM \`${QUALIFIED}.otel_metric_histogram_dedup\` WHERE metric_name='codex.turn.token_usage' AND JSON_VALUE(resource_attributes,'\$.env')='${DEMO_RUN_ID}')")
-  echo "  poll $i: logs=${LOGS:-0} spans=${SPANS:-0} tokens=${TOKENS:-0}"
-  if [ "${LOGS:-0}" -gt 0 ] && [ "${SPANS:-0}" -gt 0 ] && [ "${TOKENS:-0}" -gt 0 ]; then
-    break
+  CLAUDE=$(product_stats claude_code); CODEX=$(product_stats codex)
+  echo "  poll $i: claude_code logs,spans,tokens=${CLAUDE:-?,?,?} | codex logs,spans,tokens=${CODEX:-?,?,?}"
+  ALL_GREEN=1
+  for STATS in "${CLAUDE:-0,0,0}" "${CODEX:-0,0,0}"; do
+    IFS=, read -r L S T <<< "$STATS"
+    { [ "${L:-0}" -gt 0 ] && [ "${S:-0}" -gt 0 ] && [ "${T:-0}" -gt 0 ]; } || ALL_GREEN=0
+  done
+  # NOTE: 'if' form required — a failing '[ ] && break' is fatal under set -e.
+  if [ "$ALL_GREEN" -eq 1 ]; then break; fi
+  # One automatic top-up: if Claude surfaces are still missing halfway
+  # through the budget, run a second session rather than hoping (Claude's
+  # shutdown flush is unreliable in short sessions — observed live).
+  if [ "$i" -eq 8 ]; then
+    IFS=, read -r CL CS CT <<< "${CLAUDE:-0,0,0}"
+    if [ "${CS:-0}" -eq 0 ] || [ "${CT:-0}" -eq 0 ]; then
+      echo "  claude spans/tokens missing at poll 8 — running one top-up session"
+      claude_session
+    fi
   fi
   sleep 15
 done
-if [ "${LOGS:-0}" -eq 0 ] || [ "${SPANS:-0}" -eq 0 ] || [ "${TOKENS:-0}" -eq 0 ]; then
-  echo "ERROR: rows did not land (logs=${LOGS:-0} spans=${SPANS:-0} tokens=${TOKENS:-0}) — do not proceed to Act 3"
+if [ "$ALL_GREEN" -ne 1 ]; then
+  echo "ERROR: a product did not land all three surfaces — do not proceed to Act 3"
+  echo "  claude_code logs,spans,tokens = ${CLAUDE:-0,0,0}"
+  echo "  codex       logs,spans,tokens = ${CODEX:-0,0,0}"
   exit 1
 fi
 

--- a/demo/hero_story/sql/00_health_and_freshness.sql
+++ b/demo/hero_story/sql/00_health_and_freshness.sql
@@ -1,27 +1,37 @@
 -- Q0 (operator, not leadership): Is the pipeline healthy RIGHT NOW?
--- Boundary: @demo_run_id rides the `env` resource attribute (both products);
--- @window_hours bounds the scan. ${dataset} is substituted by run_queries.sh.
+-- Boundary: logs/metrics/spans are RUN-scoped (@demo_run_id rides the `env`
+-- resource attribute for both products, @window_hours bounds the scan);
+-- dead-letter health is deliberately DEPLOYMENT-scoped — dead letters may
+-- lack run attribution, and ingestion health is a property of the pipeline,
+-- not of one run. ${dataset} is substituted by run_queries.sh.
+-- Reads the *_dedup views so retries/replays never inflate the counts.
 -- Expected: one row per surface; healthy = fresh_rows > 0 for logs/metrics/
 -- spans and dead_letters = 0 (a zero here is an ANSWER, not an empty result).
+WITH metric_rows AS (
+  SELECT ingest_time, resource_attributes FROM `${dataset}.otel_metric_sum_dedup`
+  UNION ALL SELECT ingest_time, resource_attributes FROM `${dataset}.otel_metric_gauge_dedup`
+  UNION ALL SELECT ingest_time, resource_attributes FROM `${dataset}.otel_metric_histogram_dedup`
+  UNION ALL SELECT ingest_time, resource_attributes FROM `${dataset}.otel_metric_exponential_histogram_dedup`
+  UNION ALL SELECT ingest_time, resource_attributes FROM `${dataset}.otel_metric_summary_dedup`
+)
 SELECT 'otel_logs' AS surface,
        COUNT(*) AS fresh_rows,
        MAX(ingest_time) AS newest
-FROM `${dataset}.otel_logs`
+FROM `${dataset}.otel_logs_dedup`
 WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
   AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
 UNION ALL
-SELECT 'otel_metrics(all)', COUNT(*), MAX(ingest_time)
-FROM `${dataset}.bqaa_metrics` m
-JOIN `${dataset}.otel_metric_sum` s USING (idempotency_key)
-WHERE s.ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
-  AND JSON_VALUE(s.resource_attributes, '$.env') = @demo_run_id
+SELECT 'otel_metrics(all five)', COUNT(*), MAX(ingest_time)
+FROM metric_rows
+WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
 UNION ALL
 SELECT 'otel_spans', COUNT(*), MAX(ingest_time)
-FROM `${dataset}.otel_spans`
+FROM `${dataset}.otel_spans_dedup`
 WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
   AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
 UNION ALL
-SELECT 'dead_letters(any run)', COUNT(*), MAX(received_at)
+SELECT 'dead_letters(deployment-wide)', COUNT(*), MAX(received_at)
 FROM `${dataset}.otlp_dead_letter`
 WHERE received_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
 ORDER BY surface;

--- a/demo/hero_story/sql/00_health_and_freshness.sql
+++ b/demo/hero_story/sql/00_health_and_freshness.sql
@@ -1,0 +1,27 @@
+-- Q0 (operator, not leadership): Is the pipeline healthy RIGHT NOW?
+-- Boundary: @demo_run_id rides the `env` resource attribute (both products);
+-- @window_hours bounds the scan. ${dataset} is substituted by run_queries.sh.
+-- Expected: one row per surface; healthy = fresh_rows > 0 for logs/metrics/
+-- spans and dead_letters = 0 (a zero here is an ANSWER, not an empty result).
+SELECT 'otel_logs' AS surface,
+       COUNT(*) AS fresh_rows,
+       MAX(ingest_time) AS newest
+FROM `${dataset}.otel_logs`
+WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
+UNION ALL
+SELECT 'otel_metrics(all)', COUNT(*), MAX(ingest_time)
+FROM `${dataset}.bqaa_metrics` m
+JOIN `${dataset}.otel_metric_sum` s USING (idempotency_key)
+WHERE s.ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(s.resource_attributes, '$.env') = @demo_run_id
+UNION ALL
+SELECT 'otel_spans', COUNT(*), MAX(ingest_time)
+FROM `${dataset}.otel_spans`
+WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
+UNION ALL
+SELECT 'dead_letters(any run)', COUNT(*), MAX(received_at)
+FROM `${dataset}.otlp_dead_letter`
+WHERE received_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+ORDER BY surface;

--- a/demo/hero_story/sql/01_adoption_by_product.sql
+++ b/demo/hero_story/sql/01_adoption_by_product.sql
@@ -1,0 +1,15 @@
+-- Q1: Who is using Claude Code vs Codex — sessions and active users?
+-- Expected: one row per product from THIS demo run; Claude carries user
+-- identity in log attributes; Codex sessions count via conversation starts.
+-- user_id is HASHED for forwardable evidence (redaction rules).
+SELECT
+  l.source_product,
+  COUNT(DISTINCT JSON_VALUE(l.log_attributes, '$."session.id"')) AS claude_sessions,
+  COUNTIF(JSON_VALUE(l.log_attributes, '$."event.name"') = 'codex.conversation_starts') AS codex_conversations,
+  COUNT(DISTINCT TO_HEX(SHA256(JSON_VALUE(l.log_attributes, '$."user.id"')))) AS distinct_users_hashed,
+  COUNT(*) AS log_events
+FROM `${dataset}.otel_logs_dedup` l
+WHERE l.ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(l.resource_attributes, '$.env') = @demo_run_id
+GROUP BY l.source_product
+ORDER BY l.source_product;

--- a/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
+++ b/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
@@ -10,15 +10,27 @@ WITH rates AS (
   SELECT 'claude_code', 6.00, DATE '2026-07-07'
 ),
 tokens AS (
-  -- otel_metric_sum_dedup directly: token counters are sum-type metrics,
-  -- and the dedup view guarantees retries/replays never double-count.
+  -- The two products encode token usage as DIFFERENT metric types
+  -- (verified live): claude_code.token.usage is a sum-type counter
+  -- (otel_metric_sum_dedup.value); codex.turn.token_usage is a histogram
+  -- (otel_metric_histogram_dedup.sum holds the per-point token total).
+  -- Both read dedup views so retries/replays never double-count.
   SELECT
     source_product,
     COALESCE(JSON_VALUE(resource_attributes, '$.department'), 'unattributed') AS team,
-    SUM(CAST(value AS FLOAT64)) AS total_tokens
-  FROM `${dataset}.otel_metric_sum_dedup`
-  WHERE metric_name IN ('codex.turn.token_usage', 'claude_code.token.usage')
-    AND ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+    SUM(tokens) AS total_tokens
+  FROM (
+    SELECT source_product, resource_attributes, ingest_time,
+           CAST(value AS FLOAT64) AS tokens
+    FROM `${dataset}.otel_metric_sum_dedup`
+    WHERE metric_name = 'claude_code.token.usage'
+    UNION ALL
+    SELECT source_product, resource_attributes, ingest_time,
+           `sum` AS tokens
+    FROM `${dataset}.otel_metric_histogram_dedup`
+    WHERE metric_name = 'codex.turn.token_usage'
+  )
+  WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
     AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
   GROUP BY 1, 2
 )

--- a/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
+++ b/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
@@ -10,15 +10,16 @@ WITH rates AS (
   SELECT 'claude_code', 6.00, DATE '2026-07-07'
 ),
 tokens AS (
+  -- otel_metric_sum_dedup directly: token counters are sum-type metrics,
+  -- and the dedup view guarantees retries/replays never double-count.
   SELECT
-    s.source_product,
-    COALESCE(JSON_VALUE(s.resource_attributes, '$.department'), 'unattributed') AS team,
-    SUM(CAST(m.value AS FLOAT64)) AS total_tokens
-  FROM `${dataset}.bqaa_metrics` m
-  JOIN `${dataset}.otel_metric_sum` s USING (idempotency_key)
-  WHERE m.metric_name IN ('codex.turn.token_usage', 'claude_code.token.usage')
-    AND s.ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
-    AND JSON_VALUE(s.resource_attributes, '$.env') = @demo_run_id
+    source_product,
+    COALESCE(JSON_VALUE(resource_attributes, '$.department'), 'unattributed') AS team,
+    SUM(CAST(value AS FLOAT64)) AS total_tokens
+  FROM `${dataset}.otel_metric_sum_dedup`
+  WHERE metric_name IN ('codex.turn.token_usage', 'claude_code.token.usage')
+    AND ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+    AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
   GROUP BY 1, 2
 )
 SELECT

--- a/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
+++ b/demo/hero_story/sql/02_token_usage_and_estimated_cost_by_team.sql
@@ -1,0 +1,32 @@
+-- Q2: Where is usage going by team — and what does it roughly cost?
+-- Tokens are MEASURED. Dollars are an ESTIMATE from the rates CTE below:
+-- edit the rates for your contract; the as_of date prints in the output.
+-- Expected: >=1 row per (product, team) with token totals; est_cost_usd is
+-- NULL when no rate matches (never silently zero).
+WITH rates AS (
+  -- source: EDIT ME (contract pricing); blended $/1M tokens, as_of below
+  SELECT 'codex' AS source_product, 5.00 AS usd_per_million_tokens, DATE '2026-07-07' AS as_of
+  UNION ALL
+  SELECT 'claude_code', 6.00, DATE '2026-07-07'
+),
+tokens AS (
+  SELECT
+    s.source_product,
+    COALESCE(JSON_VALUE(s.resource_attributes, '$.department'), 'unattributed') AS team,
+    SUM(CAST(m.value AS FLOAT64)) AS total_tokens
+  FROM `${dataset}.bqaa_metrics` m
+  JOIN `${dataset}.otel_metric_sum` s USING (idempotency_key)
+  WHERE m.metric_name IN ('codex.turn.token_usage', 'claude_code.token.usage')
+    AND s.ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+    AND JSON_VALUE(s.resource_attributes, '$.env') = @demo_run_id
+  GROUP BY 1, 2
+)
+SELECT
+  t.source_product,
+  t.team,
+  t.total_tokens,
+  ROUND(t.total_tokens / 1e6 * r.usd_per_million_tokens, 4) AS est_cost_usd,
+  r.as_of AS rate_as_of
+FROM tokens t
+LEFT JOIN rates r USING (source_product)
+ORDER BY t.total_tokens DESC;

--- a/demo/hero_story/sql/03_event_mix_and_workflow.sql
+++ b/demo/hero_story/sql/03_event_mix_and_workflow.sql
@@ -1,0 +1,15 @@
+-- Q3: What are the agents actually doing?
+-- Uses the BQAA projection (agent_events_otlp), scoped to the demo run via
+-- an idempotency-key join back to native logs (the projection intentionally
+-- carries log attributes, not resource attributes).
+-- Expected: codex.* and claude_code.* event types side by side.
+SELECT
+  p.source_product,
+  p.event_type,
+  COUNT(*) AS events
+FROM `${dataset}.agent_events_otlp` p
+JOIN `${dataset}.otel_logs_dedup` l USING (idempotency_key)
+WHERE p.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(l.resource_attributes, '$.env') = @demo_run_id
+GROUP BY 1, 2
+ORDER BY p.source_product, events DESC;

--- a/demo/hero_story/sql/04_latency_from_spans.sql
+++ b/demo/hero_story/sql/04_latency_from_spans.sql
@@ -1,0 +1,18 @@
+-- Q4: How fast are the agents — p50/p95 from REAL spans, per product?
+-- Traces tier only. These are observability spans (structure + timing),
+-- not transcripts. Expected: a few marquee span names per product
+-- (claude_code.llm_request / interaction; codex run_turn / stream_request).
+SELECT
+  source_product,
+  span_name,
+  COUNT(*) AS spans,
+  APPROX_QUANTILES(TIMESTAMP_DIFF(end_timestamp, timestamp, MILLISECOND), 100)[OFFSET(50)] AS p50_ms,
+  APPROX_QUANTILES(TIMESTAMP_DIFF(end_timestamp, timestamp, MILLISECOND), 100)[OFFSET(95)] AS p95_ms
+FROM `${dataset}.otel_spans_dedup`
+WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
+  AND end_timestamp IS NOT NULL
+GROUP BY 1, 2
+HAVING COUNT(*) >= 2 OR span_name IN ('claude_code.llm_request', 'claude_code.interaction', 'run_turn', 'stream_request')
+ORDER BY source_product, spans DESC
+LIMIT 20;

--- a/demo/hero_story/sql/05_governance_privacy_dlq.sql
+++ b/demo/hero_story/sql/05_governance_privacy_dlq.sql
@@ -1,0 +1,31 @@
+-- Q5: Is privacy holding, and is ingestion clean?
+-- The privacy proof is EXACT and scoped: it searches for the scripted
+-- prompt string (@scripted_prompt) across the content-bearing columns of
+-- this warehouse. PASS means: this configuration wrote no prompt content
+-- into THIS telemetry warehouse — not a claim about other channels.
+-- Expected: three status rows, all PASS/0 for a baseline-tier run.
+SELECT 'prompt_text_in_logs' AS check_name,
+       IF(COUNTIF(
+            STRPOS(COALESCE(TO_JSON_STRING(body), ''), @scripted_prompt) > 0
+            OR STRPOS(COALESCE(TO_JSON_STRING(log_attributes), ''), @scripted_prompt) > 0
+          ) = 0, 'PASS', 'FAIL') AS status,
+       COUNT(*) AS rows_scanned
+FROM `${dataset}.otel_logs_dedup`
+WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
+UNION ALL
+SELECT 'prompt_text_in_projection',
+       IF(COUNTIF(
+            STRPOS(COALESCE(TO_JSON_STRING(p.content), ''), @scripted_prompt) > 0
+          ) = 0, 'PASS', 'FAIL'),
+       COUNT(*)
+FROM `${dataset}.agent_events_otlp` p
+JOIN `${dataset}.otel_logs_dedup` l USING (idempotency_key)
+WHERE p.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+  AND JSON_VALUE(l.resource_attributes, '$.env') = @demo_run_id
+UNION ALL
+SELECT 'dead_letter_count',
+       IF(COUNT(*) = 0, 'PASS', 'INSPECT (replayable raw_b64 preserved)'),
+       COUNT(*)
+FROM `${dataset}.otlp_dead_letter`
+WHERE received_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR);

--- a/demo/hero_story/sql/05_governance_privacy_dlq.sql
+++ b/demo/hero_story/sql/05_governance_privacy_dlq.sql
@@ -24,6 +24,8 @@ JOIN `${dataset}.otel_logs_dedup` l USING (idempotency_key)
 WHERE p.timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
   AND JSON_VALUE(l.resource_attributes, '$.env') = @demo_run_id
 UNION ALL
+-- Deployment-scoped by design: dead letters may lack run attribution, and
+-- ingestion health is a property of the pipeline, not of one demo run.
 SELECT 'dead_letter_count',
        IF(COUNT(*) = 0, 'PASS', 'INSPECT (replayable raw_b64 preserved)'),
        COUNT(*)

--- a/demo/hero_story/sql/05_governance_privacy_dlq.sql
+++ b/demo/hero_story/sql/05_governance_privacy_dlq.sql
@@ -1,13 +1,17 @@
 -- Q5: Is privacy holding, and is ingestion clean?
--- The privacy proof is EXACT and scoped: it searches for the scripted
--- prompt string (@scripted_prompt) across the content-bearing columns of
--- this warehouse. PASS means: this configuration wrote no prompt content
--- into THIS telemetry warehouse — not a claim about other channels.
+-- The privacy proof is EXACT and scoped: it searches for BOTH scripted
+-- prompt strings (@scripted_prompt_claude, @scripted_prompt_codex — the
+-- prompts the audience actually watched, sourced from
+-- scripts/demo_prompts.sh) across the content-bearing columns of this
+-- warehouse. PASS means: this configuration wrote no prompt content into
+-- THIS telemetry warehouse — not a claim about other channels.
 -- Expected: three status rows, all PASS/0 for a baseline-tier run.
 SELECT 'prompt_text_in_logs' AS check_name,
        IF(COUNTIF(
-            STRPOS(COALESCE(TO_JSON_STRING(body), ''), @scripted_prompt) > 0
-            OR STRPOS(COALESCE(TO_JSON_STRING(log_attributes), ''), @scripted_prompt) > 0
+            STRPOS(COALESCE(TO_JSON_STRING(body), ''), @scripted_prompt_claude) > 0
+            OR STRPOS(COALESCE(TO_JSON_STRING(body), ''), @scripted_prompt_codex) > 0
+            OR STRPOS(COALESCE(TO_JSON_STRING(log_attributes), ''), @scripted_prompt_claude) > 0
+            OR STRPOS(COALESCE(TO_JSON_STRING(log_attributes), ''), @scripted_prompt_codex) > 0
           ) = 0, 'PASS', 'FAIL') AS status,
        COUNT(*) AS rows_scanned
 FROM `${dataset}.otel_logs_dedup`
@@ -16,7 +20,8 @@ WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HO
 UNION ALL
 SELECT 'prompt_text_in_projection',
        IF(COUNTIF(
-            STRPOS(COALESCE(TO_JSON_STRING(p.content), ''), @scripted_prompt) > 0
+            STRPOS(COALESCE(TO_JSON_STRING(p.content), ''), @scripted_prompt_claude) > 0
+            OR STRPOS(COALESCE(TO_JSON_STRING(p.content), ''), @scripted_prompt_codex) > 0
           ) = 0, 'PASS', 'FAIL'),
        COUNT(*)
 FROM `${dataset}.agent_events_otlp` p

--- a/demo/hero_story/sql/06_raw_native_escape_hatch.sql
+++ b/demo/hero_story/sql/06_raw_native_escape_hatch.sql
@@ -1,0 +1,25 @@
+-- Q6: When a product ships a NEW event type tomorrow, do we lose it?
+-- No: native otel_logs preserves every record regardless of the projection
+-- allowlist. This surfaces records whose semantic event name is absent or
+-- unmapped — still fully queryable, before any code changes.
+-- Expected: a status row (healthy zero is an answer) plus any examples.
+WITH unmapped AS (
+  SELECT
+    source_product,
+    COALESCE(JSON_VALUE(log_attributes, '$."event.name"'), event_name, '(none)') AS raw_event,
+    COUNT(*) AS records
+  FROM `${dataset}.otel_logs_dedup`
+  WHERE ingest_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_hours HOUR)
+    AND JSON_VALUE(resource_attributes, '$.env') = @demo_run_id
+    AND JSON_VALUE(log_attributes, '$."event.name"') IS NULL
+  GROUP BY 1, 2
+)
+SELECT 'records_without_semantic_event_name' AS check_name,
+       CAST(COALESCE(SUM(records), 0) AS STRING) AS value,
+       'preserved natively; queryable without code changes' AS meaning
+FROM unmapped
+UNION ALL
+SELECT CONCAT('example: ', source_product), CONCAT(raw_event, ' x', CAST(records AS STRING)), 'raw OTLP eventName retained'
+FROM unmapped
+ORDER BY check_name
+LIMIT 10;


### PR DESCRIPTION
First increment of #344, per the [reviewed sequencing](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/344#issuecomment-4908705053): **docs + SQL only, zero cloud mutation**, so the leadership story is reviewable independently of the scripts.

## What's here

- **README.md** — the presenter track: a one-screen demo contract (audience / promise / success screen / clock), three acts (~12 min rehearse mode), the privacy refusal as a scripted beat, and the precision-reviewed wording: *one command deploys the collector and warehouse surface; two generated artifacts enable the sources*. Explicit caveats: traces ≠ replay, dollars are estimates, privacy claim scoped to this warehouse.
- **OPERATOR.md** — fresh-project track with the clock defined precisely (≤30 min, Cloud Build ~10, prerequisites excluded), a prerequisites table (incl. Claude/Codex CLI **auth** and the codex ≥ 0.142.5 pin), and a troubleshooting table where **every row is a failure that actually happened** in the #324/#317 live runs.
- **sql/00–06** — leadership-question-first queries. Every query is bounded by `@demo_run_id` (carried as the `env` resource attribute by both products — Codex can't set arbitrary resource attributes, so `[otel] environment` is the carrier) plus `@window_hours`. Healthy zeros return **status rows**, never empty results. `02` measures tokens and labels dollars as an estimate from an editable rates CTE with a visible as-of date. `05`'s privacy proof searches for the **exact scripted prompt string** across content-bearing columns and returns PASS/FAIL rows. `06` shows the native escape hatch for unmapped events (backed by a real observation).
- **evidence/template.md** — per-run record: redaction rules (no tokens, raw ids/emails, prompts, full receiver URL) and version capture (Codex behavior is version-sensitive).
- **one_pager.md** — the forwardable artifact: architecture line, run-number slots, scoped claims.

## Validation

All seven queries executed against the **live e2e dataset** (real Claude + Codex rows): six passed first try; `05` failed on a JSON-vs-STRING `COALESCE` (BigQuery JSON columns need `TO_JSON_STRING` before text search), fixed and re-verified — live result: `prompt_text_in_logs PASS / prompt_text_in_projection PASS / dead_letter_count PASS 0`.

PR 2: `preflight.sh`, `run_sessions.sh`, `run_queries.sh` + version capture. PR 3: reset/teardown with inventory-backed allowlists. PR 4: rehearsal evidence + one-pager refresh.