### PR TITLE
docs: correct LangSmith re-export guidance and document the 24h ingest window

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ For scheduled syncs, use `--incremental` with `--watermark-file=state.json`.
 The JSON summary bounds row-level diagnostics with `--max-dropped-rows` and
 reports the number omitted as `dropped_rows_truncated`.
 
+LangSmith Cloud rejects runs whose `start_time` is more than 24 hours from now,
+so an export covers recent traces rather than aged trace history. Run
+`--incremental` on a schedule frequent enough to stay inside that window. See
+[SDK.md](SDK.md#23-langsmith-export) for the exact error and its effect on
+bounded backfills.
+
 Custom schemas use a YAML mapping from LangSmith fields to source column or
 nested paths. Unmapped columns remain in `extra.metadata`; payload values are
 opaque and are never classified by event type. Optional fields omitted from a

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ The CLI intentionally accepts the API key only through
 The exporter reconstructs span parents and derives stable LangSmith UUIDs. It
 treats created runs as immutable: replaying an overlapping window is an
 idempotent no-op for existing run IDs while still creating previously unseen
-IDs. To correct already-exported data, use a fresh LangSmith project or a
-deliberately versioned `--source-id`. For scheduled syncs, use `--incremental`
-with `--watermark-file=state.json`. The JSON summary bounds row-level
-diagnostics with `--max-dropped-rows` and reports the number omitted as
-`dropped_rows_truncated`.
+IDs. Run IDs derive from the source identity and not the destination, so
+exporting to a fresh LangSmith project reuses the same IDs and creates nothing.
+To correct already-exported data, use a deliberately versioned `--source-id`.
+For scheduled syncs, use `--incremental` with `--watermark-file=state.json`.
+The JSON summary bounds row-level diagnostics with `--max-dropped-rows` and
+reports the number omitted as `dropped_rows_truncated`.
 
 Custom schemas use a YAML mapping from LangSmith fields to source column or
 nested paths. Unmapped columns remain in `extra.metadata`; payload values are

--- a/SDK.md
+++ b/SDK.md
@@ -2293,8 +2293,11 @@ the existing `span_id` / `parent_span_id` hierarchy, and adds one stable
 structural root per trace. Every source event gets a UUID derived from the
 canonical source, trace ID, and run ID. The exporter treats created runs as
 immutable: overlapping backfills are idempotent no-ops for existing run IDs
-while still creating previously unseen IDs. Correcting already-exported data
-requires a fresh LangSmith project or a deliberately versioned `--source-id`.
+while still creating previously unseen IDs. The destination project is not one
+of those UUID inputs, so exporting to a fresh LangSmith project reuses the same
+run IDs and creates nothing: the runs already exist and are immutable, and the
+new project stays empty. Correcting already-exported data therefore requires a
+deliberately versioned `--source-id`.
 
 ### Install and authenticate
 
@@ -2441,8 +2444,9 @@ has advanced but carries an equal or earlier `start_time` is not discovered by
 a later incremental run. Schedule an overlapping bounded backfill when the
 source permits late arrival. Stable IDs make the replay idempotent: previously
 unseen run IDs are created, but existing runs remain unchanged. To correct an
-already-exported run, export to a fresh LangSmith project or use a deliberately
-versioned `--source-id`.
+already-exported run, use a deliberately versioned `--source-id`. Exporting to
+a fresh LangSmith project does not achieve this, because the destination does
+not participate in run ID derivation.
 
 Each query window reconstructs hierarchy only from rows present in that
 window. If a child arrives after its parent was exported in an earlier window,

--- a/SDK.md
+++ b/SDK.md
@@ -2412,6 +2412,22 @@ bq-agent-sdk export langsmith \
   --max-dropped-rows=1000
 ```
 
+LangSmith Cloud accepts a run only when its `start_time` lies within 24 hours
+of the current time, in either direction. Rows outside that window are rejected
+by the ingest endpoint:
+
+```text
+422 Unprocessable entity: error parsing run: start_time for post must be
+within ±24 hours of current time
+```
+
+The rejection applies per batch, so a backfill over an older window fails every
+row and reports `exported: 0` with a non-zero `failed` count. The bounded
+backfill above is useful for re-running a recent window or for narrowing a
+sync with `--filter`; it cannot import trace history that has aged out. Keep
+`--incremental` on a schedule frequent enough that rows reach LangSmith inside
+the window. Self-hosted LangSmith deployments may enforce a different limit.
+
 For CLI use, `LANGSMITH_API_KEY` is intentionally environment-only so the
 secret does not appear in shell history or process arguments. Python callers
 may still pass `langsmith_api_key` to `ExportConfig` explicitly.


### PR DESCRIPTION
Two corrections to the LangSmith export docs, both found while exporting a real
`agent_events` table to LangSmith Cloud. Each one produces a silent or
confusing failure today.

## 1. A fresh LangSmith project does not re-mint run IDs

The docs offer two ways to correct already-exported data — a fresh LangSmith
project, or a versioned `--source-id`. Only the second works.

`_stable_uuid(source_fingerprint, ...)` hashes the canonical source identity
with the trace and run IDs. The destination is not an input: `project_name`
reaches `_prepare_trace_runs` but is used only as `session_name` on the emitted
payload. Exporting an unchanged `--source-id` into a new project therefore
replays run IDs that already exist, and since created runs are immutable the
batch is a no-op.

What makes this worth a doc change is how quiet it is — the exporter reports a
clean success while the destination stays empty:

```console
$ bq-agent-sdk export langsmith --source-id=demo-v1 \
    --langsmith-project=brand-new-project ...
{"exported": 21, "failed": 0, "skipped": 18, "traces_exported": 6}
# brand-new-project holds 0 runs

$ bq-agent-sdk export langsmith --source-id=demo-v2 \
    --langsmith-project=brand-new-project ...
# same project, only --source-id changed -> 27 runs
```

Corrected in all three places the claim appears (README.md, SDK.md §23 intro,
SDK.md incremental section).

## 2. LangSmith Cloud rejects runs older than 24 hours

`POST /runs/batch` refuses any run whose `start_time` is more than 24 hours
from now, and the check is per batch, so an older window fails every row:

```text
422 Unprocessable entity: error parsing run: start_time for post must be
within ±24 hours of current time (got 2026-08-06 21:54:54 +0000 UTC,
allowed range: 2026-08-11 17:30:26 ... 2026-08-13 17:30:26)

{"exported": 0, "failed": 21, "rows_read": 39, "skipped": 18}
```

Nothing surfaces this before the batch call. The bounded-backfill example
spans a week ending well before the reader runs it, so followed verbatim
against LangSmith Cloud it exports nothing. The practical consequence is worth
stating next to that example: `--since` / `--until` can re-run a *recent*
window, but aged trace history cannot be imported at all, and `--incremental`
has to run often enough that rows arrive while still eligible.

Qualified as LangSmith Cloud behaviour, since self-hosted deployments may
configure it differently.

## Testing

Docs only — no code changes. Both behaviours were reproduced against
`api.smith.langchain.com` with `bigquery-agent-analytics==0.5.0` exporting a
39-row / 6-trace `agent_events` table.
