### PR TITLE
feat(otlp): bootstrap deploys the released image by default (#349 PR2)

### DIFF
--- a/demo/hero_story/OPERATOR.md
+++ b/demo/hero_story/OPERATOR.md
@@ -35,10 +35,10 @@ export PROJECT=<your-project> DATASET=bqaa_hero_demo_$(date +%Y%m%d)
 scripts/preflight.sh "$PROJECT" "$DATASET"
 
 # Plan first (prints every command, mutates nothing), then execute:
-bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" \
+bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" --build-from-source \
   --signals logs,metrics,traces --source claude-code,codex \
   --out demo/hero_story/evidence/artifacts
-bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" \
+bqaa-otel bootstrap --project "$PROJECT" --dataset "$DATASET" --build-from-source \
   --signals logs,metrics,traces --source claude-code,codex \
   --out demo/hero_story/evidence/artifacts --execute
 ```

--- a/demo/hero_story/scripts/reset_demo.sh
+++ b/demo/hero_story/scripts/reset_demo.sh
@@ -22,6 +22,7 @@ echo "==> Bootstrap plan (mutates nothing)"
 python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
   --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
   --bq-location "$BQ_LOCATION" \
+  --build-from-source \
   --signals logs,metrics,traces --source claude-code,codex \
   --out "$EVIDENCE_DIR/artifacts" | tee "$EVIDENCE_DIR/bootstrap_plan.txt" | tail -3
 
@@ -30,6 +31,7 @@ echo "==> Bootstrap execute (fresh install ~15 min incl. Cloud Build; converges 
 python3 -m bigquery_agent_analytics_tracing.otlp.cli bootstrap \
   --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
   --bq-location "$BQ_LOCATION" \
+  --build-from-source \
   --signals logs,metrics,traces --source claude-code,codex \
   --out "$EVIDENCE_DIR/artifacts" --execute
 

--- a/deploy/otlp_receiver/README.md
+++ b/deploy/otlp_receiver/README.md
@@ -15,7 +15,8 @@ Claude Code / Codex --OTLP--> Cloud Run receiver --> Pub/Sub --> consumer --> Bi
 ```bash
 # Print the plan (runs nothing):
 PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \
-  bootstrap --project my-proj --dataset agent_analytics --region us-central1
+  bootstrap --project my-proj --dataset agent_analytics --region us-central1 \
+  --build-from-source
 
 # Apply it:
 PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \

--- a/deploy/otlp_receiver/README.md
+++ b/deploy/otlp_receiver/README.md
@@ -19,10 +19,14 @@ PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \
 
 # Apply it:
 PYTHONPATH=producers/src python3 -m bigquery_agent_analytics_tracing.otlp.cli \
-  bootstrap --project my-proj --dataset agent_analytics --region us-central1 --execute
+  bootstrap --project my-proj --dataset agent_analytics --region us-central1 \
+  --build-from-source --execute
 ```
 
-(`bqaa-otel bootstrap ...` once the producers package is installed;
+(`bqaa-otel bootstrap ...` once the producers package is installed.
+`--build-from-source` is required when running from a repository
+checkout — an installed release wheel instead embeds the released,
+digest-pinned receiver image and deploys it with no build step;
 `setup.sh` is a thin wrapper over the same command with the historical
 env-var interface: `PROJECT=my-proj bash deploy/otlp_receiver/setup.sh`.)
 

--- a/deploy/otlp_receiver/setup.sh
+++ b/deploy/otlp_receiver/setup.sh
@@ -38,6 +38,7 @@ SIGNALS="logs,metrics"
 
 PYTHONPATH="producers/src${PYTHONPATH:+:$PYTHONPATH}" exec python3 -m \
   bigquery_agent_analytics_tracing.otlp.cli bootstrap \
+  --build-from-source \
   --project "$PROJECT" --dataset "$DATASET" --region "$REGION" \
   --bq-location "$BQ_LOCATION" --signals "$SIGNALS" \
   --source-product "$SOURCE_PRODUCT" --execute

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -39,8 +39,6 @@ import shlex
 import subprocess
 from typing import Callable, Protocol
 
-from bigquery_agent_analytics_tracing.otlp import _release
-
 from . import _release
 from . import config_artifacts
 from . import ddl

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -39,7 +39,9 @@ import shlex
 import subprocess
 from typing import Callable, Protocol
 
+from . import _release
 from . import config_artifacts
+from bigquery_agent_analytics_tracing.otlp import _release
 from . import ddl
 from . import sql
 
@@ -143,6 +145,11 @@ class _PlanRunner:
 
   _PLACEHOLDERS = (
       ("projects describe", "<project-number>"),
+      # Digest-assertion captures come before the service-name needles:
+      # 'run services describe --format=...latestCreatedRevisionName' also
+      # contains the service name.
+      ("latestCreatedRevisionName", "<revision>"),
+      ("run revisions describe", "<image-digest>"),
       (RECEIVER_SVC, "<receiver-url>"),
       (CONSUMER_SVC, "<consumer-url>"),
   )
@@ -186,6 +193,11 @@ class BootstrapSettings:
   resource_attributes: dict[str, str] | None = None
   acknowledge_content_logging: bool = False
   out_dir: pathlib.Path = pathlib.Path(".")
+  # Image source (issue #349): explicit --image wins; otherwise the
+  # released image embedded in the wheel; --build-from-source keeps the
+  # legacy repo-checkout Cloud Build path.
+  image: str | None = None
+  build_from_source: bool = False
 
   def __post_init__(self):
     # Reuse the PR 1 tier validation (privacy/signals/replay ack) so the
@@ -210,6 +222,10 @@ class BootstrapSettings:
             f"unknown source {source!r}; expected one of"
             f" {config_artifacts.SOURCES}"
         )
+    if self.image is not None and self.build_from_source:
+      raise ValueError("--image and --build-from-source are mutually exclusive")
+    if self.image is not None:
+      _validate_image_reference(self.image)
 
   def _spec(self, endpoint: str) -> config_artifacts.BootstrapSpec:
     return config_artifacts.BootstrapSpec(
@@ -232,8 +248,52 @@ class BootstrapResult:
   artifact_paths: tuple[pathlib.Path, ...]
 
 
-def _image(s: BootstrapSettings) -> str:
+_IMAGE_REF_RE = re.compile(r"[A-Za-z0-9./_:@-]+")
+
+
+def _validate_image_reference(ref: str) -> None:
+  """Reject references that cannot be a pinned deployable image.
+
+  The reference lands in gcloud argv and the written inventory; it must
+  carry a real version tag ('latest' is never published per the release
+  contract) and, when digest-pinned, a well-formed sha256.
+  """
+  if not _IMAGE_REF_RE.fullmatch(ref):
+    raise ValueError(f"invalid image reference {ref!r}")
+  base, _, digest = ref.partition("@")
+  if digest and not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+    raise ValueError(f"malformed digest in image reference {ref!r}")
+  tag = base.rsplit("/", 1)[-1].partition(":")[2]
+  if not tag:
+    raise ValueError(f"image reference {ref!r} has no version tag")
+  if tag == "latest":
+    raise ValueError(
+        "image tag 'latest' is never published; pin a version"
+        " (releases are pinned by digest)"
+    )
+
+
+def _source_image(s: BootstrapSettings) -> str:
   return f"{s.region}-docker.pkg.dev/{s.project}/{AR_REPO}/otlp-receiver:latest"
+
+
+def resolve_image(s: BootstrapSettings) -> tuple[str, str]:
+  """(image reference, mode) for this run.
+
+  Modes: 'explicit' (--image), 'source' (--build-from-source), 'released'
+  (the constant the release pipeline injected into the wheel). A dev
+  checkout has no released image, so it must pick one explicitly.
+  """
+  if s.image is not None:
+    return s.image, "explicit"
+  if s.build_from_source:
+    return _source_image(s), "source"
+  if _release.RELEASE_IMAGE is not None:
+    return _release.RELEASE_IMAGE, "released"
+  raise ValueError(
+      "no released image is embedded in this installation (development"
+      " checkout): pass --image <reference> or --build-from-source"
+  )
 
 
 def _find_merge_config(listing: str | None, dataset: str) -> str | None:
@@ -282,38 +342,56 @@ def run_bootstrap(
   consumer_sa = f"{CONSUMER_SVC}@{s.project}.iam.gserviceaccount.com"
   push_sa = f"bqaa-otlp-push@{s.project}.iam.gserviceaccount.com"
 
-  echo("==> Enabling APIs")
-  runner.run(["gcloud", "services", "enable", *proj, *_APIS])
+  image, image_mode = resolve_image(s)
 
-  echo(f"==> Ensuring Artifact Registry repo {AR_REPO!r} exists")
-  if (
-      runner.try_run(
+  echo("==> Enabling APIs")
+  # Default prebuilt-image mode has ZERO build footprint in the customer
+  # project: no Cloud Build / Artifact Registry APIs, no repo (issue #349).
+  apis = (
+      _APIS
+      if image_mode == "source"
+      else tuple(
+          a
+          for a in _APIS
+          if a
+          not in (
+              "cloudbuild.googleapis.com",
+              "artifactregistry.googleapis.com",
+          )
+      )
+  )
+  runner.run(["gcloud", "services", "enable", *proj, *apis])
+
+  if image_mode == "source":
+    echo(f"==> Ensuring Artifact Registry repo {AR_REPO!r} exists")
+    if (
+        runner.try_run(
+            [
+                "gcloud",
+                "artifacts",
+                "repositories",
+                "describe",
+                AR_REPO,
+                *proj,
+                "--location",
+                s.region,
+            ]
+        )
+        is None
+    ):
+      runner.run(
           [
               "gcloud",
               "artifacts",
               "repositories",
-              "describe",
+              "create",
               AR_REPO,
               *proj,
               "--location",
               s.region,
+              "--repository-format=docker",
           ]
       )
-      is None
-  ):
-    runner.run(
-        [
-            "gcloud",
-            "artifacts",
-            "repositories",
-            "create",
-            AR_REPO,
-            *proj,
-            "--location",
-            s.region,
-            "--repository-format=docker",
-        ]
-    )
 
   echo(f"==> Creating BigQuery dataset ({s.bq_location}) + native schema")
   bq = ["bq", f"--project_id={s.project}", f"--location={s.bq_location}"]
@@ -506,19 +584,21 @@ def run_bootstrap(
       ]
   )
 
-  echo("==> Building image")
-  image = _image(s)
-  build_config = (
-      "steps:\n"
-      "- name: gcr.io/cloud-builders/docker\n"
-      f"  args: ['build','-f','deploy/otlp_receiver/Dockerfile',"
-      f"'-t','{image}','.']\n"
-      f"images: ['{image}']\n"
-  )
-  runner.run(
-      ["gcloud", "builds", "submit", *proj, "--config=/dev/stdin", "."],
-      input_text=build_config,
-  )
+  if image_mode == "source":
+    echo("==> Building image")
+    build_config = (
+        "steps:\n"
+        "- name: gcr.io/cloud-builders/docker\n"
+        f"  args: ['build','-f','deploy/otlp_receiver/Dockerfile',"
+        f"'-t','{image}','.']\n"
+        f"images: ['{image}']\n"
+    )
+    runner.run(
+        ["gcloud", "builds", "submit", *proj, "--config=/dev/stdin", "."],
+        input_text=build_config,
+    )
+  else:
+    echo(f"==> Using prebuilt image ({image_mode}): {image}")
 
   main_topic_path = f"projects/{s.project}/topics/{MAIN_TOPIC}"
 
@@ -732,6 +812,68 @@ def run_bootstrap(
           "--format=value(status.url)",
       ]
   )
+
+  if "@sha256:" in image:
+    echo("==> Asserting deployed image digest matches the pinned reference")
+    expected_digest = image.partition("@")[2]
+    for svc in (RECEIVER_SVC, CONSUMER_SVC):
+      revision = runner.run(
+          [
+              "gcloud",
+              "run",
+              "services",
+              "describe",
+              svc,
+              *proj,
+              "--region",
+              s.region,
+              "--format=value(status.latestCreatedRevisionName)",
+          ]
+      )
+      deployed = runner.run(
+          [
+              "gcloud",
+              "run",
+              "revisions",
+              "describe",
+              revision,
+              *proj,
+              "--region",
+              s.region,
+              "--format=value(status.imageDigest)",
+          ]
+      )
+      deployed = deployed.strip()
+      if deployed.startswith("<"):  # plan mode placeholder — nothing deployed
+        continue
+      if not deployed.endswith(expected_digest):
+        raise RuntimeError(
+            f"{svc}: deployed image digest {deployed.strip()!r} does not"
+            f" match the pinned reference digest {expected_digest!r}"
+        )
+
+  echo("==> Writing the resource inventory (feeds teardown)")
+  inventory = {
+      "mode": image_mode,
+      "image": image,
+      "project": s.project,
+      "dataset": s.dataset,
+      "region": s.region,
+      "bq_location": s.bq_location,
+      "cloud_run_services": [RECEIVER_SVC, CONSUMER_SVC],
+      "pubsub_topics": [MAIN_TOPIC, DLQ_TOPIC],
+      "pubsub_subscriptions": [SUBSCRIPTION, DLQ_SUBSCRIPTION],
+      "secret": SECRET,
+      "service_accounts": [RECEIVER_SVC, CONSUMER_SVC, "bqaa-otlp-push"],
+      "dts_display_name": f"{MERGE_DISPLAY_NAME}_{s.dataset}",
+  }
+  if image_mode == "source":
+    # Only the source-build path creates a customer AR repo; teardown in
+    # default released-image mode must neither expect nor delete one.
+    inventory["ar_repo"] = AR_REPO
+  inventory_path = s.out_dir / "inventory.json"
+  write_file(inventory_path, json.dumps(inventory, indent=2) + "\n")
+  echo(f"  wrote {inventory_path}")
 
   echo("==> Generating telemetry-source config artifacts")
   artifacts = config_artifacts.render_artifacts(

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/bootstrap.py
@@ -39,9 +39,10 @@ import shlex
 import subprocess
 from typing import Callable, Protocol
 
+from bigquery_agent_analytics_tracing.otlp import _release
+
 from . import _release
 from . import config_artifacts
-from bigquery_agent_analytics_tracing.otlp import _release
 from . import ddl
 from . import sql
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -198,6 +198,23 @@ def _build_parser() -> argparse.ArgumentParser:
       help="Directory to write config artifacts into after the deploy.",
   )
   boot.add_argument(
+      "--image",
+      default=None,
+      help=(
+          "Container image reference to deploy (e.g. the staging candidate"
+          " for the TestPyPI release gate). Default: the released image"
+          " embedded in this installation, pinned by digest."
+      ),
+  )
+  boot.add_argument(
+      "--build-from-source",
+      action="store_true",
+      help=(
+          "Build the image with Cloud Build from a repository checkout"
+          " (legacy path; requires running from the repo root)."
+      ),
+  )
+  boot.add_argument(
       "--execute",
       action="store_true",
       help="Apply the plan (default: print the commands and exit).",
@@ -323,7 +340,12 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
         resource_attributes=args.resource_attributes,
         acknowledge_content_logging=args.ack_content_logging,
         out_dir=args.out,
+        image=args.image,
+        build_from_source=args.build_from_source,
     )
+    # Resolve now so a dev checkout with no released image fails with the
+    # actionable message BEFORE planning or mutating anything.
+    _, image_mode = bootstrap_mod.resolve_image(settings)
   except ValueError as exc:
     return _report_settings_error(exc)
 
@@ -331,9 +353,12 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     print(bootstrap_mod.render_plan(settings))
     return 0
 
-  # The Cloud Build step uploads the *current directory* as the build
-  # context; refuse to mutate anything unless we are at the repo root.
-  if not pathlib.Path("deploy/otlp_receiver/Dockerfile").is_file():
+  # Only the source-build path uploads the current directory as the Cloud
+  # Build context; the default released-image mode needs no checkout at all.
+  if (
+      image_mode == "source"
+      and not pathlib.Path("deploy/otlp_receiver/Dockerfile").is_file()
+  ):
     print(
         "bqaa-otel: error: deploy/otlp_receiver/Dockerfile not found —"
         " run --execute from the repository root (the Cloud Build step"

--- a/producers/tests/test_bootstrap_release_image.py
+++ b/producers/tests/test_bootstrap_release_image.py
@@ -31,7 +31,8 @@ from bigquery_agent_analytics_tracing.otlp import _release
 from bigquery_agent_analytics_tracing.otlp import bootstrap
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
-from test_otlp_bootstrap import FakeRunner, _settings
+from test_otlp_bootstrap import _settings
+from test_otlp_bootstrap import FakeRunner
 
 RELEASED = (
     "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:0.2.0@sha256:"

--- a/producers/tests/test_bootstrap_release_image.py
+++ b/producers/tests/test_bootstrap_release_image.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Released-image wiring in bootstrap (issue #349 PR 2).
+
+Default customer path: the wheel embeds the released public image
+(pinned by digest) and bootstrap deploys it with ZERO Cloud Build /
+customer Artifact Registry footprint. `--image` overrides explicitly
+(the TestPyPI gate deploys the staging image this way);
+`--build-from-source` keeps the legacy repo-checkout path.
+"""
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import _release
+from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from test_otlp_bootstrap import FakeRunner, _settings
+
+RELEASED = (
+    "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:0.2.0@sha256:"
+    + "e" * 64
+)
+STAGING = (
+    "us-docker.pkg.dev/bqaa-releases/bqaa-staging/otlp-receiver:"
+    "0.2.0-candidate.99@sha256:" + "e" * 64
+)
+
+
+def _run(settings, runner=None):
+  r = runner or FakeRunner()
+  bootstrap.run_bootstrap(settings, r, echo=lambda *_: None)
+  return r
+
+
+def _deploy_images(r):
+  return [
+      c[c.index("--image") + 1]
+      for c, _ in r.calls
+      if "deploy" in c and "--image" in c
+  ]
+
+
+class TestReleasedDefault:
+
+  def test_packaged_release_image_is_the_default(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    r = _run(_settings(tmp_path, build_from_source=False))
+    assert _deploy_images(r) == [RELEASED, RELEASED]
+
+  def test_prebuilt_mode_has_zero_build_footprint(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    r = _run(_settings(tmp_path, build_from_source=False))
+    joined = [" ".join(c) for c, _ in r.calls]
+    assert not any("builds submit" in j for j in joined)
+    assert not any("artifacts repositories" in j for j in joined)
+    enable = next(j for j in joined if "services enable" in j)
+    assert "cloudbuild" not in enable
+    assert "artifactregistry" not in enable
+
+  def test_dev_checkout_requires_explicit_choice(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", None)
+    with pytest.raises(ValueError, match="--image.*--build-from-source"):
+      _run(_settings(tmp_path, build_from_source=False))
+
+
+class TestExplicitOverride:
+
+  def test_image_override_wins_over_packaged_default(
+      self, tmp_path, monkeypatch
+  ):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    r = _run(_settings(tmp_path, build_from_source=False, image=STAGING))
+    assert _deploy_images(r) == [STAGING, STAGING]
+
+  def test_plan_output_names_the_image(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", None)
+    plan = bootstrap.render_plan(
+        _settings(tmp_path, build_from_source=False, image=STAGING)
+    )
+    assert "bqaa-staging" in plan
+    assert "builds submit" not in plan
+
+  @pytest.mark.parametrize(
+      "bad",
+      [
+          "us-docker.pkg.dev/p/r/otlp-receiver",  # no tag
+          "us-docker.pkg.dev/p/r/otlp-receiver:latest",  # never 'latest'
+          "us-docker.pkg.dev/p/r/otlp-receiver:0.2.0@sha256:short",
+          "bad image`with:injection",
+      ],
+  )
+  def test_malformed_image_rejected(self, tmp_path, bad):
+    with pytest.raises(ValueError):
+      _settings(tmp_path, build_from_source=False, image=bad)
+
+  def test_image_and_build_from_source_are_mutually_exclusive(self, tmp_path):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+      _settings(tmp_path, build_from_source=True, image=STAGING)
+
+
+class TestSourceBuildPath:
+
+  def test_build_from_source_keeps_legacy_behavior(self, tmp_path):
+    r = _run(_settings(tmp_path))  # helper default: build_from_source=True
+    joined = [" ".join(c) for c, _ in r.calls]
+    assert any("builds submit" in j for j in joined)
+    enable = next(j for j in joined if "services enable" in j)
+    assert "cloudbuild" in enable and "artifactregistry" in enable
+
+
+class TestDigestAssertion:
+
+  def test_digest_pinned_deploy_asserts_deployed_digest(
+      self, tmp_path, monkeypatch
+  ):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    r = FakeRunner()
+    r.image_digest = "sha256:" + "e" * 64
+    _run(_settings(tmp_path, build_from_source=False), r)
+    joined = [" ".join(c) for c, _ in r.calls]
+    assert any("run revisions describe" in j for j in joined)
+
+  def test_digest_mismatch_fails_the_bootstrap(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    r = FakeRunner()
+    r.image_digest = "sha256:" + "f" * 64
+    with pytest.raises(RuntimeError, match="digest"):
+      _run(_settings(tmp_path, build_from_source=False), r)
+
+  def test_source_build_skips_digest_assertion(self, tmp_path):
+    r = _run(_settings(tmp_path))
+    joined = [" ".join(c) for c, _ in r.calls]
+    assert not any("run revisions describe" in j for j in joined)
+
+
+class TestInventory:
+
+  def test_inventory_records_the_deployed_image_and_resources(
+      self, tmp_path, monkeypatch
+  ):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", RELEASED)
+    _run(_settings(tmp_path, build_from_source=False))
+    inv = json.loads((tmp_path / "artifacts/inventory.json").read_text())
+    assert inv["image"] == RELEASED
+    assert inv["mode"] == "released"
+    assert inv["project"] == "my-proj"
+    assert bootstrap.RECEIVER_SVC in inv["cloud_run_services"]
+    assert bootstrap.DLQ_SUBSCRIPTION in inv["pubsub_subscriptions"]
+    assert inv["dts_display_name"].endswith(inv["dataset"])
+    # Default released-image mode creates no customer AR repo: teardown
+    # must neither expect nor delete one.
+    assert "ar_repo" not in inv
+
+  def test_source_mode_inventory_includes_the_ar_repo(self, tmp_path):
+    _run(_settings(tmp_path))
+    inv = json.loads((tmp_path / "artifacts/inventory.json").read_text())
+    assert inv["mode"] == "source"
+    assert inv["ar_repo"] == bootstrap.AR_REPO
+
+  def test_explicit_override_mode_is_recorded(self, tmp_path, monkeypatch):
+    monkeypatch.setattr(_release, "RELEASE_IMAGE", None)
+    _run(_settings(tmp_path, build_from_source=False, image=STAGING))
+    inv = json.loads((tmp_path / "artifacts/inventory.json").read_text())
+    assert inv["mode"] == "explicit"
+    assert inv["image"] == STAGING

--- a/producers/tests/test_otlp_bootstrap.py
+++ b/producers/tests/test_otlp_bootstrap.py
@@ -39,10 +39,16 @@ class FakeRunner:
     self.failing = tuple(failing)  # substrings whose try_run fails
     self.calls = []  # (argv tuple, input_text)
 
+  image_digest = "sha256:" + "e" * 64  # answered by 'run revisions describe'
+
   def _canned(self, argv):
     joined = " ".join(argv)
     if "projects describe" in joined:
       return "123456"
+    if "latestCreatedRevisionName" in joined:
+      return "rev-00001"
+    if "run revisions describe" in joined:
+      return f"us-docker.pkg.dev/x/y/z@{self.image_digest}"
     if "run services describe" in joined:
       return (
           _RECEIVER_URL if bootstrap.RECEIVER_SVC in joined else _CONSUMER_URL
@@ -94,6 +100,9 @@ def _settings(tmp_path, **kw):
       region="us-central1",
       bq_location="US",
       out_dir=tmp_path / "artifacts",
+      # Legacy source-build path: these tests predate the released-image
+      # default (issue #349) and exercise the Cloud Build sequence.
+      build_from_source=True,
   )
   defaults.update(kw)
   return bootstrap.BootstrapSettings(**defaults)

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -177,6 +177,7 @@ def test_bootstrap_default_is_plan_mode(tmp_path, capsys, monkeypatch):
           "bootstrap",
           "--project",
           "my-proj",
+          "--build-from-source",
           "--out",
           str(tmp_path),
       ]
@@ -211,6 +212,7 @@ def test_bootstrap_execute_invokes_run_bootstrap(tmp_path, monkeypatch):
           "ds1",
           "--signals",
           "logs,metrics,traces",
+          "--build-from-source",
           "--out",
           str(tmp_path),
           "--execute",
@@ -254,7 +256,7 @@ def test_bootstrap_execute_surfaces_failed_step_stderr(monkeypatch, capsys):
 
   monkeypatch.setattr(bootstrap, "run_bootstrap", _boom)
   monkeypatch.setattr("pathlib.Path.is_file", lambda self: True)
-  rc = _run(["bootstrap", "--project", "p", "--execute"])
+  rc = _run(["bootstrap", "--project", "p", "--build-from-source", "--execute"])
   assert rc == 1
   err = capsys.readouterr().err
   assert "gcloud run deploy" in err
@@ -269,9 +271,18 @@ def test_bootstrap_execute_requires_repo_root(monkeypatch, tmp_path, capsys):
 
   monkeypatch.setattr(bootstrap, "run_bootstrap", _never)
   monkeypatch.chdir(tmp_path)  # no deploy/otlp_receiver/Dockerfile here
-  rc = _run(["bootstrap", "--project", "p", "--execute"])
+  rc = _run(["bootstrap", "--project", "p", "--build-from-source", "--execute"])
   assert rc == 2
   assert "repository root" in capsys.readouterr().err
+
+
+def test_bootstrap_dev_checkout_requires_image_choice(capsys):
+  # Development checkout: no released image is embedded, so the CLI must
+  # fail actionably BEFORE planning or mutating anything (#349).
+  rc = _run(["bootstrap", "--project", "p"])
+  assert rc == 2
+  err = capsys.readouterr().err
+  assert "--image" in err and "--build-from-source" in err
 
 
 def test_bootstrap_rejects_bogus_source(capsys):


### PR DESCRIPTION
Second implementation increment of #349: the released image becomes the actual customer path.

## Resolution order (pinned by the contract)

`--image` (explicit — how the TestPyPI gate deploys the staging candidate) → `--build-from-source` (legacy Cloud Build path, still repo-root-gated) → **`_release.RELEASE_IMAGE`** (the digest-pinned constant PR 1's pipeline injects into the wheel). A dev checkout embeds `None`, so it must choose explicitly — the CLI fails with the actionable message before planning or mutating anything.

## Contract points implemented

- **Zero build footprint in default mode**: no cloudbuild/artifactregistry API enablement, no AR repo creation, no `builds submit`, no repo-root requirement — the customer project never builds or hosts the image.
- **`--image` flows through the whole pipeline**: plan output, both Cloud Run deploys, the post-deploy **digest assertion** (receiver AND consumer revisions' `imageDigest` must end with the pinned digest; mismatch fails the run), and the written inventory.
- **`inventory.json`** written to `--out` on `--execute` per the pinned teardown contract — mode, deployed image, deterministic resource names, with `ar_repo` present **only** in source mode (teardown in default mode must neither expect nor delete one).
- **Reference validation**: charset, mandatory version tag, `latest` rejected, digest shape checked; `--image`/`--build-from-source` mutually exclusive.

## Tests + validation

18 new tests (RED-first) across resolution, footprint, override, malformed refs, digest assertion (match/mismatch/source-skip), and inventory content; 4 legacy CLI tests updated to opt into `--build-from-source` explicitly (the default changed by design) + 1 new test pinning the dev-checkout error. Full producers suite: **357 passed**. Live plan-mode validation against the real project: dev checkout → actionable error; `--image` → zero `builds submit`, pinned reference on both deploys; `--build-from-source` → Cloud Build step present.

Next increment: mode-aware `bootstrap --preflight` + `bqaa-otel teardown` consuming the inventory.

Part of #349.