### PR TITLE
fix(dashboard): include today in the default date window

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -91,8 +91,8 @@ fixture parity certification or M4 visual sign-off.
 Canonical published template:
 [BigQuery Agent Analytics — Template](https://lookerstudio.google.com/reporting/5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40).
 
-All seven dashboard pages default to a rolling 365-day window ending
-yesterday. The Trace Inspector intentionally has no default date control.
+All seven dashboard pages default to a rolling 365-day window including
+today. The Trace Inspector intentionally has no default date control.
 
 The v1 report is a freeform desktop dashboard. Use a viewport at least 1280
 CSS pixels wide (1440 recommended). A cold load or page navigation can paint

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -16,7 +16,7 @@ generated_report_credential_gate:
   verification_path: Resource > Manage added data sources > Edit
 link_access: PUBLIC
 publishing_mode: MANUAL
-published_date: "2026-07-27"
+published_date: "2026-07-28"
 # This attestation covers the reviewed repository artifact. It does not prove
 # that the mutable external Looker Studio report still embeds these bytes.
 reviewed_template_sql:
@@ -24,7 +24,7 @@ reviewed_template_sql:
   reviewed_date: "2026-07-24"
   scope: repository_artifact_only
 live_template_verification:
-  verified_date: "2026-07-27"
+  verified_date: "2026-07-28"
   repository_sql_sha256: 5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0
   method:
     - connector_custom_query_review
@@ -34,6 +34,7 @@ live_template_verification:
     - published_non_degenerate_chart_data_capture
     - editor_configuration_assertions
     - published_tool_page_refresh
+    - published_include_today_default_validation
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
 product_contract: spec/product_contract.yaml
@@ -44,7 +45,7 @@ viewer_qa_contract:
   observed_baseline_comment: >-
     https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/383#issuecomment-5098030747
 product_verification:
-  verified_date: "2026-07-27"
+  verified_date: "2026-07-28"
   pages: 8
   checks:
     - expected_page_and_chart_titles_present
@@ -59,6 +60,7 @@ product_verification:
     - tool_charts_exclude_non_completed_rows
     - multi_series_charts_use_categorical_legends
     - no_partial_update_footer_after_refresh
+    - default_date_range_includes_today_on_seven_dashboard_pages
   result: PASSED
 source_contract:
   mode: BASE_TABLE

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -74,7 +74,7 @@ governance:
   transfer_status: PENDING_MAINTAINER
 default_date_range:
   mode: rolling
-  start_offset_days: 365
-  end_offset_days: 1
-  include_today: false
+  start_offset_days: 364
+  end_offset_days: 0
+  include_today: true
   page_scope: all_dashboard_pages

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -97,7 +97,7 @@ explicit chart title. Product titles use title case, “Over Time,” uppercase
 formerly inherited as “Events By Agent” is labeled **Tool Completions by
 Agent** because its metric intentionally counts only `TOOL_COMPLETED` rows.
 
-All seven dashboard pages use a rolling 365-day window ending yesterday.
+All seven dashboard pages use a rolling 365-day window including today.
 Looker Studio sends those bounds through `@DS_START_DATE` and
 `@DS_END_DATE`; the production query applies the frozen half-open UTC
 predicate. The generated manifest retains the pinned LookML's original

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -19,9 +19,9 @@ source:
 defaults:
   date_range:
     mode: rolling
-    start_offset_days: 365
-    end_offset_days: 1
-    include_today: false
+    start_offset_days: 364
+    end_offset_days: 0
+    include_today: true
     page_scope: all_dashboard_pages
 
 pages:

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -387,13 +387,14 @@ def test_report_and_web_bindings_cannot_drift():
   }
   attestation = report["reviewed_template_sql"]
   template = (DASHBOARD / "sql/events_v1.template.sql").read_bytes()
+  assert report["published_date"] == "2026-07-28"
   assert attestation == {
       "sha256": hashlib.sha256(template).hexdigest(),
       "reviewed_date": "2026-07-24",
       "scope": "repository_artifact_only",
   }
   assert report["live_template_verification"] == {
-      "verified_date": "2026-07-27",
+      "verified_date": "2026-07-28",
       "repository_sql_sha256": hashlib.sha256(template).hexdigest(),
       "method": [
           "connector_custom_query_review",
@@ -403,6 +404,7 @@ def test_report_and_web_bindings_cannot_drift():
           "published_non_degenerate_chart_data_capture",
           "editor_configuration_assertions",
           "published_tool_page_refresh",
+          "published_include_today_default_validation",
       ],
       "result": "PASSED",
       "limitation": "mutable_external_report_requires_reverification_after_changes",
@@ -418,7 +420,7 @@ def test_report_and_web_bindings_cannot_drift():
       ),
   }
   assert report["product_verification"] == {
-      "verified_date": "2026-07-27",
+      "verified_date": "2026-07-28",
       "pages": 8,
       "checks": [
           "expected_page_and_chart_titles_present",
@@ -433,6 +435,7 @@ def test_report_and_web_bindings_cannot_drift():
           "tool_charts_exclude_non_completed_rows",
           "multi_series_charts_use_categorical_legends",
           "no_partial_update_footer_after_refresh",
+          "default_date_range_includes_today_on_seven_dashboard_pages",
       ],
       "result": "PASSED",
   }

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -246,9 +246,9 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
   ]
   assert product["defaults"]["date_range"] == {
       "mode": "rolling",
-      "start_offset_days": 365,
-      "end_offset_days": 1,
-      "include_today": False,
+      "start_offset_days": 364,
+      "end_offset_days": 0,
+      "include_today": True,
       "page_scope": "all_dashboard_pages",
   }
   assert product["layout"]["percentile_order"] == {
@@ -375,9 +375,9 @@ def test_report_and_web_bindings_cannot_drift():
   assert web["dataSourceAlias"] == report["data_source_alias"]
   assert report["default_date_range"] == {
       "mode": "rolling",
-      "start_offset_days": 365,
-      "end_offset_days": 1,
-      "include_today": False,
+      "start_offset_days": 364,
+      "end_offset_days": 0,
+      "include_today": True,
       "page_scope": "all_dashboard_pages",
   }
   assert web["sentinels"] == {
@@ -447,6 +447,23 @@ def test_report_and_web_bindings_cannot_drift():
       "required_before_sharing": "VIEWERS",
       "verification_path": "Resource > Manage added data sources > Edit",
   }
+
+
+def test_default_date_range_includes_today_for_exactly_365_calendar_days():
+  product = yaml.safe_load(
+      (DASHBOARD / "spec/product_contract.yaml").read_text()
+  )
+  report = yaml.safe_load(
+      (DASHBOARD / "bindings/report_template.yaml").read_text()
+  )
+
+  date_range = product["defaults"]["date_range"]
+  assert report["default_date_range"] == date_range
+  assert date_range["include_today"] is True
+  assert date_range["end_offset_days"] == 0
+  assert (
+      date_range["start_offset_days"] - date_range["end_offset_days"] + 1 == 365
+  )
 
 
 def test_base_table_query_and_preflight_cover_the_bqaa_contract():


### PR DESCRIPTION
## Summary

Fresh BQAA installations no longer open to an empty dashboard solely because
their first events occurred today. The published report and repository
contract now use an exact 365-calendar-day window ending today
(`today - 364 days` through `today`) on all seven dashboard pages; Trace
Inspector remains without a default date control.

The real ADK 2.4.0 dataset that exposed the defect returned 0 of 77 events
under the previous ending-yesterday default and all 77 when today was
included. The Looker Studio template was republished and its publication and
verification attestations are dated 2026-07-28.

The secondary analytics and documentation observations in the issue are
deliberately outside this PR so the first-run P1 fix can ship independently.

Related: #382

## Validation

- `pytest -q tests/test_looker_studio_dashboard.py` — 20 passed
- `node dashboard/looker_studio/tools/test_web_configurator.mjs` — passed
- `bash autoformat.sh` — passed
- `ruff check tests/test_looker_studio_dashboard.py` — passed
- Live ADK 2.4.0 data — 77 of 77 events visible with the new default
- Published report — include-today default verified on seven dashboard pages

## Post-Deploy Monitoring & Validation

For the first 24 hours after merge, the PR author or dashboard maintainer
should:

1. Open the canonical template and confirm each of the seven dashboard date
   controls ends on the current date; Trace Inspector should still have no
   default date control.
2. Hydrate a copy against a BQAA table containing only current-day events and
   confirm the opening page renders non-degenerate data without changing the
   date control.
3. In BigQuery job history, filter for jobs referencing the hydrated
   `agent_events` table and confirm the current UTC date is present in the
   effective `@DS_END_DATE` window.

Healthy signals are current-day rows visible on first open, non-degenerate
charts, and a displayed range covering exactly 365 calendar dates. Failure
signals are “No data” while current-day events exist, a range ending
yesterday, or a 366-day range. If any failure appears, unpublish the changed
template revision, restore the previous report revision, and reopen #382 with
the affected page, displayed range, and BigQuery job evidence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
