### PR TITLE
fix(deps): upgrade nanoid to 3.3.18

### DIFF
--- a/dashboard_v2/package-lock.json
+++ b/dashboard_v2/package-lock.json
@@ -2980,9 +2980,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- upgrade transitive `nanoid` from 3.3.16 to 3.3.18 in `dashboard_v2/package-lock.json`
- resolve GHSA-2v37-7h3g-55p8 / CVE-2026-67213, where zero-size custom generators can loop indefinitely
- keep the change lockfile-only; `package.json` and the rest of the dependency graph are unchanged

## Verification

- `npm ci --ignore-scripts`
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm run lint`
- `npm run build`
- smoke-tested `nanoid(0)`, `customAlphabet(...)(0)`, and `customRandom(...)(0)`; all return immediately with an empty string