### PR TITLE
fix(release): deviating guard message — reject the rebuilt attempt, burn only vs the original anchor (#353)

### DIFF
--- a/producers/scripts/guard_existing_release.py
+++ b/producers/scripts/guard_existing_release.py
@@ -37,12 +37,16 @@ That makes the guard consistent with the reconciler's recoveries: an
 exact TestPyPI publication with the draft missing PROCEEDS to recreate
 the draft from the preserved original-attempt artifact, while
 production files always make the missing-release / preserved-draft
-paths authoritative. A full rerun naturally shows `deviating` because
-rebuilt bytes differ — that REJECTS the rebuilt attempt and directs
-the operator back to the recoverable original run; a burn is asserted
-only for a deviation from the ORIGINAL accepted anchor (which finalize
-reports as a burn state), never merely from a rebuilt one. A published
-release always fails: that version is burned.
+paths authoritative. `deviating` covers two situations the guard cannot
+tell apart from its inputs, so the message states both branches: on
+the ORIGINAL workflow attempt the current distributions ARE the
+original workflow build anchor, and an index conflict (pre-existing or
+tampered files) burns the version outright — finalize cannot classify
+that run because github-release fails at this guard; on a full rerun
+the mismatch proves only that the rebuilt attempt must be abandoned in
+favor of the recoverable original run. A burn is asserted against the
+original workflow build anchor, never merely against a rebuilt one. A
+published release always fails: that version is burned.
 """
 
 from __future__ import annotations
@@ -100,14 +104,16 @@ def decide(release_state: str, pypi: str, testpypi: str) -> GuardAction:
         False,
         1,
         f"{where} holds files for this version that DIFFER from THIS"
-        " attempt's dist bytes. If this is a full rerun, the rebuilt"
-        " attempt is REJECTED but the version is NOT burned: abandon"
-        " this run and re-run the FAILED jobs from the ORIGINAL"
-        " workflow attempt, whose preserved artifact matches what the"
-        " index accepted. The version is burned ONLY if the index also"
-        " deviates from the ORIGINAL accepted anchor (finalize reports"
-        " that as a burn state) — then bump the version, rebuild, and"
-        " cut a new tag. Any existing draft is preserved for forensics",
+        " attempt's dist bytes. If THIS IS the ORIGINAL workflow"
+        " attempt, these distributions ARE the original workflow build"
+        " anchor — the index already holds conflicting or pre-existing"
+        " files that cannot be replaced, so the version is BURNED: bump"
+        " the version, rebuild, and cut a new tag. If this is a full"
+        " rerun, the mismatch proves only that the rebuilt attempt must"
+        " be abandoned (NOT burned by this check alone): return to the"
+        " ORIGINAL workflow attempt and re-run its FAILED jobs for"
+        " authoritative reconciliation. Any existing draft is preserved"
+        " for forensics",
     )
   if pypi == "exact":
     if release_state == "draft":

--- a/producers/scripts/guard_existing_release.py
+++ b/producers/scripts/guard_existing_release.py
@@ -35,11 +35,14 @@ index is `absent` (explicit 404), `exact` (the index holds exactly the
 current wheel+sdist bytes), or `deviating` (anything else — burned).
 That makes the guard consistent with the reconciler's recoveries: an
 exact TestPyPI publication with the draft missing PROCEEDS to recreate
-the draft from the preserved original-attempt artifact (a full rerun
-naturally shows `deviating` because rebuilt bytes differ), while
+the draft from the preserved original-attempt artifact, while
 production files always make the missing-release / preserved-draft
-paths authoritative. A published release always fails: that version is
-burned.
+paths authoritative. A full rerun naturally shows `deviating` because
+rebuilt bytes differ — that REJECTS the rebuilt attempt and directs
+the operator back to the recoverable original run; a burn is asserted
+only for a deviation from the ORIGINAL accepted anchor (which finalize
+reports as a burn state), never merely from a rebuilt one. A published
+release always fails: that version is burned.
 """
 
 from __future__ import annotations
@@ -96,10 +99,15 @@ def decide(release_state: str, pypi: str, testpypi: str) -> GuardAction:
     return GuardAction(
         False,
         1,
-        f"{where} holds files for this version that DIFFER from the"
-        " current dist bytes — the version is burned there (bump the"
-        " version, rebuild, and cut a new tag); any existing draft is"
-        " preserved for forensics",
+        f"{where} holds files for this version that DIFFER from THIS"
+        " attempt's dist bytes. If this is a full rerun, the rebuilt"
+        " attempt is REJECTED but the version is NOT burned: abandon"
+        " this run and re-run the FAILED jobs from the ORIGINAL"
+        " workflow attempt, whose preserved artifact matches what the"
+        " index accepted. The version is burned ONLY if the index also"
+        " deviates from the ORIGINAL accepted anchor (finalize reports"
+        " that as a burn state) — then bump the version, rebuild, and"
+        " cut a new tag. Any existing draft is preserved for forensics",
     )
   if pypi == "exact":
     if release_state == "draft":

--- a/producers/tests/test_guard_existing_release.py
+++ b/producers/tests/test_guard_existing_release.py
@@ -52,15 +52,25 @@ def test_draft_with_exact_testpypi_files_is_preserved_too():
   assert "TestPyPI" in action.message
 
 
-def test_deviating_index_is_burned():
+def test_deviating_index_rejects_the_rebuilt_attempt_before_burning():
   # A full rerun rebuilds bytes, so its dist DIFFERS from what the
-  # index accepted: byte validation turns that into an explicit burn.
+  # index accepted. That REJECTS the rebuilt attempt — the message
+  # must FIRST direct an accidental full rerun back to the original
+  # workflow run, and assert a burn only for deviation from the
+  # ORIGINAL accepted anchor (#353 review).
   for release in ("absent", "draft"):
     action = guard_existing_release.decide(release, "deviating", "absent")
     assert not action.proceed
     assert action.exit_code != 0
     assert "DIFFER" in action.message
-    assert "bump" in action.message
+    assert "NOT burned" in action.message
+    assert "ORIGINAL workflow attempt" in action.message
+    assert "ORIGINAL accepted anchor" in action.message
+    assert "bump" in action.message  # the true-burn branch stays stated
+    # The original-run direction comes before the burn clause.
+    assert action.message.index("ORIGINAL workflow attempt") < (
+        action.message.index("bump")
+    )
   action = guard_existing_release.decide("absent", "absent", "deviating")
   assert not action.proceed
   assert "TestPyPI" in action.message

--- a/producers/tests/test_guard_existing_release.py
+++ b/producers/tests/test_guard_existing_release.py
@@ -52,25 +52,34 @@ def test_draft_with_exact_testpypi_files_is_preserved_too():
   assert "TestPyPI" in action.message
 
 
-def test_deviating_index_rejects_the_rebuilt_attempt_before_burning():
-  # A full rerun rebuilds bytes, so its dist DIFFERS from what the
-  # index accepted. That REJECTS the rebuilt attempt — the message
-  # must FIRST direct an accidental full rerun back to the original
-  # workflow run, and assert a burn only for deviation from the
-  # ORIGINAL accepted anchor (#353 review).
+def test_deviating_message_states_the_first_attempt_burn_branch():
+  # The guard's inputs cannot distinguish a first-attempt conflict
+  # from a full rerun, so the message must state the ORIGINAL-attempt
+  # branch explicitly (#353 review): on the original attempt the
+  # current distributions ARE the original workflow build anchor, and
+  # pre-existing/conflicting index files burn the version — finalize
+  # cannot classify that run because github-release fails here.
   for release in ("absent", "draft"):
     action = guard_existing_release.decide(release, "deviating", "absent")
     assert not action.proceed
     assert action.exit_code != 0
-    assert "DIFFER" in action.message
+    assert "ORIGINAL workflow" in action.message
+    assert "original workflow build anchor" in action.message
+    assert "BURNED" in action.message
+    assert "bump" in action.message
+    assert "accepted anchor" not in action.message  # corrected wording
+
+
+def test_deviating_message_states_the_full_rerun_reject_branch():
+  # Same inputs, second interpretation: a full rerun's rebuilt bytes
+  # prove only that the rebuilt attempt must be abandoned — return to
+  # the original run for authoritative reconciliation.
+  for release in ("absent", "draft"):
+    action = guard_existing_release.decide(release, "deviating", "absent")
+    assert "full" in action.message and "rerun" in action.message
     assert "NOT burned" in action.message
+    assert "abandoned" in action.message
     assert "ORIGINAL workflow attempt" in action.message
-    assert "ORIGINAL accepted anchor" in action.message
-    assert "bump" in action.message  # the true-burn branch stays stated
-    # The original-run direction comes before the burn clause.
-    assert action.message.index("ORIGINAL workflow attempt") < (
-        action.message.index("bump")
-    )
   action = guard_existing_release.decide("absent", "absent", "deviating")
   assert not action.proceed
   assert "TestPyPI" in action.message


### PR DESCRIPTION
Code/test follow-up requested in the #353 operational reviews: the guard's `deviating` message previously said "the version is burned there" for any mismatch against the *current attempt's* bytes, which mislabeled an accidental full rerun as a burn — and its first fix wrongly claimed `finalize` would report the burn state.

The message now states BOTH interpretations of the same guard inputs explicitly:

- **Original workflow attempt**: the current distributions ARE the **original workflow build anchor** — the index already holds conflicting or pre-existing files that can never be replaced, so the version is BURNED (bump, rebuild, re-tag). `finalize` cannot classify that run: `github-release` fails at this guard and `finalize` is gated on its success (the docstring documents this).
- **Full rerun**: the mismatch proves only that the rebuilt attempt must be abandoned (NOT burned by this check alone) — return to the ORIGINAL workflow attempt and re-run its failed jobs for authoritative reconciliation.

Two regressions pin the two interpretations (`test_deviating_message_states_the_first_attempt_burn_branch` — including an assertion that the removed "accepted anchor" wording never reappears — and `test_deviating_message_states_the_full_rerun_reject_branch`). Full producer suite: **547 passed, 4 skipped**.

**Status**: rebased onto post-#367 `main`; head `4d56520` descends directly from the #367 merge (`96a079f`). All 19 checks pass (Hash-lock drift included) plus the four expected conditional zizmor skips. Blocked only on required review.

Part of #353.