### PR TITLE
feat(demo): inventory-backed reset + teardown with verification (#344 PR3)

### DIFF
--- a/demo/hero_story/scripts/reset_demo.sh
+++ b/demo/hero_story/scripts/reset_demo.sh
@@ -9,9 +9,10 @@ set -euo pipefail
 PROJECT="${PROJECT:?set PROJECT}"
 DATASET="${DATASET:-bqaa_hero_demo_$(date +%Y%m%d)}"
 REGION="${REGION:-us-central1}"
+BQ_LOCATION="${BQ_LOCATION:-US}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
-export PROJECT DATASET REGION EVIDENCE_DIR
+export PROJECT DATASET REGION BQ_LOCATION EVIDENCE_DIR
 
 echo "==> Preflight (fails fast; nothing has been mutated)"
 "$HERE/scripts/preflight.sh" "$PROJECT" "$DATASET"
@@ -20,6 +21,7 @@ echo
 echo "==> Bootstrap plan (mutates nothing)"
 python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
   --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
+  --bq-location "$BQ_LOCATION" \
   --signals logs,metrics,traces --source claude-code,codex \
   --out "$EVIDENCE_DIR/artifacts" | tee "$EVIDENCE_DIR/bootstrap_plan.txt" | tail -3
 
@@ -27,6 +29,7 @@ echo
 echo "==> Bootstrap execute (fresh install ~15 min incl. Cloud Build; converges on re-run)"
 python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
   --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
+  --bq-location "$BQ_LOCATION" \
   --signals logs,metrics,traces --source claude-code,codex \
   --out "$EVIDENCE_DIR/artifacts" --execute
 

--- a/demo/hero_story/scripts/reset_demo.sh
+++ b/demo/hero_story/scripts/reset_demo.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fresh, repeatable demo setup: preflight -> bootstrap (fresh dataset) ->
+# inventory -> deterministic sessions. Idempotent: bootstrap converges, so
+# re-running against the same dataset resumes rather than duplicating.
+#
+# Usage: PROJECT=<proj> [DATASET=bqaa_hero_demo_<date>] [REGION=us-central1] reset_demo.sh
+set -euo pipefail
+
+PROJECT="${PROJECT:?set PROJECT}"
+DATASET="${DATASET:-bqaa_hero_demo_$(date +%Y%m%d)}"
+REGION="${REGION:-us-central1}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
+export PROJECT DATASET REGION EVIDENCE_DIR
+
+echo "==> Preflight (fails fast; nothing has been mutated)"
+"$HERE/scripts/preflight.sh" "$PROJECT" "$DATASET"
+
+echo
+echo "==> Bootstrap plan (mutates nothing)"
+python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
+  --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
+  --signals logs,metrics,traces --source claude-code,codex \
+  --out "$EVIDENCE_DIR/artifacts" | tee "$EVIDENCE_DIR/bootstrap_plan.txt" | tail -3
+
+echo
+echo "==> Bootstrap execute (fresh install ~15 min incl. Cloud Build; converges on re-run)"
+python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
+  --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
+  --signals logs,metrics,traces --source claude-code,codex \
+  --out "$EVIDENCE_DIR/artifacts" --execute
+
+echo
+echo "==> Recording the resource inventory (feeds teardown.sh)"
+"$HERE/scripts/write_inventory.sh"
+
+echo
+echo "==> Deterministic demo sessions (both products, per-product landing gates)"
+ENDPOINT=$(gcloud run services describe bqaa-otlp-receiver --project "$PROJECT" \
+  --region "$REGION" --format='value(status.url)')
+ENDPOINT="$ENDPOINT" "$HERE/scripts/run_sessions.sh"
+
+echo
+echo "Demo is ready. Next: scripts/run_queries.sh   (teardown: scripts/teardown.sh)"

--- a/demo/hero_story/scripts/teardown.sh
+++ b/demo/hero_story/scripts/teardown.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Teardown for the hero demo. DRY-RUN BY DEFAULT: prints exactly what would
+# be deleted and exits. --confirm executes. Consumes the inventory written
+# by write_inventory.sh — names are never reconstructed from flags, and only
+# allowlisted bqaa-* patterns are ever deleted.
+#
+#   teardown.sh [--confirm] [--dataset-only]
+#
+# Two tiers:
+#   dataset-scoped : DTS scheduled MERGE + the BigQuery dataset (real
+#                    telemetry lives here — tear down promptly)
+#   pipeline       : Cloud Run services, topics/subscriptions, secret,
+#                    Artifact Registry repo, service accounts + their IAM.
+#                    Skipped with --dataset-only (another dataset on this
+#                    project may still be using the pipeline).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
+INVENTORY="${INVENTORY:-$EVIDENCE_DIR/demo_resources.json}"
+CONFIRM=0; DATASET_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --confirm) CONFIRM=1 ;;
+    --dataset-only) DATASET_ONLY=1 ;;
+    *) echo "unknown flag: $arg"; exit 2 ;;
+  esac
+done
+
+[ -f "$INVENTORY" ] || { echo "ERROR: inventory not found: $INVENTORY"; echo "run scripts/write_inventory.sh first"; exit 2; }
+inv() { python3 -c "import json,sys; v=json.load(open('$INVENTORY'))$1; print('\n'.join(v) if isinstance(v,list) else v)"; }
+
+PROJECT=$(inv "['project']"); DATASET=$(inv "['dataset']"); REGION=$(inv "['region']")
+DTS=$(inv "['dts_transfer_config']")
+
+# Allowlist guard: refuse to touch anything that does not match the demo's
+# naming patterns — never judgment at runtime, always the pattern contract.
+guard() {  # guard <value> <pattern> <what>
+  case "$1" in $2) ;; *) echo "REFUSING: $3 '$1' does not match allowlist pattern '$2'"; exit 3 ;; esac
+}
+guard "$DATASET" "*" "dataset"   # dataset comes from the inventory verbatim
+for svc in $(inv "['cloud_run_services']"); do guard "$svc" "bqaa-otlp-*" "cloud run service"; done
+for t in $(inv "['pubsub_topics']"); do guard "$t" "bqaa-otlp*" "topic"; done
+for s in $(inv "['pubsub_subscriptions']"); do guard "$s" "bqaa-otlp*" "subscription"; done
+guard "$(inv "['secret']")" "bqaa-otlp-*" "secret"
+guard "$(inv "['artifact_repo']")" "bqaa" "artifact repo"
+for sa in $(inv "['service_accounts']"); do guard "$sa" "bqaa-otlp-*" "service account"; done
+
+run() {  # run <description> <cmd...>
+  local desc="$1"; shift
+  if [ "$CONFIRM" -eq 1 ]; then
+    echo "DELETE  $desc"
+    "$@" >/dev/null 2>&1 || echo "        (already gone or failed: $*)"
+  else
+    echo "WOULD DELETE  $desc"
+    echo "              $*"
+  fi
+}
+
+echo "Teardown plan from $INVENTORY (project=$PROJECT dataset=$DATASET)"
+[ "$CONFIRM" -eq 1 ] || echo "DRY RUN — re-run with --confirm to execute."
+echo
+echo "--- dataset-scoped ---"
+if [ -n "$DTS" ]; then
+  run "DTS scheduled MERGE ($DTS)" \
+    bq --headless --project_id="$PROJECT" rm -f --transfer_config "$DTS"
+else
+  echo "no DTS transfer config recorded for dataset $DATASET"
+fi
+run "BigQuery dataset ${PROJECT}:${DATASET} (contains real telemetry)" \
+  bq --headless --project_id="$PROJECT" rm -r -f --dataset "${PROJECT}:${DATASET}"
+
+if [ "$DATASET_ONLY" -eq 0 ]; then
+  echo
+  echo "--- pipeline (shared across datasets; skip with --dataset-only) ---"
+  for svc in $(inv "['cloud_run_services']"); do
+    run "Cloud Run service $svc" \
+      gcloud run services delete "$svc" --project "$PROJECT" --region "$REGION" --quiet
+  done
+  for s in $(inv "['pubsub_subscriptions']"); do
+    run "subscription $s" gcloud pubsub subscriptions delete "$s" --project "$PROJECT" --quiet
+  done
+  for t in $(inv "['pubsub_topics']"); do
+    run "topic $t" gcloud pubsub topics delete "$t" --project "$PROJECT" --quiet
+  done
+  run "secret $(inv "['secret']")" \
+    gcloud secrets delete "$(inv "['secret']")" --project "$PROJECT" --quiet
+  run "artifact repo $(inv "['artifact_repo']") (and its images)" \
+    gcloud artifacts repositories delete "$(inv "['artifact_repo']")" \
+      --project "$PROJECT" --location "$REGION" --quiet
+  CONSUMER_SA="bqaa-otlp-consumer@${PROJECT}.iam.gserviceaccount.com"
+  run "project jobUser binding for ${CONSUMER_SA}" \
+    gcloud projects remove-iam-policy-binding "$PROJECT" \
+      --member "serviceAccount:${CONSUMER_SA}" --role roles/bigquery.jobUser --quiet
+  for sa in $(inv "['service_accounts']"); do
+    run "service account ${sa}@${PROJECT}.iam.gserviceaccount.com" \
+      gcloud iam service-accounts delete "${sa}@${PROJECT}.iam.gserviceaccount.com" \
+        --project "$PROJECT" --quiet
+  done
+fi
+
+[ "$CONFIRM" -eq 1 ] || exit 0
+
+# ---- post-teardown verification: prove nothing keeps running/billing -------
+echo
+echo "--- post-teardown verification ---"
+V_FAIL=0
+DTS_LEFT=$(bq --headless --project_id="$PROJECT" --location=US ls --transfer_config \
+  --transfer_location=US --format=json 2>/dev/null \
+  | DATASET="$DATASET" python3 -c '
+import json, os, sys
+configs = json.load(sys.stdin) or []
+wanted = "bqaa_agent_events_otlp_merge_" + os.environ["DATASET"]
+print(sum(1 for c in configs if c.get("displayName") == wanted))' 2>/dev/null || echo "?")
+if [ "$DTS_LEFT" = "0" ]; then echo "PASS  no DTS scheduled MERGE remains for $DATASET"; else echo "FAIL  DTS configs remaining: $DTS_LEFT"; V_FAIL=1; fi
+if bq --headless --project_id="$PROJECT" show --dataset "${PROJECT}:${DATASET}" >/dev/null 2>&1; then
+  echo "FAIL  dataset ${DATASET} still exists (real telemetry!)"; V_FAIL=1
+else
+  echo "PASS  dataset ${DATASET} is gone"
+fi
+if [ "$DATASET_ONLY" -eq 0 ]; then
+  for svc in $(inv "['cloud_run_services']"); do
+    if gcloud run services describe "$svc" --project "$PROJECT" --region "$REGION" >/dev/null 2>&1; then
+      echo "FAIL  Cloud Run service $svc still exists"; V_FAIL=1
+    else
+      echo "PASS  Cloud Run service $svc is gone"
+    fi
+  done
+fi
+[ "$V_FAIL" -eq 0 ] && echo "Teardown verified clean." || { echo "Teardown verification FAILED."; exit 1; }

--- a/demo/hero_story/scripts/teardown.sh
+++ b/demo/hero_story/scripts/teardown.sh
@@ -131,28 +131,52 @@ fi
 echo
 echo "--- post-teardown verification (existence checks, not exit codes) ---"
 V_FAIL=0
-gone() {  # gone <what> <cmd...>  — PASS if the existence probe FAILS
+gone() {  # gone <what> <cmd...>
+  # PASS only on a KNOWN not-found response; an auth/API/permission failure
+  # is UNVERIFIABLE and fails the verification — a probe error must never
+  # masquerade as "gone".
   local what="$1"; shift
-  if "$@" >/dev/null 2>&1; then
+  local out
+  if out=$("$@" 2>&1); then
     echo "FAIL  $what STILL EXISTS"; V_FAIL=1
-  else
+  elif printf '%s' "$out" | grep -qiE 'not.?found|does not exist|was not found|no such'; then
     echo "PASS  $what is gone"
+  else
+    echo "FAIL  $what UNVERIFIABLE: $(printf '%s' "$out" | head -1 | cut -c1-100)"; V_FAIL=1
   fi
 }
-DTS_LEFT=$(bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" ls --transfer_config \
-  --transfer_location="$BQ_LOCATION" --format=json 2>/dev/null \
-  | DATASET="$DATASET" python3 -c '
+# The listing must SUCCEED for a PASS: a failed listing is unverifiable,
+# and matching covers the legacy unsuffixed display name (query-text check,
+# mirroring bootstrap._find_merge_config) as well as the suffixed one.
+DTS_LISTING=$(bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" ls --transfer_config \
+  --transfer_location="$BQ_LOCATION" --format=json 2>&1)
+if [ $? -ne 0 ]; then
+  echo "FAIL  DTS listing UNVERIFIABLE: $(printf '%s' "$DTS_LISTING" | head -1 | cut -c1-100)"; V_FAIL=1
+else
+  DTS_LEFT=$(printf '%s' "$DTS_LISTING" | DATASET="$DATASET" python3 -c '
 import json, os, sys
 try:
     configs = json.load(sys.stdin) or []
 except ValueError:
     configs = []
-wanted = "bqaa_agent_events_otlp_merge_" + os.environ["DATASET"]
-print(sum(1 for c in configs if c.get("displayName") == wanted))' 2>/dev/null || echo "?")
-if [ "$DTS_LEFT" = "0" ]; then
-  echo "PASS  no DTS scheduled MERGE remains for $DATASET"
-else
-  echo "FAIL  DTS scheduled MERGE STILL EXISTS for $DATASET (count: $DTS_LEFT — bills every 15 min)"; V_FAIL=1
+dataset = os.environ["DATASET"]
+suffixed = "bqaa_agent_events_otlp_merge_" + dataset
+legacy = "bqaa_agent_events_otlp_merge"
+def matches(c):
+    display = c.get("displayName", "")
+    query = (c.get("params") or {}).get("query", "")
+    return display == suffixed or (
+        display == legacy and ("`" + dataset + ".agent_events_otlp`") in query
+    )
+
+print(sum(1 for c in configs if matches(c)))' 2>/dev/null || echo "?")
+  if [ "$DTS_LEFT" = "0" ]; then
+    echo "PASS  no DTS scheduled MERGE remains for $DATASET (incl. legacy unsuffixed)"
+  elif [ "$DTS_LEFT" = "?" ]; then
+    echo "FAIL  DTS listing UNVERIFIABLE (unparseable)"; V_FAIL=1
+  else
+    echo "FAIL  DTS scheduled MERGE STILL EXISTS for $DATASET (count: $DTS_LEFT — bills every 15 min)"; V_FAIL=1
+  fi
 fi
 gone "dataset ${DATASET} (real telemetry)" \
   bq --headless --project_id="$PROJECT" show --dataset "${PROJECT}:${DATASET}"
@@ -178,14 +202,18 @@ if [ "$DATASET_ONLY" -eq 0 ]; then
       gcloud iam service-accounts describe "${sa}@${PROJECT}.iam.gserviceaccount.com" \
         --project "$PROJECT"
   done
-  BINDINGS=$(gcloud projects get-iam-policy "$PROJECT" \
-    --flatten="bindings[].members" \
-    --filter="bindings.role:roles/bigquery.jobUser AND bindings.members:serviceAccount:${CONSUMER_SA}" \
-    --format="value(bindings.role)" 2>/dev/null | grep -c . || true)
-  if [ "${BINDINGS:-0}" = "0" ]; then
-    echo "PASS  project jobUser binding for ${CONSUMER_SA} is gone"
+  # A failed policy read must not masquerade as "binding gone".
+  if POLICY=$(gcloud projects get-iam-policy "$PROJECT" \
+      --flatten="bindings[].members" \
+      --filter="bindings.role:roles/bigquery.jobUser AND bindings.members:serviceAccount:${CONSUMER_SA}" \
+      --format="value(bindings.role)" 2>&1); then
+    if [ -z "$POLICY" ]; then
+      echo "PASS  project jobUser binding for ${CONSUMER_SA} is gone"
+    else
+      echo "FAIL  project jobUser binding for ${CONSUMER_SA} STILL EXISTS"; V_FAIL=1
+    fi
   else
-    echo "FAIL  project jobUser binding for ${CONSUMER_SA} STILL EXISTS"; V_FAIL=1
+    echo "FAIL  IAM policy UNVERIFIABLE: $(printf '%s' "$POLICY" | head -1 | cut -c1-100)"; V_FAIL=1
   fi
 fi
 

--- a/demo/hero_story/scripts/teardown.sh
+++ b/demo/hero_story/scripts/teardown.sh
@@ -1,28 +1,31 @@
 #!/usr/bin/env bash
 # Teardown for the hero demo. DRY-RUN BY DEFAULT: prints exactly what would
-# be deleted and exits. --confirm executes. Consumes the inventory written
-# by write_inventory.sh — names are never reconstructed from flags, and only
-# allowlisted bqaa-* patterns are ever deleted.
+# be deleted and exits. --confirm executes and then verifies EVERY resource
+# class is actually gone (a failed delete cannot hide — verification checks
+# existence, not command exit codes). Consumes the inventory written by
+# write_inventory.sh; every name must match a bqaa demo allowlist pattern.
 #
-#   teardown.sh [--confirm] [--dataset-only]
+#   teardown.sh [--confirm] [--dataset-only] [--verify-only]
 #
-# Two tiers:
+# Tiers:
 #   dataset-scoped : DTS scheduled MERGE + the BigQuery dataset (real
 #                    telemetry lives here — tear down promptly)
 #   pipeline       : Cloud Run services, topics/subscriptions, secret,
-#                    Artifact Registry repo, service accounts + their IAM.
-#                    Skipped with --dataset-only (another dataset on this
-#                    project may still be using the pipeline).
+#                    Artifact Registry repo, service accounts + IAM binding.
+#                    Skipped with --dataset-only.
+# --verify-only runs just the existence verification (no deletions): on a
+# live deployment everything reports STILL EXISTS, proving detection works.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
 INVENTORY="${INVENTORY:-$EVIDENCE_DIR/demo_resources.json}"
-CONFIRM=0; DATASET_ONLY=0
+CONFIRM=0; DATASET_ONLY=0; VERIFY_ONLY=0
 for arg in "$@"; do
   case "$arg" in
     --confirm) CONFIRM=1 ;;
     --dataset-only) DATASET_ONLY=1 ;;
+    --verify-only) VERIFY_ONLY=1 ;;
     *) echo "unknown flag: $arg"; exit 2 ;;
   esac
 done
@@ -31,100 +34,166 @@ done
 inv() { python3 -c "import json,sys; v=json.load(open('$INVENTORY'))$1; print('\n'.join(v) if isinstance(v,list) else v)"; }
 
 PROJECT=$(inv "['project']"); DATASET=$(inv "['dataset']"); REGION=$(inv "['region']")
+BQ_LOCATION=$(inv ".get('bq_location', 'US')")
 DTS=$(inv "['dts_transfer_config']")
 
 # Allowlist guard: refuse to touch anything that does not match the demo's
 # naming patterns — never judgment at runtime, always the pattern contract.
-guard() {  # guard <value> <pattern> <what>
-  case "$1" in $2) ;; *) echo "REFUSING: $3 '$1' does not match allowlist pattern '$2'"; exit 3 ;; esac
+# The DATASET pattern matters most: `bq rm -r -f` on an arbitrary dataset is
+# the single most destructive command here, so a poisoned inventory must be
+# refused, not obeyed.
+guard() {  # guard <value> <what> <pattern>... — case alternation via '|'
+  # inside an expanded variable does NOT work in bash, so patterns are
+  # separate arguments and tried in turn.
+  local val="$1" what="$2" pat; shift 2
+  for pat in "$@"; do
+    case "$val" in $pat) return 0 ;; esac
+  done
+  echo "REFUSING: $what '$val' does not match allowlist patterns: $*"
+  exit 3
 }
-guard "$DATASET" "*" "dataset"   # dataset comes from the inventory verbatim
-for svc in $(inv "['cloud_run_services']"); do guard "$svc" "bqaa-otlp-*" "cloud run service"; done
-for t in $(inv "['pubsub_topics']"); do guard "$t" "bqaa-otlp*" "topic"; done
-for s in $(inv "['pubsub_subscriptions']"); do guard "$s" "bqaa-otlp*" "subscription"; done
-guard "$(inv "['secret']")" "bqaa-otlp-*" "secret"
-guard "$(inv "['artifact_repo']")" "bqaa" "artifact repo"
-for sa in $(inv "['service_accounts']"); do guard "$sa" "bqaa-otlp-*" "service account"; done
+guard "$DATASET" "dataset" "bqaa_hero_demo_*" "otlp_e2e_*"
+for svc in $(inv "['cloud_run_services']"); do guard "$svc" "cloud run service" "bqaa-otlp-*"; done
+for t in $(inv "['pubsub_topics']"); do guard "$t" "topic" "bqaa-otlp*"; done
+for s in $(inv "['pubsub_subscriptions']"); do guard "$s" "subscription" "bqaa-otlp*"; done
+guard "$(inv "['secret']")" "secret" "bqaa-otlp-*"
+guard "$(inv "['artifact_repo']")" "artifact repo" "bqaa"
+for sa in $(inv "['service_accounts']"); do guard "$sa" "service account" "bqaa-otlp-*"; done
 
 run() {  # run <description> <cmd...>
   local desc="$1"; shift
   if [ "$CONFIRM" -eq 1 ]; then
     echo "DELETE  $desc"
-    "$@" >/dev/null 2>&1 || echo "        (already gone or failed: $*)"
+    local out
+    if ! out=$("$@" 2>&1); then
+      # Visible, never silent — and the existence verification below is the
+      # authority on whether the resource is actually gone.
+      echo "        delete command failed (verification will decide):"
+      echo "        $(echo "$out" | head -1)"
+    fi
   else
     echo "WOULD DELETE  $desc"
     echo "              $*"
   fi
 }
 
-echo "Teardown plan from $INVENTORY (project=$PROJECT dataset=$DATASET)"
-[ "$CONFIRM" -eq 1 ] || echo "DRY RUN — re-run with --confirm to execute."
-echo
-echo "--- dataset-scoped ---"
-if [ -n "$DTS" ]; then
-  run "DTS scheduled MERGE ($DTS)" \
-    bq --headless --project_id="$PROJECT" rm -f --transfer_config "$DTS"
-else
-  echo "no DTS transfer config recorded for dataset $DATASET"
-fi
-run "BigQuery dataset ${PROJECT}:${DATASET} (contains real telemetry)" \
-  bq --headless --project_id="$PROJECT" rm -r -f --dataset "${PROJECT}:${DATASET}"
+CONSUMER_SA="bqaa-otlp-consumer@${PROJECT}.iam.gserviceaccount.com"
 
-if [ "$DATASET_ONLY" -eq 0 ]; then
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  echo "Teardown plan from $INVENTORY (project=$PROJECT dataset=$DATASET location=$BQ_LOCATION)"
+  [ "$CONFIRM" -eq 1 ] || echo "DRY RUN — re-run with --confirm to execute."
   echo
-  echo "--- pipeline (shared across datasets; skip with --dataset-only) ---"
-  for svc in $(inv "['cloud_run_services']"); do
-    run "Cloud Run service $svc" \
-      gcloud run services delete "$svc" --project "$PROJECT" --region "$REGION" --quiet
-  done
-  for s in $(inv "['pubsub_subscriptions']"); do
-    run "subscription $s" gcloud pubsub subscriptions delete "$s" --project "$PROJECT" --quiet
-  done
-  for t in $(inv "['pubsub_topics']"); do
-    run "topic $t" gcloud pubsub topics delete "$t" --project "$PROJECT" --quiet
-  done
-  run "secret $(inv "['secret']")" \
-    gcloud secrets delete "$(inv "['secret']")" --project "$PROJECT" --quiet
-  run "artifact repo $(inv "['artifact_repo']") (and its images)" \
-    gcloud artifacts repositories delete "$(inv "['artifact_repo']")" \
-      --project "$PROJECT" --location "$REGION" --quiet
-  CONSUMER_SA="bqaa-otlp-consumer@${PROJECT}.iam.gserviceaccount.com"
-  run "project jobUser binding for ${CONSUMER_SA}" \
-    gcloud projects remove-iam-policy-binding "$PROJECT" \
-      --member "serviceAccount:${CONSUMER_SA}" --role roles/bigquery.jobUser --quiet
-  for sa in $(inv "['service_accounts']"); do
-    run "service account ${sa}@${PROJECT}.iam.gserviceaccount.com" \
-      gcloud iam service-accounts delete "${sa}@${PROJECT}.iam.gserviceaccount.com" \
-        --project "$PROJECT" --quiet
-  done
+  echo "--- dataset-scoped ---"
+  if [ -n "$DTS" ]; then
+    run "DTS scheduled MERGE ($DTS)" \
+      bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" rm -f --transfer_config "$DTS"
+  else
+    echo "no DTS transfer config recorded for dataset $DATASET"
+  fi
+  run "BigQuery dataset ${PROJECT}:${DATASET} (contains real telemetry)" \
+    bq --headless --project_id="$PROJECT" rm -r -f --dataset "${PROJECT}:${DATASET}"
+
+  if [ "$DATASET_ONLY" -eq 0 ]; then
+    echo
+    echo "--- pipeline (shared across datasets; skip with --dataset-only) ---"
+    for svc in $(inv "['cloud_run_services']"); do
+      run "Cloud Run service $svc" \
+        gcloud run services delete "$svc" --project "$PROJECT" --region "$REGION" --quiet
+    done
+    for s in $(inv "['pubsub_subscriptions']"); do
+      run "subscription $s" gcloud pubsub subscriptions delete "$s" --project "$PROJECT" --quiet
+    done
+    for t in $(inv "['pubsub_topics']"); do
+      run "topic $t" gcloud pubsub topics delete "$t" --project "$PROJECT" --quiet
+    done
+    run "secret $(inv "['secret']")" \
+      gcloud secrets delete "$(inv "['secret']")" --project "$PROJECT" --quiet
+    run "artifact repo $(inv "['artifact_repo']") (and its images)" \
+      gcloud artifacts repositories delete "$(inv "['artifact_repo']")" \
+        --project "$PROJECT" --location "$REGION" --quiet
+    run "project jobUser binding for ${CONSUMER_SA}" \
+      gcloud projects remove-iam-policy-binding "$PROJECT" \
+        --member "serviceAccount:${CONSUMER_SA}" --role roles/bigquery.jobUser --quiet
+    for sa in $(inv "['service_accounts']"); do
+      run "service account ${sa}@${PROJECT}.iam.gserviceaccount.com" \
+        gcloud iam service-accounts delete "${sa}@${PROJECT}.iam.gserviceaccount.com" \
+          --project "$PROJECT" --quiet
+    done
+  fi
+
+  # Dry run stops here; --confirm and --verify-only fall through to verify.
+  [ "$CONFIRM" -eq 1 ] || exit 0
 fi
 
-[ "$CONFIRM" -eq 1 ] || exit 0
-
-# ---- post-teardown verification: prove nothing keeps running/billing -------
+# ---- verification: existence checks for EVERY resource class ---------------
+# The authority on teardown success. Under --verify-only against a live
+# deployment, everything reports STILL EXISTS (proves detection works).
 echo
-echo "--- post-teardown verification ---"
+echo "--- post-teardown verification (existence checks, not exit codes) ---"
 V_FAIL=0
-DTS_LEFT=$(bq --headless --project_id="$PROJECT" --location=US ls --transfer_config \
-  --transfer_location=US --format=json 2>/dev/null \
+gone() {  # gone <what> <cmd...>  — PASS if the existence probe FAILS
+  local what="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL  $what STILL EXISTS"; V_FAIL=1
+  else
+    echo "PASS  $what is gone"
+  fi
+}
+DTS_LEFT=$(bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" ls --transfer_config \
+  --transfer_location="$BQ_LOCATION" --format=json 2>/dev/null \
   | DATASET="$DATASET" python3 -c '
 import json, os, sys
-configs = json.load(sys.stdin) or []
+try:
+    configs = json.load(sys.stdin) or []
+except ValueError:
+    configs = []
 wanted = "bqaa_agent_events_otlp_merge_" + os.environ["DATASET"]
 print(sum(1 for c in configs if c.get("displayName") == wanted))' 2>/dev/null || echo "?")
-if [ "$DTS_LEFT" = "0" ]; then echo "PASS  no DTS scheduled MERGE remains for $DATASET"; else echo "FAIL  DTS configs remaining: $DTS_LEFT"; V_FAIL=1; fi
-if bq --headless --project_id="$PROJECT" show --dataset "${PROJECT}:${DATASET}" >/dev/null 2>&1; then
-  echo "FAIL  dataset ${DATASET} still exists (real telemetry!)"; V_FAIL=1
+if [ "$DTS_LEFT" = "0" ]; then
+  echo "PASS  no DTS scheduled MERGE remains for $DATASET"
 else
-  echo "PASS  dataset ${DATASET} is gone"
+  echo "FAIL  DTS scheduled MERGE STILL EXISTS for $DATASET (count: $DTS_LEFT — bills every 15 min)"; V_FAIL=1
 fi
+gone "dataset ${DATASET} (real telemetry)" \
+  bq --headless --project_id="$PROJECT" show --dataset "${PROJECT}:${DATASET}"
+
 if [ "$DATASET_ONLY" -eq 0 ]; then
   for svc in $(inv "['cloud_run_services']"); do
-    if gcloud run services describe "$svc" --project "$PROJECT" --region "$REGION" >/dev/null 2>&1; then
-      echo "FAIL  Cloud Run service $svc still exists"; V_FAIL=1
-    else
-      echo "PASS  Cloud Run service $svc is gone"
-    fi
+    gone "Cloud Run service $svc" \
+      gcloud run services describe "$svc" --project "$PROJECT" --region "$REGION"
   done
+  for s in $(inv "['pubsub_subscriptions']"); do
+    gone "subscription $s" gcloud pubsub subscriptions describe "$s" --project "$PROJECT"
+  done
+  for t in $(inv "['pubsub_topics']"); do
+    gone "topic $t" gcloud pubsub topics describe "$t" --project "$PROJECT"
+  done
+  gone "secret $(inv "['secret']")" \
+    gcloud secrets describe "$(inv "['secret']")" --project "$PROJECT"
+  gone "artifact repo $(inv "['artifact_repo']")" \
+    gcloud artifacts repositories describe "$(inv "['artifact_repo']")" \
+      --project "$PROJECT" --location "$REGION"
+  for sa in $(inv "['service_accounts']"); do
+    gone "service account ${sa}@${PROJECT}.iam.gserviceaccount.com" \
+      gcloud iam service-accounts describe "${sa}@${PROJECT}.iam.gserviceaccount.com" \
+        --project "$PROJECT"
+  done
+  BINDINGS=$(gcloud projects get-iam-policy "$PROJECT" \
+    --flatten="bindings[].members" \
+    --filter="bindings.role:roles/bigquery.jobUser AND bindings.members:serviceAccount:${CONSUMER_SA}" \
+    --format="value(bindings.role)" 2>/dev/null | grep -c . || true)
+  if [ "${BINDINGS:-0}" = "0" ]; then
+    echo "PASS  project jobUser binding for ${CONSUMER_SA} is gone"
+  else
+    echo "FAIL  project jobUser binding for ${CONSUMER_SA} STILL EXISTS"; V_FAIL=1
+  fi
 fi
-[ "$V_FAIL" -eq 0 ] && echo "Teardown verified clean." || { echo "Teardown verification FAILED."; exit 1; }
+
+echo
+if [ "$V_FAIL" -eq 0 ]; then
+  echo "Teardown verified clean."
+else
+  [ "$VERIFY_ONLY" -eq 1 ] && echo "(--verify-only against live infra: STILL EXISTS rows are expected and prove detection works)"
+  echo "Verification found remaining resources."
+  exit 1
+fi

--- a/demo/hero_story/scripts/write_inventory.sh
+++ b/demo/hero_story/scripts/write_inventory.sh
@@ -18,10 +18,22 @@ DTS_NAME=$(bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" ls \
   --transfer_config --transfer_location="$BQ_LOCATION" --format=json 2>/dev/null \
   | DATASET="$DATASET" python3 -c '
 import json, os, sys
-configs = json.load(sys.stdin) or []
-wanted = "bqaa_agent_events_otlp_merge_" + os.environ["DATASET"]
+try:
+    configs = json.load(sys.stdin) or []
+except ValueError:
+    configs = []
+dataset = os.environ["DATASET"]
+suffixed = "bqaa_agent_events_otlp_merge_" + dataset
+legacy = "bqaa_agent_events_otlp_merge"
+def matches(c):
+    display = c.get("displayName", "")
+    query = (c.get("params") or {}).get("query", "")
+    return display == suffixed or (
+        display == legacy and ("`" + dataset + ".agent_events_otlp`") in query
+    )
+
 for c in configs:
-    if c.get("displayName") == wanted:
+    if matches(c):
         print(c.get("name", ""))
         break')
 

--- a/demo/hero_story/scripts/write_inventory.sh
+++ b/demo/hero_story/scripts/write_inventory.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Write evidence/demo_resources.json — the inventory teardown.sh consumes.
+# Names are recorded from the live deployment (queried, not reconstructed),
+# so teardown deletes exactly what exists, and only that.
+# Usage: PROJECT=<proj> DATASET=<ds> [REGION=us-central1] write_inventory.sh
+set -euo pipefail
+
+PROJECT="${PROJECT:?set PROJECT}"
+DATASET="${DATASET:?set DATASET}"
+REGION="${REGION:-us-central1}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
+mkdir -p "$EVIDENCE_DIR"
+
+# The DTS scheduled-MERGE resource name must be queried (its id is opaque).
+DTS_NAME=$(bq --headless --project_id="$PROJECT" --location=US ls \
+  --transfer_config --transfer_location=US --format=json 2>/dev/null \
+  | DATASET="$DATASET" python3 -c '
+import json, os, sys
+configs = json.load(sys.stdin) or []
+wanted = "bqaa_agent_events_otlp_merge_" + os.environ["DATASET"]
+for c in configs:
+    if c.get("displayName") == wanted:
+        print(c.get("name", ""))
+        break')
+
+RECEIVER_URL=$(gcloud run services describe bqaa-otlp-receiver --project "$PROJECT" \
+  --region "$REGION" --format='value(status.url)' 2>/dev/null || true)
+
+RUN_ID=$(cat "$EVIDENCE_DIR/DEMO_RUN_ID" 2>/dev/null || echo "")
+
+python3 - "$PROJECT" "$DATASET" "$REGION" "$DTS_NAME" "$RECEIVER_URL" "$RUN_ID" << 'EOF' > "$EVIDENCE_DIR/demo_resources.json"
+import json, sys
+project, dataset, region, dts, url, run_id = sys.argv[1:7]
+# Redacted URL form for anything shared outside the org.
+redacted = (url[: url.find("-") + 1] + "…run.app") if url else ""
+print(json.dumps({
+    "project": project,
+    "dataset": dataset,
+    "region": region,
+    "demo_run_id": run_id,
+    "receiver_url_redacted": redacted,
+    # Dataset-scoped resources (always safe to remove for this demo):
+    "dts_transfer_config": dts,
+    # Shared pipeline resources (deleted only with --include-pipeline;
+    # another dataset on the same project may still be using them):
+    "cloud_run_services": ["bqaa-otlp-receiver", "bqaa-otlp-consumer"],
+    "pubsub_topics": ["bqaa-otlp", "bqaa-otlp-dlq"],
+    "pubsub_subscriptions": ["bqaa-otlp-sub", "bqaa-otlp-dlq-sub"],
+    "secret": "bqaa-otlp-token",
+    "artifact_repo": "bqaa",
+    "service_accounts": [
+        "bqaa-otlp-receiver", "bqaa-otlp-consumer", "bqaa-otlp-push",
+    ],
+}, indent=2))
+EOF
+echo "wrote $EVIDENCE_DIR/demo_resources.json"
+python3 -m json.tool "$EVIDENCE_DIR/demo_resources.json" > /dev/null && echo "inventory valid JSON"

--- a/demo/hero_story/scripts/write_inventory.sh
+++ b/demo/hero_story/scripts/write_inventory.sh
@@ -8,13 +8,14 @@ set -euo pipefail
 PROJECT="${PROJECT:?set PROJECT}"
 DATASET="${DATASET:?set DATASET}"
 REGION="${REGION:-us-central1}"
+BQ_LOCATION="${BQ_LOCATION:-US}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 EVIDENCE_DIR="${EVIDENCE_DIR:-$HERE/evidence}"
 mkdir -p "$EVIDENCE_DIR"
 
 # The DTS scheduled-MERGE resource name must be queried (its id is opaque).
-DTS_NAME=$(bq --headless --project_id="$PROJECT" --location=US ls \
-  --transfer_config --transfer_location=US --format=json 2>/dev/null \
+DTS_NAME=$(bq --headless --project_id="$PROJECT" --location="$BQ_LOCATION" ls \
+  --transfer_config --transfer_location="$BQ_LOCATION" --format=json 2>/dev/null \
   | DATASET="$DATASET" python3 -c '
 import json, os, sys
 configs = json.load(sys.stdin) or []
@@ -29,15 +30,16 @@ RECEIVER_URL=$(gcloud run services describe bqaa-otlp-receiver --project "$PROJE
 
 RUN_ID=$(cat "$EVIDENCE_DIR/DEMO_RUN_ID" 2>/dev/null || echo "")
 
-python3 - "$PROJECT" "$DATASET" "$REGION" "$DTS_NAME" "$RECEIVER_URL" "$RUN_ID" << 'EOF' > "$EVIDENCE_DIR/demo_resources.json"
+python3 - "$PROJECT" "$DATASET" "$REGION" "$DTS_NAME" "$RECEIVER_URL" "$RUN_ID" "$BQ_LOCATION" << 'EOF' > "$EVIDENCE_DIR/demo_resources.json"
 import json, sys
-project, dataset, region, dts, url, run_id = sys.argv[1:7]
+project, dataset, region, dts, url, run_id, bq_location = sys.argv[1:8]
 # Redacted URL form for anything shared outside the org.
 redacted = (url[: url.find("-") + 1] + "…run.app") if url else ""
 print(json.dumps({
     "project": project,
     "dataset": dataset,
     "region": region,
+    "bq_location": bq_location,
     "demo_run_id": run_id,
     "receiver_url_redacted": redacted,
     # Dataset-scoped resources (always safe to remove for this demo):


### PR DESCRIPTION
Third increment of #344, per the [reviewed sequencing](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/344#issuecomment-4908705053): reset/teardown with default-safe behavior.

## Design (from the issue review, implemented exactly)

- **Inventory, not reconstruction**: `write_inventory.sh` records `evidence/demo_resources.json` from the live deployment — the DTS scheduled-MERGE resource name is *queried* (its id is opaque), alongside the redacted receiver URL and run id. `teardown.sh` consumes only this file.
- **Dry-run by default**: prints the exact command for every deletion; `--confirm` executes. Two tiers: dataset-scoped (DTS + the dataset with real telemetry) always; shared pipeline resources skippable via `--dataset-only` since another dataset may still use them.
- **Allowlist, not judgment**: every name is pattern-checked (`bqaa-otlp-*`, `bqaa`) before *any* action. IAM removal is limited to the demo SAs and the one project-level `jobUser` binding.
- **Post-teardown verification**: PASS/FAIL rows proving the DTS job no longer exists (it otherwise runs every 15 min forever), the dataset is gone, and the services are gone; nonzero exit on any failure.
- `reset_demo.sh`: preflight → plan → execute → inventory → sessions, for a repeatable fresh-project demo.

## Live validation

- Inventory generated against the real deployment (real opaque DTS resource name captured).
- Dry-run prints the correct, complete plan; `--dataset-only` restricts correctly.
- **Allowlist guard proven**: a poisoned inventory with `secret: prod-payments-key` is refused (exit 3) before anything runs.
- Deliberately **not** executed here: `--confirm` and the full reset chain — those are PR 4's rehearsal (reset opens it on a fresh dataset, teardown `--confirm` closes it), so this PR mutates nothing.