### PR TITLE
fix(dashboard): define rendering and viewport support

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -51,6 +51,7 @@ billing project is supported as an optional advanced setting.
 | `tools/hydrate_dashboard.py` | Validates a BQAA table and emits a user-owned Looker Studio report URL |
 | `docs/dashboard-implementation.md` | Looker Studio page, field, formula, and live-validation implementation contract |
 | `docs/issue-377-review.md` | Live validation matrix for the UX/design backlog |
+| `docs/rendering-and-viewport-support.md` | Native-chart completion protocol and supported desktop viewport contract |
 | `oracle/queries/` | 37 independent per-chart SQL contracts used by the live validator |
 
 ## Pinned contracts
@@ -92,6 +93,13 @@ Canonical published template:
 
 All seven dashboard pages default to a rolling 365-day window ending
 yesterday. The Trace Inspector intentionally has no default date control.
+
+The v1 report is a freeform desktop dashboard. Use a viewport at least 1280
+CSS pixels wide (1440 recommended). A cold load or page navigation can paint
+native charts after the surrounding report controls; allow up to 90 seconds
+for non-degenerate chart output. Phone and narrow-tablet layouts require a
+separate responsive template and are not supported by v1. See
+[`docs/rendering-and-viewport-support.md`](docs/rendering-and-viewport-support.md).
 
 For the standard BQAA layout, open the
 [three-field dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)

--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -100,6 +100,8 @@ native charts after the surrounding report controls; allow up to 90 seconds
 for non-degenerate chart output. Phone and narrow-tablet layouts require a
 separate responsive template and are not supported by v1. See
 [`docs/rendering-and-viewport-support.md`](docs/rendering-and-viewport-support.md).
+The latest live pass used a 1568-pixel viewport, so targeted validation at the
+documented 1280-pixel minimum is still pending.
 
 For the standard BQAA layout, open the
 [three-field dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -37,6 +37,10 @@ live_template_verification:
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
 product_contract: spec/product_contract.yaml
+viewer_qa_contract:
+  issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381
+  protocol: docs/rendering-and-viewport-support.md
+  status: INVESTIGATION_OPEN
 product_verification:
   verified_date: "2026-07-27"
   pages: 8

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -40,7 +40,9 @@ product_contract: spec/product_contract.yaml
 viewer_qa_contract:
   issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381
   protocol: docs/rendering-and-viewport-support.md
-  status: INVESTIGATION_OPEN
+  status: NOT_REPRODUCED_UNDER_PROTOCOL
+  observed_baseline_comment: >-
+    https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/383#issuecomment-5098030747
 product_verification:
   verified_date: "2026-07-27"
   pages: 8

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -111,7 +111,7 @@ fixture and rendered “Too Many Rows.”
 
 ## Viewer rendering and viewport boundary
 
-The report uses native Data Studio bar, time-series, scorecard, and table
+The report uses native Looker Studio bar, time-series, scorecard, and table
 components. It does not use Vega or third-party community visualizations.
 Google-owned `usercontent.goog` render frames do not change that architecture
 and must not be used alone to diagnose a community-visualization failure.
@@ -122,12 +122,17 @@ Release-candidate validation uses three fresh loads, three complete navigation
 loops, and a per-page timeout of 90 seconds. The complete evidence and failure
 rules are defined in
 [`rendering-and-viewport-support.md`](rendering-and-viewport-support.md).
+The dated baseline in that document records a 70-second cold render and
+warm-navigation renders within 18 seconds as observations, not performance
+guarantees.
 
 Version 1 is a freeform desktop report with a minimum supported viewport width
 of 1280 CSS pixels and a recommended width of 1440 CSS pixels. A responsive
 mobile report is a separate template: the current multi-component pages cannot
 be converted in place without rebuilding their section layout and repeating
 parity, hydration, credential, and visual acceptance.
+The most recent live pass used a 1568-pixel viewport; targeted validation at
+the documented 1280-pixel minimum remains pending.
 
 ## Looker Studio measure mappings
 

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -109,6 +109,26 @@ The LLM Call Volume chart uses `event_date`, not raw `timestamp`. The raw
 timestamp dimension exceeded Looker Studio's chart row limit on the canonical
 fixture and rendered “Too Many Rows.”
 
+## Viewer rendering and viewport boundary
+
+The report uses native Data Studio bar, time-series, scorecard, and table
+components. It does not use Vega or third-party community visualizations.
+Google-owned `usercontent.goog` render frames do not change that architecture
+and must not be used alone to diagnose a community-visualization failure.
+
+Viewer QA waits for non-degenerate chart output rather than treating page
+chrome, a loading indicator, or an empty chart container as completion.
+Release-candidate validation uses three fresh loads, three complete navigation
+loops, and a per-page timeout of 90 seconds. The complete evidence and failure
+rules are defined in
+[`rendering-and-viewport-support.md`](rendering-and-viewport-support.md).
+
+Version 1 is a freeform desktop report with a minimum supported viewport width
+of 1280 CSS pixels and a recommended width of 1440 CSS pixels. A responsive
+mobile report is a separate template: the current multi-component pages cannot
+be converted in place without rebuilding their section layout and repeating
+parity, hydration, credential, and visual acceptance.
+
 ## Looker Studio measure mappings
 
 The stable source fields map to report measures as follows:

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -220,6 +220,14 @@
         helper.
       </aside>
 
+      <aside class="notice" aria-labelledby="viewing-support-title">
+        <strong id="viewing-support-title">Desktop viewing.</strong>
+        Designed for desktop screens at least 1280 px wide. On a cold load or
+        after changing pages, native charts may paint after the surrounding
+        report controls; allow up to 90 seconds before treating a chart as
+        failed. A responsive mobile template is not part of v1.
+      </aside>
+
       <footer>
         <span>Open-source dashboard · Apache 2.0</span>
         <span>

--- a/dashboard/looker_studio/docs/rendering-and-viewport-support.md
+++ b/dashboard/looker_studio/docs/rendering-and-viewport-support.md
@@ -1,14 +1,14 @@
 # Viewer rendering and viewport support
 
 This document defines how to validate the published BigQuery Agent Analytics
-Data Studio dashboard as a rendered product. It governs issue
+Looker Studio dashboard as a rendered product. It governs issue
 [#381](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/381)
 and complements the query, parity, and live-template contracts.
 
 ## Chart implementation boundary
 
-The canonical report uses Data Studio's native bar, time-series, scorecard, and
-table components. It does not use Vega or third-party community
+The canonical report uses Looker Studio's native bar, time-series, scorecard,
+and table components. It does not use Vega or third-party community
 visualizations.
 
 Native charts can still render inside Google-owned `usercontent.goog` frames.
@@ -54,6 +54,21 @@ A rendering defect is reproducible when the same chart remains blank after the
 navigation sequence produces the same failure in at least two loops. A single
 mid-render screenshot is not sufficient.
 
+### Observed baseline
+
+The 2026-07-27 live pass at a 1568 CSS-pixel viewport did not reproduce the
+blank-chart defect:
+
+- the cold load was still blank at 40 seconds and fully rendered by 70 seconds;
+- navigating away and returning rendered within 10 seconds;
+- SPA navigation to a second page rendered within 18 seconds; and
+- two complete render cycles made zero requests to `usercontent.goog` or a
+  community-visualization resource.
+
+The cold-load analytics beacon reported a cache view miss. These values are an
+environment-specific comparison baseline, not an SLA and not a substitute for
+the repeated-load acceptance protocol.
+
 ## Viewport support
 
 Version 1 is a freeform, desktop report:
@@ -63,15 +78,19 @@ Version 1 is a freeform, desktop report:
 - phone and narrow-tablet layouts are not supported.
 
 The configuration website remains responsive, but that does not make the
-external Data Studio report responsive. Freeform pages intentionally preserve
-the reviewed component geometry.
+external Looker Studio report responsive. Freeform pages intentionally
+preserve the reviewed component geometry.
 
-Data Studio only supports direct freeform-to-responsive conversion when a page
-has at most one component. Every dashboard page has multiple components, so
-mobile support requires a separately owned responsive report. That report
+Looker Studio only supports direct freeform-to-responsive conversion when a
+page has at most one component. Every dashboard page has multiple components,
+so mobile support requires a separately owned responsive report. That report
 must independently pass chart parity, Linking API hydration, Viewer
 Credentials, query-cost, and phone/tablet visual validation before it can
 replace or accompany the v1 template.
+
+The 1280-pixel minimum is a documented product-support boundary. The latest
+live pass ran at 1568 pixels, so targeted visual validation at 1280 pixels
+remains pending.
 
 ## Issue triage
 

--- a/dashboard/looker_studio/docs/rendering-and-viewport-support.md
+++ b/dashboard/looker_studio/docs/rendering-and-viewport-support.md
@@ -1,0 +1,85 @@
+# Viewer rendering and viewport support
+
+This document defines how to validate the published BigQuery Agent Analytics
+Data Studio dashboard as a rendered product. It governs issue
+[#381](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/381)
+and complements the query, parity, and live-template contracts.
+
+## Chart implementation boundary
+
+The canonical report uses Data Studio's native bar, time-series, scorecard, and
+table components. It does not use Vega or third-party community
+visualizations.
+
+Native charts can still render inside Google-owned `usercontent.goog` frames.
+The presence or lifecycle of one of those frames is not enough to classify a
+chart as a community visualization. A root-cause claim must be supported by
+the report's editor configuration or its **Resource → Manage community
+visualizations** inventory.
+
+Do not replace chart types, bindings, or filters in response to a blank frame
+until the failure reproduces under the protocol below. The report uses
+Viewer's Credentials; generated copies must also pass the credential gate
+before they are shared.
+
+## Rendering reliability protocol
+
+A page title, report toolbar, loading indicator, or empty chart container is
+not a chart-completion signal. A page passes only after every expected chart
+has one of these outcomes:
+
+1. non-degenerate rendered output with dimensions, measures, and labels
+   appropriate to the fixture; or
+2. an explicit legitimate empty state produced by a scenario whose expected
+   result is empty.
+
+For every release-candidate visual pass:
+
+1. Record the browser and version, signed-in state, extensions that can affect
+   requests, viewport in CSS pixels, and whether the load is cold or warm.
+2. Run at least three fresh report loads.
+3. In each run, visit all eight pages in report order, then repeat the complete
+   navigation loop three times without reloading.
+4. Allow up to 90 seconds per page for non-degenerate chart output. Record the
+   observed time to render; do not use disappearance of page chrome or a
+   loading indicator as the timer's success condition.
+5. Capture every page after it passes. For a failure, capture the page at the
+   timeout and record failed network requests and the corresponding BigQuery
+   job activity.
+6. Verify the native chart bindings in the editor before changing the report.
+   An empty frame alone does not establish lost bindings.
+
+A rendering defect is reproducible when the same chart remains blank after the
+90-second timeout in at least two fresh runs, or when a deterministic
+navigation sequence produces the same failure in at least two loops. A single
+mid-render screenshot is not sufficient.
+
+## Viewport support
+
+Version 1 is a freeform, desktop report:
+
+- minimum supported viewport width: 1280 CSS pixels;
+- recommended viewport width: 1440 CSS pixels;
+- phone and narrow-tablet layouts are not supported.
+
+The configuration website remains responsive, but that does not make the
+external Data Studio report responsive. Freeform pages intentionally preserve
+the reviewed component geometry.
+
+Data Studio only supports direct freeform-to-responsive conversion when a page
+has at most one component. Every dashboard page has multiple components, so
+mobile support requires a separately owned responsive report. That report
+must independently pass chart parity, Linking API hydration, Viewer
+Credentials, query-cost, and phone/tablet visual validation before it can
+replace or accompany the v1 template.
+
+## Issue triage
+
+Keep rendering reliability and responsive-layout work separate:
+
+- intermittent blank native charts are a reliability investigation against the
+  existing report;
+- mobile support is a new template and product-support decision.
+
+Neither workstream should be represented as a Vega/community-visualization
+defect without evidence from the report resource inventory.

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -134,6 +134,35 @@ visual_system:
     title_case: true
     unit_style: "(ms)"
 
+viewer_qa:
+  # Bar, time-series, scorecard, and table components use Data Studio's native
+  # chart implementation. usercontent.goog render frames are not evidence of
+  # a third-party or Vega community visualization.
+  chart_implementation: native_data_studio
+  community_visualizations: not_used
+  completion_signal: non_degenerate_rendered_output
+  cold_load_timeout_seconds: 90
+  fresh_load_runs: 3
+  navigation_loops: 3
+  required_evidence:
+    - browser_and_version
+    - signed_in_state
+    - viewport_css_pixels
+    - load_type
+    - page_navigation_sequence
+    - time_to_non_degenerate_render
+    - timestamped_page_capture
+    - failed_network_requests
+    - bigquery_job_activity
+
+viewport_support:
+  layout_mode: freeform
+  target: desktop
+  minimum_supported_width_css_px: 1280
+  recommended_width_css_px: 1440
+  narrow_screen_support: not_supported_in_v1
+  responsive_template: separate_report_required
+
 charts:
   - id: usage-token-usage-split-by-agent
     title: Token Usage by Agent
@@ -237,3 +266,11 @@ deferred_enhancements:
     dependency: Add MAX(timestamp) without conflating it with connector refresh.
   - id: google-managed-template-ownership
     dependency: Maintainer-controlled Google account and transfer approval.
+  - id: native-chart-rendering-investigation
+    dependency: >-
+      Reproduce issue #381 under the viewer_qa protocol before changing chart
+      bindings, chart types, or the published report.
+  - id: responsive-mobile-template
+    dependency: >-
+      Maintainer approval for a separately owned responsive report, followed
+      by parity, hydration, credential, and mobile-viewport validation.

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -135,7 +135,7 @@ visual_system:
     unit_style: "(ms)"
 
 viewer_qa:
-  # Bar, time-series, scorecard, and table components use Data Studio's native
+  # Bar, time-series, scorecard, and table components use Looker Studio's native
   # chart implementation. usercontent.goog render frames are not evidence of
   # a third-party or Vega community visualization.
   chart_implementation: native_data_studio
@@ -144,6 +144,21 @@ viewer_qa:
   cold_load_timeout_seconds: 90
   fresh_load_runs: 3
   navigation_loops: 3
+  # Observational evidence from one browser/viewport, not an SLA. Future
+  # verification records its own environment and timings.
+  observed_baseline:
+    verified_date: "2026-07-27"
+    viewport_width_css_px: 1568
+    cold_load:
+      blank_observed_at_seconds: 40
+      fully_rendered_by_seconds: 70
+      cache_state: view_miss
+    warm_navigation:
+      return_rendered_within_seconds: 10
+      second_page_rendered_within_seconds: 18
+    network:
+      usercontent_goog_requests: 0
+      community_visualization_requests: 0
   required_evidence:
     - browser_and_version
     - signed_in_state
@@ -162,6 +177,8 @@ viewport_support:
   recommended_width_css_px: 1440
   narrow_screen_support: not_supported_in_v1
   responsive_template: separate_report_required
+  minimum_width_validation: pending
+  last_validated_width_css_px: 1568
 
 charts:
   - id: usage-token-usage-split-by-agent
@@ -268,7 +285,8 @@ deferred_enhancements:
     dependency: Maintainer-controlled Google account and transfer approval.
   - id: native-chart-rendering-investigation
     dependency: >-
-      Reproduce issue #381 under the viewer_qa protocol before changing chart
+      Compare future time-to-render observations with the dated viewer_qa
+      baseline. Reproduce issue #381 under that protocol before changing chart
       bindings, chart types, or the published report.
   - id: responsive-mobile-template
     dependency: >-

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -20,6 +20,11 @@ assert.match(
   pageSource,
   /https:\/\/googlecloudplatform\.github\.io\/BigQuery-Agent-Analytics-SDK\//,
 );
+assert.match(
+  pageSource,
+  /Designed for desktop screens at least 1280 px wide/,
+);
+assert.match(pageSource, /allow up to 90 seconds/);
 
 const values = {
   project: "customer-project-123",

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -305,6 +305,23 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "cold_load_timeout_seconds": 90,
       "fresh_load_runs": 3,
       "navigation_loops": 3,
+      "observed_baseline": {
+          "verified_date": "2026-07-27",
+          "viewport_width_css_px": 1568,
+          "cold_load": {
+              "blank_observed_at_seconds": 40,
+              "fully_rendered_by_seconds": 70,
+              "cache_state": "view_miss",
+          },
+          "warm_navigation": {
+              "return_rendered_within_seconds": 10,
+              "second_page_rendered_within_seconds": 18,
+          },
+          "network": {
+              "usercontent_goog_requests": 0,
+              "community_visualization_requests": 0,
+          },
+      },
       "required_evidence": [
           "browser_and_version",
           "signed_in_state",
@@ -324,6 +341,8 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "recommended_width_css_px": 1440,
       "narrow_screen_support": "not_supported_in_v1",
       "responsive_template": "separate_report_required",
+      "minimum_width_validation": "pending",
+      "last_validated_width_css_px": 1568,
   }
   assert "live_series_mode" not in product["visual_system"]
   deferred = {item["id"] for item in product["deferred_enhancements"]}
@@ -392,7 +411,11 @@ def test_report_and_web_bindings_cannot_drift():
   assert report["viewer_qa_contract"] == {
       "issue": ("GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381"),
       "protocol": "docs/rendering-and-viewport-support.md",
-      "status": "INVESTIGATION_OPEN",
+      "status": "NOT_REPRODUCED_UNDER_PROTOCOL",
+      "observed_baseline_comment": (
+          "https://github.com/GoogleCloudPlatform/"
+          "BigQuery-Agent-Analytics-SDK/pull/383#issuecomment-5098030747"
+      ),
   }
   assert report["product_verification"] == {
       "verified_date": "2026-07-27",

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -298,10 +298,38 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "legend": "visible",
       "dimension_values_are_series_labels": True,
   }
-  assert "live_series_mode" not in product["visual_system"]
-  assert "llm-error-visibility" in {
-      item["id"] for item in product["deferred_enhancements"]
+  assert product["viewer_qa"] == {
+      "chart_implementation": "native_data_studio",
+      "community_visualizations": "not_used",
+      "completion_signal": "non_degenerate_rendered_output",
+      "cold_load_timeout_seconds": 90,
+      "fresh_load_runs": 3,
+      "navigation_loops": 3,
+      "required_evidence": [
+          "browser_and_version",
+          "signed_in_state",
+          "viewport_css_pixels",
+          "load_type",
+          "page_navigation_sequence",
+          "time_to_non_degenerate_render",
+          "timestamped_page_capture",
+          "failed_network_requests",
+          "bigquery_job_activity",
+      ],
   }
+  assert product["viewport_support"] == {
+      "layout_mode": "freeform",
+      "target": "desktop",
+      "minimum_supported_width_css_px": 1280,
+      "recommended_width_css_px": 1440,
+      "narrow_screen_support": "not_supported_in_v1",
+      "responsive_template": "separate_report_required",
+  }
+  assert "live_series_mode" not in product["visual_system"]
+  deferred = {item["id"] for item in product["deferred_enhancements"]}
+  assert "llm-error-visibility" in deferred
+  assert "responsive-mobile-template" in deferred
+  assert "native-chart-rendering-investigation" in deferred
   assert {
       "session_id",
       "model_version",
@@ -361,6 +389,11 @@ def test_report_and_web_bindings_cannot_drift():
       "limitation": "mutable_external_report_requires_reverification_after_changes",
   }
   assert report["product_contract"] == "spec/product_contract.yaml"
+  assert report["viewer_qa_contract"] == {
+      "issue": ("GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381"),
+      "protocol": "docs/rendering-and-viewport-support.md",
+      "status": "INVESTIGATION_OPEN",
+  }
   assert report["product_verification"] == {
       "verified_date": "2026-07-27",
       "pages": 8,
@@ -442,6 +475,8 @@ def test_googlecloudplatform_pages_configuration():
   assert 'name="twitter:card"' in page
   assert "Copy security checklist" in page
   assert "billing-project-hint" in page
+  assert "Designed for desktop screens at least 1280 px wide" in page
+  assert "allow up to 90 seconds" in page
   assert "@media (prefers-color-scheme: dark)" in styles
   assert (DASHBOARD / "docs/favicon.svg").is_file()
 


### PR DESCRIPTION
## Summary

Issue #381 combined three different concerns: intermittent blank charts, a Vega/community-visualization diagnosis, and narrow-screen layout. The published report uses native Looker Studio charts, so this PR codifies the evidence needed to investigate rendering without changing valid chart bindings and freezes the actual v1 viewport boundary.

- Defines native Looker Studio charts as the implementation contract; Google-owned render frames alone are not evidence of Vega or a community visualization.
- Adds a reproducible viewer-QA protocol: 3 fresh loads, 3 complete navigation loops, a 90-second per-page completion window, and evidence requirements for repeat failures.
- Records the first protocol baseline as dated observational evidence: blank at 40 seconds, fully rendered by 70 seconds on a cold cache miss, and warm navigation rendered within 18 seconds.
- Defines v1 as a freeform desktop report supporting viewports at least 1280 CSS px wide, with 1440 px recommended.
- Records responsive mobile support as a separate-report enhancement requiring its own parity, hydration, credential, cost, and visual validation.
- Surfaces the desktop and cold-load guidance on the public configurator and pins it in Python and Node tests.

This PR does not mutate or republish the external Looker Studio report. The report's default-date-window correction is also deliberately excluded and remains a separate workstream.

## Validation

- `pytest -q tests/test_looker_studio_dashboard.py` — 19 passed
- `node dashboard/looker_studio/tools/test_web_configurator.mjs` — passed
- `bash autoformat.sh` — passed
- `ruff check tests/test_looker_studio_dashboard.py` — passed
- `git diff --check` — passed

Repository-wide validation is currently limited by pre-existing local-environment and baseline issues:

- `pytest -q` stops during collection in three unrelated tests because the local ADK checkout imports an OpenTelemetry semantic-conventions symbol absent from the installed package.
- `ruff check .` reports 570 pre-existing findings outside this diff.

The live review pass at a 1568 CSS-pixel viewport found:

- zero `usercontent.goog` or community-visualization requests across two complete render cycles;
- a cold cache-miss load fully rendered by 70 seconds;
- navigate-away-and-return rendering within 10 seconds; and
- SPA navigation to a second page rendering within 18 seconds.

The blank-chart failure did not reproduce under the new protocol.

## Post-deploy validation

After the Pages workflow publishes the configurator:

1. Verify the deployed page contains the 1280 px support boundary and 90-second load guidance.
2. Exercise all eight report pages using the committed 3-load × 3-loop protocol.
3. Record time to non-degenerate output, failed network requests, and matching BigQuery job activity.
4. Treat the report as healthy only when every expected chart renders valid output within 90 seconds, or displays a legitimate expected empty state.
5. Open a report-side defect only when the same chart remains blank after the timeout in at least two fresh runs, or a deterministic navigation sequence reproduces it twice.

Mitigation for a repeat failure is evidence collection and report-editor binding inspection; chart types, filters, and SQL should not change until the failure is reproducible.

## Known limitations

- This PR defines the investigation and support contracts; it does not claim the intermittent native-chart behavior is fixed.
- The 1280 px minimum is a documented product-support boundary; the latest live pass ran at 1568 px, so targeted validation at 1280 px remains pending.
- Phone and narrow-tablet report layouts remain unsupported in v1.
- A responsive report must be built and validated as a separately owned template.

Related: #381

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
