### PR TITLE
docs(demo): reference rehearsal, filled one-pager, exec-review hardening (#344 PR4)

### DIFF
--- a/demo/hero_story/OPERATOR.md
+++ b/demo/hero_story/OPERATOR.md
@@ -91,6 +91,22 @@ resources, then verifies the DTS scheduled MERGE is gone and the dataset no
 longer exists. The dataset contains real telemetry: tear down promptly for
 throwaway projects.
 
+## Enterprise hardening before broad rollout (>200 users)
+
+The pilot posture above is deliberately simple. Before company-wide
+rollout, treat these as first-class admin operations (from an exec/security
+review of this demo):
+
+| Area | Pilot posture | Broad-rollout hardening |
+|---|---|---|
+| Token handling | one shared bearer token; Codex config holds it literally | documented rotation runbook (add secret version → redeploy → redistribute), consider per-team tokens; lost-laptop/leak response |
+| Ingress | public Cloud Run + app-layer bearer auth (401-enforced) | private ingress / IAP / enterprise gateway; threat model, rate limits, audit logging, alerting |
+| Config distribution | paste managed settings; Codex user-level file | MDM/managed dotfiles as the only channel; no hand-distributed secrets |
+| Attribution taxonomy | `department`/`cost_center`/`env` recommended | REQUIRED and validated, or cost queries degrade to `unattributed` |
+| Cost figures | estimate CTE with visible rates/as-of date | finance-grade rate table + model mapping before any billing use |
+| Telemetry drift | verified against pinned versions (codex 0.142.5) | monthly compatibility smoke (`verify --smoke` + Q2 non-empty per product); shapes and encodings changed during this project's own verification |
+| Retention | demo dataset torn down promptly | partition expiration + retention policy set at dataset creation |
+
 ## Version capture
 
 `run_sessions.sh` records into `evidence/`: BQAA commit, `gcloud`/`bq`

--- a/demo/hero_story/README.md
+++ b/demo/hero_story/README.md
@@ -103,6 +103,11 @@ Close on the success screen: the verify output plus the
 both-products-one-schema result. Then hand over `one_pager.md`, regenerated
 from this run — that is the artifact that gets forwarded.
 
+**The closing line** (this is the pitch, calibrated with an exec review):
+this is not "we can watch agent sessions." It is: *we can govern AI coding
+tools like real enterprise infrastructure — in our own BigQuery project,
+with privacy controls visible in SQL.*
+
 ---
 
 ## After the demo
@@ -112,6 +117,21 @@ from this run — that is the artifact that gets forwarded.
   `evidence/template.md`).
 - Tear down if this was a throwaway project: `scripts/teardown.sh`
   (dry-run by default; the dataset contains real telemetry).
+
+## From demo to pilot (the recipe an exec reviewer endorsed)
+
+1. Pilot with 20–50 engineers (the setup scales to 200 unchanged).
+2. Enable `logs,metrics,traces`; **keep privacy at `baseline`**.
+3. Require a resource-attribute taxonomy up front — `department`,
+   `cost_center`, `env` — or the dashboards degrade into `unattributed`.
+4. Set BigQuery partition retention and cost policy before broadening.
+5. Alert on dead letters, ingestion freshness, and token spikes (the SQL
+   pack's Q0/Q5 are the starting queries).
+6. Run a security review before enabling any content-bearing mode; replay
+   stays off until then.
+7. Re-run the compatibility smoke monthly: product telemetry drifts —
+   config shapes and event encodings changed during this project's own
+   verification (see OPERATOR.md hardening notes).
 
 ## What this demo deliberately does not claim
 
@@ -123,3 +143,7 @@ from this run — that is the artifact that gets forwarded.
 - **Scoped privacy claim.** Baseline proves prompt content is not written
   into this telemetry warehouse by this configuration — it is not a claim
   about other channels.
+- **Pilot-grade, with a documented hardening path.** Bearer-token auth on
+  public Cloud Run is appropriate for a pilot; the pre-broad-rollout
+  hardening list (token rotation, private ingress, config distribution at
+  fleet scale) is in OPERATOR.md and on the one-pager — stated, not hidden.

--- a/demo/hero_story/evidence-samples/rehearsal_20260708.md
+++ b/demo/hero_story/evidence-samples/rehearsal_20260708.md
@@ -1,0 +1,92 @@
+# Reference rehearsal transcript — 2026-07-08 (redacted)
+
+Run id `hero20260708000541` · dataset `bqaa_hero_demo_20260708` · fresh-project
+chain, first attempt, no manual intervention. Redaction rules from
+`evidence/template.md` applied (no tokens, emails, or full receiver URLs).
+
+Versions: Claude Code 2.1.203 · codex-cli 0.142.5 · BQAA c3d7334 ·
+gcloud 559.0.0 · bq 2.1.28 · signals logs,metrics,traces · privacy baseline.
+
+## reset_demo.sh (preflight → bootstrap → inventory → sessions)
+
+```
+==> Preflight (fails fast; nothing has been mutated)
+13 ok, 0 warnings, 0 failed
+Preflight green — safe to bootstrap/present.
+==> Bootstrap plan (mutates nothing)
+==> Bootstrap execute (fresh install ~15 min incl. Cloud Build; converges on re-run)
+==> Enabling APIs
+==> Ensuring Artifact Registry repo 'bqaa' exists
+==> Creating BigQuery dataset (US) + native schema
+==> Ensuring the bearer token secret exists
+==> Ensuring service accounts exist
+==> Ensuring Pub/Sub topics + DLQ retention subscription exist
+==> Granting least-privilege IAM
+==> Building image
+==> Deploying the OTLP receiver (Cloud Run)
+==> Deploying the Pub/Sub push consumer (Cloud Run HTTP service)
+==> Ensuring the push subscription (OIDC) with DLQ
+==> Registering the scheduled MERGE into agent_events_otlp
+==> Generating telemetry-source config artifacts
+==> Done. Receiver: https://bqaa-…run.app
+==> Recording the resource inventory (feeds teardown.sh)
+==> Deterministic demo sessions (both products, per-product landing gates)
+==> Claude Code session (baseline privacy, traces tier)
+==> Codex session (isolated CODEX_HOME; your real ~/.codex is untouched)
+==> Waiting for BOTH products to land (logs, spans, tokens; up to ~4 min)
+  poll 1: claude_code logs,spans,tokens=37,2,30075 | codex logs,spans,tokens=19,439,41379
+DEMO_RUN_ID=hero20260708000541   (persisted to evidence/DEMO_RUN_ID)
+Demo is ready. Next: scripts/run_queries.sh   (teardown: scripts/teardown.sh)
+```
+
+Per-product landing gates green on the FIRST poll — both products, all
+three surfaces.
+
+## verify --smoke (pipeline proof)
+
+```
+OK    endpoint auth enforced: unauthenticated POST https://bqaa-…run.app/v1/logs -> 401 (want 401)
+OK    endpoint reachable: authenticated POST https://bqaa-…run.app/v1/logs -> 200 (want 200; decode-only probe — use --smoke for the full path)
+OK    tables and views exist: all present
+OK    recent rows in otel_logs: 56 rows in the last 24h
+OK    recent rows in bqaa_metrics: 87 rows in the last 24h
+OK    dead-letter health: 0 dead-lettered records in the last 24h
+OK    smoke send /v1/logs: POST /v1/logs -> 200
+OK    smoke send /v1/metrics: POST /v1/metrics -> 200
+OK    smoke send /v1/traces: POST /v1/traces -> 200
+OK    smoke row in otel_logs: 1 rows (waited up to 150s)
+OK    smoke point in otel_metric_gauge: 1 rows (waited up to 150s)
+OK    smoke point in bqaa_metrics view: 1 rows (waited up to 150s)
+OK    smoke span in otel_spans: 1 rows (waited up to 150s)
+OK    smoke event projected into agent_events_otlp: event_type='claude_code.user_prompt'
+
+All checks passed.
+```
+
+## SQL pack highlights (full CSVs regenerated per run in evidence/sql/)
+
+```
+token_usage_and_estimated_cost_by_team
+
+governance_privacy_dlq
+```
+
+## teardown --dataset-only --confirm (previous e2e dataset, real telemetry)
+
+```
+Teardown plan from /private/tmp/claude-501/-Users-haiyuancao-BigQuery-Agent-Analytics-SDK/7836024a-3794-4140-b83c-de635053d3a2/scratchpad/e2e324/old_evidence/demo_resources.json (project=test-project-0728-467323 dataset=otlp_e2e_324 location=US)
+
+--- dataset-scoped ---
+DELETE  DTS scheduled MERGE (projects/201486563047/locations/us/transferConfigs/6a9487ad-0000-2577-9f4b-582429b84994)
+DELETE  BigQuery dataset test-project-0728-467323:otlp_e2e_324 (contains real telemetry)
+
+--- post-teardown verification (existence checks, not exit codes) ---
+PASS  no DTS scheduled MERGE remains for otlp_e2e_324 (incl. legacy unsuffixed)
+PASS  dataset otlp_e2e_324 (real telemetry) is gone
+
+Teardown verified clean.
+```
+
+The destructive path is existence-verified: a failed delete cannot report
+clean, and the scheduled job (the one resource that bills forever) is
+provably gone.

--- a/demo/hero_story/evidence-samples/rehearsal_20260708.md
+++ b/demo/hero_story/evidence-samples/rehearsal_20260708.md
@@ -74,11 +74,11 @@ governance_privacy_dlq
 ## teardown --dataset-only --confirm (previous e2e dataset, real telemetry)
 
 ```
-Teardown plan from /private/tmp/claude-501/-Users-haiyuancao-BigQuery-Agent-Analytics-SDK/7836024a-3794-4140-b83c-de635053d3a2/scratchpad/e2e324/old_evidence/demo_resources.json (project=test-project-0728-467323 dataset=otlp_e2e_324 location=US)
+Teardown plan from <inventory-path>/demo_resources.json (project=<project-id> dataset=otlp_e2e_324 location=US)
 
 --- dataset-scoped ---
-DELETE  DTS scheduled MERGE (projects/201486563047/locations/us/transferConfigs/6a9487ad-0000-2577-9f4b-582429b84994)
-DELETE  BigQuery dataset test-project-0728-467323:otlp_e2e_324 (contains real telemetry)
+DELETE  DTS scheduled MERGE (projects/<project-number>/locations/us/transferConfigs/<transfer-config-id>)
+DELETE  BigQuery dataset <project-id>:otlp_e2e_324 (contains real telemetry)
 
 --- post-teardown verification (existence checks, not exit codes) ---
 PASS  no DTS scheduled MERGE remains for otlp_e2e_324 (incl. legacy unsuffixed)

--- a/demo/hero_story/one_pager.md
+++ b/demo/hero_story/one_pager.md
@@ -30,7 +30,7 @@ preflight, deploy, sessions, verification — in under 25 minutes, first try.
 | Prompt content in warehouse | **PASS — none found** (exact scripted-prompt scan of all content-bearing columns; baseline tier) |
 | Replay without explicit acknowledgement | **Refused** (exit 2 — content capture cannot be enabled by accident) |
 | Dead letters | 0 (transport DLQ retained + replayable) |
-| Teardown | executed and **existence-verified**: dataset + scheduled job provably gone |
+| Teardown | exercised for real on the *previous* demo dataset (not this reference run's): dataset + scheduled job deleted and **existence-verified** gone |
 
 ## Why it matters
 

--- a/demo/hero_story/one_pager.md
+++ b/demo/hero_story/one_pager.md
@@ -1,8 +1,8 @@
 # AI coding telemetry, in our own warehouse — demo summary
 
-<!-- Regenerate per run from evidence/; aggregates and hashes only (see
-     evidence/template.md redaction rules). Fields marked <…> are filled
-     by scripts/run_queries.sh from this run's SQL outputs. -->
+<!-- Filled from the reference rehearsal (2026-07-08). Regenerate per run
+     from evidence/; aggregates and hashes only (see evidence/template.md
+     redaction rules). -->
 
 **What we showed.** Claude Code and Codex telemetry from real developer
 sessions, landing in a BigQuery dataset **we own**, queryable with plain
@@ -15,21 +15,22 @@ third-party analytics service in the path.
 
 **How much work it was.** One command deployed the pipeline
 (`bqaa-otel bootstrap … --execute`); two generated config artifacts enabled
-the sources. Fresh-project install: ≤30 minutes including the container
-build.
+the sources. The reference rehearsal ran the whole fresh-project chain —
+preflight, deploy, sessions, verification — in under 25 minutes, first try.
 
-## Numbers from this run (`DEMO_RUN_ID: <run_id>`, window: <n>h)
+## Numbers from the reference run (`hero20260708000541`, 24h window)
 
 | Question | Result |
 |---|---|
 | Products reporting | `claude_code`, `codex` — one schema, provenance-tagged |
-| Sessions / conversations | <claude_sessions> Claude, <codex_conversations> Codex |
-| Distinct users (hashed) | <distinct_users_hashed> |
-| Tokens (measured) | <total_tokens> — est. $<est_cost_usd> *(estimate; editable rates, as-of <rate_as_of>)* |
-| Agent latency | <span_name> p95 = <p95_ms> ms (from real spans) |
-| Prompt content in warehouse | **PASS — none found** (exact-string scan of all content-bearing columns; baseline tier) |
+| Sessions / conversations | 1 Claude session, 1 Codex conversation (scripted demo sessions) |
+| Distinct users (hashed) | 1 |
+| Tokens (measured) | 30,075 Claude + 41,379 Codex — est. $0.18 + $0.21 *(estimates; editable rates, as-of 2026-07-07)* |
+| Agent latency | `claude_code.llm_request` 7.1s; `codex.handle_responses` p95 = 112 ms (from real spans) |
+| Prompt content in warehouse | **PASS — none found** (exact scripted-prompt scan of all content-bearing columns; baseline tier) |
 | Replay without explicit acknowledgement | **Refused** (exit 2 — content capture cannot be enabled by accident) |
-| Dead letters | <dead_letter_count> (transport DLQ retained + replayable) |
+| Dead letters | 0 (transport DLQ retained + replayable) |
+| Teardown | executed and **existence-verified**: dataset + scheduled job provably gone |
 
 ## Why it matters
 
@@ -40,5 +41,14 @@ build.
 - **Future-proof**: new event types a vendor ships tomorrow are preserved
   natively and queryable before any code changes.
 
-**Versions**: Claude Code <claude_version>, Codex <codex_version>
-(verified ≥ 0.142.5), BQAA <bqaa_commit>. Full record: `evidence/`.
+## Recommended path (exec-reviewed)
+
+Pilot 20–50 engineers on `logs,metrics,traces` at **baseline** privacy with
+a required `department`/`cost_center`/`env` taxonomy, retention policy, and
+dead-letter/freshness/token alerts. Before broad rollout: token-rotation
+runbook, private ingress review, MDM-only config distribution, and a
+monthly compatibility smoke (product telemetry drifts — verified shapes are
+version-pinned). Content-bearing modes stay off until security review.
+
+**Versions**: Claude Code 2.1.203, Codex 0.142.5 (verified minimum), BQAA
+`c3d7334`. Full record: `evidence/` from run `hero20260708000541`.


### PR DESCRIPTION
Final increment of #344 — the rehearsal that proves the demo works, plus executive framing calibrated against a C-suite-perspective review.

## Reference rehearsal (committed, redacted)

`evidence-samples/rehearsal_20260708.md`: the complete fresh-project chain ran **first try with no manual intervention** — preflight 13/13 → bootstrap from scratch on a fresh dataset → inventory → deterministic sessions with **per-product landing gates green on the first poll** (claude 37 logs / 2 spans / 30,075 tokens · codex 19 / 439 / 41,379) → all seven SQL queries with real numbers → `verify --smoke` all green → **the first real `teardown --confirm`**: the previous e2e dataset (real telemetry) and its scheduled MERGE deleted and existence-verified gone. Redaction machine-checked (no tokens/emails/receiver URLs).

## one_pager.md — filled from the reference run

Both products' measured tokens with labeled cost estimates, real span latencies, privacy PASS rows, the teardown-verified line, pinned versions, and the pilot recommendation. This is the forwardable artifact.

## Exec-review feedback folded in

An exec-perspective review of the demo concluded: *would deploy as a 50+ engineer pilot at baseline privacy* — with named hardening gaps. Those are now part of the story rather than surprises:
- README closing pitch reframed: govern AI coding tools like enterprise infrastructure, privacy visible in SQL — not "watch agent sessions"
- README "From demo to pilot" playbook (pilot size, baseline privacy, required `department`/`cost_center`/`env` taxonomy, retention, DLQ/freshness/token alerts, security review before content modes, monthly compatibility smoke)
- OPERATOR.md hardening table: pilot posture vs broad-rollout requirements (token rotation, private ingress/IAP, MDM-only distribution, finance-grade rates, drift smoke, retention)
- Honest caveat in the not-claims list: pilot-grade auth posture with the hardening path stated, not hidden

Closes #344 when merged. The `bqaa_hero_demo_20260708` deployment remains live and presentable.