### PR TITLE
fix(dashboard): support hyphenated BQAA table IDs

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -102,6 +102,13 @@ separate responsive template and are not supported by v1. See
 [`docs/rendering-and-viewport-support.md`](docs/rendering-and-viewport-support.md).
 The latest live pass used a 1568-pixel viewport, so targeted validation at the
 documented 1280-pixel minimum is still pending.
+Issue
+[#388](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/388)
+also found that lower charts on Token Consumption and Latency can cross the
+freeform page boundary. The repository now requires every component's bottom
+edge to remain at least 24 pixels inside the page; the canonical report still
+requires an editor update and republication before that check can be marked
+verified.
 
 For the standard BQAA layout, open the
 [three-field dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)
@@ -110,6 +117,11 @@ and enter only:
 1. GCP project ID;
 2. BigQuery dataset ID;
 3. BQAA table ID (normally `agent_events`).
+
+For portable Linking API substitution, table IDs may use ASCII letters, digits,
+underscores, and hyphens, such as `events_agent_cur-phenix`. Dataset IDs retain
+BigQuery's no-hyphen restriction. Commas and backticks remain rejected because
+they would alter the `sqlReplace` binding list or the quoted SQL identifier.
 
 The configurator runs entirely in the browser and creates an official Looker
 Studio Linking API URL. Project, dataset, and table identifiers can also be

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -37,6 +37,10 @@ live_template_verification:
     - published_include_today_default_validation
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
+known_live_issues:
+  - issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388
+    scope: Token Consumption and Latency page containment
+    status: REQUIRES_EDITOR_REPUBLICATION
 product_contract: spec/product_contract.yaml
 viewer_qa_contract:
   issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -57,11 +57,14 @@ function refresh() {
     createLink.removeAttribute("href");
     createLink.setAttribute("aria-disabled", "true");
     copyButton.disabled = true;
-    if (error.field && inputs[error.field]) {
+    const hasFieldError = Boolean(error.field && inputs[error.field]);
+    if (hasFieldError) {
       inputs[error.field].setAttribute("aria-invalid", "true");
       errors[error.field].textContent = error.message;
+      setStatus("");
+    } else {
+      setStatus(error.message, "error");
     }
-    setStatus(error.message, "error");
   }
 }
 

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -1,7 +1,8 @@
 import { REPORT_CONFIG } from "./report-config.mjs";
 
 export const PROJECT_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
-export const BIGQUERY_ID_RE = /^[A-Za-z_][A-Za-z0-9_]{0,1023}$/;
+export const DATASET_RE = /^[A-Za-z_][A-Za-z0-9_]{0,1023}$/;
+export const TABLE_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$/;
 
 const VALIDATION_MESSAGES = Object.freeze({
   project:
@@ -9,7 +10,7 @@ const VALIDATION_MESSAGES = Object.freeze({
   dataset:
     "Start with a letter or underscore, then use only letters, digits, or underscores.",
   table:
-    "Start with a letter or underscore, then use only letters, digits, or underscores.",
+    "Start with a letter, digit, or underscore, then use only letters, digits, underscores, or hyphens.",
   billingProject:
     "Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit.",
 });
@@ -53,8 +54,8 @@ export function validateConfiguration(input, config = REPORT_CONFIG) {
   const project = requireValue("project", input.project, PROJECT_RE);
   const values = {
     project,
-    dataset: requireValue("dataset", input.dataset, BIGQUERY_ID_RE),
-    table: requireValue("table", input.table, BIGQUERY_ID_RE),
+    dataset: requireValue("dataset", input.dataset, DATASET_RE),
+    table: requireValue("table", input.table, TABLE_RE),
     billingProject: requireValue(
       "billingProject",
       input.billingProject || project,

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -36,6 +36,12 @@ API URL entirely in the browser. URL query
 parameters can prefill the three inputs, but the page never opens the report
 without a user click.
 
+Dataset and table IDs use separate validators. Dataset IDs allow the established
+ASCII letter/digit/underscore subset. Table IDs additionally allow hyphens,
+which BigQuery supports and which remain safe inside the report's backticked
+table path. Commas and backticks stay invalid because they would change the
+Linking API replacement list or SQL identifier boundary.
+
 Looker Studio report parameters are not the binding mechanism. They can pass
 scalar values to BigQuery custom SQL, but BigQuery query parameters cannot
 replace identifiers in `FROM` paths. Connector-level Linking API
@@ -133,6 +139,14 @@ be converted in place without rebuilding their section layout and repeating
 parity, hydration, credential, and visual acceptance.
 The most recent live pass used a 1568-pixel viewport; targeted validation at
 the documented 1280-pixel minimum remains pending.
+
+Freeform layout acceptance includes vertical containment as well as
+non-overlap. For every page, each component must satisfy
+`top + height <= page height - 24 px`. Issue #388 found that the lower charts on
+Token Consumption and Latency violate this rule in the mutable published
+report. `spec/product_contract.yaml` records the pending editor republication;
+repository metadata must not claim the live issue is closed before a new
+published visual pass verifies the component bounds.
 
 ## Looker Studio measure mappings
 

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -99,7 +99,8 @@
           <span class="field-hint" id="table-hint">
             Charts read this table directly and extract reporting fields from
             its JSON columns. The standard BQAA table is
-            <code>agent_events</code>.
+            <code>agent_events</code>. Custom table IDs may use ASCII letters,
+            digits, underscores, and hyphens.
           </span>
           <span class="field-error" id="table-error" aria-live="polite"></span>
 

--- a/dashboard/looker_studio/docs/rendering-and-viewport-support.md
+++ b/dashboard/looker_studio/docs/rendering-and-viewport-support.md
@@ -92,6 +92,20 @@ The 1280-pixel minimum is a documented product-support boundary. The latest
 live pass ran at 1568 pixels, so targeted visual validation at 1280 pixels
 remains pending.
 
+Viewport width does not prove that freeform components remain inside the page
+canvas. Release-candidate validation must also capture the editor's page height
+and every component's top and height, then verify:
+
+```text
+component top + component height <= page height - 24 px
+```
+
+Issue
+[#388](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/388)
+identified an open containment defect on Token Consumption and Latency. Until
+those pages are edited, republished, and reverified, their lower charts can be
+clipped even at supported desktop widths.
+
 ## Issue triage
 
 Keep rendering reliability and responsive-layout work separate:

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -63,6 +63,14 @@ layout:
     trend_title_top: 611
     trend_chart_top: 670
     overlap_free: true
+  page_bounds:
+    affected_pages:
+      - Token Consumption
+      - Latency
+    minimum_bottom_padding_px: 24
+    acceptance_rule: component_top_plus_height_lte_page_height_minus_bottom_padding
+    verification_status: pending_editor_republication
+    tracking_issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388
 
 behavioral_fixes:
   usage-llm-call-trends:

--- a/dashboard/looker_studio/tools/hydrate_dashboard.py
+++ b/dashboard/looker_studio/tools/hydrate_dashboard.py
@@ -16,7 +16,8 @@ import urllib.parse
 import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-ID_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
+DATASET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
+TABLE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$")
 PROJECT_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
 LOCATION_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
@@ -163,8 +164,8 @@ def main() -> int:
 
   try:
     project = require_identifier("project ID", args.project, PROJECT_RE)
-    dataset = require_identifier("dataset ID", args.dataset, ID_RE)
-    table = require_identifier("table ID", args.table, ID_RE)
+    dataset = require_identifier("dataset ID", args.dataset, DATASET_RE)
+    table = require_identifier("table ID", args.table, TABLE_RE)
     billing = require_identifier(
         "billing project ID",
         args.billing_project or project,

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -34,6 +34,12 @@ const values = {
 };
 assert.deepEqual(validateConfiguration(values), values);
 
+const hyphenatedTable = {
+  ...values,
+  table: "events_agent_cur-phenix",
+};
+assert.deepEqual(validateConfiguration(hyphenatedTable), hyphenatedTable);
+
 const dashboard = new URL(buildDashboardUrl(values));
 assert.equal(dashboard.origin, "https://lookerstudio.google.com");
 assert.equal(dashboard.pathname, "/reporting/create");
@@ -58,6 +64,19 @@ assert.equal(dashboard.searchParams.get("ds.ds230.refreshFields"), "false");
 assert.match(
   dashboard.searchParams.get("r.reportName"),
   /agent_analytics\.agent_events$/,
+);
+
+const hyphenatedDashboard = new URL(buildDashboardUrl(hyphenatedTable));
+assert.equal(
+  hyphenatedDashboard.searchParams.get("ds.ds230.sqlReplace"),
+  [
+    "test-project-0728-467323",
+    "customer-project-123",
+    "bqaa_fixture_adk_1_27_0",
+    "agent_analytics",
+    "sentinelbqaaevents",
+    "events_agent_cur-phenix",
+  ].join(","),
 );
 
 const setup = new URL(
@@ -128,6 +147,85 @@ for (const safeCollision of [
 ]) {
   assert.doesNotThrow(() => buildDashboardUrl(safeCollision));
 }
+
+class FakeElement {
+  constructor(value = "") {
+    this.value = value;
+    this.textContent = "";
+    this.dataset = {};
+    this.disabled = false;
+    this.href = "";
+    this.listeners = {};
+    this.attributes = new Map();
+  }
+
+  addEventListener(name, listener) {
+    this.listeners[name] = listener;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+    if (name === "href") this.href = "";
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value);
+  }
+
+  querySelectorAll() {
+    return [];
+  }
+}
+
+const fakeElements = new Map([
+  ["#configurator", new FakeElement()],
+  ["#create-dashboard", new FakeElement()],
+  ["#copy-link", new FakeElement()],
+  ["#copy-checklist", new FakeElement()],
+  ["#security-checklist", new FakeElement()],
+  ["#form-status", new FakeElement()],
+  ["#project", new FakeElement(values.project)],
+  ["#dataset", new FakeElement(values.dataset)],
+  ["#table", new FakeElement(values.table)],
+  ["#billing-project", new FakeElement("")],
+  ["#project-error", new FakeElement()],
+  ["#dataset-error", new FakeElement()],
+  ["#table-error", new FakeElement()],
+  ["#billing-project-error", new FakeElement()],
+]);
+globalThis.document = {
+  querySelector(selector) {
+    return fakeElements.get(selector);
+  },
+};
+globalThis.window = {
+  location: {
+    href: "https://example.test/configure",
+    search: "",
+  },
+  open() {},
+};
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: {
+    clipboard: {
+      async writeText() {},
+    },
+  },
+});
+
+await import("../docs/app.mjs");
+fakeElements.get("#table").value = "table,other";
+fakeElements.get("#table").listeners.input();
+assert.match(
+  fakeElements.get("#table-error").textContent,
+  /letters, digits/,
+);
+assert.equal(
+  fakeElements.get("#form-status").textContent,
+  "",
+  "field validation must not repeat the inline error in the form status",
+);
 
 console.log(
   "web configurator OK: identifiers and sentinels validated; Linking API URL deterministic",

--- a/dashboard/looker_studio/tools/validate_live_bqaa.py
+++ b/dashboard/looker_studio/tools/validate_live_bqaa.py
@@ -20,7 +20,8 @@ import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJECT_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
-ID_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
+DATASET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
+TABLE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$")
 LOCATION_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 FILTER_PARAMS = (
     "filter_agent",
@@ -118,8 +119,8 @@ def main() -> int:
   try:
     require_identifier("project ID", args.project, PROJECT_RE)
     require_identifier("billing project ID", billing_project, PROJECT_RE)
-    require_identifier("dataset ID", args.dataset, ID_RE)
-    require_identifier("table ID", args.table, ID_RE)
+    require_identifier("dataset ID", args.dataset, DATASET_RE)
+    require_identifier("table ID", args.table, TABLE_RE)
     require_identifier("location", args.location, LOCATION_RE)
   except ValueError as exc:
     raise SystemExit(str(exc)) from exc

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -69,14 +69,48 @@ def test_portable_linking_api_configuration():
   ]
 
 
+def test_hyphenated_bigquery_table_ids_are_supported_by_python_tools():
+  table = "events_agent_cur-phenix"
+  hydration = _load_hydration_module()
+  live_validation = _load_dashboard_module("validate_live_bqaa")
+
+  assert hasattr(hydration, "DATASET_RE")
+  assert hasattr(hydration, "TABLE_RE")
+  assert hasattr(live_validation, "DATASET_RE")
+  assert hasattr(live_validation, "TABLE_RE")
+  assert (
+      hydration.require_identifier("table ID", table, hydration.TABLE_RE)
+      == table
+  )
+  assert (
+      live_validation.require_identifier(
+          "table ID", table, live_validation.TABLE_RE
+      )
+      == table
+  )
+
+  link = hydration.build_link(
+      "customer-project-123",
+      "agent_analytics",
+      table,
+      "billing-project-123",
+      "Customer BQAA",
+  )
+  sql_replace = urllib.parse.parse_qs(
+      urllib.parse.urlparse(link).query
+  )["ds.ds230.sqlReplace"][0].split(",")
+  assert sql_replace[-2:] == ["sentinelbqaaevents", table]
+
+
 @pytest.mark.parametrize(
     ("label", "value", "pattern"),
     [
         ("project ID", "UPPERCASE", "PROJECT_RE"),
         ("project ID", "project;drop", "PROJECT_RE"),
-        ("dataset ID", "bad-dataset", "ID_RE"),
-        ("dataset ID", "data`set", "ID_RE"),
-        ("table ID", "table,other", "ID_RE"),
+        ("dataset ID", "bad-dataset", "DATASET_RE"),
+        ("dataset ID", "data`set", "DATASET_RE"),
+        ("table ID", "table,other", "TABLE_RE"),
+        ("table ID", "data`set", "TABLE_RE"),
     ],
 )
 def test_hydration_identifiers_fail_closed(label, value, pattern):
@@ -274,6 +308,17 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "trend_chart_top": 670,
       "overlap_free": True,
   }
+  assert product["layout"]["page_bounds"] == {
+      "affected_pages": ["Token Consumption", "Latency"],
+      "minimum_bottom_padding_px": 24,
+      "acceptance_rule": (
+          "component_top_plus_height_lte_page_height_minus_bottom_padding"
+      ),
+      "verification_status": "pending_editor_republication",
+      "tracking_issue": (
+          "GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388"
+      ),
+  }
   assert product["filtering"]["top_user_rankings"] == {
       "group_remaining_as_others": False,
       "charts": [
@@ -439,6 +484,13 @@ def test_report_and_web_bindings_cannot_drift():
       ],
       "result": "PASSED",
   }
+  assert report["known_live_issues"] == [
+      {
+          "issue": "GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388",
+          "scope": "Token Consumption and Latency page containment",
+          "status": "REQUIRES_EDITOR_REPUBLICATION",
+      }
+  ]
   assert report["source_contract"] == {
       "mode": "BASE_TABLE",
       "generated_views_required": False,

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -96,9 +96,9 @@ def test_hyphenated_bigquery_table_ids_are_supported_by_python_tools():
       "billing-project-123",
       "Customer BQAA",
   )
-  sql_replace = urllib.parse.parse_qs(
-      urllib.parse.urlparse(link).query
-  )["ds.ds230.sqlReplace"][0].split(",")
+  sql_replace = urllib.parse.parse_qs(urllib.parse.urlparse(link).query)[
+      "ds.ds230.sqlReplace"
+  ][0].split(",")
   assert sql_replace[-2:] == ["sentinelbqaaevents", table]
 
 


### PR DESCRIPTION
## Summary

Customers can now configure the dashboard against valid BigQuery table IDs such as `events_agent_cur-phenix`. Dataset IDs retain their stricter no-hyphen rule, while commas and backticks still fail closed because they could change the Linking API replacement list or SQL identifier boundary.

Invalid field values now appear once beside the affected input instead of being duplicated in the form-level status. The report contract also records a 24-pixel page-containment rule and truthfully marks the two published pages that still need an authenticated Looker Studio editor update.

Related: #388

## Validation

- Added the regression tests first and observed 8 expected failures before implementation; the completed suite passes 22/22 tests plus the Node configurator suite and Ruff checks.
- Exercised the configurator in a browser: the exact hyphenated table enables the dashboard link, while a comma-delimited adversarial value disables it and renders only one inline error.
- Copied real ADK 2.4.0 BQAA data (77 rows across 10 event types) into a temporary table named `events_agent_cur-phenix`, preserving partitioning and clustering.
- Against that table, the hydration preflight passed, the production custom query returned real data, and all 37 dashboard oracle queries completed successfully.
- Confirmed comma and backtick payloads are rejected by both Python entry points, then deleted the temporary BigQuery dataset.

## Live report follow-up

This PR does not claim that repository metadata can repair a mutable external Looker Studio canvas. The Token Consumption and Latency pages still need their page height extended (or empty bands reclaimed), followed by republication and a fresh visual attestation before the pending containment status can be changed to verified.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
