### PR TITLE
[Dashboard/configurator] Trust cluster: wait expectation, dialog pre-empt, Google Cloud palette (#398 #399 #400)

### DIFF
--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -130,7 +130,7 @@ inputs.billingProject.addEventListener("input", refresh);
 
 const WAITING_MESSAGE =
   "Opening Looker Studio in a new tab. Building your report copy can take " +
-  "up to ~15 seconds and may briefly show an error page — don’t close it.";
+  "up to ~10 seconds and may briefly show an error page — don’t close it.";
 
 form.addEventListener("submit", (event) => {
   event.preventDefault();

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -128,10 +128,15 @@ for (const input of tableInputs) {
 
 inputs.billingProject.addEventListener("input", refresh);
 
+const WAITING_MESSAGE =
+  "Opening Looker Studio in a new tab. Building your report copy can take " +
+  "up to ~15 seconds and may briefly show an error page — don’t close it.";
+
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   refresh();
   if (createLink.href) {
+    setStatus(WAITING_MESSAGE, "waiting");
     window.open(createLink.href, "_blank", "noopener,noreferrer");
   }
 });
@@ -140,7 +145,9 @@ createLink.addEventListener("click", (event) => {
   if (!createLink.href) {
     event.preventDefault();
     refresh();
+    return;
   }
+  setStatus(WAITING_MESSAGE, "waiting");
 });
 
 copyButton.addEventListener("click", async () => {

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -76,6 +76,18 @@ installations, in this order:
 Malformed metadata values use `SAFE_CAST` and fall through instead of
 aborting every report chart.
 
+## Configurator release checks
+
+Every configurator release and every template republish re-runs the dated
+acknowledgement-dialog comparison required by issue #399: a maintainer
+opens the real authenticated Linking API flow, confirms the configurator's
+step-02 description still matches the acknowledgement dialog Looker Studio
+actually shows, and records the date and result on #399. The step-02 copy
+must not drift from the live dialog between releases. The stated
+provisioning duration in the configurator comes from measured cold-cache
+runs recorded on #398; the test suite forces the static note and the
+click-time status message to state the same value.
+
 ## Pages and chart inventory
 
 The report implements all 37 manifest charts plus one non-parity Trace

--- a/dashboard/looker_studio/docs/favicon.svg
+++ b/dashboard/looker_studio/docs/favicon.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="BigQuery Agent Analytics">
-  <rect width="64" height="64" rx="14" fill="#096b5a"/>
+  <rect width="64" height="64" rx="14" fill="#1967d2"/>
   <path d="M17 18h12v12H17zm18 0h12v12H35zM17 36h12v12H17zm18 0h12v12H35z" fill="#fff"/>
-  <circle cx="23" cy="24" r="3" fill="#7dd3c7"/>
+  <circle cx="23" cy="24" r="3" fill="#8ab4f8"/>
   <circle cx="41" cy="42" r="3" fill="#f9ab00"/>
   <path d="M26 26l12 12M29 42h6M41 30v6" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -167,9 +167,10 @@
           <span class="step-number">02</span>
           <h3>Review in Google</h3>
           <p>
-            After a short provisioning wait, Looker Studio shows an
-            acknowledgement dialog. It appears because you’re about to create
-            a data source that runs a SQL query this page supplied —
+            The new tab may briefly show a loading or “not found” page while
+            Google provisions your copy — don’t close it. Looker Studio then
+            shows an acknowledgement dialog. It appears because you’re about
+            to create a data source that runs a SQL query this page supplied —
             <a href="https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/dashboard/looker_studio/sql/events_v1.template.sql">
               read the exact query</a>. The dialog lists that query, your
             billing project, and the new data source’s owner; nothing is

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -140,7 +140,7 @@
           </div>
           <p class="create-note" id="create-wait-note">
             Opens <code>lookerstudio.google.com</code> in a new tab. Building
-            your private copy can take up to ~15 seconds, and the tab may
+            your private copy can take up to ~10 seconds, and the tab may
             briefly show an error page while Google provisions the report —
             don’t close it.
           </p>
@@ -173,9 +173,10 @@
             to create a data source that runs a SQL query this page supplied —
             <a href="https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/dashboard/looker_studio/sql/events_v1.template.sql">
               read the exact query</a>. The dialog lists that query, your
-            billing project, and the new data source’s owner; nothing is
-            created until you acknowledge it. The query reads only your
-            table, with your credentials, in your billing project.
+            billing project, and that the new data source initially uses
+            Owner’s Credentials; nothing is created until you acknowledge it.
+            The query reads only your table, using the opener’s credentials,
+            in your billing project.
           </p>
         </article>
         <article class="step">

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="Create a private Looker Studio dashboard from your BigQuery Agent Analytics installation."
     >
-    <meta name="theme-color" content="#096b5a">
+    <meta name="theme-color" content="#1967d2">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Configure BigQuery Agent Analytics">
     <meta
@@ -132,14 +132,24 @@
               target="_blank"
               rel="noopener noreferrer"
               aria-disabled="true"
+              aria-describedby="create-wait-note"
             >Create my dashboard</a>
             <button class="button button-secondary" id="copy-link" type="button">
               Copy setup link
             </button>
           </div>
+          <p class="create-note" id="create-wait-note">
+            Opens <code>lookerstudio.google.com</code> in a new tab. Building
+            your private copy can take up to ~15 seconds, and the tab may
+            briefly show an error page while Google provisions the report —
+            don’t close it.
+          </p>
           <p class="privacy">
             This page has no backend. It sends no identifiers or credentials
             to the template owner; it only creates a Google Looker Studio URL.
+            <a href="https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main/dashboard/looker_studio/docs">
+              Verify in this page’s source.
+            </a>
           </p>
         </form>
       </section>
@@ -157,8 +167,14 @@
           <span class="step-number">02</span>
           <h3>Review in Google</h3>
           <p>
-            Looker Studio shows the substituted custom query and billing
-            project before creating anything.
+            After a short provisioning wait, Looker Studio shows an
+            acknowledgement dialog. It appears because you’re about to create
+            a data source that runs a SQL query this page supplied —
+            <a href="https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/dashboard/looker_studio/sql/events_v1.template.sql">
+              read the exact query</a>. The dialog lists that query, your
+            billing project, and the new data source’s owner; nothing is
+            created until you acknowledge it. The query reads only your
+            table, with your credentials, in your billing project.
           </p>
         </article>
         <article class="step">
@@ -172,7 +188,7 @@
         </article>
       </section>
 
-      <aside class="notice">
+      <aside class="notice notice-warning">
         <strong>Keep the new report private until the credential check.</strong>
         The Linking API creates a data source owned by the person opening the
         link and its review dialog can show Owner’s Credentials. In the saved

--- a/dashboard/looker_studio/docs/styles.css
+++ b/dashboard/looker_studio/docs/styles.css
@@ -1,15 +1,21 @@
 :root {
   color-scheme: light dark;
-  --ink: #17212b;
-  --muted: #5b6672;
-  --line: #dce3e8;
+  --ink: #202124;
+  --muted: #5f6368;
+  --line: #dadce0;
   --paper: #ffffff;
-  --canvas: #f3f6f5;
-  --green: #096b5a;
-  --green-dark: #064c40;
-  --green-soft: #e5f3ef;
-  --orange: #c95f25;
-  --shadow: 0 24px 70px rgba(24, 45, 39, 0.12);
+  --canvas: #f8f9fa;
+  /* Google Blue: 600 (#1a73e8) sits at ~4.4:1 against white, borderline for
+     AA normal text, so it is reserved for focus rings and UI borders (3:1).
+     Text and button fills use Blue 700/900, both comfortably over 4.5:1. */
+  --action: #1967d2;
+  --action-dark: #174ea6;
+  --action-soft: #e8f0fe;
+  --focus: #1a73e8;
+  --warning: #b06000;
+  --error: #c5221f;
+  --input-border: #80868b;
+  --shadow: 0 24px 70px rgba(60, 64, 67, 0.15);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -24,8 +30,8 @@ body {
   margin: 0;
   color: var(--ink);
   background:
-    radial-gradient(circle at 12% 4%, rgba(9, 107, 90, 0.12), transparent 27rem),
-    linear-gradient(145deg, #f7f9f8 0%, var(--canvas) 60%, #edf2f0 100%);
+    radial-gradient(circle at 12% 4%, rgba(26, 115, 232, 0.1), transparent 27rem),
+    linear-gradient(145deg, #f8f9fa 0%, var(--canvas) 60%, #f1f3f4 100%);
 }
 
 main {
@@ -36,7 +42,7 @@ main {
 
 .eyebrow,
 .step-number {
-  color: var(--green);
+  color: var(--action);
   font-size: 0.75rem;
   font-weight: 750;
   letter-spacing: 0.12em;
@@ -78,9 +84,9 @@ h1 {
 
 .facts li {
   padding: 8px 12px;
-  border: 1px solid rgba(9, 107, 90, 0.18);
+  border: 1px solid rgba(25, 103, 210, 0.24);
   border-radius: 999px;
-  color: var(--green-dark);
+  color: var(--action-dark);
   background: rgba(255, 255, 255, 0.68);
   font-size: 0.84rem;
   font-weight: 650;
@@ -88,7 +94,7 @@ h1 {
 
 .card {
   padding: 30px;
-  border: 1px solid rgba(220, 227, 232, 0.9);
+  border: 1px solid rgba(218, 220, 224, 0.9);
   border-radius: 22px;
   background: var(--paper);
   box-shadow: var(--shadow);
@@ -118,7 +124,7 @@ input {
   width: 100%;
   min-height: 48px;
   padding: 0 13px;
-  border: 1px solid #bdc9c5;
+  border: 1px solid var(--input-border);
   border-radius: 10px;
   color: var(--ink);
   background: #fbfcfc;
@@ -130,8 +136,8 @@ input {
 }
 
 input:focus {
-  border-color: var(--green);
-  box-shadow: 0 0 0 3px rgba(9, 107, 90, 0.12);
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.16);
 }
 
 .field-hint,
@@ -148,13 +154,13 @@ input:focus {
 
 .field-error {
   min-height: 1.05rem;
-  color: #a33b26;
+  color: var(--error);
   font-weight: 650;
 }
 
 input[aria-invalid="true"] {
-  border-color: #a33b26;
-  box-shadow: 0 0 0 3px rgba(163, 59, 38, 0.1);
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px rgba(197, 34, 31, 0.1);
 }
 
 details {
@@ -164,7 +170,7 @@ details {
 }
 
 summary {
-  color: var(--green-dark);
+  color: var(--action-dark);
   font-size: 0.82rem;
   font-weight: 750;
   cursor: pointer;
@@ -178,11 +184,16 @@ summary {
 }
 
 #form-status[data-kind="ready"] {
-  color: var(--green);
+  color: var(--action);
+}
+
+#form-status[data-kind="waiting"] {
+  color: var(--action-dark);
+  font-weight: 650;
 }
 
 #form-status[data-kind="error"] {
-  color: #a33b26;
+  color: var(--error);
 }
 
 .actions {
@@ -206,18 +217,24 @@ summary {
   cursor: pointer;
 }
 
+.button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
 .button-primary {
   color: white;
-  background: var(--green);
+  background: var(--action);
 }
 
 .button-primary:hover {
-  background: var(--green-dark);
+  background: var(--action-dark);
 }
 
 .button-secondary {
-  color: var(--green-dark);
-  background: var(--green-soft);
+  color: var(--action-dark);
+  background: var(--action-soft);
 }
 
 .button[aria-disabled="true"],
@@ -226,11 +243,23 @@ summary {
   opacity: 0.48;
 }
 
+.create-note {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
 .privacy {
   margin: 16px 0 0;
   color: var(--muted);
   font-size: 0.74rem;
   line-height: 1.45;
+}
+
+.privacy a,
+.create-note a {
+  color: var(--action-dark);
 }
 
 .how {
@@ -257,14 +286,22 @@ summary {
   line-height: 1.55;
 }
 
+.step a {
+  color: var(--action-dark);
+}
+
 .notice {
   margin-top: 28px;
   padding: 17px 20px;
-  border-left: 3px solid var(--orange);
+  border-left: 3px solid var(--action);
   background: rgba(255, 255, 255, 0.58);
   color: var(--muted);
   font-size: 0.82rem;
   line-height: 1.55;
+}
+
+.notice-warning {
+  border-left-color: var(--warning);
 }
 
 .notice strong {
@@ -281,7 +318,7 @@ summary {
   border: 1px solid var(--line);
   border-radius: 18px;
   background: var(--paper);
-  box-shadow: 0 14px 44px rgba(24, 45, 39, 0.08);
+  box-shadow: 0 14px 44px rgba(60, 64, 67, 0.1);
 }
 
 .post-create h2 {
@@ -324,51 +361,67 @@ footer {
 }
 
 footer a {
-  color: var(--green-dark);
+  color: var(--action-dark);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --ink: #edf5f2;
-    --muted: #b8c7c2;
-    --line: #3c4a46;
-    --paper: #17221f;
-    --canvas: #0f1715;
-    --green: #7dd3c7;
-    --green-dark: #a6e4dc;
-    --green-soft: #243b36;
-    --orange: #f6a06d;
+    --ink: #e8eaed;
+    --muted: #9aa0a6;
+    --line: #3c4043;
+    --paper: #202124;
+    --canvas: #17181b;
+    --action: #8ab4f8;
+    --action-dark: #aecbfa;
+    --action-soft: #2d3140;
+    --focus: #8ab4f8;
+    --warning: #fdd663;
+    --error: #f28b82;
+    --input-border: #9aa0a6;
     --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
   }
 
   body {
     background:
-      radial-gradient(circle at 12% 4%, rgba(125, 211, 199, 0.12), transparent 27rem),
-      linear-gradient(145deg, #111b18 0%, var(--canvas) 60%, #0c1311 100%);
+      radial-gradient(circle at 12% 4%, rgba(138, 180, 248, 0.1), transparent 27rem),
+      linear-gradient(145deg, #17181b 0%, var(--canvas) 60%, #141518 100%);
   }
 
   .facts li,
   .notice {
-    background: rgba(23, 34, 31, 0.78);
+    background: rgba(32, 33, 36, 0.78);
+  }
+
+  .facts li {
+    border-color: rgba(138, 180, 248, 0.3);
   }
 
   input {
-    border-color: #53645f;
-    background: #111a18;
+    border-color: var(--input-border);
+    background: #1a1c1f;
+  }
+
+  input:focus {
+    box-shadow: 0 0 0 3px rgba(138, 180, 248, 0.2);
+  }
+
+  input[aria-invalid="true"] {
+    border-color: var(--error);
+    box-shadow: 0 0 0 3px rgba(242, 139, 130, 0.14);
   }
 
   #form-status[data-kind="error"],
   .field-error {
-    color: #ffb19d;
+    color: var(--error);
   }
 
   .button-primary {
-    color: #0b1714;
-    background: #7dd3c7;
+    color: #202124;
+    background: var(--action);
   }
 
   .button-primary:hover {
-    background: #a6e4dc;
+    background: var(--action-dark);
   }
 }
 

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -60,6 +60,32 @@ assert.match(pageSource, /sql\/events_v1\.template\.sql/);
 assert.match(pageSource, /class="notice notice-warning"/);
 assert.doesNotMatch(pageSource, /#096b5a/);
 
+// #398 requires the transient-error warning both at the button AND in
+// step 02, and the stated duration must be the same everywhere it appears.
+const dontClose = pageSource.match(/don’t close it/g) ?? [];
+assert.ok(
+  dontClose.length >= 2,
+  "the do-not-close warning must appear at the button and in step 02",
+);
+assert.match(
+  pageSource,
+  /provisions your copy — don’t close it\. Looker Studio then\s+shows an acknowledgement dialog/,
+  "step 02 must repeat the transient-error warning before the dialog",
+);
+
+const appSource = readFileSync(
+  new URL("../docs/app.mjs", import.meta.url),
+  "utf8",
+);
+const waitingDuration = appSource.match(/up to (~\d+ seconds)/)?.[1];
+const noteDuration = pageSource.match(/up to\s+(~\d+ seconds)/s)?.[1];
+assert.ok(waitingDuration, "WAITING_MESSAGE must state a duration");
+assert.equal(
+  noteDuration,
+  waitingDuration,
+  "the static wait note and WAITING_MESSAGE must state the same duration",
+);
+
 const stylesSource = readFileSync(
   new URL("../docs/styles.css", import.meta.url),
   "utf8",

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -50,6 +50,26 @@ assert.match(
 );
 assert.match(pageSource, /allow up to 90 seconds/);
 
+// Trust-cluster contract (#398/#399/#400): the wait expectation is set
+// before the click, the acknowledgement dialog is explained with a link to
+// the exact SQL, and the palette carries no legacy teal.
+assert.match(pageSource, /aria-describedby="create-wait-note"/);
+assert.match(pageSource, /id="create-wait-note"/);
+assert.match(pageSource, /lookerstudio\.google\.com/);
+assert.match(pageSource, /sql\/events_v1\.template\.sql/);
+assert.match(pageSource, /class="notice notice-warning"/);
+assert.doesNotMatch(pageSource, /#096b5a/);
+
+const stylesSource = readFileSync(
+  new URL("../docs/styles.css", import.meta.url),
+  "utf8",
+);
+assert.match(stylesSource, /--action: #1967d2/);
+assert.match(stylesSource, /--focus: #1a73e8/);
+assert.match(stylesSource, /\.notice-warning/);
+assert.match(stylesSource, /@media \(prefers-color-scheme: dark\)/);
+assert.doesNotMatch(stylesSource, /#096b5a|#7dd3c7|#a6e4dc/);
+
 const values = {
   project: "customer-project-123",
   dataset: "agent_analytics",
@@ -630,6 +650,61 @@ for (const field of ["project", "dataset", "table"]) {
     `qualified ID pasted into ${field} fills all identifier fields`,
   );
 }
+
+// #398: clicking the enabled create link sets the provisioning expectation
+// without blocking navigation, and the message clears on the next change.
+resetTableInputs();
+fakeElements.get("#project").listeners.input({
+  target: fakeElements.get("#project"),
+});
+assert.match(fakeElements.get("#form-status").textContent, /^Ready for /);
+
+let navigationPrevented = false;
+fakeElements.get("#create-dashboard").listeners.click({
+  preventDefault() {
+    navigationPrevented = true;
+  },
+});
+assert.equal(
+  navigationPrevented,
+  false,
+  "an enabled create link must still navigate",
+);
+assert.match(
+  fakeElements.get("#form-status").textContent,
+  /may briefly show an error page/,
+  "clicking the enabled link warns about the provisioning delay",
+);
+assert.equal(fakeElements.get("#form-status").dataset.kind, "waiting");
+
+fakeElements.get("#project").listeners.input({
+  target: fakeElements.get("#project"),
+});
+assert.doesNotMatch(
+  fakeElements.get("#form-status").textContent,
+  /error page/,
+  "the waiting message clears on the next valid state change",
+);
+
+fakeElements.get("#configurator").listeners.submit({ preventDefault() {} });
+assert.equal(
+  fakeElements.get("#form-status").dataset.kind,
+  "waiting",
+  "submitting the form sets the same provisioning expectation",
+);
+
+fakeElements.get("#create-dashboard").href = "";
+navigationPrevented = false;
+fakeElements.get("#create-dashboard").listeners.click({
+  preventDefault() {
+    navigationPrevented = true;
+  },
+});
+assert.equal(
+  navigationPrevented,
+  true,
+  "a disabled create link must not navigate",
+);
 
 console.log(
   "web configurator OK: identifiers and sentinels validated; Linking API URL deterministic",

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -668,6 +668,13 @@ def test_googlecloudplatform_pages_configuration():
   assert "#096b5a" not in page
   assert "#096b5a" not in styles
 
+  # The recurring #399 dialog verification is a durable release control,
+  # not an issue comment: it must stay in the implementation contract.
+  impl = (DASHBOARD / "docs/dashboard-implementation.md").read_text()
+  assert "## Configurator release checks" in impl
+  assert "acknowledgement-dialog comparison" in impl
+  assert "every template republish" in impl
+
   workflow = (ROOT / ".github/workflows/looker-studio-pages.yml").read_text()
   assert "path: dashboard/looker_studio/docs" in workflow
   assert "pages: write" in workflow

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -660,6 +660,7 @@ def test_googlecloudplatform_pages_configuration():
   # explanation with the exact SQL linked, and the Google Blue palette.
   assert 'content="#1967d2"' in page
   assert "create-wait-note" in page
+  assert page.count("don’t close it") >= 2  # at the button AND in step 02
   assert "lookerstudio.google.com" in page
   assert "sql/events_v1.template.sql" in page
   assert 'class="notice notice-warning"' in page

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -656,6 +656,17 @@ def test_googlecloudplatform_pages_configuration():
   assert "@media (prefers-color-scheme: dark)" in styles
   assert (DASHBOARD / "docs/favicon.svg").is_file()
 
+  # Trust cluster (#398/#399/#400): pre-click wait expectation, dialog
+  # explanation with the exact SQL linked, and the Google Blue palette.
+  assert 'content="#1967d2"' in page
+  assert "create-wait-note" in page
+  assert "lookerstudio.google.com" in page
+  assert "sql/events_v1.template.sql" in page
+  assert 'class="notice notice-warning"' in page
+  assert "--action: #1967d2" in styles
+  assert "#096b5a" not in page
+  assert "#096b5a" not in styles
+
   workflow = (ROOT / ".github/workflows/looker-studio-pages.yml").read_text()
   assert "path: dashboard/looker_studio/docs" in workflow
   assert "pages: write" in workflow


### PR DESCRIPTION
## Summary

Lands the #404 trust cluster in one PR, per the plan: the three consecutive first-run impressions are one trust problem, so they ship together.

**#398 — the transient error page.** The enabled `#create-dashboard` anchor sets a persistent waiting status on click; the same expectation is set *before* the click by a static note tied to the button with `aria-describedby`, **and repeated in step 02** before the dialog description. The message clears on the next state change (tested); the do-not-close warning is pinned to appear at least twice (button + step 02) in both the Node suite and pytest; a consistency test forces `WAITING_MESSAGE` and the static note to state the same duration. Three authenticated hard-reload runs measured 9.657 s, 8.446 s, and 8.341 s to rendered report, so both copies now say **“up to ~10 seconds.”**

**#399 — pre-empting the acknowledgement dialog.** Step 02 mirrors the dialog (why it appears, what it lists) with a link to [the exact SQL](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/dashboard/looker_studio/sql/events_v1.template.sql); the no-backend claim is paired with a view-source link; `lookerstudio.google.com` is named at the button. The dated authenticated comparison confirmed the current dialog’s custom SQL, billing project, and **Owner’s Credentials** mode; the prose now uses that exact credential-mode wording. **The recurring dated dialog verification is a durable repo control**: a “Configurator release checks” section in `docs/dashboard-implementation.md` requires it on every configurator release and template republish, pinned by pytest so it cannot silently disappear.

**#400 — palette phase only** (per the #400 amendment). Teal → Google Blue with WCAG driving the mapping: Blue 600 `#1a73e8` measures ~4.4:1 on white (borderline for AA text), so fills/text use Blue 700 `#1967d2` / Blue 900 `#174ea6` and `#1a73e8` is reserved for focus rings and borders; warning vs informational notice tiers; dark theme re-derived on Google dark tokens; `theme-color` + favicon updated. Typography/lockup deferred.

## Verification

At head `5ebf36c`, rebased onto current `main`:

- `node dashboard/looker_studio/tools/test_web_configurator.mjs`
- `pytest -q tests/test_looker_studio_dashboard.py` — 25 passed
- `bash dashboard/looker_studio/tools/browser_smoke.sh`
- `bash dashboard/looker_studio/tools/browser_smoke.sh --self-test` — all five negative fixtures detected

## Maintainer evidence gates — complete

1. **#398 timings:** [three authenticated hard-reload measurements recorded on #398](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/398#issuecomment-5249610893); measured copy applied at this head.
2. **#399 dated dialog comparison:** [current authenticated dialog compared and recorded on #399](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/399#issuecomment-5249611089); the one wording mismatch was corrected at this head.

Part of #404. Closes #398. Closes #399. #400 stays open (palette phase delivered; typography/lockup deferred).
