### PR TITLE
grafana: one-command local run — from checkout to a rendering dashboard (fixes #421)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ deploy/streaming_evaluation/.streaming_evaluation_state.json
 .DS_Store?
 ._*
 grafana/datasource.yaml
+grafana/.local/
 
 # Service-account credentials (never commit downloaded JSON keys).
 grafana/*.json

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -29,14 +29,20 @@ On macOS or Linux with `gcloud auth application-default login` already run:
 python3 grafana/run_local.py --project YOUR_PROJECT --dataset YOUR_DATASET
 ```
 
-That downloads a pinned Grafana (cached after the first run), installs the
-BigQuery plugin, provisions the datasource against your Application Default
-Credentials (no service-account key needed for local evaluation), fills in
-all six dashboard constants, creates the `adk_*` views when `bq-agent-sdk`
-is on PATH, and prints the dashboard URL. `--sa-key key.json` switches to
-the JWT auth documented below; `--stop` tears it down; everything generated
-lives in the disposable, gitignored `grafana/.local/`. Production setups
-should still follow the full steps below with a scoped service account.
+That downloads a pinned Grafana (cached and checksum-verified after the
+first run), installs the pinned BigQuery plugin, provisions the datasource
+against your Application Default Credentials (no service-account key needed
+for local evaluation), fills in all six dashboard constants, creates the
+prefixed views when `bq-agent-sdk` is on PATH, and prints the dashboard
+URL. The instance binds to **127.0.0.1 only**, and the generated datasource
+keeps the example file's **100 MB per-query `MaxBytesBilled` cap**
+(`--max-bytes-billed` to change it). Datasets outside the `US` multi-region
+work by default — the job location is selected automatically; pass
+`--processing-location EU` (or a region) to pin it. `--sa-key key.json`
+switches to the JWT auth documented below and writes the credential file
+with `0600` permissions; `--stop` tears it down; everything generated lives
+in the disposable, gitignored `grafana/.local/`. Production setups should
+still follow the full steps below with a scoped service account.
 
 > **Known pitfalls if you run Grafana your own way instead:**
 > the current plugin requires **Grafana ≥ 11.6.11** (its

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -21,6 +21,31 @@ AI Agent app ──SDK──▶ BigQuery agent_events ──ViewManager──▶
 
 ## Setup
 
+### Quick start (local, one command)
+
+On macOS or Linux with `gcloud auth application-default login` already run:
+
+```bash
+python3 grafana/run_local.py --project YOUR_PROJECT --dataset YOUR_DATASET
+```
+
+That downloads a pinned Grafana (cached after the first run), installs the
+BigQuery plugin, provisions the datasource against your Application Default
+Credentials (no service-account key needed for local evaluation), fills in
+all six dashboard constants, creates the `adk_*` views when `bq-agent-sdk`
+is on PATH, and prints the dashboard URL. `--sa-key key.json` switches to
+the JWT auth documented below; `--stop` tears it down; everything generated
+lives in the disposable, gitignored `grafana/.local/`. Production setups
+should still follow the full steps below with a scoped service account.
+
+> **Known pitfalls if you run Grafana your own way instead:**
+> the current plugin requires **Grafana ≥ 11.6.11** (its
+> `grafanaDependency` also accepts 12.0.10+/12.1.7+/12.2.5+), and a failed
+> background plugin preinstall can break **all** plugin loading with an
+> opaque `react/jsx-runtime` 404 on every panel — launch with
+> `GF_PLUGINS_PREINSTALL_DISABLED=true` to rule that out. The quick-start
+> script handles both.
+
 ### 1. Check prerequisites
 
 - A GCP project with the SDK installed (`pip install bigquery-agent-analytics`)

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -351,13 +351,53 @@ def verify_sha256(archive: Path, expected: str) -> None:
     )
 
 
+def _validated_members(tar: tarfile.TarFile, dest: Path) -> list:
+  """Containment-checked member list for interpreters without tar filters.
+
+  Mirrors the intent of the stdlib "data" filter: only regular files and
+  directories, no absolute paths, no `..` traversal, no links, no special
+  files. Anything else is rejected loudly rather than skipped, so a
+  tampered archive cannot partially extract.
+  """
+  dest = dest.resolve()
+  safe = []
+  for member in tar.getmembers():
+    if not (member.isreg() or member.isdir()):
+      raise RuntimeError(
+          f"refusing to extract {member.name!r}: only regular files and"
+          " directories are allowed."
+      )
+    name = member.name
+    if name.startswith(("/", "\\")) or (len(name) > 1 and name[1] == ":"):
+      raise RuntimeError(f"refusing to extract absolute path {name!r}.")
+    target = (dest / name).resolve()
+    if dest != target and dest not in target.parents:
+      raise RuntimeError(
+          f"refusing to extract {name!r}: it escapes the destination."
+      )
+    safe.append(member)
+  return safe
+
+
+def _extract_without_filter(tar: tarfile.TarFile, dest: Path) -> None:
+  members = _validated_members(tar, dest)
+  if "filter" in inspect.signature(tar.extractall).parameters:
+    # Belt and braces where the stdlib filter exists (this path still runs
+    # under tests on modern interpreters); legacy interpreters rely on the
+    # explicit validation above.
+    tar.extractall(dest, members=members, filter="data")
+  else:
+    tar.extractall(dest, members=members)
+
+
 def _extractall(tar: tarfile.TarFile, dest: Path) -> None:
   # The "data" filter exists on 3.12+ and the 3.10.12/3.11.4 security
-  # backports; older 3.10/3.11 patch releases lack the parameter.
+  # backports; older supported patch releases fall back to an explicit
+  # containment check — never to unrestricted extraction.
   if "filter" in inspect.signature(tar.extractall).parameters:
     tar.extractall(dest, filter="data")
   else:
-    tar.extractall(dest)  # pre-backport interpreter; no filter available
+    _extract_without_filter(tar, dest)
 
 
 def ensure_grafana(
@@ -368,10 +408,26 @@ def ensure_grafana(
   Downloads are verified against the .sha256 published alongside the
   release tarball (integrity against corruption/truncation; it shares the
   origin, so pass --grafana-sha256 for an independently pinned hash).
+  A verified extraction records its archive hash in .provenance.json; an
+  explicitly supplied hash is always honored — a cached extraction whose
+  provenance disagrees is discarded and rebuilt, never silently reused.
   """
   extracted = workdir / f"grafana-home-{GRAFANA_VERSION}"
+  provenance_file = extracted / ".provenance.json"
   if (extracted / "bin").is_dir():
-    return extracted
+    if archive_sha256 is None:
+      return extracted
+    expected = archive_sha256.strip().split()[0].lower()
+    recorded = None
+    if provenance_file.exists():
+      recorded = json.loads(provenance_file.read_text()).get("sha256")
+    if recorded == expected:
+      return extracted
+    print(
+        f"cached extraction provenance ({recorded}) does not match the"
+        f" requested SHA256 ({expected}); rebuilding from the archive."
+    )
+    shutil.rmtree(extracted)
   if archive is None:
     dist = pick_dist()
     archive = workdir / f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
@@ -407,12 +463,37 @@ def ensure_grafana(
     raise RuntimeError(f"unexpected archive layout: {roots}")
   roots[0].rename(extracted)
   staging.rmdir()
+  provenance_file.write_text(
+      json.dumps({"sha256": sha256_of(archive), "source": str(archive)})
+  )
   return extracted
 
 
+def plugin_needs_install(plugins_dir: Path) -> bool:
+  """True unless a cached plugin manifest matches the pinned version.
+
+  A cached directory with a different (or unreadable) manifest would
+  silently bypass the version pin across reruns, so mismatches are
+  reinstalled rather than trusted.
+  """
+  manifest = plugins_dir / PLUGIN_ID / "plugin.json"
+  if not manifest.exists():
+    return True
+  try:
+    version = json.loads(manifest.read_text())["info"]["version"]
+  except (ValueError, KeyError, TypeError):
+    return True
+  return version != PLUGIN_VERSION
+
+
 def install_plugin(home: Path, plugins_dir: Path) -> None:
-  if (plugins_dir / PLUGIN_ID / "plugin.json").exists():
+  if not plugin_needs_install(plugins_dir):
     return
+  cached = plugins_dir / PLUGIN_ID
+  if cached.exists():
+    print(f"cached plugin does not match the {PLUGIN_VERSION} pin;"
+          " reinstalling.")
+    shutil.rmtree(cached)
   subprocess.run(
       build_plugin_install_command(home, plugins_dir), check=True, cwd=home
   )
@@ -433,17 +514,36 @@ def maybe_create_views(
     )
 
 
-def _pid_matches_home(pid: int, home_marker: str) -> bool:
+def _probe_process(pid: int) -> tuple | None:
+  """Returns (start_time, command) for a live pid, or None."""
   try:
     listing = subprocess.run(
-        ["ps", "-p", str(pid), "-o", "command="],
+        ["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="],
         capture_output=True,
         text=True,
         check=True,
-    ).stdout
+    ).stdout.strip()
   except subprocess.CalledProcessError:
+    return None
+  if not listing:
+    return None
+  # lstart is a fixed-width 24-char timestamp ("Tue Aug 12 09:00:00 2026").
+  return listing[:24].strip(), listing[24:].strip()
+
+
+def _identity_matches(record: dict, start: str, command: str) -> bool:
+  """Strong launch identity: exact executable, homepath arg, start time.
+
+  A substring check alone would let --stop signal any process that merely
+  mentions the home path in an argument, and PID reuse would defeat a
+  command-only check — the start time recorded at launch guards that.
+  """
+  expected_exe = record["exe"]
+  if not (command == expected_exe or command.startswith(expected_exe + " ")):
     return False
-  return home_marker in listing
+  if f"--homepath {record['home']}" not in command:
+    return False
+  return start == record["start"]
 
 
 def stop(workdir: Path) -> int:
@@ -452,18 +552,23 @@ def stop(workdir: Path) -> int:
     print(f"nothing to stop (no {pidfile})")
     return 0
   record = json.loads(pidfile.read_text())
-  pid, home = int(record["pid"]), record["home"]
-  if not _pid_matches_home(pid, home):
+  pid = int(record["pid"])
+
+  def matches() -> bool:
+    probe = _probe_process(pid)
+    return probe is not None and _identity_matches(record, *probe)
+
+  if not matches():
     print(
-        f"pid {pid} is not this launcher's grafana anymore (stale pidfile);"
-        " not sending any signal."
+        f"pid {pid} is not this launcher's grafana anymore (stale pidfile"
+        " or reused pid); not sending any signal."
     )
     pidfile.unlink()
     return 0
   os.kill(pid, signal.SIGTERM)
   deadline = time.monotonic() + 15
   while time.monotonic() < deadline:
-    if not _pid_matches_home(pid, home):
+    if not matches():
       print(f"stopped grafana (pid {pid})")
       pidfile.unlink()
       return 0
@@ -627,8 +732,14 @@ def main(argv: list[str] | None = None) -> int:
         stdout=log_handle,
         stderr=log_handle,
     )
+  probe = _probe_process(process.pid)
   (workdir / "grafana.pid").write_text(
-      json.dumps({"pid": process.pid, "home": str(home)})
+      json.dumps({
+          "pid": process.pid,
+          "home": str(home),
+          "exe": str(home / "bin" / "grafana"),
+          "start": probe[0] if probe else "",
+      })
   )
 
   deadline = time.monotonic() + 90

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""One-command local Grafana for BigQuery Agent Analytics.
+
+    python3 grafana/run_local.py --project MY_PROJECT --dataset MY_DATASET
+
+does everything the manual setup chain in grafana/README.md does: downloads
+a pinned Grafana, installs the BigQuery datasource plugin, provisions the
+datasource (Application Default Credentials by default, --sa-key for the
+documented JWT path), writes a copy of bqaa-dashboard.json with the six
+constant variables filled in, and launches with the plugin preinstaller
+disabled. `--stop` tears it down. Everything generated lives under
+grafana/.local/ and is disposable; the committed dashboard and example
+files are never modified.
+
+Requires only the Python standard library. Views (`adk_*`) are created via
+`bq-agent-sdk views create-all` when that CLI is on PATH; otherwise the
+command to run is printed and the dashboard will show "No data" until the
+views exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.request
+
+# The BigQuery datasource plugin (>=3.3.1) declares
+# grafanaDependency ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || ...
+# || >=12.2.5-0". A stock 11.6.0 fails with an opaque
+# "react/jsx-runtime 404" (issue #421); this pin satisfies the
+# unbounded ">=12.2.5-0" range.
+GRAFANA_VERSION = "12.3.0"
+PLUGIN_ID = "grafana-bigquery-datasource"
+DASHBOARD_UID = "bqaa-dashboard"
+DATASOURCE_UID = "bqaa-bigquery"
+
+# Identifier rules mirror dashboard/looker_studio/tools/hydrate_dashboard.py
+# (the repository's source of truth for BigQuery identifier hygiene).
+PROJECT_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
+DATASET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
+TABLE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$")
+VIEW_PREFIX_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+# The two price constants are interpolated into panel arithmetic
+# (grafana/README.md warns a Textbox there is an injection risk), so only a
+# strict decimal literal is accepted.
+PRICE_RE = re.compile(r"^\d{1,9}(\.\d{1,9})?$")
+
+CONSTANT_VARIABLES = (
+    "project",
+    "dataset",
+    "table",
+    "view_prefix",
+    "price_per_1m_input_tokens",
+    "price_per_1m_output_tokens",
+)
+
+
+def require_identifier(label: str, value: str, pattern: re.Pattern) -> str:
+  value = str(value).strip()
+  if not pattern.fullmatch(value):
+    raise ValueError(
+        f"{label} {value!r} does not match {pattern.pattern}; refusing to"
+        " write it into provisioning or dashboard constants."
+    )
+  return value
+
+
+def require_price(label: str, value: str) -> str:
+  value = str(value).strip()
+  if not PRICE_RE.fullmatch(value):
+    raise ValueError(
+        f"{label} {value!r} must be a plain decimal like 1.25 (it is"
+        " interpolated into panel arithmetic; see grafana/README.md)."
+    )
+  return value
+
+
+def patch_dashboard(
+    dashboard: dict,
+    constants: dict,
+    time_from: str | None = None,
+    time_to: str | None = None,
+) -> dict:
+  """Returns a copy with the constant variables filled in.
+
+  Only variables of type `constant` are ever written: the dashboard's
+  injection-safety contract (constants stay constants) is enforced here,
+  not merely documented.
+  """
+  unknown = set(constants) - set(CONSTANT_VARIABLES)
+  if unknown:
+    raise ValueError(f"not a patchable constant: {sorted(unknown)}")
+  patched = copy.deepcopy(dashboard)
+  seen = set()
+  for variable in patched.get("templating", {}).get("list", []):
+    name = variable.get("name")
+    if name not in constants:
+      continue
+    if variable.get("type") != "constant":
+      raise ValueError(
+          f"dashboard variable {name!r} is {variable.get('type')!r}, not"
+          " constant; refusing to patch a non-constant variable."
+      )
+    value = constants[name]
+    variable["query"] = value
+    variable["current"] = {"text": value, "value": value}
+    seen.add(name)
+  missing = set(constants) - seen
+  if missing:
+    raise ValueError(f"dashboard has no constant variable: {sorted(missing)}")
+  if time_from and time_to:
+    patched["time"] = {"from": time_from, "to": time_to}
+  return patched
+
+
+def load_service_account_key(path: Path) -> dict:
+  key = json.loads(path.read_text())
+  for field in ("client_email", "private_key", "token_uri"):
+    if not key.get(field):
+      raise ValueError(f"service-account key {path} is missing {field!r}")
+  return key
+
+
+def render_datasource_yaml(
+    default_project: str, sa_key: dict | None = None
+) -> str:
+  """Provisioning YAML for the BigQuery datasource.
+
+  With no key: `gce` authentication, which the plugin resolves through
+  Application Default Credentials when Grafana runs off-GCE — no
+  service-account key needed for local evaluation. With a key: the JWT path
+  documented in grafana/README.md, with the private key as a real YAML
+  block scalar (never literal \\n escapes).
+  """
+  header = (
+      "apiVersion: 1\n"
+      "datasources:\n"
+      "  - name: BigQuery\n"
+      f"    type: {PLUGIN_ID}\n"
+      f"    uid: {DATASOURCE_UID}\n"
+      "    access: proxy\n"
+      "    isDefault: true\n"
+      "    jsonData:\n"
+  )
+  if sa_key is None:
+    return header + (
+        "      authenticationType: gce\n"
+        f"      defaultProject: {default_project}\n"
+        "      processingLocation: US\n"
+    )
+  private_key = "".join(
+      f"        {line}\n" for line in sa_key["private_key"].splitlines()
+  )
+  return header + (
+      "      authenticationType: jwt\n"
+      f"      clientEmail: {sa_key['client_email']}\n"
+      f"      defaultProject: {default_project}\n"
+      f"      tokenUri: {sa_key['token_uri']}\n"
+      "      processingLocation: US\n"
+      "    secureJsonData:\n"
+      "      privateKey: |\n"
+      f"{private_key}"
+  )
+
+
+def render_dashboards_yaml(dashboards_dir: Path) -> str:
+  return (
+      "apiVersion: 1\n"
+      "providers:\n"
+      "  - name: bqaa\n"
+      "    type: file\n"
+      "    options:\n"
+      f"      path: {dashboards_dir}\n"
+  )
+
+
+def pick_dist(system: str | None = None, machine: str | None = None) -> str:
+  system = (system or platform.system()).lower()
+  machine = (machine or platform.machine()).lower()
+  arch = {
+      "arm64": "arm64",
+      "aarch64": "arm64",
+      "x86_64": "amd64",
+      "amd64": "amd64",
+  }.get(machine)
+  if system not in ("darwin", "linux") or arch is None:
+    raise ValueError(
+        f"unsupported platform {system}/{machine}: this launcher covers"
+        " macOS and Linux on amd64/arm64; on other platforms follow the"
+        " manual steps in grafana/README.md."
+    )
+  return f"{system}-{arch}"
+
+
+def port_free(port: int) -> bool:
+  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+    return probe.connect_ex(("127.0.0.1", port)) != 0
+
+
+def ensure_grafana(workdir: Path, archive: Path | None) -> Path:
+  """Downloads (or reuses) and extracts the pinned Grafana; returns homepath."""
+  extracted = workdir / f"grafana-home-{GRAFANA_VERSION}"
+  if (extracted / "bin").is_dir():
+    return extracted
+  if archive is None:
+    dist = pick_dist()
+    archive = workdir / f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
+    if not archive.exists():
+      url = (
+          "https://dl.grafana.com/oss/release/"
+          f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
+      )
+      print(f"downloading {url} (~250 MB, cached for next time)")
+      with urllib.request.urlopen(url) as response:
+        partial = archive.with_suffix(".partial")
+        with open(partial, "wb") as out:
+          shutil.copyfileobj(response, out)
+        partial.rename(archive)
+  staging = workdir / "extract-staging"
+  if staging.exists():
+    shutil.rmtree(staging)
+  staging.mkdir(parents=True)
+  with tarfile.open(archive) as tar:
+    tar.extractall(staging, filter="data")
+  roots = [p for p in staging.iterdir() if p.is_dir()]
+  if len(roots) != 1:
+    raise RuntimeError(f"unexpected archive layout: {roots}")
+  roots[0].rename(extracted)
+  staging.rmdir()
+  return extracted
+
+
+def install_plugin(home: Path, plugins_dir: Path) -> None:
+  if (plugins_dir / PLUGIN_ID / "plugin.json").exists():
+    return
+  subprocess.run(
+      [
+          str(home / "bin" / "grafana"),
+          "cli",
+          "--homepath",
+          str(home),
+          "--pluginsDir",
+          str(plugins_dir),
+          "plugins",
+          "install",
+          PLUGIN_ID,
+      ],
+      check=True,
+      cwd=home,
+  )
+
+
+def maybe_create_views(project: str, dataset: str, table: str) -> None:
+  command = [
+      "bq-agent-sdk",
+      "views",
+      "create-all",
+      "--project-id",
+      project,
+      "--dataset-id",
+      dataset,
+      "--table-id",
+      table,
+  ]
+  if shutil.which("bq-agent-sdk"):
+    print("creating adk_* views (idempotent):", " ".join(command))
+    subprocess.run(command, check=True)
+  else:
+    print(
+        "bq-agent-sdk not on PATH — the dashboard reads adk_* views, so"
+        " before expecting data run:\n  pip install"
+        " bigquery-agent-analytics && " + " ".join(command)
+    )
+
+
+def stop(workdir: Path) -> int:
+  pidfile = workdir / "grafana.pid"
+  if not pidfile.exists():
+    print(f"nothing to stop (no {pidfile})")
+    return 0
+  pid = int(pidfile.read_text().strip())
+  try:
+    os.kill(pid, signal.SIGTERM)
+    print(f"stopped grafana (pid {pid})")
+  except ProcessLookupError:
+    print(f"grafana (pid {pid}) was not running")
+  pidfile.unlink()
+  return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser(
+      description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+  )
+  parser.add_argument("--project", help="GCP project holding the BQAA table")
+  parser.add_argument("--dataset", help="BigQuery dataset ID")
+  parser.add_argument("--table", default="agent_events")
+  parser.add_argument("--view-prefix", default="adk_")
+  parser.add_argument("--input-price", default="1.25")
+  parser.add_argument("--output-price", default="5.00")
+  parser.add_argument("--port", type=int, default=3000)
+  parser.add_argument(
+      "--sa-key",
+      type=Path,
+      help="service-account key JSON for the documented JWT auth path;"
+      " default is Application Default Credentials (no key)",
+  )
+  parser.add_argument(
+      "--grafana-archive",
+      type=Path,
+      help="reuse a local grafana tarball instead of downloading",
+  )
+  parser.add_argument(
+      "--time-from", help="dashboard default range start (ISO), e.g. for demos"
+  )
+  parser.add_argument("--time-to", help="dashboard default range end (ISO)")
+  parser.add_argument(
+      "--skip-views", action="store_true", help="do not run views create-all"
+  )
+  parser.add_argument(
+      "--provision-only",
+      action="store_true",
+      help="write provisioning + patched dashboard, then exit (no download,"
+      " no launch)",
+  )
+  parser.add_argument("--stop", action="store_true", help="stop and exit")
+  parser.add_argument(
+      "--workdir", type=Path, default=Path(__file__).parent / ".local"
+  )
+  args = parser.parse_args(argv)
+
+  workdir = args.workdir.resolve()
+  if args.stop:
+    return stop(workdir)
+  if not args.project or not args.dataset:
+    parser.error("--project and --dataset are required (except with --stop)")
+
+  try:
+    constants = {
+        "project": require_identifier("project", args.project, PROJECT_RE),
+        "dataset": require_identifier("dataset", args.dataset, DATASET_RE),
+        "table": require_identifier("table", args.table, TABLE_RE),
+        "view_prefix": require_identifier(
+            "view prefix", args.view_prefix, VIEW_PREFIX_RE
+        ),
+        "price_per_1m_input_tokens": require_price(
+            "input price", args.input_price
+        ),
+        "price_per_1m_output_tokens": require_price(
+            "output price", args.output_price
+        ),
+    }
+  except ValueError as error:
+    parser.error(str(error))
+
+  workdir.mkdir(parents=True, exist_ok=True)
+  provisioning = workdir / "provisioning"
+  dashboards_dir = workdir / "dashboards"
+  for sub in (provisioning / "datasources", provisioning / "dashboards",
+              dashboards_dir, workdir / "data", workdir / "plugins"):
+    sub.mkdir(parents=True, exist_ok=True)
+
+  sa_key = load_service_account_key(args.sa_key) if args.sa_key else None
+  datasource_yaml = render_datasource_yaml(constants["project"], sa_key)
+  (provisioning / "datasources" / "bigquery.yaml").write_text(datasource_yaml)
+  (provisioning / "dashboards" / "bqaa.yaml").write_text(
+      render_dashboards_yaml(dashboards_dir)
+  )
+
+  source = Path(__file__).parent / "bqaa-dashboard.json"
+  patched = patch_dashboard(
+      json.loads(source.read_text()),
+      constants,
+      time_from=args.time_from,
+      time_to=args.time_to,
+  )
+  (dashboards_dir / "bqaa-dashboard.json").write_text(
+      json.dumps(patched, indent=1)
+  )
+  print(f"provisioning written under {workdir}")
+  if args.provision_only:
+    return 0
+
+  if not port_free(args.port):
+    print(
+        f"port {args.port} is already in use (another Grafana?); pass"
+        " --port to pick a free one.",
+        file=sys.stderr,
+    )
+    return 1
+
+  if not args.skip_views:
+    maybe_create_views(
+        constants["project"], constants["dataset"], constants["table"]
+    )
+
+  home = ensure_grafana(workdir, args.grafana_archive)
+  install_plugin(home, workdir / "plugins")
+
+  env = dict(
+      os.environ,
+      GF_PATHS_DATA=str(workdir / "data"),
+      GF_PATHS_PLUGINS=str(workdir / "plugins"),
+      GF_PATHS_PROVISIONING=str(provisioning),
+      GF_SERVER_HTTP_PORT=str(args.port),
+      GF_ANALYTICS_REPORTING_ENABLED="false",
+      # A failed background preinstall can break ALL plugin frontend
+      # loading with an opaque react/jsx-runtime 404 (issue #421).
+      GF_PLUGINS_PREINSTALL_DISABLED="true",
+  )
+  log = workdir / "grafana.log"
+  with open(log, "ab") as log_handle:
+    process = subprocess.Popen(
+        [str(home / "bin" / "grafana"), "server", "--homepath", str(home)],
+        cwd=home,
+        env=env,
+        stdout=log_handle,
+        stderr=log_handle,
+    )
+  (workdir / "grafana.pid").write_text(str(process.pid))
+
+  deadline = time.monotonic() + 90
+  url = f"http://localhost:{args.port}"
+  while time.monotonic() < deadline:
+    if process.poll() is not None:
+      print(f"grafana exited early; see {log}", file=sys.stderr)
+      return 1
+    try:
+      with urllib.request.urlopen(f"{url}/api/health", timeout=2) as response:
+        if response.status == 200:
+          break
+    except OSError:
+      pass
+    time.sleep(1)
+  else:
+    print(f"grafana did not become healthy in 90s; see {log}", file=sys.stderr)
+    return 1
+
+  print(
+      f"\nGrafana is up: {url}/d/{DASHBOARD_UID}\n"
+      "  login: admin / admin (fresh instance; it will offer a password"
+      " change)\n"
+      "  panels query on first view; allow a few seconds per row.\n"
+      f"  stop with: python3 {Path(__file__).name} --stop\n"
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -519,7 +519,10 @@ def _probe_process(pid: int) -> tuple | None:
   """Returns (start_time, command) for a live pid, or None."""
   try:
     listing = subprocess.run(
-        ["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="],
+        # -ww: unlimited width on both procps and BSD ps — without it,
+        # Linux truncates the command at ~80 columns, cutting long
+        # --homepath values and making live instances look stale.
+        ["ps", "-ww", "-p", str(pid), "-o", "lstart=", "-o", "command="],
         capture_output=True,
         text=True,
         check=True,

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -546,6 +546,33 @@ def _identity_matches(record: dict, start: str, command: str) -> bool:
   return start == record["start"]
 
 
+def make_stop_hint(workdir: Path) -> str:
+  hint = f"python3 {Path(__file__).name} --stop"
+  if workdir != (Path(__file__).parent / ".local").resolve():
+    hint += f" --workdir {workdir}"
+  return hint
+
+
+def live_instance(workdir: Path) -> dict | None:
+  """Returns the pidfile record if it still identifies a live launcher-owned
+  Grafana; removes a stale pidfile and returns None otherwise.
+
+  A workdir holds exactly one pidfile, so a second launch that overwrote it
+  would orphan the first instance: --stop would tear down only the newer
+  process and report success while an admin/admin Grafana backed by the
+  operator's credentials kept running with no record left to stop it.
+  """
+  pidfile = workdir / "grafana.pid"
+  if not pidfile.exists():
+    return None
+  record = json.loads(pidfile.read_text())
+  probe = _probe_process(int(record["pid"]))
+  if probe is not None and _identity_matches(record, *probe):
+    return record
+  pidfile.unlink()
+  return None
+
+
 def stop(workdir: Path) -> int:
   pidfile = workdir / "grafana.pid"
   if not pidfile.exists():
@@ -637,6 +664,15 @@ def main(argv: list[str] | None = None) -> int:
   workdir = args.workdir.resolve()
   if args.stop:
     return stop(workdir)
+  running = live_instance(workdir) if workdir.exists() else None
+  if running is not None:
+    print(
+        f"a launcher-owned grafana is already running from this workdir"
+        f" (pid {running['pid']}, port {running.get('port', '?')});"
+        f" stop it first with: {make_stop_hint(workdir)}",
+        file=sys.stderr,
+    )
+    return 1
   if not args.project or not args.dataset:
     parser.error("--project and --dataset are required (except with --stop)")
   if bool(args.time_from) != bool(args.time_to):
@@ -739,6 +775,7 @@ def main(argv: list[str] | None = None) -> int:
           "home": str(home),
           "exe": str(home / "bin" / "grafana"),
           "start": probe[0] if probe else "",
+          "port": args.port,
       })
   )
 
@@ -759,9 +796,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"grafana did not become healthy in 90s; see {log}", file=sys.stderr)
     return 1
 
-  stop_hint = f"python3 {Path(__file__).name} --stop"
-  if workdir != (Path(__file__).parent / ".local").resolve():
-    stop_hint += f" --workdir {workdir}"
+  stop_hint = make_stop_hint(workdir)
   print(
       f"\nGrafana is up (bound to 127.0.0.1 only): {url}/d/{DASHBOARD_UID}\n"
       "  login: admin / admin (fresh instance; it will offer a password"

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -17,13 +17,13 @@
     python3 grafana/run_local.py --project MY_PROJECT --dataset MY_DATASET
 
 does everything the manual setup chain in grafana/README.md does: downloads
-a pinned Grafana, installs the BigQuery datasource plugin, provisions the
-datasource (Application Default Credentials by default, --sa-key for the
+a pinned Grafana, installs the pinned BigQuery datasource plugin, provisions
+the datasource (Application Default Credentials by default, --sa-key for the
 documented JWT path), writes a copy of bqaa-dashboard.json with the six
-constant variables filled in, and launches with the plugin preinstaller
-disabled. `--stop` tears it down. Everything generated lives under
-grafana/.local/ and is disposable; the committed dashboard and example
-files are never modified.
+constant variables filled in, and launches bound to 127.0.0.1 with the
+plugin preinstaller disabled. `--stop` tears it down. Everything generated
+lives under grafana/.local/ and is disposable; the committed dashboard and
+example files are never modified.
 
 Requires only the Python standard library. Views (`adk_*`) are created via
 `bq-agent-sdk views create-all` when that CLI is on PATH; otherwise the
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
+import inspect
 import json
 import os
 from pathlib import Path
@@ -53,11 +55,17 @@ import urllib.request
 # grafanaDependency ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || ...
 # || >=12.2.5-0". A stock 11.6.0 fails with an opaque
 # "react/jsx-runtime 404" (issue #421); this pin satisfies the
-# unbounded ">=12.2.5-0" range.
+# unbounded ">=12.2.5-0" range. The plugin version is pinned too so a
+# future plugin release cannot silently raise the floor above this
+# Grafana pin and reintroduce the same failure.
 GRAFANA_VERSION = "12.3.0"
 PLUGIN_ID = "grafana-bigquery-datasource"
+PLUGIN_VERSION = "3.3.1"
 DASHBOARD_UID = "bqaa-dashboard"
 DATASOURCE_UID = "bqaa-bigquery"
+# Matches grafana/datasource.example.yaml: a per-query BigQuery cost cap of
+# 100 MB billed. The key spelling is significant (see the example file).
+DEFAULT_MAX_BYTES_BILLED = "100000000"
 
 # Identifier rules mirror dashboard/looker_studio/tools/hydrate_dashboard.py
 # (the repository's source of truth for BigQuery identifier hygiene).
@@ -65,10 +73,14 @@ PROJECT_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
 DATASET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,1023}$")
 TABLE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$")
 VIEW_PREFIX_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+# BigQuery locations: multi-regions ("US", "EU") or regions
+# ("us-central1", "asia-northeast1").
+LOCATION_RE = re.compile(r"^[A-Za-z][A-Za-z0-9-]{0,31}$")
 # The two price constants are interpolated into panel arithmetic
 # (grafana/README.md warns a Textbox there is an injection risk), so only a
-# strict decimal literal is accepted.
+# strict decimal literal is accepted. Same reasoning for the bytes cap.
 PRICE_RE = re.compile(r"^\d{1,9}(\.\d{1,9})?$")
+BYTES_RE = re.compile(r"^[1-9]\d{0,17}$")
 
 CONSTANT_VARIABLES = (
     "project",
@@ -96,6 +108,16 @@ def require_price(label: str, value: str) -> str:
     raise ValueError(
         f"{label} {value!r} must be a plain decimal like 1.25 (it is"
         " interpolated into panel arithmetic; see grafana/README.md)."
+    )
+  return value
+
+
+def require_max_bytes(value: str) -> str:
+  value = str(value).strip()
+  if not BYTES_RE.fullmatch(value):
+    raise ValueError(
+        f"max bytes billed {value!r} must be a positive integer (bytes);"
+        " to run uncapped, edit the generated datasource YAML deliberately."
     )
   return value
 
@@ -147,7 +169,10 @@ def load_service_account_key(path: Path) -> dict:
 
 
 def render_datasource_yaml(
-    default_project: str, sa_key: dict | None = None
+    default_project: str,
+    sa_key: dict | None = None,
+    processing_location: str | None = None,
+    max_bytes_billed: str = DEFAULT_MAX_BYTES_BILLED,
 ) -> str:
   """Provisioning YAML for the BigQuery datasource.
 
@@ -156,6 +181,11 @@ def render_datasource_yaml(
   service-account key needed for local evaluation. With a key: the JWT path
   documented in grafana/README.md, with the private key as a real YAML
   block scalar (never literal \\n escapes).
+
+  `processingLocation` is omitted by default so the plugin selects the job
+  location automatically; hard-coding a multi-region breaks datasets that
+  live anywhere else. `MaxBytesBilled` preserves the per-query cost cap
+  from grafana/datasource.example.yaml.
   """
   header = (
       "apiVersion: 1\n"
@@ -167,11 +197,18 @@ def render_datasource_yaml(
       "    isDefault: true\n"
       "    jsonData:\n"
   )
+  location_line = (
+      f"      processingLocation: {processing_location}\n"
+      if processing_location
+      else ""
+  )
+  guard_line = f"      MaxBytesBilled: {max_bytes_billed}\n"
   if sa_key is None:
     return header + (
         "      authenticationType: gce\n"
         f"      defaultProject: {default_project}\n"
-        "      processingLocation: US\n"
+        + location_line
+        + guard_line
     )
   private_key = "".join(
       f"        {line}\n" for line in sa_key["private_key"].splitlines()
@@ -181,8 +218,9 @@ def render_datasource_yaml(
       f"      clientEmail: {sa_key['client_email']}\n"
       f"      defaultProject: {default_project}\n"
       f"      tokenUri: {sa_key['token_uri']}\n"
-      "      processingLocation: US\n"
-      "    secureJsonData:\n"
+      + location_line
+      + guard_line
+      + "    secureJsonData:\n"
       "      privateKey: |\n"
       f"{private_key}"
   )
@@ -197,6 +235,79 @@ def render_dashboards_yaml(dashboards_dir: Path) -> str:
       "    options:\n"
       f"      path: {dashboards_dir}\n"
   )
+
+
+def write_private(path: Path, text: str) -> None:
+  """Writes a credential-bearing file atomically with mode 0600.
+
+  The parent directory is tightened to 0700 first so no window exists in
+  which another local account can list or read the provisioning secrets
+  (the JWT path copies a service-account private key into this file).
+  """
+  os.chmod(path.parent, 0o700)
+  tmp = path.with_suffix(path.suffix + ".tmp")
+  descriptor = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+  try:
+    with os.fdopen(descriptor, "w") as handle:
+      handle.write(text)
+  except Exception:
+    tmp.unlink(missing_ok=True)
+    raise
+  os.replace(tmp, path)
+
+
+def launch_env(workdir: Path, provisioning: Path, port: int) -> dict:
+  """Environment for the Grafana process. Pure, so tests can pin it.
+
+  GF_SERVER_HTTP_ADDR is 127.0.0.1: Grafana's default (empty) http_addr
+  binds every interface, which would expose an admin/admin instance backed
+  by the operator's own credentials to the local network.
+  GF_PLUGINS_PREINSTALL_DISABLED avoids the failed-preinstall import-map
+  poisoning that breaks all plugin loading (issue #421).
+  """
+  return dict(
+      os.environ,
+      GF_PATHS_DATA=str(workdir / "data"),
+      GF_PATHS_PLUGINS=str(workdir / "plugins"),
+      GF_PATHS_PROVISIONING=str(provisioning),
+      GF_SERVER_HTTP_ADDR="127.0.0.1",
+      GF_SERVER_HTTP_PORT=str(port),
+      GF_ANALYTICS_REPORTING_ENABLED="false",
+      GF_PLUGINS_PREINSTALL_DISABLED="true",
+  )
+
+
+def build_views_command(
+    project: str, dataset: str, table: str, prefix: str
+) -> list:
+  return [
+      "bq-agent-sdk",
+      "views",
+      "create-all",
+      "--project-id",
+      project,
+      "--dataset-id",
+      dataset,
+      "--table-id",
+      table,
+      "--prefix",
+      prefix,
+  ]
+
+
+def build_plugin_install_command(home: Path, plugins_dir: Path) -> list:
+  return [
+      str(home / "bin" / "grafana"),
+      "cli",
+      "--homepath",
+      str(home),
+      "--pluginsDir",
+      str(plugins_dir),
+      "plugins",
+      "install",
+      PLUGIN_ID,
+      PLUGIN_VERSION,
+  ]
 
 
 def pick_dist(system: str | None = None, machine: str | None = None) -> str:
@@ -222,31 +333,75 @@ def port_free(port: int) -> bool:
     return probe.connect_ex(("127.0.0.1", port)) != 0
 
 
-def ensure_grafana(workdir: Path, archive: Path | None) -> Path:
-  """Downloads (or reuses) and extracts the pinned Grafana; returns homepath."""
+def sha256_of(path: Path) -> str:
+  digest = hashlib.sha256()
+  with open(path, "rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+      digest.update(chunk)
+  return digest.hexdigest()
+
+
+def verify_sha256(archive: Path, expected: str) -> None:
+  expected = expected.strip().split()[0].lower()
+  actual = sha256_of(archive)
+  if actual != expected:
+    raise RuntimeError(
+        f"SHA256 mismatch for {archive}: expected {expected}, got {actual};"
+        " delete the file and retry."
+    )
+
+
+def _extractall(tar: tarfile.TarFile, dest: Path) -> None:
+  # The "data" filter exists on 3.12+ and the 3.10.12/3.11.4 security
+  # backports; older 3.10/3.11 patch releases lack the parameter.
+  if "filter" in inspect.signature(tar.extractall).parameters:
+    tar.extractall(dest, filter="data")
+  else:
+    tar.extractall(dest)  # pre-backport interpreter; no filter available
+
+
+def ensure_grafana(
+    workdir: Path, archive: Path | None, archive_sha256: str | None = None
+) -> Path:
+  """Downloads (or reuses) and extracts the pinned Grafana; returns homepath.
+
+  Downloads are verified against the .sha256 published alongside the
+  release tarball (integrity against corruption/truncation; it shares the
+  origin, so pass --grafana-sha256 for an independently pinned hash).
+  """
   extracted = workdir / f"grafana-home-{GRAFANA_VERSION}"
   if (extracted / "bin").is_dir():
     return extracted
   if archive is None:
     dist = pick_dist()
     archive = workdir / f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
+    url = (
+        "https://dl.grafana.com/oss/release/"
+        f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
+    )
     if not archive.exists():
-      url = (
-          "https://dl.grafana.com/oss/release/"
-          f"grafana-{GRAFANA_VERSION}.{dist}.tar.gz"
-      )
       print(f"downloading {url} (~250 MB, cached for next time)")
       with urllib.request.urlopen(url) as response:
         partial = archive.with_suffix(".partial")
         with open(partial, "wb") as out:
           shutil.copyfileobj(response, out)
         partial.rename(archive)
+    if archive_sha256 is None:
+      with urllib.request.urlopen(url + ".sha256") as response:
+        archive_sha256 = response.read().decode()
+  if archive_sha256:
+    verify_sha256(archive, archive_sha256)
+  else:
+    print(
+        f"note: no checksum given for {archive}; pass --grafana-sha256 to"
+        " verify a locally supplied archive."
+    )
   staging = workdir / "extract-staging"
   if staging.exists():
     shutil.rmtree(staging)
   staging.mkdir(parents=True)
   with tarfile.open(archive) as tar:
-    tar.extractall(staging, filter="data")
+    _extractall(tar, staging)
   roots = [p for p in staging.iterdir() if p.is_dir()]
   if len(roots) != 1:
     raise RuntimeError(f"unexpected archive layout: {roots}")
@@ -259,43 +414,36 @@ def install_plugin(home: Path, plugins_dir: Path) -> None:
   if (plugins_dir / PLUGIN_ID / "plugin.json").exists():
     return
   subprocess.run(
-      [
-          str(home / "bin" / "grafana"),
-          "cli",
-          "--homepath",
-          str(home),
-          "--pluginsDir",
-          str(plugins_dir),
-          "plugins",
-          "install",
-          PLUGIN_ID,
-      ],
-      check=True,
-      cwd=home,
+      build_plugin_install_command(home, plugins_dir), check=True, cwd=home
   )
 
 
-def maybe_create_views(project: str, dataset: str, table: str) -> None:
-  command = [
-      "bq-agent-sdk",
-      "views",
-      "create-all",
-      "--project-id",
-      project,
-      "--dataset-id",
-      dataset,
-      "--table-id",
-      table,
-  ]
+def maybe_create_views(
+    project: str, dataset: str, table: str, prefix: str
+) -> None:
+  command = build_views_command(project, dataset, table, prefix)
   if shutil.which("bq-agent-sdk"):
-    print("creating adk_* views (idempotent):", " ".join(command))
+    print("creating typed views (idempotent):", " ".join(command))
     subprocess.run(command, check=True)
   else:
     print(
-        "bq-agent-sdk not on PATH — the dashboard reads adk_* views, so"
+        "bq-agent-sdk not on PATH — the dashboard reads prefixed views, so"
         " before expecting data run:\n  pip install"
         " bigquery-agent-analytics && " + " ".join(command)
     )
+
+
+def _pid_matches_home(pid: int, home_marker: str) -> bool:
+  try:
+    listing = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "command="],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+  except subprocess.CalledProcessError:
+    return False
+  return home_marker in listing
 
 
 def stop(workdir: Path) -> int:
@@ -303,14 +451,25 @@ def stop(workdir: Path) -> int:
   if not pidfile.exists():
     print(f"nothing to stop (no {pidfile})")
     return 0
-  pid = int(pidfile.read_text().strip())
-  try:
-    os.kill(pid, signal.SIGTERM)
-    print(f"stopped grafana (pid {pid})")
-  except ProcessLookupError:
-    print(f"grafana (pid {pid}) was not running")
-  pidfile.unlink()
-  return 0
+  record = json.loads(pidfile.read_text())
+  pid, home = int(record["pid"]), record["home"]
+  if not _pid_matches_home(pid, home):
+    print(
+        f"pid {pid} is not this launcher's grafana anymore (stale pidfile);"
+        " not sending any signal."
+    )
+    pidfile.unlink()
+    return 0
+  os.kill(pid, signal.SIGTERM)
+  deadline = time.monotonic() + 15
+  while time.monotonic() < deadline:
+    if not _pid_matches_home(pid, home):
+      print(f"stopped grafana (pid {pid})")
+      pidfile.unlink()
+      return 0
+    time.sleep(0.5)
+  print(f"grafana (pid {pid}) did not exit within 15s", file=sys.stderr)
+  return 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -325,6 +484,17 @@ def main(argv: list[str] | None = None) -> int:
   parser.add_argument("--output-price", default="5.00")
   parser.add_argument("--port", type=int, default=3000)
   parser.add_argument(
+      "--processing-location",
+      help="BigQuery job location (e.g. EU, us-central1); default lets the"
+      " plugin select automatically",
+  )
+  parser.add_argument(
+      "--max-bytes-billed",
+      default=DEFAULT_MAX_BYTES_BILLED,
+      help="per-query BigQuery cost cap in bytes (default 100000000, matching"
+      " grafana/datasource.example.yaml)",
+  )
+  parser.add_argument(
       "--sa-key",
       type=Path,
       help="service-account key JSON for the documented JWT auth path;"
@@ -334,6 +504,11 @@ def main(argv: list[str] | None = None) -> int:
       "--grafana-archive",
       type=Path,
       help="reuse a local grafana tarball instead of downloading",
+  )
+  parser.add_argument(
+      "--grafana-sha256",
+      help="expected SHA256 of the grafana archive (downloads verify against"
+      " the published .sha256 automatically)",
   )
   parser.add_argument(
       "--time-from", help="dashboard default range start (ISO), e.g. for demos"
@@ -359,6 +534,8 @@ def main(argv: list[str] | None = None) -> int:
     return stop(workdir)
   if not args.project or not args.dataset:
     parser.error("--project and --dataset are required (except with --stop)")
+  if bool(args.time_from) != bool(args.time_to):
+    parser.error("--time-from and --time-to must be given together")
 
   try:
     constants = {
@@ -375,6 +552,14 @@ def main(argv: list[str] | None = None) -> int:
             "output price", args.output_price
         ),
     }
+    location = (
+        require_identifier(
+            "processing location", args.processing_location, LOCATION_RE
+        )
+        if args.processing_location
+        else None
+    )
+    max_bytes = require_max_bytes(args.max_bytes_billed)
   except ValueError as error:
     parser.error(str(error))
 
@@ -386,8 +571,15 @@ def main(argv: list[str] | None = None) -> int:
     sub.mkdir(parents=True, exist_ok=True)
 
   sa_key = load_service_account_key(args.sa_key) if args.sa_key else None
-  datasource_yaml = render_datasource_yaml(constants["project"], sa_key)
-  (provisioning / "datasources" / "bigquery.yaml").write_text(datasource_yaml)
+  datasource_yaml = render_datasource_yaml(
+      constants["project"],
+      sa_key,
+      processing_location=location,
+      max_bytes_billed=max_bytes,
+  )
+  write_private(
+      provisioning / "datasources" / "bigquery.yaml", datasource_yaml
+  )
   (provisioning / "dashboards" / "bqaa.yaml").write_text(
       render_dashboards_yaml(dashboards_dir)
   )
@@ -416,23 +608,16 @@ def main(argv: list[str] | None = None) -> int:
 
   if not args.skip_views:
     maybe_create_views(
-        constants["project"], constants["dataset"], constants["table"]
+        constants["project"],
+        constants["dataset"],
+        constants["table"],
+        constants["view_prefix"],
     )
 
-  home = ensure_grafana(workdir, args.grafana_archive)
+  home = ensure_grafana(workdir, args.grafana_archive, args.grafana_sha256)
   install_plugin(home, workdir / "plugins")
 
-  env = dict(
-      os.environ,
-      GF_PATHS_DATA=str(workdir / "data"),
-      GF_PATHS_PLUGINS=str(workdir / "plugins"),
-      GF_PATHS_PROVISIONING=str(provisioning),
-      GF_SERVER_HTTP_PORT=str(args.port),
-      GF_ANALYTICS_REPORTING_ENABLED="false",
-      # A failed background preinstall can break ALL plugin frontend
-      # loading with an opaque react/jsx-runtime 404 (issue #421).
-      GF_PLUGINS_PREINSTALL_DISABLED="true",
-  )
+  env = launch_env(workdir, provisioning, args.port)
   log = workdir / "grafana.log"
   with open(log, "ab") as log_handle:
     process = subprocess.Popen(
@@ -442,10 +627,12 @@ def main(argv: list[str] | None = None) -> int:
         stdout=log_handle,
         stderr=log_handle,
     )
-  (workdir / "grafana.pid").write_text(str(process.pid))
+  (workdir / "grafana.pid").write_text(
+      json.dumps({"pid": process.pid, "home": str(home)})
+  )
 
   deadline = time.monotonic() + 90
-  url = f"http://localhost:{args.port}"
+  url = f"http://127.0.0.1:{args.port}"
   while time.monotonic() < deadline:
     if process.poll() is not None:
       print(f"grafana exited early; see {log}", file=sys.stderr)
@@ -461,12 +648,15 @@ def main(argv: list[str] | None = None) -> int:
     print(f"grafana did not become healthy in 90s; see {log}", file=sys.stderr)
     return 1
 
+  stop_hint = f"python3 {Path(__file__).name} --stop"
+  if workdir != (Path(__file__).parent / ".local").resolve():
+    stop_hint += f" --workdir {workdir}"
   print(
-      f"\nGrafana is up: {url}/d/{DASHBOARD_UID}\n"
+      f"\nGrafana is up (bound to 127.0.0.1 only): {url}/d/{DASHBOARD_UID}\n"
       "  login: admin / admin (fresh instance; it will offer a password"
       " change)\n"
       "  panels query on first view; allow a few seconds per row.\n"
-      f"  stop with: python3 {Path(__file__).name} --stop\n"
+      f"  stop with: {stop_hint}\n"
   )
   return 0
 

--- a/grafana/run_local.py
+++ b/grafana/run_local.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import fcntl
 import hashlib
 import inspect
 import json
@@ -553,6 +554,27 @@ def make_stop_hint(workdir: Path) -> str:
   return hint
 
 
+def acquire_launch_lock(workdir: Path):
+  """Exclusive, non-blocking ownership of the workdir's launch lifecycle.
+
+  live_instance() alone is a check-then-act race: two overlapping launches
+  can both observe no pidfile, and the loser's record overwrite would
+  orphan the winner's Grafana. The flock is taken before the liveness
+  check and held through process launch and pidfile publication, so
+  exactly one contender may own the sequence. Returns the open lock file
+  (keep it referenced until publication is done) or None if another
+  launcher holds it.
+  """
+  workdir.mkdir(parents=True, exist_ok=True)
+  lock_file = open(workdir / "launch.lock", "w")
+  try:
+    fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+  except OSError:
+    lock_file.close()
+    return None
+  return lock_file
+
+
 def live_instance(workdir: Path) -> dict | None:
   """Returns the pidfile record if it still identifies a live launcher-owned
   Grafana; removes a stale pidfile and returns None otherwise.
@@ -574,6 +596,14 @@ def live_instance(workdir: Path) -> dict | None:
 
 
 def stop(workdir: Path) -> int:
+  lock = acquire_launch_lock(workdir)
+  if lock is None:
+    print(
+        "a launch is in progress in this workdir; retry --stop once it"
+        " finishes.",
+        file=sys.stderr,
+    )
+    return 1
   pidfile = workdir / "grafana.pid"
   if not pidfile.exists():
     print(f"nothing to stop (no {pidfile})")
@@ -664,7 +694,20 @@ def main(argv: list[str] | None = None) -> int:
   workdir = args.workdir.resolve()
   if args.stop:
     return stop(workdir)
-  running = live_instance(workdir) if workdir.exists() else None
+  launch_lock = acquire_launch_lock(workdir)
+  if launch_lock is None:
+    print(
+        "another launch is already in progress in this workdir; wait for it"
+        " or use a different --workdir.",
+        file=sys.stderr,
+    )
+    return 1
+  # Test-only seam: lets the concurrency regression widen the race window
+  # deterministically. Has no effect unless the variable is set.
+  test_hold = float(os.environ.get("_BQAA_RUN_LOCAL_TEST_HOLD_LOCK", 0) or 0)
+  if test_hold:
+    time.sleep(test_hold)
+  running = live_instance(workdir)
   if running is not None:
     print(
         f"a launcher-owned grafana is already running from this workdir"

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -14,6 +14,7 @@
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -573,12 +574,16 @@ def _fake_live_instance(tmp_path, home):
   )
   probe = runner._probe_process(process.pid)
   assert probe is not None
+  # Record the executable exactly as ps reports it: Ubuntu and macOS
+  # canonicalize the bash path differently, and the identity matcher
+  # requires an exact command prefix.
+  reported_exe = probe[1].split(" ", 1)[0]
   (tmp_path / "grafana.pid").write_text(
       json.dumps(
           {
               "pid": process.pid,
               "home": str(home),
-              "exe": "/bin/bash",
+              "exe": reported_exe,
               "start": probe[0],
               "port": 39987,
           }
@@ -674,3 +679,48 @@ def test_cached_extraction_honors_explicit_checksum(tmp_path):
   with pytest.raises(RuntimeError, match="SHA256 mismatch"):
     runner.ensure_grafana(workdir, archive, "0" * 64)
   assert not home.exists()
+
+
+def test_launch_lock_is_exclusive(tmp_path):
+  first = runner.acquire_launch_lock(tmp_path)
+  assert first is not None
+  # A second open file description on the same lock must not acquire it,
+  # even within one process.
+  assert runner.acquire_launch_lock(tmp_path) is None
+  first.close()
+  released = runner.acquire_launch_lock(tmp_path)
+  assert released is not None
+  released.close()
+
+
+def test_concurrent_launches_yield_exactly_one_owner(tmp_path):
+  # The check-then-act race: two contenders that both observe no pidfile
+  # must not both proceed — the flock is taken before the liveness check
+  # and held through publication, so exactly one may own the sequence.
+  # The test-only hold widens the critical section deterministically.
+  env = dict(os.environ, _BQAA_RUN_LOCAL_TEST_HOLD_LOCK="1.5")
+  argv = [
+      sys.executable,
+      str(RUNNER),
+      "--project",
+      "customer-project-123",
+      "--dataset",
+      "agent_analytics",
+      "--provision-only",
+      "--workdir",
+      str(tmp_path),
+  ]
+  first = subprocess.Popen(
+      argv, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+  )
+  second = subprocess.Popen(
+      argv, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+  )
+  out_a = first.communicate(timeout=30)
+  out_b = second.communicate(timeout=30)
+  codes = sorted([first.returncode, second.returncode])
+  assert codes == [0, 1], (codes, out_a, out_b)
+  loser_err = out_a[1] if first.returncode == 1 else out_b[1]
+  assert "already in progress" in loser_err
+  # The winner's provisioning exists exactly once and intact.
+  assert (tmp_path / "provisioning" / "datasources" / "bigquery.yaml").exists()

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -614,7 +614,14 @@ def test_second_launch_refused_while_instance_lives(tmp_path):
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 1
+    assert result.returncode == 1, {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "probe": runner._probe_process(victim.pid),
+        "pidfile": (tmp_path / "grafana.pid").read_text()
+        if (tmp_path / "grafana.pid").exists()
+        else "GONE",
+    }
     assert "already running" in result.stderr
     assert "--stop" in result.stderr
     # The live record must survive untouched and the process unharmed.

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -407,3 +407,174 @@ def test_sha256_verification(tmp_path):
   runner.verify_sha256(archive, f"{good}  a.tar.gz\n")
   with pytest.raises(RuntimeError, match="SHA256 mismatch"):
     runner.verify_sha256(archive, "0" * 64)
+
+
+def _tar_with(tmp_path, name, members):
+  import tarfile as tarlib
+
+  archive = tmp_path / name
+  with tarlib.open(archive, "w:gz") as tar:
+    for member_name, kind in members:
+      info = tarlib.TarInfo(member_name)
+      if kind == "dir":
+        info.type = tarlib.DIRTYPE
+        info.mode = 0o755
+        tar.addfile(info)
+      elif kind == "link":
+        info.type = tarlib.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tar.addfile(info)
+      else:
+        payload = b"x"
+        info.size = len(payload)
+        info.mode = 0o644
+        import io
+
+        tar.addfile(info, io.BytesIO(payload))
+  return archive
+
+
+def test_fallback_extraction_rejects_traversal(tmp_path):
+  # The pre-3.10.12 code path must never fall back to unrestricted
+  # extractall: a member named ../escaped.txt has to fail loudly and
+  # write nothing outside the destination.
+  import tarfile as tarlib
+
+  archive = _tar_with(tmp_path, "evil.tgz", [("../escaped.txt", "file")])
+  dest = tmp_path / "dest"
+  dest.mkdir()
+  with tarlib.open(archive) as tar:
+    with pytest.raises(RuntimeError, match="escapes the destination"):
+      runner._extract_without_filter(tar, dest)
+  assert not (tmp_path / "escaped.txt").exists()
+
+
+@pytest.mark.parametrize(
+    ("member", "kind", "match"),
+    [
+        ("/abs.txt", "file", "absolute path"),
+        ("link", "link", "regular files and directories"),
+    ],
+)
+def test_fallback_extraction_rejects_unsafe_members(
+    tmp_path, member, kind, match
+):
+  import tarfile as tarlib
+
+  archive = _tar_with(tmp_path, "evil2.tgz", [(member, kind)])
+  dest = tmp_path / "dest2"
+  dest.mkdir()
+  with tarlib.open(archive) as tar:
+    with pytest.raises(RuntimeError, match=match):
+      runner._extract_without_filter(tar, dest)
+
+
+def test_fallback_extraction_allows_benign_archives(tmp_path):
+  import tarfile as tarlib
+
+  archive = _tar_with(
+      tmp_path, "ok.tgz", [("top", "dir"), ("top/bin/file.txt", "file")]
+  )
+  dest = tmp_path / "dest3"
+  dest.mkdir()
+  with tarlib.open(archive) as tar:
+    runner._extract_without_filter(tar, dest)
+  assert (dest / "top" / "bin" / "file.txt").read_bytes() == b"x"
+
+
+def test_stop_identity_rejects_lookalike_and_reused_pids():
+  record = {
+      "pid": 12345,
+      "home": "/work/grafana-home-12.3.0",
+      "exe": "/work/grafana-home-12.3.0/bin/grafana",
+      "start": "Tue Aug 12 09:00:00 2026",
+  }
+  good = (
+      "/work/grafana-home-12.3.0/bin/grafana server --homepath"
+      " /work/grafana-home-12.3.0"
+  )
+  assert runner._identity_matches(record, "Tue Aug 12 09:00:00 2026", good)
+  # An unrelated process that merely mentions the home path as an
+  # argument must never be signalled (the reviewer's sleep repro).
+  lookalike = "python3 -c sleep /work/grafana-home-12.3.0"
+  assert not runner._identity_matches(
+      record, "Tue Aug 12 09:00:00 2026", lookalike
+  )
+  # Same command shape but a different start time means the pid was
+  # recycled into a new process.
+  assert not runner._identity_matches(record, "Tue Aug 12 10:30:00 2026", good)
+  # Prefix-spoofed executables do not match the exact-exe rule.
+  spoofed = good.replace("bin/grafana ", "bin/grafana-evil ")
+  assert not runner._identity_matches(
+      record, "Tue Aug 12 09:00:00 2026", spoofed
+  )
+
+
+def test_stop_never_signals_live_lookalike_process(tmp_path):
+  # End-to-end: a real unrelated process whose argv contains the home
+  # path survives a stop() call against a pidfile pointing at it.
+  home = tmp_path / "grafana-home-12.3.0"
+  victim = subprocess.Popen(
+      [sys.executable, "-c", f"import time; '{home}'; time.sleep(30)"]
+  )
+  try:
+    probe = runner._probe_process(victim.pid)
+    assert probe is not None
+    (tmp_path / "grafana.pid").write_text(
+        json.dumps(
+            {
+                "pid": victim.pid,
+                "home": str(home),
+                "exe": str(home / "bin" / "grafana"),
+                "start": probe[0],
+            }
+        )
+    )
+    assert runner.stop(tmp_path) == 0
+    assert victim.poll() is None, "stop() signalled an unrelated process"
+  finally:
+    victim.kill()
+    victim.wait()
+
+
+def test_plugin_pin_enforced_against_cached_manifests(tmp_path):
+  plugin_dir = tmp_path / runner.PLUGIN_ID
+  plugin_dir.mkdir()
+  assert runner.plugin_needs_install(tmp_path)  # no manifest
+  manifest = plugin_dir / "plugin.json"
+  manifest.write_text(json.dumps({"info": {"version": "0.0.1"}}))
+  assert runner.plugin_needs_install(tmp_path)  # version mismatch
+  manifest.write_text("{corrupt")
+  assert runner.plugin_needs_install(tmp_path)  # unreadable manifest
+  manifest.write_text(json.dumps({"info": {"version": runner.PLUGIN_VERSION}}))
+  assert not runner.plugin_needs_install(tmp_path)
+
+
+def test_cached_extraction_honors_explicit_checksum(tmp_path):
+  # Build a tiny valid "grafana" archive.
+  import io
+  import tarfile as tarlib
+
+  archive = tmp_path / "grafana.tgz"
+  with tarlib.open(archive, "w:gz") as tar:
+    info = tarlib.TarInfo("grafana-x/bin/grafana")
+    payload = b"#!/bin/sh\n"
+    info.size = len(payload)
+    tar.addfile(info, io.BytesIO(payload))
+  good = runner.sha256_of(archive)
+
+  workdir = tmp_path / "work"
+  workdir.mkdir()
+  home = runner.ensure_grafana(workdir, archive, good)
+  assert (home / "bin" / "grafana").exists()
+  provenance = json.loads((home / ".provenance.json").read_text())
+  assert provenance["sha256"] == good
+
+  # Reuse with the matching hash: same home, no rebuild needed.
+  assert runner.ensure_grafana(workdir, archive, good) == home
+  # A cached home must not satisfy a DIFFERENT explicit hash: the stale
+  # extraction is discarded and the archive re-verified — here the
+  # mismatch fails closed before anything is reused.
+  with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+    runner.ensure_grafana(workdir, archive, "0" * 64)
+  assert not home.exists()

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -552,6 +552,100 @@ def test_plugin_pin_enforced_against_cached_manifests(tmp_path):
   assert not runner.plugin_needs_install(tmp_path)
 
 
+def _fake_live_instance(tmp_path, home):
+  """A live process whose identity record matches like a launched Grafana.
+
+  /bin/bash is exec'd by its literal path, so ps reports a command that
+  begins with the recorded executable — the same property a directly
+  launched grafana binary has (macOS rewrites sys.executable to the
+  framework binary, so python is unsuitable here).
+  """
+  process = subprocess.Popen(
+      [
+          "/bin/bash",
+          "-c",
+          "sleep 30; true",
+          "grafana",
+          "server",
+          "--homepath",
+          str(home),
+      ]
+  )
+  probe = runner._probe_process(process.pid)
+  assert probe is not None
+  (tmp_path / "grafana.pid").write_text(
+      json.dumps(
+          {
+              "pid": process.pid,
+              "home": str(home),
+              "exe": "/bin/bash",
+              "start": probe[0],
+              "port": 39987,
+          }
+      )
+  )
+  return process
+
+
+def test_second_launch_refused_while_instance_lives(tmp_path):
+  # The duplicate-launch hole: overwriting the single pidfile would orphan
+  # the first Grafana — --stop would report success while an admin/admin
+  # instance kept running with no record left to stop it.
+  home = tmp_path / "grafana-home-12.3.0"
+  victim = _fake_live_instance(tmp_path, home)
+  try:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--project",
+            "customer-project-123",
+            "--dataset",
+            "agent_analytics",
+            "--provision-only",
+            "--workdir",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "already running" in result.stderr
+    assert "--stop" in result.stderr
+    # The live record must survive untouched and the process unharmed.
+    assert (tmp_path / "grafana.pid").exists()
+    assert victim.poll() is None
+    assert not (tmp_path / "provisioning").exists()
+  finally:
+    victim.kill()
+    victim.wait()
+
+
+def test_stale_pidfile_is_cleared_and_launch_proceeds(tmp_path):
+  home = tmp_path / "grafana-home-12.3.0"
+  victim = _fake_live_instance(tmp_path, home)
+  victim.kill()
+  victim.wait()
+  result = subprocess.run(
+      [
+          sys.executable,
+          str(RUNNER),
+          "--project",
+          "customer-project-123",
+          "--dataset",
+          "agent_analytics",
+          "--provision-only",
+          "--workdir",
+          str(tmp_path),
+      ],
+      capture_output=True,
+      text=True,
+      check=True,
+  )
+  assert "provisioning written" in result.stdout
+  assert not (tmp_path / "grafana.pid").exists()
+
+
 def test_cached_extraction_honors_explicit_checksum(tmp_path):
   # Build a tiny valid "grafana" archive.
   import io

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -260,3 +260,150 @@ def test_rejects_bad_identifiers_before_writing(tmp_path):
   )
   assert result.returncode != 0
   assert not (tmp_path / "provisioning").exists()
+
+
+def test_launch_env_binds_loopback_and_disables_preinstall(tmp_path):
+  env = runner.launch_env(tmp_path, tmp_path / "provisioning", 3123)
+  # An empty http_addr binds every interface, exposing an admin/admin
+  # instance backed by the operator's own credentials to the network.
+  assert env["GF_SERVER_HTTP_ADDR"] == "127.0.0.1"
+  assert env["GF_SERVER_HTTP_PORT"] == "3123"
+  assert env["GF_PLUGINS_PREINSTALL_DISABLED"] == "true"
+  assert env["GF_ANALYTICS_REPORTING_ENABLED"] == "false"
+
+
+def test_views_command_forwards_the_validated_prefix():
+  assert runner.build_views_command(
+      "customer-project-123", "agent_analytics", "agent_events", "custom_"
+  ) == [
+      "bq-agent-sdk",
+      "views",
+      "create-all",
+      "--project-id",
+      "customer-project-123",
+      "--dataset-id",
+      "agent_analytics",
+      "--table-id",
+      "agent_events",
+      "--prefix",
+      "custom_",
+  ]
+
+
+def test_plugin_install_command_pins_the_version(tmp_path):
+  command = runner.build_plugin_install_command(tmp_path, tmp_path / "p")
+  assert command[-2:] == [runner.PLUGIN_ID, runner.PLUGIN_VERSION]
+  assert runner.PLUGIN_VERSION == "3.3.1"
+
+
+def test_datasource_yaml_keeps_the_cost_guard_in_both_shapes(tmp_path):
+  adc = runner.render_datasource_yaml("customer-project-123")
+  assert f"MaxBytesBilled: {runner.DEFAULT_MAX_BYTES_BILLED}" in adc
+  key_path = tmp_path / "key.json"
+  key_path.write_text(
+      json.dumps(
+          {
+              "client_email": "g@example.com",
+              "private_key": "-----BEGIN PRIVATE KEY-----\nA\n-----END-----\n",
+              "token_uri": "https://oauth2.example.com/token",
+          }
+      )
+  )
+  jwt = runner.render_datasource_yaml(
+      "customer-project-123",
+      runner.load_service_account_key(key_path),
+      max_bytes_billed="42000000",
+  )
+  assert "MaxBytesBilled: 42000000" in jwt
+  # The cap must sit under jsonData, before the secure block.
+  assert jwt.index("MaxBytesBilled") < jwt.index("secureJsonData")
+
+
+def test_datasource_yaml_omits_processing_location_by_default():
+  # Hard-coding a multi-region breaks any dataset outside it; the plugin
+  # selects the job location automatically when the field is absent.
+  rendered = runner.render_datasource_yaml("customer-project-123")
+  assert "processingLocation" not in rendered
+  explicit = runner.render_datasource_yaml(
+      "customer-project-123", processing_location="EU"
+  )
+  assert "processingLocation: EU" in explicit
+
+
+@pytest.mark.parametrize("value", ["100000000", "1", "42000000"])
+def test_max_bytes_accepted(value):
+  assert runner.require_max_bytes(value) == value
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "1e6", "abc", "", "1.5"])
+def test_max_bytes_rejected(value):
+  with pytest.raises(ValueError):
+    runner.require_max_bytes(value)
+
+
+def test_one_sided_time_flags_are_rejected(tmp_path):
+  result = subprocess.run(
+      [
+          sys.executable,
+          str(RUNNER),
+          "--project",
+          "customer-project-123",
+          "--dataset",
+          "agent_analytics",
+          "--time-from",
+          "2026-06-15T00:00:00Z",
+          "--provision-only",
+          "--workdir",
+          str(tmp_path),
+      ],
+      capture_output=True,
+      text=True,
+  )
+  assert result.returncode != 0
+  assert "must be given together" in result.stderr
+
+
+def test_jwt_provisioning_file_is_private(tmp_path):
+  key_path = tmp_path / "key.json"
+  key_path.write_text(
+      json.dumps(
+          {
+              "client_email": "g@example.com",
+              "private_key": "-----BEGIN PRIVATE KEY-----\nA\n-----END-----\n",
+              "token_uri": "https://oauth2.example.com/token",
+          }
+      )
+  )
+  workdir = tmp_path / "work"
+  subprocess.run(
+      [
+          sys.executable,
+          str(RUNNER),
+          "--project",
+          "customer-project-123",
+          "--dataset",
+          "agent_analytics",
+          "--sa-key",
+          str(key_path),
+          "--provision-only",
+          "--workdir",
+          str(workdir),
+      ],
+      capture_output=True,
+      text=True,
+      check=True,
+  )
+  datasource = workdir / "provisioning" / "datasources" / "bigquery.yaml"
+  assert (datasource.stat().st_mode & 0o777) == 0o600
+  assert (datasource.parent.stat().st_mode & 0o777) == 0o700
+  assert not datasource.with_suffix(".yaml.tmp").exists()
+
+
+def test_sha256_verification(tmp_path):
+  archive = tmp_path / "a.tar.gz"
+  archive.write_bytes(b"grafana bytes")
+  good = runner.sha256_of(archive)
+  runner.verify_sha256(archive, good)
+  runner.verify_sha256(archive, f"{good}  a.tar.gz\n")
+  with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+    runner.verify_sha256(archive, "0" * 64)

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "grafana" / "run_local.py"
+
+
+def _load_runner():
+  spec = importlib.util.spec_from_file_location("grafana_run_local", RUNNER)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+runner = _load_runner()
+
+
+@pytest.mark.parametrize(
+    ("value", "pattern"),
+    [
+        ("customer-project-123", runner.PROJECT_RE),
+        ("agent_analytics", runner.DATASET_RE),
+        ("agent_events", runner.TABLE_RE),
+        ("events_agent_cur-phenix", runner.TABLE_RE),
+        ("adk_", runner.VIEW_PREFIX_RE),
+    ],
+)
+def test_identifiers_accepted(value, pattern):
+  assert runner.require_identifier("x", value, pattern) == value
+
+
+@pytest.mark.parametrize(
+    ("value", "pattern"),
+    [
+        ("UPPERCASE", runner.PROJECT_RE),
+        ("short", runner.PROJECT_RE),
+        ("project;drop", runner.PROJECT_RE),
+        ("bad-dataset", runner.DATASET_RE),
+        ("data`set", runner.DATASET_RE),
+        ("table,other", runner.TABLE_RE),
+        ("pre fix", runner.VIEW_PREFIX_RE),
+    ],
+)
+def test_identifiers_rejected(value, pattern):
+  with pytest.raises(ValueError):
+    runner.require_identifier("x", value, pattern)
+
+
+@pytest.mark.parametrize("value", ["1.25", "5.00", "0", "12"])
+def test_prices_accepted(value):
+  assert runner.require_price("x", value) == value
+
+
+@pytest.mark.parametrize(
+    "value", ["1e3", "-1", "abc", "1.25; DROP", "1/0", "", "NaN", ".5"]
+)
+def test_prices_rejected(value):
+  # These constants are interpolated into panel arithmetic, so anything
+  # that is not a plain decimal must fail closed.
+  with pytest.raises(ValueError):
+    runner.require_price("x", value)
+
+
+def _real_dashboard():
+  return json.loads((ROOT / "grafana" / "bqaa-dashboard.json").read_text())
+
+
+def test_patch_dashboard_fills_all_six_constants():
+  constants = {
+      "project": "customer-project-123",
+      "dataset": "agent_analytics",
+      "table": "agent_events",
+      "view_prefix": "adk_",
+      "price_per_1m_input_tokens": "1.25",
+      "price_per_1m_output_tokens": "5.00",
+  }
+  patched = runner.patch_dashboard(_real_dashboard(), constants)
+  by_name = {v["name"]: v for v in patched["templating"]["list"]}
+  for name, value in constants.items():
+    assert by_name[name]["type"] == "constant"
+    assert by_name[name]["query"] == value
+    assert by_name[name]["current"] == {"text": value, "value": value}
+
+
+def test_patch_dashboard_leaves_query_variables_untouched():
+  original = _real_dashboard()
+  patched = runner.patch_dashboard(original, {"project": "customer-p-123"})
+  originals = {v["name"]: v for v in original["templating"]["list"]}
+  for variable in patched["templating"]["list"]:
+    if variable["name"] != "project":
+      assert variable == originals[variable["name"]]
+
+
+def test_patch_dashboard_refuses_non_constant_targets():
+  # "agent" is a query variable; writing it would break the dashboard's
+  # constants-stay-constants injection-safety contract.
+  with pytest.raises(ValueError, match="not a patchable constant"):
+    runner.patch_dashboard(_real_dashboard(), {"agent": "billing-agent"})
+
+
+def test_patch_dashboard_refuses_type_mismatch():
+  dashboard = _real_dashboard()
+  for variable in dashboard["templating"]["list"]:
+    if variable["name"] == "project":
+      variable["type"] = "textbox"
+  with pytest.raises(ValueError, match="not\\s+constant"):
+    runner.patch_dashboard(dashboard, {"project": "customer-p-123"})
+
+
+def test_patch_dashboard_optional_time_window():
+  patched = runner.patch_dashboard(
+      _real_dashboard(),
+      {"project": "customer-p-123"},
+      time_from="2026-06-15T00:00:00Z",
+      time_to="2026-08-11T00:00:00Z",
+  )
+  assert patched["time"] == {
+      "from": "2026-06-15T00:00:00Z",
+      "to": "2026-08-11T00:00:00Z",
+  }
+  untouched = runner.patch_dashboard(
+      _real_dashboard(), {"project": "customer-p-123"}
+  )
+  assert untouched["time"] == _real_dashboard()["time"]
+
+
+def test_datasource_yaml_defaults_to_adc():
+  rendered = runner.render_datasource_yaml("customer-project-123")
+  assert "authenticationType: gce" in rendered
+  assert "defaultProject: customer-project-123" in rendered
+  assert "privateKey" not in rendered
+
+
+def test_datasource_yaml_jwt_uses_block_scalar(tmp_path):
+  key_path = tmp_path / "key.json"
+  key_path.write_text(
+      json.dumps(
+          {
+              "client_email": "grafana@customer-project-123.iam.example.com",
+              "private_key": (
+                  "-----BEGIN PRIVATE KEY-----\nAAAA\nBBBB\n-----END PRIVATE"
+                  " KEY-----\n"
+              ),
+              "token_uri": "https://oauth2.example.com/token",
+          }
+      )
+  )
+  key = runner.load_service_account_key(key_path)
+  rendered = runner.render_datasource_yaml("customer-project-123", key)
+  assert "authenticationType: jwt" in rendered
+  assert "clientEmail: grafana@customer-project-123.iam.example.com" in (
+      rendered
+  )
+  # Real line breaks under a block scalar, never literal \n escapes
+  # (grafana/README.md calls this out explicitly).
+  assert "privateKey: |" in rendered
+  assert "        -----BEGIN PRIVATE KEY-----\n        AAAA\n" in rendered
+  assert "\\n" not in rendered
+
+
+def test_service_account_key_must_be_complete(tmp_path):
+  key_path = tmp_path / "key.json"
+  key_path.write_text(json.dumps({"client_email": "x@example.com"}))
+  with pytest.raises(ValueError, match="private_key"):
+    runner.load_service_account_key(key_path)
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "expected"),
+    [
+        ("Darwin", "arm64", "darwin-arm64"),
+        ("Darwin", "x86_64", "darwin-amd64"),
+        ("Linux", "aarch64", "linux-arm64"),
+        ("Linux", "x86_64", "linux-amd64"),
+    ],
+)
+def test_pick_dist(system, machine, expected):
+  assert runner.pick_dist(system, machine) == expected
+
+
+def test_pick_dist_rejects_unsupported():
+  with pytest.raises(ValueError, match="manual steps"):
+    runner.pick_dist("Windows", "AMD64")
+
+
+def test_grafana_pin_satisfies_plugin_floor():
+  # The plugin's grafanaDependency ranges end unbounded at >=12.2.5-0
+  # (issue #421); a pin below 12.2.5 would reintroduce the opaque
+  # react/jsx-runtime failure on fresh installs.
+  major, minor, patch = (int(x) for x in runner.GRAFANA_VERSION.split("."))
+  assert (major, minor, patch) >= (12, 2, 5)
+
+
+def test_provision_only_writes_everything_without_network(tmp_path):
+  result = subprocess.run(
+      [
+          sys.executable,
+          str(RUNNER),
+          "--project",
+          "customer-project-123",
+          "--dataset",
+          "agent_analytics",
+          "--provision-only",
+          "--workdir",
+          str(tmp_path),
+      ],
+      capture_output=True,
+      text=True,
+      check=True,
+  )
+  assert "provisioning written" in result.stdout
+  datasource = (tmp_path / "provisioning/datasources/bigquery.yaml").read_text()
+  assert "authenticationType: gce" in datasource
+  dashboard = json.loads(
+      (tmp_path / "dashboards/bqaa-dashboard.json").read_text()
+  )
+  by_name = {v["name"]: v for v in dashboard["templating"]["list"]}
+  assert by_name["project"]["query"] == "customer-project-123"
+  assert by_name["table"]["query"] == "agent_events"
+  # The committed dashboard is a source file and must never be mutated.
+  committed = {v["name"]: v for v in _real_dashboard()["templating"]["list"]}
+  assert committed["project"]["query"] != "customer-project-123"
+
+
+def test_rejects_bad_identifiers_before_writing(tmp_path):
+  result = subprocess.run(
+      [
+          sys.executable,
+          str(RUNNER),
+          "--project",
+          "UPPERCASE",
+          "--dataset",
+          "agent_analytics",
+          "--provision-only",
+          "--workdir",
+          str(tmp_path),
+      ],
+      capture_output=True,
+      text=True,
+  )
+  assert result.returncode != 0
+  assert not (tmp_path / "provisioning").exists()

--- a/tests/test_grafana_local_runner.py
+++ b/tests/test_grafana_local_runner.py
@@ -473,7 +473,9 @@ def test_fallback_extraction_allows_benign_archives(tmp_path):
   import tarfile as tarlib
 
   archive = _tar_with(
-      tmp_path, "ok.tgz", [("top", "dir"), ("top/bin/file.txt", "file")]
+      tmp_path,
+      "ok.tgz",
+      [("top", "dir"), ("top/bin", "dir"), ("top/bin/file.txt", "file")],
   )
   dest = tmp_path / "dest3"
   dest.mkdir()


### PR DESCRIPTION
## Summary

Fixes #421. The Grafana e2e path collapses from seven manual steps (plus two undocumented failure modes) to:

```bash
python3 grafana/run_local.py --project MY_PROJECT --dataset MY_DATASET
```

The script (stdlib-only, macOS/Linux, amd64/arm64) downloads, checksum-verifies, and caches a pinned Grafana, installs the **pinned** BigQuery datasource plugin (3.3.1, manifest-verified on every rerun), provisions auth, patches a **copy** of `bqaa-dashboard.json` with all six constants, creates the prefixed views when `bq-agent-sdk` is on PATH, launches **bound to 127.0.0.1**, health-polls, and prints the dashboard URL. `--stop` tears it down with strong process-identity verification. Everything generated lives in gitignored `grafana/.local/`; committed sources are never mutated.

## Hardening (both review rounds)

- **Loopback-only** (`GF_SERVER_HTTP_ADDR=127.0.0.1`, env pinned by test) — never a wildcard listener with admin/admin.
- **Credential files**: datasource YAML written atomically at `0600` in a `0700` dir (JWT path carries a private key).
- **No hard-coded location**: `processingLocation` omitted (plugin auto-selects); validated `--processing-location` override.
- **Cost guard preserved**: `MaxBytesBilled: 100000000` default from `datasource.example.yaml`, validated override, both auth shapes.
- **Safe extraction on every interpreter**: stdlib `data` filter where available; on pre-3.10.12/3.11.4 the fallback validates every member (no traversal, no absolute paths, no links/special files) and **fails loudly** — regression-tested with malicious archives.
- **`--stop` cannot kill an unrelated process**: exact-executable + `--homepath` argument + recorded process start time (defeats PID reuse); a live test proves a lookalike process whose argv mentions the home path is never signalled.
- **Atomic launch ownership**: an exclusive `flock` on the workdir is taken before the liveness check and held through pidfile publication — concurrent launches yield exactly one owner (two-contender regression), a second launch is refused with the pid/port/stop command while an instance lives, and `--stop` takes the same lock so it cannot race a launch in flight.
- **Cache integrity**: cached plugin manifests are checked against the pin (mismatch/corrupt → reinstall); extractions record archive-hash provenance, and an explicit `--grafana-sha256` is always honored — mismatched caches are discarded and fail closed.
- Downloads verified against the published `.sha256`; one-sided `--time-from`/`--time-to` rejected; identifiers/prices validated before any write; the patcher refuses non-constant variables (the dashboard's injection-safety contract, enforced in code).

## Verification

- **Live e2e of the script** against a 100,023-event table: checksum-verified extract → loopback-only listener (`netstat`) → datasource health OK → `jsonData` carries the cost cap and no pinned location → live query under the cap returned 100,023 → `--stop` clean.
- **Tests: 69 in the runner suite, 95 combined with the dashboard suite** — no network, including malicious-archive, lookalike-process, recycled-pid, cached-manifest, and cached-extraction-vs-explicit-hash regressions.

## Files

- `grafana/run_local.py` — the launcher
- `tests/test_grafana_local_runner.py` — 69 tests
- `grafana/README.md` — Quick-start + known pitfalls
- `.gitignore` — `grafana/.local/`
