### PR TITLE
feat(release): staging→promote image pipeline with digest injection (#349 PR1)

### DIFF
--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -294,18 +294,21 @@ jobs:
           path: dist/
 
       - name: Strip non-PyPI artifacts
-        # The plugin tarball is a release artifact, not a PyPI
-        # distribution. Filename uses hyphens in
-        # 'bigquery-agent-analytics-tracing-claude-code-*' so it's
-        # distinguishable from the underscore-named sdist.
+        # The plugin tarball and SHA256SUMS are release artifacts, not
+        # PyPI distributions — twine rejects unknown file types, and
+        # checksums belong on the GitHub release only.
         run: |
           rm -f dist/bigquery-agent-analytics-tracing-claude-code-*.tar.gz
+          rm -f dist/SHA256SUMS
           ls -la dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        # No skip-existing: the version-burn rule requires byte-identical
+        # artifacts at the same version on TestPyPI and PyPI. If the
+        # version already exists, the upload MUST fail loudly — a burned
+        # version silently skipping would make the gate test old bytes.
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
 
   promote:
     name: Promote image + publish release
@@ -321,15 +324,23 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Install crane (pinned + checksum-verified, BEFORE credentials exist)
+        # Supply-chain guard: never fetch a mutable 'latest' binary in a
+        # job that holds release credentials. Pinned version, pinned
+        # sha256, and installed before the auth step mints any token.
+        env:
+          CRANE_VERSION: v0.20.2
+          CRANE_SHA256: c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b
+        run: |
+          curl -sL -o crane.tar.gz \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz"
+          echo "${CRANE_SHA256}  crane.tar.gz" | sha256sum -c -
+          tar -xzf crane.tar.gz crane && sudo mv crane /usr/local/bin/
+
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.RELEASE_SA }}
-
-      - name: Install crane
-        run: |
-          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" \
-            | tar -xz crane && sudo mv crane /usr/local/bin/
 
       - name: Promote staging digest to the public coordinate
         # Content-addressed copy: the digest the artifacts already embed
@@ -372,6 +383,7 @@ jobs:
       - name: Strip non-PyPI artifacts
         run: |
           rm -f dist/bigquery-agent-analytics-tracing-claude-code-*.tar.gz
+          rm -f dist/SHA256SUMS
           ls -la dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -20,15 +20,36 @@
 # is distinct from the root `vX.Y.Z` tags used by the consumption SDK
 # so the two release pipelines never collide.
 #
-# Pipeline:
+# Pipeline (issue #349 release contract — staging→promote, digest-pinned):
 #   verify          - tag matches pyproject; run producer tests on 3.12
-#   build           - wheel + sdist + Claude Code plugin tarball
-#   github-release  - attach all artifacts to the GitHub release for
-#                     this tag, with auto-generated release notes
+#   build-image     - build the receiver image, SELF-TEST it (packaged
+#                     version must match the tag; app factories import),
+#                     push to the PRIVATE staging repo with a candidate
+#                     tag, capture the digest. Auth: Workload Identity
+#                     Federation (no long-lived keys).
+#   build           - inject the FINAL public coordinate + digest into
+#                     _release.py, then build wheel + sdist (BOTH embed
+#                     the constant), plugin tarball, run the mechanical
+#                     digest-equality gate, write SHA256SUMS
+#   github-release  - DRAFT release with all artifacts + checksums; it
+#                     is published only by `promote`, after the TestPyPI
+#                     full-lifecycle gate passes
 #   publish-testpypi - upload wheel + sdist to TestPyPI via Trusted
-#                      Publishing (no secrets)
-#   publish-pypi    - same, to PyPI (gated by the `pypi` environment
-#                     so maintainers can require manual approval)
+#                      Publishing (no secrets). The full-lifecycle gate
+#                      (install from TestPyPI → bootstrap --image
+#                      <staging>@digest → verify → teardown) runs against
+#                      this upload BEFORE `release-promote` is approved.
+#   promote         - manual-approval environment `release-promote`:
+#                     crane-copy staging@digest → public coordinate
+#                     (content-addressed; digest unchanged), assert the
+#                     public digest equals the packaged constant, then
+#                     publish the draft GitHub release
+#   publish-pypi    - PyPI (gated by the `pypi` environment). Version-burn
+#                     rule: a candidate that failed the gate burns its
+#                     version; never re-tag — bump and rebuild.
+#
+# One-time GitHub setup: environments `testpypi`, `pypi`, and
+# `release-promote` (the latter two with required reviewers).
 #
 # Trusted Publishing setup (one-time, on the PyPI side):
 #   - https://docs.pypi.org/trusted-publishers/adding-a-publisher/
@@ -52,6 +73,13 @@ on:
 concurrency:
   group: release-tracing-${{ github.ref }}
   cancel-in-progress: false
+
+env:
+  # Frozen coordinate (issue #349): the project id is the stable asset.
+  PUBLIC_IMAGE: us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver
+  STAGING_IMAGE: us-docker.pkg.dev/bqaa-releases/bqaa-staging/otlp-receiver
+  WIF_PROVIDER: projects/383897661993/locations/global/workloadIdentityPools/github/providers/github-actions
+  RELEASE_SA: bqaa-release-publisher@bqaa-releases.iam.gserviceaccount.com
 
 jobs:
   verify:
@@ -88,10 +116,65 @@ jobs:
       - name: Run tests
         run: pytest --tb=short -q
 
+  build-image:
+    name: Build + self-test + stage receiver image
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+      staging_ref: ${{ steps.digest.outputs.staging_ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image (repo root context, per Dockerfile contract)
+        run: |
+          docker build -f deploy/otlp_receiver/Dockerfile \
+            -t "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}" .
+
+      - name: Self-test image BEFORE anything is pushed
+        # Gate: packaged version must equal the release tag, and both
+        # Cloud Run entrypoint factories must import. A digest is only
+        # captured for an image that passed.
+        run: |
+          docker run --rm \
+            "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}" \
+            python -c "
+          import importlib.metadata as m
+          v = m.version('bigquery-agent-analytics-tracing')
+          assert v == '${{ needs.verify.outputs.version }}', f'image has {v}'
+          from bigquery_agent_analytics_tracing.otlp import app, consumer
+          assert callable(app.make_app)
+          assert callable(consumer.make_push_app_from_env)
+          print('self-test ok:', v)
+          "
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_SA }}
+
+      - name: Push candidate to the private staging repo
+        run: |
+          gcloud auth configure-docker us-docker.pkg.dev --quiet
+          docker push "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}"
+
+      - name: Capture digest
+        id: digest
+        run: |
+          DIGEST=$(gcloud artifacts docker images describe \
+            "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}" \
+            --format='value(image_summary.digest)')
+          echo "staged: ${STAGING_IMAGE}@${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "staging_ref=${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build wheel + plugin tarball
     runs-on: ubuntu-latest
-    needs: verify
+    needs: [verify, build-image]
     defaults:
       run:
         working-directory: producers
@@ -105,8 +188,25 @@ jobs:
       - name: Install build tools
         run: pip install build
 
+      - name: Inject the pinned public image reference
+        # BEFORE building: wheel AND sdist must both embed the constant.
+        # The image itself never carries it (a digest cannot appear in
+        # the artifact it is computed from).
+        run: |
+          python scripts/release_image_tool.py inject \
+            --target src/bigquery_agent_analytics_tracing/otlp/_release.py \
+            --coordinate "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}" \
+            --digest "${{ needs.build-image.outputs.digest }}"
+
       - name: Build wheel and sdist
         run: python -m build
+
+      - name: Digest-equality gate (wheel == sdist == expected)
+        run: |
+          python scripts/release_image_tool.py verify \
+            --wheel dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl \
+            --sdist dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz \
+            --expected "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}@${{ needs.build-image.outputs.digest }}"
 
       - name: Install built wheel
         # importlib.metadata.version() needs to see the dist-info so
@@ -128,6 +228,9 @@ jobs:
           test -f dist/bigquery-agent-analytics-tracing-claude-code-${{ needs.verify.outputs.version }}.tar.gz \
             || (echo "::error::missing plugin tarball" && exit 1)
 
+      - name: Write SHA256SUMS
+        run: python scripts/release_image_tool.py checksums --dist-dir dist/
+
       - uses: actions/upload-artifact@v4
         with:
           name: release-tracing-dist
@@ -135,9 +238,9 @@ jobs:
           if-no-files-found: error
 
   github-release:
-    name: Create GitHub release
+    name: Create GitHub release (draft)
     runs-on: ubuntu-latest
-    needs: [verify, build]
+    needs: [verify, build-image, build]
     permissions:
       contents: write
     steps:
@@ -151,17 +254,24 @@ jobs:
       - name: List downloaded artifacts
         run: ls -la dist/
 
-      - name: Create release with artifacts
+      - name: Create DRAFT release with artifacts
+        # Draft until `promote` publishes it — nothing customer-visible
+        # exists for a candidate that never survived the TestPyPI gate.
         uses: softprops/action-gh-release@v2
         with:
           name: "Tracing ${{ github.ref_name }}"
           tag_name: ${{ github.ref_name }}
+          draft: true
           generate_release_notes: true
           fail_on_unmatched_files: true
+          body: |
+            **Receiver image (pinned by digest):**
+            `${{ env.PUBLIC_IMAGE }}:${{ needs.verify.outputs.version }}@${{ needs.build-image.outputs.digest }}`
           files: |
             dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl
             dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz
             dist/bigquery-agent-analytics-tracing-claude-code-${{ needs.verify.outputs.version }}.tar.gz
+            dist/SHA256SUMS
 
   publish-testpypi:
     name: Publish to TestPyPI
@@ -197,10 +307,57 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
+  promote:
+    name: Promote image + publish release
+    runs-on: ubuntu-latest
+    # Manual approval on `release-promote` = the TestPyPI full-lifecycle
+    # gate verdict (install from TestPyPI → bootstrap --image
+    # <staging_ref>@digest → verify --smoke → teardown, evidence on the
+    # release issue). Approving asserts the gate passed.
+    needs: [verify, build-image, publish-testpypi]
+    environment:
+      name: release-promote
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_SA }}
+
+      - name: Install crane
+        run: |
+          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz crane && sudo mv crane /usr/local/bin/
+
+      - name: Promote staging digest to the public coordinate
+        # Content-addressed copy: the digest the artifacts already embed
+        # is preserved; only the public tag comes into existence here.
+        run: |
+          crane auth login us-docker.pkg.dev -u oauth2accesstoken \
+            --password "$(gcloud auth print-access-token)"
+          crane copy \
+            "${STAGING_IMAGE}@${{ needs.build-image.outputs.digest }}" \
+            "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}"
+
+      - name: Assert public digest equals the packaged constant
+        run: |
+          PUBLIC_DIGEST=$(crane digest "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}")
+          echo "public:  ${PUBLIC_DIGEST}"
+          echo "staged:  ${{ needs.build-image.outputs.digest }}"
+          test "${PUBLIC_DIGEST}" = "${{ needs.build-image.outputs.digest }}" \
+            || (echo "::error::digest drift between staging and public" && exit 1)
+
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft=false
+
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [verify, publish-testpypi]
+    needs: [verify, promote, publish-testpypi]
     environment:
       name: pypi
       url: https://pypi.org/p/bigquery-agent-analytics-tracing

--- a/producers/RELEASING.md
+++ b/producers/RELEASING.md
@@ -36,26 +36,72 @@ git tag -a "tracing-v${VERSION}" -m "tracing ${VERSION}"
 git push origin "tracing-v${VERSION}"
 ```
 
-The workflow takes over from there. Total wall-clock is ~5 minutes.
+The workflow takes over from there. Automated stages run in ~10
+minutes; the release then WAITS at two manual approval gates
+(`release-promote`, then `pypi`) — see the gate section below.
 
-## What CI does
+## What CI does (issue #349 release contract)
 
 1. **`verify`** — confirms the tag matches `pyproject.toml`, then
    runs the producer test suite on Python 3.12.
-2. **`build`** — `python -m build` for wheel + sdist, then
-   `python scripts/build_claude_plugin.py` for the plugin tarball.
-   Verifies all three expected artifacts landed in `dist/`.
-3. **`github-release`** — creates the GitHub release for the tag with
-   auto-generated notes and attaches all three artifacts.
-4. **`publish-testpypi`** — uploads wheel + sdist to TestPyPI via
-   Trusted Publishing (no secrets). The plugin tarball is stripped
-   from the upload set before this step.
-5. **`publish-pypi`** — same, to PyPI. Gated by the `pypi`
-   environment, so maintainers can require manual approval here
-   without blocking the GitHub release.
+2. **`build-image`** — builds the receiver image from the repo-root
+   Dockerfile, **self-tests it before anything is pushed** (packaged
+   version must equal the tag; both Cloud Run entrypoint factories
+   must import), pushes it to the **private** staging repo
+   (`us-docker.pkg.dev/bqaa-releases/bqaa-staging/otlp-receiver`) with
+   a `<version>-candidate.<run_id>` tag, and captures the digest.
+   Auth is Workload Identity Federation — no stored keys.
+3. **`build`** — injects the pinned public image reference
+   (`us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:<version>@sha256:…`)
+   into `_release.py` **before** `python -m build`, so wheel and sdist
+   both embed it; builds the plugin tarball; runs the mechanical
+   digest-equality gate (`scripts/release_image_tool.py verify`);
+   writes `SHA256SUMS`.
+4. **`github-release`** — creates a **draft** release with all
+   artifacts + checksums and the pinned image reference in the body.
+   Nothing is customer-visible yet.
+5. **`publish-testpypi`** — uploads wheel + sdist to TestPyPI via
+   Trusted Publishing. No `skip-existing`: if the version already
+   exists there, the upload fails loudly — that version is burned
+   (see below).
+6. **`promote`** — waits on the `release-promote` environment. Run
+   the TestPyPI full-lifecycle gate BEFORE approving (see next
+   section). On approval: crane-copies the staging digest to the
+   public coordinate (content-addressed — the digest the artifacts
+   embed is unchanged), asserts public digest == packaged constant,
+   and publishes the draft release.
+7. **`publish-pypi`** — PyPI, gated by the `pypi` environment;
+   requires `promote`.
 
-The plugin tarball is **never** uploaded to PyPI — it ships only as a
-GitHub release asset.
+The plugin tarball and `SHA256SUMS` are **never** uploaded to PyPI —
+they ship only as GitHub release assets.
+
+## The TestPyPI full-lifecycle gate (before approving `release-promote`)
+
+In a clean venv on a machine with NO repo checkout:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            bigquery-agent-analytics-tracing==${VERSION}
+bqaa-otel bootstrap --preflight ...
+bqaa-otel bootstrap ... --image <staging-ref>@sha256:<digest> --execute
+bqaa-otel verify --smoke ...
+bqaa-otel teardown ...
+```
+
+(The staging ref + digest are in the `build-image` job output.) All
+green → approve `release-promote`, then run the post-promotion smoke
+WITHOUT `--image` (embedded public default), then approve `pypi`.
+Post evidence on the release issue.
+
+## Version-burn rule
+
+TestPyPI and PyPI must carry **byte-identical artifacts at the same
+version**. If a candidate fails the gate, that version is burned
+everywhere: bump the version, re-tag, rebuild from scratch. Never
+re-upload, never re-tag an image (staging and public tags are
+immutable — enforced at the repository level).
 
 ## Verifying the release
 
@@ -88,8 +134,13 @@ tar -tzf /tmp/plugin.tar.gz | head
   `PackageNotFoundError`; the `Install built wheel` step should have
   prevented this. Check that step's logs and rebuild.
 - **`publish-testpypi` fails with OIDC error** — Trusted Publisher is
-  not configured on the TestPyPI side. The GitHub release is still
-  good; configure TestPyPI then re-run the `publish-testpypi` job.
+  not configured on the TestPyPI side. Configure TestPyPI then re-run
+  the `publish-testpypi` job.
+- **`publish-testpypi` fails with "version already exists"** — that
+  version was burned by an earlier candidate. Bump, re-tag, rebuild.
+- **`build-image` fails WIF auth** — check the pool/provider and the
+  `bqaa-release-publisher` SA bindings in `bqaa-releases` (see the
+  workflow `env:` block for the exact resource names).
 - **`publish-pypi` fails the same way** — same fix on the PyPI side.
 
 If a release ships a broken artifact, do **not** delete the tag.
@@ -113,6 +164,11 @@ TestPyPI) and add a publisher with:
 
 These names must match exactly — the `environment:` blocks in the
 workflow are the binding contract.
+
+GitHub-side one-time setup: create environments `testpypi`, `pypi`,
+and `release-promote` in the repo settings, with required reviewers
+on `pypi` and `release-promote` (approving `release-promote` asserts
+the TestPyPI full-lifecycle gate passed).
 
 Until both publishers are configured, the `publish-testpypi` and
 `publish-pypi` jobs will fail with a clear error. The `build` and

--- a/producers/scripts/release_image_tool.py
+++ b/producers/scripts/release_image_tool.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Release image injection + artifact verification (issue #349).
+
+Three subcommands used by release-tracing.yml:
+
+  inject     write the pinned public image reference into _release.py
+             BEFORE wheel/sdist are built (both embed the same constant)
+  verify     assert wheel and sdist embed the identical expected reference
+             (the mechanical digest-equality gate)
+  checksums  write SHA256SUMS for every file in the dist directory
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import pathlib
+import re
+import sys
+import tarfile
+import zipfile
+
+_MODULE_RELPATH = "bigquery_agent_analytics_tracing/otlp/_release.py"
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+_TEMPLATE = '''\
+"""Released receiver image reference — written by release_image_tool.py.
+
+Pinned by digest per the issue #349 release contract; the version tag is
+present for human readability only.
+"""
+
+RELEASE_IMAGE = "{reference}"
+'''
+
+
+class ReleaseVerificationError(Exception):
+  """A release artifact does not embed the expected image reference."""
+
+
+def inject(target: pathlib.Path, coordinate: str, digest: str) -> str:
+  """Write the pinned reference into ``target``; returns the reference."""
+  if not _DIGEST_RE.match(digest):
+    raise ValueError(f"malformed digest {digest!r} (want sha256:<64 hex>)")
+  tag = coordinate.rsplit("/", 1)[-1].partition(":")[2]
+  if not tag:
+    raise ValueError(f"coordinate {coordinate!r} has no version tag")
+  if tag == "latest":
+    raise ValueError("'latest' is never published per the release contract")
+  if "@" in coordinate:
+    raise ValueError(f"coordinate {coordinate!r} must not already pin a digest")
+  reference = f"{coordinate}@{digest}"
+  target.write_text(_TEMPLATE.format(reference=reference))
+  return reference
+
+
+def _reference_from_source(text: str, origin: str) -> str | None:
+  """Extract the RELEASE_IMAGE constant from module source via AST."""
+  for node in ast.parse(text).body:
+    if isinstance(node, ast.Assign):
+      for name in node.targets:
+        if isinstance(name, ast.Name) and name.id == "RELEASE_IMAGE":
+          value = ast.literal_eval(node.value)
+          return value
+  raise ReleaseVerificationError(f"no RELEASE_IMAGE constant in {origin}")
+
+
+def extract_from_wheel(wheel: pathlib.Path) -> str | None:
+  with zipfile.ZipFile(wheel) as zf:
+    text = zf.read(_MODULE_RELPATH).decode()
+  return _reference_from_source(text, f"wheel {wheel.name}")
+
+
+def extract_from_sdist(sdist: pathlib.Path) -> str | None:
+  with tarfile.open(sdist) as tf:
+    for member in tf.getmembers():
+      if member.name.endswith(_MODULE_RELPATH):
+        text = tf.extractfile(member).read().decode()
+        return _reference_from_source(text, f"sdist {sdist.name}")
+  raise ReleaseVerificationError(f"no {_MODULE_RELPATH} in sdist {sdist.name}")
+
+
+def verify_artifacts(
+    wheel: pathlib.Path, sdist: pathlib.Path, expected: str
+) -> None:
+  """The mechanical equality gate: wheel == sdist == expected, no placeholders."""
+  from_wheel = extract_from_wheel(wheel)
+  from_sdist = extract_from_sdist(sdist)
+  if from_wheel is None or from_sdist is None:
+    raise ReleaseVerificationError(
+        "artifact still carries the dev placeholder (RELEASE_IMAGE = None) — "
+        "inject must run before build"
+    )
+  if from_wheel != from_sdist:
+    raise ReleaseVerificationError(
+        f"wheel embeds {from_wheel!r} but sdist embeds {from_sdist!r}"
+    )
+  if from_wheel != expected:
+    raise ReleaseVerificationError(
+        f"artifacts embed {from_wheel!r} but expected {expected!r}"
+    )
+
+
+def write_checksums(dist_dir: pathlib.Path) -> pathlib.Path:
+  out = dist_dir / "SHA256SUMS"
+  lines = []
+  for path in sorted(dist_dir.iterdir()):
+    if path.is_file() and path.name != out.name:
+      digest = hashlib.sha256(path.read_bytes()).hexdigest()
+      lines.append(f"{digest}  {path.name}")
+  out.write_text("\n".join(lines) + "\n")
+  return out
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  sub = parser.add_subparsers(dest="command", required=True)
+
+  p_inject = sub.add_parser("inject")
+  p_inject.add_argument("--target", type=pathlib.Path, required=True)
+  p_inject.add_argument("--coordinate", required=True)
+  p_inject.add_argument("--digest", required=True)
+
+  p_verify = sub.add_parser("verify")
+  p_verify.add_argument("--wheel", type=pathlib.Path, required=True)
+  p_verify.add_argument("--sdist", type=pathlib.Path, required=True)
+  p_verify.add_argument("--expected", required=True)
+
+  p_sums = sub.add_parser("checksums")
+  p_sums.add_argument("--dist-dir", type=pathlib.Path, required=True)
+
+  args = parser.parse_args(argv)
+  try:
+    if args.command == "inject":
+      print(inject(args.target, args.coordinate, args.digest))
+    elif args.command == "verify":
+      verify_artifacts(args.wheel, args.sdist, expected=args.expected)
+      print(f"digest-equality gate passed: {args.expected}")
+    elif args.command == "checksums":
+      print(write_checksums(args.dist_dir))
+  except (ValueError, ReleaseVerificationError) as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    return 2
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/_release.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/_release.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Released receiver image reference (issue #349 release contract).
+
+Written by scripts/release_image_tool.py during the release pipeline,
+AFTER the image is built and its digest captured — a digest cannot appear
+inside the artifact it is computed from, so this constant exists only in
+the Python packaging artifacts, never in the image itself.
+
+``None`` in development checkouts: bootstrap then requires an explicit
+``--image`` or the source-build path.
+"""
+
+RELEASE_IMAGE = None

--- a/producers/tests/test_release_image_tool.py
+++ b/producers/tests/test_release_image_tool.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the release image injection/verification tool (issue #349).
+
+The release contract: the public image coordinate + digest are injected
+into the source tree BEFORE wheel/sdist are built (both must embed the
+identical value), and the release job asserts equality mechanically.
+"""
+
+import hashlib
+import pathlib
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "scripts"))
+import release_image_tool as tool
+
+GOOD_COORDINATE = "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:0.2.0"
+GOOD_DIGEST = "sha256:" + "a" * 64
+MODULE_RELPATH = "bigquery_agent_analytics_tracing/otlp/_release.py"
+
+
+def _exec_release_module(text):
+  ns = {}
+  exec(text, ns)  # noqa: S102 - executing our own generated constant module
+  return ns
+
+
+class TestInject:
+
+  def test_written_module_defines_pinned_reference(self, tmp_path):
+    target = tmp_path / "_release.py"
+    tool.inject(target, GOOD_COORDINATE, GOOD_DIGEST)
+    ns = _exec_release_module(target.read_text())
+    assert ns["RELEASE_IMAGE"] == f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+
+  def test_rejects_malformed_digest(self, tmp_path):
+    with pytest.raises(ValueError, match="digest"):
+      tool.inject(tmp_path / "_release.py", GOOD_COORDINATE, "sha256:short")
+
+  def test_rejects_latest_tag(self, tmp_path):
+    with pytest.raises(ValueError, match="latest"):
+      tool.inject(
+          tmp_path / "_release.py",
+          "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:latest",
+          GOOD_DIGEST,
+      )
+
+  def test_rejects_coordinate_without_version_tag(self, tmp_path):
+    with pytest.raises(ValueError, match="tag"):
+      tool.inject(
+          tmp_path / "_release.py",
+          "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver",
+          GOOD_DIGEST,
+      )
+
+
+class TestExtract:
+
+  def _wheel_with(self, tmp_path, text):
+    path = tmp_path / "pkg-0.2.0-py3-none-any.whl"
+    with zipfile.ZipFile(path, "w") as zf:
+      zf.writestr(MODULE_RELPATH, text)
+    return path
+
+  def _sdist_with(self, tmp_path, text):
+    src = tmp_path / "srcdir" / f"pkg-0.2.0/src/{MODULE_RELPATH}"
+    src.parent.mkdir(parents=True)
+    src.write_text(text)
+    path = tmp_path / "pkg-0.2.0.tar.gz"
+    with tarfile.open(path, "w:gz") as tf:
+      tf.add(src, arcname=f"pkg-0.2.0/src/{MODULE_RELPATH}")
+    return path
+
+  def test_extracts_reference_from_wheel(self, tmp_path):
+    ref = f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+    wheel = self._wheel_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    assert tool.extract_from_wheel(wheel) == ref
+
+  def test_extracts_reference_from_sdist(self, tmp_path):
+    ref = f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+    sdist = self._sdist_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    assert tool.extract_from_sdist(sdist) == ref
+
+  def test_verify_passes_when_wheel_sdist_and_expected_agree(self, tmp_path):
+    ref = f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+    wheel = self._wheel_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    sdist = self._sdist_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    tool.verify_artifacts(wheel, sdist, expected=ref)
+
+  def test_verify_fails_on_wheel_sdist_mismatch(self, tmp_path):
+    ref = f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+    other = ref.replace("a" * 64, "b" * 64)
+    wheel = self._wheel_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    sdist = self._sdist_with(tmp_path, f'RELEASE_IMAGE = "{other}"\n')
+    with pytest.raises(tool.ReleaseVerificationError, match="sdist"):
+      tool.verify_artifacts(wheel, sdist, expected=ref)
+
+  def test_verify_fails_when_expected_differs(self, tmp_path):
+    ref = f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+    wheel = self._wheel_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    sdist = self._sdist_with(tmp_path, f'RELEASE_IMAGE = "{ref}"\n')
+    with pytest.raises(tool.ReleaseVerificationError, match="expected"):
+      tool.verify_artifacts(
+          wheel, sdist, expected=ref.replace("a" * 64, "c" * 64)
+      )
+
+  def test_verify_fails_on_dev_placeholder(self, tmp_path):
+    wheel = self._wheel_with(tmp_path, "RELEASE_IMAGE = None\n")
+    sdist = self._sdist_with(tmp_path, "RELEASE_IMAGE = None\n")
+    with pytest.raises(tool.ReleaseVerificationError, match="placeholder"):
+      tool.verify_artifacts(
+          wheel, sdist, expected=f"{GOOD_COORDINATE}@{GOOD_DIGEST}"
+      )
+
+
+class TestChecksums:
+
+  def test_writes_sha256sums_in_standard_format(self, tmp_path):
+    (tmp_path / "a.whl").write_bytes(b"wheel-bytes")
+    (tmp_path / "b.tar.gz").write_bytes(b"sdist-bytes")
+    out = tool.write_checksums(tmp_path)
+    lines = out.read_text().splitlines()
+    expect_a = hashlib.sha256(b"wheel-bytes").hexdigest()
+    assert f"{expect_a}  a.whl" in lines
+    assert len(lines) == 2
+    assert not any("SHA256SUMS" in l for l in lines)
+
+
+class TestDevPlaceholder:
+
+  def test_packaged_release_module_defaults_to_none(self):
+    from bigquery_agent_analytics_tracing.otlp import _release
+
+    assert _release.RELEASE_IMAGE is None
+
+
+class TestCli:
+
+  def test_inject_and_verify_roundtrip_via_cli(self, tmp_path):
+    target = tmp_path / "_release.py"
+    script = (
+        pathlib.Path(__file__).parent.parent / "scripts/release_image_tool.py"
+    )
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "inject",
+            "--target",
+            str(target),
+            "--coordinate",
+            GOOD_COORDINATE,
+            "--digest",
+            GOOD_DIGEST,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    ns = _exec_release_module(target.read_text())
+    assert ns["RELEASE_IMAGE"].endswith(GOOD_DIGEST)


### PR DESCRIPTION
First implementation increment of the #349 release contract: the `release-tracing.yml` image pipeline plus the TDD'd tooling it calls.

## The 7-step contract, as jobs

- **`build-image`** — builds the receiver image from the repo-root Dockerfile, **self-tests before anything is pushed** (packaged version must equal the release tag; both Cloud Run entrypoint factories must import), pushes to the **private** `bqaa-staging` repo as `<version>-candidate.<run_id>` (staging tags never touch the public namespace), captures the digest. Auth via Workload Identity Federation — no long-lived keys; the WIF provider + release SA were created and existence-verified on the issue.
- **`build`** — `inject` writes the pinned public reference into `_release.py` **before** `python -m build`, so wheel AND sdist embed the identical constant; then the **mechanical digest-equality gate** (`verify`: wheel == sdist == expected, AST-extracted, dev-placeholder detected specifically) and `SHA256SUMS`.
- **`github-release`** — now a **draft** carrying the pinned reference in the body + checksums; nothing customer-visible until promote.
- **`promote`** (new; environment `release-promote` = the manual approval asserting the TestPyPI full-lifecycle gate passed) — crane-copies `staging@digest` → public coordinate (content-addressed, digest unchanged), **asserts public digest == packaged constant**, then publishes the draft. `publish-pypi` now requires promote.

## Tooling (TDD, 13 tests written RED-first)

`producers/scripts/release_image_tool.py`: `inject` (rejects malformed digests, `latest`, tagless and pre-pinned coordinates), `verify`, `checksums`. `_release.py` ships `RELEASE_IMAGE = None` in dev — the constant exists only in the Python artifacts, never in the image (a digest cannot appear inside the artifact it is computed from).

## Validation beyond unit tests

The exact `inject → python -m build → verify` chain the workflow runs was executed locally against a **real wheel + sdist** — gate passed, placeholder restored. Full producers suite: 339 passed.

## One-time setup this expects (documented in the workflow header)

GitHub environments `testpypi`, `pypi`, `release-promote` (latter two with required reviewers). GCP side is already live and verified (repos with enforced immutable tags, allUsers reader on public only, WIF, budget guardrail — evidence on #349).

Next increments per #349: bootstrap `--image`/default-constant wiring + mode-aware `--preflight`, `bqaa-otel teardown`, docs flip, release-notes template.

Part of #349.