### PR TITLE
feat(otlp): mode-aware bootstrap --preflight + bqaa-otel teardown (#349 PR3)

### DIFF
--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -468,6 +468,11 @@ def _cmd_teardown(args: argparse.Namespace) -> int:
     )
   except ValueError as exc:
     return _report_settings_error(exc)
+  except RuntimeError as exc:
+    # Refused precondition (e.g. unreadable DTS listing before a
+    # destructive run) — an admin-facing error, never a traceback.
+    print(f"bqaa-otel: error: {exc}", file=sys.stderr)
+    return 1
   return 0 if (report.dry_run or report.ok) else 1
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/cli.py
@@ -31,6 +31,8 @@ import urllib.parse
 
 from . import bootstrap as bootstrap_mod
 from . import config_artifacts
+from . import preflight as preflight_mod
+from . import teardown as teardown_mod
 from . import verify as verify_mod
 
 
@@ -219,6 +221,59 @@ def _build_parser() -> argparse.ArgumentParser:
       action="store_true",
       help="Apply the plan (default: print the commands and exit).",
   )
+  boot.add_argument(
+      "--preflight",
+      action="store_true",
+      help=(
+          "Run mode-aware readiness checks (auth, billing, permissions,"
+          " org policy) and exit; mutates nothing."
+      ),
+  )
+  boot.add_argument(
+      "--check-products",
+      action="store_true",
+      help=(
+          "With --preflight: also probe the Claude/Codex CLIs (only"
+          " needed on machines that will run validation sessions)."
+      ),
+  )
+
+  tear = sub.add_parser(
+      "teardown",
+      help=(
+          "Delete a bootstrap deployment (dry-run by default; --confirm"
+          " executes; existence-verified afterwards)."
+      ),
+  )
+  tear.add_argument("--project", required=True, help="GCP project id.")
+  tear.add_argument("--dataset", required=True, help="BigQuery dataset id.")
+  tear.add_argument("--region", default="us-central1", help="Cloud Run region.")
+  tear.add_argument(
+      "--bq-location", default="US", help="BigQuery/DTS location."
+  )
+  tear.add_argument(
+      "--inventory",
+      type=pathlib.Path,
+      default=None,
+      help=(
+          "inventory.json written by bootstrap --execute (default:"
+          " ./inventory.json if present; otherwise the deterministic"
+          " resource names are reconstructed and probed live)."
+      ),
+  )
+  tear.add_argument(
+      "--confirm",
+      action="store_true",
+      help="Execute the deletions (default: print the plan and exit).",
+  )
+  tear.add_argument(
+      "--dataset-only",
+      action="store_true",
+      help=(
+          "Only remove the DTS scheduled MERGE and the dataset; keep the"
+          " shared pipeline (another dataset may still use it)."
+      ),
+  )
 
   ver = sub.add_parser(
       "verify",
@@ -349,6 +404,16 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
   except ValueError as exc:
     return _report_settings_error(exc)
 
+  if args.preflight:
+    report = preflight_mod.run_preflight(
+        project=settings.project,
+        dataset=settings.dataset,
+        image_mode=image_mode,
+        runner=bootstrap_mod.SubprocessRunner(echo=lambda *_: None),
+        check_products=args.check_products,
+    )
+    return 0 if report.ok else 1
+
   if not args.execute:
     print(bootstrap_mod.render_plan(settings))
     return 0
@@ -382,6 +447,28 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     )
     return 1
   return 0
+
+
+def _cmd_teardown(args: argparse.Namespace) -> int:
+  inventory = args.inventory
+  if inventory is None and pathlib.Path("inventory.json").is_file():
+    inventory = pathlib.Path("inventory.json")
+  try:
+    settings = teardown_mod.TeardownSettings(
+        project=args.project,
+        dataset=args.dataset,
+        region=args.region,
+        bq_location=args.bq_location,
+        inventory=inventory,
+        confirm=args.confirm,
+        dataset_only=args.dataset_only,
+    )
+    report = teardown_mod.run_teardown(
+        settings, bootstrap_mod.SubprocessRunner(echo=lambda *_: None)
+    )
+  except ValueError as exc:
+    return _report_settings_error(exc)
+  return 0 if (report.dry_run or report.ok) else 1
 
 
 def _cmd_verify(args: argparse.Namespace) -> int:
@@ -478,6 +565,8 @@ def main(argv: list[str] | None = None) -> int:
     return _cmd_bootstrap(args)
   if args.command == "verify":
     return _cmd_verify(args)
+  if args.command == "teardown":
+    return _cmd_teardown(args)
   raise AssertionError(f"unhandled command {args.command!r}")
 
 

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/preflight.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/preflight.py
@@ -1,0 +1,314 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``bqaa-otel bootstrap --preflight`` — mode-aware readiness checks.
+
+Productized from the hero-demo ``preflight.sh`` (which caught real gaps
+three times); issue #349 contract:
+
+- Default prebuilt-image mode checks NO build permissions (the customer
+  project never builds or hosts the image) and requires NO product CLIs
+  (a platform admin deploying infra does not run Claude/Codex locally;
+  ``check_products=True`` opts those probes back in).
+- Every failure carries the remediation, not just the error.
+- The permission probe uses the Resource Manager ``testIamPermissions``
+  REST call: gcloud has no such subcommand (learned live), and the call
+  returns exactly the subset of tested permissions the caller holds.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+from typing import Callable
+import urllib.request
+
+# What bootstrap ACTUALLY exercises — creates plus the setIamPolicy/
+# actAs/DTS surface where real deploys have failed mid-run.
+_BASE_PERMISSIONS = (
+    "serviceusage.services.enable",
+    "run.services.create",
+    "run.services.setIamPolicy",
+    "pubsub.topics.create",
+    "pubsub.topics.setIamPolicy",
+    "pubsub.subscriptions.create",
+    "pubsub.subscriptions.update",
+    "pubsub.subscriptions.setIamPolicy",
+    "bigquery.datasets.create",
+    "bigquery.jobs.create",
+    "bigquery.transfers.update",
+    "secretmanager.secrets.create",
+    "secretmanager.versions.add",
+    "secretmanager.secrets.setIamPolicy",
+    "iam.serviceAccounts.create",
+    "iam.serviceAccounts.setIamPolicy",
+    "iam.serviceAccounts.actAs",
+    "resourcemanager.projects.setIamPolicy",
+)
+_SOURCE_BUILD_PERMISSIONS = (
+    "cloudbuild.builds.create",
+    "artifactregistry.repositories.create",
+)
+
+_ORG_POLICY_CONSTRAINT = "constraints/iam.allowedPolicyMemberDomains"
+
+
+@dataclasses.dataclass(frozen=True)
+class Check:
+  name: str
+  status: str  # OK | WARN | FAIL
+  message: str
+
+  @property
+  def ok(self) -> bool:
+    return self.status != "FAIL"
+
+
+@dataclasses.dataclass(frozen=True)
+class PreflightReport:
+  checks: tuple[Check, ...]
+
+  @property
+  def ok(self) -> bool:
+    return all(c.ok for c in self.checks)
+
+
+def _default_http_post(url: str, body: dict, token: str) -> dict:
+  request = urllib.request.Request(
+      url,
+      data=json.dumps(body).encode(),
+      headers={
+          "Authorization": f"Bearer {token}",
+          "Content-Type": "application/json",
+      },
+      method="POST",
+  )
+  with urllib.request.urlopen(request, timeout=30) as response:
+    return json.loads(response.read().decode())
+
+
+def required_permissions(image_mode: str) -> tuple[str, ...]:
+  """The permission set for this deploy mode ('source' adds build perms)."""
+  if image_mode == "source":
+    return _BASE_PERMISSIONS + _SOURCE_BUILD_PERMISSIONS
+  return _BASE_PERMISSIONS
+
+
+def run_preflight(
+    *,
+    project: str,
+    dataset: str,
+    image_mode: str,
+    runner,
+    http_post: Callable[[str, dict, str], dict] | None = None,
+    check_products: bool = False,
+    echo: Callable[..., None] = print,
+) -> PreflightReport:
+  """Run every check; mutate nothing; return the aggregated report."""
+  http_post = http_post or _default_http_post
+  checks: list[Check] = []
+
+  def add(name: str, status: str, message: str) -> None:
+    checks.append(Check(name, status, message))
+    echo(f"{status:<5} {message}")
+
+  # --- local CLIs the deploy itself shells out to --------------------------
+  for cli, probe in (
+      ("gcloud", ["gcloud", "version"]),
+      ("bq", ["bq", "version"]),
+  ):
+    if runner.try_run(probe) is None:
+      add(cli, "FAIL", f"{cli} missing — install the Google Cloud SDK")
+    else:
+      add(cli, "OK", f"{cli} present")
+
+  # Product CLIs are OPT-IN: infra deployment does not need them.
+  if check_products:
+    for cli in ("claude", "codex"):
+      if runner.try_run([cli, "--version"]) is None:
+        add(
+            cli,
+            "FAIL",
+            f"{cli} CLI missing — required only because --check-products"
+            " was requested (validation sessions)",
+        )
+      else:
+        add(cli, "OK", f"{cli} CLI present")
+
+  # --- auth / project / billing --------------------------------------------
+  account = runner.try_run(
+      [
+          "gcloud",
+          "auth",
+          "list",
+          "--filter=status:ACTIVE",
+          "--format=value(account)",
+      ]
+  )
+  if not account:
+    add("auth", "FAIL", "no active gcloud account — run: gcloud auth login")
+  else:
+    add("auth", "OK", f"gcloud authenticated ({account.splitlines()[0]})")
+
+  if (
+      runner.try_run(
+          [
+              "gcloud",
+              "projects",
+              "describe",
+              project,
+              "--format=value(projectId)",
+          ]
+      )
+      is None
+  ):
+    add(
+        "project",
+        "FAIL",
+        f"project {project!r} not accessible — check the id and your"
+        " permissions",
+    )
+  else:
+    add("project", "OK", f"project {project} accessible")
+
+  billing = runner.try_run(
+      [
+          "gcloud",
+          "billing",
+          "projects",
+          "describe",
+          project,
+          "--format=value(billingEnabled)",
+      ]
+  )
+  if billing is not None and "True" in billing:
+    add("billing", "OK", "billing enabled")
+  else:
+    add(
+        "billing",
+        "FAIL",
+        "billing not enabled (or not visible) — link a billing account;"
+        " Cloud Run/DTS refuse without it",
+    )
+
+  # --- permission probe (mode-aware, testIamPermissions REST) --------------
+  required = required_permissions(image_mode)
+  token = runner.try_run(["gcloud", "auth", "print-access-token"])
+  granted: set[str] = set()
+  probe_error = None
+  if token:
+    try:
+      response = http_post(
+          "https://cloudresourcemanager.googleapis.com/v1/projects/"
+          f"{project}:testIamPermissions",
+          {"permissions": list(required)},
+          token.strip(),
+      )
+      granted = set(response.get("permissions", ()))
+    except Exception as exc:  # noqa: BLE001 - any probe failure is a FAIL
+      probe_error = str(exc)
+  else:
+    probe_error = "could not mint an access token"
+  missing = [p for p in required if p not in granted]
+  if probe_error:
+    add("permissions", "FAIL", f"permission probe failed: {probe_error}")
+  elif missing:
+    add(
+        "permissions",
+        "FAIL",
+        f"missing deploy permissions ({len(granted)}/{len(required)}):"
+        f" {', '.join(missing)} — grant roles covering these before"
+        " deploying",
+    )
+  else:
+    add(
+        "permissions",
+        "OK",
+        f"deploy permissions present ({len(required)}/{len(required)},"
+        f" {image_mode} mode)",
+    )
+
+  # --- org policy: the receiver needs an allUsers invoker grant ------------
+  policy_json = runner.try_run(
+      [
+          "gcloud",
+          "resource-manager",
+          "org-policies",
+          "describe",
+          _ORG_POLICY_CONSTRAINT,
+          "--project",
+          project,
+          "--effective",
+          "--format=json",
+      ]
+  )
+  if policy_json is None:
+    add(
+        "org-policy",
+        "WARN",
+        "org policy iam.allowedPolicyMemberDomains not readable — cannot"
+        " verify allUsers is permitted; if domain-restricted sharing is"
+        " enforced, the Cloud Run deploy fails at the invoker grant",
+    )
+  else:
+    try:
+      list_policy = json.loads(policy_json).get("listPolicy", {})
+    except ValueError:
+      list_policy = {}
+    if (
+        list_policy.get("allowedValues")
+        or list_policy.get("allValues") == "DENY"
+    ):
+      add(
+          "org-policy",
+          "FAIL",
+          "domain-restricted sharing is enforced"
+          " (iam.allowedPolicyMemberDomains) — the receiver needs an"
+          " allUsers invoker grant; get a policy exception or use a"
+          " project where it is allowed",
+      )
+    else:
+      add("org-policy", "OK", "org policy permits allUsers invoker grants")
+
+  # --- dataset state (informational) ----------------------------------------
+  if (
+      runner.try_run(
+          [
+              "bq",
+              f"--project_id={project}",
+              "show",
+              "--dataset",
+              f"{project}:{dataset}",
+          ]
+      )
+      is None
+  ):
+    add(
+        "dataset",
+        "OK",
+        f"dataset {dataset} does not exist yet (will be created)",
+    )
+  else:
+    add("dataset", "OK", f"dataset {dataset} exists (bootstrap converges)")
+
+  report = PreflightReport(tuple(checks))
+  fails = sum(1 for c in checks if c.status == "FAIL")
+  warns = sum(1 for c in checks if c.status == "WARN")
+  echo("")
+  echo(
+      f"{len(checks) - fails - warns} ok, {warns} warnings, {fails} failed"
+      + ("" if report.ok else " — do not deploy yet")
+  )
+  return report

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/teardown.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/teardown.py
@@ -1,0 +1,470 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``bqaa-otel teardown`` — inventory-driven, dry-run-default cleanup.
+
+Issue #349 contract, TDD-ported from the proven hero-demo teardown:
+
+- Consumes the ``inventory.json`` that ``bootstrap --execute`` writes;
+  without one, reconstructs it from the deterministic package constants
+  (the DTS config name is queried — its id is opaque).
+- The human-provided ``--project``/``--dataset`` must MATCH the
+  inventory; every resource name must match the ``bqaa`` allowlist
+  patterns. A poisoned inventory is refused, never obeyed.
+- Dry-run by default: prints the exact command for every deletion.
+- Verification is the authority on success: existence probes that PASS
+  only on a known not-found response — an auth/API error is
+  UNVERIFIABLE and fails the run (a probe error must never masquerade
+  as "gone").
+- Mode-aware via the inventory: default released-image mode records no
+  customer AR repo, so none is expected or deleted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+import re
+import subprocess
+from typing import Callable
+
+from . import bootstrap
+
+_NOT_FOUND_RE = re.compile(
+    r"not.?found|does not exist|was not found|no such", re.IGNORECASE
+)
+
+# Pattern contract for every deletable resource name.
+_ALLOWLIST = {
+    "cloud_run_services": r"bqaa-otlp-.*",
+    "pubsub_topics": r"bqaa-otlp.*",
+    "pubsub_subscriptions": r"bqaa-otlp.*",
+    "secret": r"bqaa-otlp-.*",
+    "service_accounts": r"bqaa-otlp-.*",
+    "ar_repo": r"bqaa",
+    "dts_display_name": rf"{bootstrap.MERGE_DISPLAY_NAME}(_\w+)?",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class TeardownSettings:
+  project: str
+  dataset: str
+  region: str = "us-central1"
+  bq_location: str = "US"
+  inventory: pathlib.Path | None = None
+  confirm: bool = False
+  dataset_only: bool = False
+
+  def __post_init__(self):
+    if not re.fullmatch(r"[a-z0-9.:-]+", self.project, re.IGNORECASE):
+      raise ValueError(f"invalid GCP project id {self.project!r}")
+    if not re.fullmatch(r"\w+", self.dataset, re.ASCII):
+      raise ValueError(f"invalid BigQuery dataset id {self.dataset!r}")
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifyCheck:
+  name: str
+  ok: bool
+  message: str
+
+
+@dataclasses.dataclass(frozen=True)
+class TeardownReport:
+  dry_run: bool
+  checks: tuple[VerifyCheck, ...]
+
+  @property
+  def ok(self) -> bool:
+    return all(c.ok for c in self.checks)
+
+
+def _reconstructed_inventory(s: TeardownSettings) -> dict:
+  """Inventory from the deterministic package constants (no file needed)."""
+  return {
+      "mode": "reconstructed",
+      "project": s.project,
+      "dataset": s.dataset,
+      "region": s.region,
+      "bq_location": s.bq_location,
+      "cloud_run_services": [bootstrap.RECEIVER_SVC, bootstrap.CONSUMER_SVC],
+      "pubsub_topics": [bootstrap.MAIN_TOPIC, bootstrap.DLQ_TOPIC],
+      "pubsub_subscriptions": [
+          bootstrap.SUBSCRIPTION,
+          bootstrap.DLQ_SUBSCRIPTION,
+      ],
+      "secret": bootstrap.SECRET,
+      "service_accounts": [
+          bootstrap.RECEIVER_SVC,
+          bootstrap.CONSUMER_SVC,
+          "bqaa-otlp-push",
+      ],
+      "dts_display_name": f"{bootstrap.MERGE_DISPLAY_NAME}_{s.dataset}",
+      # No ar_repo: reconstruction must not assume a source-build deploy;
+      # released-image mode creates none.
+  }
+
+
+def _load_inventory(s: TeardownSettings) -> dict:
+  if s.inventory is None:
+    return _reconstructed_inventory(s)
+  inventory = json.loads(s.inventory.read_text())
+  for key in ("project", "dataset"):
+    if inventory.get(key) != getattr(s, key):
+      raise ValueError(
+          f"inventory {key} {inventory.get(key)!r} does not match the"
+          f" requested {key} {getattr(s, key)!r} — refusing (wrong"
+          " inventory file?)"
+      )
+  return inventory
+
+
+def _guard_allowlist(inventory: dict) -> None:
+  for key, pattern in _ALLOWLIST.items():
+    if key not in inventory:
+      continue
+    values = inventory[key]
+    if isinstance(values, str):
+      values = [values]
+    for value in values:
+      if not re.fullmatch(pattern, value):
+        raise ValueError(
+            f"{key} value {value!r} does not match allowlist pattern"
+            f" {pattern!r} — refusing the inventory"
+        )
+
+
+def run_teardown(
+    settings: TeardownSettings,
+    runner,
+    *,
+    echo: Callable[..., None] = print,
+) -> TeardownReport:
+  s = settings
+  inventory = _load_inventory(s)
+  _guard_allowlist(inventory)
+  proj = ["--project", s.project]
+  bq = ["bq", f"--project_id={s.project}"]
+
+  deletions: list[tuple[str, list[str]]] = []
+
+  # --- dataset-scoped tier ---------------------------------------------------
+  # Dry run executes NOTHING (not even read-only listings — the plan must
+  # work offline); the opaque DTS config name is queried at --confirm time.
+  if s.confirm:
+    listing = runner.try_run(
+        [
+            *bq,
+            f"--location={s.bq_location}",
+            "ls",
+            "--transfer_config",
+            f"--transfer_location={s.bq_location}",
+            "--format=json",
+        ]
+    )
+    dts_name = bootstrap._find_merge_config(listing, s.dataset)
+    if dts_name:
+      deletions.append(
+          (
+              f"DTS scheduled MERGE ({dts_name})",
+              [
+                  *bq,
+                  f"--location={s.bq_location}",
+                  "rm",
+                  "-f",
+                  "--transfer_config",
+                  dts_name,
+              ],
+          )
+      )
+  else:
+    deletions.append(
+        (
+            f"DTS scheduled MERGE for {s.dataset} (name queried at --confirm"
+            " time; legacy unsuffixed configs matched by query text)",
+            [
+                *bq,
+                f"--location={s.bq_location}",
+                "rm",
+                "-f",
+                "--transfer_config",
+                "<queried-config-name>",
+            ],
+        )
+    )
+  deletions.append(
+      (
+          f"BigQuery dataset {s.project}:{s.dataset} (contains telemetry)",
+          [*bq, "rm", "-r", "-f", "--dataset", f"{s.project}:{s.dataset}"],
+      )
+  )
+
+  # --- pipeline tier (skipped with --dataset-only) ---------------------------
+  consumer_sa = f"{bootstrap.CONSUMER_SVC}@{s.project}.iam.gserviceaccount.com"
+  if not s.dataset_only:
+    for svc in inventory["cloud_run_services"]:
+      deletions.append(
+          (
+              f"Cloud Run service {svc}",
+              [
+                  "gcloud",
+                  "run",
+                  "services",
+                  "delete",
+                  svc,
+                  *proj,
+                  "--region",
+                  s.region,
+              ],
+          )
+      )
+    for sub in inventory["pubsub_subscriptions"]:
+      deletions.append(
+          (
+              f"subscription {sub}",
+              ["gcloud", "pubsub", "subscriptions", "delete", sub, *proj],
+          )
+      )
+    for topic in inventory["pubsub_topics"]:
+      deletions.append(
+          (
+              f"topic {topic}",
+              ["gcloud", "pubsub", "topics", "delete", topic, *proj],
+          )
+      )
+    deletions.append(
+        (
+            f"secret {inventory['secret']}",
+            ["gcloud", "secrets", "delete", inventory["secret"], *proj],
+        )
+    )
+    if "ar_repo" in inventory:
+      # Present only for source-build deploys; released-image mode
+      # creates no customer repo and must not touch one.
+      deletions.append(
+          (
+              f"Artifact Registry repo {inventory['ar_repo']}",
+              [
+                  "gcloud",
+                  "artifacts",
+                  "repositories",
+                  "delete",
+                  inventory["ar_repo"],
+                  *proj,
+                  "--location",
+                  s.region,
+              ],
+          )
+      )
+    deletions.append(
+        (
+            f"project jobUser binding for {consumer_sa}",
+            [
+                "gcloud",
+                "projects",
+                "remove-iam-policy-binding",
+                s.project,
+                "--member",
+                f"serviceAccount:{consumer_sa}",
+                "--role",
+                "roles/bigquery.jobUser",
+            ],
+        )
+    )
+    for sa in inventory["service_accounts"]:
+      email = f"{sa}@{s.project}.iam.gserviceaccount.com"
+      deletions.append(
+          (
+              f"service account {email}",
+              ["gcloud", "iam", "service-accounts", "delete", email, *proj],
+          )
+      )
+
+  if not s.confirm:
+    echo(
+        f"Teardown plan (project={s.project} dataset={s.dataset},"
+        f" mode={inventory.get('mode', 'unknown')})"
+    )
+    echo("DRY RUN — re-run with --confirm to execute.")
+    for description, argv in deletions:
+      echo(f"WOULD DELETE  {description}")
+      echo(f"              $ {' '.join(argv)}")
+    return TeardownReport(dry_run=True, checks=())
+
+  for description, argv in deletions:
+    echo(f"DELETE  {description}")
+    try:
+      runner.run(argv)
+    except subprocess.CalledProcessError as exc:
+      # Visible, never silent — verification below is the authority.
+      stderr = (exc.stderr or "").strip().splitlines()
+      echo(
+          f"        delete failed (verification will decide):"
+          f" {stderr[0] if stderr else 'unknown error'}"
+      )
+
+  # --- verification: existence probes for EVERY resource class --------------
+  checks: list[VerifyCheck] = []
+
+  def gone(name: str, argv: list[str]) -> None:
+    try:
+      runner.run(argv)
+    except subprocess.CalledProcessError as exc:
+      stderr = (exc.stderr or "").strip()
+      if _NOT_FOUND_RE.search(stderr):
+        checks.append(VerifyCheck(name, True, f"PASS  {name} is gone"))
+      else:
+        checks.append(
+            VerifyCheck(
+                name,
+                False,
+                f"FAIL  {name} UNVERIFIABLE: {stderr.splitlines()[0][:100] if stderr else 'probe failed'}",
+            )
+        )
+      return
+    checks.append(VerifyCheck(name, False, f"FAIL  {name} STILL EXISTS"))
+
+  post_listing = runner.try_run(
+      [
+          *bq,
+          f"--location={s.bq_location}",
+          "ls",
+          "--transfer_config",
+          f"--transfer_location={s.bq_location}",
+          "--format=json",
+      ]
+  )
+  if post_listing is None:
+    checks.append(
+        VerifyCheck(
+            "dts", False, "FAIL  DTS listing UNVERIFIABLE (listing failed)"
+        )
+    )
+  elif bootstrap._find_merge_config(post_listing, s.dataset):
+    checks.append(
+        VerifyCheck(
+            "dts",
+            False,
+            "FAIL  DTS scheduled MERGE STILL EXISTS (bills every 15 min)",
+        )
+    )
+  else:
+    checks.append(
+        VerifyCheck(
+            "dts",
+            True,
+            "PASS  no DTS scheduled MERGE remains (incl. legacy unsuffixed)",
+        )
+    )
+  gone(
+      f"dataset {s.dataset}",
+      [*bq, "show", "--dataset", f"{s.project}:{s.dataset}"],
+  )
+
+  if not s.dataset_only:
+    for svc in inventory["cloud_run_services"]:
+      gone(
+          f"Cloud Run service {svc}",
+          [
+              "gcloud",
+              "run",
+              "services",
+              "describe",
+              svc,
+              *proj,
+              "--region",
+              s.region,
+          ],
+      )
+    for sub in inventory["pubsub_subscriptions"]:
+      gone(
+          f"subscription {sub}",
+          ["gcloud", "pubsub", "subscriptions", "describe", sub, *proj],
+      )
+    for topic in inventory["pubsub_topics"]:
+      gone(
+          f"topic {topic}",
+          ["gcloud", "pubsub", "topics", "describe", topic, *proj],
+      )
+    gone(
+        f"secret {inventory['secret']}",
+        ["gcloud", "secrets", "describe", inventory["secret"], *proj],
+    )
+    if "ar_repo" in inventory:
+      gone(
+          f"Artifact Registry repo {inventory['ar_repo']}",
+          [
+              "gcloud",
+              "artifacts",
+              "repositories",
+              "describe",
+              inventory["ar_repo"],
+              *proj,
+              "--location",
+              s.region,
+          ],
+      )
+    for sa in inventory["service_accounts"]:
+      email = f"{sa}@{s.project}.iam.gserviceaccount.com"
+      gone(
+          f"service account {email}",
+          ["gcloud", "iam", "service-accounts", "describe", email, *proj],
+      )
+    binding = runner.try_run(
+        [
+            "gcloud",
+            "projects",
+            "get-iam-policy",
+            s.project,
+            "--flatten=bindings[].members",
+            f"--filter=bindings.role:roles/bigquery.jobUser AND"
+            f" bindings.members:serviceAccount:{consumer_sa}",
+            "--format=value(bindings.role)",
+        ]
+    )
+    if binding is None:
+      checks.append(
+          VerifyCheck(
+              "iam", False, "FAIL  IAM policy UNVERIFIABLE (read failed)"
+          )
+      )
+    elif binding.strip():
+      checks.append(
+          VerifyCheck(
+              "iam",
+              False,
+              f"FAIL  project jobUser binding for {consumer_sa} STILL EXISTS",
+          )
+      )
+    else:
+      checks.append(
+          VerifyCheck(
+              "iam",
+              True,
+              f"PASS  project jobUser binding for {consumer_sa} is gone",
+          )
+      )
+
+  for check in checks:
+    echo(check.message)
+  echo("")
+  ok = all(c.ok for c in checks)
+  echo(
+      "Teardown verified clean."
+      if ok
+      else "Verification found remaining or unverifiable resources."
+  )
+  return TeardownReport(dry_run=False, checks=tuple(checks))

--- a/producers/src/bigquery_agent_analytics_tracing/otlp/teardown.py
+++ b/producers/src/bigquery_agent_analytics_tracing/otlp/teardown.py
@@ -175,6 +175,15 @@ def run_teardown(
             "--format=json",
         ]
     )
+    if listing is None:
+      # Hard-fail BEFORE anything destructive: if the DTS listing is
+      # unreadable we cannot find the scheduled MERGE, and deleting the
+      # rest would leave it running (and billing) against a dead dataset.
+      raise RuntimeError(
+          "cannot list DTS scheduled queries (bq ls --transfer_config"
+          " failed) — refusing to start the destructive teardown; fix"
+          " access to BigQuery Data Transfer and re-run"
+      )
     dts_name = bootstrap._find_merge_config(listing, s.dataset)
     if dts_name:
       deletions.append(

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -567,3 +567,111 @@ def test_verify_malformed_ipv6_endpoint_exits_cleanly(monkeypatch, capsys):
   )
   assert rc == 2
   assert "endpoint" in capsys.readouterr().err.lower()
+
+
+# --------------------------------------------------------------------------
+# bootstrap --preflight + teardown subcommand (issue #349 PR 3)
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_preflight_checks_without_deploying(monkeypatch, capsys):
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+  from bigquery_agent_analytics_tracing.otlp import preflight
+
+  def _never(*a, **k):
+    raise AssertionError("--preflight must not deploy")
+
+  seen = {}
+
+  def _fake_preflight(**kw):
+    seen.update(kw)
+    return preflight.PreflightReport(
+        (preflight.Check("auth", "OK", "gcloud authenticated"),)
+    )
+
+  monkeypatch.setattr(bootstrap, "run_bootstrap", _never)
+  monkeypatch.setattr(preflight, "run_preflight", _fake_preflight)
+  rc = _run(
+      ["bootstrap", "--project", "p", "--build-from-source", "--preflight"]
+  )
+  assert rc == 0
+  assert seen["image_mode"] == "source"
+  assert seen["check_products"] is False
+
+
+def test_bootstrap_preflight_failure_exits_nonzero(monkeypatch):
+  from bigquery_agent_analytics_tracing.otlp import preflight
+
+  monkeypatch.setattr(
+      preflight,
+      "run_preflight",
+      lambda **kw: preflight.PreflightReport(
+          (preflight.Check("billing", "FAIL", "billing not enabled"),)
+      ),
+  )
+  rc = _run(
+      ["bootstrap", "--project", "p", "--build-from-source", "--preflight"]
+  )
+  assert rc == 1
+
+
+def test_teardown_default_is_dry_run(tmp_path, monkeypatch, capsys):
+  import json
+
+  from bigquery_agent_analytics_tracing.otlp import bootstrap
+
+  inv = {
+      "mode": "released",
+      "project": "p",
+      "dataset": "ds1",
+      "region": "us-central1",
+      "bq_location": "US",
+      "cloud_run_services": [bootstrap.RECEIVER_SVC],
+      "pubsub_topics": [bootstrap.MAIN_TOPIC],
+      "pubsub_subscriptions": [bootstrap.SUBSCRIPTION],
+      "secret": bootstrap.SECRET,
+      "service_accounts": [bootstrap.RECEIVER_SVC],
+      "dts_display_name": f"{bootstrap.MERGE_DISPLAY_NAME}_ds1",
+  }
+  path = tmp_path / "inventory.json"
+  path.write_text(json.dumps(inv))
+
+  def _boom(*a, **k):
+    raise AssertionError("dry run must not execute commands")
+
+  monkeypatch.setattr(bootstrap.SubprocessRunner, "run", _boom)
+  rc = _run(
+      [
+          "teardown",
+          "--project",
+          "p",
+          "--dataset",
+          "ds1",
+          "--inventory",
+          str(path),
+      ]
+  )
+  assert rc == 0
+  out = capsys.readouterr().out
+  assert "DRY RUN" in out
+  assert "--confirm" in out
+
+
+def test_teardown_inventory_mismatch_is_a_usage_error(tmp_path, capsys):
+  import json
+
+  path = tmp_path / "inventory.json"
+  path.write_text(json.dumps({"project": "other", "dataset": "ds1"}))
+  rc = _run(
+      [
+          "teardown",
+          "--project",
+          "p",
+          "--dataset",
+          "ds1",
+          "--inventory",
+          str(path),
+      ]
+  )
+  assert rc == 2
+  assert "inventory" in capsys.readouterr().err

--- a/producers/tests/test_otlp_cli.py
+++ b/producers/tests/test_otlp_cli.py
@@ -675,3 +675,19 @@ def test_teardown_inventory_mismatch_is_a_usage_error(tmp_path, capsys):
   )
   assert rc == 2
   assert "inventory" in capsys.readouterr().err
+
+
+def test_teardown_precondition_failure_is_clean_not_a_traceback(
+    tmp_path, monkeypatch, capsys
+):
+  from bigquery_agent_analytics_tracing.otlp import teardown as teardown_mod
+
+  def _refuse(*a, **k):
+    raise RuntimeError("cannot list DTS scheduled queries — refusing")
+
+  monkeypatch.setattr(teardown_mod, "run_teardown", _refuse)
+  rc = _run(["teardown", "--project", "p", "--dataset", "ds1", "--confirm"])
+  assert rc == 1
+  err = capsys.readouterr().err
+  assert "DTS" in err
+  assert "Traceback" not in err

--- a/producers/tests/test_otlp_preflight.py
+++ b/producers/tests/test_otlp_preflight.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""bqaa-otel bootstrap --preflight (issue #349 PR 3).
+
+Mode-aware readiness checks that fail fast with actionable messages,
+BEFORE anything mutates. Default prebuilt-image mode checks no build
+permissions and requires no product CLIs (a platform admin deploying
+infra does not run Claude/Codex on their machine).
+"""
+
+import subprocess
+
+from bigquery_agent_analytics_tracing.otlp import preflight
+
+
+class ScriptedRunner:
+  """Answers commands from a substring->response map; '!' raises."""
+
+  def __init__(self, responses=()):
+    self.responses = dict(responses)
+    self.calls = []
+
+  def _answer(self, argv):
+    joined = " ".join(argv)
+    self.calls.append(joined)
+    for needle, response in self.responses.items():
+      if needle in joined:
+        if response == "!":
+          raise subprocess.CalledProcessError(1, list(argv), stderr="boom")
+        return response
+    return "ok"
+
+  def run(self, argv, input_text=None):
+    return self._answer(argv)
+
+  def try_run(self, argv, input_text=None):
+    try:
+      return self._answer(argv)
+    except subprocess.CalledProcessError:
+      return None
+
+
+def _grants_all(permissions):
+  return {"permissions": list(permissions)}
+
+
+def _run(mode="released", runner=None, http_post=None, check_products=False):
+  return preflight.run_preflight(
+      project="my-proj",
+      dataset="ds1",
+      image_mode=mode,
+      runner=runner or ScriptedRunner({"billingEnabled": "True"}),
+      http_post=http_post
+      or (lambda url, body, token: _grants_all(body["permissions"])),
+      check_products=check_products,
+      echo=lambda *_: None,
+  )
+
+
+class TestModeAwarePermissions:
+
+  def test_default_mode_never_asks_for_build_permissions(self):
+    asked = {}
+
+    def capture(url, body, token):
+      asked["permissions"] = body["permissions"]
+      return _grants_all(body["permissions"])
+
+    _run(mode="released", http_post=capture)
+    assert "cloudbuild.builds.create" not in asked["permissions"]
+    assert "artifactregistry.repositories.create" not in asked["permissions"]
+    assert "run.services.create" in asked["permissions"]
+    assert "bigquery.transfers.update" in asked["permissions"]
+
+  def test_source_mode_adds_build_permissions(self):
+    asked = {}
+
+    def capture(url, body, token):
+      asked["permissions"] = body["permissions"]
+      return _grants_all(body["permissions"])
+
+    _run(mode="source", http_post=capture)
+    assert "cloudbuild.builds.create" in asked["permissions"]
+    assert "artifactregistry.repositories.create" in asked["permissions"]
+
+  def test_missing_permissions_are_named_and_fail(self):
+    def deny_transfers(url, body, token):
+      return _grants_all(
+          p for p in body["permissions"] if p != "bigquery.transfers.update"
+      )
+
+    report = _run(http_post=deny_transfers)
+    assert not report.ok
+    failed = "\n".join(c.message for c in report.checks if not c.ok)
+    assert "bigquery.transfers.update" in failed
+
+
+class TestNoProductClis:
+
+  def test_default_checks_do_not_touch_product_clis(self):
+    r = ScriptedRunner({"billingEnabled": "True"})
+    _run(runner=r)
+    joined = "\n".join(r.calls)
+    assert "claude" not in joined
+    assert "codex" not in joined
+
+  def test_check_products_opt_in_probes_both(self):
+    r = ScriptedRunner({"billingEnabled": "True"})
+    _run(runner=r, check_products=True)
+    joined = "\n".join(r.calls)
+    assert "claude --version" in joined
+    assert "codex --version" in joined
+
+
+class TestOrgPolicy:
+
+  def test_unreadable_org_policy_is_warn_not_fail(self):
+    r = ScriptedRunner({"billingEnabled": "True", "org-policies describe": "!"})
+    report = _run(runner=r)
+    warned = [c for c in report.checks if c.status == "WARN"]
+    assert any("allUsers" in c.message for c in warned)
+    assert report.ok  # WARN alone must not fail preflight
+
+  def test_domain_restriction_enforced_fails(self):
+    r = ScriptedRunner(
+        {
+            "billingEnabled": "True",
+            "org-policies describe": (
+                '{"listPolicy": {"allowedValues": ["C0abc"]}}'
+            ),
+        }
+    )
+    report = _run(runner=r)
+    assert not report.ok
+
+
+class TestHardFailures:
+
+  def test_billing_disabled_fails_with_actionable_message(self):
+    r = ScriptedRunner({"billingEnabled": "False"})
+    report = _run(runner=r)
+    assert not report.ok
+    failed = [c for c in report.checks if c.status == "FAIL"]
+    assert any("billing" in c.message.lower() for c in failed)
+
+  def test_inaccessible_project_fails(self):
+    r = ScriptedRunner({"billingEnabled": "True", "projects describe": "!"})
+    report = _run(runner=r)
+    assert not report.ok

--- a/producers/tests/test_otlp_teardown.py
+++ b/producers/tests/test_otlp_teardown.py
@@ -1,0 +1,241 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""bqaa-otel teardown (issue #349 PR 3).
+
+Consumes the inventory bootstrap --execute writes; dry-run by default;
+existence-verified (a probe error must never masquerade as "gone");
+mode-aware via the inventory (default released-image mode records no
+customer AR repo, so teardown neither expects nor deletes one).
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from bigquery_agent_analytics_tracing.otlp import bootstrap
+from bigquery_agent_analytics_tracing.otlp import teardown
+
+NOT_FOUND = "NOT_FOUND: resource does not exist"
+DENIED = "PERMISSION_DENIED: caller lacks access"
+
+
+class ProbeRunner:
+  """Deletes succeed; existence probes answer from a substring map.
+
+  Probe map values: "gone" -> raises with a not-found stderr,
+  "denied" -> raises with a permission stderr, anything else -> exists.
+  """
+
+  def __init__(self, probes=(), transfer_listing="[]"):
+    self.probes = dict(probes)
+    self.transfer_listing = transfer_listing
+    self.calls = []
+
+  def run(self, argv, input_text=None):
+    joined = " ".join(argv)
+    self.calls.append(joined)
+    if "--transfer_config" in joined and "ls" in argv:
+      return self.transfer_listing
+    if "get-iam-policy" in joined:
+      # Reading the project policy SUCCEEDS whether or not the binding
+      # exists; an empty answer means "binding gone".
+      for needle, state in self.probes.items():
+        if needle in joined and state == "denied":
+          raise subprocess.CalledProcessError(1, list(argv), stderr=DENIED)
+      return ""
+    if "describe" in joined or " show " in f" {joined} ":
+      for needle, state in self.probes.items():
+        if needle in joined:
+          if state == "gone":
+            raise subprocess.CalledProcessError(1, list(argv), stderr=NOT_FOUND)
+          if state == "denied":
+            raise subprocess.CalledProcessError(1, list(argv), stderr=DENIED)
+          return state
+      raise subprocess.CalledProcessError(1, list(argv), stderr=NOT_FOUND)
+    return ""
+
+  def try_run(self, argv, input_text=None):
+    try:
+      return self.run(argv, input_text)
+    except subprocess.CalledProcessError:
+      return None
+
+
+def _inventory(tmp_path, **overrides):
+  inv = {
+      "mode": "released",
+      "image": "us-docker.pkg.dev/bqaa-releases/bqaa/otlp-receiver:0.2.0",
+      "project": "my-proj",
+      "dataset": "ds1",
+      "region": "us-central1",
+      "bq_location": "US",
+      "cloud_run_services": [bootstrap.RECEIVER_SVC, bootstrap.CONSUMER_SVC],
+      "pubsub_topics": [bootstrap.MAIN_TOPIC, bootstrap.DLQ_TOPIC],
+      "pubsub_subscriptions": [
+          bootstrap.SUBSCRIPTION,
+          bootstrap.DLQ_SUBSCRIPTION,
+      ],
+      "secret": bootstrap.SECRET,
+      "service_accounts": [
+          bootstrap.RECEIVER_SVC,
+          bootstrap.CONSUMER_SVC,
+          "bqaa-otlp-push",
+      ],
+      "dts_display_name": f"{bootstrap.MERGE_DISPLAY_NAME}_ds1",
+  }
+  inv.update(overrides)
+  path = tmp_path / "inventory.json"
+  path.write_text(json.dumps(inv))
+  return path
+
+
+def _settings(tmp_path, **kw):
+  # Lazily default the inventory: an eager _inventory() call would
+  # overwrite a custom one the test already wrote to the same path.
+  if "inventory" not in kw:
+    kw["inventory"] = _inventory(tmp_path)
+  defaults = dict(project="my-proj", dataset="ds1")
+  defaults.update(kw)
+  return teardown.TeardownSettings(**defaults)
+
+
+class TestSafety:
+
+  def test_dry_run_is_the_default_and_deletes_nothing(self, tmp_path):
+    r = ProbeRunner()
+    report = teardown.run_teardown(_settings(tmp_path), r, echo=lambda *_: None)
+    assert report.dry_run
+    joined = "\n".join(r.calls)
+    assert "delete" not in joined
+    assert "rm" not in joined.split()
+
+  def test_dry_run_plan_names_every_deletion(self, tmp_path, capsys):
+    lines = []
+    teardown.run_teardown(_settings(tmp_path), ProbeRunner(), echo=lines.append)
+    plan = "\n".join(lines)
+    assert bootstrap.RECEIVER_SVC in plan
+    assert bootstrap.SECRET in plan
+    assert "my-proj:ds1" in plan
+
+  def test_inventory_project_dataset_must_match_args(self, tmp_path):
+    with pytest.raises(ValueError, match="inventory"):
+      teardown.run_teardown(
+          _settings(tmp_path, dataset="other_ds"),
+          ProbeRunner(),
+          echo=lambda *_: None,
+      )
+
+  def test_non_bqaa_resource_names_in_inventory_are_refused(self, tmp_path):
+    path = _inventory(tmp_path, secret="prod-payments-key")
+    with pytest.raises(ValueError, match="allowlist"):
+      teardown.run_teardown(
+          _settings(tmp_path, inventory=path),
+          ProbeRunner(),
+          echo=lambda *_: None,
+      )
+
+  def test_default_mode_inventory_never_touches_an_ar_repo(self, tmp_path):
+    r = ProbeRunner()
+    teardown.run_teardown(
+        _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+    )
+    assert not any("artifacts repositories" in c for c in r.calls)
+
+  def test_source_mode_inventory_includes_the_ar_repo(self, tmp_path):
+    path = _inventory(tmp_path, mode="source", ar_repo=bootstrap.AR_REPO)
+    r = ProbeRunner()
+    teardown.run_teardown(
+        _settings(tmp_path, inventory=path, confirm=True),
+        r,
+        echo=lambda *_: None,
+    )
+    deletes = [c for c in r.calls if "repositories delete" in c]
+    assert len(deletes) == 1 and bootstrap.AR_REPO in deletes[0]
+
+
+class TestConfirmAndVerify:
+
+  def test_confirm_deletes_and_verifies_every_class(self, tmp_path):
+    r = ProbeRunner()  # all probes answer not-found after deletion
+    report = teardown.run_teardown(
+        _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+    )
+    assert not report.dry_run
+    assert report.ok
+    joined = "\n".join(r.calls)
+    assert "run services delete" in joined
+    assert "secrets delete" in joined
+    assert "topics delete" in joined
+    assert "subscriptions delete" in joined
+    assert "service-accounts delete" in joined
+    assert "remove-iam-policy-binding" in joined
+
+  def test_permission_error_is_unverifiable_not_gone(self, tmp_path):
+    r = ProbeRunner(probes={bootstrap.SECRET: "denied"})
+    report = teardown.run_teardown(
+        _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+    )
+    assert not report.ok
+    failed = "\n".join(c.message for c in report.checks if not c.ok)
+    assert "UNVERIFIABLE" in failed or "unverifiable" in failed
+
+  def test_surviving_resource_fails_verification(self, tmp_path):
+    r = ProbeRunner(probes={bootstrap.SECRET: "still-here"})
+    report = teardown.run_teardown(
+        _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+    )
+    assert not report.ok
+
+  def test_legacy_unsuffixed_dts_config_is_found_and_deleted(self, tmp_path):
+    listing = json.dumps(
+        [
+            {
+                "name": "projects/1/locations/us/transferConfigs/abc",
+                "displayName": bootstrap.MERGE_DISPLAY_NAME,
+                "params": {"query": "MERGE `ds1.agent_events_otlp` t ..."},
+            }
+        ]
+    )
+    r = ProbeRunner(transfer_listing=listing)
+    teardown.run_teardown(
+        _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+    )
+    assert any("--transfer_config" in c and "rm" in c.split() for c in r.calls)
+
+  def test_dataset_only_skips_the_pipeline_tier(self, tmp_path):
+    r = ProbeRunner()
+    teardown.run_teardown(
+        _settings(tmp_path, confirm=True, dataset_only=True),
+        r,
+        echo=lambda *_: None,
+    )
+    joined = "\n".join(r.calls)
+    assert "run services delete" not in joined
+    assert "secrets delete" not in joined
+    assert any("rm" in c.split() and "--dataset" in c for c in r.calls)
+
+
+class TestLiveReconstruction:
+
+  def test_missing_inventory_reconstructs_from_constants(self, tmp_path):
+    settings = teardown.TeardownSettings(
+        project="my-proj", dataset="ds1", inventory=None
+    )
+    r = ProbeRunner(probes={bootstrap.SECRET: "exists"})
+    report = teardown.run_teardown(settings, r, echo=lambda *_: None)
+    assert report.dry_run
+    # The plan still covers the deterministic resource classes.
+    assert any(bootstrap.SECRET in c.message for c in report.checks) or True

--- a/producers/tests/test_otlp_teardown.py
+++ b/producers/tests/test_otlp_teardown.py
@@ -234,8 +234,37 @@ class TestLiveReconstruction:
     settings = teardown.TeardownSettings(
         project="my-proj", dataset="ds1", inventory=None
     )
-    r = ProbeRunner(probes={bootstrap.SECRET: "exists"})
-    report = teardown.run_teardown(settings, r, echo=lambda *_: None)
+    lines = []
+    report = teardown.run_teardown(settings, ProbeRunner(), echo=lines.append)
     assert report.dry_run
-    # The plan still covers the deterministic resource classes.
-    assert any(bootstrap.SECRET in c.message for c in report.checks) or True
+    plan = "\n".join(lines)
+    # The reconstructed plan covers every deterministic resource class...
+    assert bootstrap.SECRET in plan
+    assert bootstrap.RECEIVER_SVC in plan
+    assert bootstrap.DLQ_SUBSCRIPTION in plan
+    assert "my-proj:ds1" in plan
+    # ...and never assumes a source-build AR repo.
+    assert "repositories delete" not in plan
+
+
+class TestDtsListingGate:
+
+  def test_unreadable_dts_listing_refuses_before_any_deletion(self, tmp_path):
+    class ListingFailsRunner(ProbeRunner):
+
+      def run(self, argv, input_text=None):
+        joined = " ".join(argv)
+        if "--transfer_config" in joined and "ls" in argv:
+          self.calls.append(joined)
+          raise subprocess.CalledProcessError(1, list(argv), stderr="boom")
+        return super().run(argv, input_text)
+
+    r = ListingFailsRunner()
+    with pytest.raises(RuntimeError, match="DTS"):
+      teardown.run_teardown(
+          _settings(tmp_path, confirm=True), r, echo=lambda *_: None
+      )
+    # The refusal happened BEFORE anything destructive ran: the scheduled
+    # MERGE must never survive while the rest of the deployment is gone.
+    assert not any("delete" in c for c in r.calls)
+    assert not any("rm" in c.split() for c in r.calls)


### PR DESCRIPTION
Third implementation increment of #349: the two subcommands the TestPyPI full-lifecycle gate depends on — TDD (25 new tests RED-first), productized from logic already proven live in the hero demo, with every demo assumption the issue reviews flagged removed.

## `bootstrap --preflight`

- **Mode-aware permission probe** via the Resource Manager `testIamPermissions` REST call (gcloud has no such subcommand — learned live in #345): 18 permissions covering the real bootstrap surface in default prebuilt-image mode; the two build permissions added **only** for `--build-from-source`. Acceptance-criterion behavior: passes on a project with no Cloud Build/AR permissions.
- **No product CLIs required** — the demo-session assumption the review caught; `claude`/`codex` probes are opt-in via `--check-products`.
- Org-policy check for the `allUsers` invoker grant with an honest WARN when the effective policy is unreadable; every failure carries its remediation.

## `bqaa-otel teardown`

- Consumes `inventory.json` from `bootstrap --execute` (PR 2); without one, **reconstructs from the deterministic package constants** — never assuming an AR repo (released-image mode creates none; a source-mode inventory's repo is deleted exactly once).
- **Safety stack**: `--project`/`--dataset` must match the inventory (wrong file → refused); every name must match the `bqaa` allowlist patterns (poisoned inventory → refused); **dry-run by default, and the dry run executes literally nothing** — not even read-only listings, so the plan works offline; the opaque DTS config name is queried at `--confirm` time with legacy unsuffixed configs matched by query text.
- **Verification is the authority**: probes PASS only on known not-found stderr; permission/API errors are UNVERIFIABLE failures; a failed IAM policy read is never "binding gone".

## Validation

25 new tests RED-first; full producers suite **382 passed**. Live: `--preflight` ran 8/8 green against the real GCP project (real REST probe, 18/18 permissions in prebuilt mode, real org-policy read); `teardown` dry-run reconstructed the complete plan offline with zero commands executed.

With this, the no-checkout lifecycle (`pipx install → bootstrap --preflight → bootstrap --image <staging> --execute → verify --smoke → teardown`) is fully expressible — next step after merge is running that gate for real.

Part of #349.