### PR TITLE
ci: harden GitHub Actions workflows for Zizmor enablement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Format check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -67,7 +67,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [format, test]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: no job here needs write access to repo contents.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -29,9 +33,11 @@ jobs:
     name: Format check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -61,9 +67,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -78,9 +86,11 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [format, test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -97,7 +107,7 @@ jobs:
           ls -la dist/
           ls dist/ | grep "${VERSION}" || (echo "Version mismatch in built artifacts" && exit 1)
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/looker-studio-pages.yml
+++ b/.github/workflows/looker-studio-pages.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:

--- a/.github/workflows/producers-ci.yml
+++ b/.github/workflows/producers-ci.yml
@@ -51,7 +51,7 @@ jobs:
     name: Producers format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -76,7 +76,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [format, test]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -142,7 +142,7 @@ jobs:
         # build context (unlike the other jobs, which run in producers/).
         working-directory: .
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
       - name: Build the receiver image (hash-locked deps)
@@ -161,7 +161,7 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
       - name: Regenerate locks with the exact pinned generator

--- a/.github/workflows/producers-ci.yml
+++ b/.github/workflows/producers-ci.yml
@@ -34,6 +34,10 @@ on:
       - '.github/workflows/producers-ci.yml'
       - '.github/workflows/release-tracing.yml'
 
+# Least privilege: all jobs are build/test only.
+permissions:
+  contents: read
+
 concurrency:
   group: producers-ci-${{ github.ref }}
   cancel-in-progress: true
@@ -48,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -71,6 +77,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -88,6 +96,8 @@ jobs:
     needs: [format, test]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -133,6 +143,8 @@ jobs:
         working-directory: .
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - name: Build the receiver image (hash-locked deps)
         run: |
           VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('producers/pyproject.toml','rb'))['project']['version'])")
@@ -150,6 +162,8 @@ jobs:
         working-directory: .
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - name: Regenerate locks with the exact pinned generator
         run: bash deploy/otlp_receiver/regen-locks.sh
       - name: Locks must match the reviewed files (all three)

--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -139,7 +139,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -201,15 +201,19 @@ jobs:
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
       staging_ref: ${{ steps.digest.outputs.staging_ref }}
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      RUN_ID: ${{ github.run_id }}
+      RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
       - name: Build image (repo root context, per Dockerfile contract)
         run: |
           docker build -f deploy/otlp_receiver/Dockerfile \
-            -t "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}.${{ github.run_attempt }}" .
+            -t "${STAGING_IMAGE}:${VERSION}-candidate.${RUN_ID}.${RUN_ATTEMPT}" .
 
       - name: Self-test image BEFORE anything is pushed (checked-in script)
         # deploy/otlp_receiver/selftest.sh — also executed by PR CI, so
@@ -218,8 +222,8 @@ jobs:
         # host installs while this job holds id-token: write).
         id: selftest
         run: |
-          IMG="${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}.${{ github.run_attempt }}"
-          bash deploy/otlp_receiver/selftest.sh "$IMG" "${{ needs.verify.outputs.version }}" | tee selftest.log
+          IMG="${STAGING_IMAGE}:${VERSION}-candidate.${RUN_ID}.${RUN_ATTEMPT}"
+          bash deploy/otlp_receiver/selftest.sh "$IMG" "${VERSION}" | tee selftest.log
           echo "image_id=$(grep '^SELFTEST_IMAGE_ID=' selftest.log | cut -d= -f2)" >> "$GITHUB_OUTPUT"
 
       - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
@@ -228,14 +232,16 @@ jobs:
           service_account: ${{ env.RELEASE_SA }}
 
       - name: Push candidate to the private staging repo
+        env:
+          SELFTEST_IMAGE_ID: ${{ steps.selftest.outputs.image_id }}
         # The image ID is re-checked against the one the self-test ran:
         # nothing that executed since (including the auth action) can
         # swap in untested bytes.
         run: |
-          IMG="${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}.${{ github.run_attempt }}"
+          IMG="${STAGING_IMAGE}:${VERSION}-candidate.${RUN_ID}.${RUN_ATTEMPT}"
           NOW=$(docker inspect "$IMG" --format '{{.Id}}')
-          test "$NOW" = "${{ steps.selftest.outputs.image_id }}" \
-            || (echo "::error::image ID changed after self-test (${NOW} != ${{ steps.selftest.outputs.image_id }})" && exit 1)
+          test "$NOW" = "${SELFTEST_IMAGE_ID}" \
+            || (echo "::error::image ID changed after self-test (${NOW} != ${SELFTEST_IMAGE_ID})" && exit 1)
           gcloud auth configure-docker us-docker.pkg.dev --quiet
           docker push "$IMG"
 
@@ -243,11 +249,11 @@ jobs:
         id: digest
         run: |
           DIGEST=$(gcloud artifacts docker images describe \
-            "${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}.${{ github.run_attempt }}" \
+            "${STAGING_IMAGE}:${VERSION}-candidate.${RUN_ID}.${RUN_ATTEMPT}" \
             --format='value(image_summary.digest)')
           echo "staged: ${STAGING_IMAGE}@${DIGEST}"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "staging_ref=${STAGING_IMAGE}:${{ needs.verify.outputs.version }}-candidate.${{ github.run_id }}.${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "staging_ref=${STAGING_IMAGE}:${VERSION}-candidate.${RUN_ID}.${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build wheel + plugin tarball
@@ -265,8 +271,11 @@ jobs:
     defaults:
       run:
         working-directory: producers
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      IMAGE_DIGEST: ${{ needs.build-image.outputs.digest }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -288,8 +297,8 @@ jobs:
         run: |
           python scripts/release_image_tool.py inject \
             --target src/bigquery_agent_analytics_tracing/otlp/_release.py \
-            --coordinate "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}" \
-            --digest "${{ needs.build-image.outputs.digest }}"
+            --coordinate "${PUBLIC_IMAGE}:${VERSION}" \
+            --digest "${IMAGE_DIGEST}"
 
       - name: Build wheel and sdist (no isolation — locked backend)
         run: python -m build --no-isolation
@@ -297,9 +306,9 @@ jobs:
       - name: Digest-equality gate (wheel == sdist == expected)
         run: |
           python scripts/release_image_tool.py verify \
-            --wheel dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl \
-            --sdist dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz \
-            --expected "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}@${{ needs.build-image.outputs.digest }}"
+            --wheel dist/bigquery_agent_analytics_tracing-${VERSION}-py3-none-any.whl \
+            --sdist dist/bigquery_agent_analytics_tracing-${VERSION}.tar.gz \
+            --expected "${PUBLIC_IMAGE}:${VERSION}@${IMAGE_DIGEST}"
 
       - name: Install built wheel (metadata only, no dependency resolution)
         # importlib.metadata.version() needs to see the dist-info so
@@ -314,11 +323,11 @@ jobs:
       - name: Verify all expected artifacts are present
         run: |
           ls -la dist/
-          test -f dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}.tar.gz \
+          test -f dist/bigquery_agent_analytics_tracing-${VERSION}.tar.gz \
             || (echo "::error::missing sdist" && exit 1)
-          test -f dist/bigquery_agent_analytics_tracing-${{ needs.verify.outputs.version }}-py3-none-any.whl \
+          test -f dist/bigquery_agent_analytics_tracing-${VERSION}-py3-none-any.whl \
             || (echo "::error::missing wheel" && exit 1)
-          test -f dist/bigquery-agent-analytics-tracing-claude-code-${{ needs.verify.outputs.version }}.tar.gz \
+          test -f dist/bigquery-agent-analytics-tracing-claude-code-${VERSION}.tar.gz \
             || (echo "::error::missing plugin tarball" && exit 1)
 
       - name: Write SHA256SUMS
@@ -338,7 +347,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -505,7 +514,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -660,7 +669,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 
@@ -737,7 +746,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -346,6 +346,9 @@ jobs:
     needs: [verify, build-image, build]
     permissions:
       contents: write
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      IMAGE_DIGEST: ${{ needs.build-image.outputs.digest }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
@@ -362,9 +365,9 @@ jobs:
       - name: Render customer-first release notes (PR-tested script)
         run: |
           python3 producers/scripts/render_release_notes.py \
-            --version "${{ needs.verify.outputs.version }}" \
-            --digest "${{ needs.build-image.outputs.digest }}" \
-            --public-image "${{ env.PUBLIC_IMAGE }}" \
+            --version "${VERSION}" \
+            --digest "${IMAGE_DIGEST}" \
+            --public-image "${PUBLIC_IMAGE}" \
             --out release_body.md
 
       - name: Fail closed on existing-release state
@@ -602,6 +605,9 @@ jobs:
       # No contents: write — promote copies the image and asserts digests;
       # only finalize touches the GitHub release.
       id-token: write
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      IMAGE_DIGEST: ${{ needs.build-image.outputs.digest }}
     steps:
       - name: Install crane (pinned + checksum-verified, BEFORE credentials exist)
         # Supply-chain guard: never fetch a mutable 'latest' binary in a
@@ -632,19 +638,19 @@ jobs:
           gcloud auth print-access-token \
             | crane auth login us-docker.pkg.dev -u oauth2accesstoken --password-stdin
           set +e
-          EXISTING=$(crane digest "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}" 2> digest.err)
+          EXISTING=$(crane digest "${PUBLIC_IMAGE}:${VERSION}" 2> digest.err)
           RC=$?
           set -e
           if [ $RC -eq 0 ]; then
-            test "$EXISTING" = "${{ needs.build-image.outputs.digest }}" \
-              || (echo "::error::public tag exists with digest ${EXISTING}, expected ${{ needs.build-image.outputs.digest }} — version is burned" && exit 1)
+            test "$EXISTING" = "${IMAGE_DIGEST}" \
+              || (echo "::error::public tag exists with digest ${EXISTING}, expected ${IMAGE_DIGEST} — version is burned" && exit 1)
             echo "public tag already carries the expected digest (rerun) — skipping copy"
           elif grep -qi "MANIFEST_UNKNOWN\|manifest unknown" digest.err; then
             # ONLY an explicit manifest-not-found enters the mutating path;
             # auth/rate-limit/network failures must never become a copy.
             crane copy \
-              "${STAGING_IMAGE}@${{ needs.build-image.outputs.digest }}" \
-              "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}"
+              "${STAGING_IMAGE}@${IMAGE_DIGEST}" \
+              "${PUBLIC_IMAGE}:${VERSION}"
           else
             echo "::error::registry state INDETERMINATE: $(head -1 digest.err)"
             exit 1
@@ -652,10 +658,10 @@ jobs:
 
       - name: Assert public digest equals the packaged constant
         run: |
-          PUBLIC_DIGEST=$(crane digest "${PUBLIC_IMAGE}:${{ needs.verify.outputs.version }}")
+          PUBLIC_DIGEST=$(crane digest "${PUBLIC_IMAGE}:${VERSION}")
           echo "public:  ${PUBLIC_DIGEST}"
-          echo "staged:  ${{ needs.build-image.outputs.digest }}"
-          test "${PUBLIC_DIGEST}" = "${{ needs.build-image.outputs.digest }}" \
+          echo "staged:  ${IMAGE_DIGEST}"
+          test "${PUBLIC_DIGEST}" = "${IMAGE_DIGEST}" \
             || (echo "::error::digest drift between staging and public" && exit 1)
 
   publish-pypi:
@@ -745,6 +751,8 @@ jobs:
     needs: [verify, build, github-release, publish-pypi]
     permissions:
       contents: write
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
@@ -973,8 +981,8 @@ jobs:
             # title/body/prerelease are verified on every snapshot and
             # repaired where GitHub permits edits (#356 rounds 12-13).
             python3 producers/scripts/publish_release_body.py \
-              --version "${{ needs.verify.outputs.version }}" \
-              --public-image "${{ env.PUBLIC_IMAGE }}" \
+              --version "${VERSION}" \
+              --public-image "${PUBLIC_IMAGE}" \
               --anchor-dir anchor/ \
               --tag "${GITHUB_REF_NAME}" \
               --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/release-tracing.yml
+++ b/.github/workflows/release-tracing.yml
@@ -106,6 +106,10 @@ on:
     tags:
       - 'tracing-v*'
 
+# Deny by default at the workflow level; each job below grants only
+# the scopes it needs.
+permissions: {}
+
 concurrency:
   group: release-tracing-${{ github.ref }}
   cancel-in-progress: false
@@ -126,6 +130,8 @@ jobs:
   verify:
     name: Verify version + tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     defaults:
       run:
@@ -136,6 +142,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify the tag points at the CURRENT protected-main head
         # Tag provenance: any tracing-v* tag triggers this workflow, and
@@ -196,6 +203,8 @@ jobs:
       staging_ref: ${{ steps.digest.outputs.staging_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Build image (repo root context, per Dockerfile contract)
         run: |
@@ -243,6 +252,8 @@ jobs:
   build:
     name: Build wheel + plugin tarball
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     needs: [verify, build-image]
     outputs:
@@ -256,6 +267,8 @@ jobs:
         working-directory: producers
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -326,6 +339,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -491,6 +506,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -644,6 +661,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -719,6 +738,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
   release:
     types: [published]
 
+# Least privilege at workflow level; the publish jobs opt in to
+# `id-token: write` individually for PyPI trusted publishing.
+permissions:
+  contents: read
+
 # The release event has no tag-pattern filter, so any published
 # release fires this workflow. The producer pipeline publishes
 # `tracing-vX.Y.Z` releases (release-tracing.yml); without this
@@ -33,9 +38,11 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -56,7 +63,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist
           path: dist/
@@ -69,13 +76,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
 
   publish-testpypi:
     name: Publish to TestPyPI
@@ -85,12 +92,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Prepares this repo for Zizmor enablement (b/544708036) by clearing existing findings **before** the `ghss-action-scanning-optin` property is flipped, so GitHub Actions PRs don't start getting blocked on pre-existing issues.

## Findings fixed

**`unpinned-uses`** — 14 mutable action refs pinned to SHAs in `ci.yml` and `release.yml`. The other four workflows were already pinned; these two were the stragglers.

The one worth calling out: `pypa/gh-action-pypi-publish@release/v1` was pinned to a **branch**, on the job that holds `id-token: write` for PyPI trusted publishing. Now pinned to v1.14.2 (`dc37677`).

**`excessive-permissions`** — four workflows had no top-level `permissions` and inherited the repo default:

| Workflow | Added |
| --- | --- |
| `ci.yml` | `contents: read` |
| `release.yml` | `contents: read` (publish jobs keep their own `id-token: write`) |
| `producers-ci.yml` | `contents: read` (all 5 jobs are build/test only) |
| `release-tracing.yml` | `permissions: {}` — deny by default |

**`artipacked`** — `persist-credentials: false` on every `actions/checkout` (18 of them; only `grafana-sync-check.yml` had it before).

## Two notes for the reviewer

**`release-tracing.yml` needed care.** Deny-by-default at the top would have left `verify` and `build` with *zero* scopes — neither had a job-level block. Both now declare `contents: read` explicitly, and all 8 jobs in that workflow state their own permissions rather than inheriting anything.

**Dropping persisted credentials is safe here** — checked rather than assumed. There is no `git push`, `git commit`, or `git tag` in any workflow; release publishing goes through `gh` with `GH_TOKEN` env and `softprops/action-gh-release`, neither of which uses the git credential helper that `persist-credentials` controls.

## Validation

All six workflows parse, and a re-audit reports zero remaining findings for these rules. No behavioural change to any pipeline.

Note: this was a hand audit against Zizmor's rule set — I was not able to run the Zizmor binary locally (PyPI access is Airlock-gated on corp machines). Worth a real scan before the property is flipped. The ~40 `${{ }}`-in-`run:` occurrences in `release-tracing.yml` were assessed and dismissed: they are all `github.run_id`, `github.run_attempt` and `needs.*.outputs.*` on a tag-triggered workflow, none of which are attacker-controllable contexts.
