### PR TITLE
[Dashboard/configurator] Add browser-level smoke check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,20 @@ jobs:
       - name: Run tests
         run: pytest --tb=short -q
 
+  configurator-browser-smoke:
+    name: Configurator browser smoke
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Run the smoke check's own negative fixtures
+        run: bash dashboard/looker_studio/tools/browser_smoke.sh --self-test
+
+      - name: Load the configurator in headless Chrome
+        run: bash dashboard/looker_studio/tools/browser_smoke.sh
+
   build:
     name: Build package
     runs-on: ubuntu-22.04

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Loads the configurator in a real headless browser and fails on any
+# page-level error or if the page's module never executed. Guards the class
+# of failure the Node suite structurally cannot see: specifiers or APIs that
+# resolve in Node but not in a browser (issue #404; the `node:path` incident
+# on #405).
+#
+# Detection is instrumentation-based, not keyword-based: a script injected
+# ahead of the module records window "error" events (capture phase, so
+# failed module/resource loads count), unhandled promise rejections, and
+# console.error calls, then stamps the count into the DOM where the dumped
+# document can be asserted. Chrome's own exit status and stderr are
+# additional failure triggers.
+#
+# Usage:
+#   browser_smoke.sh              run the check against ../docs
+#   browser_smoke.sh --self-test  run the negative fixtures (a page with a
+#                                 console error, an occupied port, a failing
+#                                 browser binary) and require each to fail
+#
+# Env: CHROME_BIN, SMOKE_PORT, SMOKE_DOCS_DIR override discovery.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/$(basename "$0")"
+DOCS_DIR="$(cd "${SMOKE_DOCS_DIR:-$SCRIPT_DIR/../docs}" && pwd)"
+OUT_DIR="$(mktemp -d)"
+SERVER_PID=""
+CHROME_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
+  if [ -n "$CHROME_PID" ]; then kill "$CHROME_PID" 2>/dev/null || true; fi
+  rm -rf "$OUT_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "browser smoke: $*" >&2
+  exit 1
+}
+
+find_chrome() {
+  if [ -n "${CHROME_BIN:-}" ]; then
+    echo "$CHROME_BIN"
+    return
+  fi
+  for candidate in google-chrome google-chrome-stable chromium-browser chromium \
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: every fixture below must make the main check FAIL.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+  CHROME="$(find_chrome)"
+  [ -n "$CHROME" ] || fail "no Chrome/Chromium binary found (set CHROME_BIN)"
+
+  # 1. A page that reports a generic console error (no keyword the old
+  #    grep would have matched) but otherwise looks healthy, including the
+  #    aria-invalid marker.
+  FIXTURE="$OUT_DIR/fixture-console-error"
+  mkdir -p "$FIXTURE"
+  cat > "$FIXTURE/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<input aria-invalid="true">
+<script>console.error("generic boom");</script>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$FIXTURE" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 1 FAILED: a page with a console error passed"
+  fi
+  echo "self-test 1 OK: generic console error is detected"
+
+  # 2. An occupied port serving the WRONG tree: the check must notice it
+  #    does not own the port instead of validating a stranger's content.
+  DECOY="$OUT_DIR/decoy"
+  mkdir -p "$DECOY"
+  cp "$DOCS_DIR/index.html" "$DECOY/index.html" 2>/dev/null || echo "<body></body>" > "$DECOY/index.html"
+  BUSY_PORT=$((30000 + RANDOM % 10000))
+  python3 -m http.server "$BUSY_PORT" --directory "$DECOY" >/dev/null 2>&1 &
+  DECOY_PID=$!
+  disown "$DECOY_PID" 2>/dev/null || true
+  sleep 1
+  if SMOKE_PORT="$BUSY_PORT" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    kill "$DECOY_PID" 2>/dev/null || true
+    fail "self-test 2 FAILED: an occupied port was treated as our server"
+  fi
+  kill "$DECOY_PID" 2>/dev/null || true
+  echo "self-test 2 OK: occupied/stale port is detected"
+
+  # 3. A browser binary that exits nonzero without producing output.
+  if CHROME_BIN="/bin/false" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 3 FAILED: a failing browser binary passed"
+  fi
+  echo "self-test 3 OK: nonzero browser exit is detected"
+
+  echo "browser smoke self-test OK: all negative fixtures fail as required"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Main check.
+# ---------------------------------------------------------------------------
+CHROME_BIN="$(find_chrome)"
+[ -n "$CHROME_BIN" ] || fail "no Chrome/Chromium binary found (set CHROME_BIN)"
+
+# Instrumented copy of the site: the injected script runs before the module
+# and records everything the page throws.
+SITE="$OUT_DIR/site"
+mkdir -p "$SITE"
+cp -R "$DOCS_DIR/." "$SITE/"
+python3 - "$SITE/index.html" <<'EOF'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+source = path.read_text()
+instrument = """<script>
+window.__smokeErrors = [];
+(function () {
+  var record = function (message) {
+    window.__smokeErrors.push(String(message));
+  };
+  window.addEventListener("error", function (event) {
+    record(event.message || (event.target && (event.target.src || event.target.href)) || "resource error");
+  }, true);
+  window.addEventListener("unhandledrejection", function (event) {
+    record(event.reason);
+  });
+  var original = console.error;
+  console.error = function () {
+    record(Array.prototype.join.call(arguments, " "));
+    original.apply(console, arguments);
+  };
+  window.addEventListener("load", function () {
+    setTimeout(function () {
+      var el = document.createElement("div");
+      el.id = "smoke-result";
+      el.setAttribute("data-errors", String(window.__smokeErrors.length));
+      el.setAttribute("data-detail", window.__smokeErrors.join(" | ").slice(0, 500));
+      document.body.appendChild(el);
+    }, 400);
+  });
+})();
+</script>"""
+marker = "<body>"
+assert marker in source, "index.html has no <body> tag to instrument"
+path.write_text(source.replace(marker, marker + instrument, 1))
+EOF
+
+# The server must provably be OURS: readiness is a nonce round-trip, not a
+# sleep, so an occupied port (our bind fails, a stranger answers) is caught.
+NONCE="smoke-nonce-$$-$RANDOM"
+echo "$NONCE" > "$SITE/$NONCE.txt"
+PORT="${SMOKE_PORT:-$((20000 + RANDOM % 20000))}"
+python3 -m http.server "$PORT" --directory "$SITE" >/dev/null 2>&1 &
+SERVER_PID=$!
+disown "$SERVER_PID" 2>/dev/null || true
+
+READY=""
+for _ in $(seq 1 20); do
+  BODY="$(curl -fsS --max-time 2 "http://127.0.0.1:$PORT/$NONCE.txt" 2>/dev/null || true)"
+  if [ "$BODY" = "$NONCE" ]; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+[ -n "$READY" ] || fail "server did not become ready on port $PORT (occupied by another process, or failed to start)"
+
+# Chrome occasionally lingers after dumping the DOM, so it runs in the
+# background with a deadline; a natural nonzero exit is a failure.
+"$CHROME_BIN" --headless=new --disable-gpu --no-first-run --no-sandbox \
+  --user-data-dir="$OUT_DIR/profile" --enable-logging=stderr \
+  --virtual-time-budget=5000 --dump-dom "http://127.0.0.1:$PORT/index.html" \
+  > "$OUT_DIR/dom.html" 2> "$OUT_DIR/console.log" &
+CHROME_PID=$!
+
+CHROME_STATUS=""
+for _ in $(seq 1 45); do
+  if ! kill -0 "$CHROME_PID" 2>/dev/null; then
+    wait "$CHROME_PID" && CHROME_STATUS=0 || CHROME_STATUS=$?
+    break
+  fi
+  if [ -s "$OUT_DIR/dom.html" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -z "$CHROME_STATUS" ] && kill -0 "$CHROME_PID" 2>/dev/null; then
+  sleep 2
+  kill "$CHROME_PID" 2>/dev/null || true
+  wait "$CHROME_PID" 2>/dev/null || true
+  CHROME_STATUS=0
+fi
+CHROME_PID=""
+if [ -n "$CHROME_STATUS" ] && [ "$CHROME_STATUS" -ne 0 ]; then
+  fail "browser exited with status $CHROME_STATUS"
+fi
+
+grep -q 'id="smoke-result"' "$OUT_DIR/dom.html" \
+  || fail "instrumentation marker missing — the page never finished loading"
+if ! grep -q 'data-errors="0"' "$OUT_DIR/dom.html"; then
+  DETAIL="$(grep -o 'data-detail="[^"]*"' "$OUT_DIR/dom.html" | head -1)"
+  fail "page-level errors recorded: ${DETAIL:-unknown}"
+fi
+# With no query parameters the project field is empty, so a successfully
+# loaded module runs refresh() and marks the field invalid. Static HTML
+# never contains this attribute; its presence proves app.mjs executed.
+grep -q 'aria-invalid="true"' "$OUT_DIR/dom.html" \
+  || fail "validation never ran — app.mjs did not execute in the browser"
+# Belt and braces: anything Chrome itself logs as an error still fails.
+if grep -Eiq 'CONSOLE.*\b(error|blocked|failed|uncaught)\b' "$OUT_DIR/console.log"; then
+  fail "browser stderr reported console errors"
+fi
+
+echo "browser smoke OK: module loaded, zero page-level errors, validation ran"

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -14,11 +14,12 @@
 #
 # Usage:
 #   browser_smoke.sh              run the check against ../docs
-#   browser_smoke.sh --self-test  run the four negative fixtures (a page
-#                                 with a console error, an occupied port, a
-#                                 failing browser binary, and a browser that
-#                                 writes healthy DOM then exits nonzero) and
-#                                 require each to fail
+#   browser_smoke.sh --self-test  run the negative fixtures and require each
+#                                 to fail: an immediate console error, an
+#                                 occupied port, a failing browser binary, a
+#                                 browser that writes healthy DOM then exits
+#                                 nonzero, and a console error delayed past
+#                                 the marker's creation
 #
 # Env: CHROME_BIN, SMOKE_PORT, SMOKE_DOCS_DIR override discovery.
 set -euo pipefail
@@ -125,6 +126,27 @@ FAKE
   fi
   echo "self-test 4 OK: nonzero exit after healthy DOM is detected"
 
+  # 5. A generic console error that fires AFTER the marker is created
+  #    (900 ms past load, inside the virtual-time budget). Only a live
+  #    marker — not a one-shot snapshot — catches this one.
+  DELAYED="$OUT_DIR/fixture-delayed-error"
+  mkdir -p "$DELAYED"
+  cat > "$DELAYED/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<input aria-invalid="true">
+<script>
+window.addEventListener("load", function () {
+  setTimeout(function () { console.error("generic delayed boom"); }, 900);
+});
+</script>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$DELAYED" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 5 FAILED: a delayed console error passed"
+  fi
+  echo "self-test 5 OK: post-snapshot delayed error is detected"
+
   echo "browser smoke self-test OK: all negative fixtures fail as required"
   exit 0
 fi
@@ -149,8 +171,20 @@ source = path.read_text()
 instrument = """<script>
 window.__smokeErrors = [];
 (function () {
+  // The marker is LIVE: every recorded error re-stamps it, so anything
+  // that fires before the DOM dump (the whole virtual-time budget) is
+  // reflected, not just errors before a one-shot snapshot.
+  var marker = null;
+  var stamp = function () {
+    if (!marker) {
+      return;
+    }
+    marker.setAttribute("data-errors", String(window.__smokeErrors.length));
+    marker.setAttribute("data-detail", window.__smokeErrors.join(" | ").slice(0, 500));
+  };
   var record = function (message) {
     window.__smokeErrors.push(String(message));
+    stamp();
   };
   window.addEventListener("error", function (event) {
     record(event.message || (event.target && (event.target.src || event.target.href)) || "resource error");
@@ -165,11 +199,10 @@ window.__smokeErrors = [];
   };
   window.addEventListener("load", function () {
     setTimeout(function () {
-      var el = document.createElement("div");
-      el.id = "smoke-result";
-      el.setAttribute("data-errors", String(window.__smokeErrors.length));
-      el.setAttribute("data-detail", window.__smokeErrors.join(" | ").slice(0, 500));
-      document.body.appendChild(el);
+      marker = document.createElement("div");
+      marker.id = "smoke-result";
+      document.body.appendChild(marker);
+      stamp();
     }, 400);
   });
 })();

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -14,9 +14,11 @@
 #
 # Usage:
 #   browser_smoke.sh              run the check against ../docs
-#   browser_smoke.sh --self-test  run the negative fixtures (a page with a
-#                                 console error, an occupied port, a failing
-#                                 browser binary) and require each to fail
+#   browser_smoke.sh --self-test  run the four negative fixtures (a page
+#                                 with a console error, an occupied port, a
+#                                 failing browser binary, and a browser that
+#                                 writes healthy DOM then exits nonzero) and
+#                                 require each to fail
 #
 # Env: CHROME_BIN, SMOKE_PORT, SMOKE_DOCS_DIR override discovery.
 set -euo pipefail

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -102,6 +102,27 @@ HTML
   fi
   echo "self-test 3 OK: nonzero browser exit is detected"
 
+  # 4. A browser that writes a healthy-looking instrumented DOM (markers
+  #    that would satisfy every DOM assertion), lingers briefly, and THEN
+  #    exits nonzero. Only honest exit-status reaping catches this one.
+  FAKE_CHROME="$OUT_DIR/fake-chrome-slow-nonzero.sh"
+  cat > "$FAKE_CHROME" <<'FAKE'
+#!/usr/bin/env bash
+cat <<'DOM'
+<html><body>
+<input aria-invalid="true">
+<div id="smoke-result" data-errors="0" data-detail=""></div>
+</body></html>
+DOM
+sleep 1
+exit 42
+FAKE
+  chmod +x "$FAKE_CHROME"
+  if CHROME_BIN="$FAKE_CHROME" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 4 FAILED: nonzero exit after healthy DOM passed"
+  fi
+  echo "self-test 4 OK: nonzero exit after healthy DOM is detected"
+
   echo "browser smoke self-test OK: all negative fixtures fail as required"
   exit 0
 fi
@@ -180,17 +201,19 @@ done
 [ -n "$READY" ] || fail "server did not become ready on port $PORT (occupied by another process, or failed to start)"
 
 # Chrome occasionally lingers after dumping the DOM, so it runs in the
-# background with a deadline; a natural nonzero exit is a failure.
+# background with a deadline. The child's exit status is ALWAYS reaped and
+# honored: a natural nonzero exit fails the check even when it happens
+# after a healthy-looking DOM was written. The only exempt exit is the
+# deliberate timeout kill below — and only when this script's own kill
+# succeeded, so a racing natural exit still surfaces its real status.
 "$CHROME_BIN" --headless=new --disable-gpu --no-first-run --no-sandbox \
   --user-data-dir="$OUT_DIR/profile" --enable-logging=stderr \
   --virtual-time-budget=5000 --dump-dom "http://127.0.0.1:$PORT/index.html" \
   > "$OUT_DIR/dom.html" 2> "$OUT_DIR/console.log" &
 CHROME_PID=$!
 
-CHROME_STATUS=""
 for _ in $(seq 1 45); do
   if ! kill -0 "$CHROME_PID" 2>/dev/null; then
-    wait "$CHROME_PID" && CHROME_STATUS=0 || CHROME_STATUS=$?
     break
   fi
   if [ -s "$OUT_DIR/dom.html" ]; then
@@ -198,14 +221,23 @@ for _ in $(seq 1 45); do
   fi
   sleep 1
 done
-if [ -z "$CHROME_STATUS" ] && kill -0 "$CHROME_PID" 2>/dev/null; then
-  sleep 2
-  kill "$CHROME_PID" 2>/dev/null || true
-  wait "$CHROME_PID" 2>/dev/null || true
-  CHROME_STATUS=0
+# Grace window: let a browser that already produced output finish and
+# report its real status instead of assuming success.
+for _ in $(seq 1 10); do
+  if ! kill -0 "$CHROME_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+TIMED_OUT_KILL=""
+if kill -0 "$CHROME_PID" 2>/dev/null; then
+  if kill "$CHROME_PID" 2>/dev/null; then
+    TIMED_OUT_KILL=1
+  fi
 fi
+wait "$CHROME_PID" && CHROME_STATUS=0 || CHROME_STATUS=$?
 CHROME_PID=""
-if [ -n "$CHROME_STATUS" ] && [ "$CHROME_STATUS" -ne 0 ]; then
+if [ -z "$TIMED_OUT_KILL" ] && [ "$CHROME_STATUS" -ne 0 ]; then
   fail "browser exited with status $CHROME_STATUS"
 fi
 

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -15,6 +15,7 @@
 import hashlib
 import importlib.util
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -574,12 +575,40 @@ def _chrome_available():
   ).exists()
 
 
-@pytest.mark.skipif(
-    not _chrome_available(), reason="No Chrome/Chromium available"
-)
+def _browser_gate_disposition(chrome_available, in_ci):
+  """A missing browser may downgrade the gate locally, never in CI.
+
+  Returns "run" or "skip"; raises when the required merge gate would be
+  silently lost (CI without a browser must be a hard failure, not a skip).
+  """
+  if chrome_available:
+    return "run"
+  if in_ci:
+    raise AssertionError(
+        "Chrome/Chromium is missing on a CI runner: the browser gate would"
+        " be silently skipped inside a required check. Provision a browser"
+        " or fail loudly — do not skip."
+    )
+  return "skip"
+
+
+def test_browser_gate_cannot_silently_skip_in_ci():
+  assert _browser_gate_disposition(True, True) == "run"
+  assert _browser_gate_disposition(True, False) == "run"
+  assert _browser_gate_disposition(False, False) == "skip"
+  with pytest.raises(AssertionError, match="silently skipped"):
+    _browser_gate_disposition(False, True)
+
+
 def test_configurator_loads_in_a_real_browser():
   # Runs inside the required Test (Python N) checks so the browser-level
   # gate is enforced by the existing main ruleset, not by an optional job.
+  # In CI a missing browser is a hard failure (see disposition above).
+  disposition = _browser_gate_disposition(
+      _chrome_available(), bool(os.environ.get("CI"))
+  )
+  if disposition == "skip":
+    pytest.skip("No Chrome/Chromium available outside CI")
   subprocess.run(
       ["bash", "tools/browser_smoke.sh"],
       cwd=DASHBOARD,

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -560,6 +560,33 @@ def test_browser_configurator_javascript_contract():
   )
 
 
+def _chrome_available():
+  candidates = [
+      "google-chrome",
+      "google-chrome-stable",
+      "chromium-browser",
+      "chromium",
+  ]
+  if any(shutil.which(c) for c in candidates):
+    return True
+  return Path(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  ).exists()
+
+
+@pytest.mark.skipif(
+    not _chrome_available(), reason="No Chrome/Chromium available"
+)
+def test_configurator_loads_in_a_real_browser():
+  # Runs inside the required Test (Python N) checks so the browser-level
+  # gate is enforced by the existing main ruleset, not by an optional job.
+  subprocess.run(
+      ["bash", "tools/browser_smoke.sh"],
+      cwd=DASHBOARD,
+      check=True,
+  )
+
+
 def test_googlecloudplatform_pages_configuration():
   page = (DASHBOARD / "docs/index.html").read_text()
   styles = (DASHBOARD / "docs/styles.css").read_text()

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -616,6 +616,23 @@ def test_configurator_loads_in_a_real_browser():
   )
 
 
+def test_browser_smoke_negative_fixtures_are_detected():
+  # The four negative fixtures — including the nonzero-exit-after-healthy-
+  # DOM regression — must be enforced by the required Test checks, not
+  # only by the optional standalone smoke job: a reintroduced false-pass
+  # path has to turn a REQUIRED check red.
+  disposition = _browser_gate_disposition(
+      _chrome_available(), bool(os.environ.get("CI"))
+  )
+  if disposition == "skip":
+    pytest.skip("No Chrome/Chromium available outside CI")
+  subprocess.run(
+      ["bash", "tools/browser_smoke.sh", "--self-test"],
+      cwd=DASHBOARD,
+      check=True,
+  )
+
+
 def test_googlecloudplatform_pages_configuration():
   page = (DASHBOARD / "docs/index.html").read_text()
   styles = (DASHBOARD / "docs/styles.css").read_text()

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -617,10 +617,11 @@ def test_configurator_loads_in_a_real_browser():
 
 
 def test_browser_smoke_negative_fixtures_are_detected():
-  # The four negative fixtures — including the nonzero-exit-after-healthy-
-  # DOM regression — must be enforced by the required Test checks, not
-  # only by the optional standalone smoke job: a reintroduced false-pass
-  # path has to turn a REQUIRED check red.
+  # The five negative fixtures — including nonzero-exit-after-healthy-DOM
+  # and the delayed error that only the live marker reflects (the 5 s
+  # virtual-time budget is the observation window) — must be enforced by
+  # the required Test checks, not only by the optional standalone smoke
+  # job: a reintroduced false-pass path has to turn a REQUIRED check red.
   disposition = _browser_gate_disposition(
       _chrome_available(), bool(os.environ.get("CI"))
   )


### PR DESCRIPTION
## Summary

Adds the browser-level gate from #404: the Node suite structurally cannot see browser-only failures — the `node:path` incident on #405 shipped past a green suite and briefly made the production page inert.

Branch is synced with current `main` (post-#412/#413).

## Enforcement — everything rides the REQUIRED Test checks

The active `main` ruleset requires only `Format check` and `Test (Python 3.10–3.14)`, so both the positive gate **and the negative fixtures** run inside pytest:

- `test_configurator_loads_in_a_real_browser` — the positive smoke.
- `test_browser_smoke_negative_fixtures_are_detected` — runs `browser_smoke.sh --self-test`; a reintroduced false-pass path turns a **required** check red, not just the optional job.
- **Missing Chrome in CI is a hard failure, not a skip**: `_browser_gate_disposition` raises when `CI` is set and no browser is found, skips only outside CI, unit-tested for all four combinations. A runner image losing Chrome cannot silently drop the gate.
- The standalone `Configurator browser smoke` job remains as a fast signal; nothing depends on it being required.

## The check itself — no false-pass paths

- **Live error marker**: an injected script (ahead of the module) records capture-phase `error` events (failed module/resource loads included), unhandled rejections, and `console.error` calls, and **re-stamps `#smoke-result` on every recorded error** — the dumped DOM reflects the entire observation window, not a post-load snapshot. **The observation window is the 5-second virtual-time budget**; an error scheduled beyond it is invisible to any dump-based check by construction — that budget is the stated contract.
- **Port ownership proven**: randomized high port + nonce round-trip; an occupied or stale port fails instead of validating a stranger's content.
- **Exit status always reaped**: the child's natural exit status is honored even after a healthy-looking DOM; the only exempt exit is a timeout kill this script itself delivered (guarded against a racing natural exit).

## Negative fixtures — FIVE, all must fail, all enforced in the required path

`browser_smoke.sh --self-test`: (1) an immediate generic console error; (2) an occupied port serving the wrong tree; (3) a browser binary exiting nonzero with no output; (4) a browser that writes a healthy instrumented DOM, lingers, then exits 42 — the exit-status pin; (5) **a generic console error delayed 900 ms past load — the live-marker pin**. Runs in the required pytest path *and* as a step in the standalone job.

## Verification

At this head: positive smoke green, all five fixtures detected, dashboard pytest 25/25; a 4.9 s error inside the window is caught (reviewer-verified).

Part of #404.