### PR TITLE
docs(dashboard): verify page containment after republication

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -104,11 +104,13 @@ The latest live pass used a 1568-pixel viewport, so targeted validation at the
 documented 1280-pixel minimum is still pending.
 Issue
 [#388](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/388)
-also found that lower charts on Token Consumption and Latency can cross the
-freeform page boundary. The repository now requires every component's bottom
-edge to remain at least 24 pixels inside the page; the canonical report still
-requires an editor update and republication before that check can be marked
-verified.
+also found that lower charts on Token Consumption and Latency crossed the
+freeform page boundary. The pages were resized in the editor (1030 px and
+1100 px) and the report was republished on 2026-07-29; a published-version
+probe verified 31 px and 30 px of bottom padding, above the required 24 px
+minimum. Reports copied through the Linking API before that date keep their
+own snapshot of the old geometry — create a fresh copy from the configurator
+to pick up the fix.
 
 For the standard BQAA layout, open the
 [three-field dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -16,7 +16,7 @@ generated_report_credential_gate:
   verification_path: Resource > Manage added data sources > Edit
 link_access: PUBLIC
 publishing_mode: MANUAL
-published_date: "2026-07-28"
+published_date: "2026-07-29"
 # This attestation covers the reviewed repository artifact. It does not prove
 # that the mutable external Looker Studio report still embeds these bytes.
 reviewed_template_sql:
@@ -24,10 +24,11 @@ reviewed_template_sql:
   reviewed_date: "2026-07-24"
   scope: repository_artifact_only
 live_template_verification:
-  verified_date: "2026-07-28"
+  verified_date: "2026-07-29"
   repository_sql_sha256: 5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0
   method:
     - connector_custom_query_review
+    - page_bounds_containment_probe
     - sqlreplace_table_only_smoke_test
     - canonical_viewer_credentials_review
     - published_eight_page_ux_smoke_test
@@ -37,10 +38,7 @@ live_template_verification:
     - published_include_today_default_validation
   result: PASSED
   limitation: mutable_external_report_requires_reverification_after_changes
-known_live_issues:
-  - issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388
-    scope: Token Consumption and Latency page containment
-    status: REQUIRES_EDITOR_REPUBLICATION
+known_live_issues: []
 product_contract: spec/product_contract.yaml
 viewer_qa_contract:
   issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#381

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -142,11 +142,14 @@ the documented 1280-pixel minimum remains pending.
 
 Freeform layout acceptance includes vertical containment as well as
 non-overlap. For every page, each component must satisfy
-`top + height <= page height - 24 px`. Issue #388 found that the lower charts on
-Token Consumption and Latency violate this rule in the mutable published
-report. `spec/product_contract.yaml` records the pending editor republication;
-repository metadata must not claim the live issue is closed before a new
-published visual pass verifies the component bounds.
+`top + height <= page height - 24 px`. Issue #388 found that the lower charts
+on Token Consumption and Latency violated this rule; those pages were resized
+(1030 px and 1100 px) and the report was republished on 2026-07-29, with a
+published-version probe verifying 31 px and 30 px of bottom padding.
+`spec/product_contract.yaml#layout.page_bounds` records the verified
+page-local measurements. The report remains mutable, so any later geometry
+edit requires a fresh published-version probe before the contract may keep
+claiming containment.
 
 ## Looker Studio measure mappings
 

--- a/dashboard/looker_studio/docs/rendering-and-viewport-support.md
+++ b/dashboard/looker_studio/docs/rendering-and-viewport-support.md
@@ -102,9 +102,12 @@ component top + component height <= page height - 24 px
 
 Issue
 [#388](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/388)
-identified an open containment defect on Token Consumption and Latency. Until
-those pages are edited, republished, and reverified, their lower charts can be
-clipped even at supported desktop widths.
+identified a containment defect on Token Consumption and Latency. Both pages
+were resized and republished on 2026-07-29, and a published-version probe
+verified the rule holds (31 px and 30 px of bottom padding). Linking API
+copies created before that date retain the old geometry; a fresh copy is
+required to pick up the fix. Because the report is mutable, later geometry
+edits require reverification under this protocol.
 
 ## Issue triage
 

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -64,13 +64,21 @@ layout:
     trend_chart_top: 670
     overlap_free: true
   page_bounds:
-    affected_pages:
-      - Token Consumption
-      - Latency
     minimum_bottom_padding_px: 24
     acceptance_rule: component_top_plus_height_lte_page_height_minus_bottom_padding
-    verification_status: pending_editor_republication
+    coordinate_space: page_local_css_px
+    verification_status: verified
+    verified_date: "2026-07-29"
     tracking_issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388
+    pages:
+      - name: Token Consumption
+        page_height: 1030
+        max_component_bottom: 999
+        bottom_padding: 31
+      - name: Latency
+        page_height: 1100
+        max_component_bottom: 1070
+        bottom_padding: 30
 
 behavioral_fixes:
   usage-llm-call-trends:

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -324,13 +324,13 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "Latency",
   ]
   for page in page_bounds["pages"]:
-      assert (
-          page["max_component_bottom"]
-          <= page["page_height"] - page_bounds["minimum_bottom_padding_px"]
-      )
-      assert page["bottom_padding"] == (
-          page["page_height"] - page["max_component_bottom"]
-      )
+    assert (
+        page["max_component_bottom"]
+        <= page["page_height"] - page_bounds["minimum_bottom_padding_px"]
+    )
+    assert page["bottom_padding"] == (
+        page["page_height"] - page["max_component_bottom"]
+    )
   assert product["filtering"]["top_user_rankings"] == {
       "group_remaining_as_others": False,
       "charts": [

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -308,17 +308,29 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "trend_chart_top": 670,
       "overlap_free": True,
   }
-  assert product["layout"]["page_bounds"] == {
-      "affected_pages": ["Token Consumption", "Latency"],
-      "minimum_bottom_padding_px": 24,
-      "acceptance_rule": (
-          "component_top_plus_height_lte_page_height_minus_bottom_padding"
-      ),
-      "verification_status": "pending_editor_republication",
-      "tracking_issue": (
-          "GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388"
-      ),
-  }
+  page_bounds = product["layout"]["page_bounds"]
+  assert page_bounds["minimum_bottom_padding_px"] == 24
+  assert page_bounds["acceptance_rule"] == (
+      "component_top_plus_height_lte_page_height_minus_bottom_padding"
+  )
+  assert page_bounds["coordinate_space"] == "page_local_css_px"
+  assert page_bounds["verification_status"] == "verified"
+  assert page_bounds["verified_date"] == "2026-07-29"
+  assert page_bounds["tracking_issue"] == (
+      "GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388"
+  )
+  assert [page["name"] for page in page_bounds["pages"]] == [
+      "Token Consumption",
+      "Latency",
+  ]
+  for page in page_bounds["pages"]:
+      assert (
+          page["max_component_bottom"]
+          <= page["page_height"] - page_bounds["minimum_bottom_padding_px"]
+      )
+      assert page["bottom_padding"] == (
+          page["page_height"] - page["max_component_bottom"]
+      )
   assert product["filtering"]["top_user_rankings"] == {
       "group_remaining_as_others": False,
       "charts": [
@@ -432,17 +444,18 @@ def test_report_and_web_bindings_cannot_drift():
   }
   attestation = report["reviewed_template_sql"]
   template = (DASHBOARD / "sql/events_v1.template.sql").read_bytes()
-  assert report["published_date"] == "2026-07-28"
+  assert report["published_date"] == "2026-07-29"
   assert attestation == {
       "sha256": hashlib.sha256(template).hexdigest(),
       "reviewed_date": "2026-07-24",
       "scope": "repository_artifact_only",
   }
   assert report["live_template_verification"] == {
-      "verified_date": "2026-07-28",
+      "verified_date": "2026-07-29",
       "repository_sql_sha256": hashlib.sha256(template).hexdigest(),
       "method": [
           "connector_custom_query_review",
+          "page_bounds_containment_probe",
           "sqlreplace_table_only_smoke_test",
           "canonical_viewer_credentials_review",
           "published_eight_page_ux_smoke_test",
@@ -484,13 +497,7 @@ def test_report_and_web_bindings_cannot_drift():
       ],
       "result": "PASSED",
   }
-  assert report["known_live_issues"] == [
-      {
-          "issue": "GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#388",
-          "scope": "Token Consumption and Latency page containment",
-          "status": "REQUIRES_EDITOR_REPUBLICATION",
-      }
-  ]
+  assert report["known_live_issues"] == []
   assert report["source_contract"] == {
       "mode": "BASE_TABLE",
       "generated_views_required": False,


### PR DESCRIPTION
Closes the remaining item from #388 (follow-up to #389).

## What changed in the live report (editor work, already published)

- **Token Consumption**: page height 953 → **1030 px** (max component bottom 999, padding 31 px)
- **Latency**: page height 953 → **1100 px** (max component bottom 1070, padding 30 px)
- Republished 2026-07-29.

## Verification on the published version

A bottom-of-page probe on both pages after republication confirmed the previously clipped charts now render completely:

- `Top 5 Users by Token Consumption` shows its full x-axis (0–160K) with whitespace before the canvas edge;
- both `LLM Latency Over Time` and `Tool Latency Over Time` show complete plots and both staggered rows of x-axis date labels;
- paint hit-testing inside the bottom chart regions now returns chart content (previously returned background, proving the clip).

## Repository changes

- `spec/product_contract.yaml#layout.page_bounds`: `verification_status: verified` (dated), explicit `coordinate_space: page_local_css_px` (addressing the earlier review note about mixed coordinate spaces), and per-page `page_height` / `max_component_bottom` / `bottom_padding` measurements.
- `bindings/report_template.yaml`: `known_live_issues` cleared; `published_date` and `live_template_verification` re-dated with `page_bounds_containment_probe` added to the method list.
- `tests/test_looker_studio_dashboard.py`: asserts the containment arithmetic on the **recorded contract values** (`max_component_bottom ≤ page_height − 24` and padding consistency), so the committed record can never drift into claiming an invalid geometry. This protects the contract, not the live report: the report remains a mutable external artifact, and any later geometry edit requires a fresh published-version probe per the existing `mutable_external_report_requires_reverification_after_changes` limitation.
- Prose updated in README, `dashboard-implementation.md`, and `rendering-and-viewport-support.md` to reflect the verified state, the fresh-copy requirement for pre-existing Linking API copies, and the reverification boundary.

22/22 dashboard tests and the Node configurator suite pass.