### PR TITLE
feat(export): add BigQuery-to-LangSmith connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,16 @@ The CLI intentionally accepts the API key only through
 `LANGSMITH_API_KEY`, keeping it out of shell history and process arguments.
 
 The exporter reconstructs span parents, derives stable LangSmith UUIDs, and
-uses batch upserts, so replaying an overlapping window does not duplicate runs.
-For scheduled syncs, add `--incremental --watermark-file=state.json`. The JSON
-summary bounds row-level diagnostics with `--max-dropped-rows` and reports the
-number omitted as `dropped_rows_truncated`.
+uses separate create and update batches, so replaying an overlapping window
+updates existing runs without creating duplicates. For scheduled syncs, add
+`--incremental --watermark-file=state.json`. The JSON summary bounds row-level
+diagnostics with `--max-dropped-rows` and reports the number omitted as
+`dropped_rows_truncated`.
 
 Custom schemas use a YAML mapping from LangSmith fields to source column or
 nested paths. Unmapped columns remain in `extra.metadata`; payload values are
-opaque and are never classified by event type:
+opaque and are never classified by event type. Optional fields omitted from a
+custom mapping remain unmapped rather than inheriting ADK column names:
 
 ```yaml
 fields:

--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ bq-agent-sdk export langsmith \
 The CLI intentionally accepts the API key only through
 `LANGSMITH_API_KEY`, keeping it out of shell history and process arguments.
 
-The exporter reconstructs span parents, derives stable LangSmith UUIDs, and
-uses separate create and update batches, so replaying an overlapping window
-updates existing runs without creating duplicates. For scheduled syncs, add
-`--incremental --watermark-file=state.json`. The JSON summary bounds row-level
+The exporter reconstructs span parents and derives stable LangSmith UUIDs. It
+treats created runs as immutable: replaying an overlapping window is an
+idempotent no-op for existing run IDs while still creating previously unseen
+IDs. To correct already-exported data, use a fresh LangSmith project or a
+deliberately versioned `--source-id`. For scheduled syncs, use `--incremental`
+with `--watermark-file=state.json`. The JSON summary bounds row-level
 diagnostics with `--max-dropped-rows` and reports the number omitted as
 `dropped_rows_truncated`.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ With BigFrames support:
 pip install bigquery-agent-analytics[bigframes]
 ```
 
+With LangSmith export support:
+
+```bash
+pip install bigquery-agent-analytics[langsmith]
+```
+
 ## Quick Start
 
 ```python
@@ -95,6 +101,52 @@ client = Client(project_id="my-project", dataset_id="analytics")
 trace = client.get_trace("trace-abc-123")
 trace.render()
 ```
+
+### Export traces to LangSmith
+
+Export the standard ADK `agent_events` schema with Application Default
+Credentials and LangSmith's standard environment variables:
+
+```bash
+export LANGSMITH_API_KEY=lsv2_...
+export LANGSMITH_PROJECT=agent-production
+
+bq-agent-sdk export langsmith \
+  --source=my-project.analytics.agent_events \
+  --since=2026-08-01T00:00:00Z
+```
+
+The CLI intentionally accepts the API key only through
+`LANGSMITH_API_KEY`, keeping it out of shell history and process arguments.
+
+The exporter reconstructs span parents, derives stable LangSmith UUIDs, and
+uses batch upserts, so replaying an overlapping window does not duplicate runs.
+For scheduled syncs, add `--incremental --watermark-file=state.json`. The JSON
+summary bounds row-level diagnostics with `--max-dropped-rows` and reports the
+number omitted as `dropped_rows_truncated`.
+
+Custom schemas use a YAML mapping from LangSmith fields to source column or
+nested paths. Unmapped columns remain in `extra.metadata`; payload values are
+opaque and are never classified by event type:
+
+```yaml
+fields:
+  run_id: event_key
+  trace_id: trace.key
+  parent_run_id: parent_key
+  name: kind
+  start_time: occurred_at
+  inputs: payload
+```
+
+```bash
+bq-agent-sdk export langsmith \
+  --source='SELECT * FROM `my-project.custom.events`' \
+  --mapping=mapping.yaml --source-id=custom-events-v1
+```
+
+See [SDK.md](SDK.md#23-langsmith-export) for the Python API, incremental
+watermark contract, filtering, and operational controls.
 
 For session reads, `session_id` is a reusable conversation identifier rather
 than a unique trace key. `client.get_session_trace()` resolves user, root agent,
@@ -229,6 +281,12 @@ src/bigquery_agent_analytics/
 │   ├── insights.py                # Multi-stage insights pipeline
 │   ├── feedback.py                # Drift detection & question distribution
 │   └── memory_service.py          # Long-horizon agent memory
+│
+├── Export
+│   └── export/
+│       ├── __init__.py             # Stable public export API
+│       ├── cli.py                  # bq-agent-sdk export command group
+│       └── langsmith.py            # Schema-agnostic LangSmith connector
 │
 ├── Agent Context Graph
 │   ├── context_graph.py           # Decision-trace extraction & GQL traversal

--- a/SDK.md
+++ b/SDK.md
@@ -2291,9 +2291,10 @@ The optional LangSmith connector exports a BigQuery table or arbitrary SQL
 result as LangSmith run trees. It streams rows ordered by trace, reconstructs
 the existing `span_id` / `parent_span_id` hierarchy, and adds one stable
 structural root per trace. Every source event gets a UUID derived from the
-canonical source, trace ID, and run ID. Each batch uses separate create and
-update requests, so overlapping backfills update the same LangSmith runs
-instead of creating duplicates or silently leaving stale data.
+canonical source, trace ID, and run ID. The exporter treats created runs as
+immutable: overlapping backfills are idempotent no-ops for existing run IDs
+while still creating previously unseen IDs. Correcting already-exported data
+requires a fresh LangSmith project or a deliberately versioned `--source-id`.
 
 ### Install and authenticate
 
@@ -2334,11 +2335,14 @@ print(stats.to_dict())
 `ExportStats.to_dict()` reports source rows read, exported, skipped, failed,
 successful traces, batches, the current watermark, bounded `dropped_rows`
 details, and `dropped_rows_truncated` (the number omitted from that list).
+`exported` counts source rows in batches accepted by the client, not destination
+mutations, so a replay of existing IDs can report exported rows while leaving
+the server-side runs unchanged.
 Retryable 408/425/429 and 5xx errors use bounded exponential backoff. A create
-conflict is expected during replay, is not retried, and is followed by the
-update request. `requests_per_second` and `max_retries` govern exporter calls
-to `batch_ingest_runs`; the LangSmith SDK may split or retry transport requests
-inside one call. A failed batch never advances incremental state.
+conflict is expected during replay, is not retried, and is treated as an
+idempotent success. `requests_per_second` and `max_retries` govern exporter
+calls to `batch_ingest_runs`; the LangSmith SDK may split or retry transport
+requests inside one call. A failed batch never advances incremental state.
 
 ### Custom schemas and opaque values
 
@@ -2435,8 +2439,10 @@ be retained.
 The cursor is based on source event time. A row that arrives after the cursor
 has advanced but carries an equal or earlier `start_time` is not discovered by
 a later incremental run. Schedule an overlapping bounded backfill when the
-source permits late arrival; stable IDs and update batches make that replay
-safe.
+source permits late arrival. Stable IDs make the replay idempotent: previously
+unseen run IDs are created, but existing runs remain unchanged. To correct an
+already-exported run, export to a fresh LangSmith project or use a deliberately
+versioned `--source-id`.
 
 Each query window reconstructs hierarchy only from rows present in that
 window. If a child arrives after its parent was exported in an earlier window,

--- a/SDK.md
+++ b/SDK.md
@@ -2250,7 +2250,7 @@ pipeline.
 | --- | ----- |
 | `sdk` | constant `bigquery-agent-analytics` |
 | `sdk_version` | package version, BQ-safe (e.g. `0-4-0`) |
-| `sdk_surface` | `python` \| `cli` \| `remote-function` \| `langsmith_export` |
+| `sdk_surface` | `python` \| `cli` \| `remote-function` \| `langsmith-export` |
 | `sdk_feature` | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` \| `langsmith-export` |
 | `sdk_ai_function` | set only on AI/ML invocations: `ai-generate` \| `ai-embed` \| `ai-classify` \| `ai-forecast` \| `ai-detect-anomalies` \| `ml-generate-text` \| `ml-generate-embedding` \| `ml-detect-anomalies` \| `ml-forecast` |
 
@@ -2291,8 +2291,9 @@ The optional LangSmith connector exports a BigQuery table or arbitrary SQL
 result as LangSmith run trees. It streams rows ordered by trace, reconstructs
 the existing `span_id` / `parent_span_id` hierarchy, and adds one stable
 structural root per trace. Every source event gets a UUID derived from the
-canonical source, trace ID, and run ID; overlapping backfills therefore upsert
-the same LangSmith runs instead of creating duplicates.
+canonical source, trace ID, and run ID. Each batch uses separate create and
+update requests, so overlapping backfills update the same LangSmith runs
+instead of creating duplicates or silently leaving stale data.
 
 ### Install and authenticate
 
@@ -2306,7 +2307,7 @@ export LANGSMITH_WORKSPACE_ID=...
 ```
 
 BigQuery uses Application Default Credentials, consistent with the rest of the
-SDK. The export query carries `sdk_surface=langsmith_export` and
+SDK. The export query carries `sdk_surface=langsmith-export` and
 `sdk_feature=langsmith-export` labels.
 
 ### Python API
@@ -2333,8 +2334,11 @@ print(stats.to_dict())
 `ExportStats.to_dict()` reports source rows read, exported, skipped, failed,
 successful traces, batches, the current watermark, bounded `dropped_rows`
 details, and `dropped_rows_truncated` (the number omitted from that list).
-Retryable 408/409/425/429 and 5xx errors use bounded exponential backoff. A
-failed batch never advances incremental state.
+Retryable 408/425/429 and 5xx errors use bounded exponential backoff. A create
+conflict is expected during replay, is not retried, and is followed by the
+update request. `requests_per_second` and `max_retries` govern exporter calls
+to `batch_ingest_runs`; the LangSmith SDK may split or retry transport requests
+inside one call. A failed batch never advances incremental state.
 
 ### Custom schemas and opaque values
 
@@ -2357,14 +2361,17 @@ fields:
   outputs: result
 ```
 
-Only declared paths are traversed, and only when the source value is already a
-mapping. JSON strings are not decoded or interpreted. A mapped scalar/list is
-wrapped as `{"value": ...}` because LangSmith inputs and outputs are objects.
-Unmapped columns are copied to `extra.metadata`. When a nested path is mapped,
-the original top-level column also remains in metadata so sibling data is not
-lost. Non-JSON BigQuery scalars use loss-minimizing transport encodings:
-decimal/date/time values become strings and bytes become a tagged base64
-object.
+Only declared paths are traversed, and omitted optional fields remain unmapped;
+custom mappings never inherit ADK defaults. Custom JSON strings are not decoded
+or interpreted. The built-in ADK mapping is the narrow exception: it decodes
+the standard `content` and `latency_ms` JSON columns because BigQuery clients
+may return those JSON values as either mappings or strings. A mapped
+scalar/list is wrapped as `{"value": ...}` because LangSmith inputs and outputs
+are objects. Unmapped columns are copied to `extra.metadata`. When a nested
+path is mapped, the original top-level column also remains in metadata so
+sibling data is not lost. Non-JSON BigQuery scalars use loss-minimizing
+transport encodings: decimal/date/time values become strings and bytes become
+a tagged base64 object.
 
 ```python
 from bigquery_agent_analytics.export import FieldMapping
@@ -2402,16 +2409,41 @@ For CLI use, `LANGSMITH_API_KEY` is intentionally environment-only so the
 secret does not appear in shell history or process arguments. Python callers
 may still pass `langsmith_api_key` to `ExportConfig` explicitly.
 
+The synthetic root keeps a fixed epoch segment only in `dotted_order`, where a
+stable prefix is required across overlapping windows. When mapped source times
+are valid, its displayed `start_time` and `end_time` use the earliest and latest
+source-run times in the current window instead of forcing the root to 1970.
+
 Incremental state contains a timestamp plus source run-ID tie breaker and is
 atomically replaced. It is bound to the canonical source and field-mapping
 fingerprint; reusing it for another table/query or mapping fails closed. Use a
 separate state file per export job and a single scheduler writer. For mutable
-SQL text, set `--source-id` to a stable logical source name. Exit code `1`
-means at least one source row was skipped or LangSmith batch failed;
-configuration/query failures use exit code `2`. The JSON summary always
-reports total skipped/failed counts;
-`--max-dropped-rows` only bounds retained per-row diagnostics. Set it to `0`
-when row-level details should not be retained.
+SQL text, set `--source-id` to a stable logical source name. Incremental mode
+requires a `start_time` mapping. Time predicates safely cast the mapped value
+to `TIMESTAMP`, so ISO-8601 STRING columns are supported; unparseable values do
+not match a filtered query.
+
+Successfully processed rows, including rows reported as skipped, advance the
+cursor so one permanently malformed row cannot wedge every later scheduled
+run. A LangSmith batch failure blocks advancement for the whole invocation.
+Exit code `1` means at least one source row was skipped or a LangSmith batch
+failed; configuration/query failures use exit code `2`. The JSON summary
+always reports total skipped/failed counts; `--max-dropped-rows` only bounds
+retained per-row diagnostics. Set it to `0` when row-level details should not
+be retained.
+
+The cursor is based on source event time. A row that arrives after the cursor
+has advanced but carries an equal or earlier `start_time` is not discovered by
+a later incremental run. Schedule an overlapping bounded backfill when the
+source permits late arrival; stable IDs and update batches make that replay
+safe.
+
+Each query window reconstructs hierarchy only from rows present in that
+window. If a child arrives after its parent was exported in an earlier window,
+the child is attached to the synthetic root and its original parent ID remains
+in `extra.bqaa.source_parent_run_id`. For sources with long-lived traces,
+prefer filtering for traces that have been quiescent for an appropriate delay
+before export to avoid these cross-window splits.
 
 The v1 connector is one-way and scheduled/batch only. It does not import
 LangSmith data or provide a real-time streaming surface.

--- a/SDK.md
+++ b/SDK.md
@@ -2250,8 +2250,8 @@ pipeline.
 | --- | ----- |
 | `sdk` | constant `bigquery-agent-analytics` |
 | `sdk_version` | package version, BQ-safe (e.g. `0-4-0`) |
-| `sdk_surface` | `python` \| `cli` \| `remote-function` |
-| `sdk_feature` | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` |
+| `sdk_surface` | `python` \| `cli` \| `remote-function` \| `langsmith_export` |
+| `sdk_feature` | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` \| `langsmith-export` |
 | `sdk_ai_function` | set only on AI/ML invocations: `ai-generate` \| `ai-embed` \| `ai-classify` \| `ai-forecast` \| `ai-detect-anomalies` \| `ml-generate-text` \| `ml-generate-embedding` \| `ml-detect-anomalies` \| `ml-forecast` |
 
 All labels also apply to load jobs submitted by the SDK (e.g. the
@@ -2285,6 +2285,139 @@ and surface attribution.
 
 ---
 
+## 23. LangSmith Export
+
+The optional LangSmith connector exports a BigQuery table or arbitrary SQL
+result as LangSmith run trees. It streams rows ordered by trace, reconstructs
+the existing `span_id` / `parent_span_id` hierarchy, and adds one stable
+structural root per trace. Every source event gets a UUID derived from the
+canonical source, trace ID, and run ID; overlapping backfills therefore upsert
+the same LangSmith runs instead of creating duplicates.
+
+### Install and authenticate
+
+```bash
+pip install 'bigquery-agent-analytics[langsmith]'
+
+export LANGSMITH_API_KEY=lsv2_...
+export LANGSMITH_PROJECT=agent-production
+# Required only for organization-scoped keys:
+export LANGSMITH_WORKSPACE_ID=...
+```
+
+BigQuery uses Application Default Credentials, consistent with the rest of the
+SDK. The export query carries `sdk_surface=langsmith_export` and
+`sdk_feature=langsmith-export` labels.
+
+### Python API
+
+```python
+from pathlib import Path
+
+from bigquery_agent_analytics.export import export
+from bigquery_agent_analytics.export import ExportConfig
+
+stats = export(
+    "my-project.analytics.agent_events",
+    config=ExportConfig(
+        langsmith_project="agent-production",
+        since=None,
+        batch_size=100,
+        requests_per_second=5,
+        max_retries=3,
+    ),
+)
+print(stats.to_dict())
+```
+
+`ExportStats.to_dict()` reports source rows read, exported, skipped, failed,
+successful traces, batches, the current watermark, bounded `dropped_rows`
+details, and `dropped_rows_truncated` (the number omitted from that list).
+Retryable 408/409/425/429 and 5xx errors use bounded exponential backoff. A
+failed batch never advances incremental state.
+
+### Custom schemas and opaque values
+
+The default `FieldMapping.standard_adk()` targets the standard ADK
+`agent_events` fields. A YAML/JSON mapping uses LangSmith field names on the
+left and source columns or nested mapping paths on the right:
+
+```yaml
+fields:
+  run_id: event_key
+  trace_id: trace.key
+  parent_run_id: parent_key
+  name: event_kind
+  run_type: operation_type
+  start_time: occurred_at
+  end_time: completed_at
+  latency_ms: timing.total_ms
+  error: failure_message
+  inputs: payload
+  outputs: result
+```
+
+Only declared paths are traversed, and only when the source value is already a
+mapping. JSON strings are not decoded or interpreted. A mapped scalar/list is
+wrapped as `{"value": ...}` because LangSmith inputs and outputs are objects.
+Unmapped columns are copied to `extra.metadata`. When a nested path is mapped,
+the original top-level column also remains in metadata so sibling data is not
+lost. Non-JSON BigQuery scalars use loss-minimizing transport encodings:
+decimal/date/time values become strings and bytes become a tagged base64
+object.
+
+```python
+from bigquery_agent_analytics.export import FieldMapping
+
+mapping = FieldMapping.from_file("mapping.yaml")
+stats = export(
+    "SELECT * FROM `my-project.custom.events` WHERE environment = 'prod'",
+    config=ExportConfig(
+        mapping=mapping,
+        # Stabilizes IDs and watermark ownership if harmless SQL text changes.
+        source_id="custom-events-v1",
+    ),
+)
+```
+
+### Backfill and incremental CLI
+
+```bash
+# Bounded backfill. --filter is trusted SQL appended to the outer query.
+bq-agent-sdk export langsmith \
+  --source=my-project.analytics.agent_events \
+  --since=2026-08-01T00:00:00Z \
+  --until=2026-08-08T00:00:00Z \
+  --filter="status != 'DEBUG'"
+
+# Scheduler-friendly incremental sync.
+bq-agent-sdk export langsmith \
+  --source=my-project.analytics.agent_events \
+  --incremental \
+  --watermark-file=/var/lib/bqaa/langsmith-watermark.json \
+  --max-dropped-rows=1000
+```
+
+For CLI use, `LANGSMITH_API_KEY` is intentionally environment-only so the
+secret does not appear in shell history or process arguments. Python callers
+may still pass `langsmith_api_key` to `ExportConfig` explicitly.
+
+Incremental state contains a timestamp plus source run-ID tie breaker and is
+atomically replaced. It is bound to the canonical source and field-mapping
+fingerprint; reusing it for another table/query or mapping fails closed. Use a
+separate state file per export job and a single scheduler writer. For mutable
+SQL text, set `--source-id` to a stable logical source name. Exit code `1`
+means at least one source row was skipped or LangSmith batch failed;
+configuration/query failures use exit code `2`. The JSON summary always
+reports total skipped/failed counts;
+`--max-dropped-rows` only bounds retained per-row diagnostics. Set it to `0`
+when row-level details should not be retained.
+
+The v1 connector is one-way and scheduled/batch only. It does not import
+LangSmith data or provide a real-time streaming surface.
+
+---
+
 ## Module Architecture
 
 ```
@@ -2310,6 +2443,12 @@ bigquery_agent_analytics/
 │   ├── ai_ml_integration.py   ← AI.GENERATE, embeddings, anomaly detection
 │   ├── memory_service.py      ← Long-horizon agent memory (requires google-adk)
 │   └── bigframes_evaluator.py ← BigFrames DataFrame evaluator (optional)
+│
+│   Export
+│   └── export/
+│       ├── __init__.py         ← Stable public export API
+│       ├── cli.py              ← `bq-agent-sdk export` command group
+│       └── langsmith.py        ← BigQuery-to-LangSmith connector (optional)
 │
 │   Agent Context Graph
 │   └── context_graph.py       ← Decision-trace extraction, GQL, world-change

--- a/docs/sdk_usage_tracking.md
+++ b/docs/sdk_usage_tracking.md
@@ -19,8 +19,8 @@ load job (`LoadJobConfig.labels`) it submits.
 | ------------------ | ------------------------------------------ | ----- |
 | `sdk`              | constant `bigquery-agent-analytics`        | every SDK job |
 | `sdk_version`      | `__version__`, BQ-safe (e.g. `0-4-0`)      | every SDK job |
-| `sdk_surface`      | `python` \| `cli` \| `remote-function`     | every SDK job |
-| `sdk_feature`      | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` | per-call site |
+| `sdk_surface`      | `python` \| `cli` \| `remote-function` \| `langsmith_export` | every SDK job |
+| `sdk_feature`      | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` \| `langsmith-export` | per-call site |
 | `sdk_ai_function`  | `ai-generate` \| `ai-embed` \| `ai-classify` \| `ai-forecast` \| `ai-detect-anomalies` \| `ml-generate-text` \| `ml-generate-embedding` \| `ml-detect-anomalies` \| `ml-forecast` | AI/ML invocations only |
 
 **Reserved namespace.** All `sdk*` keys are managed by the SDK. If a
@@ -142,8 +142,8 @@ ORDER BY day DESC, jobs DESC;
 
 ### 5. Surface attribution (who is calling the SDK?)
 
-Split spend across direct Python users, CLI invocations, and the
-deployed remote-function runtime.
+Split spend across direct Python users, CLI invocations, LangSmith exports,
+and the deployed remote-function runtime.
 
 ```sql
 SELECT

--- a/docs/sdk_usage_tracking.md
+++ b/docs/sdk_usage_tracking.md
@@ -19,7 +19,7 @@ load job (`LoadJobConfig.labels`) it submits.
 | ------------------ | ------------------------------------------ | ----- |
 | `sdk`              | constant `bigquery-agent-analytics`        | every SDK job |
 | `sdk_version`      | `__version__`, BQ-safe (e.g. `0-4-0`)      | every SDK job |
-| `sdk_surface`      | `python` \| `cli` \| `remote-function` \| `langsmith_export` | every SDK job |
+| `sdk_surface`      | `python` \| `cli` \| `remote-function` \| `langsmith-export` | every SDK job |
 | `sdk_feature`      | `trace-read` \| `eval-code` \| `eval-llm-judge` \| `eval-categorical` \| `insights` \| `drift` \| `memory` \| `context-graph` \| `ontology-build` \| `ontology-gql` \| `views` \| `ai-ml` \| `feedback` \| `langsmith-export` | per-call site |
 | `sdk_ai_function`  | `ai-generate` \| `ai-embed` \| `ai-classify` \| `ai-forecast` \| `ai-detect-anomalies` \| `ml-generate-text` \| `ml-generate-embedding` \| `ml-detect-anomalies` \| `ml-forecast` | AI/ML invocations only |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ llm = [
 bigframes = [
   "bigframes>=1.0.0",
 ]
+langsmith = [
+  "langsmith>=0.10.0",
+]
 owl = [
   "rdflib>=7.0",
 ]
@@ -57,7 +60,7 @@ improvement = [
   "python-dotenv>=1.0.0",
 ]
 all = [
-  "bigquery-agent-analytics[llm,bigframes,owl,cli,dev,improvement]",
+  "bigquery-agent-analytics[llm,bigframes,langsmith,owl,cli,dev,improvement]",
 ]
 
 [project.scripts]

--- a/src/bigquery_agent_analytics/_telemetry.py
+++ b/src/bigquery_agent_analytics/_telemetry.py
@@ -190,8 +190,9 @@ def make_bq_client(project, location=None, sdk_surface="python", **kwargs):
     project: GCP project ID.
     location: Optional BigQuery location.
     sdk_surface: Which SDK entry point is constructing this client. One of
-      ``"python"``, ``"cli"``, ``"remote-function"``. Drives the
-      ``sdk_surface`` label on every job this client submits.
+      ``"python"``, ``"cli"``, ``"remote-function"``, or
+      ``"langsmith_export"``. Drives the ``sdk_surface`` label on every job
+      this client submits.
     **kwargs: Forwarded to ``bigquery.Client`` (e.g. ``credentials``).
 
   Returns:

--- a/src/bigquery_agent_analytics/_telemetry.py
+++ b/src/bigquery_agent_analytics/_telemetry.py
@@ -191,7 +191,7 @@ def make_bq_client(project, location=None, sdk_surface="python", **kwargs):
     location: Optional BigQuery location.
     sdk_surface: Which SDK entry point is constructing this client. One of
       ``"python"``, ``"cli"``, ``"remote-function"``, or
-      ``"langsmith_export"``. Drives the ``sdk_surface`` label on every job
+      ``"langsmith-export"``. Drives the ``sdk_surface`` label on every job
       this client submits.
     **kwargs: Forwarded to ``bigquery.Client`` (e.g. ``credentials``).
 

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -42,6 +42,7 @@ import typer
 from .evaluators import EvaluationReport
 from .evaluators import LLMAsJudge
 from .evaluators import SystemEvaluator
+from .export.cli import export_app
 from .formatter import format_output
 from .trace import AmbiguousSessionError
 from .trace import TraceFilter
@@ -52,6 +53,9 @@ app = typer.Typer(
     help="BigQuery Agent Analytics SDK CLI.",
     add_completion=False,
 )
+
+app.add_typer(export_app, name="export")
+
 
 # Product-facing CLI surface. Wraps the same handlers that ``bq-agent-sdk``
 # exposes under their implementation-shaped names, but presents them with

--- a/src/bigquery_agent_analytics/export/__init__.py
+++ b/src/bigquery_agent_analytics/export/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export connectors for BigQuery Agent Analytics data."""
+
+from .langsmith import DroppedRow
+from .langsmith import export
+from .langsmith import ExportConfig
+from .langsmith import ExportStats
+from .langsmith import FieldMapping
+
+__all__ = [
+    "DroppedRow",
+    "export",
+    "ExportConfig",
+    "ExportStats",
+    "FieldMapping",
+]

--- a/src/bigquery_agent_analytics/export/cli.py
+++ b/src/bigquery_agent_analytics/export/cli.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command-line interface for export connectors."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+export_app = typer.Typer(
+    name="export",
+    help="Export BigQuery Agent Analytics data to external systems.",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+@export_app.callback()
+def _export_callback() -> None:
+  """Export BigQuery Agent Analytics data."""
+  return None
+
+
+def _parse_datetime(value: str | None, option: str) -> datetime | None:
+  """Parse an ISO-8601 CLI timestamp as an aware UTC datetime."""
+  if value is None:
+    return None
+  try:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+  except ValueError as exc:
+    raise typer.BadParameter(f"{option} must be an ISO-8601 timestamp") from exc
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return parsed.astimezone(timezone.utc)
+
+
+@export_app.command("langsmith")
+def export_langsmith(
+    source: str = typer.Option(
+        ..., help="BigQuery table reference or arbitrary SQL query."
+    ),
+    mapping: Optional[Path] = typer.Option(
+        None,
+        exists=True,
+        readable=True,
+        help="YAML/JSON source-to-run field mapping.",
+    ),
+    project_id: Optional[str] = typer.Option(
+        None,
+        envvar="BQ_AGENT_PROJECT",
+        help="GCP project ID. [env: BQ_AGENT_PROJECT]",
+    ),
+    location: Optional[str] = typer.Option(None, help="BigQuery location."),
+    langsmith_project: Optional[str] = typer.Option(
+        None,
+        envvar="LANGSMITH_PROJECT",
+        help="Destination LangSmith project.",
+    ),
+    langsmith_endpoint: Optional[str] = typer.Option(
+        None,
+        envvar="LANGSMITH_ENDPOINT",
+        help="LangSmith API endpoint.",
+    ),
+    langsmith_workspace_id: Optional[str] = typer.Option(
+        None,
+        envvar="LANGSMITH_WORKSPACE_ID",
+        help="LangSmith workspace ID for org-scoped keys.",
+    ),
+    source_id: Optional[str] = typer.Option(
+        None,
+        help="Stable source namespace for SQL whose text may change.",
+    ),
+    since: Optional[str] = typer.Option(
+        None, help="Inclusive ISO-8601 start timestamp."
+    ),
+    until: Optional[str] = typer.Option(
+        None, help="Exclusive ISO-8601 end timestamp."
+    ),
+    where: Optional[str] = typer.Option(
+        None,
+        "--filter",
+        help="Additional trusted BigQuery SQL predicate.",
+    ),
+    incremental: bool = typer.Option(
+        False, help="Resume from a persisted timestamp/run-ID watermark."
+    ),
+    watermark_file: Path = typer.Option(
+        Path(".bqaa-langsmith-watermark.json"),
+        help="Incremental watermark state file.",
+    ),
+    batch_size: int = typer.Option(
+        100, min=1, help="Maximum source rows per LangSmith batch."
+    ),
+    requests_per_second: float = typer.Option(
+        5.0, min=0.001, help="Maximum LangSmith API requests per second."
+    ),
+    max_retries: int = typer.Option(
+        3, min=0, help="Retries for transient LangSmith API errors."
+    ),
+    max_dropped_rows: int = typer.Option(
+        1000,
+        min=0,
+        help="Maximum dropped-row details retained in the JSON report.",
+    ),
+) -> None:
+  """Export a BigQuery table or SQL result to LangSmith run trees."""
+  try:
+    from . import export
+    from . import ExportConfig
+    from . import FieldMapping
+
+    field_mapping = (
+        FieldMapping.from_file(mapping)
+        if mapping is not None
+        else FieldMapping.standard_adk()
+    )
+    config = ExportConfig(
+        mapping=field_mapping,
+        project_id=project_id,
+        location=location,
+        langsmith_project=langsmith_project,
+        langsmith_endpoint=langsmith_endpoint,
+        langsmith_workspace_id=langsmith_workspace_id,
+        source_id=source_id,
+        since=_parse_datetime(since, "--since"),
+        until=_parse_datetime(until, "--until"),
+        where=where,
+        incremental=incremental,
+        watermark_path=watermark_file,
+        batch_size=batch_size,
+        requests_per_second=requests_per_second,
+        max_retries=max_retries,
+        max_dropped_rows=max_dropped_rows,
+    )
+    stats = export(source, config=config)
+    typer.echo(json.dumps(stats.to_dict(), sort_keys=True))
+    if stats.failed or stats.skipped:
+      raise typer.Exit(code=1)
+  except typer.Exit:
+    raise
+  except Exception as exc:
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)

--- a/src/bigquery_agent_analytics/export/cli.py
+++ b/src/bigquery_agent_analytics/export/cli.py
@@ -22,7 +22,10 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from google.api_core.exceptions import GoogleAPIError
+from google.auth.exceptions import GoogleAuthError
 import typer
+import yaml
 
 export_app = typer.Typer(
     name="export",
@@ -30,6 +33,17 @@ export_app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+
+
+def _langsmith_error_types() -> tuple[type[Exception], ...]:
+  try:
+    from langsmith import utils as langsmith_utils
+  except ImportError:
+    return ()
+  error_type = getattr(langsmith_utils, "LangSmithError", None)
+  if isinstance(error_type, type) and issubclass(error_type, Exception):
+    return (error_type,)
+  return ()
 
 
 @export_app.callback()
@@ -109,10 +123,10 @@ def export_langsmith(
         100, min=1, help="Maximum source rows per LangSmith batch."
     ),
     requests_per_second: float = typer.Option(
-        5.0, min=0.001, help="Maximum LangSmith API requests per second."
+        5.0, min=0.001, help="Maximum exporter batch calls per second."
     ),
     max_retries: int = typer.Option(
-        3, min=0, help="Retries for transient LangSmith API errors."
+        3, min=0, help="Retries for transient LangSmith batch-call errors."
     ),
     max_dropped_rows: int = typer.Option(
         1000,
@@ -121,11 +135,11 @@ def export_langsmith(
     ),
 ) -> None:
   """Export a BigQuery table or SQL result to LangSmith run trees."""
-  try:
-    from . import export
-    from . import ExportConfig
-    from . import FieldMapping
+  from . import export
+  from . import ExportConfig
+  from . import FieldMapping
 
+  try:
     field_mapping = (
         FieldMapping.from_file(mapping)
         if mapping is not None
@@ -149,12 +163,24 @@ def export_langsmith(
         max_retries=max_retries,
         max_dropped_rows=max_dropped_rows,
     )
-    stats = export(source, config=config)
-    typer.echo(json.dumps(stats.to_dict(), sort_keys=True))
-    if stats.failed or stats.skipped:
-      raise typer.Exit(code=1)
-  except typer.Exit:
-    raise
-  except Exception as exc:
+  except (OSError, ValueError, yaml.YAMLError) as exc:
     typer.echo(f"Error: {exc}", err=True)
     raise typer.Exit(code=2)
+
+  operational_errors = (
+      ImportError,
+      OSError,
+      ValueError,
+      GoogleAPIError,
+      GoogleAuthError,
+      yaml.YAMLError,
+      *_langsmith_error_types(),
+  )
+  try:
+    stats = export(source, config=config)
+  except operational_errors as exc:
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+  typer.echo(json.dumps(stats.to_dict(), sort_keys=True))
+  if stats.failed or stats.skipped:
+    raise typer.Exit(code=1)

--- a/src/bigquery_agent_analytics/export/langsmith.py
+++ b/src/bigquery_agent_analytics/export/langsmith.py
@@ -1,0 +1,1234 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export arbitrary BigQuery trace rows to LangSmith.
+
+The connector deliberately knows nothing about event payload semantics. A
+``FieldMapping`` declares the small set of values needed to construct a
+LangSmith run. Every other source column is copied to run metadata, and mapped
+payloads are passed through without event-type-specific interpretation.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import date
+from datetime import datetime
+from datetime import time as datetime_time
+from datetime import timedelta
+from datetime import timezone
+from decimal import Decimal
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import tempfile
+import time
+from typing import Any
+import uuid
+
+from google.cloud import bigquery
+import yaml
+
+from .._telemetry import make_bq_client
+from .._telemetry import with_sdk_labels
+from ..trace import _build_span_tree
+from ..trace import Span
+
+_LOGGER = logging.getLogger(__name__)
+_TABLE_REFERENCE_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_-]*\.[A-Za-z0-9_][A-Za-z0-9_]*\."
+    r"[A-Za-z0-9_][A-Za-z0-9_$-]*$"
+)
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_LANGSMITH_NAMESPACE = uuid.UUID("d9f0dc62-d16c-4fc1-9b72-08dc8cf77a84")
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_MISSING = object()
+_SOURCE_STATUS_ERROR = "[SOURCE_STATUS_ERROR]"
+_WATERMARK_VERSION = 1
+
+
+@dataclass(frozen=True)
+class FieldMapping:
+  """Source paths used to populate LangSmith run fields.
+
+  Paths are tuples of mapping keys. Dotted strings in configuration files are
+  converted to tuples; they are traversed only when the source value is already
+  a mapping. JSON strings are never decoded or inspected.
+  """
+
+  run_id: tuple[str, ...]
+  trace_id: tuple[str, ...]
+  parent_run_id: tuple[str, ...] | None = None
+  name: tuple[str, ...] | None = None
+  run_type: tuple[str, ...] | None = None
+  start_time: tuple[str, ...] | None = None
+  end_time: tuple[str, ...] | None = None
+  latency_ms: tuple[str, ...] | None = None
+  error: tuple[str, ...] | None = None
+  status: tuple[str, ...] | None = None
+  inputs: tuple[str, ...] | None = None
+  outputs: tuple[str, ...] | None = None
+
+  @classmethod
+  def standard_adk(cls) -> FieldMapping:
+    """Return the mapping for the ADK ``agent_events`` schema."""
+    return cls(
+        run_id=("span_id",),
+        trace_id=("trace_id",),
+        parent_run_id=("parent_span_id",),
+        name=("event_type",),
+        start_time=("timestamp",),
+        latency_ms=("latency_ms", "total_ms"),
+        error=("error_message",),
+        status=("status",),
+        inputs=("content",),
+    )
+
+  @classmethod
+  def from_dict(cls, values: Mapping[str, Any]) -> FieldMapping:
+    """Build a mapping from LangSmith-field-to-source-path values."""
+    if "fields" in values:
+      nested = values["fields"]
+      if not isinstance(nested, Mapping):
+        raise ValueError("mapping.fields must be an object")
+      values = nested
+
+    defaults = asdict(cls.standard_adk())
+    unknown = set(values) - set(defaults)
+    if unknown:
+      raise ValueError(
+          "unknown mapping field(s): " + ", ".join(sorted(unknown))
+      )
+    parsed: dict[str, tuple[str, ...] | None] = {}
+    for name, default in defaults.items():
+      raw = values.get(name, default)
+      parsed[name] = _parse_path(raw, field_name=name)
+    if not parsed["run_id"]:
+      raise ValueError("mapping run_id is required")
+    if not parsed["trace_id"]:
+      raise ValueError("mapping trace_id is required")
+    return cls(**parsed)  # type: ignore[arg-type]
+
+  @classmethod
+  def from_file(cls, path: str | Path) -> FieldMapping:
+    """Load a mapping from a YAML or JSON file."""
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+      raise ValueError("mapping file must contain an object")
+    return cls.from_dict(raw)
+
+  def fingerprint(self) -> str:
+    """Return a stable fingerprint used to bind incremental state."""
+    payload = json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+  def mapped_whole_columns(self) -> frozenset[str]:
+    """Return columns wholly represented by mapped LangSmith fields.
+
+    A nested mapping such as ``payload.trace.id`` does not consume the whole
+    ``payload`` column. It remains in metadata so sibling fields are not lost.
+    """
+    return frozenset(
+        path[0]
+        for name, path in asdict(self).items()
+        if name != "status" and path is not None and len(path) == 1
+    )
+
+
+@dataclass(frozen=True)
+class ExportConfig:
+  """Operational settings for :func:`export`."""
+
+  mapping: FieldMapping = field(default_factory=FieldMapping.standard_adk)
+  project_id: str | None = None
+  location: str | None = None
+  langsmith_project: str | None = None
+  langsmith_api_key: str | None = None
+  langsmith_endpoint: str | None = None
+  langsmith_workspace_id: str | None = None
+  source_id: str | None = None
+  since: datetime | None = None
+  until: datetime | None = None
+  where: str | None = None
+  incremental: bool = False
+  watermark_path: Path = Path(".bqaa-langsmith-watermark.json")
+  batch_size: int = 100
+  requests_per_second: float | None = 5.0
+  max_retries: int = 3
+  retry_backoff_seconds: float = 1.0
+  max_dropped_rows: int = 1000
+
+  def __post_init__(self) -> None:
+    if self.batch_size < 1:
+      raise ValueError("batch_size must be at least 1")
+    if self.requests_per_second is not None and self.requests_per_second <= 0:
+      raise ValueError("requests_per_second must be positive or None")
+    if self.max_retries < 0:
+      raise ValueError("max_retries cannot be negative")
+    if self.retry_backoff_seconds < 0:
+      raise ValueError("retry_backoff_seconds cannot be negative")
+    if self.max_dropped_rows < 0:
+      raise ValueError("max_dropped_rows cannot be negative")
+    if self.since and self.until and self.since >= self.until:
+      raise ValueError("since must be before until")
+
+
+@dataclass(frozen=True)
+class DroppedRow:
+  """A source row that could not be exported."""
+
+  source_run_id: str
+  reason: str
+
+
+@dataclass(frozen=True)
+class ExportStats:
+  """Summary returned by an export job."""
+
+  rows_read: int
+  exported: int
+  skipped: int
+  failed: int
+  traces_exported: int
+  batches: int
+  dropped_rows: tuple[DroppedRow, ...]
+  dropped_rows_truncated: int = 0
+  watermark: datetime | None = None
+
+  def to_dict(self) -> dict[str, Any]:
+    """Return a JSON-friendly summary."""
+    return {
+        "rows_read": self.rows_read,
+        "exported": self.exported,
+        "skipped": self.skipped,
+        "failed": self.failed,
+        "traces_exported": self.traces_exported,
+        "batches": self.batches,
+        "dropped_rows": [asdict(row) for row in self.dropped_rows],
+        "dropped_rows_truncated": self.dropped_rows_truncated,
+        "watermark": self.watermark.isoformat() if self.watermark else None,
+    }
+
+
+@dataclass(frozen=True)
+class _Watermark:
+  timestamp: datetime
+  trace_id: str
+  run_id: str
+
+
+def _max_watermark(
+    first: _Watermark | None, second: _Watermark | None
+) -> _Watermark | None:
+  candidates = [item for item in (first, second) if item is not None]
+  if not candidates:
+    return None
+  return max(
+      candidates,
+      key=lambda item: (item.timestamp, item.trace_id, item.run_id),
+  )
+
+
+@dataclass(frozen=True)
+class _MappedRow:
+  source_run_id: str
+  source_trace_id: str
+  source_parent_id: str | None
+  name: str
+  run_type: str
+  start_time: datetime
+  end_time: datetime | None
+  error: str | None
+  status: str | None
+  inputs: dict[str, Any]
+  outputs: dict[str, Any] | None
+  metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _PreparedTrace:
+  runs: list[dict[str, Any]]
+  source_run_ids: tuple[str, ...]
+  skipped: tuple[DroppedRow, ...] = ()
+  skipped_count: int = 0
+  watermark_candidate: _Watermark | None = None
+
+
+@dataclass
+class _PendingBatch:
+  runs: list[dict[str, Any]] = field(default_factory=list)
+  source_run_ids: list[str] = field(default_factory=list)
+  trace_tokens: list[int] = field(default_factory=list)
+
+  def add(
+      self,
+      root: dict[str, Any],
+      source_runs: list[dict[str, Any]],
+      source_run_ids: list[str],
+      trace_token: int,
+  ) -> None:
+    self.runs.append(root)
+    self.runs.extend(source_runs)
+    self.source_run_ids.extend(source_run_ids)
+    self.trace_tokens.append(trace_token)
+
+  def clear(self) -> None:
+    self.runs.clear()
+    self.source_run_ids.clear()
+    self.trace_tokens.clear()
+
+
+@dataclass
+class _TraceProgress:
+  remaining_chunks: int
+  successful: bool
+  watermark: _Watermark | None
+
+
+@dataclass
+class _DroppedRowCollector:
+  maximum: int
+  rows: list[DroppedRow] = field(default_factory=list)
+  total: int = 0
+
+  def add(self, row: DroppedRow) -> None:
+    self.total += 1
+    if len(self.rows) < self.maximum:
+      self.rows.append(row)
+
+  def extend(self, rows: Iterable[DroppedRow]) -> None:
+    for row in rows:
+      self.add(row)
+
+  def record_omitted(self, count: int) -> None:
+    self.total += count
+
+  @property
+  def truncated(self) -> int:
+    return self.total - len(self.rows)
+
+
+def _parse_path(value: Any, *, field_name: str) -> tuple[str, ...] | None:
+  if value is None:
+    return None
+  if isinstance(value, str):
+    path = tuple(value.split("."))
+  elif isinstance(value, (list, tuple)) and all(
+      isinstance(item, str) for item in value
+  ):
+    path = tuple(value)
+  else:
+    raise ValueError(f"mapping {field_name} must be a dotted path or null")
+  if not path or any(not segment for segment in path):
+    raise ValueError(f"mapping {field_name} contains an empty path segment")
+  return path
+
+
+def _path_value(row: Mapping[str, Any], path: tuple[str, ...] | None) -> Any:
+  if path is None:
+    return _MISSING
+  value: Any = row
+  for segment in path:
+    if not isinstance(value, Mapping) or segment not in value:
+      return _MISSING
+    value = value[segment]
+  return value
+
+
+def _required_string(
+    row: Mapping[str, Any], path: tuple[str, ...], name: str
+) -> str:
+  value = _path_value(row, path)
+  if value is _MISSING or value is None or value == "":
+    raise ValueError(f"missing mapped {name}")
+  if not isinstance(value, (str, int, float, Decimal)):
+    raise ValueError(f"mapped {name} must be a scalar")
+  return str(value)
+
+
+def _optional_string(
+    row: Mapping[str, Any], path: tuple[str, ...] | None
+) -> str | None:
+  value = _path_value(row, path)
+  if value is _MISSING or value is None:
+    return None
+  if not isinstance(value, (str, int, float, Decimal)):
+    return None
+  return str(value)
+
+
+def _as_datetime(value: Any) -> datetime | None:
+  if isinstance(value, datetime):
+    parsed = value
+  elif isinstance(value, str):
+    try:
+      parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+      return None
+  else:
+    return None
+  if parsed.tzinfo is None:
+    return parsed.replace(tzinfo=timezone.utc)
+  return parsed.astimezone(timezone.utc)
+
+
+def _as_io(value: Any) -> dict[str, Any] | None:
+  if value is _MISSING or value is None:
+    return None
+  if callable(getattr(value, "items", None)):
+    return _json_compatible(value)
+  return {"value": _json_compatible(value)}
+
+
+def _json_compatible(value: Any) -> Any:
+  """Encode BigQuery scalar/container values without inspecting semantics."""
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  if isinstance(value, bytes):
+    return {
+        "encoding": "base64",
+        "data": base64.b64encode(value).decode("ascii"),
+    }
+  if isinstance(value, Decimal):
+    return str(value)
+  if isinstance(value, (datetime, date, datetime_time)):
+    return value.isoformat()
+  if isinstance(value, uuid.UUID):
+    return str(value)
+  items = getattr(value, "items", None)
+  if callable(items):
+    return {str(key): _json_compatible(item) for key, item in items()}
+  if isinstance(value, (list, tuple)):
+    return [_json_compatible(item) for item in value]
+  return str(value)
+
+
+def _map_row(
+    row: Mapping[str, Any],
+    mapping: FieldMapping,
+    consumed_columns: frozenset[str],
+) -> _MappedRow:
+  source_run_id = _required_string(row, mapping.run_id, "run_id")
+  source_trace_id = _required_string(row, mapping.trace_id, "trace_id")
+  source_parent_id = _optional_string(row, mapping.parent_run_id)
+  name = _optional_string(row, mapping.name) or "BQAA event"
+  run_type = _optional_string(row, mapping.run_type) or "chain"
+  start_time = _as_datetime(_path_value(row, mapping.start_time)) or _EPOCH
+  end_time = _as_datetime(_path_value(row, mapping.end_time))
+  latency = _path_value(row, mapping.latency_ms)
+  if end_time is None and isinstance(latency, (int, float)):
+    end_time = start_time + timedelta(milliseconds=float(latency))
+  error = _optional_string(row, mapping.error)
+  status = _optional_string(row, mapping.status)
+  if not error and status is not None and status.upper() == "ERROR":
+    error = _SOURCE_STATUS_ERROR
+  inputs = _as_io(_path_value(row, mapping.inputs)) or {}
+  outputs = _as_io(_path_value(row, mapping.outputs))
+  metadata = {
+      key: _json_compatible(value)
+      for key, value in row.items()
+      if key not in consumed_columns
+  }
+  return _MappedRow(
+      source_run_id=source_run_id,
+      source_trace_id=source_trace_id,
+      source_parent_id=source_parent_id,
+      name=name,
+      run_type=run_type,
+      start_time=start_time,
+      end_time=end_time,
+      error=error,
+      status=status,
+      inputs=inputs,
+      outputs=outputs,
+      metadata=metadata,
+  )
+
+
+def _stable_uuid(source: str, *parts: str) -> uuid.UUID:
+  return uuid.uuid5(_LANGSMITH_NAMESPACE, "\x1f".join((source, *parts)))
+
+
+def _dotted_segment(timestamp: datetime, run_id: uuid.UUID) -> str:
+  normalized = timestamp.astimezone(timezone.utc)
+  return f"{normalized.strftime('%Y%m%dT%H%M%S%fZ')}{run_id}"
+
+
+def _prepare_trace_runs(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    mapping: FieldMapping,
+    source_fingerprint: str,
+    project_name: str,
+    max_dropped_rows: int | None = None,
+) -> _PreparedTrace:
+  """Map one source trace to a LangSmith run tree.
+
+  ``Trace._build_tree`` is the hierarchy authority used by the rest of the SDK.
+  An exporter-owned synthetic root gives every LangSmith trace exactly one
+  root, including source traces with multiple roots.
+  """
+  mapped: list[_MappedRow] = []
+  skipped: list[DroppedRow] = []
+  skipped_count = 0
+  seen: set[tuple[str, str]] = set()
+  consumed_columns = mapping.mapped_whole_columns()
+
+  def record_skipped(row: DroppedRow) -> None:
+    nonlocal skipped_count
+    skipped_count += 1
+    if max_dropped_rows is None or len(skipped) < max_dropped_rows:
+      skipped.append(row)
+
+  for index, row in enumerate(rows):
+    try:
+      item = _map_row(row, mapping, consumed_columns)
+    except ValueError as exc:
+      fallback = _optional_string(row, mapping.run_id) or f"row-{index}"
+      record_skipped(DroppedRow(fallback, str(exc)))
+      continue
+    identity = (item.source_trace_id, item.source_run_id)
+    if identity in seen:
+      record_skipped(DroppedRow(item.source_run_id, "duplicate source run_id"))
+      continue
+    seen.add(identity)
+    mapped.append(item)
+
+  if not mapped:
+    return _PreparedTrace(
+        runs=[],
+        source_run_ids=(),
+        skipped=tuple(skipped),
+        skipped_count=skipped_count,
+    )
+
+  trace_ids = {item.source_trace_id for item in mapped}
+  if len(trace_ids) != 1:
+    raise ValueError("_prepare_trace_runs requires rows from exactly one trace")
+  source_trace_id = mapped[0].source_trace_id
+  mapped.sort(key=lambda item: (item.start_time, item.source_run_id))
+
+  span_to_row: dict[int, _MappedRow] = {}
+  spans: list[Span] = []
+  for item in mapped:
+    span = Span(
+        event_type=item.name,
+        agent=None,
+        timestamp=item.start_time,
+        span_id=item.source_run_id,
+        parent_span_id=item.source_parent_id,
+    )
+    spans.append(span)
+    span_to_row[id(span)] = item
+  roots = _build_span_tree(spans)
+
+  trace_uuid = _stable_uuid(source_fingerprint, "trace", source_trace_id)
+  # The synthetic root may be emitted by multiple overlapping or incremental
+  # windows. A fixed structural timestamp keeps its wire representation and
+  # every descendant's dotted-order prefix stable when a window does not
+  # contain the source trace's first event. Source event timestamps remain
+  # unchanged on their individual runs.
+  root_dotted = _dotted_segment(_EPOCH, trace_uuid)
+  runs: list[dict[str, Any]] = [
+      {
+          "id": trace_uuid,
+          "trace_id": trace_uuid,
+          "parent_run_id": None,
+          "dotted_order": root_dotted,
+          "session_name": project_name,
+          "name": "BQAA trace",
+          "run_type": "chain",
+          "inputs": {},
+          "start_time": _EPOCH,
+          "end_time": _EPOCH,
+          "extra": {
+              "metadata": {},
+              "bqaa": {"source_trace_id": source_trace_id},
+          },
+      }
+  ]
+  visited: set[str] = set()
+
+  def append_component(
+      component_root: Span, parent_uuid: uuid.UUID, parent_dotted: str
+  ) -> None:
+    # Iterative preorder traversal avoids failing on traces whose nesting depth
+    # exceeds Python's recursion limit.
+    stack = [(component_root, parent_uuid, parent_dotted)]
+    while stack:
+      span, span_parent_uuid, span_parent_dotted = stack.pop()
+      item = span_to_row[id(span)]
+      if item.source_run_id in visited:
+        continue
+      visited.add(item.source_run_id)
+      run_uuid = _stable_uuid(
+          source_fingerprint,
+          "run",
+          item.source_trace_id,
+          item.source_run_id,
+      )
+      dotted = (
+          span_parent_dotted + "." + _dotted_segment(item.start_time, run_uuid)
+      )
+      run: dict[str, Any] = {
+          "id": run_uuid,
+          "trace_id": trace_uuid,
+          "parent_run_id": span_parent_uuid,
+          "dotted_order": dotted,
+          "session_name": project_name,
+          "name": item.name,
+          "run_type": item.run_type,
+          "inputs": item.inputs,
+          "start_time": item.start_time,
+          "extra": {
+              "metadata": item.metadata,
+              "bqaa": {
+                  "source_trace_id": item.source_trace_id,
+                  "source_run_id": item.source_run_id,
+                  **(
+                      {"source_parent_run_id": item.source_parent_id}
+                      if item.source_parent_id is not None
+                      else {}
+                  ),
+              },
+          },
+      }
+      if item.end_time is not None:
+        run["end_time"] = item.end_time
+      if item.outputs is not None:
+        run["outputs"] = item.outputs
+      if item.error is not None:
+        run["error"] = item.error
+      runs.append(run)
+      children = sorted(
+          span.children,
+          key=lambda value: (
+              span_to_row[id(value)].start_time,
+              span_to_row[id(value)].source_run_id,
+          ),
+          reverse=True,
+      )
+      stack.extend((child, run_uuid, dotted) for child in children)
+
+  for root in sorted(
+      roots,
+      key=lambda value: (
+          span_to_row[id(value)].start_time,
+          span_to_row[id(value)].source_run_id,
+      ),
+  ):
+    # A query window may omit an ancestor. Pointing at that absent run while
+    # using the synthetic root's dotted prefix creates a contradictory tree.
+    # Flatten roots under the synthetic run; the original source parent stays
+    # available in ``extra.bqaa.source_parent_run_id``.
+    append_component(root, trace_uuid, root_dotted)
+
+  # Existing trace reconstruction intentionally yields no roots for a cycle.
+  # Keep every source row exportable by breaking each remaining component at a
+  # deterministic node and placing that node below the synthetic root.
+  for span in spans:
+    item = span_to_row[id(span)]
+    if item.source_run_id not in visited:
+      append_component(span, trace_uuid, root_dotted)
+
+  watermark_candidate = max(
+      (
+          _Watermark(
+              item.start_time,
+              item.source_trace_id,
+              item.source_run_id,
+          )
+          for item in mapped
+      ),
+      key=lambda item: (item.timestamp, item.trace_id, item.run_id),
+  )
+  return _PreparedTrace(
+      runs=runs,
+      source_run_ids=tuple(item.source_run_id for item in mapped),
+      skipped=tuple(skipped),
+      skipped_count=skipped_count,
+      watermark_candidate=watermark_candidate,
+  )
+
+
+def _sql_path(path: tuple[str, ...] | None, *, field_name: str) -> str:
+  if path is None:
+    raise ValueError(f"mapping {field_name} is required for this filter")
+  if any(not _PATH_SEGMENT_RE.fullmatch(segment) for segment in path):
+    raise ValueError(
+        f"mapping {field_name} must contain BigQuery identifier segments"
+    )
+  return "bqaa_source." + ".".join(f"`{segment}`" for segment in path)
+
+
+def _normalize_sql_source(source: str) -> str:
+  return source.strip().removesuffix(";").rstrip()
+
+
+def _build_source_query(
+    source: str,
+    *,
+    mapping: FieldMapping,
+    since: datetime | None,
+    until: datetime | None,
+    where: str | None,
+    watermark: _Watermark | None,
+) -> tuple[str, list[bigquery.ScalarQueryParameter]]:
+  """Build the outer query and bound time/watermark parameters."""
+  source = source.strip()
+  if not source:
+    raise ValueError("source cannot be empty")
+  if _TABLE_REFERENCE_RE.fullmatch(source):
+    sql = f"SELECT * FROM `{source}` AS bqaa_source"
+  else:
+    query = _normalize_sql_source(source)
+    sql = f"SELECT * FROM (\n{query}\n) AS bqaa_source"
+
+  conditions: list[str] = []
+  parameters: list[bigquery.ScalarQueryParameter] = []
+  if since is not None:
+    timestamp = _sql_path(mapping.start_time, field_name="start_time")
+    conditions.append(f"{timestamp} >= @bqaa_since")
+    parameters.append(
+        bigquery.ScalarQueryParameter("bqaa_since", "TIMESTAMP", since)
+    )
+  if until is not None:
+    timestamp = _sql_path(mapping.start_time, field_name="start_time")
+    conditions.append(f"{timestamp} < @bqaa_until")
+    parameters.append(
+        bigquery.ScalarQueryParameter("bqaa_until", "TIMESTAMP", until)
+    )
+  if watermark is not None:
+    timestamp = _sql_path(mapping.start_time, field_name="start_time")
+    trace_id = _sql_path(mapping.trace_id, field_name="trace_id")
+    run_id = _sql_path(mapping.run_id, field_name="run_id")
+    conditions.append(
+        f"({timestamp} > @bqaa_watermark_timestamp OR "
+        f"({timestamp} = @bqaa_watermark_timestamp AND "
+        f"(CAST({trace_id} AS STRING) > @bqaa_watermark_trace_id OR "
+        f"(CAST({trace_id} AS STRING) = @bqaa_watermark_trace_id AND "
+        f"CAST({run_id} AS STRING) > @bqaa_watermark_run_id))))"
+    )
+    parameters.extend(
+        [
+            bigquery.ScalarQueryParameter(
+                "bqaa_watermark_timestamp", "TIMESTAMP", watermark.timestamp
+            ),
+            bigquery.ScalarQueryParameter(
+                "bqaa_watermark_trace_id", "STRING", watermark.trace_id
+            ),
+            bigquery.ScalarQueryParameter(
+                "bqaa_watermark_run_id", "STRING", watermark.run_id
+            ),
+        ]
+    )
+  if where:
+    conditions.append(f"({where})")
+  if conditions:
+    sql += "\nWHERE " + " AND ".join(conditions)
+  trace_path = _sql_path(mapping.trace_id, field_name="trace_id")
+  run_path = _sql_path(mapping.run_id, field_name="run_id")
+  ordering = [f"CAST({trace_path} AS STRING)"]
+  if mapping.start_time is not None:
+    ordering.append(_sql_path(mapping.start_time, field_name="start_time"))
+  ordering.append(f"CAST({run_path} AS STRING)")
+  sql += "\nORDER BY " + ", ".join(ordering)
+  return sql, parameters
+
+
+def _canonical_source(source: str, source_id: str | None) -> str:
+  if source_id:
+    return source_id
+  stripped = source.strip()
+  if _TABLE_REFERENCE_RE.fullmatch(stripped):
+    return "table:" + stripped.lower()
+  normalized = _normalize_sql_source(stripped)
+  return "sql:" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _load_watermark(
+    path: Path,
+    *,
+    source: str,
+    mapping: FieldMapping,
+    destination: Mapping[str, str | None],
+) -> _Watermark | None:
+  if not path.exists():
+    return None
+  raw = json.loads(path.read_text(encoding="utf-8"))
+  if not isinstance(raw, dict):
+    raise ValueError("watermark file must contain an object")
+  if raw.get("version") != _WATERMARK_VERSION:
+    raise ValueError("unsupported watermark version")
+  if (
+      raw.get("source") != source
+      or raw.get("mapping") != mapping.fingerprint()
+      or raw.get("destination") != dict(destination)
+  ):
+    raise ValueError(
+        "watermark belongs to a different source, field mapping, or destination"
+    )
+  timestamp = _as_datetime(raw.get("timestamp"))
+  trace_id = raw.get("trace_id")
+  run_id = raw.get("run_id")
+  if (
+      timestamp is None
+      or not isinstance(trace_id, str)
+      or not isinstance(run_id, str)
+  ):
+    raise ValueError("watermark timestamp/trace_id/run_id is invalid")
+  return _Watermark(timestamp, trace_id, run_id)
+
+
+def _save_watermark(
+    path: Path,
+    watermark: _Watermark,
+    *,
+    source: str,
+    mapping: FieldMapping,
+    destination: Mapping[str, str | None],
+) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  payload = json.dumps(
+      {
+          "version": _WATERMARK_VERSION,
+          "source": source,
+          "mapping": mapping.fingerprint(),
+          "destination": dict(destination),
+          "timestamp": watermark.timestamp.isoformat(),
+          "trace_id": watermark.trace_id,
+          "run_id": watermark.run_id,
+      },
+      sort_keys=True,
+      indent=2,
+  )
+  fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+  try:
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+      stream.write(payload)
+      stream.write("\n")
+      stream.flush()
+      os.fsync(stream.fileno())
+    os.replace(temporary, path)
+  except BaseException:
+    Path(temporary).unlink(missing_ok=True)
+    raise
+
+
+def _is_retryable(exc: Exception) -> bool:
+  nested = getattr(exc, "exceptions", None)
+  if isinstance(nested, (list, tuple)):
+    return bool(nested) and all(
+        isinstance(item, Exception) and _is_retryable(item) for item in nested
+    )
+
+  try:
+    from langsmith import utils as langsmith_utils
+  except ImportError:
+    langsmith_utils = None
+  if langsmith_utils is not None:
+    retryable_types = tuple(
+        exception_type
+        for name in (
+            "LangSmithAPIError",
+            "LangSmithConflictError",
+            "LangSmithConnectionError",
+            "LangSmithRateLimitError",
+            "LangSmithRequestTimeout",
+        )
+        if isinstance(
+            exception_type := getattr(langsmith_utils, name, None), type
+        )
+    )
+    if retryable_types and isinstance(exc, retryable_types):
+      return True
+
+  status = getattr(exc, "status_code", None)
+  if status is None:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+  if status in (408, 409, 425, 429):
+    return True
+  if isinstance(status, int) and status >= 500:
+    return True
+  return isinstance(exc, (ConnectionError, TimeoutError))
+
+
+class _RateLimiter:
+
+  def __init__(
+      self,
+      requests_per_second: float | None,
+      *,
+      sleep: Callable[[float], None],
+      monotonic: Callable[[], float],
+  ) -> None:
+    self._interval = (
+        None if requests_per_second is None else 1.0 / requests_per_second
+    )
+    self._sleep = sleep
+    self._monotonic = monotonic
+    self._last_request: float | None = None
+
+  def wait(self) -> None:
+    if self._interval is None:
+      return
+    now = self._monotonic()
+    if self._last_request is not None:
+      remaining = self._interval - (now - self._last_request)
+      if remaining > 0:
+        self._sleep(remaining)
+        now = self._monotonic()
+    self._last_request = now
+
+
+def _call_with_retry(
+    operation: Callable[[], None],
+    *,
+    config: ExportConfig,
+    limiter: _RateLimiter,
+    sleep: Callable[[float], None],
+) -> None:
+  for attempt in range(config.max_retries + 1):
+    limiter.wait()
+    try:
+      operation()
+      return
+    except Exception as exc:
+      if attempt >= config.max_retries or not _is_retryable(exc):
+        raise
+      sleep(config.retry_backoff_seconds * (2**attempt))
+
+
+class _ErrorReportingLangSmithClient:
+  """Make LangSmith's tracing-error callback observable to the exporter.
+
+  ``Client.batch_ingest_runs`` reports terminal HTTP failures through its
+  callback and then returns. Without this adapter the exporter would count a
+  swallowed failure as success and advance its watermark past lost rows.
+  """
+
+  def __init__(self, client: Any, errors: list[Exception]) -> None:
+    self._client = client
+    self._errors = errors
+
+  def batch_ingest_runs(self, *, create=None, update=None) -> None:
+    self._errors.clear()
+    self._client.batch_ingest_runs(create=create, update=update)
+    if self._errors:
+      raise self._errors[0]
+
+
+def _create_langsmith_client(config: ExportConfig) -> Any:
+  try:
+    from langsmith import Client
+  except ImportError as exc:
+    raise ImportError(
+        "LangSmith export requires the optional dependency; install "
+        "bigquery-agent-analytics[langsmith]"
+    ) from exc
+  errors: list[Exception] = []
+  client = Client(
+      api_url=config.langsmith_endpoint,
+      api_key=config.langsmith_api_key,
+      workspace_id=config.langsmith_workspace_id,
+      auto_batch_tracing=False,
+      tracing_error_callback=errors.append,
+  )
+  return _ErrorReportingLangSmithClient(client, errors)
+
+
+def _resolved_destination(
+    config: ExportConfig, project_name: str, client: Any
+) -> dict[str, str | None]:
+  raw_client = getattr(client, "_client", client)
+  endpoint = (
+      config.langsmith_endpoint
+      or getattr(raw_client, "api_url", None)
+      or os.environ.get("LANGSMITH_ENDPOINT")
+      or os.environ.get("LANGCHAIN_ENDPOINT")
+      or "https://api.smith.langchain.com"
+  )
+  workspace = (
+      config.langsmith_workspace_id
+      or getattr(raw_client, "workspace_id", None)
+      or os.environ.get("LANGSMITH_WORKSPACE_ID")
+      or os.environ.get("LANGCHAIN_WORKSPACE_ID")
+  )
+  return {
+      "project": project_name,
+      "endpoint": str(endpoint).rstrip("/"),
+      "workspace_id": str(workspace) if workspace is not None else None,
+  }
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+  items = getattr(row, "items", None)
+  if callable(items):
+    return dict(items())
+  raise TypeError("BigQuery query returned a row without mapping semantics")
+
+
+def export(
+    source: str,
+    *,
+    config: ExportConfig | None = None,
+    mapping: FieldMapping | Mapping[str, Any] | None = None,
+    bq_client: Any = None,
+    langsmith_client: Any = None,
+) -> ExportStats:
+  """Export a BigQuery table or SQL result to LangSmith.
+
+  Injected clients are supported for controlled runtimes and tests. Otherwise
+  BigQuery uses Application Default Credentials, and the optional LangSmith SDK
+  reads its standard environment variables unless explicit config values are
+  supplied.
+  """
+  config = config or ExportConfig()
+  if mapping is None:
+    resolved_mapping = config.mapping
+  elif isinstance(mapping, FieldMapping):
+    resolved_mapping = mapping
+  else:
+    resolved_mapping = FieldMapping.from_dict(mapping)
+
+  canonical_source = _canonical_source(source, config.source_id)
+  project_name = (
+      config.langsmith_project
+      or os.environ.get("LANGSMITH_PROJECT")
+      or os.environ.get("LANGCHAIN_PROJECT")
+      or "default"
+  )
+  if langsmith_client is None:
+    langsmith_client = _create_langsmith_client(config)
+  destination = _resolved_destination(config, project_name, langsmith_client)
+  watermark = None
+  if config.incremental:
+    watermark = _load_watermark(
+        config.watermark_path,
+        source=canonical_source,
+        mapping=resolved_mapping,
+        destination=destination,
+    )
+  sql, parameters = _build_source_query(
+      source,
+      mapping=resolved_mapping,
+      since=config.since,
+      until=config.until,
+      where=config.where,
+      watermark=watermark,
+  )
+  if bq_client is None:
+    project = config.project_id
+    if project is None and _TABLE_REFERENCE_RE.fullmatch(source.strip()):
+      project = source.strip().split(".", 1)[0]
+    bq_client = make_bq_client(
+        project,
+        location=config.location,
+        sdk_surface="langsmith_export",
+    )
+  job_config = bigquery.QueryJobConfig(query_parameters=parameters)
+  job_config = with_sdk_labels(job_config, feature="langsmith-export")
+  dropped_rows = _DroppedRowCollector(config.max_dropped_rows)
+  limiter = _RateLimiter(
+      config.requests_per_second,
+      sleep=time.sleep,
+      monotonic=time.monotonic,
+  )
+
+  rows_read = 0
+  exported = 0
+  skipped = 0
+  failed = 0
+  batches = 0
+  traces_exported = 0
+  exported_watermark: _Watermark | None = None
+  pending = _PendingBatch()
+  trace_progress: dict[int, _TraceProgress] = {}
+  next_trace_token = 0
+
+  def flush() -> None:
+    nonlocal exported, failed, batches, traces_exported
+    nonlocal exported_watermark
+    if not pending.runs:
+      return
+    batches += 1
+    batch_runs = list(pending.runs)
+    try:
+      _call_with_retry(
+          lambda: langsmith_client.batch_ingest_runs(create=batch_runs),
+          config=config,
+          limiter=limiter,
+          sleep=time.sleep,
+      )
+    except Exception as exc:
+      failed += len(pending.source_run_ids)
+      for source_run_id in pending.source_run_ids:
+        dropped_rows.add(DroppedRow(source_run_id, type(exc).__name__))
+      for token in pending.trace_tokens:
+        trace_progress[token].successful = False
+      _LOGGER.warning(
+          "LangSmith export batch failed for %d row(s): %s",
+          len(pending.source_run_ids),
+          type(exc).__name__,
+      )
+    else:
+      exported += len(pending.source_run_ids)
+    for token in pending.trace_tokens:
+      progress = trace_progress[token]
+      progress.remaining_chunks -= 1
+      if progress.remaining_chunks == 0:
+        if progress.successful:
+          traces_exported += 1
+          exported_watermark = _max_watermark(
+              exported_watermark, progress.watermark
+          )
+        del trace_progress[token]
+    _LOGGER.info(
+        "LangSmith export progress: exported=%d skipped=%d failed=%d",
+        exported,
+        skipped,
+        failed,
+    )
+    pending.clear()
+
+  def enqueue(trace: _PreparedTrace) -> None:
+    nonlocal skipped, next_trace_token
+    skipped += trace.skipped_count
+    dropped_rows.extend(trace.skipped)
+    dropped_rows.record_omitted(trace.skipped_count - len(trace.skipped))
+    if not trace.runs:
+      return
+    root = trace.runs[0]
+    source_runs = trace.runs[1:]
+    source_run_ids = [
+        str(run["extra"]["bqaa"]["source_run_id"]) for run in source_runs
+    ]
+    if len(source_runs) != len(trace.source_run_ids):
+      raise ValueError("prepared trace run/source accounting is inconsistent")
+    source_count = len(source_runs)
+    chunk_count = (source_count + config.batch_size - 1) // config.batch_size
+    trace_token = next_trace_token
+    next_trace_token += 1
+    trace_progress[trace_token] = _TraceProgress(
+        remaining_chunks=chunk_count,
+        successful=trace.skipped_count == 0,
+        watermark=trace.watermark_candidate,
+    )
+
+    if pending.source_run_ids and (
+        source_count > config.batch_size
+        or len(pending.source_run_ids) + source_count > config.batch_size
+    ):
+      flush()
+    for offset in range(0, source_count, config.batch_size):
+      chunk_runs = source_runs[offset : offset + config.batch_size]
+      chunk_ids = source_run_ids[offset : offset + config.batch_size]
+      pending.add(root, chunk_runs, chunk_ids, trace_token)
+      if len(pending.source_run_ids) == config.batch_size:
+        flush()
+
+  query_rows = bq_client.query(sql, job_config=job_config).result(
+      page_size=config.batch_size
+  )
+  current_trace_id: str | None = None
+  current_rows: list[dict[str, Any]] = []
+  for raw_row in query_rows:
+    row_index = rows_read
+    rows_read += 1
+    row = _row_dict(raw_row)
+    try:
+      trace_id = _required_string(row, resolved_mapping.trace_id, "trace_id")
+    except ValueError as exc:
+      run_id = (
+          _optional_string(row, resolved_mapping.run_id) or f"row-{row_index}"
+      )
+      skipped += 1
+      dropped_rows.add(DroppedRow(run_id, str(exc)))
+      continue
+    if current_trace_id is not None and trace_id != current_trace_id:
+      enqueue(
+          _prepare_trace_runs(
+              current_rows,
+              mapping=resolved_mapping,
+              source_fingerprint=canonical_source,
+              project_name=project_name,
+              max_dropped_rows=max(
+                  config.max_dropped_rows - len(dropped_rows.rows), 0
+              ),
+          )
+      )
+      current_rows = []
+    current_trace_id = trace_id
+    current_rows.append(row)
+  if current_rows:
+    enqueue(
+        _prepare_trace_runs(
+            current_rows,
+            mapping=resolved_mapping,
+            source_fingerprint=canonical_source,
+            project_name=project_name,
+            max_dropped_rows=max(
+                config.max_dropped_rows - len(dropped_rows.rows), 0
+            ),
+        )
+    )
+  flush()
+
+  final_watermark = watermark.timestamp if watermark else None
+  # Never advance past a failed API batch. Replaying successful rows is safe
+  # because IDs are stable, while advancing could permanently skip failures.
+  if (
+      config.incremental
+      and skipped == 0
+      and failed == 0
+      and exported_watermark is not None
+  ):
+    next_watermark = exported_watermark
+    _save_watermark(
+        config.watermark_path,
+        next_watermark,
+        source=canonical_source,
+        mapping=resolved_mapping,
+        destination=destination,
+    )
+    final_watermark = next_watermark.timestamp
+
+  return ExportStats(
+      rows_read=rows_read,
+      exported=exported,
+      skipped=skipped,
+      failed=failed,
+      traces_exported=traces_exported,
+      batches=batches,
+      dropped_rows=tuple(dropped_rows.rows),
+      dropped_rows_truncated=dropped_rows.truncated,
+      watermark=final_watermark,
+  )
+
+
+__all__ = [
+    "DroppedRow",
+    "ExportConfig",
+    "ExportStats",
+    "FieldMapping",
+    "export",
+]

--- a/src/bigquery_agent_analytics/export/langsmith.py
+++ b/src/bigquery_agent_analytics/export/langsmith.py
@@ -1163,14 +1163,6 @@ def export(
       except Exception as exc:
         if not _is_conflict(exc):
           raise
-      _call_with_retry(
-          lambda: langsmith_client.batch_ingest_runs(
-              update=copy.deepcopy(pending.runs)
-          ),
-          config=config,
-          limiter=limiter,
-          sleep=time.sleep,
-      )
     except Exception as exc:
       failed += len(pending.source_run_ids)
       for source_run_id in pending.source_run_ids:

--- a/src/bigquery_agent_analytics/export/langsmith.py
+++ b/src/bigquery_agent_analytics/export/langsmith.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable, Iterable, Mapping
+import copy
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
@@ -63,6 +64,20 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 _MISSING = object()
 _SOURCE_STATUS_ERROR = "[SOURCE_STATUS_ERROR]"
 _WATERMARK_VERSION = 1
+_FIELD_MAPPING_NAMES = (
+    "run_id",
+    "trace_id",
+    "parent_run_id",
+    "name",
+    "run_type",
+    "start_time",
+    "end_time",
+    "latency_ms",
+    "error",
+    "status",
+    "inputs",
+    "outputs",
+)
 
 
 @dataclass(frozen=True)
@@ -70,8 +85,9 @@ class FieldMapping:
   """Source paths used to populate LangSmith run fields.
 
   Paths are tuples of mapping keys. Dotted strings in configuration files are
-  converted to tuples; they are traversed only when the source value is already
-  a mapping. JSON strings are never decoded or inspected.
+  converted to tuples; custom mappings traverse only values that are already
+  mappings. The built-in ADK mapping also accepts JSON columns returned as
+  strings by BigQuery clients.
   """
 
   run_id: tuple[str, ...]
@@ -86,6 +102,9 @@ class FieldMapping:
   status: tuple[str, ...] | None = None
   inputs: tuple[str, ...] | None = None
   outputs: tuple[str, ...] | None = None
+  _decode_standard_adk_json: bool = field(
+      default=False, repr=False, compare=False
+  )
 
   @classmethod
   def standard_adk(cls) -> FieldMapping:
@@ -100,6 +119,7 @@ class FieldMapping:
         error=("error_message",),
         status=("status",),
         inputs=("content",),
+        _decode_standard_adk_json=True,
     )
 
   @classmethod
@@ -111,15 +131,14 @@ class FieldMapping:
         raise ValueError("mapping.fields must be an object")
       values = nested
 
-    defaults = asdict(cls.standard_adk())
-    unknown = set(values) - set(defaults)
+    unknown = set(values) - set(_FIELD_MAPPING_NAMES)
     if unknown:
       raise ValueError(
           "unknown mapping field(s): " + ", ".join(sorted(unknown))
       )
     parsed: dict[str, tuple[str, ...] | None] = {}
-    for name, default in defaults.items():
-      raw = values.get(name, default)
+    for name in _FIELD_MAPPING_NAMES:
+      raw = values.get(name)
       parsed[name] = _parse_path(raw, field_name=name)
     if not parsed["run_id"]:
       raise ValueError("mapping run_id is required")
@@ -137,7 +156,9 @@ class FieldMapping:
 
   def fingerprint(self) -> str:
     """Return a stable fingerprint used to bind incremental state."""
-    payload = json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+    mapping = {name: getattr(self, name) for name in _FIELD_MAPPING_NAMES}
+    mapping["_decode_standard_adk_json"] = self._decode_standard_adk_json
+    payload = json.dumps(mapping, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
   def mapped_whole_columns(self) -> frozenset[str]:
@@ -148,7 +169,8 @@ class FieldMapping:
     """
     return frozenset(
         path[0]
-        for name, path in asdict(self).items()
+        for name in _FIELD_MAPPING_NAMES
+        if (path := getattr(self, name)) is not None
         if name != "status" and path is not None and len(path) == 1
     )
 
@@ -257,7 +279,6 @@ class _MappedRow:
   start_time: datetime
   end_time: datetime | None
   error: str | None
-  status: str | None
   inputs: dict[str, Any]
   outputs: dict[str, Any] | None
   metadata: dict[str, Any]
@@ -266,10 +287,7 @@ class _MappedRow:
 @dataclass(frozen=True)
 class _PreparedTrace:
   runs: list[dict[str, Any]]
-  source_run_ids: tuple[str, ...]
-  skipped: tuple[DroppedRow, ...] = ()
   skipped_count: int = 0
-  watermark_candidate: _Watermark | None = None
 
 
 @dataclass
@@ -300,7 +318,6 @@ class _PendingBatch:
 class _TraceProgress:
   remaining_chunks: int
   successful: bool
-  watermark: _Watermark | None
 
 
 @dataclass
@@ -313,13 +330,6 @@ class _DroppedRowCollector:
     self.total += 1
     if len(self.rows) < self.maximum:
       self.rows.append(row)
-
-  def extend(self, rows: Iterable[DroppedRow]) -> None:
-    for row in rows:
-      self.add(row)
-
-  def record_omitted(self, count: int) -> None:
-    self.total += count
 
   @property
   def truncated(self) -> int:
@@ -342,14 +352,29 @@ def _parse_path(value: Any, *, field_name: str) -> tuple[str, ...] | None:
   return path
 
 
-def _path_value(row: Mapping[str, Any], path: tuple[str, ...] | None) -> Any:
+def _path_value(
+    row: Mapping[str, Any],
+    path: tuple[str, ...] | None,
+    *,
+    decode_json: bool = False,
+) -> Any:
   if path is None:
     return _MISSING
   value: Any = row
   for segment in path:
+    if decode_json and isinstance(value, str):
+      try:
+        value = json.loads(value)
+      except (json.JSONDecodeError, TypeError):
+        return _MISSING
     if not isinstance(value, Mapping) or segment not in value:
       return _MISSING
     value = value[segment]
+  if decode_json and isinstance(value, str):
+    try:
+      return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+      pass
   return value
 
 
@@ -433,14 +458,31 @@ def _map_row(
   run_type = _optional_string(row, mapping.run_type) or "chain"
   start_time = _as_datetime(_path_value(row, mapping.start_time)) or _EPOCH
   end_time = _as_datetime(_path_value(row, mapping.end_time))
-  latency = _path_value(row, mapping.latency_ms)
-  if end_time is None and isinstance(latency, (int, float)):
+  latency = _path_value(
+      row,
+      mapping.latency_ms,
+      decode_json=mapping._decode_standard_adk_json,
+  )
+  if (
+      end_time is None
+      and not isinstance(latency, bool)
+      and isinstance(latency, (int, float, Decimal))
+  ):
     end_time = start_time + timedelta(milliseconds=float(latency))
   error = _optional_string(row, mapping.error)
   status = _optional_string(row, mapping.status)
   if not error and status is not None and status.upper() == "ERROR":
     error = _SOURCE_STATUS_ERROR
-  inputs = _as_io(_path_value(row, mapping.inputs)) or {}
+  inputs = (
+      _as_io(
+          _path_value(
+              row,
+              mapping.inputs,
+              decode_json=mapping._decode_standard_adk_json,
+          )
+      )
+      or {}
+  )
   outputs = _as_io(_path_value(row, mapping.outputs))
   metadata = {
       key: _json_compatible(value)
@@ -456,7 +498,6 @@ def _map_row(
       start_time=start_time,
       end_time=end_time,
       error=error,
-      status=status,
       inputs=inputs,
       outputs=outputs,
       metadata=metadata,
@@ -478,7 +519,7 @@ def _prepare_trace_runs(
     mapping: FieldMapping,
     source_fingerprint: str,
     project_name: str,
-    max_dropped_rows: int | None = None,
+    dropped_rows: _DroppedRowCollector | None = None,
 ) -> _PreparedTrace:
   """Map one source trace to a LangSmith run tree.
 
@@ -487,7 +528,6 @@ def _prepare_trace_runs(
   root, including source traces with multiple roots.
   """
   mapped: list[_MappedRow] = []
-  skipped: list[DroppedRow] = []
   skipped_count = 0
   seen: set[tuple[str, str]] = set()
   consumed_columns = mapping.mapped_whole_columns()
@@ -495,8 +535,8 @@ def _prepare_trace_runs(
   def record_skipped(row: DroppedRow) -> None:
     nonlocal skipped_count
     skipped_count += 1
-    if max_dropped_rows is None or len(skipped) < max_dropped_rows:
-      skipped.append(row)
+    if dropped_rows is not None:
+      dropped_rows.add(row)
 
   for index, row in enumerate(rows):
     try:
@@ -513,12 +553,7 @@ def _prepare_trace_runs(
     mapped.append(item)
 
   if not mapped:
-    return _PreparedTrace(
-        runs=[],
-        source_run_ids=(),
-        skipped=tuple(skipped),
-        skipped_count=skipped_count,
-    )
+    return _PreparedTrace(runs=[], skipped_count=skipped_count)
 
   trace_ids = {item.source_trace_id for item in mapped}
   if len(trace_ids) != 1:
@@ -542,11 +577,12 @@ def _prepare_trace_runs(
 
   trace_uuid = _stable_uuid(source_fingerprint, "trace", source_trace_id)
   # The synthetic root may be emitted by multiple overlapping or incremental
-  # windows. A fixed structural timestamp keeps its wire representation and
-  # every descendant's dotted-order prefix stable when a window does not
-  # contain the source trace's first event. Source event timestamps remain
-  # unchanged on their individual runs.
+  # windows. A fixed structural dotted-order segment keeps every descendant's
+  # prefix stable when a window omits the trace's first event. The root's
+  # displayed times below still reflect the current source window.
   root_dotted = _dotted_segment(_EPOCH, trace_uuid)
+  root_start_time = min(item.start_time for item in mapped)
+  root_end_time = max(item.end_time or item.start_time for item in mapped)
   runs: list[dict[str, Any]] = [
       {
           "id": trace_uuid,
@@ -557,8 +593,8 @@ def _prepare_trace_runs(
           "name": "BQAA trace",
           "run_type": "chain",
           "inputs": {},
-          "start_time": _EPOCH,
-          "end_time": _EPOCH,
+          "start_time": root_start_time,
+          "end_time": root_end_time,
           "extra": {
               "metadata": {},
               "bqaa": {"source_trace_id": source_trace_id},
@@ -649,23 +685,9 @@ def _prepare_trace_runs(
     if item.source_run_id not in visited:
       append_component(span, trace_uuid, root_dotted)
 
-  watermark_candidate = max(
-      (
-          _Watermark(
-              item.start_time,
-              item.source_trace_id,
-              item.source_run_id,
-          )
-          for item in mapped
-      ),
-      key=lambda item: (item.timestamp, item.trace_id, item.run_id),
-  )
   return _PreparedTrace(
       runs=runs,
-      source_run_ids=tuple(item.source_run_id for item in mapped),
-      skipped=tuple(skipped),
       skipped_count=skipped_count,
-      watermark_candidate=watermark_candidate,
   )
 
 
@@ -677,6 +699,29 @@ def _sql_path(path: tuple[str, ...] | None, *, field_name: str) -> str:
         f"mapping {field_name} must contain BigQuery identifier segments"
     )
   return "bqaa_source." + ".".join(f"`{segment}`" for segment in path)
+
+
+def _sql_timestamp_path(
+    path: tuple[str, ...] | None, *, field_name: str
+) -> str:
+  return f"SAFE_CAST({_sql_path(path, field_name=field_name)} AS TIMESTAMP)"
+
+
+def _sql_cursor_timestamp_path(
+    path: tuple[str, ...] | None, *, field_name: str
+) -> str:
+  return (
+      f"COALESCE({_sql_timestamp_path(path, field_name=field_name)}, "
+      "TIMESTAMP('1970-01-01T00:00:00+00:00'))"
+  )
+
+
+def _sql_cursor_string_path(
+    path: tuple[str, ...] | None, *, field_name: str
+) -> str:
+  return (
+      f"COALESCE(CAST({_sql_path(path, field_name=field_name)} AS STRING), '')"
+  )
 
 
 def _normalize_sql_source(source: str) -> str:
@@ -705,27 +750,29 @@ def _build_source_query(
   conditions: list[str] = []
   parameters: list[bigquery.ScalarQueryParameter] = []
   if since is not None:
-    timestamp = _sql_path(mapping.start_time, field_name="start_time")
+    timestamp = _sql_timestamp_path(mapping.start_time, field_name="start_time")
     conditions.append(f"{timestamp} >= @bqaa_since")
     parameters.append(
         bigquery.ScalarQueryParameter("bqaa_since", "TIMESTAMP", since)
     )
   if until is not None:
-    timestamp = _sql_path(mapping.start_time, field_name="start_time")
+    timestamp = _sql_timestamp_path(mapping.start_time, field_name="start_time")
     conditions.append(f"{timestamp} < @bqaa_until")
     parameters.append(
         bigquery.ScalarQueryParameter("bqaa_until", "TIMESTAMP", until)
     )
   if watermark is not None:
-    timestamp = _sql_path(mapping.start_time, field_name="start_time")
-    trace_id = _sql_path(mapping.trace_id, field_name="trace_id")
-    run_id = _sql_path(mapping.run_id, field_name="run_id")
+    timestamp = _sql_cursor_timestamp_path(
+        mapping.start_time, field_name="start_time"
+    )
+    trace_id = _sql_cursor_string_path(mapping.trace_id, field_name="trace_id")
+    run_id = _sql_cursor_string_path(mapping.run_id, field_name="run_id")
     conditions.append(
         f"({timestamp} > @bqaa_watermark_timestamp OR "
         f"({timestamp} = @bqaa_watermark_timestamp AND "
-        f"(CAST({trace_id} AS STRING) > @bqaa_watermark_trace_id OR "
-        f"(CAST({trace_id} AS STRING) = @bqaa_watermark_trace_id AND "
-        f"CAST({run_id} AS STRING) > @bqaa_watermark_run_id))))"
+        f"({trace_id} > @bqaa_watermark_trace_id OR "
+        f"({trace_id} = @bqaa_watermark_trace_id AND "
+        f"{run_id} > @bqaa_watermark_run_id))))"
     )
     parameters.extend(
         [
@@ -744,12 +791,12 @@ def _build_source_query(
     conditions.append(f"({where})")
   if conditions:
     sql += "\nWHERE " + " AND ".join(conditions)
-  trace_path = _sql_path(mapping.trace_id, field_name="trace_id")
-  run_path = _sql_path(mapping.run_id, field_name="run_id")
-  ordering = [f"CAST({trace_path} AS STRING)"]
+  ordering = [_sql_cursor_string_path(mapping.trace_id, field_name="trace_id")]
   if mapping.start_time is not None:
-    ordering.append(_sql_path(mapping.start_time, field_name="start_time"))
-  ordering.append(f"CAST({run_path} AS STRING)")
+    ordering.append(
+        _sql_cursor_timestamp_path(mapping.start_time, field_name="start_time")
+    )
+  ordering.append(_sql_cursor_string_path(mapping.run_id, field_name="run_id"))
   sql += "\nORDER BY " + ", ".join(ordering)
   return sql, parameters
 
@@ -759,9 +806,18 @@ def _canonical_source(source: str, source_id: str | None) -> str:
     return source_id
   stripped = source.strip()
   if _TABLE_REFERENCE_RE.fullmatch(stripped):
-    return "table:" + stripped.lower()
+    return "table:" + stripped
   normalized = _normalize_sql_source(stripped)
   return "sql:" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _row_watermark(row: Mapping[str, Any], mapping: FieldMapping) -> _Watermark:
+  """Return a total-order cursor even when the row itself is malformed."""
+  return _Watermark(
+      _as_datetime(_path_value(row, mapping.start_time)) or _EPOCH,
+      _optional_string(row, mapping.trace_id) or "",
+      _optional_string(row, mapping.run_id) or "",
+  )
 
 
 def _load_watermark(
@@ -833,6 +889,29 @@ def _save_watermark(
     raise
 
 
+def _is_conflict(exc: Exception) -> bool:
+  nested = getattr(exc, "exceptions", None)
+  if isinstance(nested, (list, tuple)):
+    return bool(nested) and all(
+        isinstance(item, Exception) and _is_conflict(item) for item in nested
+    )
+
+  try:
+    from langsmith import utils as langsmith_utils
+  except ImportError:
+    langsmith_utils = None
+  if langsmith_utils is not None:
+    conflict_type = getattr(langsmith_utils, "LangSmithConflictError", None)
+    if isinstance(conflict_type, type) and isinstance(exc, conflict_type):
+      return True
+
+  status = getattr(exc, "status_code", None)
+  if status is None:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+  return status == 409
+
+
 def _is_retryable(exc: Exception) -> bool:
   nested = getattr(exc, "exceptions", None)
   if isinstance(nested, (list, tuple)):
@@ -849,7 +928,6 @@ def _is_retryable(exc: Exception) -> bool:
         exception_type
         for name in (
             "LangSmithAPIError",
-            "LangSmithConflictError",
             "LangSmithConnectionError",
             "LangSmithRateLimitError",
             "LangSmithRequestTimeout",
@@ -865,7 +943,7 @@ def _is_retryable(exc: Exception) -> bool:
   if status is None:
     response = getattr(exc, "response", None)
     status = getattr(response, "status_code", None)
-  if status in (408, 409, 425, 429):
+  if status in (408, 425, 429):
     return True
   if isinstance(status, int) and status >= 500:
     return True
@@ -1009,6 +1087,8 @@ def export(
     resolved_mapping = mapping
   else:
     resolved_mapping = FieldMapping.from_dict(mapping)
+  if config.incremental and resolved_mapping.start_time is None:
+    raise ValueError("incremental export requires a start_time mapping")
 
   canonical_source = _canonical_source(source, config.source_id)
   project_name = (
@@ -1043,7 +1123,7 @@ def export(
     bq_client = make_bq_client(
         project,
         location=config.location,
-        sdk_surface="langsmith_export",
+        sdk_surface="langsmith-export",
     )
   job_config = bigquery.QueryJobConfig(query_parameters=parameters)
   job_config = with_sdk_labels(job_config, feature="langsmith-export")
@@ -1060,21 +1140,33 @@ def export(
   failed = 0
   batches = 0
   traces_exported = 0
-  exported_watermark: _Watermark | None = None
+  read_watermark: _Watermark | None = None
   pending = _PendingBatch()
   trace_progress: dict[int, _TraceProgress] = {}
   next_trace_token = 0
 
   def flush() -> None:
     nonlocal exported, failed, batches, traces_exported
-    nonlocal exported_watermark
     if not pending.runs:
       return
     batches += 1
-    batch_runs = list(pending.runs)
     try:
+      try:
+        _call_with_retry(
+            lambda: langsmith_client.batch_ingest_runs(
+                create=copy.deepcopy(pending.runs)
+            ),
+            config=config,
+            limiter=limiter,
+            sleep=time.sleep,
+        )
+      except Exception as exc:
+        if not _is_conflict(exc):
+          raise
       _call_with_retry(
-          lambda: langsmith_client.batch_ingest_runs(create=batch_runs),
+          lambda: langsmith_client.batch_ingest_runs(
+              update=copy.deepcopy(pending.runs)
+          ),
           config=config,
           limiter=limiter,
           sleep=time.sleep,
@@ -1098,9 +1190,6 @@ def export(
       if progress.remaining_chunks == 0:
         if progress.successful:
           traces_exported += 1
-          exported_watermark = _max_watermark(
-              exported_watermark, progress.watermark
-          )
         del trace_progress[token]
     _LOGGER.info(
         "LangSmith export progress: exported=%d skipped=%d failed=%d",
@@ -1113,8 +1202,6 @@ def export(
   def enqueue(trace: _PreparedTrace) -> None:
     nonlocal skipped, next_trace_token
     skipped += trace.skipped_count
-    dropped_rows.extend(trace.skipped)
-    dropped_rows.record_omitted(trace.skipped_count - len(trace.skipped))
     if not trace.runs:
       return
     root = trace.runs[0]
@@ -1122,16 +1209,13 @@ def export(
     source_run_ids = [
         str(run["extra"]["bqaa"]["source_run_id"]) for run in source_runs
     ]
-    if len(source_runs) != len(trace.source_run_ids):
-      raise ValueError("prepared trace run/source accounting is inconsistent")
     source_count = len(source_runs)
     chunk_count = (source_count + config.batch_size - 1) // config.batch_size
     trace_token = next_trace_token
     next_trace_token += 1
     trace_progress[trace_token] = _TraceProgress(
         remaining_chunks=chunk_count,
-        successful=trace.skipped_count == 0,
-        watermark=trace.watermark_candidate,
+        successful=True,
     )
 
     if pending.source_run_ids and (
@@ -1155,6 +1239,10 @@ def export(
     row_index = rows_read
     rows_read += 1
     row = _row_dict(raw_row)
+    if config.incremental:
+      read_watermark = _max_watermark(
+          read_watermark, _row_watermark(row, resolved_mapping)
+      )
     try:
       trace_id = _required_string(row, resolved_mapping.trace_id, "trace_id")
     except ValueError as exc:
@@ -1171,9 +1259,7 @@ def export(
               mapping=resolved_mapping,
               source_fingerprint=canonical_source,
               project_name=project_name,
-              max_dropped_rows=max(
-                  config.max_dropped_rows - len(dropped_rows.rows), 0
-              ),
+              dropped_rows=dropped_rows,
           )
       )
       current_rows = []
@@ -1186,9 +1272,7 @@ def export(
             mapping=resolved_mapping,
             source_fingerprint=canonical_source,
             project_name=project_name,
-            max_dropped_rows=max(
-                config.max_dropped_rows - len(dropped_rows.rows), 0
-            ),
+            dropped_rows=dropped_rows,
         )
     )
   flush()
@@ -1196,13 +1280,8 @@ def export(
   final_watermark = watermark.timestamp if watermark else None
   # Never advance past a failed API batch. Replaying successful rows is safe
   # because IDs are stable, while advancing could permanently skip failures.
-  if (
-      config.incremental
-      and skipped == 0
-      and failed == 0
-      and exported_watermark is not None
-  ):
-    next_watermark = exported_watermark
+  if config.incremental and failed == 0 and read_watermark is not None:
+    next_watermark = read_watermark
     _save_watermark(
         config.watermark_path,
         next_watermark,

--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -396,6 +396,24 @@ class Span:
     return text
 
 
+def _build_span_tree(spans: Sequence[Span]) -> list[Span]:
+  """Link spans by ``parent_span_id`` and return their roots."""
+  by_id: dict[str, Span] = {}
+  for span in spans:
+    if span.span_id:
+      by_id[span.span_id] = span
+    span.children = []
+
+  roots: list[Span] = []
+  for span in spans:
+    parent = span.parent_span_id
+    if parent and parent in by_id:
+      by_id[parent].children.append(span)
+    else:
+      roots.append(span)
+  return roots
+
+
 _TIME_WINDOW_RE = re.compile(r"^(\d+)([mhd])$")
 
 
@@ -2661,21 +2679,7 @@ class Trace(_WeakrefableSlotted):
 
   def _build_tree(self) -> list[Span]:
     """Builds a tree of spans using parent_span_id relationships."""
-    by_id: dict[str, Span] = {}
-    for span in self.spans:
-      if span.span_id:
-        by_id[span.span_id] = span
-      span.children = []
-
-    roots: list[Span] = []
-    for span in self.spans:
-      parent = span.parent_span_id
-      if parent and parent in by_id:
-        by_id[parent].children.append(span)
-      else:
-        roots.append(span)
-
-    return roots
+    return _build_span_tree(self.spans)
 
   def render(self, format: str = "tree", color: bool = False) -> str:
     """Renders the trace as a hierarchical DAG view.

--- a/tests/test_cli_langsmith_export.py
+++ b/tests/test_cli_langsmith_export.py
@@ -190,7 +190,9 @@ def test_langsmith_export_preserves_typer_datetime_validation() -> None:
 
   assert result.exit_code == 2
   assert "Invalid value" in result.stderr
-  assert "--since must be an ISO-8601 timestamp" in result.stderr
+  assert "--since" in result.stderr
+  assert "ISO-8601" in result.stderr
+  assert "timestamp" in result.stderr
   assert "Error:" not in result.stderr
 
 

--- a/tests/test_cli_langsmith_export.py
+++ b/tests/test_cli_langsmith_export.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI tests for ``bq-agent-sdk export langsmith``."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics.cli import app
+from bigquery_agent_analytics.cli import bqaa_app
+from bigquery_agent_analytics.export import DroppedRow
+from bigquery_agent_analytics.export import export
+from bigquery_agent_analytics.export import ExportConfig
+from bigquery_agent_analytics.export import ExportStats
+from bigquery_agent_analytics.export import FieldMapping
+
+runner = CliRunner()
+
+
+def test_langsmith_export_command_builds_config_and_mapping(
+    tmp_path: Path, monkeypatch
+) -> None:
+  mapping_path = tmp_path / "mapping.yaml"
+  mapping_path.write_text(
+      "fields:\n"
+      "  run_id: event_key\n"
+      "  trace_id: trace_key\n"
+      "  start_time: occurred_at\n"
+      "  inputs: payload\n",
+      encoding="utf-8",
+  )
+  watermark_path = tmp_path / "state.json"
+  monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+  monkeypatch.setenv("LANGSMITH_PROJECT", "test-project")
+  stats = ExportStats(
+      rows_read=2,
+      exported=2,
+      skipped=0,
+      failed=0,
+      traces_exported=1,
+      batches=1,
+      dropped_rows=(),
+      watermark=datetime(2026, 8, 10, tzinfo=timezone.utc),
+  )
+
+  with patch(
+      "bigquery_agent_analytics.export.export", return_value=stats
+  ) as run_export:
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "langsmith",
+            "--source=project.dataset.events",
+            f"--mapping={mapping_path}",
+            "--project-id=project",
+            "--location=US",
+            "--since=2026-08-01T00:00:00Z",
+            "--until=2026-08-11T00:00:00Z",
+            "--filter=status = 'OK'",
+            "--incremental",
+            f"--watermark-file={watermark_path}",
+            "--batch-size=25",
+            "--requests-per-second=4",
+            "--max-retries=2",
+            "--max-dropped-rows=10",
+        ],
+    )
+
+  assert result.exit_code == 0, result.output
+  assert json.loads(result.stdout)["exported"] == 2
+  source = run_export.call_args.args[0]
+  config = run_export.call_args.kwargs["config"]
+  assert source == "project.dataset.events"
+  assert config.mapping.run_id == ("event_key",)
+  assert config.project_id == "project"
+  assert config.location == "US"
+  # The CLI leaves authentication to LangSmith's standard environment
+  # handling instead of copying a secret from argv or environment.
+  assert config.langsmith_api_key is None
+  assert config.langsmith_project == "test-project"
+  assert config.since == datetime(2026, 8, 1, tzinfo=timezone.utc)
+  assert config.until == datetime(2026, 8, 11, tzinfo=timezone.utc)
+  assert config.where == "status = 'OK'"
+  assert config.incremental is True
+  assert config.watermark_path == watermark_path
+  assert config.batch_size == 25
+  assert config.requests_per_second == 4
+  assert config.max_retries == 2
+  assert config.max_dropped_rows == 10
+
+
+@pytest.mark.parametrize(("skipped", "failed"), [(1, 0), (0, 1)])
+def test_langsmith_export_command_returns_nonzero_for_dropped_rows(
+    skipped: int, failed: int
+) -> None:
+  stats = ExportStats(
+      rows_read=1,
+      exported=0,
+      skipped=skipped,
+      failed=failed,
+      traces_exported=0,
+      batches=1,
+      dropped_rows=(),
+  )
+  with patch("bigquery_agent_analytics.export.export", return_value=stats):
+    result = runner.invoke(
+        app,
+        ["export", "langsmith", "--source=project.dataset.events"],
+    )
+
+  assert result.exit_code == 1
+  assert json.loads(result.stdout)["skipped"] == skipped
+  assert json.loads(result.stdout)["failed"] == failed
+
+
+def test_langsmith_export_help_is_nested() -> None:
+  result = runner.invoke(app, ["export", "langsmith", "--help"])
+  root_command = get_command(app)
+  export_command = root_command.get_command(None, "export")
+  assert export_command is not None
+  langsmith_command = export_command.get_command(None, "langsmith")
+  assert langsmith_command is not None
+  option_names = {
+      option
+      for parameter in langsmith_command.params
+      for option in getattr(parameter, "opts", ())
+  }
+
+  assert result.exit_code == 0
+  assert "--source" in result.stdout
+  assert "--mapping" in result.stdout
+  assert "--incremental" in result.stdout
+  assert "--max-dropped-rows" in option_names
+  assert "--langsmith-api-key" not in option_names
+
+
+def test_langsmith_export_rejects_api_key_option() -> None:
+  result = runner.invoke(
+      app,
+      [
+          "export",
+          "langsmith",
+          "--source=project.dataset.events",
+          "--langsmith-api-key=must-not-enter-argv",
+      ],
+  )
+
+  assert result.exit_code != 0
+  assert "No such option" in result.stderr
+  assert "must-not-enter-argv" not in result.stderr
+
+
+def test_langsmith_export_is_not_added_to_bqaa() -> None:
+  result = runner.invoke(bqaa_app, ["--help"])
+
+  assert result.exit_code == 0
+  assert "langsmith" not in result.stdout.lower()
+  assert "export" not in result.stdout.lower()
+
+
+def test_export_package_exposes_stable_public_surface() -> None:
+  assert callable(export)
+  assert ExportConfig.__name__ == "ExportConfig"
+  assert ExportStats.__name__ == "ExportStats"
+  assert FieldMapping.__name__ == "FieldMapping"
+  assert DroppedRow.__name__ == "DroppedRow"

--- a/tests/test_cli_langsmith_export.py
+++ b/tests/test_cli_langsmith_export.py
@@ -186,14 +186,16 @@ def test_langsmith_export_preserves_typer_datetime_validation() -> None:
           "--source=project.dataset.events",
           "--since=not-a-timestamp",
       ],
+      color=True,
   )
 
+  error_text = click.unstyle(result.stderr)
   assert result.exit_code == 2
-  assert "Invalid value" in result.stderr
-  assert "--since" in result.stderr
-  assert "ISO-8601" in result.stderr
-  assert "timestamp" in result.stderr
-  assert "Error:" not in result.stderr
+  assert "Invalid value" in error_text
+  assert "--since" in error_text
+  assert "ISO-8601" in error_text
+  assert "timestamp" in error_text
+  assert "Error:" not in error_text
 
 
 def test_langsmith_export_does_not_mask_unexpected_programming_errors() -> None:

--- a/tests/test_cli_langsmith_export.py
+++ b/tests/test_cli_langsmith_export.py
@@ -22,6 +22,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
@@ -146,11 +147,12 @@ def test_langsmith_export_help_is_nested() -> None:
       for parameter in langsmith_command.params
       for option in getattr(parameter, "opts", ())
   }
+  help_text = click.unstyle(result.stdout)
 
   assert result.exit_code == 0
-  assert "--source" in result.stdout
-  assert "--mapping" in result.stdout
-  assert "--incremental" in result.stdout
+  assert "--source" in help_text
+  assert "--mapping" in help_text
+  assert "--incremental" in help_text
   assert "--max-dropped-rows" in option_names
   assert "--langsmith-api-key" not in option_names
 

--- a/tests/test_cli_langsmith_export.py
+++ b/tests/test_cli_langsmith_export.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import click
+from google.api_core import exceptions as google_exceptions
 import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
@@ -94,6 +95,9 @@ def test_langsmith_export_command_builds_config_and_mapping(
   config = run_export.call_args.kwargs["config"]
   assert source == "project.dataset.events"
   assert config.mapping.run_id == ("event_key",)
+  assert config.mapping.status is None
+  assert config.mapping.error is None
+  assert config.mapping.latency_ms is None
   assert config.project_id == "project"
   assert config.location == "US"
   # The CLI leaves authentication to LangSmith's standard environment
@@ -171,6 +175,73 @@ def test_langsmith_export_rejects_api_key_option() -> None:
   assert result.exit_code != 0
   assert "No such option" in result.stderr
   assert "must-not-enter-argv" not in result.stderr
+
+
+def test_langsmith_export_preserves_typer_datetime_validation() -> None:
+  result = runner.invoke(
+      app,
+      [
+          "export",
+          "langsmith",
+          "--source=project.dataset.events",
+          "--since=not-a-timestamp",
+      ],
+  )
+
+  assert result.exit_code == 2
+  assert "Invalid value" in result.stderr
+  assert "--since must be an ISO-8601 timestamp" in result.stderr
+  assert "Error:" not in result.stderr
+
+
+def test_langsmith_export_does_not_mask_unexpected_programming_errors() -> None:
+  with patch(
+      "bigquery_agent_analytics.export.export",
+      side_effect=RuntimeError("unexpected implementation bug"),
+  ):
+    result = runner.invoke(
+        app,
+        ["export", "langsmith", "--source=project.dataset.events"],
+    )
+
+  assert result.exit_code == 1
+  assert isinstance(result.exception, RuntimeError)
+  assert "Error: unexpected implementation bug" not in result.output
+
+
+def test_langsmith_export_reports_google_operational_errors() -> None:
+  with patch(
+      "bigquery_agent_analytics.export.export",
+      side_effect=google_exceptions.ServiceUnavailable("service unavailable"),
+  ):
+    result = runner.invoke(
+        app,
+        ["export", "langsmith", "--source=project.dataset.events"],
+    )
+
+  assert result.exit_code == 2
+  assert "Error: 503 service unavailable" in result.stderr
+
+
+def test_langsmith_export_reports_malformed_mapping_yaml(
+    tmp_path: Path,
+) -> None:
+  mapping_path = tmp_path / "invalid.yaml"
+  mapping_path.write_text("fields: [", encoding="utf-8")
+
+  result = runner.invoke(
+      app,
+      [
+          "export",
+          "langsmith",
+          "--source=project.dataset.events",
+          f"--mapping={mapping_path}",
+      ],
+  )
+
+  assert result.exit_code == 2
+  assert "Error:" in result.stderr
+  assert result.exception is not None
 
 
 def test_langsmith_export_is_not_added_to_bqaa() -> None:

--- a/tests/test_langsmith_export.py
+++ b/tests/test_langsmith_export.py
@@ -133,21 +133,18 @@ class _FailOnCallLangSmithClient(_LangSmithClient):
     super().batch_ingest_runs(create=create, update=update)
 
 
-class _StatefulLangSmithClient(_LangSmithClient):
+class _CreateOnlyLangSmithClient(_LangSmithClient):
 
   def __init__(self) -> None:
     super().__init__()
     self.runs: dict[str, dict[str, Any]] = {}
 
   def batch_ingest_runs(self, *, create=None, update=None) -> None:
+    if update is not None:
+      raise AssertionError("the exporter must not send run updates")
     super().batch_ingest_runs(create=create, update=update)
     for run in create or []:
       self.runs.setdefault(str(run["id"]), dict(run))
-    for run in update or []:
-      run_id = str(run["id"])
-      if run_id not in self.runs:
-        raise AssertionError("cannot update a run before it is created")
-      self.runs[run_id].update(run)
 
 
 class _RetryableError(RuntimeError):
@@ -600,7 +597,7 @@ def test_unsafe_or_invalid_table_ids_are_not_interpolated_as_identifiers(
   assert "SELECT * FROM (" in sql
 
 
-def test_export_batches_create_then_update_and_reports_rows() -> None:
+def test_export_batches_create_only_and_reports_rows() -> None:
   bq = _BigQueryClient(_standard_rows())
   langsmith = _LangSmithClient()
   stats = export(
@@ -618,23 +615,23 @@ def test_export_batches_create_then_update_and_reports_rows() -> None:
   assert stats.exported == 2
   assert stats.failed == 0
   assert stats.traces_exported == 1
-  assert len(langsmith.calls) == 2
+  assert len(langsmith.calls) == 1
   assert langsmith.calls[0]["create"] is not None
   assert langsmith.calls[0]["update"] is None
-  assert langsmith.calls[1]["create"] is None
-  assert langsmith.calls[1]["update"] is not None
   query_config = bq.queries[0][1]
   assert query_config.labels["sdk_feature"] == "langsmith-export"
 
 
-def test_replaying_window_updates_changed_runs_without_duplicates() -> None:
-  langsmith = _StatefulLangSmithClient()
+def test_replaying_window_keeps_existing_runs_immutable_without_duplicates() -> (
+    None
+):
+  langsmith = _CreateOnlyLangSmithClient()
   config = ExportConfig(
       langsmith_project="destination", requests_per_second=None
   )
 
   first_rows = _standard_rows()
-  export(
+  first = export(
       "project.dataset.agent_events",
       config=config,
       bq_client=_BigQueryClient(first_rows),
@@ -643,14 +640,18 @@ def test_replaying_window_updates_changed_runs_without_duplicates() -> None:
   replay_rows = _standard_rows()
   replay_rows[1]["error_message"] = "backfilled failure detail"
   replay_rows[1]["content"] = {"backfilled": True}
-  export(
+  replay = export(
       "project.dataset.agent_events",
       config=config,
       bq_client=_BigQueryClient(replay_rows),
       langsmith_client=langsmith,
   )
 
-  assert len(langsmith.calls) == 4
+  assert first.exported == 2
+  assert first.failed == 0
+  assert replay.exported == 2
+  assert replay.failed == 0
+  assert len(langsmith.calls) == 2
   assert len(langsmith.runs) == 3
   child = next(
       run
@@ -658,13 +659,11 @@ def test_replaying_window_updates_changed_runs_without_duplicates() -> None:
       if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
       == "span-child"
   )
-  assert child["error"] == "backfilled failure detail"
-  assert child["inputs"] == {"backfilled": True}
+  assert child["error"] == "tool failed"
+  assert child["inputs"] == {"value": ["opaque", {"payload": True}]}
 
 
-def test_surfaced_create_conflict_is_not_retried_and_update_still_runs() -> (
-    None
-):
+def test_surfaced_create_conflict_is_treated_as_idempotent_success() -> None:
   class _ConflictOnCreateClient(_LangSmithClient):
 
     def __init__(self) -> None:
@@ -686,9 +685,7 @@ def test_surfaced_create_conflict_is_not_retried_and_update_still_runs() -> (
   )
 
   assert langsmith.create_attempts == 1
-  assert len(langsmith.calls) == 1
-  assert langsmith.calls[0]["create"] is None
-  assert langsmith.calls[0]["update"] is not None
+  assert langsmith.calls == []
   assert stats.exported == 2
   assert stats.failed == 0
 
@@ -1013,7 +1010,7 @@ def test_batch_size_and_rate_limit_apply_between_api_requests() -> None:
     )
 
   assert stats.batches == 2
-  assert sleeps == [0.5, 0.5, 0.5]
+  assert sleeps == [0.5]
 
 
 def test_batch_size_is_hard_limit_for_one_oversized_trace() -> None:
@@ -1071,7 +1068,7 @@ def test_partial_oversized_trace_failure_is_not_counted_or_watermarked(
           requests_per_second=None,
       ),
       bq_client=_BigQueryClient(rows),
-      langsmith_client=_FailOnCallLangSmithClient(call_number=3),
+      langsmith_client=_FailOnCallLangSmithClient(call_number=2),
   )
 
   assert stats.exported == 3
@@ -1221,7 +1218,7 @@ def test_real_client_adapter_resurfaces_sdk_swallowed_ingest_errors() -> None:
     client.batch_ingest_runs(create=[{"id": "run"}])
 
 
-def test_real_langsmith_client_serializes_separate_create_and_update_batches(
+def test_real_langsmith_client_serializes_one_create_only_batch(
     monkeypatch,
 ) -> None:
   langsmith = pytest.importorskip("langsmith")
@@ -1246,21 +1243,12 @@ def test_real_langsmith_client_serializes_separate_create_and_update_batches(
   )
 
   assert stats.exported == 2
-  assert len(request_bodies) == 2
+  assert len(request_bodies) == 1
   assert len(request_bodies[0]["post"]) == 3
   assert "patch" not in request_bodies[0]
-  assert len(request_bodies[1]["patch"]) == 3
-  assert "post" not in request_bodies[1]
-  child_update = next(
-      run
-      for run in request_bodies[1]["patch"]
-      if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
-      == "span-child"
-  )
-  assert child_update["error"] == "tool failed"
 
 
-def test_real_langsmith_retry_rebuilds_mutated_update_payloads(
+def test_real_langsmith_retry_rebuilds_mutated_create_payloads(
     monkeypatch,
 ) -> None:
   langsmith = pytest.importorskip("langsmith")
@@ -1269,18 +1257,18 @@ def test_real_langsmith_retry_rebuilds_mutated_update_payloads(
       auto_batch_tracing=False,
       info={},
   )
-  patch_bodies: list[dict[str, Any]] = []
+  request_bodies: list[dict[str, Any]] = []
 
-  def fail_first_patch(_client, body: bytes, **kwargs) -> None:
+  def fail_first_create(_client, body: bytes, **kwargs) -> None:
     del _client, kwargs
     decoded = json.loads(body)
-    if "patch" not in decoded:
-      return
-    patch_bodies.append(decoded)
-    if len(patch_bodies) == 1:
+    request_bodies.append(decoded)
+    if len(request_bodies) == 1:
       raise _RetryableError(429)
 
-  monkeypatch.setattr(type(client), "_post_batch_ingest_runs", fail_first_patch)
+  monkeypatch.setattr(
+      type(client), "_post_batch_ingest_runs", fail_first_create
+  )
 
   stats = export(
       "project.dataset.agent_events",
@@ -1294,10 +1282,11 @@ def test_real_langsmith_retry_rebuilds_mutated_update_payloads(
   )
 
   assert stats.exported == 2
-  assert len(patch_bodies) == 2
+  assert len(request_bodies) == 2
+  assert all("patch" not in body for body in request_bodies)
   retried_child = next(
       run
-      for run in patch_bodies[1]["patch"]
+      for run in request_bodies[1]["post"]
       if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
       == "span-child"
   )

--- a/tests/test_langsmith_export.py
+++ b/tests/test_langsmith_export.py
@@ -1,0 +1,919 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the BigQuery-to-LangSmith export connector."""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import datetime
+from datetime import timezone
+from decimal import Decimal
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+import uuid
+
+import pytest
+
+from bigquery_agent_analytics.export.langsmith import _build_source_query
+from bigquery_agent_analytics.export.langsmith import _create_langsmith_client
+from bigquery_agent_analytics.export.langsmith import _is_retryable
+from bigquery_agent_analytics.export.langsmith import _prepare_trace_runs
+from bigquery_agent_analytics.export.langsmith import export
+from bigquery_agent_analytics.export.langsmith import ExportConfig
+from bigquery_agent_analytics.export.langsmith import FieldMapping
+
+_T0 = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+_T1 = datetime(2026, 8, 10, 12, 0, 1, tzinfo=timezone.utc)
+
+
+class _QueryJob:
+
+  def __init__(self, rows: list[dict[str, Any]]) -> None:
+    self._rows = rows
+    self.page_sizes: list[int | None] = []
+
+  def result(self, *, page_size: int | None = None):
+    self.page_sizes.append(page_size)
+    return list(self._rows)
+
+
+class _BigQueryClient:
+
+  def __init__(self, rows: list[dict[str, Any]]) -> None:
+    self.job = _QueryJob(rows)
+    self.queries: list[tuple[str, Any]] = []
+
+  def query(self, sql: str, *, job_config: Any):
+    self.queries.append((sql, job_config))
+    return self.job
+
+
+class _LangSmithClient:
+
+  def __init__(self, failures: int = 0) -> None:
+    self.failures = failures
+    self.calls: list[dict[str, Any]] = []
+
+  def batch_ingest_runs(self, *, create=None, update=None) -> None:
+    if self.failures:
+      self.failures -= 1
+      raise _RetryableError(429)
+    self.calls.append({"create": create, "update": update})
+
+
+class _FailOnCallLangSmithClient(_LangSmithClient):
+
+  def __init__(self, call_number: int) -> None:
+    super().__init__()
+    self.call_number = call_number
+    self.attempts = 0
+
+  def batch_ingest_runs(self, *, create=None, update=None) -> None:
+    self.attempts += 1
+    if self.attempts == self.call_number:
+      raise _RetryableError(429)
+    super().batch_ingest_runs(create=create, update=update)
+
+
+class _StatefulLangSmithClient(_LangSmithClient):
+
+  def __init__(self) -> None:
+    super().__init__()
+    self.runs: dict[str, dict[str, Any]] = {}
+
+  def batch_ingest_runs(self, *, create=None, update=None) -> None:
+    super().batch_ingest_runs(create=create, update=update)
+    for run in create or update or []:
+      self.runs[str(run["id"])] = run
+
+
+class _RetryableError(RuntimeError):
+
+  def __init__(self, status_code: int) -> None:
+    super().__init__(f"HTTP {status_code}")
+    self.status_code = status_code
+
+
+def _standard_rows() -> list[dict[str, Any]]:
+  return [
+      {
+          "timestamp": _T0,
+          "event_type": "AGENT_START",
+          "trace_id": "trace-1",
+          "span_id": "span-root",
+          "parent_span_id": None,
+          "content": {"prompt": "opaque input"},
+          "attributes": {"model": "not interpreted"},
+          "latency_ms": {"total_ms": 1000},
+          "status": "OK",
+          "error_message": None,
+          "custom_record": {"tenant_shape": [1, 2, 3]},
+      },
+      {
+          "timestamp": _T1,
+          "event_type": "TOOL_ERROR",
+          "trace_id": "trace-1",
+          "span_id": "span-child",
+          "parent_span_id": "span-root",
+          "content": ["opaque", {"payload": True}],
+          "attributes": {},
+          "latency_ms": {"total_ms": 25},
+          "status": "ERROR",
+          "error_message": "tool failed",
+          "custom_record": {"tenant_shape": [4]},
+      },
+  ]
+
+
+def test_default_mapping_builds_one_root_and_preserves_hierarchy() -> None:
+  prepared = _prepare_trace_runs(
+      _standard_rows(),
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source-a",
+      project_name="langsmith-project",
+  )
+
+  assert len(prepared.runs) == 3
+  synthetic_root, parent, child = prepared.runs
+  assert synthetic_root["id"] == synthetic_root["trace_id"]
+  assert synthetic_root["parent_run_id"] is None
+  assert parent["parent_run_id"] == synthetic_root["id"]
+  assert child["parent_run_id"] == parent["id"]
+  assert parent["dotted_order"].startswith(synthetic_root["dotted_order"] + ".")
+  assert child["dotted_order"].startswith(parent["dotted_order"] + ".")
+  assert parent["inputs"] == {"prompt": "opaque input"}
+  assert child["inputs"] == {"value": ["opaque", {"payload": True}]}
+  assert child["error"] == "tool failed"
+  assert parent["end_time"] == _T1
+  assert parent["extra"]["metadata"]["custom_record"] == {
+      "tenant_shape": [1, 2, 3]
+  }
+  assert parent["extra"]["metadata"]["attributes"] == {
+      "model": "not interpreted"
+  }
+  assert "content" not in parent["extra"]["metadata"]
+  for run in prepared.runs:
+    uuid.UUID(str(run["id"]))
+    uuid.UUID(str(run["trace_id"]))
+    assert run["session_name"] == "langsmith-project"
+    assert run["dotted_order"].endswith(str(run["id"]))
+
+
+def test_custom_mapping_treats_payload_as_opaque_and_keeps_unknown_columns() -> (
+    None
+):
+  mapping = FieldMapping.from_dict(
+      {
+          "run_id": "event_key",
+          "trace_id": "group.key",
+          "parent_run_id": "parent_key",
+          "name": "kind",
+          "start_time": "occurred_at",
+          "inputs": "payload",
+          "error": None,
+          "latency_ms": None,
+      }
+  )
+  payload = "{not parsed as JSON}"
+  row = {
+      "event_key": "custom-1",
+      "group": {"key": "custom-trace", "other": "covered column"},
+      "parent_key": None,
+      "kind": "CUSTOM",
+      "occurred_at": _T0,
+      "payload": payload,
+      "unknown_scalar": "survives",
+      "unknown_nested": {"arbitrary": [True, None]},
+  }
+
+  prepared = _prepare_trace_runs(
+      [row], mapping=mapping, source_fingerprint="custom", project_name="p"
+  )
+  run = prepared.runs[1]
+
+  assert run["inputs"] == {"value": payload}
+  assert run["extra"]["metadata"]["unknown_scalar"] == "survives"
+  assert run["extra"]["metadata"]["unknown_nested"] == {
+      "arbitrary": [True, None]
+  }
+  # A nested path covers only that value, not the rest of its top-level
+  # record. Keeping the record in metadata avoids dropping ``group.other``.
+  assert run["extra"]["metadata"]["group"] == {
+      "key": "custom-trace",
+      "other": "covered column",
+  }
+
+
+def test_non_json_bigquery_scalars_use_loss_minimizing_metadata_encoding() -> (
+    None
+):
+  row = {
+      "event_key": "custom-1",
+      "trace_key": "trace-1",
+      "payload": b"\x00opaque",
+      "amount": Decimal("1.20"),
+      "day": date(2026, 8, 10),
+  }
+  mapping = FieldMapping.from_dict(
+      {
+          "run_id": "event_key",
+          "trace_id": "trace_key",
+          "start_time": None,
+          "inputs": "payload",
+          "latency_ms": None,
+          "error": None,
+      }
+  )
+
+  run = _prepare_trace_runs(
+      [row], mapping=mapping, source_fingerprint="custom", project_name="p"
+  ).runs[1]
+
+  assert run["inputs"] == {
+      "value": {"encoding": "base64", "data": "AG9wYXF1ZQ=="}
+  }
+  assert run["extra"]["metadata"]["amount"] == "1.20"
+  assert run["extra"]["metadata"]["day"] == "2026-08-10"
+  json.dumps(run["inputs"])
+  json.dumps(run["extra"])
+
+
+def test_decimal_identity_scalars_are_accepted() -> None:
+  mapping = FieldMapping.from_dict(
+      {
+          "run_id": "event_key",
+          "trace_id": "trace_key",
+          "parent_run_id": "parent_key",
+          "start_time": None,
+      }
+  )
+  prepared = _prepare_trace_runs(
+      [
+          {
+              "event_key": Decimal("1.20"),
+              "trace_key": Decimal("7"),
+              "parent_key": Decimal("0"),
+          }
+      ],
+      mapping=mapping,
+      source_fingerprint="decimal-source",
+      project_name="p",
+  )
+
+  run = prepared.runs[1]
+  assert run["extra"]["bqaa"]["source_run_id"] == "1.20"
+  assert run["extra"]["bqaa"]["source_trace_id"] == "7"
+  assert run["extra"]["bqaa"]["source_parent_run_id"] == "0"
+
+
+@pytest.mark.parametrize("error_message", [None, ""])
+def test_standard_status_only_error_sets_marker_and_keeps_status_metadata(
+    error_message: str | None,
+) -> None:
+  row = {
+      **_standard_rows()[0],
+      "status": "ERROR",
+      "error_message": error_message,
+  }
+
+  run = _prepare_trace_runs(
+      [row],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source",
+      project_name="p",
+  ).runs[1]
+
+  assert run["error"] == "[SOURCE_STATUS_ERROR]"
+  assert run["extra"]["metadata"]["status"] == "ERROR"
+
+
+def test_run_ids_are_stable_across_replays() -> None:
+  first = _prepare_trace_runs(
+      _standard_rows(),
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  )
+  second = _prepare_trace_runs(
+      _standard_rows(),
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  )
+
+  assert [run["id"] for run in first.runs] == [run["id"] for run in second.runs]
+  assert [run["dotted_order"] for run in first.runs] == [
+      run["dotted_order"] for run in second.runs
+  ]
+
+
+def test_table_and_sql_sources_are_wrapped_without_rewriting_payloads() -> None:
+  table_sql, _ = _build_source_query(
+      "project.dataset.agent_events",
+      mapping=FieldMapping.standard_adk(),
+      since=None,
+      until=None,
+      where=None,
+      watermark=None,
+  )
+  custom_sql, _ = _build_source_query(
+      "SELECT odd, payload FROM custom_source WHERE opaque = true;",
+      mapping=FieldMapping.from_dict(
+          {
+              "run_id": "odd",
+              "trace_id": "odd",
+              "start_time": None,
+              "inputs": "payload",
+          }
+      ),
+      since=None,
+      until=None,
+      where=None,
+      watermark=None,
+  )
+
+  assert "FROM `project.dataset.agent_events`" in table_sql
+  assert (
+      "SELECT odd, payload FROM custom_source WHERE opaque = true" in custom_sql
+  )
+  assert "ORDER BY" in table_sql
+  assert "ORDER BY" in custom_sql
+  assert "CAST(bqaa_source.`odd` AS STRING)" in custom_sql
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        "project.9dataset.7table",
+        "project.dataset.table-with-dashes",
+    ],
+)
+def test_valid_digit_leading_and_hyphenated_table_ids_are_recognized(
+    table: str,
+) -> None:
+  sql, _ = _build_source_query(
+      table,
+      mapping=FieldMapping.standard_adk(),
+      since=None,
+      until=None,
+      where=None,
+      watermark=None,
+  )
+
+  assert f"FROM `{table}` AS bqaa_source" in sql
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "project.dataset.`table`",
+        "project.dataset.table; DELETE FROM x",
+        "project.data-set.table",
+    ],
+)
+def test_unsafe_or_invalid_table_ids_are_not_interpolated_as_identifiers(
+    source: str,
+) -> None:
+  sql, _ = _build_source_query(
+      source,
+      mapping=FieldMapping.standard_adk(),
+      since=None,
+      until=None,
+      where=None,
+      watermark=None,
+  )
+
+  assert f"FROM `{source}`" not in sql
+  assert "SELECT * FROM (" in sql
+
+
+def test_export_batches_upserts_and_reports_rows() -> None:
+  bq = _BigQueryClient(_standard_rows())
+  langsmith = _LangSmithClient()
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          langsmith_project="destination",
+          batch_size=100,
+          requests_per_second=None,
+      ),
+      bq_client=bq,
+      langsmith_client=langsmith,
+  )
+
+  assert stats.rows_read == 2
+  assert stats.exported == 2
+  assert stats.failed == 0
+  assert stats.traces_exported == 1
+  assert len(langsmith.calls) == 1
+  assert langsmith.calls[0]["create"] is not None
+  assert langsmith.calls[0]["update"] is None
+  query_config = bq.queries[0][1]
+  assert query_config.labels["sdk_feature"] == "langsmith-export"
+
+
+def test_replaying_window_upserts_without_duplicate_runs() -> None:
+  langsmith = _StatefulLangSmithClient()
+  config = ExportConfig(
+      langsmith_project="destination", requests_per_second=None
+  )
+
+  export(
+      "project.dataset.agent_events",
+      config=config,
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=langsmith,
+  )
+  export(
+      "project.dataset.agent_events",
+      config=config,
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=langsmith,
+  )
+
+  assert len(langsmith.calls) == 2
+  assert len(langsmith.runs) == 3
+
+
+def test_same_span_id_in_different_traces_gets_distinct_run_ids() -> None:
+  first = _standard_rows()[0]
+  second = {**first, "trace_id": "trace-2"}
+  run_1 = _prepare_trace_runs(
+      [first],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  ).runs[1]
+  run_2 = _prepare_trace_runs(
+      [second],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  ).runs[1]
+
+  assert run_1["id"] != run_2["id"]
+
+
+def test_orphan_child_is_flattened_without_contradictory_dotted_order() -> None:
+  _, child = _standard_rows()
+  synthetic_root, child_run = _prepare_trace_runs(
+      [child],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  ).runs
+
+  assert child_run["parent_run_id"] == synthetic_root["id"]
+  assert child_run["dotted_order"].startswith(
+      synthetic_root["dotted_order"] + "."
+  )
+  assert child_run["extra"]["bqaa"]["source_parent_run_id"] == "span-root"
+
+
+def test_synthetic_root_identity_and_order_are_stable_across_windows() -> None:
+  parent, child = _standard_rows()
+  first = _prepare_trace_runs(
+      [parent],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  ).runs[0]
+  second = _prepare_trace_runs(
+      [child],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="same-source",
+      project_name="p",
+  ).runs[0]
+
+  assert first["id"] == second["id"]
+  assert first["dotted_order"] == second["dotted_order"]
+  assert first["start_time"] == second["start_time"]
+
+
+def test_incremental_export_persists_and_reuses_watermark(
+    tmp_path: Path,
+) -> None:
+  watermark_path = tmp_path / "watermark.json"
+  config = ExportConfig(
+      langsmith_project="destination",
+      incremental=True,
+      watermark_path=watermark_path,
+      requests_per_second=None,
+  )
+  first_bq = _BigQueryClient(_standard_rows())
+  first = export(
+      "project.dataset.agent_events",
+      config=config,
+      bq_client=first_bq,
+      langsmith_client=_LangSmithClient(),
+  )
+
+  stored = json.loads(watermark_path.read_text(encoding="utf-8"))
+  assert first.watermark == _T1
+  assert stored["timestamp"] == _T1.isoformat()
+  assert stored["trace_id"] == "trace-1"
+  assert stored["run_id"] == "span-child"
+
+  second_bq = _BigQueryClient([])
+  second = export(
+      "project.dataset.agent_events",
+      config=config,
+      bq_client=second_bq,
+      langsmith_client=_LangSmithClient(),
+  )
+  sql, job_config = second_bq.queries[0]
+  parameters = {p.name: p.value for p in job_config.query_parameters}
+  assert "@bqaa_watermark_timestamp" in sql
+  assert "@bqaa_watermark_trace_id" in sql
+  assert "@bqaa_watermark_run_id" in sql
+  assert parameters["bqaa_watermark_timestamp"] == _T1
+  assert parameters["bqaa_watermark_trace_id"] == "trace-1"
+  assert parameters["bqaa_watermark_run_id"] == "span-child"
+  assert second.exported == 0
+
+
+def test_skipped_row_blocks_incremental_watermark_advancement(
+    tmp_path: Path,
+) -> None:
+  valid = _standard_rows()[0]
+  invalid = {**valid, "span_id": None}
+  watermark_path = tmp_path / "watermark.json"
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          incremental=True,
+          watermark_path=watermark_path,
+          requests_per_second=None,
+      ),
+      bq_client=_BigQueryClient([valid, invalid]),
+      langsmith_client=_LangSmithClient(),
+  )
+
+  assert stats.exported == 1
+  assert stats.skipped == 1
+  assert stats.traces_exported == 0
+  assert not watermark_path.exists()
+
+
+def test_watermark_total_order_includes_trace_id(tmp_path: Path) -> None:
+  template = _standard_rows()[0]
+  rows = [
+      {**template, "trace_id": "trace-a", "span_id": "same"},
+      {**template, "trace_id": "trace-z", "span_id": "same"},
+  ]
+  watermark_path = tmp_path / "watermark.json"
+
+  export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          incremental=True,
+          watermark_path=watermark_path,
+          requests_per_second=None,
+      ),
+      bq_client=_BigQueryClient(rows),
+      langsmith_client=_LangSmithClient(),
+  )
+
+  stored = json.loads(watermark_path.read_text(encoding="utf-8"))
+  assert stored["trace_id"] == "trace-z"
+  assert stored["run_id"] == "same"
+
+
+def test_watermark_rejects_unknown_version_and_destination_change(
+    tmp_path: Path,
+) -> None:
+  watermark_path = tmp_path / "watermark.json"
+  base = ExportConfig(
+      incremental=True,
+      watermark_path=watermark_path,
+      langsmith_project="project-a",
+      langsmith_endpoint="https://one.example",
+      langsmith_workspace_id="workspace-a",
+      requests_per_second=None,
+  )
+  export(
+      "project.dataset.agent_events",
+      config=base,
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=_LangSmithClient(),
+  )
+
+  changed_destination = ExportConfig(
+      incremental=True,
+      watermark_path=watermark_path,
+      langsmith_project="project-b",
+      langsmith_endpoint="https://one.example",
+      langsmith_workspace_id="workspace-a",
+      requests_per_second=None,
+  )
+  with pytest.raises(ValueError, match="different source.*destination"):
+    export(
+        "project.dataset.agent_events",
+        config=changed_destination,
+        bq_client=_BigQueryClient([]),
+        langsmith_client=_LangSmithClient(),
+    )
+
+  stored = json.loads(watermark_path.read_text(encoding="utf-8"))
+  stored["version"] = 999
+  watermark_path.write_text(json.dumps(stored), encoding="utf-8")
+  with pytest.raises(ValueError, match="unsupported watermark version"):
+    export(
+        "project.dataset.agent_events",
+        config=base,
+        bq_client=_BigQueryClient([]),
+        langsmith_client=_LangSmithClient(),
+    )
+
+
+def test_incremental_watermark_rejects_a_different_source(
+    tmp_path: Path,
+) -> None:
+  watermark_path = tmp_path / "watermark.json"
+  config = ExportConfig(
+      langsmith_project="destination",
+      incremental=True,
+      watermark_path=watermark_path,
+      requests_per_second=None,
+  )
+  export(
+      "project.dataset.first",
+      config=config,
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=_LangSmithClient(),
+  )
+
+  with pytest.raises(ValueError, match="different source"):
+    export(
+        "project.dataset.second",
+        config=config,
+        bq_client=_BigQueryClient([]),
+        langsmith_client=_LangSmithClient(),
+    )
+
+
+def test_default_client_uses_langsmith_export_surface() -> None:
+  bq = _BigQueryClient([])
+  with patch(
+      "bigquery_agent_analytics.export.langsmith.make_bq_client",
+      return_value=bq,
+  ) as make_client:
+    export(
+        "project.dataset.agent_events",
+        config=ExportConfig(requests_per_second=None),
+        langsmith_client=_LangSmithClient(),
+    )
+
+  make_client.assert_called_once_with(
+      "project", location=None, sdk_surface="langsmith_export"
+  )
+
+
+def test_batch_size_and_rate_limit_apply_between_api_requests() -> None:
+  rows = [_standard_rows()[0]]
+  rows.append({**rows[0], "trace_id": "trace-2", "span_id": "span-2"})
+  sleeps: list[float] = []
+  clock = iter([0.0, 0.0, 0.5])
+  with (
+      patch(
+          "bigquery_agent_analytics.export.langsmith.time.sleep",
+          side_effect=sleeps.append,
+      ),
+      patch(
+          "bigquery_agent_analytics.export.langsmith.time.monotonic",
+          side_effect=lambda: next(clock),
+      ),
+  ):
+    stats = export(
+        "project.dataset.agent_events",
+        config=ExportConfig(
+            batch_size=1,
+            requests_per_second=2,
+            max_retries=0,
+        ),
+        bq_client=_BigQueryClient(rows),
+        langsmith_client=_LangSmithClient(),
+    )
+
+  assert stats.batches == 2
+  assert sleeps == [0.5]
+
+
+def test_batch_size_is_hard_limit_for_one_oversized_trace() -> None:
+  template = _standard_rows()[0]
+  rows = [
+      {
+          **template,
+          "timestamp": _T0.replace(microsecond=index),
+          "span_id": f"span-{index}",
+      }
+      for index in range(5)
+  ]
+  langsmith = _LangSmithClient()
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(batch_size=2, requests_per_second=None),
+      bq_client=_BigQueryClient(rows),
+      langsmith_client=langsmith,
+  )
+
+  source_counts = [
+      sum("source_run_id" in run["extra"]["bqaa"] for run in call["create"])
+      for call in langsmith.calls
+  ]
+  assert source_counts == [2, 2, 1]
+  assert stats.exported == 5
+  assert stats.failed == 0
+  assert stats.batches == 3
+  assert stats.traces_exported == 1
+
+
+def test_partial_oversized_trace_failure_is_not_counted_or_watermarked(
+    tmp_path: Path,
+) -> None:
+  template = _standard_rows()[0]
+  rows = [
+      {
+          **template,
+          "timestamp": _T0.replace(microsecond=index),
+          "span_id": f"span-{index}",
+      }
+      for index in range(5)
+  ]
+  watermark_path = tmp_path / "watermark.json"
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          incremental=True,
+          watermark_path=watermark_path,
+          batch_size=2,
+          max_retries=0,
+          requests_per_second=None,
+      ),
+      bq_client=_BigQueryClient(rows),
+      langsmith_client=_FailOnCallLangSmithClient(call_number=2),
+  )
+
+  assert stats.exported == 3
+  assert stats.failed == 2
+  assert stats.traces_exported == 0
+  assert not watermark_path.exists()
+
+
+def test_cycle_is_broken_below_synthetic_root_without_dropping_rows() -> None:
+  first, second = _standard_rows()
+  first["parent_span_id"] = "span-child"
+  second["parent_span_id"] = "span-root"
+
+  prepared = _prepare_trace_runs(
+      [first, second],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source",
+      project_name="p",
+  )
+
+  assert len(prepared.runs) == 3
+  assert set(prepared.source_run_ids) == {"span-root", "span-child"}
+
+
+def test_deep_trace_does_not_depend_on_python_recursion_limit() -> None:
+  template = _standard_rows()[0]
+  depth = 1100
+  rows = [
+      {
+          **template,
+          "timestamp": _T0.replace(microsecond=index),
+          "span_id": f"span-{index}",
+          "parent_span_id": f"span-{index - 1}" if index else None,
+      }
+      for index in range(depth)
+  ]
+
+  prepared = _prepare_trace_runs(
+      rows,
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source",
+      project_name="p",
+  )
+
+  assert len(prepared.runs) == depth + 1
+  assert prepared.runs[-1]["extra"]["bqaa"]["source_run_id"] == "span-1099"
+
+
+def test_failed_batch_is_reported_and_does_not_advance_watermark(
+    tmp_path: Path,
+) -> None:
+  sleeps: list[float] = []
+  watermark_path = tmp_path / "watermark.json"
+  with patch(
+      "bigquery_agent_analytics.export.langsmith.time.sleep",
+      side_effect=sleeps.append,
+  ):
+    stats = export(
+        "project.dataset.agent_events",
+        config=ExportConfig(
+            langsmith_project="destination",
+            incremental=True,
+            watermark_path=watermark_path,
+            max_retries=1,
+            retry_backoff_seconds=0.25,
+            requests_per_second=None,
+        ),
+        bq_client=_BigQueryClient(_standard_rows()),
+        langsmith_client=_LangSmithClient(failures=2),
+    )
+
+  assert sleeps == [0.25]
+  assert stats.exported == 0
+  assert stats.failed == 2
+  assert {d.source_run_id for d in stats.dropped_rows} == {
+      "span-root",
+      "span-child",
+  }
+  assert not watermark_path.exists()
+
+
+def test_dropped_row_details_are_capped_without_losing_totals() -> None:
+  template = _standard_rows()[0]
+  rows = [
+      {**template, "span_id": None, "custom_row_number": index}
+      for index in range(5)
+  ]
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          max_dropped_rows=2,
+          requests_per_second=None,
+      ),
+      bq_client=_BigQueryClient(rows),
+      langsmith_client=_LangSmithClient(),
+  )
+
+  assert stats.skipped == 5
+  assert stats.failed == 0
+  assert len(stats.dropped_rows) == 2
+  assert stats.dropped_rows_truncated == 3
+  assert stats.to_dict()["dropped_rows_truncated"] == 3
+
+
+def test_invalid_mapping_rejects_missing_identity_fields() -> None:
+  with pytest.raises(ValueError, match="run_id"):
+    FieldMapping.from_dict({"run_id": None, "trace_id": "trace"})
+
+
+def test_real_client_adapter_resurfaces_sdk_swallowed_ingest_errors() -> None:
+  class _SwallowingClient:
+
+    def __init__(self, **kwargs) -> None:
+      self.callback = kwargs["tracing_error_callback"]
+
+    def batch_ingest_runs(self, *, create=None, update=None) -> None:
+      del create, update
+      self.callback(_RetryableError(429))
+
+  module = SimpleNamespace(Client=_SwallowingClient)
+  with patch.dict(sys.modules, {"langsmith": module}):
+    client = _create_langsmith_client(ExportConfig(requests_per_second=None))
+
+  with pytest.raises(_RetryableError):
+    client.batch_ingest_runs(create=[{"id": "run"}])
+
+
+def test_real_langsmith_transient_errors_and_groups_are_retryable() -> None:
+  langsmith_utils = pytest.importorskip("langsmith.utils")
+  transient = [
+      langsmith_utils.LangSmithAPIError("server"),
+      langsmith_utils.LangSmithConnectionError("connection"),
+      langsmith_utils.LangSmithRateLimitError("rate"),
+      langsmith_utils.LangSmithRequestTimeout("timeout"),
+  ]
+
+  assert all(_is_retryable(exc) for exc in transient)
+  assert _is_retryable(
+      langsmith_utils.LangSmithExceptionGroup(exceptions=transient)
+  )
+  assert not _is_retryable(
+      langsmith_utils.LangSmithExceptionGroup(
+          exceptions=[transient[0], langsmith_utils.LangSmithAuthError("auth")]
+      )
+  )

--- a/tests/test_langsmith_export.py
+++ b/tests/test_langsmith_export.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from decimal import Decimal
 import json
@@ -31,9 +32,12 @@ import uuid
 import pytest
 
 from bigquery_agent_analytics.export.langsmith import _build_source_query
+from bigquery_agent_analytics.export.langsmith import _canonical_source
 from bigquery_agent_analytics.export.langsmith import _create_langsmith_client
+from bigquery_agent_analytics.export.langsmith import _DroppedRowCollector
 from bigquery_agent_analytics.export.langsmith import _is_retryable
 from bigquery_agent_analytics.export.langsmith import _prepare_trace_runs
+from bigquery_agent_analytics.export.langsmith import _Watermark
 from bigquery_agent_analytics.export.langsmith import export
 from bigquery_agent_analytics.export.langsmith import ExportConfig
 from bigquery_agent_analytics.export.langsmith import FieldMapping
@@ -60,6 +64,44 @@ class _BigQueryClient:
     self.queries: list[tuple[str, Any]] = []
 
   def query(self, sql: str, *, job_config: Any):
+    self.queries.append((sql, job_config))
+    return self.job
+
+
+class _IncrementalBigQueryClient(_BigQueryClient):
+
+  def __init__(self, rows: list[dict[str, Any]]) -> None:
+    super().__init__(rows)
+    self._source_rows = rows
+
+  def query(self, sql: str, *, job_config: Any):
+    parameters = {
+        parameter.name: parameter.value
+        for parameter in job_config.query_parameters
+    }
+    watermark_time = parameters.get("bqaa_watermark_timestamp")
+    if watermark_time is None:
+      selected = self._source_rows
+    else:
+      watermark_trace = parameters["bqaa_watermark_trace_id"]
+      watermark_run = parameters["bqaa_watermark_run_id"]
+
+      def follows_watermark(row: dict[str, Any]) -> bool:
+        timestamp = row.get("timestamp")
+        if not isinstance(timestamp, datetime):
+          return False
+        if timestamp != watermark_time:
+          return timestamp > watermark_time
+        trace_id = row.get("trace_id")
+        if not isinstance(trace_id, str):
+          return False
+        if trace_id != watermark_trace:
+          return trace_id > watermark_trace
+        run_id = row.get("span_id")
+        return isinstance(run_id, str) and run_id > watermark_run
+
+      selected = [row for row in self._source_rows if follows_watermark(row)]
+    self.job = _QueryJob(selected)
     self.queries.append((sql, job_config))
     return self.job
 
@@ -99,8 +141,13 @@ class _StatefulLangSmithClient(_LangSmithClient):
 
   def batch_ingest_runs(self, *, create=None, update=None) -> None:
     super().batch_ingest_runs(create=create, update=update)
-    for run in create or update or []:
-      self.runs[str(run["id"])] = run
+    for run in create or []:
+      self.runs.setdefault(str(run["id"]), dict(run))
+    for run in update or []:
+      run_id = str(run["id"])
+      if run_id not in self.runs:
+        raise AssertionError("cannot update a run before it is created")
+      self.runs[run_id].update(run)
 
 
 class _RetryableError(RuntimeError):
@@ -218,6 +265,89 @@ def test_custom_mapping_treats_payload_as_opaque_and_keeps_unknown_columns() -> 
       "key": "custom-trace",
       "other": "covered column",
   }
+
+
+def test_custom_mapping_does_not_inherit_undeclared_adk_fields() -> None:
+  mapping = FieldMapping.from_dict(
+      {"run_id": "event_key", "trace_id": "trace_key"}
+  )
+  row = {
+      "event_key": "custom-1",
+      "trace_key": "trace-1",
+      "status": "ERROR",
+      "error_message": "domain error, not a trace failure",
+      "latency_ms": 42,
+  }
+
+  run = _prepare_trace_runs(
+      [row], mapping=mapping, source_fingerprint="custom", project_name="p"
+  ).runs[1]
+
+  assert mapping.status is None
+  assert mapping.error is None
+  assert mapping.latency_ms is None
+  assert "error" not in run
+  assert "end_time" not in run
+  assert run["extra"]["metadata"]["status"] == "ERROR"
+  assert run["extra"]["metadata"]["error_message"] == (
+      "domain error, not a trace failure"
+  )
+  assert run["extra"]["metadata"]["latency_ms"] == 42
+
+
+def test_default_mapping_decodes_adk_json_string_content_and_latency() -> None:
+  row = {
+      **_standard_rows()[0],
+      "content": json.dumps({"prompt": "decoded ADK payload"}),
+      "latency_ms": json.dumps({"total_ms": 1250}),
+  }
+
+  run = _prepare_trace_runs(
+      [row],
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source",
+      project_name="p",
+  ).runs[1]
+
+  assert run["inputs"] == {"prompt": "decoded ADK payload"}
+  assert run["end_time"] == _T0.replace(microsecond=0) + timedelta(
+      milliseconds=1250
+  )
+
+
+@pytest.mark.parametrize(
+    ("latency", "expected_end_time"),
+    [
+        (Decimal("12.5"), _T0 + timedelta(milliseconds=12.5)),
+        (True, None),
+    ],
+)
+def test_latency_accepts_decimal_but_not_bool(
+    latency: object, expected_end_time: datetime | None
+) -> None:
+  mapping = FieldMapping.from_dict(
+      {
+          "run_id": "event_key",
+          "trace_id": "trace_key",
+          "start_time": "occurred_at",
+          "latency_ms": "duration_ms",
+      }
+  )
+  run = _prepare_trace_runs(
+      [
+          {
+              "event_key": "custom-1",
+              "trace_key": "trace-1",
+              "occurred_at": _T0,
+              "duration_ms": latency,
+          }
+      ],
+      mapping=mapping,
+      source_fingerprint="custom",
+      project_name="p",
+  ).runs[1]
+
+  assert run.get("end_time") == expected_end_time
 
 
 def test_non_json_bigquery_scalars_use_loss_minimizing_metadata_encoding() -> (
@@ -357,6 +487,73 @@ def test_table_and_sql_sources_are_wrapped_without_rewriting_payloads() -> None:
   assert "CAST(bqaa_source.`odd` AS STRING)" in custom_sql
 
 
+def test_time_filters_cast_string_mapped_timestamps() -> None:
+  sql, _ = _build_source_query(
+      "project.dataset.events",
+      mapping=FieldMapping.from_dict(
+          {
+              "run_id": "event_key",
+              "trace_id": "trace_key",
+              "start_time": "occurred_at",
+          }
+      ),
+      since=_T0,
+      until=_T1,
+      where=None,
+      watermark=None,
+  )
+
+  timestamp = "SAFE_CAST(bqaa_source.`occurred_at` AS TIMESTAMP)"
+  assert f"{timestamp} >= @bqaa_since" in sql
+  assert f"{timestamp} < @bqaa_until" in sql
+  assert (
+      "ORDER BY COALESCE(CAST(bqaa_source.`trace_key` AS STRING), ''), "
+      "COALESCE(SAFE_CAST(bqaa_source.`occurred_at` AS TIMESTAMP), "
+      "TIMESTAMP('1970-01-01T00:00:00+00:00'))" in sql
+  )
+
+
+def test_watermark_query_coalesces_invalid_cursor_components() -> None:
+  mapping = FieldMapping.from_dict(
+      {
+          "run_id": "event_key",
+          "trace_id": "trace_key",
+          "start_time": "occurred_at",
+      }
+  )
+  sql, _ = _build_source_query(
+      "project.dataset.events",
+      mapping=mapping,
+      since=None,
+      until=None,
+      where=None,
+      watermark=_Watermark(datetime(1970, 1, 1, tzinfo=timezone.utc), "", ""),
+  )
+
+  assert (
+      "COALESCE(SAFE_CAST(bqaa_source.`occurred_at` AS TIMESTAMP), "
+      "TIMESTAMP('1970-01-01T00:00:00+00:00')) > "
+      "@bqaa_watermark_timestamp" in sql
+  )
+  assert (
+      "COALESCE(CAST(bqaa_source.`trace_key` AS STRING), '') > "
+      "@bqaa_watermark_trace_id" in sql
+  )
+  assert (
+      "COALESCE(CAST(bqaa_source.`event_key` AS STRING), '') > "
+      "@bqaa_watermark_run_id" in sql
+  )
+
+
+def test_table_source_identity_preserves_case() -> None:
+  upper = _canonical_source("Project.DataSet.Events", None)
+  lower = _canonical_source("project.dataset.events", None)
+
+  assert upper == "table:Project.DataSet.Events"
+  assert lower == "table:project.dataset.events"
+  assert upper != lower
+
+
 @pytest.mark.parametrize(
     "table",
     [
@@ -403,7 +600,7 @@ def test_unsafe_or_invalid_table_ids_are_not_interpolated_as_identifiers(
   assert "SELECT * FROM (" in sql
 
 
-def test_export_batches_upserts_and_reports_rows() -> None:
+def test_export_batches_create_then_update_and_reports_rows() -> None:
   bq = _BigQueryClient(_standard_rows())
   langsmith = _LangSmithClient()
   stats = export(
@@ -421,34 +618,79 @@ def test_export_batches_upserts_and_reports_rows() -> None:
   assert stats.exported == 2
   assert stats.failed == 0
   assert stats.traces_exported == 1
-  assert len(langsmith.calls) == 1
+  assert len(langsmith.calls) == 2
   assert langsmith.calls[0]["create"] is not None
   assert langsmith.calls[0]["update"] is None
+  assert langsmith.calls[1]["create"] is None
+  assert langsmith.calls[1]["update"] is not None
   query_config = bq.queries[0][1]
   assert query_config.labels["sdk_feature"] == "langsmith-export"
 
 
-def test_replaying_window_upserts_without_duplicate_runs() -> None:
+def test_replaying_window_updates_changed_runs_without_duplicates() -> None:
   langsmith = _StatefulLangSmithClient()
   config = ExportConfig(
       langsmith_project="destination", requests_per_second=None
   )
 
+  first_rows = _standard_rows()
   export(
       "project.dataset.agent_events",
       config=config,
-      bq_client=_BigQueryClient(_standard_rows()),
+      bq_client=_BigQueryClient(first_rows),
       langsmith_client=langsmith,
   )
+  replay_rows = _standard_rows()
+  replay_rows[1]["error_message"] = "backfilled failure detail"
+  replay_rows[1]["content"] = {"backfilled": True}
   export(
       "project.dataset.agent_events",
       config=config,
+      bq_client=_BigQueryClient(replay_rows),
+      langsmith_client=langsmith,
+  )
+
+  assert len(langsmith.calls) == 4
+  assert len(langsmith.runs) == 3
+  child = next(
+      run
+      for run in langsmith.runs.values()
+      if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
+      == "span-child"
+  )
+  assert child["error"] == "backfilled failure detail"
+  assert child["inputs"] == {"backfilled": True}
+
+
+def test_surfaced_create_conflict_is_not_retried_and_update_still_runs() -> (
+    None
+):
+  class _ConflictOnCreateClient(_LangSmithClient):
+
+    def __init__(self) -> None:
+      super().__init__()
+      self.create_attempts = 0
+
+    def batch_ingest_runs(self, *, create=None, update=None) -> None:
+      if create is not None:
+        self.create_attempts += 1
+        raise _RetryableError(409)
+      super().batch_ingest_runs(create=create, update=update)
+
+  langsmith = _ConflictOnCreateClient()
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(requests_per_second=None),
       bq_client=_BigQueryClient(_standard_rows()),
       langsmith_client=langsmith,
   )
 
-  assert len(langsmith.calls) == 2
-  assert len(langsmith.runs) == 3
+  assert langsmith.create_attempts == 1
+  assert len(langsmith.calls) == 1
+  assert langsmith.calls[0]["create"] is None
+  assert langsmith.calls[0]["update"] is not None
+  assert stats.exported == 2
+  assert stats.failed == 0
 
 
 def test_same_span_id_in_different_traces_gets_distinct_run_ids() -> None:
@@ -503,7 +745,12 @@ def test_synthetic_root_identity_and_order_are_stable_across_windows() -> None:
 
   assert first["id"] == second["id"]
   assert first["dotted_order"] == second["dotted_order"]
-  assert first["start_time"] == second["start_time"]
+  assert first["start_time"] == parent["timestamp"]
+  assert first["end_time"] == parent["timestamp"] + timedelta(milliseconds=1000)
+  assert second["start_time"] == child["timestamp"]
+  assert second["end_time"] == child["timestamp"] + timedelta(milliseconds=25)
+  assert first["start_time"].year != 1970
+  assert second["start_time"].year != 1970
 
 
 def test_incremental_export_persists_and_reuses_watermark(
@@ -548,28 +795,81 @@ def test_incremental_export_persists_and_reuses_watermark(
   assert second.exported == 0
 
 
-def test_skipped_row_blocks_incremental_watermark_advancement(
+def test_skipped_row_is_checkpointed_and_does_not_stall_incremental_sync(
     tmp_path: Path,
 ) -> None:
   valid = _standard_rows()[0]
-  invalid = {**valid, "span_id": None}
+  invalid = {**valid, "timestamp": _T1, "span_id": None}
+  invalid_time = {
+      **valid,
+      "timestamp": "not-a-timestamp",
+      "trace_id": "trace-2",
+      "span_id": "bad-time",
+  }
   watermark_path = tmp_path / "watermark.json"
+  config = ExportConfig(
+      incremental=True,
+      watermark_path=watermark_path,
+      requests_per_second=None,
+  )
+  bq = _IncrementalBigQueryClient([valid, invalid, invalid_time])
 
-  stats = export(
+  first = export(
       "project.dataset.agent_events",
-      config=ExportConfig(
-          incremental=True,
-          watermark_path=watermark_path,
-          requests_per_second=None,
-      ),
-      bq_client=_BigQueryClient([valid, invalid]),
+      config=config,
+      bq_client=bq,
       langsmith_client=_LangSmithClient(),
   )
 
-  assert stats.exported == 1
-  assert stats.skipped == 1
-  assert stats.traces_exported == 0
-  assert not watermark_path.exists()
+  assert first.exported == 2
+  assert first.skipped == 1
+  assert first.traces_exported == 2
+  stored = json.loads(watermark_path.read_text(encoding="utf-8"))
+  assert stored["timestamp"] == _T1.isoformat()
+  assert stored["trace_id"] == "trace-1"
+  assert stored["run_id"] == ""
+
+  second = export(
+      "project.dataset.agent_events",
+      config=config,
+      bq_client=bq,
+      langsmith_client=_LangSmithClient(),
+  )
+
+  assert second.rows_read == 0
+  assert second.watermark == _T1
+  sql, job_config = bq.queries[1]
+  assert "@bqaa_watermark_timestamp" in sql
+  parameters = {item.name: item.value for item in job_config.query_parameters}
+  assert parameters["bqaa_watermark_timestamp"] == _T1
+
+
+def test_incremental_mapping_requires_start_time_before_query(
+    tmp_path: Path,
+) -> None:
+  bq = _BigQueryClient([])
+  langsmith = _LangSmithClient()
+  mapping = FieldMapping.from_dict(
+      {"run_id": "event_key", "trace_id": "trace_key"}
+  )
+
+  with pytest.raises(
+      ValueError, match="incremental export requires a start_time mapping"
+  ):
+    export(
+        "project.dataset.events",
+        config=ExportConfig(
+            mapping=mapping,
+            incremental=True,
+            watermark_path=tmp_path / "watermark.json",
+            requests_per_second=None,
+        ),
+        bq_client=bq,
+        langsmith_client=langsmith,
+    )
+
+  assert bq.queries == []
+  assert langsmith.calls == []
 
 
 def test_watermark_total_order_includes_trace_id(tmp_path: Path) -> None:
@@ -669,7 +969,7 @@ def test_incremental_watermark_rejects_a_different_source(
     )
 
 
-def test_default_client_uses_langsmith_export_surface() -> None:
+def test_default_client_uses_hyphenated_langsmith_export_surface() -> None:
   bq = _BigQueryClient([])
   with patch(
       "bigquery_agent_analytics.export.langsmith.make_bq_client",
@@ -682,7 +982,7 @@ def test_default_client_uses_langsmith_export_surface() -> None:
     )
 
   make_client.assert_called_once_with(
-      "project", location=None, sdk_surface="langsmith_export"
+      "project", location=None, sdk_surface="langsmith-export"
   )
 
 
@@ -690,7 +990,7 @@ def test_batch_size_and_rate_limit_apply_between_api_requests() -> None:
   rows = [_standard_rows()[0]]
   rows.append({**rows[0], "trace_id": "trace-2", "span_id": "span-2"})
   sleeps: list[float] = []
-  clock = iter([0.0, 0.0, 0.5])
+  clock = iter([0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.5])
   with (
       patch(
           "bigquery_agent_analytics.export.langsmith.time.sleep",
@@ -713,7 +1013,7 @@ def test_batch_size_and_rate_limit_apply_between_api_requests() -> None:
     )
 
   assert stats.batches == 2
-  assert sleeps == [0.5]
+  assert sleeps == [0.5, 0.5, 0.5]
 
 
 def test_batch_size_is_hard_limit_for_one_oversized_trace() -> None:
@@ -738,6 +1038,7 @@ def test_batch_size_is_hard_limit_for_one_oversized_trace() -> None:
   source_counts = [
       sum("source_run_id" in run["extra"]["bqaa"] for run in call["create"])
       for call in langsmith.calls
+      if call["create"] is not None
   ]
   assert source_counts == [2, 2, 1]
   assert stats.exported == 5
@@ -770,7 +1071,7 @@ def test_partial_oversized_trace_failure_is_not_counted_or_watermarked(
           requests_per_second=None,
       ),
       bq_client=_BigQueryClient(rows),
-      langsmith_client=_FailOnCallLangSmithClient(call_number=2),
+      langsmith_client=_FailOnCallLangSmithClient(call_number=3),
   )
 
   assert stats.exported == 3
@@ -792,7 +1093,9 @@ def test_cycle_is_broken_below_synthetic_root_without_dropping_rows() -> None:
   )
 
   assert len(prepared.runs) == 3
-  assert set(prepared.source_run_ids) == {"span-root", "span-child"}
+  assert {
+      run["extra"]["bqaa"]["source_run_id"] for run in prepared.runs[1:]
+  } == {"span-root", "span-child"}
 
 
 def test_deep_trace_does_not_depend_on_python_recursion_limit() -> None:
@@ -876,6 +1179,25 @@ def test_dropped_row_details_are_capped_without_losing_totals() -> None:
   assert stats.to_dict()["dropped_rows_truncated"] == 3
 
 
+def test_trace_preparation_uses_shared_bounded_dropped_row_collector() -> None:
+  template = _standard_rows()[0]
+  rows = [{**template, "span_id": None} for _ in range(5)]
+  dropped_rows = _DroppedRowCollector(maximum=2)
+
+  prepared = _prepare_trace_runs(
+      rows,
+      mapping=FieldMapping.standard_adk(),
+      source_fingerprint="source",
+      project_name="p",
+      dropped_rows=dropped_rows,
+  )
+
+  assert prepared.skipped_count == 5
+  assert dropped_rows.total == 5
+  assert len(dropped_rows.rows) == 2
+  assert dropped_rows.truncated == 3
+
+
 def test_invalid_mapping_rejects_missing_identity_fields() -> None:
   with pytest.raises(ValueError, match="run_id"):
     FieldMapping.from_dict({"run_id": None, "trace_id": "trace"})
@@ -899,6 +1221,90 @@ def test_real_client_adapter_resurfaces_sdk_swallowed_ingest_errors() -> None:
     client.batch_ingest_runs(create=[{"id": "run"}])
 
 
+def test_real_langsmith_client_serializes_separate_create_and_update_batches(
+    monkeypatch,
+) -> None:
+  langsmith = pytest.importorskip("langsmith")
+  client = langsmith.Client(
+      api_key="test-key",
+      auto_batch_tracing=False,
+      info={},
+  )
+  request_bodies: list[dict[str, Any]] = []
+
+  def capture_batch(_client, body: bytes, **kwargs) -> None:
+    del _client, kwargs
+    request_bodies.append(json.loads(body))
+
+  monkeypatch.setattr(type(client), "_post_batch_ingest_runs", capture_batch)
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(requests_per_second=None),
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=client,
+  )
+
+  assert stats.exported == 2
+  assert len(request_bodies) == 2
+  assert len(request_bodies[0]["post"]) == 3
+  assert "patch" not in request_bodies[0]
+  assert len(request_bodies[1]["patch"]) == 3
+  assert "post" not in request_bodies[1]
+  child_update = next(
+      run
+      for run in request_bodies[1]["patch"]
+      if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
+      == "span-child"
+  )
+  assert child_update["error"] == "tool failed"
+
+
+def test_real_langsmith_retry_rebuilds_mutated_update_payloads(
+    monkeypatch,
+) -> None:
+  langsmith = pytest.importorskip("langsmith")
+  client = langsmith.Client(
+      api_key="test-key",
+      auto_batch_tracing=False,
+      info={},
+  )
+  patch_bodies: list[dict[str, Any]] = []
+
+  def fail_first_patch(_client, body: bytes, **kwargs) -> None:
+    del _client, kwargs
+    decoded = json.loads(body)
+    if "patch" not in decoded:
+      return
+    patch_bodies.append(decoded)
+    if len(patch_bodies) == 1:
+      raise _RetryableError(429)
+
+  monkeypatch.setattr(type(client), "_post_batch_ingest_runs", fail_first_patch)
+
+  stats = export(
+      "project.dataset.agent_events",
+      config=ExportConfig(
+          requests_per_second=None,
+          max_retries=1,
+          retry_backoff_seconds=0,
+      ),
+      bq_client=_BigQueryClient(_standard_rows()),
+      langsmith_client=client,
+  )
+
+  assert stats.exported == 2
+  assert len(patch_bodies) == 2
+  retried_child = next(
+      run
+      for run in patch_bodies[1]["patch"]
+      if run.get("extra", {}).get("bqaa", {}).get("source_run_id")
+      == "span-child"
+  )
+  assert retried_child["inputs"] == {"value": ["opaque", {"payload": True}]}
+  assert retried_child["error"] == "tool failed"
+
+
 def test_real_langsmith_transient_errors_and_groups_are_retryable() -> None:
   langsmith_utils = pytest.importorskip("langsmith.utils")
   transient = [
@@ -917,3 +1323,5 @@ def test_real_langsmith_transient_errors_and_groups_are_retryable() -> None:
           exceptions=[transient[0], langsmith_utils.LangSmithAuthError("auth")]
       )
   )
+  assert not _is_retryable(langsmith_utils.LangSmithConflictError("conflict"))
+  assert not _is_retryable(_RetryableError(409))


### PR DESCRIPTION
## Summary

BQAA trace data can now flow from BigQuery into LangSmith without a custom ETL. The connector accepts a table or arbitrary SQL, maps only declared fields, and carries all other columns into run metadata without interpreting payload semantics.

It supports bounded backfills and scheduler-friendly incremental sync. Stable source-derived UUIDs make overlapping runs idempotent, while failure-aware watermarking checkpoints reported skips so they do not wedge later runs, while any failed LangSmith batch blocks advancement.

Closes #410.

## Design decisions

- **Schema independence:** `FieldMapping` uses ADK defaults only when no custom mapping is supplied, while custom mappings opt into every field they consume. BigQuery-specific scalar values receive transport-safe encodings; only the built-in ADK content and latency JSON fields are decoded when a client returns them as strings.
- **Trace integrity:** the SDK's existing span-tree builder remains the hierarchy authority. Each trace gets one stable synthetic LangSmith root, complete dotted ancestry, deterministic child ordering, cycle handling, and safe orphan flattening when a query window omits an ancestor.
- **Honest delivery:** batches have a hard source-row cap, transient LangSmith errors use bounded exponential retry, per-trace chunk accounting prevents partial success from advancing state, and dropped-row details are bounded without losing aggregate counts.
- **Operational safety:** incremental state is atomically replaced and bound to the source, field mapping, and LangSmith destination. The CLI keeps the API key environment-only, exits nonzero for skipped or failed rows, and labels BigQuery jobs with `sdk_surface=langsmith-export` and `sdk_feature=langsmith-export`.

## Validation

- `3990 passed, 69 skipped` on Python 3.13 after the review-fix pass.
- Repository autoformat and `git diff --check` are clean.
- A live LangSmith 0.10.17 run on the prior head confirmed stable UUID ingestion, real synthetic-root times in recent-window queries, multi-chunk traces, and duplicate-free replay. It also proved exporter replays cannot mutate existing run IDs; this head now uses create-only batches to match that server policy.
- Intercepted LangSmith 0.10.17 serializer tests verify one create request per batch and full payload reconstruction on retry.
- Isolated sdist and wheel builds succeeded, and the wheel contains the exporter/CLI modules plus the `langsmith` optional dependency metadata.

## New concepts

### LangSmith dotted-order ancestry

LangSmith batch ingestion needs both a stable `trace_id` and a `dotted_order` string that contains the full path from the trace root to each run. `parent_run_id` alone is not enough for the batch API.

This connector derives UUIDv5 IDs from the canonical BigQuery source plus source trace/run IDs. A stable synthetic root gives multi-root BQAA traces one LangSmith tree, and every child appends its timestamp/UUID segment to its parent's dotted order. Create-only batches carry the complete run on first write. Stable IDs make replay an idempotent no-op for existing IDs while still allowing previously unseen IDs; corrections require a fresh LangSmith project or a deliberately versioned `--source-id`.

This pattern is specific to importing existing hierarchical traces. New traces created through LangSmith's normal tracing helpers should let the SDK construct these fields.

## Post-deploy verification

- **Logs:** watch `LangSmith export progress` and `LangSmith export batch failed`.
- **BigQuery:** verify jobs in `INFORMATION_SCHEMA.JOBS*` carry `sdk_surface=langsmith-export` and `sdk_feature=langsmith-export`; track job errors and bytes billed.
- **Connector metrics:** track exported/skipped/failed rows, completed batches, and watermark age. Healthy runs have `failed=0`, no unexpected skips, and an advancing watermark. Replaying the same window must not increase the destination run count.
- **Failure response:** pause the scheduler if failures rise above zero, the watermark stalls, 429/5xx errors repeat, or query cost changes unexpectedly. Correct the cause and replay the same window; stable IDs make that retry safe.
- **Window and owner:** validate for 24–48 hours after first scheduled use. The connector operator (or PR owner for the initial rollout) owns the check and rollback decision.