### PR TITLE
feat(dashboard): resolve validated UX backlog

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -38,6 +38,7 @@ billing project is supported as an optional advanced setting.
 | Path | What it is |
 |---|---|
 | `spec/chart_manifest.yaml` | Reviewed consumer snapshot: 37 chart records, 9 non-data elements, controls, listener matrix, layout, and oracle mappings |
+| `spec/product_contract.yaml` | Current product-layer titles, layout, filters, live fixes, and intentional divergences from the pinned block |
 | `sql/events_v1.sql.tmpl` | Reviewed base-table query (**generated** by `tools/gen_events_tmpl.py`) |
 | `sql/events_v1.template.sql` | Sentinel-rendered SQL embedded in the canonical report (**generated** by `tools/render_template.py`) |
 | `sql/preflight.sql.tmpl` / `.template.sql` | Structural compatibility check, run by the hydration helper before emitting a link |
@@ -49,6 +50,7 @@ billing project is supported as an optional advanced setting.
 | `docs/index.html` | Three-field, client-only configurator for the public dashboard template |
 | `tools/hydrate_dashboard.py` | Validates a BQAA table and emits a user-owned Looker Studio report URL |
 | `docs/dashboard-implementation.md` | Looker Studio page, field, formula, and live-validation implementation contract |
+| `docs/issue-377-review.md` | Live validation matrix for the UX/design backlog |
 | `oracle/queries/` | 37 independent per-chart SQL contracts used by the live validator |
 
 ## Pinned contracts
@@ -169,6 +171,33 @@ publication review must repeat the live check after every template change.
 
 `--table` is both the object validated by the CLI and the only BigQuery object
 queried by the dashboard.
+
+## Large-table operating guidance
+
+Every chart reads the same date-pruned custom query over the configured
+`agent_events` table. Cost therefore scales primarily with the selected date
+window, event volume, and number of chart interactions.
+
+- Keep the BQAA table partitioned on its event timestamp and retain the
+  dashboard's `@DS_START_DATE` / `@DS_END_DATE` predicate. Do not wrap the
+  partition column in a transformation that prevents pruning.
+- Use the shortest date range that answers the operational question. The
+  365-day default is an onboarding view, not a recommendation for every
+  high-volume installation.
+- Set BigQuery partition expiration to the retention period your incident and
+  compliance policies actually require.
+- Monitor bytes processed in BigQuery job history before and after changing
+  the dashboard or retention window.
+- For repeatedly queried, high-volume installations, evaluate BI Engine or a
+  scheduled, date-partitioned rollup table. Keep the raw table for Inspector
+  workflows and validate rollup semantics against the independent oracle
+  queries before switching dashboard charts.
+- Use a separate billing project when teams need dashboard-specific quotas,
+  reservations, or cost attribution.
+
+The report footer's “Data Last Updated” value is a Looker Studio connector
+refresh time. It is not the latest BQAA event timestamp and must not be treated
+as a data-freshness guarantee.
 
 To run the browser configurator from this checkout:
 

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -16,7 +16,7 @@ generated_report_credential_gate:
   verification_path: Resource > Manage added data sources > Edit
 link_access: PUBLIC
 publishing_mode: MANUAL
-published_date: "2026-07-25"
+published_date: "2026-07-27"
 # This attestation covers the reviewed repository artifact. It does not prove
 # that the mutable external Looker Studio report still embeds these bytes.
 reviewed_template_sql:
@@ -24,18 +24,21 @@ reviewed_template_sql:
   reviewed_date: "2026-07-24"
   scope: repository_artifact_only
 live_template_verification:
-  verified_date: "2026-07-25"
+  verified_date: "2026-07-27"
   repository_sql_sha256: 5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0
   method:
     - connector_custom_query_review
     - sqlreplace_table_only_smoke_test
     - canonical_viewer_credentials_review
     - published_eight_page_ux_smoke_test
+    - published_non_degenerate_chart_data_capture
+    - editor_configuration_assertions
+    - published_tool_page_refresh
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
 product_contract: spec/product_contract.yaml
 product_verification:
-  verified_date: "2026-07-25"
+  verified_date: "2026-07-27"
   pages: 8
   checks:
     - expected_page_and_chart_titles_present
@@ -43,6 +46,13 @@ product_verification:
     - no_date_control_chart_overlaps
     - llm_call_volume_dimension_is_event_date
     - llm_and_tool_percentile_order_is_p50_p75_p90_p99
+    - llm_and_token_p1_bindings_render_non_degenerate_data
+    - latency_sections_are_aligned_and_non_overlapping
+    - single_series_legends_do_not_expose_internal_field_names
+    - top_user_rankings_do_not_group_remaining_users_as_others
+    - tool_charts_exclude_non_completed_rows
+    - multi_series_charts_use_categorical_legends
+    - no_partial_update_footer_after_refresh
   result: PASSED
 source_contract:
   mode: BASE_TABLE

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -16,7 +16,7 @@ generated_report_credential_gate:
   verification_path: Resource > Manage added data sources > Edit
 link_access: PUBLIC
 publishing_mode: MANUAL
-published_date: "2026-07-24"
+published_date: "2026-07-25"
 # This attestation covers the reviewed repository artifact. It does not prove
 # that the mutable external Looker Studio report still embeds these bytes.
 reviewed_template_sql:
@@ -24,14 +24,26 @@ reviewed_template_sql:
   reviewed_date: "2026-07-24"
   scope: repository_artifact_only
 live_template_verification:
-  verified_date: "2026-07-24"
+  verified_date: "2026-07-25"
   repository_sql_sha256: 5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0
   method:
     - connector_custom_query_review
     - sqlreplace_table_only_smoke_test
     - canonical_viewer_credentials_review
+    - published_eight_page_ux_smoke_test
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
+product_contract: spec/product_contract.yaml
+product_verification:
+  verified_date: "2026-07-25"
+  pages: 8
+  checks:
+    - expected_page_and_chart_titles_present
+    - no_too_many_rows_errors
+    - no_date_control_chart_overlaps
+    - llm_call_volume_dimension_is_event_date
+    - llm_and_tool_percentile_order_is_p50_p75_p90_p99
+  result: PASSED
 source_contract:
   mode: BASE_TABLE
   generated_views_required: false

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -8,12 +8,20 @@ import { REPORT_CONFIG } from "./report-config.mjs";
 const form = document.querySelector("#configurator");
 const createLink = document.querySelector("#create-dashboard");
 const copyButton = document.querySelector("#copy-link");
+const checklistButton = document.querySelector("#copy-checklist");
+const checklist = document.querySelector("#security-checklist");
 const status = document.querySelector("#form-status");
 const inputs = {
   project: document.querySelector("#project"),
   dataset: document.querySelector("#dataset"),
   table: document.querySelector("#table"),
   billingProject: document.querySelector("#billing-project"),
+};
+const errors = {
+  project: document.querySelector("#project-error"),
+  dataset: document.querySelector("#dataset-error"),
+  table: document.querySelector("#table-error"),
+  billingProject: document.querySelector("#billing-project-error"),
 };
 
 function currentValues() {
@@ -27,7 +35,15 @@ function setStatus(message, kind = "") {
   status.dataset.kind = kind;
 }
 
+function clearFieldErrors() {
+  for (const [name, input] of Object.entries(inputs)) {
+    input.removeAttribute("aria-invalid");
+    errors[name].textContent = "";
+  }
+}
+
 function refresh() {
+  clearFieldErrors();
   try {
     const values = validateConfiguration(currentValues());
     createLink.href = buildDashboardUrl(values);
@@ -41,6 +57,10 @@ function refresh() {
     createLink.removeAttribute("href");
     createLink.setAttribute("aria-disabled", "true");
     copyButton.disabled = true;
+    if (error.field && inputs[error.field]) {
+      inputs[error.field].setAttribute("aria-invalid", "true");
+      errors[error.field].textContent = error.message;
+    }
     setStatus(error.message, "error");
   }
 }
@@ -80,6 +100,18 @@ copyButton.addEventListener("click", async () => {
     setStatus("Setup link copied. It contains identifiers, never credentials.", "ready");
   } catch (error) {
     setStatus(error.message || "Could not copy the setup link.", "error");
+  }
+});
+
+checklistButton.addEventListener("click", async () => {
+  const text = [...checklist.querySelectorAll("li")]
+    .map((item, index) => `${index + 1}. ${item.textContent.trim()}`)
+    .join("\n");
+  try {
+    await navigator.clipboard.writeText(text);
+    setStatus("Security checklist copied.", "ready");
+  } catch {
+    setStatus("Could not copy the security checklist.", "error");
   }
 });
 

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -3,10 +3,29 @@ import { REPORT_CONFIG } from "./report-config.mjs";
 export const PROJECT_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 export const BIGQUERY_ID_RE = /^[A-Za-z_][A-Za-z0-9_]{0,1023}$/;
 
-function requireValue(label, value, pattern) {
+const VALIDATION_MESSAGES = Object.freeze({
+  project:
+    "Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit.",
+  dataset:
+    "Start with a letter or underscore, then use only letters, digits, or underscores.",
+  table:
+    "Start with a letter or underscore, then use only letters, digits, or underscores.",
+  billingProject:
+    "Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit.",
+});
+
+export class ConfigurationError extends Error {
+  constructor(field, message) {
+    super(message);
+    this.name = "ConfigurationError";
+    this.field = field;
+  }
+}
+
+function requireValue(field, value, pattern) {
   const normalized = String(value ?? "").trim();
   if (!pattern.test(normalized)) {
-    throw new Error(`Enter a valid BigQuery ${label}.`);
+    throw new ConfigurationError(field, VALIDATION_MESSAGES[field]);
   }
   return normalized;
 }
@@ -31,13 +50,13 @@ function rejectSentinelCollisions(values, config) {
 }
 
 export function validateConfiguration(input, config = REPORT_CONFIG) {
-  const project = requireValue("project ID", input.project, PROJECT_RE);
+  const project = requireValue("project", input.project, PROJECT_RE);
   const values = {
     project,
-    dataset: requireValue("dataset ID", input.dataset, BIGQUERY_ID_RE),
-    table: requireValue("table ID", input.table, BIGQUERY_ID_RE),
+    dataset: requireValue("dataset", input.dataset, BIGQUERY_ID_RE),
+    table: requireValue("table", input.table, BIGQUERY_ID_RE),
     billingProject: requireValue(
-      "billing project ID",
+      "billingProject",
       input.billingProject || project,
       PROJECT_RE,
     ),

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -4,6 +4,11 @@ This document connects the generated parity manifest to the canonical report
 implementation. It contains no report ID, production project/dataset name, or
 result values.
 
+The manifest is an immutable snapshot of the pinned community block. Current
+product behavior and intentional divergences are recorded separately in
+`../spec/product_contract.yaml`; see `issue-377-review.md` for the live
+validation that established the boundary.
+
 ## Data-source boundary
 
 The report has exactly one embedded BigQuery data source. Its custom query is
@@ -86,6 +91,12 @@ The Inspector exposes timestamp, event type, agent, user, trace, span, and
 status from the same production data source. It is a drill-through aid, not a
 38th parity tile.
 
+Every page has a visible page heading, and every non-scorecard chart has an
+explicit chart title. Product titles use title case, “Over Time,” uppercase
+“LLM,” plural “Sessions,” and `(ms)` for latency units. The Tool Usage chart
+formerly inherited as “Events By Agent” is labeled **Tool Completions by
+Agent** because its metric intentionally counts only `TOOL_COMPLETED` rows.
+
 All seven dashboard pages use a rolling 365-day window ending yesterday.
 Looker Studio sends those bounds through `@DS_START_DATE` and
 `@DS_END_DATE`; the production query applies the frozen half-open UTC
@@ -93,6 +104,10 @@ predicate. The generated manifest retains the pinned LookML's original
 14-day Usage and 7-day Performance defaults as source-provenance metadata;
 the published template intentionally overrides them for the product default.
 The Trace Inspector has no default date control.
+
+The LLM Call Volume chart uses `event_date`, not raw `timestamp`. The raw
+timestamp dimension exceeded Looker Studio's chart row limit on the canonical
+fixture and rendered “Too Many Rows.”
 
 ## Looker Studio measure mappings
 

--- a/dashboard/looker_studio/docs/favicon.svg
+++ b/dashboard/looker_studio/docs/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="BigQuery Agent Analytics">
+  <rect width="64" height="64" rx="14" fill="#096b5a"/>
+  <path d="M17 18h12v12H17zm18 0h12v12H35zM17 36h12v12H17zm18 0h12v12H35z" fill="#fff"/>
+  <circle cx="23" cy="24" r="3" fill="#7dd3c7"/>
+  <circle cx="41" cy="42" r="3" fill="#f9ab00"/>
+  <path d="M26 26l12 12M29 42h6M41 30v6" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -7,11 +7,29 @@
       name="description"
       content="Create a private Looker Studio dashboard from your BigQuery Agent Analytics installation."
     >
+    <meta name="theme-color" content="#096b5a">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Configure BigQuery Agent Analytics">
+    <meta
+      property="og:description"
+      content="Create a private Looker Studio dashboard from your BQAA event table."
+    >
+    <meta
+      property="og:url"
+      content="https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/"
+    >
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Configure BigQuery Agent Analytics">
+    <meta
+      name="twitter:description"
+      content="Create a private Looker Studio dashboard from your BQAA event table."
+    >
     <title>Configure BigQuery Agent Analytics</title>
     <link
       rel="canonical"
       href="https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/"
     >
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="./styles.css">
   </head>
   <body>
@@ -45,8 +63,14 @@
             name="project"
             autocomplete="off"
             placeholder="my-gcp-project"
+            aria-describedby="project-hint project-error"
             required
           >
+          <span class="field-hint" id="project-hint">
+            6–30 characters: lowercase letters, digits, and hyphens. Start
+            with a letter and end with a letter or digit.
+          </span>
+          <span class="field-error" id="project-error" aria-live="polite"></span>
 
           <label for="dataset">Dataset ID</label>
           <input
@@ -54,8 +78,14 @@
             name="dataset"
             autocomplete="off"
             placeholder="agent_analytics"
+            aria-describedby="dataset-hint dataset-error"
             required
           >
+          <span class="field-hint" id="dataset-hint">
+            Start with a letter or underscore; then use letters, digits, or
+            underscores.
+          </span>
+          <span class="field-error" id="dataset-error" aria-live="polite"></span>
 
           <label for="table">BQAA table ID</label>
           <input
@@ -63,12 +93,15 @@
             name="table"
             autocomplete="off"
             value="agent_events"
+            aria-describedby="table-hint table-error"
             required
           >
-          <span class="hint">
+          <span class="field-hint" id="table-hint">
             Charts read this table directly and extract reporting fields from
-            its JSON columns.
+            its JSON columns. The standard BQAA table is
+            <code>agent_events</code>.
           </span>
+          <span class="field-error" id="table-error" aria-live="polite"></span>
 
           <details>
             <summary>Advanced settings</summary>
@@ -78,7 +111,16 @@
               name="billingProject"
               autocomplete="off"
               placeholder="Defaults to the source project"
+              aria-describedby="billing-project-hint billing-project-error"
             >
+            <span class="field-hint" id="billing-project-hint">
+              Optional. Leave blank to run queries in the source project.
+            </span>
+            <span
+              class="field-error"
+              id="billing-project-error"
+              aria-live="polite"
+            ></span>
           </details>
 
           <p id="form-status" role="status" aria-live="polite"></p>
@@ -139,6 +181,36 @@
           Learn about Looker Studio data credentials.
         </a>
       </aside>
+
+      <section class="post-create" aria-labelledby="post-create-title">
+        <div>
+          <div class="eyebrow">Required security check</div>
+          <h2 id="post-create-title">Before you share the new report</h2>
+          <p>
+            The Linking API creates a new data source owned by the person who
+            opens the link. Keep the report private until these checks pass.
+          </p>
+        </div>
+        <ol id="security-checklist">
+          <li>Select <strong>Edit and share</strong> to save your copy.</li>
+          <li>Keep the report private while configuring its data source.</li>
+          <li>
+            Open <strong>Resource → Manage added data sources → Edit</strong>.
+          </li>
+          <li>
+            Set <strong>Data credentials</strong> to
+            <strong>Viewer’s Credentials</strong>.
+          </li>
+          <li>Test the report with an account that has only viewer access.</li>
+        </ol>
+        <button
+          class="button button-secondary checklist-copy"
+          id="copy-checklist"
+          type="button"
+        >
+          Copy security checklist
+        </button>
+      </section>
 
       <aside class="notice">
         <strong>No generated views required.</strong>

--- a/dashboard/looker_studio/docs/issue-377-review.md
+++ b/dashboard/looker_studio/docs/issue-377-review.md
@@ -1,0 +1,75 @@
+# Issue #377 validation and resolution
+
+Issue #377 was initially derived from the pinned Looker block snapshot in
+`spec/chart_manifest.yaml`. That file is a parity/provenance contract, not a
+serialization of the current Looker Studio report. On 2026-07-25, the
+canonical report was reviewed directly in an authenticated Chrome session,
+page by page, at report ID `5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40`.
+
+The review keeps the source snapshot unchanged and records current product
+behavior in `spec/product_contract.yaml`.
+
+## Confirmed and fixed
+
+- The LLM Call Volume chart used raw `timestamp` and rendered **Too Many
+  Rows**. Its dimension is now `event_date`; the chart renders successfully.
+- Every page now has a visible page heading.
+- Every non-scorecard chart now has an explicit, title-cased title. This
+  includes **Tool Completions by Agent**, whose query is intentionally scoped
+  to `TOOL_COMPLETED`.
+- Date controls are aligned in the upper-right. Scorecards on LLM
+  Interactions, User Analytics, Latency, and Errors no longer overlap them.
+- The final Tool P99 card is aligned with the P50/P75/P90 row.
+- User-facing copy uses “Over Time,” “LLM,” plural “Sessions,” and one `(ms)`
+  unit style.
+- The web configurator now has a favicon, OpenGraph/Twitter metadata,
+  field-specific format guidance and error placement, a dark color scheme,
+  and a copyable post-create security checklist.
+- Large-table operating guidance is documented in the README.
+
+## Already correct or not present in the live report
+
+- Both live percentile rows were already P50 → P75 → P90 → P99. The claimed
+  LLM P50 → P99 → P75 → P90 order exists only in the pinned manifest.
+- The live report contained none of the empty buttons/text elements or the
+  single “Agent” section header described from the LookML snapshot.
+- All seven dashboard pages already used the product default of rolling 365
+  days ending yesterday.
+- The live report used one blue series color, not the orange/pink/red
+  inconsistencies quoted from the manifest. A semantic multi-color palette is
+  therefore an enhancement, not a repair.
+- Live legends were not centered on all 37 charts. The more important live
+  problem was missing chart titles, which this change fixes.
+- The live component geometry does not use the manifest's 24-column
+  coordinates. Ratio, width, and height claims based only on those coordinates
+  were not applied to the report.
+
+## Filter decision
+
+The live report has a report filter bar backed by the single `agent_events`
+data source. Agent, User ID, Trace ID, Span ID, Session ID, and Model Version
+are available there and apply to compatible charts.
+
+A predefined Tool Name filter is deliberately not published yet. The current
+typed schema has separate `tool_completed_name` and `tool_error_name` fields.
+Using either one as a report-wide control would silently exclude the other
+event family. The accepted follow-up is a unified `tool_name` field plus a
+page-scoped control verified across Tool Usage, Latency, and Errors.
+
+## Valid enhancements that require separate acceptance work
+
+The remaining ideas are useful but are not safe one-line UX fixes:
+
+- semantic colors, value labels, and compact number formats require contrast,
+  color-blind, truncation, and precision QA;
+- percentile trends and hourly grain add query-cost and layout decisions;
+- error rates require frozen denominator semantics;
+- estimated spend requires a maintained, user-configurable pricing source;
+- Inspector drill-through requires copied-report filter propagation testing;
+- true data freshness must use `MAX(timestamp)`, not Looker Studio's connector
+  refresh footer; and
+- Google-managed ownership requires maintainer action outside the repository.
+
+These dependencies are executable entries in
+`spec/product_contract.yaml#deferred_enhancements`; they are not represented
+as completed work.

--- a/dashboard/looker_studio/docs/issue-377-review.md
+++ b/dashboard/looker_studio/docs/issue-377-review.md
@@ -5,6 +5,8 @@ Issue #377 was initially derived from the pinned Looker block snapshot in
 serialization of the current Looker Studio report. On 2026-07-25, the
 canonical report was reviewed directly in an authenticated Chrome session,
 page by page, at report ID `5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40`.
+The published report was reviewed again on 2026-07-27 after PR feedback found
+that the first title-only smoke test could miss incomplete chart renders.
 
 The review keeps the source snapshot unchanged and records current product
 behavior in `spec/product_contract.yaml`.
@@ -19,7 +21,16 @@ behavior in `spec/product_contract.yaml`.
   to `TOOL_COMPLETED`.
 - Date controls are aligned in the upper-right. Scorecards on LLM
   Interactions, User Analytics, Latency, and Errors no longer overlap them.
-- The final Tool P99 card is aligned with the P50/P75/P90 row.
+- Both percentile rows are aligned four-card grids. The trend titles and
+  charts sit below them without overlapping either row.
+- Single-series chart legends are hidden when the nearby title already names
+  the metric, so source field IDs such as `llm_response_pk`, `invocation_id`,
+  and `tool_error_pk` no longer leak into the presentation.
+- The four Top-5 user charts no longer group all remaining users into an
+  **Others** bucket that overwhelms the named users.
+- Tool Invocations, Tool Calls Over Time, and Tool Latency Over Time explicitly
+  use the existing **Tool completed rows** filter. This removes blank and
+  `null` tool-name series and preserves the pinned `TOOL_COMPLETED` semantics.
 - User-facing copy uses “Over Time,” “LLM,” plural “Sessions,” and one `(ms)`
   unit style.
 - The web configurator now has a favicon, OpenGraph/Twitter metadata,
@@ -35,9 +46,10 @@ behavior in `spec/product_contract.yaml`.
   single “Agent” section header described from the LookML snapshot.
 - All seven dashboard pages already used the product default of rolling 365
   days ending yesterday.
-- The live report used one blue series color, not the orange/pink/red
-  inconsistencies quoted from the manifest. A semantic multi-color palette is
-  therefore an enhancement, not a repair.
+- Single-series charts use Google blue. Breakdown charts correctly use a
+  categorical multi-color palette. The earlier `single_google_blue` contract
+  wording was inaccurate and has been replaced with separate single-series
+  and multi-series rules.
 - Live legends were not centered on all 37 charts. The more important live
   problem was missing chart titles, which this change fixes.
 - The live component geometry does not use the manifest's 24-column
@@ -56,6 +68,27 @@ Using either one as a report-wide control would silently exclude the other
 event family. The accepted follow-up is a unified `tool_name` field plus a
 page-scoped control verified across Tool Usage, Latency, and Errors.
 
+## Follow-up published-report verification
+
+The second visual pass initially observed empty or degenerate rendering for
+**LLM Call Volume Over Time**, **Top 5 Agents by LLM Calls**, and **Token Usage
+by Agent**. A clean published reload showed their persisted bindings and data
+were intact:
+
+- LLM Call Volume uses `event_date` with distinct `llm_response_pk`;
+- Top 5 Agents uses `agent` with distinct `llm_response_pk`; and
+- Token Usage by Agent uses `agent` with summed `usage_total_tokens`.
+
+This was an incomplete-render/stale-update state, not persisted field loss.
+The 2026-07-27 verification therefore checks the editor bindings and requires
+non-degenerate rendered data before passing; title presence alone is no longer
+sufficient.
+
+Tool Usage also retained a partial-update footer after publication even though
+all three charts rendered. Running the standard viewer **Refresh data** action
+cleared the footer, and a separate 30-second viewer load confirmed it did not
+return.
+
 ## Valid enhancements that require separate acceptance work
 
 The remaining ideas are useful but are not safe one-line UX fixes:
@@ -64,6 +97,8 @@ The remaining ideas are useful but are not safe one-line UX fixes:
   color-blind, truncation, and precision QA;
 - percentile trends and hourly grain add query-cost and layout decisions;
 - error rates require frozen denominator semantics;
+- LLM error visibility requires explicit `LLM_ERROR` measures before a rate
+  can be defined;
 - estimated spend requires a maintained, user-configurable pricing source;
 - Inspector drill-through requires copied-report filter propagation testing;
 - true data freshness must use `MAX(timestamp)`, not Looker Studio's connector

--- a/dashboard/looker_studio/docs/styles.css
+++ b/dashboard/looker_studio/docs/styles.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   --ink: #17212b;
   --muted: #5b6672;
   --line: #dce3e8;
@@ -134,12 +134,27 @@ input:focus {
   box-shadow: 0 0 0 3px rgba(9, 107, 90, 0.12);
 }
 
-.hint {
+.field-hint,
+.field-error {
   display: block;
   margin-top: 6px;
-  color: var(--muted);
   font-size: 0.75rem;
   line-height: 1.4;
+}
+
+.field-hint {
+  color: var(--muted);
+}
+
+.field-error {
+  min-height: 1.05rem;
+  color: #a33b26;
+  font-weight: 650;
+}
+
+input[aria-invalid="true"] {
+  border-color: #a33b26;
+  box-shadow: 0 0 0 3px rgba(163, 59, 38, 0.1);
 }
 
 details {
@@ -256,6 +271,49 @@ summary {
   color: var(--ink);
 }
 
+.post-create {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(340px, 1.2fr);
+  gap: 32px;
+  align-items: start;
+  margin-top: 46px;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--paper);
+  box-shadow: 0 14px 44px rgba(24, 45, 39, 0.08);
+}
+
+.post-create h2 {
+  margin: 8px 0 10px;
+  font-size: 1.45rem;
+}
+
+.post-create p,
+.post-create ol {
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+.post-create p {
+  margin: 0;
+}
+
+.post-create ol {
+  margin: 0;
+  padding-left: 1.35rem;
+}
+
+.post-create li + li {
+  margin-top: 6px;
+}
+
+.checklist-copy {
+  grid-column: 2;
+  justify-self: start;
+}
+
 footer {
   display: flex;
   justify-content: space-between;
@@ -269,6 +327,51 @@ footer a {
   color: var(--green-dark);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #edf5f2;
+    --muted: #b8c7c2;
+    --line: #3c4a46;
+    --paper: #17221f;
+    --canvas: #0f1715;
+    --green: #7dd3c7;
+    --green-dark: #a6e4dc;
+    --green-soft: #243b36;
+    --orange: #f6a06d;
+    --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+  }
+
+  body {
+    background:
+      radial-gradient(circle at 12% 4%, rgba(125, 211, 199, 0.12), transparent 27rem),
+      linear-gradient(145deg, #111b18 0%, var(--canvas) 60%, #0c1311 100%);
+  }
+
+  .facts li,
+  .notice {
+    background: rgba(23, 34, 31, 0.78);
+  }
+
+  input {
+    border-color: #53645f;
+    background: #111a18;
+  }
+
+  #form-status[data-kind="error"],
+  .field-error {
+    color: #ffb19d;
+  }
+
+  .button-primary {
+    color: #0b1714;
+    background: #7dd3c7;
+  }
+
+  .button-primary:hover {
+    background: #a6e4dc;
+  }
+}
+
 @media (max-width: 820px) {
   main {
     width: min(100% - 28px, 620px);
@@ -276,7 +379,8 @@ footer a {
   }
 
   .hero,
-  .how {
+  .how,
+  .post-create {
     grid-template-columns: 1fr;
   }
 
@@ -291,6 +395,10 @@ footer a {
 
   .actions {
     grid-template-columns: 1fr;
+  }
+
+  .checklist-copy {
+    grid-column: 1;
   }
 
   footer {

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -1,0 +1,204 @@
+# Product-layer contract for the published Looker Studio report.
+#
+# spec/chart_manifest.yaml remains the immutable translation of the pinned
+# community Looker block. This file records intentional product behavior and
+# live-report fixes that differ from that source snapshot.
+meta:
+  contract_version: 1
+  review_issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#377
+  source_parity_contract: spec/chart_manifest.yaml
+  live_review_date: "2026-07-25"
+  report_id: 5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40
+
+source:
+  mode: BASE_TABLE
+  object_default: agent_events
+  generated_views_required: false
+  data_source_count: 1
+
+defaults:
+  date_range:
+    mode: rolling
+    start_offset_days: 365
+    end_offset_days: 1
+    include_today: false
+    page_scope: all_dashboard_pages
+
+pages:
+  - name: Token Consumption
+    id: p_70hoa89q5d
+  - name: Agent & Sessions
+    id: JjD
+  - name: Tool Usage
+    id: KjD
+  - name: LLM Interactions
+    id: MjD
+  - name: User Analytics
+    id: 00IH
+  - name: Latency
+    id: p_9om48zps5d
+  - name: Errors
+    id: v0IH
+  - name: Trace Inspector
+    id: BKJH
+
+layout:
+  page_heading:
+    present_on_every_page: true
+    left: 68
+    top_range: [43, 45]
+  date_control:
+    present_on_dashboard_pages: true
+    left: 825
+    top_range: [43, 45]
+  scorecard_start:
+    left: 68
+    top_range: [130, 132]
+  percentile_order:
+    llm: [P50, P75, P90, P99]
+    tool: [P50, P75, P90, P99]
+
+behavioral_fixes:
+  usage-llm-call-trends:
+    dimension: event_date
+    reason: Raw timestamp exceeded the Looker Studio chart row limit.
+  usage-events-by-agent:
+    event_scope: TOOL_COMPLETED
+    display_title: Tool Completions by Agent
+
+filtering:
+  filter_bar:
+    enabled: true
+    available_fields:
+      - agent
+      - user_id
+      - trace_id
+      - span_id
+      - session_id
+      - model_version
+  date_controls:
+    apply_to_all_charts_on_page: true
+  predefined_tool_name_control:
+    status: intentionally_not_published
+    reason: >-
+      A report-wide tool_completed_name filter would exclude TOOL_ERROR rows,
+      while tool_error_name would exclude TOOL_COMPLETED rows. A unified
+      tool_name source field and page-scoped control are required before this
+      control can be correct.
+  user_id:
+    status: available_in_filter_bar
+    applies_to_all_compatible_charts: true
+
+visual_system:
+  live_series_mode: single_google_blue
+  live_series_color: "#4285f4"
+  semantic_palette:
+    status: deferred
+    reason: >-
+      The live report does not contain the orange/pink/red inconsistencies
+      asserted from the pinned manifest. A multi-color semantic palette should
+      be introduced only with contrast and color-blind testing.
+  chart_titles:
+    present_for_all_non_scorecard_charts: true
+    title_case: true
+    unit_style: "(ms)"
+
+charts:
+  - id: usage-token-usage-split-by-agent
+    title: Token Usage by Agent
+  - id: usage-top-5-users-with-most-tokens-consumption
+    title: Top 5 Users by Token Consumption
+  - id: usage-total-tokens-consumption-over-the-time
+    title: Token Consumption Over Time
+  - id: usage-total-tokens
+    title: Total Tokens
+  - id: usage-top-5-users-with-most-traces
+    title: Top 5 Users by Traces
+  - id: usage-total-traces
+    title: Total Traces
+  - id: usage-traces-split-by-agent
+    title: Traces by Agent
+  - id: usage-total-traces-generation-over-the-time
+    title: Trace Volume Over Time
+  - id: usage-total-sessions
+    title: Total Sessions
+  - id: usage-number-of-sessions-trend
+    title: Session Volume Over Time
+  - id: usage-top-5-agents-split-by-session-count
+    title: Top 5 Agents by Sessions
+  - id: usage-tool-invocations
+    title: Tool Invocations
+  - id: usage-events-by-agent
+    title: Tool Completions by Agent
+  - id: usage-tool-calls-over-time
+    title: Tool Calls Over Time
+  - id: usage-total-calls
+    title: Total LLM Calls
+  - id: usage-llm-call-trends
+    title: LLM Call Volume Over Time
+  - id: usage-top-5-agents-by-llm-calls
+    title: Top 5 Agents by LLM Calls
+  - id: usage-total-users
+    title: Total Users
+  - id: usage-user-growth-over-time
+    title: User Growth Over Time
+  - id: usage-top-5-users-by-session
+    title: Top 5 Users by Sessions
+  - id: usage-top-5-users-by-events
+    title: Top 5 Users by Events
+  - id: performance-average-tool-latency-ms
+    title: Average Tool Latency (ms)
+  - id: performance-tool-latency-trend
+    title: Tool Latency Over Time
+  - id: performance-average-llm-latency-in-ms
+    title: Average LLM Latency (ms)
+  - id: performance-llm-latency-trend
+    title: LLM Latency Over Time
+  - id: performance-p50-tool-latency
+    title: P50 Tool Latency
+  - id: performance-p75-tool-latency
+    title: P75 Tool Latency
+  - id: performance-p90-tool-latency
+    title: P90 Tool Latency
+  - id: performance-p99-tool-latency
+    title: P99 Tool Latency
+  - id: performance-p50-llm-latency
+    title: P50 LLM Latency
+  - id: performance-p75-llm-latency
+    title: P75 LLM Latency
+  - id: performance-p90-llm-latency
+    title: P90 LLM Latency
+  - id: performance-p99-llm-latency
+    title: P99 LLM Latency
+  - id: performance-total-errors
+    title: Tool Errors
+  - id: performance-tool-errors-trend
+    title: Tool Errors Over Time
+  - id: performance-top-5-agents-by-errors
+    title: Top 5 Agents by Tool Errors
+  - id: performance-top-5-tools-by-errors
+    title: Top 5 Tools by Errors
+
+deferred_enhancements:
+  - id: scoped-tool-name-filter
+    dependency: Add a unified tool_name field and verify grouped control scope.
+  - id: semantic-palette
+    dependency: Contrast and color-blind QA for every chart role.
+  - id: value-labels
+    dependency: Truncation QA for long agent, user, and tool identifiers.
+  - id: compact-number-formatting
+    dependency: Confirm scorecard and tooltip precision requirements.
+  - id: percentile-trends
+    dependency: Product design and query-cost measurement.
+  - id: error-rates
+    dependency: Freeze denominator semantics for tool and LLM failures.
+  - id: estimated-cost
+    dependency: Versioned, user-configurable model pricing source.
+  - id: hourly-grain
+    dependency: Add an event_hour field and remeasure chart query cost.
+  - id: inspector-drill-through
+    dependency: Verify cross-page filter carry-over in copied reports.
+  - id: data-freshness-scorecard
+    dependency: Add MAX(timestamp) without conflating it with connector refresh.
+  - id: google-managed-template-ownership
+    dependency: Maintainer-controlled Google account and transfer approval.

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -7,7 +7,7 @@ meta:
   contract_version: 1
   review_issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#377
   source_parity_contract: spec/chart_manifest.yaml
-  live_review_date: "2026-07-25"
+  live_review_date: "2026-07-27"
   report_id: 5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40
 
 source:
@@ -57,14 +57,32 @@ layout:
   percentile_order:
     llm: [P50, P75, P90, P99]
     tool: [P50, P75, P90, P99]
+  latency_sections:
+    llm_percentile_top: 377
+    tool_percentile_top: 494
+    trend_title_top: 611
+    trend_chart_top: 670
+    overlap_free: true
 
 behavioral_fixes:
   usage-llm-call-trends:
     dimension: event_date
+    oracle_grain: minute
+    compare_at: event_date
     reason: Raw timestamp exceeded the Looker Studio chart row limit.
   usage-events-by-agent:
     event_scope: TOOL_COMPLETED
     display_title: Tool Completions by Agent
+  tool-completed-charts:
+    filter_name: Tool completed rows
+    event_scope: TOOL_COMPLETED
+    charts:
+      - usage-tool-invocations
+      - usage-tool-calls-over-time
+      - performance-tool-latency-trend
+    reason: >-
+      Excluding non-completed event rows removes blank and null tool-name
+      categories while preserving the pinned query semantics.
 
 filtering:
   filter_bar:
@@ -88,16 +106,29 @@ filtering:
   user_id:
     status: available_in_filter_bar
     applies_to_all_compatible_charts: true
+  top_user_rankings:
+    group_remaining_as_others: false
+    charts:
+      - usage-top-5-users-with-most-tokens-consumption
+      - usage-top-5-users-with-most-traces
+      - usage-top-5-users-by-session
+      - usage-top-5-users-by-events
 
 visual_system:
-  live_series_mode: single_google_blue
-  live_series_color: "#4285f4"
+  single_series:
+    mode: google_blue
+    color: "#4285f4"
+    legend: hidden_when_title_defines_metric
+  multi_series:
+    mode: categorical_google_palette
+    legend: visible
+    dimension_values_are_series_labels: true
   semantic_palette:
     status: deferred
     reason: >-
-      The live report does not contain the orange/pink/red inconsistencies
-      asserted from the pinned manifest. A multi-color semantic palette should
-      be introduced only with contrast and color-blind testing.
+      The live report uses a categorical palette only to distinguish
+      breakdown values. A cross-chart semantic palette should be introduced
+      only with contrast and color-blind testing.
   chart_titles:
     present_for_all_non_scorecard_charts: true
     title_case: true
@@ -192,6 +223,10 @@ deferred_enhancements:
     dependency: Product design and query-cost measurement.
   - id: error-rates
     dependency: Freeze denominator semantics for tool and LLM failures.
+  - id: llm-error-visibility
+    dependency: >-
+      Add LLM_ERROR measures and charts, then freeze their relationship to
+      request and response events before defining rates.
   - id: estimated-cost
     dependency: Versioned, user-configurable model pricing source.
   - id: hourly-grain

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -86,8 +86,24 @@ for (const invalid of [
   { ...values, table: "table,other" },
   { ...values, billingProject: "UPPERCASE" },
 ]) {
-  assert.throws(() => buildDashboardUrl(invalid));
+  assert.throws(
+    () => buildDashboardUrl(invalid),
+    (error) => typeof error.field === "string" && error.message.length > 20,
+  );
 }
+
+assert.throws(
+  () => buildDashboardUrl({ ...values, project: "short" }),
+  (error) =>
+    error.field === "project" &&
+    /6–30 lowercase letters, digits, or hyphens/.test(error.message),
+);
+assert.throws(
+  () => buildDashboardUrl({ ...values, dataset: "bad-dataset" }),
+  (error) =>
+    error.field === "dataset" &&
+    /letter or underscore/.test(error.message),
+);
 
 for (const collision of [
   { ...values, project: "xsentinelbqaaevents" },

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -212,6 +212,63 @@ def test_chart_manifest_and_independent_queries_are_complete():
   assert mapped == observed
 
 
+def test_product_contract_covers_every_parity_chart_and_live_fix():
+  manifest = yaml.safe_load(
+      (DASHBOARD / "spec/chart_manifest.yaml").read_text()
+  )
+  product = yaml.safe_load(
+      (DASHBOARD / "spec/product_contract.yaml").read_text()
+  )
+
+  source_ids = {chart["id"] for chart in manifest["charts"]}
+  product_charts = product["charts"]
+  assert {chart["id"] for chart in product_charts} == source_ids
+  assert len(product_charts) == 37
+  assert len({chart["title"] for chart in product_charts}) == 37
+
+  titles = {chart["id"]: chart["title"] for chart in product_charts}
+  assert titles["usage-events-by-agent"] == "Tool Completions by Agent"
+  assert titles["usage-total-calls"] == "Total LLM Calls"
+  assert titles["usage-top-5-users-by-session"] == "Top 5 Users by Sessions"
+  assert titles["performance-average-llm-latency-in-ms"].endswith("(ms)")
+  assert all("Llm" not in title for title in titles.values())
+  assert all("Over the Time" not in title for title in titles.values())
+
+  assert [page["name"] for page in product["pages"]] == [
+      "Token Consumption",
+      "Agent & Sessions",
+      "Tool Usage",
+      "LLM Interactions",
+      "User Analytics",
+      "Latency",
+      "Errors",
+      "Trace Inspector",
+  ]
+  assert product["defaults"]["date_range"] == {
+      "mode": "rolling",
+      "start_offset_days": 365,
+      "end_offset_days": 1,
+      "include_today": False,
+      "page_scope": "all_dashboard_pages",
+  }
+  assert product["layout"]["percentile_order"] == {
+      "llm": ["P50", "P75", "P90", "P99"],
+      "tool": ["P50", "P75", "P90", "P99"],
+  }
+  assert (
+      product["behavioral_fixes"]["usage-llm-call-trends"]["dimension"]
+      == "event_date"
+  )
+  assert {
+      "session_id",
+      "model_version",
+  }.issubset(product["filtering"]["filter_bar"]["available_fields"])
+  assert (
+      product["filtering"]["predefined_tool_name_control"]["status"]
+      == "intentionally_not_published"
+  )
+
+
 def test_report_and_web_bindings_cannot_drift():
   report = yaml.safe_load(
       (DASHBOARD / "bindings/report_template.yaml").read_text()
@@ -246,15 +303,29 @@ def test_report_and_web_bindings_cannot_drift():
       "scope": "repository_artifact_only",
   }
   assert report["live_template_verification"] == {
-      "verified_date": "2026-07-24",
+      "verified_date": "2026-07-25",
       "repository_sql_sha256": hashlib.sha256(template).hexdigest(),
       "method": [
           "connector_custom_query_review",
           "sqlreplace_table_only_smoke_test",
           "canonical_viewer_credentials_review",
+          "published_eight_page_ux_smoke_test",
       ],
       "result": "PASSED",
       "limitation": "mutable_external_report_requires_reverification_after_changes",
+  }
+  assert report["product_contract"] == "spec/product_contract.yaml"
+  assert report["product_verification"] == {
+      "verified_date": "2026-07-25",
+      "pages": 8,
+      "checks": [
+          "expected_page_and_chart_titles_present",
+          "no_too_many_rows_errors",
+          "no_date_control_chart_overlaps",
+          "llm_call_volume_dimension_is_event_date",
+          "llm_and_tool_percentile_order_is_p50_p75_p90_p99",
+      ],
+      "result": "PASSED",
   }
   assert report["source_contract"] == {
       "mode": "BASE_TABLE",
@@ -303,6 +374,7 @@ def test_browser_configurator_javascript_contract():
 
 def test_googlecloudplatform_pages_configuration():
   page = (DASHBOARD / "docs/index.html").read_text()
+  styles = (DASHBOARD / "docs/styles.css").read_text()
   assert "github.com/caohy1988" not in page
   assert (
       "https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK"
@@ -312,6 +384,13 @@ def test_googlecloudplatform_pages_configuration():
       "https://googlecloudplatform.github.io/"
       "BigQuery-Agent-Analytics-SDK/" in page
   )
+  assert 'rel="icon" href="./favicon.svg"' in page
+  assert 'property="og:title"' in page
+  assert 'name="twitter:card"' in page
+  assert "Copy security checklist" in page
+  assert "billing-project-hint" in page
+  assert "@media (prefers-color-scheme: dark)" in styles
+  assert (DASHBOARD / "docs/favicon.svg").is_file()
 
   workflow = (ROOT / ".github/workflows/looker-studio-pages.yml").read_text()
   assert "path: dashboard/looker_studio/docs" in workflow

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -259,6 +259,49 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       product["behavioral_fixes"]["usage-llm-call-trends"]["dimension"]
       == "event_date"
   )
+  assert (
+      product["behavioral_fixes"]["usage-llm-call-trends"]["oracle_grain"]
+      == "minute"
+  )
+  assert (
+      product["behavioral_fixes"]["usage-llm-call-trends"]["compare_at"]
+      == "event_date"
+  )
+  assert product["layout"]["latency_sections"] == {
+      "llm_percentile_top": 377,
+      "tool_percentile_top": 494,
+      "trend_title_top": 611,
+      "trend_chart_top": 670,
+      "overlap_free": True,
+  }
+  assert product["filtering"]["top_user_rankings"] == {
+      "group_remaining_as_others": False,
+      "charts": [
+          "usage-top-5-users-with-most-tokens-consumption",
+          "usage-top-5-users-with-most-traces",
+          "usage-top-5-users-by-session",
+          "usage-top-5-users-by-events",
+      ],
+  }
+  assert product["behavioral_fixes"]["tool-completed-charts"]["charts"] == [
+      "usage-tool-invocations",
+      "usage-tool-calls-over-time",
+      "performance-tool-latency-trend",
+  ]
+  assert product["visual_system"]["single_series"] == {
+      "mode": "google_blue",
+      "color": "#4285f4",
+      "legend": "hidden_when_title_defines_metric",
+  }
+  assert product["visual_system"]["multi_series"] == {
+      "mode": "categorical_google_palette",
+      "legend": "visible",
+      "dimension_values_are_series_labels": True,
+  }
+  assert "live_series_mode" not in product["visual_system"]
+  assert "llm-error-visibility" in {
+      item["id"] for item in product["deferred_enhancements"]
+  }
   assert {
       "session_id",
       "model_version",
@@ -303,20 +346,23 @@ def test_report_and_web_bindings_cannot_drift():
       "scope": "repository_artifact_only",
   }
   assert report["live_template_verification"] == {
-      "verified_date": "2026-07-25",
+      "verified_date": "2026-07-27",
       "repository_sql_sha256": hashlib.sha256(template).hexdigest(),
       "method": [
           "connector_custom_query_review",
           "sqlreplace_table_only_smoke_test",
           "canonical_viewer_credentials_review",
           "published_eight_page_ux_smoke_test",
+          "published_non_degenerate_chart_data_capture",
+          "editor_configuration_assertions",
+          "published_tool_page_refresh",
       ],
       "result": "PASSED",
       "limitation": "mutable_external_report_requires_reverification_after_changes",
   }
   assert report["product_contract"] == "spec/product_contract.yaml"
   assert report["product_verification"] == {
-      "verified_date": "2026-07-25",
+      "verified_date": "2026-07-27",
       "pages": 8,
       "checks": [
           "expected_page_and_chart_titles_present",
@@ -324,6 +370,13 @@ def test_report_and_web_bindings_cannot_drift():
           "no_date_control_chart_overlaps",
           "llm_call_volume_dimension_is_event_date",
           "llm_and_tool_percentile_order_is_p50_p75_p90_p99",
+          "llm_and_token_p1_bindings_render_non_degenerate_data",
+          "latency_sections_are_aligned_and_non_overlapping",
+          "single_series_legends_do_not_expose_internal_field_names",
+          "top_user_rankings_do_not_group_remaining_users_as_others",
+          "tool_charts_exclude_non_completed_rows",
+          "multi_series_charts_use_categorical_legends",
+          "no_partial_update_footer_after_refresh",
       ],
       "result": "PASSED",
   }


### PR DESCRIPTION
## Summary

Refs #377.

This change validates the issue backlog against the actual published Looker
Studio report instead of treating the pinned LookML parity manifest as a
serialization of the live product.

### Published dashboard

- fixes a previously unreported production bug: the LLM Call Volume chart used
  raw `timestamp`, exceeded Looker Studio's row limit, and rendered **Too Many
  Rows**; it now uses `event_date`;
- adds a consistent page heading to all 8 pages;
- adds explicit, normalized titles to every non-scorecard chart, including
  **Tool Completions by Agent**;
- aligns date controls and scorecards so they do not overlap;
- aligns both percentile rows and separates the cards, trend titles, and trend
  charts into non-overlapping sections;
- hides redundant single-series legends so internal field IDs do not leak;
- disables the overwhelming **Others** bucket on all four Top-5 user charts;
- filters the three completed-tool charts to remove blank and `null` tool-name
  categories while preserving `TOOL_COMPLETED` semantics; and
- republishes and data-aware smoke-tests the canonical report on all 8 pages.

### Repository contract

- preserves `spec/chart_manifest.yaml` as the immutable pinned-block parity
  artifact;
- adds `spec/product_contract.yaml` for current product behavior, titles,
  layout, filtering decisions, live fixes, and explicitly deferred
  enhancements;
- records the LLM trend's minute-grain oracle versus `event_date` comparison
  rule and explicitly tracks missing `LLM_ERROR` visibility;
- adds `docs/issue-377-review.md`, which classifies every issue section as
  fixed, already correct/not present live, deliberately rejected, or deferred
  with a concrete dependency;
- records the 2026-07-27 publication and product verification in
  `bindings/report_template.yaml`; and
- adds regression tests requiring all 37 parity chart IDs to have normalized
  product titles and pinning the live fixes.

### Configurator and operations

- adds a favicon and OpenGraph/Twitter metadata;
- adds field-level format guidance and accessible inline validation errors;
- adds a tested dark color scheme;
- adds a copyable post-create Viewer-Credentials security checklist; and
- documents large-table cost, pruning, retention, BI Engine/rollup, and
  freshness guidance.

## Key review corrections

The live audit disproved several manifest-only claims:

- both percentile rows were already ordered P50 → P75 → P90 → P99;
- the empty elements and single “Agent” header did not exist live;
- all dashboard pages already used the 365-day product default;
- single-series charts use Google blue while breakdown charts correctly use a
  categorical multi-color palette; and
- live geometry did not match the manifest's 24-column coordinates.

A predefined Tool Name control is intentionally not added. The one-source
schema currently has separate `tool_completed_name` and `tool_error_name`
fields; either field used report-wide would silently exclude the other event
family. The product contract requires a unified `tool_name` field plus a
verified page-scoped control before publishing that feature.

## Validation

- `ruff check tests/test_looker_studio_dashboard.py`
- `pytest -q tests/test_looker_studio_dashboard.py` — 19 passed
- `node dashboard/looker_studio/tools/test_web_configurator.mjs`
- local browser QA in light and dark modes, including field-level errors and
  generated Linking API URL
- authenticated editor configuration audit:
  - 18 redundant single-series legends hidden
  - **Others** disabled on all 4 Top-5 user charts
  - `Tool completed rows` present on all 3 affected tool charts
  - LLM and token P1 bindings intact
  - latency sections aligned and non-overlapping
- post-publication viewer verification:
  - all 8 pages and all expected chart titles present
  - the three P1 charts render non-degenerate data
  - scorecards are labeled and formatted
  - no blank or `null` tool-name categories
  - no internal single-series field-name legends
  - Tool Usage's stale partial-update footer cleared by **Refresh data** and
    remained clear in a separate 30-second load

The machine-wide `pytest` collection also reaches unrelated SDK tests, but the
local editable `adk-python` checkout has an incompatible OpenTelemetry
semantic-conventions package. CI provides the repository's isolated dependency
environment; the dashboard-specific acceptance suite above is green.

## External state

The mutable canonical Looker Studio report was published before this PR so the
live user-facing defects are already removed. The repository metadata records
the verification date and method; future report-owner changes still require
the existing manual reverification gate.
