### PR TITLE
fix(dashboard): default report to 90-day range

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -91,8 +91,9 @@ fixture parity certification or M4 visual sign-off.
 Canonical published template:
 [BigQuery Agent Analytics — Template](https://lookerstudio.google.com/reporting/5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40).
 
-All seven dashboard pages default to a rolling 365-day window including
-today. The Trace Inspector intentionally has no default date control.
+All eight report pages share one report-level date control. It defaults to a
+rolling 90-day window including today; changing the range on any page persists
+across navigation, including the Trace Inspector.
 
 The v1 report is a freeform desktop dashboard. Use a viewport at least 1280
 CSS pixels wide (1440 recommended). A cold load or page navigation can paint
@@ -219,7 +220,7 @@ window, event volume, and number of chart interactions.
   dashboard's `@DS_START_DATE` / `@DS_END_DATE` predicate. Do not wrap the
   partition column in a transformation that prevents pruning.
 - Use the shortest date range that answers the operational question. The
-  365-day default is an onboarding view, not a recommendation for every
+  90-day default is an onboarding view, not a recommendation for every
   high-volume installation.
 - Set BigQuery partition expiration to the retention period your incident and
   compliance policies actually require.

--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -101,8 +101,10 @@ native charts after the surrounding report controls; allow up to 90 seconds
 for non-degenerate chart output. Phone and narrow-tablet layouts require a
 separate responsive template and are not supported by v1. See
 [`docs/rendering-and-viewport-support.md`](docs/rendering-and-viewport-support.md).
-The latest live pass used a 1568-pixel viewport, so targeted validation at the
-documented 1280-pixel minimum is still pending.
+The 2026-08-11 live pass validated every page at the documented 1280-pixel
+minimum with the Looker Studio navigation drawer collapsed. At that width the
+expanded drawer is viewer chrome that overlays the report canvas; collapse it
+to keep the full left edge visible.
 Issue
 [#388](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/388)
 also found that lower charts on Token Consumption and Latency crossed the

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -16,7 +16,7 @@ generated_report_credential_gate:
   verification_path: Resource > Manage added data sources > Edit
 link_access: PUBLIC
 publishing_mode: MANUAL
-published_date: "2026-07-29"
+published_date: "2026-08-11"
 # This attestation covers the reviewed repository artifact. It does not prove
 # that the mutable external Looker Studio report still embeds these bytes.
 reviewed_template_sql:
@@ -24,7 +24,7 @@ reviewed_template_sql:
   reviewed_date: "2026-07-24"
   scope: repository_artifact_only
 live_template_verification:
-  verified_date: "2026-07-29"
+  verified_date: "2026-08-11"
   repository_sql_sha256: 5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0
   method:
     - connector_custom_query_review
@@ -47,7 +47,7 @@ viewer_qa_contract:
   observed_baseline_comment: >-
     https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/383#issuecomment-5098030747
 product_verification:
-  verified_date: "2026-07-28"
+  verified_date: "2026-08-11"
   pages: 8
   checks:
     - expected_page_and_chart_titles_present
@@ -62,7 +62,7 @@ product_verification:
     - tool_charts_exclude_non_completed_rows
     - multi_series_charts_use_categorical_legends
     - no_partial_update_footer_after_refresh
-    - default_date_range_includes_today_on_seven_dashboard_pages
+    - default_date_range_includes_today_on_all_eight_report_pages
   result: PASSED
 source_contract:
   mode: BASE_TABLE

--- a/dashboard/looker_studio/bindings/report_template.yaml
+++ b/dashboard/looker_studio/bindings/report_template.yaml
@@ -78,7 +78,7 @@ governance:
   transfer_status: PENDING_MAINTAINER
 default_date_range:
   mode: rolling
-  start_offset_days: 364
+  start_offset_days: 89
   end_offset_days: 0
   include_today: true
-  page_scope: all_dashboard_pages
+  page_scope: all_report_pages

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -150,8 +150,10 @@ of 1280 CSS pixels and a recommended width of 1440 CSS pixels. A responsive
 mobile report is a separate template: the current multi-component pages cannot
 be converted in place without rebuilding their section layout and repeating
 parity, hydration, credential, and visual acceptance.
-The most recent live pass used a 1568-pixel viewport; targeted validation at
-the documented 1280-pixel minimum remains pending.
+The 2026-08-11 live pass validated all eight pages at the documented
+1280-pixel minimum with the Looker Studio navigation drawer collapsed. At that
+width the expanded drawer is viewer chrome that overlays the report canvas;
+collapse it to keep the full left edge visible.
 
 Freeform layout acceptance includes vertical containment as well as
 non-overlap. For every page, each component must satisfy
@@ -203,3 +205,13 @@ On 2026-07-24, the base-table-only implementation:
 No live result rows or source identifiers are committed. This smoke result
 proves installation compatibility and query executability; it does not replace
 seeded parity certification or M4 visual sign-off.
+
+The 2026-08-11 90-day publication gate repeated the table-only hydration and
+exact-production-query checks against a sanctioned real BQAA test table. With
+`@DS_START_DATE=20260514` and `@DS_END_DATE=20260811`, the uncached query
+processed 60,248 bytes and billed 10,485,760 bytes. A subsequent authenticated
+**Refresh data** walk of all eight published pages produced five query-cache
+hits and billed zero additional bytes. The absolute 90-day measurement is
+environment-specific; it does not imply a linear cost reduction from the
+former 365-day default. The same exact-query check verified that events dated
+2026-08-11 were included, preserving the include-today contract.

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -115,13 +115,14 @@ explicit chart title. Product titles use title case, “Over Time,” uppercase
 formerly inherited as “Events By Agent” is labeled **Tool Completions by
 Agent** because its metric intentionally counts only `TOOL_COMPLETED` rows.
 
-All seven dashboard pages use a rolling 365-day window including today.
-Looker Studio sends those bounds through `@DS_START_DATE` and
-`@DS_END_DATE`; the production query applies the frozen half-open UTC
-predicate. The generated manifest retains the pinned LookML's original
-14-day Usage and 7-day Performance defaults as source-provenance metadata;
-the published template intentionally overrides them for the product default.
-The Trace Inspector has no default date control.
+All eight report pages share one report-level date control with a rolling
+90-day window including today. Looker Studio sends those bounds through
+`@DS_START_DATE` and `@DS_END_DATE`; the production query applies the frozen
+half-open UTC predicate. Changing the range on any page persists across page
+navigation, including the Trace Inspector. The generated manifest retains the
+pinned LookML's original 14-day Usage and 7-day Performance defaults as
+source-provenance metadata; the published template intentionally overrides
+them for the product default.
 
 The LLM Call Volume chart uses `event_date`, not raw `timestamp`. The raw
 timestamp dimension exceeded Looker Studio's chart row limit on the canonical

--- a/dashboard/looker_studio/docs/rendering-and-viewport-support.md
+++ b/dashboard/looker_studio/docs/rendering-and-viewport-support.md
@@ -88,9 +88,11 @@ must independently pass chart parity, Linking API hydration, Viewer
 Credentials, query-cost, and phone/tablet visual validation before it can
 replace or accompany the v1 template.
 
-The 1280-pixel minimum is a documented product-support boundary. The latest
-live pass ran at 1568 pixels, so targeted visual validation at 1280 pixels
-remains pending.
+The 1280-pixel minimum is a documented product-support boundary. The
+2026-08-11 publication pass validated all eight pages at 1280 pixels with the
+Looker Studio navigation drawer collapsed. At that width the expanded drawer
+is viewer chrome that overlays the report canvas; collapse it to keep the full
+left edge visible.
 
 Viewport width does not prove that freeform components remain inside the page
 canvas. Release-candidate validation must also capture the editor's page height

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -7,7 +7,7 @@ meta:
   contract_version: 1
   review_issue: GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK#377
   source_parity_contract: spec/chart_manifest.yaml
-  live_review_date: "2026-07-27"
+  live_review_date: "2026-08-11"
   report_id: 5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40
 
 source:
@@ -201,8 +201,10 @@ viewport_support:
   recommended_width_css_px: 1440
   narrow_screen_support: not_supported_in_v1
   responsive_template: separate_report_required
-  minimum_width_validation: pending
-  last_validated_width_css_px: 1568
+  minimum_width_validation: passed
+  minimum_width_navigation_drawer_state: collapsed
+  last_validated_width_css_px: 1280
+  last_validated_date: "2026-08-11"
 
 charts:
   - id: usage-token-usage-split-by-agent

--- a/dashboard/looker_studio/spec/product_contract.yaml
+++ b/dashboard/looker_studio/spec/product_contract.yaml
@@ -19,10 +19,10 @@ source:
 defaults:
   date_range:
     mode: rolling
-    start_offset_days: 364
+    start_offset_days: 89
     end_offset_days: 0
     include_today: true
-    page_scope: all_dashboard_pages
+    page_scope: all_report_pages
 
 pages:
   - name: Token Consumption
@@ -48,7 +48,8 @@ layout:
     left: 68
     top_range: [43, 45]
   date_control:
-    present_on_dashboard_pages: true
+    scope: report_level
+    present_on_all_pages: true
     left: 825
     top_range: [43, 45]
   scorecard_start:
@@ -112,6 +113,13 @@ filtering:
       - model_version
   date_controls:
     apply_to_all_charts_on_page: true
+    report_level_override:
+      field: agent_events.timestamp_date
+      default_range_days: 90
+      persists_across_pages: true
+      supersedes:
+        - usage-control-date
+        - performance-control-date
   predefined_tool_name_control:
     status: intentionally_not_published
     reason: >-

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -417,8 +417,10 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
       "recommended_width_css_px": 1440,
       "narrow_screen_support": "not_supported_in_v1",
       "responsive_template": "separate_report_required",
-      "minimum_width_validation": "pending",
-      "last_validated_width_css_px": 1568,
+      "minimum_width_validation": "passed",
+      "minimum_width_navigation_drawer_state": "collapsed",
+      "last_validated_width_css_px": 1280,
+      "last_validated_date": "2026-08-11",
   }
   assert "live_series_mode" not in product["visual_system"]
   deferred = {item["id"] for item in product["deferred_enhancements"]}
@@ -463,14 +465,14 @@ def test_report_and_web_bindings_cannot_drift():
   }
   attestation = report["reviewed_template_sql"]
   template = (DASHBOARD / "sql/events_v1.template.sql").read_bytes()
-  assert report["published_date"] == "2026-07-29"
+  assert report["published_date"] == "2026-08-11"
   assert attestation == {
       "sha256": hashlib.sha256(template).hexdigest(),
       "reviewed_date": "2026-07-24",
       "scope": "repository_artifact_only",
   }
   assert report["live_template_verification"] == {
-      "verified_date": "2026-07-29",
+      "verified_date": "2026-08-11",
       "repository_sql_sha256": hashlib.sha256(template).hexdigest(),
       "method": [
           "connector_custom_query_review",
@@ -497,7 +499,7 @@ def test_report_and_web_bindings_cannot_drift():
       ),
   }
   assert report["product_verification"] == {
-      "verified_date": "2026-07-28",
+      "verified_date": "2026-08-11",
       "pages": 8,
       "checks": [
           "expected_page_and_chart_titles_present",
@@ -512,7 +514,7 @@ def test_report_and_web_bindings_cannot_drift():
           "tool_charts_exclude_non_completed_rows",
           "multi_series_charts_use_categorical_legends",
           "no_partial_update_footer_after_refresh",
-          "default_date_range_includes_today_on_seven_dashboard_pages",
+          "default_date_range_includes_today_on_all_eight_report_pages",
       ],
       "result": "PASSED",
   }

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -281,10 +281,28 @@ def test_product_contract_covers_every_parity_chart_and_live_fix():
   ]
   assert product["defaults"]["date_range"] == {
       "mode": "rolling",
-      "start_offset_days": 364,
+      "start_offset_days": 89,
       "end_offset_days": 0,
       "include_today": True,
-      "page_scope": "all_dashboard_pages",
+      "page_scope": "all_report_pages",
+  }
+  assert product["layout"]["date_control"] == {
+      "scope": "report_level",
+      "present_on_all_pages": True,
+      "left": 825,
+      "top_range": [43, 45],
+  }
+  assert product["filtering"]["date_controls"] == {
+      "apply_to_all_charts_on_page": True,
+      "report_level_override": {
+          "field": "agent_events.timestamp_date",
+          "default_range_days": 90,
+          "persists_across_pages": True,
+          "supersedes": [
+              "usage-control-date",
+              "performance-control-date",
+          ],
+      },
   }
   assert product["layout"]["percentile_order"] == {
       "llm": ["P50", "P75", "P90", "P99"],
@@ -433,10 +451,10 @@ def test_report_and_web_bindings_cannot_drift():
   assert web["dataSourceAlias"] == report["data_source_alias"]
   assert report["default_date_range"] == {
       "mode": "rolling",
-      "start_offset_days": 364,
+      "start_offset_days": 89,
       "end_offset_days": 0,
       "include_today": True,
-      "page_scope": "all_dashboard_pages",
+      "page_scope": "all_report_pages",
   }
   assert web["sentinels"] == {
       "project": bindings["PROJECT"],
@@ -512,7 +530,7 @@ def test_report_and_web_bindings_cannot_drift():
   }
 
 
-def test_default_date_range_includes_today_for_exactly_365_calendar_days():
+def test_report_level_date_range_includes_today_for_exactly_90_calendar_days():
   product = yaml.safe_load(
       (DASHBOARD / "spec/product_contract.yaml").read_text()
   )
@@ -524,9 +542,39 @@ def test_default_date_range_includes_today_for_exactly_365_calendar_days():
   assert report["default_date_range"] == date_range
   assert date_range["include_today"] is True
   assert date_range["end_offset_days"] == 0
+  assert date_range["page_scope"] == "all_report_pages"
   assert (
-      date_range["start_offset_days"] - date_range["end_offset_days"] + 1 == 365
+      date_range["start_offset_days"] - date_range["end_offset_days"] + 1 == 90
   )
+
+  date_controls = product["filtering"]["date_controls"]
+  report_override = date_controls["report_level_override"]
+  assert report_override["default_range_days"] == 90
+  assert report_override["persists_across_pages"] is True
+  assert report_override["supersedes"] == [
+      "usage-control-date",
+      "performance-control-date",
+  ]
+
+
+def test_report_level_override_preserves_the_immutable_source_controls():
+  manifest = yaml.safe_load(
+      (DASHBOARD / "spec/chart_manifest.yaml").read_text()
+  )
+
+  date_controls = {
+      control["id"]: control
+      for control in manifest["controls"]
+      if control["id"] in {"usage-control-date", "performance-control-date"}
+  }
+  assert date_controls["usage-control-date"]["default_value"] == "14 day"
+  assert date_controls["performance-control-date"]["default_value"] == "7 day"
+  assert {
+      control["source_dashboard"] for control in date_controls.values()
+  } == {
+      "usage",
+      "performance",
+  }
 
 
 def test_base_table_query_and_preflight_cover_the_bqaa_contract():


### PR DESCRIPTION
Closes #401.

## What changed

- Changes the product and report-binding default from 365 calendar days to 90 (`start_offset_days: 89`, `end_offset_days: 0`, `include_today: true`).
- Defines one report-level date control on all eight pages, including Trace Inspector. The control persists across navigation and supersedes the pinned 14-day Usage and 7-day Performance controls.
- Keeps `spec/chart_manifest.yaml` immutable as the source-provenance snapshot.
- Updates the README, implementation and viewport guides, live attestations, cost evidence, and regression coverage.

## Live publication and rollback

- Publish/rollback owner: `@haiyuan-eng-google`.
- Canonical report: `5a3f85ef-fc9c-4730-8ef2-8ef9129ddb40`.
- Published: 2026-08-11.
- Exact rollback target: Looker Studio version-history entry **“July 29, 2026 3:40 AM”**, authored by **haiyuan cao**, marked **“Current published version”** (`America/Los_Angeles`; `2026-07-29 10:40 UTC`).
- Rollback procedure: restore that exact entry and republish it if a regression is found.
- #415 remained decoupled.

## Completed publication gate

- Draft preflight: changed the range to Aug 5–11, traversed all eight pages, returned to Trace Inspector with the same state, then Reset restored the 90-day default.
- Published propagation probe: the 7-day range and its changed results propagated across all eight pages; returning to Token Consumption retained the range; Reset restored May 14–Aug 11 and the non-degenerate 90-day result.
- Rendering protocol: Chrome 145, signed in, three fresh loads × three complete eight-page loops at 1280×900 CSS pixels with the navigation drawer collapsed. Every expected page/chart marker rendered; no blank or degenerate chart remained.
- 1280-pixel containment: all pages passed; Token Consumption and Latency retained their published bottom containment. The collapsed-drawer condition is now explicit in the contract because expanded viewer chrome overlays the left edge at the minimum width.
- Connector: the live custom query SHA-256 is `5a4f455f9d17286d95396d1ced9e55ca35cbca7b33849e5ef3ced25ab25513b0`, byte-identical to `sql/events_v1.template.sql`; date-range parameters are enabled; Legacy SQL is off; Viewer credentials are active; community visualizations are off.
- Hydration: a sanctioned real BQAA base table passed preflight and emitted exactly one ordered `ds230.sqlReplace` PROJECT/DATASET/TABLE binding; no generated views were required.
- Include-today: the exact production query for May 14–Aug 11 returned 7,531 rows including 332 dated Aug 11. Moving the end to Aug 10 returned 7,199 rows and zero Aug 11 rows. The source identifier is intentionally withheld.
- Cost: the uncached exact 90-day query processed 60,248 bytes and billed 10,485,760 bytes. An authenticated published **Refresh data** walk of all eight pages then produced five cache-hit jobs and billed zero additional bytes. This is an environment-specific absolute measurement, not a claimed linear reduction from 365 days.
- Tool Usage refresh: Tool Invocations, Tool Completions by Agent, and Tool Calls Over Time all rendered; the update timestamp advanced; zero console errors and zero failed HTTP requests were observed.
- All nine `live_template_verification.method` checks passed, then `published_date`, `live_template_verification.verified_date`, and `product_verification.verified_date` were re-dated to 2026-08-11.

## Verification at `44ecb43717cf362463274a3306ebd1d9afc57f66`

- `uv run pytest tests/test_looker_studio_dashboard.py -q` → 26 passed in 61.35s
- `uv run pyink --check tests/test_looker_studio_dashboard.py`
- `node dashboard/looker_studio/tools/test_web_configurator.mjs`
- real table-only hydration preflight and ordered `sqlReplace` assertion
- `git diff --check upstream/main...HEAD`
