### PR TITLE
feat(eval): make categorical persistence identity-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and full Gemini API fallback. Unmapped traces still run without context;
   empty resolved work makes no model call. Context-aware logs redact model
   text/raw retry responses so a model echo cannot disclose trusted context.
+- **Identity-safe categorical persistence and latest views (#358 U5)** —
+  categorical result tables gain nullable identity and context-provenance
+  columns through idempotent additive migrations; historical rows are not
+  backfilled. Deploy and roll back in schema → writer → view order. Latest
+  views preserve separate rows for identities that share a `session_id`; while
+  data straddles the migration, a sole typed identity supersedes matching
+  legacy metric/prompt rows, while zero or multiple identities retain the
+  `legacy:<session_id>` lane. Trusted judge/golden-answer input and model
+  echoes are never persisted — only SDK-owned provenance is. U5 closes the
+  remaining #358 persistence/report gate and unlocks U6/#360.
 
 ### Changed
 
@@ -61,10 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This release aligns read, trajectory-evaluation, CLI/Remote Function,
   example, report, and categorical judge-context surfaces at one boundary.
   Context is trusted prompt material: it is a query parameter/model input,
-  never SQL text, a job label, or persisted input. The identity-safe
-  persistence/view cardinality migration remains U5; until it lands, context
-  calls reject `persist_results=True` rather than writing colliding identities
-  into the legacy session-only results schema.
+  never SQL text, a job label, or persisted input. U5 now provides the
+  identity-safe persistence/view-cardinality path for contextual results.
 
 ## [0.4.0] - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ through AI.GENERATE, retry, and API fallback. It is never interpolated into
 SQL, logged, persisted, or placed in job labels. Apply the same data-governance
 policy you use for evaluation prompts.
 
+When `persist_results=True`, categorical results use an additive, nullable
+identity/provenance schema; existing historical rows are not backfilled.
+Deploy or roll back safely in this order: **schema, then writer, then views**.
+The latest-results view keeps identities distinct even when they share a
+`session_id`. During a legacy/schema straddle, a sole typed identity supersedes
+matching legacy metric/prompt rows; zero or multiple typed identities leave
+legacy rows in their separate `legacy:<session_id>` lane. Trusted judge or
+golden-answer context — including any model echo — is never persisted; only
+SDK-owned context provenance is. This U5 migration completes #358's remaining
+persistence/report gate and unlocks U6/#360.
+
 See [SDK.md](SDK.md) for the full API walkthrough with code examples for every
 feature.
 

--- a/docs/superpowers/plans/2026-07-25-identity-safe-categorical-persistence-u5.md
+++ b/docs/superpowers/plans/2026-07-25-identity-safe-categorical-persistence-u5.md
@@ -1,0 +1,164 @@
+# Identity-Safe Categorical Persistence (U5) Implementation Plan
+
+> Issue scope: #358 U5, sequenced by #361 after merged U4.
+> This unit carries U2/U4 identity and judge-context provenance through
+> categorical results, persistence, views, and quality reports. U6 remains
+> responsible for removing the demo workarounds after this unit lands.
+
+## Contract
+
+- Every identity-resolved categorical result may carry its immutable
+  `TraceIdentity`, exact `TraceScope`, whether trusted judge context was
+  applied, the SDK-defined context-source enum, and its execution mode.
+- Persistence uses an additive, rollback-safe migration in strict
+  schema → writer → view order. Historical rows remain untouched.
+- New rows contain nullable identity dimensions, a canonical scope key, a
+  versioned identity key, and provenance. They never contain judge context,
+  expected answers, caller-controlled source strings, or context
+  fingerprints.
+- The latest-results view deduplicates new rows by the versioned identity key.
+  A legacy session with exactly one post-migration identity is superseded by
+  that identity; legacy sessions with zero or multiple post-migration
+  identities retain a namespaced `legacy:<session_id>` lane.
+- The quality-report BigQuery path binds golden answers by exact resolved
+  selector, not session id, and correlates golden metadata to the same
+  identity-safe result.
+- Retry/fallback reconciliation may replace only the failed resolved identity.
+  In-memory, serialized report, persisted table, and dashboard view
+  cardinality agree for colliding session ids.
+
+## Task 1: Add typed result identity and provenance
+
+**Files**
+
+- Modify: `src/bigquery_agent_analytics/categorical_evaluator.py`
+- Modify: `src/bigquery_agent_analytics/client.py`
+- Test: `tests/test_categorical_evaluator.py`
+- Test: `tests/test_sdk_client.py`
+
+**Test-first scenarios**
+
+1. AI.GENERATE and Gemini API results for two selectors sharing a session id
+   retain distinct `TraceIdentity`/`TraceScope` values.
+2. Context-applied and context-source values are assigned from the normalized
+   evaluation input, not model output or caller-provided result details.
+3. Retry replacement matches the full resolved selector and replaces only the
+   failed identity.
+4. AI.CLASSIFY, contextual AI.GENERATE, and API fallback expose distinct,
+   stable execution provenance.
+5. Legacy session-only results remain constructible and serializable.
+
+**Verification**
+
+```bash
+uv run pytest -q tests/test_categorical_evaluator.py tests/test_sdk_client.py -k "identity or provenance or context or retry"
+```
+
+## Task 2: Migrate the table before enabling the writer
+
+**Files**
+
+- Modify: `src/bigquery_agent_analytics/categorical_evaluator.py`
+- Modify: `src/bigquery_agent_analytics/client.py`
+- Test: `tests/test_categorical_evaluator.py`
+- Test: `tests/test_sdk_client.py`
+
+**Test-first scenarios**
+
+1. Flattened rows include nullable identity fields, canonical `scope_key`,
+   deterministic versioned `identity_key`, context provenance, and execution
+   mode.
+2. Raw expected answers and judge context never appear in flattened rows.
+3. Table creation plus every `ADD COLUMN IF NOT EXISTS` migration runs before
+   `insert_rows_json`; rerunning the migration is harmless.
+4. Contextual persistence, previously gated in U4, succeeds only after the
+   schema sequence completes.
+5. A schema migration failure performs no insert and records a persistence
+   failure without leaking context.
+
+**Verification**
+
+```bash
+uv run pytest -q tests/test_categorical_evaluator.py tests/test_sdk_client.py -k "persist or flatten or migration"
+```
+
+## Task 3: Make latest-result views migration- and collision-safe
+
+**Files**
+
+- Modify: `src/bigquery_agent_analytics/categorical_views.py`
+- Test: `tests/test_categorical_views.py`
+
+**Test-first scenarios**
+
+1. Two post-migration identities sharing a session id remain two latest rows.
+2. A legacy-only session deduplicates within `legacy:<session_id>`.
+3. When exactly one post-migration identity exists, its latest row supersedes
+   legacy rows for that session and prompt version.
+4. When multiple post-migration identities exist, the ambiguous legacy lane
+   remains separate and never merges into either identity.
+5. Prompt-version and metric partitioning remain intact and helper columns do
+   not escape the base view.
+
+**Verification**
+
+```bash
+uv run pytest -q tests/test_categorical_views.py
+```
+
+## Task 4: Bind quality-report golden context by exact selector
+
+**Files**
+
+- Modify: `scripts/quality_report.py`
+- Test: `tests/test_quality_report_helpers.py`
+- Test: `tests/test_sdk_client.py`
+
+**Test-first scenarios**
+
+1. Two resolved traces sharing a session id independently match golden Q&A and
+   produce two selector-keyed contexts.
+2. `run_evaluation()` passes those contexts to
+   `Client.evaluate_categorical()` with the SDK-defined golden-answer source.
+3. JSON/report enrichment attaches each golden match to the corresponding
+   identity-attributed result; unattributed collisions fail closed.
+4. Legacy unique-session report inputs retain their existing behavior.
+5. Persisted categorical rows record only provenance and never golden text.
+
+**Verification**
+
+```bash
+uv run pytest -q tests/test_quality_report_helpers.py tests/test_sdk_client.py -k "golden or report or context"
+```
+
+## Task 5: Document the migration and verify the full chain
+
+**Files**
+
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: relevant API docstrings
+- Test: all focused U4/U5 tests
+
+**Content**
+
+- Document the additive schema, rollback behavior, legacy straddle semantics,
+  identity-safe report cardinality, and the no-raw-context guarantee.
+- State the schema → writer → view deployment order and that historical rows
+  are not backfilled.
+- Record that U5 satisfies the remaining #358 persistence/report gate and
+  unlocks U6/#360.
+
+**Final verification**
+
+```bash
+uv run pytest -q tests/test_categorical_evaluator.py tests/test_sdk_client.py tests/test_client_labels.py tests/test_categorical_views.py tests/test_quality_report_helpers.py
+uv run pytest -q
+uv run autoformat
+git diff --check
+uv run pytest -q tests/test_trace_identity_bigquery_live.py
+```
+
+Before closing #358, run the live collision fixture with persistence enabled
+and compare the in-memory result count, inserted-row identity keys, and latest
+view cardinality for two identities sharing one session id.

--- a/scripts/quality_report.py
+++ b/scripts/quality_report.py
@@ -51,6 +51,7 @@ import warnings
 warnings.filterwarnings("ignore")
 
 import argparse
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import json
@@ -383,16 +384,20 @@ def match_golden_qa(
   """Match session questions to golden Q&A by embedding cosine similarity.
 
   Args:
-    question_by_sid: dict mapping session_id -> user question text.
+    question_by_sid: dict mapping an opaque evaluation key (normally an exact
+        ``ResolvedTraceSelector`` on the BigQuery path, or a session id on the
+        local-conversation path) to user question text.
     golden_qa: list of dicts with ``question`` and optional
         ``expected_answer``, ``topic``, ``expected_behavior``.
     threshold: minimum cosine similarity (0-1) for a match.
 
   Returns:
     (per_session_context, golden_metadata):
-      - per_session_context maps session_id -> a judge-context string
+      - per_session_context preserves each input key and maps it to a
+        judge-context string
         (expected answer and/or a "should decline" note).
-      - golden_metadata maps session_id -> match details (matched flag,
+      - golden_metadata preserves each input key and maps it to match details
+        (matched flag,
         matched question, expected answer, topic, out_of_scope, similarity).
   """
   if not golden_qa or not question_by_sid:
@@ -485,10 +490,20 @@ def _inject_golden_summary(report, golden_metadata):
       "unmatched_partial": 0,
   }
   mismatches = []
+  session_id_counts = Counter(
+      session.get("session_id", "") for session in report.get("sessions", [])
+  )
 
   for session in report.get("sessions", []):
     sid = session.get("session_id", "")
-    meta = golden_metadata.get(sid)
+    selector = _resolved_selector_from_context(session)
+    meta = (
+        golden_metadata.get(selector)
+        if selector is not None and selector in golden_metadata
+        else None
+    )
+    if meta is None and selector is None and session_id_counts[sid] == 1:
+      meta = golden_metadata.get(sid)
     if meta is None:
       session["golden_eval"] = None
       continue
@@ -553,6 +568,40 @@ def _inject_golden_summary(report, golden_metadata):
       ),
       "mismatches": mismatches,
   }
+
+
+def _resolved_selector_from_context(context):
+  """Rebuild an exact selector from report-safe identity/scope fields."""
+  from bigquery_agent_analytics.trace import ResolvedTraceSelector
+  from bigquery_agent_analytics.trace import TraceIdentity
+  from bigquery_agent_analytics.trace import TraceScope
+
+  identity_fields = (
+      "session_id",
+      "user_id",
+      "root_agent_name",
+      "scope_signature",
+  )
+  if any(field not in context for field in identity_fields):
+    return None
+  if context["session_id"] is None or context["scope_signature"] is None:
+    return None
+  try:
+    identity = TraceIdentity(
+        session_id=context.get("session_id"),
+        user_id=context.get("user_id"),
+        root_agent_name=context.get("root_agent_name"),
+    )
+    scope = TraceScope(
+        experiment_id=context.get("experiment_id"),
+        custom_labels=context.get("custom_labels"),
+    )
+  except (TypeError, ValueError):
+    return None
+  signature = context.get("scope_signature")
+  if signature is not None and signature != scope.scope_signature:
+    return None
+  return ResolvedTraceSelector(identity=identity, scope=scope)
 
 
 # ---------------------------------------------------------------------------
@@ -1468,6 +1517,7 @@ def run_evaluation(
 ) -> dict:
   from bigquery_agent_analytics import CategoricalEvaluationConfig
   from bigquery_agent_analytics import TraceFilter
+  from bigquery_agent_analytics.categorical_evaluator import CategoricalContextSource
 
   model = model or EVAL_MODEL_ID
   client = get_client()
@@ -1522,15 +1572,8 @@ def run_evaluation(
     if app_name:
       trace_filter.root_agent_name = app_name
 
-  # Fetch traces and match golden Q&A BEFORE evaluation, so golden metadata
-  # (matched question / expected answer per session) is available to the
-  # report either way.
-  # KNOWN LIMITATION (SDK issue #358): the server-side AI.GENERATE judge
-  # cannot receive per-session expected answers, so on this path golden Q&A
-  # drives the golden_eval_summary regression headline and per-session
-  # matched/expected reporting -- but does NOT ground the judge's
-  # correctness verdict (that is conversations-path only; scope/ground_truth
-  # still ground the judge on both paths).
+  # Fetch traces and match golden Q&A BEFORE evaluation so the server-side
+  # judge and report enrichment use the same exact resolved selector keys.
   explicit_sessions = bool(session_id or session_ids)
   if explicit_sessions:
     traces, trace_filter = _list_complete_report_traces(client, trace_filter)
@@ -1540,32 +1583,32 @@ def run_evaluation(
   resolved_map = _index_resolved_entries(resolved)
 
   golden_metadata = {}
+  golden_ctx = {}
   golden_qa = (eval_spec or {}).get("golden_qa")
   if golden_qa:
     # Matching keys off the conversation's FIRST user message (the
     # topic anchor), consistent with the conversations-file path.
-    question_by_sid = {}
-    for sid in {ctx.get("session_id") for ctx in resolved_map.values()}:
-      ctx = _resolved_context_for_session(resolved_map, sid)
-      if ctx:
-        question_by_sid[sid] = ctx.get("first_question") or ctx.get(
+    question_by_selector = {}
+    for ctx in resolved_map.values():
+      selector = _resolved_selector_from_context(ctx)
+      if selector is not None:
+        question_by_selector[selector] = ctx.get("first_question") or ctx.get(
             "question", ""
         )
-    _golden_ctx, golden_metadata = match_golden_qa(
-        question_by_sid, golden_qa, threshold=golden_threshold
-    )
-    logger.warning(
-        "Golden Q&A on the BigQuery path produces the golden_eval_summary"
-        " and per-session matches, but the server-side judge cannot take"
-        " per-session expected answers -- expected-answer correctness"
-        " grounding applies on the --conversations-file path only"
-        " (scope/ground_truth ground both paths). See SDK issue #358."
+    golden_ctx, golden_metadata = match_golden_qa(
+        question_by_selector, golden_qa, threshold=golden_threshold
     )
 
-  report = client.evaluate_categorical(
+  evaluation_kwargs = dict(
       config=cat_config,
       filters=trace_filter,
   )
+  if golden_ctx:
+    evaluation_kwargs.update(
+        per_session_context=golden_ctx,
+        context_source=CategoricalContextSource.GOLDEN_EXPECTED_ANSWER,
+    )
+  report = client.evaluate_categorical(**evaluation_kwargs)
 
   all_session_ids = [sr.session_id for sr in report.session_results]
   logger.info("Resolving responses for %d sessions...", len(all_session_ids))
@@ -4608,6 +4651,11 @@ def _build_json_output(report, resolved_map, trajectories=None):
   sessions = []
   for sr in report.session_results:
     ctx = _resolved_context_for_score(resolved_map, sr)
+    identity = getattr(sr, "identity", None)
+    scope = getattr(sr, "scope", None)
+    context_source = getattr(sr, "context_source", None)
+    if hasattr(context_source, "value"):
+      context_source = context_source.value
     metrics = {}
     quality_scores = {}
     for mr in sr.metrics:
@@ -4623,18 +4671,39 @@ def _build_json_output(report, resolved_map, trajectories=None):
         }
     session_dict = {
         "session_id": sr.session_id,
-        "user_id": (getattr(sr, "details", None) or {}).get(
-            "user_id", ctx.get("user_id")
+        "user_id": (
+            identity.user_id
+            if identity is not None
+            else (getattr(sr, "details", None) or {}).get(
+                "user_id", ctx.get("user_id")
+            )
         ),
-        "root_agent_name": (getattr(sr, "details", None) or {}).get(
-            "root_agent_name", ctx.get("root_agent_name")
+        "root_agent_name": (
+            identity.root_agent_name
+            if identity is not None
+            else (getattr(sr, "details", None) or {}).get(
+                "root_agent_name", ctx.get("root_agent_name")
+            )
         ),
-        "experiment_id": ctx.get("experiment_id"),
-        "custom_labels": ctx.get("custom_labels"),
-        "scope_signature": (getattr(sr, "details", None) or {}).get(
-            "scope_signature", ctx.get("scope_signature")
+        "experiment_id": (
+            scope.experiment_id
+            if scope is not None
+            else ctx.get("experiment_id")
+        ),
+        "custom_labels": (
+            scope.labels_dict if scope is not None else ctx.get("custom_labels")
+        ),
+        "scope_signature": (
+            scope.scope_signature
+            if scope is not None
+            else (getattr(sr, "details", None) or {}).get(
+                "scope_signature", ctx.get("scope_signature")
+            )
         ),
         "scope_coverage": ctx.get("scope_coverage"),
+        "context_applied": getattr(sr, "context_applied", False),
+        "context_source": context_source,
+        "execution_mode": getattr(sr, "execution_mode", None),
         "question": ctx.get("question", ""),
         "response": ctx.get("response", ""),
         "answered_by": ctx.get("answered_by", ""),

--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -365,6 +365,7 @@ except ImportError as e:
 
 # Categorical Evaluator
 try:
+  from .categorical_evaluator import CategoricalContextSource
   from .categorical_evaluator import CategoricalEvaluationConfig
   from .categorical_evaluator import CategoricalEvaluationReport
   from .categorical_evaluator import CategoricalMetricCategory
@@ -374,6 +375,7 @@ try:
 
   __all__.extend(
       [
+          "CategoricalContextSource",
           "CategoricalEvaluationConfig",
           "CategoricalEvaluationReport",
           "CategoricalMetricCategory",

--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -62,6 +62,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
+from enum import Enum
+import hashlib
 import json
 import logging
 from typing import Any, Optional
@@ -69,6 +71,7 @@ from typing import Any, Optional
 from google.cloud import bigquery
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import model_validator
 
 from bigquery_agent_analytics.evaluators import strip_markdown_fences
 from bigquery_agent_analytics.trace import AmbiguousSessionError
@@ -83,6 +86,13 @@ logger = logging.getLogger("bigquery_agent_analytics." + __name__)
 DEFAULT_ENDPOINT = "gemini-2.5-flash"
 
 
+class CategoricalContextSource(str, Enum):
+  """SDK-defined provenance for trusted categorical judge context."""
+
+  TRUSTED_JUDGE_CONTEXT = "trusted_judge_context"
+  GOLDEN_EXPECTED_ANSWER = "golden_expected_answer"
+
+
 @dataclass(frozen=True, slots=True)
 class _CategoricalEvaluationInput:
   """One exact resolved trace and its trusted judge input."""
@@ -90,6 +100,7 @@ class _CategoricalEvaluationInput:
   selector: ResolvedTraceSelector
   transcript: str
   judge_context: Optional[str] = None
+  context_source: Optional[CategoricalContextSource] = None
 
   @property
   def evaluation_key(self) -> str:
@@ -163,6 +174,9 @@ def _trace_to_categorical_transcript(trace: Trace) -> str:
 def _normalize_categorical_evaluation_inputs(
     traces: list[Trace],
     per_session_context: Mapping[ResolvedTraceSelector | str, str],
+    context_source: CategoricalContextSource = (
+        CategoricalContextSource.TRUSTED_JUDGE_CONTEXT
+    ),
 ) -> list[_CategoricalEvaluationInput]:
   """Binds trusted context to a deduplicated exact-selector population.
 
@@ -237,6 +251,9 @@ def _normalize_categorical_evaluation_inputs(
           selector=selector,
           transcript=transcript,
           judge_context=bound_context.get(selector),
+          context_source=(
+              context_source if selector in bound_context else None
+          ),
       )
       for selector, transcript in population.items()
   ]
@@ -403,8 +420,28 @@ class CategoricalSessionResult(BaseModel):
   """Classification results for all metrics on a single session."""
 
   session_id: str
+  identity: Optional[TraceIdentity] = None
+  scope: Optional[TraceScope] = None
+  context_applied: bool = False
+  context_source: Optional[CategoricalContextSource] = None
+  execution_mode: Optional[str] = None
   metrics: list[CategoricalMetricResult] = Field(default_factory=list)
   details: dict[str, Any] = Field(default_factory=dict)
+
+  @model_validator(mode="after")
+  def _validate_provenance(self):
+    if (
+        self.identity is not None
+        and self.identity.session_id != self.session_id
+    ):
+      raise ValueError("identity.session_id must match session_id.")
+    if (self.identity is None) != (self.scope is None):
+      raise ValueError("identity and scope must be attached together.")
+    if self.context_applied != (self.context_source is not None):
+      raise ValueError(
+          "context_source must be set exactly when context_applied is true."
+      )
+    return self
 
 
 class CategoricalEvaluationReport(BaseModel):
@@ -456,6 +493,13 @@ DEFAULT_RESULTS_TABLE = "categorical_results"
 CATEGORICAL_RESULTS_DDL = """\
 CREATE TABLE IF NOT EXISTS `{project}.{dataset}.{results_table}` (
   session_id STRING,
+  user_id STRING,
+  root_agent_name STRING,
+  experiment_id STRING,
+  scope_key STRING,
+  identity_key STRING,
+  context_applied BOOL,
+  context_source STRING,
   metric_name STRING,
   category STRING,
   justification STRING,
@@ -468,6 +512,21 @@ CREATE TABLE IF NOT EXISTS `{project}.{dataset}.{results_table}` (
   created_at TIMESTAMP
 )
 """
+
+CATEGORICAL_RESULTS_MIGRATIONS = tuple(
+    f"""ALTER TABLE `{{project}}.{{dataset}}.{{results_table}}`
+ADD COLUMN IF NOT EXISTS {column}"""
+    for column in (
+        "user_id STRING",
+        "root_agent_name STRING",
+        "experiment_id STRING",
+        "scope_key STRING",
+        "identity_key STRING",
+        "context_applied BOOL",
+        "context_source STRING",
+        "execution_mode STRING",
+    )
+)
 
 CATEGORICAL_TRANSCRIPT_QUERY = """\
 SELECT
@@ -1104,6 +1163,10 @@ async def classify_sessions_via_api(
     endpoint: str = DEFAULT_ENDPOINT,
     per_session_context: dict[str, str] | None = None,
     resolved_selectors: dict[str, ResolvedTraceSelector] | None = None,
+    context_source: CategoricalContextSource = (
+        CategoricalContextSource.TRUSTED_JUDGE_CONTEXT
+    ),
+    execution_mode: str = "api_fallback",
 ) -> list[CategoricalSessionResult]:
   """Classifies sessions using the Gemini API (fallback).
 
@@ -1134,6 +1197,9 @@ async def classify_sessions_via_api(
           When present, transcript/context keys remain internal correlation
           keys while returned results carry the selector's public session id
           plus reserved identity/scope attribution.
+      context_source: SDK-defined provenance assigned to results that received
+          trusted context.
+      execution_mode: Per-result execution provenance.
 
   Returns:
       One ``CategoricalSessionResult`` per session, in input order.
@@ -1233,11 +1299,19 @@ async def classify_sessions_via_api(
                 len(raw_text),
                 repr(raw_text[:500]),
             )
-        return CategoricalSessionResult(
+        result = CategoricalSessionResult(
             session_id=sid,
             metrics=metrics,
             details=details,
         )
+        _apply_categorical_result_provenance(
+            result,
+            selector=selector,
+            context_applied=has_judge_context,
+            context_source=context_source if has_judge_context else None,
+            execution_mode=execution_mode,
+        )
+        return result
       except Exception as e:
         if has_judge_context:
           logger.warning(
@@ -1255,7 +1329,7 @@ async def classify_sessions_via_api(
               e,
               type(e).__name__,
           )
-        return CategoricalSessionResult(
+        result = CategoricalSessionResult(
             session_id=sid,
             metrics=[
                 CategoricalMetricResult(
@@ -1268,10 +1342,42 @@ async def classify_sessions_via_api(
             ],
             details=details,
         )
+        _apply_categorical_result_provenance(
+            result,
+            selector=selector,
+            context_applied=has_judge_context,
+            context_source=context_source if has_judge_context else None,
+            execution_mode=execution_mode,
+        )
+        return result
 
   tasks = [_classify_one(key, text) for key, text in transcripts.items()]
   results = await asyncio.gather(*tasks)
   return list(results)
+
+
+def _apply_categorical_result_provenance(
+    result: CategoricalSessionResult,
+    *,
+    selector: Optional[ResolvedTraceSelector],
+    context_applied: bool,
+    context_source: Optional[CategoricalContextSource],
+    execution_mode: str,
+) -> None:
+  """Assigns SDK-owned identity and execution provenance to one result."""
+  result.identity = selector.identity if selector is not None else None
+  result.scope = selector.scope if selector is not None else None
+  result.context_applied = context_applied
+  result.context_source = context_source if context_applied else None
+  result.execution_mode = execution_mode
+  if selector is not None:
+    result.details.update(
+        {
+            "user_id": selector.identity.user_id,
+            "root_agent_name": selector.identity.root_agent_name,
+            "scope_signature": selector.scope_signature,
+        }
+    )
 
 
 # ------------------------------------------------------------------ #
@@ -1284,7 +1390,12 @@ def flatten_results_to_rows(
     config: CategoricalEvaluationConfig,
     endpoint: str,
 ) -> list[dict]:
-  """Flattens session results to one row per (session_id, metric_name).
+  """Flattens session results to persistence rows with identity provenance.
+
+  Identity/scope fields are nullable for historical-compatible rows. Contextual
+  rows retain only SDK-owned provenance; their justification and raw response
+  are omitted so trusted judge/golden-answer context, including model echoes,
+  cannot be persisted.
 
   Args:
       report: The evaluation report to flatten.
@@ -1298,20 +1409,70 @@ def flatten_results_to_rows(
   created_at = report.created_at.isoformat()
   rows = []
   for sr in report.session_results:
+    sr._validate_provenance()
+    identity = sr.identity
+    scope = sr.scope
+    identity_key = (
+        _categorical_identity_key(identity, scope)
+        if identity is not None
+        else None
+    )
+    result_execution_mode = sr.execution_mode or execution_mode
     for mr in sr.metrics:
       rows.append(
           {
               "session_id": sr.session_id,
+              "user_id": identity.user_id if identity is not None else None,
+              "root_agent_name": (
+                  identity.root_agent_name if identity is not None else None
+              ),
+              "experiment_id": (
+                  scope.experiment_id if scope is not None else None
+              ),
+              "scope_key": (
+                  scope.scope_signature if scope is not None else None
+              ),
+              "identity_key": identity_key,
+              "context_applied": sr.context_applied,
+              "context_source": (
+                  sr.context_source.value
+                  if sr.context_source is not None
+                  else None
+              ),
               "metric_name": mr.metric_name,
               "category": mr.category,
-              "justification": mr.justification,
+              "justification": (
+                  None if sr.context_applied else mr.justification
+              ),
               "passed_validation": mr.passed_validation,
               "parse_error": mr.parse_error,
-              "raw_response": mr.raw_response,
+              # A model may echo its trusted judge input. Persisting the raw
+              # envelope for a contextual evaluation could therefore copy a
+              # golden answer even though the SDK never writes the input
+              # directly.
+              "raw_response": (None if sr.context_applied else mr.raw_response),
               "endpoint": endpoint,
-              "execution_mode": execution_mode,
+              "execution_mode": result_execution_mode,
               "prompt_version": config.prompt_version,
               "created_at": created_at,
           }
       )
   return rows
+
+
+def _categorical_identity_key(
+    identity: TraceIdentity,
+    scope: Optional[TraceScope],
+) -> str:
+  """Returns a versioned stable key for one resolved trace identity/scope."""
+  canonical = json.dumps(
+      [
+          identity.session_id,
+          identity.user_id,
+          identity.root_agent_name,
+          scope.scope_signature if scope is not None else None,
+      ],
+      ensure_ascii=False,
+      separators=(",", ":"),
+  ).encode("utf-8")
+  return "v1:" + hashlib.sha256(canonical).hexdigest()

--- a/src/bigquery_agent_analytics/categorical_views.py
+++ b/src/bigquery_agent_analytics/categorical_views.py
@@ -21,6 +21,12 @@ dashboard summaries.
 All downstream views read from the dedup base view
 (``categorical_results_latest``), never from the raw table.  This
 ensures retries and overlapping micro-batch runs do not inflate counts.
+The base view keeps identity-safe cardinality when a ``session_id`` is reused:
+typed identities remain separate, while historical rows occupy a
+``legacy:<session_id>`` lane unless exactly one typed identity exists for that
+session. In that sole-identity migration straddle, the typed result supersedes
+matching legacy metric/prompt rows. Apply the additive schema, writer, and
+views in that order; historical rows are intentionally not backfilled.
 
 Example usage::
 
@@ -58,15 +64,43 @@ logger = logging.getLogger("bigquery_agent_analytics." + __name__)
 _CATEGORICAL_VIEW_DEFS: dict[str, str] = {
     "categorical_results_latest": """\
 CREATE OR REPLACE VIEW `{project}.{dataset}.{prefix}categorical_results_latest` AS
-WITH ranked AS (
+WITH identity_population AS (
+  SELECT
+    session_id,
+    COUNT(DISTINCT identity_key) AS _identity_count,
+    MIN(identity_key) AS _sole_identity_key
+  FROM `{project}.{dataset}.{results_table}`
+  WHERE identity_key IS NOT NULL
+  GROUP BY session_id
+),
+population_joined AS (
+  SELECT
+    results.*,
+    COALESCE(_identity_count, 0) AS _identity_count,
+    _sole_identity_key
+  FROM `{project}.{dataset}.{results_table}` AS results
+  LEFT JOIN identity_population USING (session_id)
+),
+keyed AS (
+  SELECT *,
+    CASE
+      WHEN identity_key IS NOT NULL THEN identity_key
+      WHEN _identity_count = 1 THEN _sole_identity_key
+      ELSE CONCAT('legacy:', session_id)
+    END AS _effective_identity_key
+  FROM population_joined
+),
+ranked AS (
   SELECT *,
     ROW_NUMBER() OVER (
-      PARTITION BY session_id, metric_name, COALESCE(prompt_version, '')
-      ORDER BY created_at DESC, raw_response DESC
+      PARTITION BY _effective_identity_key, metric_name, COALESCE(prompt_version, '')
+      ORDER BY identity_key IS NOT NULL DESC, created_at DESC, raw_response DESC
     ) AS _rn
-  FROM `{project}.{dataset}.{results_table}`
+  FROM keyed
 )
-SELECT * EXCEPT(_rn) FROM ranked WHERE _rn = 1
+SELECT * EXCEPT(_identity_count, _sole_identity_key, _effective_identity_key, _rn)
+FROM ranked
+WHERE _rn = 1
 """,
     "categorical_daily_counts": """\
 CREATE OR REPLACE VIEW `{project}.{dataset}.{prefix}categorical_daily_counts` AS
@@ -97,10 +131,12 @@ SELECT
   endpoint,
   COUNTIF(parse_error) AS parse_errors,
   COUNTIF(NOT passed_validation AND NOT parse_error) AS validation_failures,
-  COUNTIF(execution_mode = 'api_fallback') AS fallback_count,
+  COUNTIF(execution_mode IN ('api_fallback', 'api_retry')) AS fallback_count,
   COUNT(*) AS total,
   SAFE_DIVIDE(COUNTIF(parse_error), COUNT(*)) AS parse_error_rate,
-  SAFE_DIVIDE(COUNTIF(execution_mode = 'api_fallback'), COUNT(*)) AS fallback_rate
+  SAFE_DIVIDE(
+    COUNTIF(execution_mode IN ('api_fallback', 'api_retry')), COUNT(*)
+  ) AS fallback_rate
 FROM `{project}.{dataset}.{prefix}categorical_results_latest`
 GROUP BY 1, 2, 3
 """,

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -60,6 +60,7 @@ from google.cloud import bigquery
 from ._telemetry import LabeledBigQueryClient
 from ._telemetry import make_bq_client
 from ._telemetry import with_sdk_labels
+from .categorical_evaluator import _apply_categorical_result_provenance
 from .categorical_evaluator import _build_evaluation_inputs_parameter
 from .categorical_evaluator import _CategoricalEvaluationInput
 from .categorical_evaluator import _normalize_categorical_evaluation_inputs
@@ -71,7 +72,9 @@ from .categorical_evaluator import build_categorical_prompt
 from .categorical_evaluator import build_categorical_report
 from .categorical_evaluator import CATEGORICAL_AI_GENERATE_QUERY
 from .categorical_evaluator import CATEGORICAL_RESULTS_DDL
+from .categorical_evaluator import CATEGORICAL_RESULTS_MIGRATIONS
 from .categorical_evaluator import CATEGORICAL_TRANSCRIPT_QUERY
+from .categorical_evaluator import CategoricalContextSource
 from .categorical_evaluator import CategoricalEvaluationConfig
 from .categorical_evaluator import CategoricalEvaluationReport
 from .categorical_evaluator import classify_sessions_via_api
@@ -2465,6 +2468,7 @@ class Client:
       per_session_context: Optional[
           Mapping[ResolvedTraceSelector | str, str]
       ] = None,
+      context_source: Optional[CategoricalContextSource] = None,
   ) -> CategoricalEvaluationReport:
     """Runs categorical evaluation over traces.
 
@@ -2476,6 +2480,11 @@ class Client:
       AI.GENERATE → Gemini API
     * With any non-empty ``per_session_context``:
       identity-safe resolution → AI.GENERATE → Gemini API
+
+    With ``persist_results=True``, deploy the additive schema before this
+    writer and create/update latest-result views last. Historical legacy rows
+    are not backfilled; views preserve colliding identities and retain
+    ambiguous legacy rows in a separate namespace.
 
     Args:
         config: Categorical evaluation configuration with metric
@@ -2495,9 +2504,13 @@ class Client:
             ignored. Treat values as trusted evaluator material subject to the
             same data-governance policy as evaluation prompts. Context is sent
             only as a query parameter/model prompt; it is not interpolated into
-            SQL, logged, persisted, or placed in job labels. Context calls
-            reject ``config.persist_results=True`` until the U5 identity-safe
-            persistence migration lands.
+            SQL, logged, or placed in job labels. When persistence is enabled,
+            only identity and SDK-owned provenance are written; contextual raw
+            model responses are omitted to prevent an echoed golden answer
+            from reaching the results table.
+        context_source: Optional SDK-defined provenance for a non-empty context
+            mapping. Defaults to ``trusted_judge_context``. Arbitrary strings
+            are rejected rather than persisted as caller-controlled labels.
 
     Returns:
         CategoricalEvaluationReport with per-session results and
@@ -2515,11 +2528,11 @@ class Client:
         else {}
     )
     if context_snapshot:
-      if config.persist_results:
-        raise ValueError(
-            "Identity-bound judge context requires identity-safe persistence"
-            " from issue #358 U5; disable persist_results until that schema,"
-            " writer, and view migration is installed."
+      if context_source is None:
+        context_source = CategoricalContextSource.TRUSTED_JUDGE_CONTEXT
+      elif type(context_source) is not CategoricalContextSource:
+        raise TypeError(
+            "context_source must be a CategoricalContextSource value."
         )
       # Resolve the same exact identity/scope population used by U2 before
       # any model call. One detached filter snapshot feeds SQL fragments,
@@ -2542,6 +2555,7 @@ class Client:
       identity_bound_inputs = _normalize_categorical_evaluation_inputs(
           traces,
           context_snapshot,
+          context_source=context_source,
       )
       classify_skip_reason = (
           "AI.CLASSIFY skipped: identity-bound judge context requires"
@@ -2590,6 +2604,8 @@ class Client:
             endpoint,
             connection_id,
         )
+        for result in session_results:
+          result.execution_mode = "ai_classify"
         report = build_categorical_report(
             dataset=f"{table_ref} WHERE {where}",
             session_results=session_results,
@@ -2661,6 +2677,8 @@ class Client:
           endpoint,
           evaluation_inputs=identity_bound_inputs,
       )
+      for result in session_results:
+        result.execution_mode = "api_fallback"
       report = build_categorical_report(
           dataset=f"{table_ref} WHERE {where}",
           session_results=session_results,
@@ -2813,15 +2831,15 @@ class Client:
       parsed = parse_categorical_row(sid, r, config)
       input_item = inputs_by_key.get(input_key)
       if input_item is not None:
-        parsed.details.update(
-            {
-                "user_id": input_item.selector.identity.user_id,
-                "root_agent_name": (
-                    input_item.selector.identity.root_agent_name
-                ),
-                "scope_signature": input_item.selector.scope_signature,
-            }
+        _apply_categorical_result_provenance(
+            parsed,
+            selector=input_item.selector,
+            context_applied=input_item.judge_context is not None,
+            context_source=input_item.context_source,
+            execution_mode="ai_generate",
         )
+      else:
+        parsed.execution_mode = "ai_generate"
       has_parse_error = any(m.parse_error for m in parsed.metrics)
       if has_parse_error and r.get("transcript"):
         failed_sessions[input_key] = r.get("transcript", "")
@@ -2850,6 +2868,11 @@ class Client:
         retry_kwargs["resolved_selectors"] = {
             key: inputs_by_key[key].selector for key in failed_sessions
         }
+        retry_kwargs["context_sources"] = {
+            key: inputs_by_key[key].context_source
+            for key in failed_sessions
+            if inputs_by_key[key].context_source is not None
+        }
       retried = self._retry_failed_sessions(
           failed_sessions,
           config,
@@ -2867,13 +2890,9 @@ class Client:
           for key in failed_sessions:
             selector = inputs_by_key[key].selector
             for index, retried_result in enumerate(unmatched):
-              details = retried_result.details
               if (
-                  retried_result.session_id == selector.identity.session_id
-                  and details.get("user_id") == selector.identity.user_id
-                  and details.get("root_agent_name")
-                  == selector.identity.root_agent_name
-                  and details.get("scope_signature") == selector.scope_signature
+                  retried_result.identity == selector.identity
+                  and retried_result.scope == selector.scope
               ):
                 retried_map[key] = unmatched.pop(index)
                 break
@@ -2917,6 +2936,7 @@ class Client:
       max_retries: int = 3,
       per_session_context: Optional[dict[str, str]] = None,
       resolved_selectors: Optional[dict[str, ResolvedTraceSelector]] = None,
+      context_sources: Optional[dict[str, CategoricalContextSource]] = None,
   ) -> list:
     """Retries classification for failed sessions via Gemini API.
 
@@ -2930,6 +2950,8 @@ class Client:
         max_retries: Maximum number of retry attempts.
         per_session_context: Context keyed like ``transcripts``.
         resolved_selectors: Exact selector metadata keyed like
+            ``transcripts``.
+        context_sources: SDK-defined context provenance keyed like
             ``transcripts``.
 
     Returns:
@@ -2974,6 +2996,30 @@ class Client:
         )
         still_failed = {}
         for input_key, r in zip(remaining_keys, results):
+          selector = (
+              resolved_selectors.get(input_key)
+              if resolved_selectors is not None
+              else None
+          )
+          has_context = (
+              per_session_context is not None
+              and input_key in per_session_context
+          )
+          source = (
+              context_sources.get(
+                  input_key,
+                  CategoricalContextSource.TRUSTED_JUDGE_CONTEXT,
+              )
+              if context_sources is not None
+              else CategoricalContextSource.TRUSTED_JUDGE_CONTEXT
+          )
+          _apply_categorical_result_provenance(
+              r,
+              selector=selector,
+              context_applied=has_context,
+              context_source=source if has_context else None,
+              execution_mode="api_retry",
+          )
           has_error = any(m.parse_error for m in r.metrics)
           if has_error:
             still_failed[input_key] = remaining[input_key]
@@ -3069,7 +3115,7 @@ class Client:
       selectors = {
           item.evaluation_key: item.selector for item in evaluation_inputs
       }
-      return _run_sync(
+      results = _run_sync(
           classify_sessions_via_api(
               transcripts,
               config,
@@ -3078,6 +3124,15 @@ class Client:
               resolved_selectors=selectors,
           )
       )
+      for item, result in zip(evaluation_inputs, results):
+        _apply_categorical_result_provenance(
+            result,
+            selector=item.selector,
+            context_applied=item.judge_context is not None,
+            context_source=item.context_source,
+            execution_mode="api_fallback",
+        )
+      return results
 
     query = CATEGORICAL_TRANSCRIPT_QUERY.format(
         project=self.project_id,
@@ -3107,9 +3162,12 @@ class Client:
   ) -> None:
     """Persists categorical results to BigQuery when configured.
 
-    Creates the results table if it does not exist, flattens
-    session results to one row per ``(session_id, metric_name)``,
-    and writes via streaming insert.
+    Creates the results table if it does not exist, completes every additive
+    nullable schema migration, then flattens session results and writes via
+    streaming insert. Migrations run before the writer so deployment/rollback
+    order is schema → writer → view; historical rows are not backfilled.
+    Contextual rows persist identity plus SDK-owned provenance only, never
+    trusted context or a raw model response that could echo it.
     """
     if not config.persist_results:
       return
@@ -3130,6 +3188,13 @@ class Client:
           bigquery.QueryJobConfig(), feature="eval-categorical"
       )
       self.bq_client.query(ddl, job_config=ddl_config).result()
+      for migration_template in CATEGORICAL_RESULTS_MIGRATIONS:
+        migration = migration_template.format(
+            project=self.project_id,
+            dataset=self.dataset_id,
+            results_table=results_table,
+        )
+        self.bq_client.query(migration, job_config=ddl_config).result()
 
       rows = flatten_results_to_rows(report, config, endpoint)
       table_ref = f"{self.project_id}.{self.dataset_id}.{results_table}"
@@ -3151,12 +3216,25 @@ class Client:
         report.details["persisted_rows"] = len(rows)
         report.details["results_table"] = table_ref
     except Exception as e:
-      logger.warning(
-          "Failed to persist categorical results: %s",
-          e,
+      has_contextual_results = any(
+          result.context_applied for result in report.session_results
       )
+      if has_contextual_results:
+        persistence_error = (
+            f"categorical persistence failed ({type(e).__name__})"
+        )
+        logger.warning(
+            "Failed to persist contextual categorical results (%s).",
+            type(e).__name__,
+        )
+      else:
+        persistence_error = str(e)
+        logger.warning(
+            "Failed to persist categorical results: %s",
+            e,
+        )
       report.details["persisted"] = False
-      report.details["persist_error"] = str(e)
+      report.details["persist_error"] = persistence_error
 
   # -------------------------------------------------------------- #
   # Categorical Views                                                #

--- a/tests/test_categorical_evaluator.py
+++ b/tests/test_categorical_evaluator.py
@@ -36,7 +36,9 @@ from bigquery_agent_analytics.categorical_evaluator import build_categorical_rep
 from bigquery_agent_analytics.categorical_evaluator import build_classify_categories_literal
 from bigquery_agent_analytics.categorical_evaluator import CATEGORICAL_AI_GENERATE_QUERY
 from bigquery_agent_analytics.categorical_evaluator import CATEGORICAL_RESULTS_DDL
+from bigquery_agent_analytics.categorical_evaluator import CATEGORICAL_RESULTS_MIGRATIONS
 from bigquery_agent_analytics.categorical_evaluator import CATEGORICAL_TRANSCRIPT_QUERY
+from bigquery_agent_analytics.categorical_evaluator import CategoricalContextSource
 from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationConfig
 from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationReport
 from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricCategory
@@ -857,6 +859,11 @@ class TestClassifySessionsViaApi:
         "shared",
         "shared",
     ]
+    assert [result.identity for result in results] == [
+        alice.identity,
+        bob.identity,
+    ]
+    assert [result.scope for result in results] == [alice.scope, bob.scope]
     assert [result.details["user_id"] for result in results] == [
         "alice",
         "bob",
@@ -1079,6 +1086,13 @@ class TestCategoricalResultsDDL:
   def test_contains_all_schema_columns(self):
     for col in [
         "session_id STRING",
+        "user_id STRING",
+        "root_agent_name STRING",
+        "experiment_id STRING",
+        "scope_key STRING",
+        "identity_key STRING",
+        "context_applied BOOL",
+        "context_source STRING",
         "metric_name STRING",
         "category STRING",
         "justification STRING",
@@ -1091,6 +1105,26 @@ class TestCategoricalResultsDDL:
         "created_at TIMESTAMP",
     ]:
       assert col in CATEGORICAL_RESULTS_DDL
+
+  def test_additive_migrations_cover_identity_and_provenance(self):
+    migration_sql = "\n".join(CATEGORICAL_RESULTS_MIGRATIONS)
+    for column in [
+        "user_id STRING",
+        "root_agent_name STRING",
+        "experiment_id STRING",
+        "scope_key STRING",
+        "identity_key STRING",
+        "context_applied BOOL",
+        "context_source STRING",
+        "execution_mode STRING",
+    ]:
+      assert f"ADD COLUMN IF NOT EXISTS {column}" in migration_sql
+    assert all(
+        statement.startswith(
+            "ALTER TABLE `{project}.{dataset}.{results_table}`"
+        )
+        for statement in CATEGORICAL_RESULTS_MIGRATIONS
+    )
 
   def test_format_succeeds(self):
     formatted = CATEGORICAL_RESULTS_DDL.format(
@@ -1230,6 +1264,117 @@ class TestFlattenResultsToRows:
     assert len(rows) == 4
     session_ids = [r["session_id"] for r in rows]
     assert session_ids == ["s1", "s1", "s2", "s2"]
+
+  def test_identity_and_context_provenance_are_persisted_without_raw_context(
+      self,
+  ):
+    config = _make_config()
+    identity = TraceIdentity(
+        session_id="shared",
+        user_id="alice",
+        root_agent_name="root",
+    )
+    scope = TraceScope(
+        experiment_id="exp-a",
+        custom_labels={"run": "v1"},
+    )
+    secret = "golden-answer-secret-581"
+    result = CategoricalSessionResult(
+        session_id="shared",
+        identity=identity,
+        scope=scope,
+        context_applied=True,
+        context_source=CategoricalContextSource.GOLDEN_EXPECTED_ANSWER,
+        execution_mode="ai_generate",
+        metrics=[
+            CategoricalMetricResult(
+                metric_name="tone",
+                category="positive",
+                justification=secret,
+                raw_response=secret,
+            )
+        ],
+        details={"judge_context": secret},
+    )
+    report = build_categorical_report("test_ds", [result], config)
+    report.details["execution_mode"] = "ai_generate"
+
+    row = flatten_results_to_rows(report, config, "gemini-2.5-flash")[0]
+
+    assert row["user_id"] == "alice"
+    assert row["root_agent_name"] == "root"
+    assert row["experiment_id"] == "exp-a"
+    assert row["scope_key"] == scope.scope_signature
+    assert row["identity_key"].startswith("v1:")
+    assert row["context_applied"] is True
+    assert row["context_source"] == "golden_expected_answer"
+    assert row["execution_mode"] == "ai_generate"
+    assert row["justification"] is None
+    assert row["raw_response"] is None
+    assert secret not in json.dumps(row)
+
+  def test_identity_key_separates_reused_session_and_legacy_rows_stay_nullable(
+      self,
+  ):
+    config = _make_config()
+    alice = CategoricalSessionResult(
+        session_id="shared",
+        identity=TraceIdentity("shared", "alice", "root"),
+        scope=TraceScope(custom_labels={"run": "v1"}),
+        metrics=[CategoricalMetricResult(metric_name="tone")],
+    )
+    bob = CategoricalSessionResult(
+        session_id="shared",
+        identity=TraceIdentity("shared", "bob", "root"),
+        scope=TraceScope(custom_labels={"run": "v1"}),
+        metrics=[CategoricalMetricResult(metric_name="tone")],
+    )
+    legacy = CategoricalSessionResult(
+        session_id="legacy",
+        metrics=[CategoricalMetricResult(metric_name="tone")],
+    )
+    report = build_categorical_report("test_ds", [alice, bob, legacy], config)
+
+    rows = flatten_results_to_rows(report, config, "endpoint")
+
+    assert rows[0]["identity_key"] != rows[1]["identity_key"]
+    assert rows[2]["identity_key"] is None
+    assert rows[2]["scope_key"] is None
+    assert rows[2]["context_applied"] is False
+    assert rows[2]["context_source"] is None
+
+  @pytest.mark.parametrize(
+      "kwargs",
+      [
+          {
+              "session_id": "one",
+              "identity": TraceIdentity("one", "u", "root"),
+          },
+          {
+              "session_id": "one",
+              "identity": TraceIdentity("two", "u", "root"),
+          },
+          {
+              "session_id": "one",
+              "scope": TraceScope(custom_labels={"run": "v1"}),
+          },
+          {
+              "session_id": "one",
+              "context_applied": True,
+          },
+          {
+              "session_id": "one",
+              "context_source": (
+                  CategoricalContextSource.GOLDEN_EXPECTED_ANSWER
+              ),
+          },
+      ],
+  )
+  def test_result_rejects_incoherent_identity_or_context_provenance(
+      self, kwargs
+  ):
+    with pytest.raises(ValueError):
+      CategoricalSessionResult(**kwargs)
 
 
 # ------------------------------------------------------------------ #
@@ -2409,6 +2554,8 @@ class TestRetryFailedSessions:
     retried = [
         CategoricalSessionResult(
             session_id="shared",
+            identity=alice.identity,
+            scope=alice.scope,
             metrics=[
                 CategoricalMetricResult(metric_name="tone", category="positive")
             ],
@@ -2420,6 +2567,8 @@ class TestRetryFailedSessions:
         ),
         CategoricalSessionResult(
             session_id="shared",
+            identity=bob.identity,
+            scope=bob.scope,
             metrics=[
                 CategoricalMetricResult(metric_name="tone", category="negative")
             ],
@@ -2462,11 +2611,84 @@ class TestRetryFailedSessions:
         "alice",
         "bob",
     ]
+    assert [result.identity for result in results] == [
+        alice.identity,
+        bob.identity,
+    ]
+    assert [result.scope for result in results] == [alice.scope, bob.scope]
     assert [result.metrics[0].category for result in results] == [
         "positive",
         "negative",
     ]
     assert retry_meta["retry_resolved"] == 2
+
+  def test_ai_generate_retry_matches_typed_selector_not_result_details(self):
+    """Retry replacement ignores mutable details for reused session ids."""
+    client = self._make_client()
+    config = _make_config()
+    alice = TestIdentityBoundEvaluationInputs._selector(user_id="alice")
+    bob = TestIdentityBoundEvaluationInputs._selector(user_id="bob")
+    inputs = [
+        _CategoricalEvaluationInput(alice, "alice transcript"),
+        _CategoricalEvaluationInput(bob, "bob transcript"),
+    ]
+    client.bq_client.query.return_value.result.return_value = [
+        {
+            "evaluation_key": item.evaluation_key,
+            "session_id": "shared",
+            "transcript": item.transcript,
+            "classifications": None,
+        }
+        for item in inputs
+    ]
+    retried = [
+        CategoricalSessionResult(
+            session_id="shared",
+            identity=bob.identity,
+            scope=bob.scope,
+            metrics=[
+                CategoricalMetricResult(metric_name="tone", category="negative")
+            ],
+            details={
+                "user_id": "alice",
+                "root_agent_name": "root",
+                "scope_signature": alice.scope_signature,
+            },
+        ),
+        CategoricalSessionResult(
+            session_id="shared",
+            identity=alice.identity,
+            scope=alice.scope,
+            metrics=[
+                CategoricalMetricResult(metric_name="tone", category="positive")
+            ],
+            details={
+                "user_id": "bob",
+                "root_agent_name": "root",
+                "scope_signature": bob.scope_signature,
+            },
+        ),
+    ]
+
+    with patch.object(client, "_retry_failed_sessions", return_value=retried):
+      results, _ = client._categorical_ai_generate(
+          config,
+          "t",
+          "1=1",
+          [],
+          "gemini-2.5-flash",
+          evaluation_inputs=inputs,
+      )
+
+    assert [result.identity for result in results] == [
+        alice.identity,
+        bob.identity,
+    ]
+    assert [result.scope for result in results] == [alice.scope, bob.scope]
+    assert [result.metrics[0].category for result in results] == [
+        "positive",
+        "negative",
+    ]
 
   def test_identity_bound_results_follow_resolved_input_order(self):
     client = self._make_client()

--- a/tests/test_categorical_views.py
+++ b/tests/test_categorical_views.py
@@ -14,6 +14,7 @@
 
 """Tests for the CategoricalViewManager and dashboard view generation."""
 
+import sqlite3
 from unittest import mock
 
 import pytest
@@ -35,6 +36,46 @@ def vm():
   )
 
 
+@pytest.fixture
+def run_latest_view(vm):
+  """Executes the generated base-view CTEs against fixture rows."""
+  sql = vm.get_view_sql("categorical_results_latest")
+  query = sql.split(" AS\n", 1)[1]
+  query = query.replace(
+      f"`{PROJECT}.{DATASET}.categorical_results`", "categorical_results"
+  )
+  query = query.replace(
+      "CONCAT('legacy:', session_id)", "('legacy:' || session_id)"
+  )
+  query = query.replace(
+      "SELECT * EXCEPT(_identity_count, _sole_identity_key, "
+      "_effective_identity_key, _rn)\nFROM ranked",
+      "SELECT session_id, identity_key, metric_name, prompt_version, "
+      "created_at, raw_response, _effective_identity_key\nFROM ranked",
+  )
+
+  def run(rows):
+    with sqlite3.connect(":memory:") as connection:
+      connection.row_factory = sqlite3.Row
+      connection.execute(
+          """CREATE TABLE categorical_results (
+            session_id TEXT NOT NULL,
+            identity_key TEXT,
+            metric_name TEXT NOT NULL,
+            prompt_version TEXT,
+            created_at TEXT NOT NULL,
+            raw_response TEXT
+          )"""
+      )
+      connection.executemany(
+          "INSERT INTO categorical_results VALUES (?, ?, ?, ?, ?, ?)",
+          rows,
+      )
+      return [dict(row) for row in connection.execute(query)]
+
+  return run
+
+
 class TestCategoricalViewManager:
 
   def test_available_views(self, vm):
@@ -53,10 +94,136 @@ class TestCategoricalViewManager:
     assert "CREATE OR REPLACE VIEW" in sql
     assert f"`{PROJECT}.{DATASET}." in sql
     assert "ROW_NUMBER()" in sql
-    assert "PARTITION BY session_id, metric_name" in sql
+    assert "PARTITION BY _effective_identity_key, metric_name" in sql
     assert "COALESCE(prompt_version, '')" in sql
-    assert "ORDER BY created_at DESC, raw_response DESC" in sql
+    assert "identity_key IS NOT NULL DESC" in sql
+    assert "created_at DESC, raw_response DESC" in sql
     assert "categorical_results`" in sql
+
+  def test_base_view_uses_versioned_identity_and_namespaced_legacy_lane(
+      self, vm
+  ):
+    sql = vm.get_view_sql("categorical_results_latest")
+
+    assert "COUNT(DISTINCT identity_key) AS _identity_count" in sql
+    assert "MIN(identity_key) AS _sole_identity_key" in sql
+    assert "WHEN identity_key IS NOT NULL THEN identity_key" in sql
+    assert "WHEN _identity_count = 1 THEN _sole_identity_key" in sql
+    assert "CONCAT('legacy:', session_id)" in sql
+
+  def test_base_view_single_identity_supersedes_matching_legacy_rows(self, vm):
+    sql = vm.get_view_sql("categorical_results_latest")
+
+    # A legacy row is assigned the sole post-migration identity key. It then
+    # shares a metric/prompt partition with the versioned row, whose explicit
+    # identity wins even if timestamps tie.
+    assert "LEFT JOIN identity_population USING (session_id)" in sql
+    assert (
+        "PARTITION BY _effective_identity_key, metric_name,"
+        " COALESCE(prompt_version, '')" in sql
+    )
+    assert (
+        "ORDER BY identity_key IS NOT NULL DESC, created_at DESC,"
+        " raw_response DESC" in sql
+    )
+
+  def test_base_view_ambiguous_legacy_session_never_merges(self, vm):
+    sql = vm.get_view_sql("categorical_results_latest")
+
+    # Only an exactly-one identity population inherits the versioned key.
+    # Zero/multiple identities retain an isolated legacy namespace.
+    assert "WHEN _identity_count = 1" in sql
+    assert "ELSE CONCAT('legacy:', session_id)" in sql
+
+  def test_base_view_keeps_colliding_post_migration_identities(
+      self, run_latest_view
+  ):
+    rows = run_latest_view(
+        [
+            ("shared", "v1:alice", "tone", "p1", "2026-01-01", "a"),
+            ("shared", "v1:bob", "tone", "p1", "2026-01-02", "b"),
+        ]
+    )
+
+    assert len(rows) == 2
+    assert {row["_effective_identity_key"] for row in rows} == {
+        "v1:alice",
+        "v1:bob",
+    }
+
+  def test_base_view_deduplicates_legacy_only_session(self, run_latest_view):
+    rows = run_latest_view(
+        [
+            ("legacy", None, "tone", "p1", "2026-01-01", "old"),
+            ("legacy", None, "tone", "p1", "2026-01-02", "new"),
+        ]
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["_effective_identity_key"] == "legacy:legacy"
+    assert rows[0]["raw_response"] == "new"
+
+  def test_base_view_explicit_identity_supersedes_newer_legacy_row(
+      self, run_latest_view
+  ):
+    rows = run_latest_view(
+        [
+            ("shared", "v1:alice", "tone", "p1", "2026-01-01", "typed"),
+            ("shared", None, "tone", "p1", "2026-01-02", "legacy"),
+        ]
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["identity_key"] == "v1:alice"
+    assert rows[0]["_effective_identity_key"] == "v1:alice"
+    assert rows[0]["raw_response"] == "typed"
+
+  def test_base_view_keeps_ambiguous_legacy_lane_separate(
+      self, run_latest_view
+  ):
+    rows = run_latest_view(
+        [
+            ("shared", "v1:alice", "tone", "p1", "2026-01-01", "a"),
+            ("shared", "v1:bob", "tone", "p1", "2026-01-02", "b"),
+            ("shared", None, "tone", "p1", "2026-01-03", "legacy"),
+        ]
+    )
+
+    assert len(rows) == 3
+    assert {row["_effective_identity_key"] for row in rows} == {
+        "v1:alice",
+        "v1:bob",
+        "legacy:shared",
+    }
+    legacy = next(row for row in rows if row["identity_key"] is None)
+    assert legacy["_effective_identity_key"] == "legacy:shared"
+
+  def test_base_view_preserves_metric_and_prompt_partitions(
+      self, run_latest_view
+  ):
+    rows = run_latest_view(
+        [
+            ("shared", "v1:alice", "tone", "p1", "2026-01-01", "old"),
+            ("shared", "v1:alice", "tone", "p1", "2026-01-02", "new"),
+            ("shared", "v1:alice", "safety", "p1", "2026-01-01", "s1"),
+            ("shared", "v1:alice", "tone", "p2", "2026-01-01", "t2"),
+            ("shared", "v1:alice", "safety", "p2", "2026-01-01", "s2"),
+        ]
+    )
+
+    assert len(rows) == 4
+    assert {(row["metric_name"], row["prompt_version"]) for row in rows} == {
+        ("tone", "p1"),
+        ("safety", "p1"),
+        ("tone", "p2"),
+        ("safety", "p2"),
+    }
+    tone_p1 = next(
+        row
+        for row in rows
+        if row["metric_name"] == "tone" and row["prompt_version"] == "p1"
+    )
+    assert tone_p1["raw_response"] == "new"
 
   def test_get_view_sql_daily_counts(self, vm):
     sql = vm.get_view_sql("categorical_daily_counts")
@@ -88,6 +255,11 @@ class TestCategoricalViewManager:
     assert "validation_failures" in sql
     assert "fallback_count" in sql
     assert "fallback_rate" in sql
+    fallback_countif = (
+        "COUNTIF(execution_mode IN ('api_fallback', 'api_retry'))"
+    )
+    assert f"{fallback_countif} AS fallback_count" in sql
+    assert sql.count(fallback_countif) == 2
     assert "categorical_results_latest" in sql
 
   def test_get_view_sql_unknown_raises(self, vm):
@@ -201,7 +373,10 @@ class TestCategoricalViewManager:
   def test_base_view_dedup_excludes_rn(self, vm):
     """The base view uses SELECT * EXCEPT(_rn) to hide the helper column."""
     sql = vm.get_view_sql("categorical_results_latest")
-    assert "EXCEPT(_rn)" in sql
+    assert (
+        "EXCEPT(_identity_count, _sole_identity_key,"
+        " _effective_identity_key, _rn)" in sql
+    )
     assert "_rn = 1" in sql
 
   def test_operational_metrics_excludes_parse_errors_from_validation(self, vm):

--- a/tests/test_quality_report_helpers.py
+++ b/tests/test_quality_report_helpers.py
@@ -27,9 +27,14 @@ import sys
 import tempfile
 from types import SimpleNamespace
 
+import pytest
+
 import bigquery_agent_analytics
+from bigquery_agent_analytics.categorical_evaluator import CategoricalContextSource
 from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationReport
+from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricResult
 from bigquery_agent_analytics.categorical_evaluator import CategoricalSessionResult
+from bigquery_agent_analytics.trace import ResolvedTraceSelector
 from bigquery_agent_analytics.trace import Span
 from bigquery_agent_analytics.trace import Trace
 from bigquery_agent_analytics.trace import TraceIdentity
@@ -274,6 +279,109 @@ class TestIdentityAwareReportMaps:
         "alice",
         "bob",
     }
+
+  def test_golden_matching_preserves_exact_selector_keys(self, monkeypatch):
+    traces = [self._trace("alice", "v0"), self._trace("bob", "v1")]
+    selectors = [
+        ResolvedTraceSelector(
+            identity=trace.identity,
+            scope=trace.scope,
+        )
+        for trace in traces
+    ]
+    questions = {
+        selectors[0]: "alice question",
+        selectors[1]: "bob question",
+    }
+    golden = [
+        {"question": "alice golden", "expected_answer": "alice answer"},
+        {"question": "bob golden", "expected_answer": "bob answer"},
+    ]
+
+    def fake_embeddings(texts, **kwargs):
+      return [[1.0, 0.0] if "alice" in text else [0.0, 1.0] for text in texts]
+
+    monkeypatch.setattr(quality_report_module, "_embed_texts", fake_embeddings)
+
+    contexts, metadata = quality_report_module.match_golden_qa(
+        questions, golden
+    )
+
+    assert set(contexts) == set(selectors)
+    assert set(metadata) == set(selectors)
+    assert "alice answer" in contexts[selectors[0]]
+    assert "bob answer" in contexts[selectors[1]]
+
+  def test_bigquery_run_passes_selector_keyed_golden_context(self, monkeypatch):
+    traces = [self._trace("alice", "v0"), self._trace("bob", "v1")]
+    captured = {}
+
+    class FakeClient:
+
+      def list_traces(self, filter_criteria):
+        return traces
+
+      def evaluate_categorical(self, **kwargs):
+        captured.update(kwargs)
+        results = []
+        for trace in traces:
+          results.append(
+              CategoricalSessionResult(
+                  session_id=trace.session_id,
+                  identity=trace.identity,
+                  scope=trace.scope,
+                  metrics=[
+                      CategoricalMetricResult(
+                          metric_name="response_usefulness",
+                          category="meaningful",
+                      )
+                  ],
+                  details={
+                      "user_id": trace.identity.user_id,
+                      "root_agent_name": trace.identity.root_agent_name,
+                      "scope_signature": trace.scope.scope_signature,
+                  },
+              )
+          )
+        return CategoricalEvaluationReport(
+            dataset="test",
+            total_sessions=2,
+            session_results=results,
+        )
+
+    def fake_match(questions, golden_qa, threshold):
+      captured["question_keys"] = set(questions)
+      return (
+          {
+              selector: f"context:{selector.identity.user_id}"
+              for selector in questions
+          },
+          {selector: {"matched": True} for selector in questions},
+      )
+
+    monkeypatch.setattr(quality_report_module, "get_client", FakeClient)
+    monkeypatch.setattr(quality_report_module, "match_golden_qa", fake_match)
+
+    quality_report_module.run_evaluation(
+        model="gemini-test",
+        limit=2,
+        eval_spec={
+            "golden_qa": [
+                {"question": "q", "expected_answer": "a"},
+            ]
+        },
+    )
+
+    expected = {
+        ResolvedTraceSelector(identity=trace.identity, scope=trace.scope)
+        for trace in traces
+    }
+    assert captured["question_keys"] == expected
+    assert set(captured["per_session_context"]) == expected
+    assert (
+        captured["context_source"]
+        is CategoricalContextSource.GOLDEN_EXPECTED_ANSWER
+    )
 
   def test_trace_fetch_limit_counts_resolved_identity_scope_candidates(self):
     resolved = quality_report_module._index_resolved_entries(
@@ -527,6 +635,11 @@ class TestIdentityAwareReportMaps:
     scores = [
         CategoricalSessionResult(
             session_id="shared",
+            identity=trace.identity,
+            scope=trace.scope,
+            context_applied=True,
+            context_source=(CategoricalContextSource.GOLDEN_EXPECTED_ANSWER),
+            execution_mode="ai_generate",
             details={
                 "user_id": trace.identity.user_id,
                 "root_agent_name": trace.identity.root_agent_name,
@@ -551,6 +664,13 @@ class TestIdentityAwareReportMaps:
         "question-v0",
         "question-v1",
     ]
+    assert all(row["context_applied"] is True for row in output["sessions"])
+    assert {row["context_source"] for row in output["sessions"]} == {
+        "golden_expected_answer"
+    }
+    assert {row["execution_mode"] for row in output["sessions"]} == {
+        "ai_generate"
+    }
     suffix = quality_report_module._report_identity_suffix(
         resolved[next(iter(resolved))]
     )
@@ -1159,6 +1279,206 @@ class TestInjectGoldenSummary:
     gs = report["summary"]["golden_eval_summary"]
     assert gs["matched_meaningful"] == 1
     assert gs["matched_unhelpful"] == 0
+
+  def test_unattributed_collision_does_not_use_legacy_golden_metadata(self):
+    sessions = [
+        {
+            "session_id": "shared",
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        },
+        {
+            "session_id": "shared",
+            "metrics": {"response_usefulness": {"category": "unhelpful"}},
+        },
+    ]
+    report = self._report(sessions)
+
+    _inject_golden_summary(
+        report,
+        {
+            "shared": {
+                "matched": True,
+                "expected_answer": "must not attach",
+                "similarity": 1.0,
+            }
+        },
+    )
+
+    assert [session["golden_eval"] for session in sessions] == [None, None]
+    assert report["summary"]["golden_eval_summary"]["total_sessions"] == 0
+
+  def test_attributed_row_does_not_use_legacy_golden_metadata(self):
+    scope = TraceScope(custom_labels={"run": "v0"})
+    sessions = [
+        {
+            "session_id": "shared",
+            "user_id": "alice",
+            "root_agent_name": "root",
+            "experiment_id": None,
+            "custom_labels": {"run": "v0"},
+            "scope_signature": scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        }
+    ]
+    report = self._report(sessions)
+
+    _inject_golden_summary(
+        report,
+        {
+            "shared": {
+                "matched": True,
+                "expected_answer": "must not attach",
+                "similarity": 1.0,
+            }
+        },
+    )
+
+    assert sessions[0]["golden_eval"] is None
+    assert report["summary"]["golden_eval_summary"]["total_sessions"] == 0
+
+  def test_colliding_session_ids_receive_their_exact_golden_match(self):
+    alice_scope = TraceScope(custom_labels={"run": "v0"})
+    bob_scope = TraceScope(custom_labels={"run": "v1"})
+    alice = ResolvedTraceSelector(
+        identity=TraceIdentity("shared", "alice", "root"),
+        scope=alice_scope,
+    )
+    bob = ResolvedTraceSelector(
+        identity=TraceIdentity("shared", "bob", "root"),
+        scope=bob_scope,
+    )
+    sessions = [
+        {
+            "session_id": "shared",
+            "user_id": "alice",
+            "root_agent_name": "root",
+            "experiment_id": None,
+            "custom_labels": {"run": "v0"},
+            "scope_signature": alice_scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        },
+        {
+            "session_id": "shared",
+            "user_id": "bob",
+            "root_agent_name": "root",
+            "experiment_id": None,
+            "custom_labels": {"run": "v1"},
+            "scope_signature": bob_scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "unhelpful"}},
+        },
+    ]
+    report = self._report(sessions)
+
+    _inject_golden_summary(
+        report,
+        {
+            alice: {
+                "matched": True,
+                "expected_answer": "alice answer",
+                "topic": "alice",
+                "similarity": 1.0,
+            },
+            bob: {
+                "matched": True,
+                "expected_answer": "bob answer",
+                "topic": "bob",
+                "similarity": 1.0,
+            },
+        },
+    )
+
+    assert sessions[0]["golden_eval"]["expected_answer"] == "alice answer"
+    assert sessions[1]["golden_eval"]["expected_answer"] == "bob answer"
+    assert report["summary"]["golden_eval_summary"]["matched"] == 2
+
+  def test_nullable_identity_dimensions_receive_exact_golden_match(self):
+    anonymous_scope = TraceScope(custom_labels={"run": "anonymous"})
+    named_scope = TraceScope(custom_labels={"run": "named"})
+    anonymous = ResolvedTraceSelector(
+        identity=TraceIdentity("shared", None, None),
+        scope=anonymous_scope,
+    )
+    named = ResolvedTraceSelector(
+        identity=TraceIdentity("shared", "alice", "root"),
+        scope=named_scope,
+    )
+    sessions = [
+        {
+            "session_id": "shared",
+            "user_id": None,
+            "root_agent_name": None,
+            "experiment_id": None,
+            "custom_labels": {"run": "anonymous"},
+            "scope_signature": anonymous_scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        },
+        {
+            "session_id": "shared",
+            "user_id": "alice",
+            "root_agent_name": "root",
+            "experiment_id": None,
+            "custom_labels": {"run": "named"},
+            "scope_signature": named_scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        },
+    ]
+    report = self._report(sessions)
+
+    _inject_golden_summary(
+        report,
+        {
+            anonymous: {
+                "matched": True,
+                "expected_answer": "anonymous answer",
+                "similarity": 1.0,
+            },
+            named: {
+                "matched": True,
+                "expected_answer": "named answer",
+                "similarity": 1.0,
+            },
+        },
+    )
+
+    assert sessions[0]["golden_eval"]["expected_answer"] == "anonymous answer"
+    assert sessions[1]["golden_eval"]["expected_answer"] == "named answer"
+    assert report["summary"]["golden_eval_summary"]["matched"] == 2
+
+  @pytest.mark.parametrize("invalid_labels", [False, 0])
+  def test_invalid_falsy_labels_do_not_rebuild_exact_selector(
+      self, invalid_labels
+  ):
+    scope = TraceScope()
+    selector = ResolvedTraceSelector(
+        identity=TraceIdentity("shared", None, None),
+        scope=scope,
+    )
+    sessions = [
+        {
+            "session_id": "shared",
+            "user_id": None,
+            "root_agent_name": None,
+            "experiment_id": None,
+            "custom_labels": invalid_labels,
+            "scope_signature": scope.scope_signature,
+            "metrics": {"response_usefulness": {"category": "meaningful"}},
+        }
+    ]
+    report = self._report(sessions)
+
+    _inject_golden_summary(
+        report,
+        {
+            selector: {
+                "matched": True,
+                "expected_answer": "must not attach",
+                "similarity": 1.0,
+            }
+        },
+    )
+
+    assert sessions[0]["golden_eval"] is None
+    assert report["summary"]["golden_eval_summary"]["total_sessions"] == 0
 
 
 # ================================================================== #

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -22,6 +22,8 @@ from unittest.mock import patch
 import pytest
 
 from bigquery_agent_analytics.categorical_evaluator import _resolved_selector_key
+from bigquery_agent_analytics.categorical_evaluator import CATEGORICAL_RESULTS_MIGRATIONS
+from bigquery_agent_analytics.categorical_evaluator import CategoricalContextSource
 from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationConfig
 from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricCategory
 from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricDefinition
@@ -1689,6 +1691,14 @@ class TestEvaluateCategoricalIdentityBoundContext:
     assert context == "Expected answer: Alice"
     assert "Expected answer: Alice" not in repr(job_config.labels)
     assert report.details["execution_mode"] == "ai_generate"
+    result = report.session_results[0]
+    assert result.identity == alice.identity
+    assert result.scope == alice.scope
+    assert result.context_applied is True
+    assert (
+        result.context_source is CategoricalContextSource.TRUSTED_JUDGE_CONTEXT
+    )
+    assert result.execution_mode == "ai_generate"
     assert (
         "identity-bound judge context" in report.details["classify_skip_reason"]
     )
@@ -1728,21 +1738,110 @@ class TestEvaluateCategoricalIdentityBoundContext:
     mock_fetch.assert_not_called()
     mock_bq.query.assert_not_called()
 
-  def test_context_persistence_fails_closed_until_identity_schema_u5(self):
+  def test_context_persistence_migrates_then_writes_identity_provenance(self):
     client, mock_bq = self._client()
     selector = self._selector()
+    secret = "Expected answer secret 991"
+    valid = '[{"metric_name":"tone","category":"positive"}]'
+    timeline = []
 
-    with (
-        patch.object(client, "_fetch_filtered_traces") as mock_fetch,
-        pytest.raises(ValueError, match="identity-safe persistence"),
+    def query_side_effect(sql, **kwargs):
+      timeline.append(("query", sql))
+      result = MagicMock()
+      if "AI.GENERATE" in sql:
+        result.result.return_value = [
+            {
+                "evaluation_key": _resolved_selector_key(selector),
+                "session_id": "shared-session",
+                "transcript": "A transcript long enough to judge.",
+                "classifications": valid,
+            }
+        ]
+      else:
+        result.result.return_value = None
+      return result
+
+    def insert_side_effect(table, rows):
+      timeline.append(("insert", table))
+      return []
+
+    mock_bq.query.side_effect = query_side_effect
+    mock_bq.insert_rows_json.side_effect = insert_side_effect
+
+    with patch.object(
+        client, "_fetch_filtered_traces", return_value=[self._trace(selector)]
     ):
-      client.evaluate_categorical(
+      report = client.evaluate_categorical(
           config=_make_categorical_config(persist_results=True),
-          per_session_context={selector: "Expected answer"},
+          per_session_context={selector: secret},
       )
 
-    mock_fetch.assert_not_called()
-    mock_bq.query.assert_not_called()
+    schema_steps = [
+        sql
+        for kind, sql in timeline
+        if kind == "query" and "AI.GENERATE" not in sql
+    ]
+    assert len(schema_steps) == 1 + len(CATEGORICAL_RESULTS_MIGRATIONS)
+    assert "CREATE TABLE IF NOT EXISTS" in schema_steps[0]
+    assert all("ADD COLUMN IF NOT EXISTS" in sql for sql in schema_steps[1:])
+    assert timeline[-1][0] == "insert"
+    row = mock_bq.insert_rows_json.call_args.args[1][0]
+    assert row["user_id"] == "alice"
+    assert row["root_agent_name"] == "root"
+    assert row["experiment_id"] == "exp"
+    assert row["scope_key"] == selector.scope_signature
+    assert row["identity_key"].startswith("v1:")
+    assert row["context_applied"] is True
+    assert row["context_source"] == "trusted_judge_context"
+    assert secret not in repr(row)
+    assert report.details["persisted"] is True
+
+  def test_context_persistence_migration_failure_skips_insert_and_redacts_error(
+      self,
+  ):
+    client, mock_bq = self._client()
+    selector = self._selector()
+    secret = "golden-answer-secret-migration-882"
+    valid = '[{"metric_name":"tone","category":"positive"}]'
+
+    def query_side_effect(sql, **kwargs):
+      result = MagicMock()
+      if "AI.GENERATE" in sql:
+        result.result.return_value = [
+            {
+                "evaluation_key": _resolved_selector_key(selector),
+                "session_id": "shared-session",
+                "transcript": "A transcript long enough to judge.",
+                "classifications": valid,
+            }
+        ]
+      elif "ADD COLUMN IF NOT EXISTS" in sql:
+        result.result.side_effect = RuntimeError(
+            f"migration failed while processing {secret}"
+        )
+      else:
+        result.result.return_value = None
+      return result
+
+    mock_bq.query.side_effect = query_side_effect
+
+    with (
+        patch.object(
+            client,
+            "_fetch_filtered_traces",
+            return_value=[self._trace(selector)],
+        ),
+        patch("bigquery_agent_analytics.client.logger") as mock_logger,
+    ):
+      report = client.evaluate_categorical(
+          config=_make_categorical_config(persist_results=True),
+          per_session_context={selector: secret},
+      )
+
+    mock_bq.insert_rows_json.assert_not_called()
+    assert report.details["persisted"] is False
+    assert secret not in repr(report.details)
+    assert secret not in repr(mock_logger.warning.call_args_list)
 
   def test_empty_resolved_population_makes_no_model_call(self):
     client, mock_bq = self._client()
@@ -2011,11 +2110,15 @@ class TestEvaluateCategoricalPersistence:
     )
     report = client.evaluate_categorical(config=config)
 
-    # Two queries: AI.GENERATE + DDL.
-    assert mock_bq.query.call_count == 2
+    # AI.GENERATE, CREATE TABLE, then every idempotent additive migration.
+    assert mock_bq.query.call_count == 2 + len(CATEGORICAL_RESULTS_MIGRATIONS)
     ddl_sql = mock_bq.query.call_args_list[1][0][0]
     assert "CREATE TABLE IF NOT EXISTS" in ddl_sql
     assert "my_results" in ddl_sql
+    assert all(
+        "ADD COLUMN IF NOT EXISTS" in call.args[0]
+        for call in mock_bq.query.call_args_list[2:]
+    )
 
     # insert_rows_json called with flattened rows.
     mock_bq.insert_rows_json.assert_called_once()

--- a/tests/test_trace_identity_bigquery_live.py
+++ b/tests/test_trace_identity_bigquery_live.py
@@ -527,6 +527,119 @@ class TestCategoricalContextCollisionLive:
       )
 
 
+class TestCategoricalPersistenceCollisionLive:
+  """U5 persistence and latest views preserve colliding identities."""
+
+  def test_persisted_and_latest_cardinality_match_identity_results(
+      self, sdk_client, bq_client, collision_dataset
+  ):
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalContextSource
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationConfig
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalEvaluationReport
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricCategory
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricDefinition
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalMetricResult
+    from bigquery_agent_analytics.categorical_evaluator import CategoricalSessionResult
+    from bigquery_agent_analytics.trace import TraceIdentity
+    from bigquery_agent_analytics.trace import TraceScope
+
+    project, dataset_id = collision_dataset
+    results_table = "categorical_results_u5"
+    view_prefix = "u5_"
+    secret = "golden-answer-live-secret"
+    session_results = [
+        CategoricalSessionResult(
+            session_id="collide",
+            identity=TraceIdentity("collide", user_id, None),
+            scope=TraceScope(),
+            context_applied=True,
+            context_source=CategoricalContextSource.GOLDEN_EXPECTED_ANSWER,
+            execution_mode="ai_generate",
+            metrics=[
+                CategoricalMetricResult(
+                    metric_name="tone",
+                    category=category,
+                    justification=secret,
+                    raw_response=secret,
+                )
+            ],
+        )
+        for user_id, category in (
+            ("alice", "positive"),
+            ("bob", "negative"),
+        )
+    ]
+    config = CategoricalEvaluationConfig(
+        metrics=[
+            CategoricalMetricDefinition(
+                name="tone",
+                definition="Overall tone.",
+                categories=[
+                    CategoricalMetricCategory(
+                        name="positive",
+                        definition="Positive tone.",
+                    ),
+                    CategoricalMetricCategory(
+                        name="negative",
+                        definition="Negative tone.",
+                    ),
+                ],
+            )
+        ],
+        persist_results=True,
+        results_table=results_table,
+        prompt_version="u5-live",
+    )
+    report = CategoricalEvaluationReport(
+        dataset=dataset_id,
+        total_sessions=len(session_results),
+        session_results=session_results,
+    )
+
+    sdk_client._persist_categorical_if_configured(
+        report,
+        config,
+        endpoint="gemini-2.5-flash",
+    )
+    created = sdk_client.create_categorical_views(
+        results_table=results_table,
+        view_prefix=view_prefix,
+    )
+
+    assert report.details["persisted"] is True
+    assert len(report.session_results) == 2
+    assert "categorical_results_latest" in created
+
+    raw = list(
+        bq_client.query(
+            f"""
+            SELECT
+              COUNT(*) AS row_count,
+              COUNT(DISTINCT identity_key) AS identity_count,
+              COUNTIF(justification IS NOT NULL OR raw_response IS NOT NULL)
+                AS contextual_payload_count
+            FROM `{project}.{dataset_id}.{results_table}`
+            """
+        ).result()
+    )[0]
+    latest = list(
+        bq_client.query(
+            f"""
+            SELECT
+              COUNT(*) AS row_count,
+              COUNT(DISTINCT identity_key) AS identity_count
+            FROM `{project}.{dataset_id}.{view_prefix}categorical_results_latest`
+            """
+        ).result()
+    )[0]
+
+    assert raw.row_count == len(report.session_results)
+    assert raw.identity_count == len(report.session_results)
+    assert raw.contextual_payload_count == 0
+    assert latest.row_count == len(report.session_results)
+    assert latest.identity_count == len(report.session_results)
+
+
 class TestLiveCollisionFixture:
   """Reused session ids must not cross-contaminate (issue #359)."""
 


### PR DESCRIPTION
## Summary

Categorical evaluations can now persist trusted-context results without collapsing distinct trace identities that reuse a `session_id`. This removes the persistence gate from the identity-bound judge path while keeping golden answers and model echoes out of the results table.

The migration is additive and backward-compatible: existing rows remain nullable and are not backfilled. Deploy in schema -> writer -> views order; typed identities stay separate, a sole typed identity supersedes matching legacy rows, and ambiguous legacy rows remain isolated in a `legacy:<session_id>` lane.

## Design decisions

| Area | Contract |
|---|---|
| Result provenance | Each categorical session result carries its resolved `TraceIdentity` and `TraceScope`, trusted-context source, and execution mode through AI.GENERATE, retry, and API fallback paths. |
| Persistence compatibility | Idempotent `ADD COLUMN IF NOT EXISTS` migrations run before inserts. A versioned identity key preserves cardinality without requiring historical backfill. |
| Privacy and attribution | Contextual rows persist only SDK-owned provenance; justification and raw model output are omitted. Quality reports match golden metadata by exact resolved selector and use legacy session fallback only for a unique unattributed row. |
| Operational reporting | Successful `api_retry` traffic is counted with API fallback traffic, so fallback metrics reflect both fallback paths. |

## Validation

- `uv run pytest -q` — 3,916 passed, 68 skipped.
- Live BigQuery collision fixture — 1 passed: two in-memory results produced two distinct persisted identity keys and two latest-view rows, with zero contextual payload fields persisted.
- `bash autoformat.sh`
- `git diff upstream/main..HEAD --check`

## Related

Fixes #358

Related: #360
