### PR TITLE
chore(locks): regenerate for yanked build==1.5.1 (#353)

### DIFF
--- a/deploy/otlp_receiver/pip-tools.lock
+++ b/deploy/otlp_receiver/pip-tools.lock
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=/out/candidate.lock --strip-extras /src/deploy/otlp_receiver/pip-tools.in
 #
-build==1.5.1 \
-    --hash=sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb \
-    --hash=sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
     # via pip-tools
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \

--- a/producers/build-requirements.lock
+++ b/producers/build-requirements.lock
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=/out/build-requirements.lock --strip-extras /src/deploy/otlp_receiver/build-toolchain.in
 #
-build==1.5.1 \
-    --hash=sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb \
-    --hash=sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
     # via -r /src/deploy/otlp_receiver/build-toolchain.in
 hatchling==1.31.0 \
     --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \


### PR DESCRIPTION
Focused lock refresh per the #353 operational review: upstream yanked `build==1.5.1` ([PyPI](https://pypi.org/pypi/build/json)), so `regen-locks.sh` (run inside the pinned base image; generator converged in one phase) now resolves `build==1.5.0` in `deploy/otlp_receiver/pip-tools.lock` and `producers/build-requirements.lock` — the exact drift failing the Hash-lock drift check on `main` (`d7b41e3`) and blocking docs PR #366 and guard PR #369.

Only the two `build==` pins and their hashes change; the new hashes match PyPI's non-yanked 1.5.0 wheel and sdist.

After this merges, **update/rebase #366 and #369 onto the new `main`** so their pull-request workflow runs contain this fix — a plain re-run of their existing runs reuses the original `GITHUB_SHA` and cannot pick it up ([docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs)).

Part of #353.