### PR TITLE
feat(dashboard): accept BigQuery Console table links

### DIFF
--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -2,8 +2,8 @@ import {
   buildDashboardUrl,
   buildSetupUrl,
   validateConfiguration,
-  splitQualifiedTableId,
-  parseQualifiedTableIdForInput,
+  parseTableReference,
+  parseTableReferenceForInput,
 } from "./configurator.mjs";
 import { REPORT_CONFIG } from "./report-config.mjs";
 
@@ -104,7 +104,7 @@ if (!inputs.table.value) {
 for (const input of tableInputs) {
   input.addEventListener("input", refresh);
   input.addEventListener("change", (event) => {
-    const parsed = parseQualifiedTableIdForInput(event.target.value);
+    const parsed = parseTableReferenceForInput(event.target.value);
 
     if (parsed) {
       afterQualifiedTableId(parsed);
@@ -117,7 +117,7 @@ for (const input of tableInputs) {
 for (const input of tableInputs) {
   input.addEventListener("paste", (event) => {
     const text = event.clipboardData.getData("text");
-    const parsed = splitQualifiedTableId(text);
+    const parsed = parseTableReference(text);
 
     if (parsed) {
       event.preventDefault();

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -8,8 +8,11 @@ const BIGQUERY_CONSOLE_HOSTS = new Set([
   "console.cloud.google.com",
   "pantheon.corp.google.com",
 ]);
-const BIGQUERY_WORKSPACE_TABLE_RE =
-  /!1m5!1m4!4m3!1s([^!]+)!2s([^!]+)!3s([^!]+)(?=!|$)/g;
+// The `!4m3!1s<project>!2s<dataset>!3s<table>` submessage is the stable core
+// of a Console table reference. The group counts that precede it (for example
+// `!1m5!1m4` or `!1m6!1m5`) vary with UI-state fields the Console appends,
+// such as `!23sRESOURCE_LIST`, so they must not be part of the contract.
+const BIGQUERY_WORKSPACE_TABLE_RE = /!4m3!1s([^!]+)!2s([^!]+)!3s([^!]+)/g;
 const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 const VALIDATION_MESSAGES = Object.freeze({
@@ -175,7 +178,19 @@ export function parseBigQueryConsoleTableUrl(value) {
   const matches = [
     ...workspaceValues[0].matchAll(BIGQUERY_WORKSPACE_TABLE_RE),
   ];
-  if (matches.length !== 1) {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  // A workspace URL can reference the same table more than once (for example
+  // one entry per open tab). That is still unambiguous, so collapse the
+  // matches and only reject when they name different tables.
+  const distinctReferences = new Set(
+    matches.map(([, project, dataset, table]) =>
+      [project, dataset, table].join("!"),
+    ),
+  );
+  if (distinctReferences.size !== 1) {
     return null;
   }
 

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -15,7 +15,9 @@ const BIGQUERY_CONSOLE_HOSTS = new Set([
 const BIGQUERY_WORKSPACE_TABLE_RE = /!4m3!1s([^!]+)!2s([^!]+)!3s([^!]+)/g;
 // Every table submessage starts with this marker; comparing marker starts to
 // complete matches rejects workspaces holding a truncated table reference.
-const BIGQUERY_WORKSPACE_TABLE_MARKER_RE = /!4m3!/g;
+// The lookahead accepts a following field delimiter or end of string, so a
+// workspace truncated exactly at a dangling `!4m3` still counts as a marker.
+const BIGQUERY_WORKSPACE_TABLE_MARKER_RE = /!4m3(?=!|$)/g;
 // Dataset views encode a `!3m2!1s<project>!2s<dataset>` resource. When one
 // coexists with a table reference the active resource cannot be proved from
 // the undocumented `ws` encoding, so such workspaces are rejected outright.

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -22,7 +22,13 @@ const BIGQUERY_WORKSPACE_TABLE_MARKER_RE = /!4m3(?=!|$)/g;
 // coexists with a table reference the active resource cannot be proved from
 // the undocumented `ws` encoding, so such workspaces are rejected outright.
 const BIGQUERY_WORKSPACE_DATASET_RE = /!3m2!1s[^!]+!2s[^!]+/;
-const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+// Any scheme followed by `//` is URL-shaped, and so are slashless `http:` /
+// `https:` spellings, which `new URL()` canonicalizes to the `://` form
+// (`https:evil.example` parses as `https://evil.example/`). Routing those
+// spellings here keeps them out of the legacy `project:dataset.table` colon
+// normalization; no legitimate colon-form paste can start with them because
+// `PROJECT_RE` requires at least six characters.
+const URL_SHAPED_RE = /^(?:[a-z][a-z0-9+.-]*:\/\/|https?:)/i;
 
 const VALIDATION_MESSAGES = Object.freeze({
   project:
@@ -218,7 +224,7 @@ export function parseBigQueryConsoleTableUrl(value) {
 
 export function parseTableReference(value) {
   const normalized = String(value ?? "").trim();
-  if (ABSOLUTE_URL_RE.test(normalized)) {
+  if (URL_SHAPED_RE.test(normalized)) {
     return parseBigQueryConsoleTableUrl(normalized);
   }
   return splitQualifiedTableId(normalized);

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -4,6 +4,14 @@ export const PROJECT_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 export const DATASET_RE = /^[A-Za-z_][A-Za-z0-9_]{0,1023}$/;
 export const TABLE_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]{0,1023}$/;
 
+const BIGQUERY_CONSOLE_HOSTS = new Set([
+  "console.cloud.google.com",
+  "pantheon.corp.google.com",
+]);
+const BIGQUERY_WORKSPACE_TABLE_RE =
+  /!1m5!1m4!4m3!1s([^!]+)!2s([^!]+)!3s([^!]+)(?=!|$)/g;
+const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 const VALIDATION_MESSAGES = Object.freeze({
   project:
     "Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit.",
@@ -125,17 +133,66 @@ export function splitQualifiedTableId(value) {
 export function parseQualifiedTableIdForInput(value) {
   const parsed = splitQualifiedTableId(value);
 
+  return hasValidTableIdentifiers(parsed) ? parsed : null;
+}
+
+function hasValidTableIdentifiers(parsed) {
   if (!parsed) {
+    return false;
+  }
+
+  return (
+    PROJECT_RE.test(parsed.project) &&
+    DATASET_RE.test(parsed.dataset) &&
+    TABLE_RE.test(parsed.table)
+  );
+}
+
+export function parseBigQueryConsoleTableUrl(value) {
+  let url;
+  try {
+    url = new URL(String(value ?? "").trim());
+  } catch {
     return null;
   }
 
   if (
-    !PROJECT_RE.test(parsed.project) ||
-    !DATASET_RE.test(parsed.dataset) ||
-    !TABLE_RE.test(parsed.table)
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.port ||
+    !BIGQUERY_CONSOLE_HOSTS.has(url.hostname) ||
+    url.pathname !== "/bigquery"
   ) {
     return null;
   }
 
-  return parsed;
+  const workspaceValues = url.searchParams.getAll("ws");
+  if (workspaceValues.length !== 1) {
+    return null;
+  }
+
+  const matches = [
+    ...workspaceValues[0].matchAll(BIGQUERY_WORKSPACE_TABLE_RE),
+  ];
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  const [, project, dataset, table] = matches[0];
+  const parsed = { project, dataset, table };
+  return hasValidTableIdentifiers(parsed) ? parsed : null;
+}
+
+export function parseTableReference(value) {
+  const normalized = String(value ?? "").trim();
+  if (ABSOLUTE_URL_RE.test(normalized)) {
+    return parseBigQueryConsoleTableUrl(normalized);
+  }
+  return splitQualifiedTableId(normalized);
+}
+
+export function parseTableReferenceForInput(value) {
+  const parsed = parseTableReference(value);
+  return hasValidTableIdentifiers(parsed) ? parsed : null;
 }

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -13,6 +13,13 @@ const BIGQUERY_CONSOLE_HOSTS = new Set([
 // `!1m5!1m4` or `!1m6!1m5`) vary with UI-state fields the Console appends,
 // such as `!23sRESOURCE_LIST`, so they must not be part of the contract.
 const BIGQUERY_WORKSPACE_TABLE_RE = /!4m3!1s([^!]+)!2s([^!]+)!3s([^!]+)/g;
+// Every table submessage starts with this marker; comparing marker starts to
+// complete matches rejects workspaces holding a truncated table reference.
+const BIGQUERY_WORKSPACE_TABLE_MARKER_RE = /!4m3!/g;
+// Dataset views encode a `!3m2!1s<project>!2s<dataset>` resource. When one
+// coexists with a table reference the active resource cannot be proved from
+// the undocumented `ws` encoding, so such workspaces are rejected outright.
+const BIGQUERY_WORKSPACE_DATASET_RE = /!3m2!1s[^!]+!2s[^!]+/;
 const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 const VALIDATION_MESSAGES = Object.freeze({
@@ -175,10 +182,18 @@ export function parseBigQueryConsoleTableUrl(value) {
     return null;
   }
 
-  const matches = [
-    ...workspaceValues[0].matchAll(BIGQUERY_WORKSPACE_TABLE_RE),
-  ];
+  const workspace = workspaceValues[0];
+  const matches = [...workspace.matchAll(BIGQUERY_WORKSPACE_TABLE_RE)];
   if (matches.length === 0) {
+    return null;
+  }
+
+  const markerStarts = workspace.match(BIGQUERY_WORKSPACE_TABLE_MARKER_RE);
+  if ((markerStarts?.length ?? 0) !== matches.length) {
+    return null;
+  }
+
+  if (BIGQUERY_WORKSPACE_DATASET_RE.test(workspace)) {
     return null;
   }
 

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -69,6 +69,8 @@
           <span class="field-hint" id="project-hint">
             6–30 characters: lowercase letters, digits, and hyphens. Start
             with a letter and end with a letter or digit.
+            Paste a fully qualified table ID or BigQuery Console table link
+            into any identifier field to fill all three.
           </span>
           <span class="field-error" id="project-error" aria-live="polite"></span>
 

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -773,6 +773,77 @@ for (const field of ["project", "dataset", "table"]) {
   );
 }
 
+for (const [description, consoleUrl] of [
+  ["Pantheon", pantheonTableUrl],
+  ["public Console", publicConsoleTableUrl],
+]) {
+  for (const field of ["project", "dataset", "table"]) {
+    resetTableInputs();
+
+    assert.equal(
+      pasteIntoProject(field, consoleUrl),
+      true,
+      `${description} URL pasted into ${field} is handled`,
+    );
+    assert.deepEqual(
+      {
+        project: fakeElements.get("#project").value,
+        dataset: fakeElements.get("#dataset").value,
+        table: fakeElements.get("#table").value,
+      },
+      consoleTableId,
+      `${description} URL pasted into ${field} fills all identifier fields`,
+    );
+    assert.equal(
+      fakeElements.get("#form-status").textContent,
+      'Split "haiyuan-anarres-dev-806843.bqaa_looker_demo.agent_events" into the three fields.',
+      `${description} URL reports the extracted table`,
+    );
+    assert.equal(fakeElements.get("#form-status").dataset.kind, "ready");
+  }
+}
+
+resetTableInputs();
+fakeElements.get("#dataset").value = encodedConsoleTableUrl;
+fakeElements.get("#dataset").listeners.change({
+  target: fakeElements.get("#dataset"),
+});
+assert.deepEqual(
+  {
+    project: fakeElements.get("#project").value,
+    dataset: fakeElements.get("#dataset").value,
+    table: fakeElements.get("#table").value,
+  },
+  consoleTableId,
+  "the committed-input fallback recognizes an encoded Console URL",
+);
+
+for (const rejectedUrl of [
+  "https://evil.example/bigquery?ws=" + workspaceReference,
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+]) {
+  resetTableInputs();
+  assert.equal(
+    pasteIntoProject("dataset", rejectedUrl),
+    false,
+    "a rejected Console URL retains ordinary paste behavior",
+  );
+  assert.equal(fakeElements.get("#project").value, values.project);
+  assert.equal(fakeElements.get("#dataset").value, values.dataset);
+  assert.equal(fakeElements.get("#table").value, values.table);
+
+  // Simulate the browser applying the unintercepted paste to its target.
+  fakeElements.get("#dataset").value = rejectedUrl;
+  fakeElements.get("#dataset").listeners.input({
+    target: fakeElements.get("#dataset"),
+  });
+  assert.equal(fakeElements.get("#project").value, values.project);
+  assert.equal(fakeElements.get("#table").value, values.table);
+}
+
 // #398: clicking the enabled create link sets the provisioning expectation
 // without blocking navigation, and the message clears on the next change.
 resetTableInputs();

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -186,11 +186,31 @@ const encodedConsoleTableUrl =
   "https://console.cloud.google.com/bigquery?ws=" +
   "%211m5%211m4%214m3%211shaiyuan-anarres-dev-806843" +
   "%212sbqaa_looker_demo%213sagent_events";
+// The live Console appends UI-state fields such as `!23sRESOURCE_LIST`
+// (clicked table) or `!23sWS_URL_PARAM` (link navigation), which also bump
+// the enclosing group counts from `!1m5!1m4` to `!1m6!1m5`. Captured from a
+// real session on 2026-08-12.
+const clickedTableUrl =
+  "https://console.cloud.google.com/bigquery?project=another-project&ws=" +
+  "!1m6!1m5!4m3!1shaiyuan-anarres-dev-806843" +
+  "!2sbqaa_looker_demo!3sagent_events!23sRESOURCE_LIST";
+const linkNavigationTableUrl =
+  "https://console.cloud.google.com/bigquery?ws=" +
+  "!1m6!1m5!4m3!1shaiyuan-anarres-dev-806843" +
+  "!2sbqaa_looker_demo!3sagent_events!23sWS_URL_PARAM";
+// One table open in two workspace tabs still names a single table.
+const repeatedReferenceTableUrl =
+  "https://console.cloud.google.com/bigquery?ws=" +
+  workspaceReference +
+  workspaceReference;
 
 for (const url of [
   pantheonTableUrl,
   publicConsoleTableUrl,
   encodedConsoleTableUrl,
+  clickedTableUrl,
+  linkNavigationTableUrl,
+  repeatedReferenceTableUrl,
 ]) {
   assert.deepEqual(
     parseBigQueryConsoleTableUrl(url),
@@ -223,8 +243,15 @@ for (const rejectedUrl of [
     workspaceReference + "&ws=" + workspaceReference,
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  // Two different tables in one workspace are ambiguous.
   "https://console.cloud.google.com/bigquery?ws=" +
-    workspaceReference + workspaceReference,
+    workspaceReference +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+    "!2sbqaa_looker_demo!3sother_table",
+  // A dataset view (`!3m2` marker) names no table.
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
+    "!2sbqaa_looker_demo!23sRESOURCE_LIST",
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
   "https://console.cloud.google.com/bigquery?ws=" +
@@ -760,6 +787,7 @@ for (const field of ["project", "dataset", "table"]) {
 for (const [description, consoleUrl] of [
   ["Pantheon", pantheonTableUrl],
   ["public Console", publicConsoleTableUrl],
+  ["clicked-table", clickedTableUrl],
 ]) {
   for (const field of ["project", "dataset", "table"]) {
     resetTableInputs();

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -203,6 +203,10 @@ const repeatedReferenceTableUrl =
   "https://console.cloud.google.com/bigquery?ws=" +
   workspaceReference +
   workspaceReference;
+// Browsers accept the slashless `https:` spelling and canonicalize it to
+// the `://` form, so an allowlisted link keeps working without slashes.
+const slashlessConsoleTableUrl =
+  "https:console.cloud.google.com/bigquery?ws=" + workspaceReference;
 // A table tab alongside the Console's left-panel group (`!16m3`, not a
 // table or dataset resource). Captured from a real session on 2026-08-12.
 const leftPanelTableUrl =
@@ -219,6 +223,7 @@ for (const url of [
   linkNavigationTableUrl,
   repeatedReferenceTableUrl,
   leftPanelTableUrl,
+  slashlessConsoleTableUrl,
 ]) {
   assert.deepEqual(
     parseBigQueryConsoleTableUrl(url),

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -274,6 +274,11 @@ for (const rejectedUrl of [
   "https://console.cloud.google.com/bigquery?ws=" + workspaceReference + "!4m3",
   // URL-shaped input whose URL constructor throws.
   "https://",
+  // Slashless HTTP(S) spellings canonicalize to real URLs and must not fall
+  // through to the legacy colon-form normalization.
+  "https:evil.example",
+  "HTTPS:evil.example",
+  "http:evil.example",
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
   "https://console.cloud.google.com/bigquery?ws=" +
@@ -867,6 +872,7 @@ for (const rejectedUrl of [
     "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
   "https://console.cloud.google.com/bigquery?ws=" + workspaceReference + "!4m3",
   "https://",
+  "https:evil.example",
 ]) {
   resetTableInputs();
   assert.equal(

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
+import * as configurator from "../docs/configurator.mjs";
 import {
   buildDashboardUrl,
   buildSetupUrl,
@@ -116,6 +117,24 @@ const qualifiedTableId = {
   table: "my_table",
 };
 
+assert.equal(
+  typeof configurator.parseBigQueryConsoleTableUrl,
+  "function",
+  "the configurator exports a pure BigQuery Console URL parser",
+);
+
+assert.equal(
+  typeof configurator.parseTableReference,
+  "function",
+  "the configurator exports a unified paste parser",
+);
+
+assert.equal(
+  typeof configurator.parseTableReferenceForInput,
+  "function",
+  "the configurator exports a validated committed-input parser",
+);
+
 assert.deepEqual(
   splitQualifiedTableId("my-project.my_dataset.my_table"),
   qualifiedTableId,
@@ -165,6 +184,83 @@ assert.equal(
   parseQualifiedTableIdForInput("my-project.my_dataset.table@1234"),
   null,
 );
+
+const consoleTableId = {
+  project: "haiyuan-anarres-dev-806843",
+  dataset: "bqaa_looker_demo",
+  table: "agent_events",
+};
+const workspaceReference =
+  "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+  "!2sbqaa_looker_demo!3sagent_events";
+const pantheonTableUrl =
+  "https://pantheon.corp.google.com/bigquery?ws=" + workspaceReference;
+const publicConsoleTableUrl =
+  "https://console.cloud.google.com/bigquery?project=another-project&ws=" +
+  workspaceReference;
+const encodedConsoleTableUrl =
+  "https://console.cloud.google.com/bigquery?ws=" +
+  "%211m5%211m4%214m3%211shaiyuan-anarres-dev-806843" +
+  "%212sbqaa_looker_demo%213sagent_events";
+
+for (const url of [
+  pantheonTableUrl,
+  publicConsoleTableUrl,
+  encodedConsoleTableUrl,
+]) {
+  assert.deepEqual(
+    configurator.parseBigQueryConsoleTableUrl(url),
+    consoleTableId,
+    `${url} resolves to the copied BigQuery table`,
+  );
+  assert.deepEqual(
+    configurator.parseTableReference(url),
+    consoleTableId,
+    `${url} is accepted by the unified paste parser`,
+  );
+  assert.deepEqual(
+    configurator.parseTableReferenceForInput(url),
+    consoleTableId,
+    `${url} is accepted by the committed-input parser`,
+  );
+}
+
+for (const rejectedUrl of [
+  "http://console.cloud.google.com/bigquery?ws=" + workspaceReference,
+  "https://evil.example/bigquery?ws=" + workspaceReference,
+  "https://console.cloud.google.com.evil.example/bigquery?ws=" +
+    workspaceReference,
+  "https://user@console.cloud.google.com/bigquery?ws=" + workspaceReference,
+  "https://console.cloud.google.com:8443/bigquery?ws=" + workspaceReference,
+  "https://console.cloud.google.com/bigquery/?ws=" + workspaceReference,
+  "https://console.cloud.google.com/not-bigquery?ws=" + workspaceReference,
+  "https://console.cloud.google.com/bigquery",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference + "&ws=" + workspaceReference,
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference + workspaceReference,
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+    "!2sbad-dataset!3sagent_events",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+    "!2sbqaa_looker_demo!3stable$20260812",
+]) {
+  assert.equal(
+    configurator.parseBigQueryConsoleTableUrl(rejectedUrl),
+    null,
+    `${rejectedUrl} is rejected without extracting identifiers`,
+  );
+  assert.equal(
+    configurator.parseTableReference(rejectedUrl),
+    null,
+    `${rejectedUrl} cannot fall through to qualified-ID parsing`,
+  );
+}
 
 const dashboard = new URL(buildDashboardUrl(values));
 assert.equal(dashboard.origin, "https://lookerstudio.google.com");

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -252,6 +252,18 @@ for (const rejectedUrl of [
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
     "!2sbqaa_looker_demo!23sRESOURCE_LIST",
+  // A dataset view alongside a table reference leaves the active resource
+  // unprovable, so the table must not be autofilled.
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference +
+    "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
+    "!2sother_dataset!23sRESOURCE_LIST",
+  // A truncated second table marker signals malformed workspace state.
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  // URL-shaped input whose URL constructor throws.
+  "https://",
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
   "https://console.cloud.google.com/bigquery?ws=" +
@@ -836,6 +848,11 @@ for (const rejectedUrl of [
     "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
   "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference +
+    "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
+    "!2sother_dataset!23sRESOURCE_LIST",
+  "https://",
 ]) {
   resetTableInputs();
   assert.equal(

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -203,6 +203,13 @@ const repeatedReferenceTableUrl =
   "https://console.cloud.google.com/bigquery?ws=" +
   workspaceReference +
   workspaceReference;
+// A table tab alongside the Console's left-panel group (`!16m3`, not a
+// table or dataset resource). Captured from a real session on 2026-08-12.
+const leftPanelTableUrl =
+  "https://console.cloud.google.com/bigquery?project=another-project&ws=" +
+  "!1m12!1m5!4m3!1shaiyuan-anarres-dev-806843" +
+  "!2sbqaa_looker_demo!3sagent_events!23sWS_URL_PARAM" +
+  "!1m5!16m3!1m1!1shaiyuan-anarres-dev-806843!3e2!23sLEFT_PANEL";
 
 for (const url of [
   pantheonTableUrl,
@@ -211,6 +218,7 @@ for (const url of [
   clickedTableUrl,
   linkNavigationTableUrl,
   repeatedReferenceTableUrl,
+  leftPanelTableUrl,
 ]) {
   assert.deepEqual(
     parseBigQueryConsoleTableUrl(url),
@@ -262,6 +270,8 @@ for (const rejectedUrl of [
   "https://console.cloud.google.com/bigquery?ws=" +
     workspaceReference +
     "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  // So does a workspace truncated exactly at a dangling terminal marker.
+  "https://console.cloud.google.com/bigquery?ws=" + workspaceReference + "!4m3",
   // URL-shaped input whose URL constructor throws.
   "https://",
   "https://console.cloud.google.com/bigquery?ws=" +
@@ -852,6 +862,10 @@ for (const rejectedUrl of [
     workspaceReference +
     "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
     "!2sother_dataset!23sRESOURCE_LIST",
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
+  "https://console.cloud.google.com/bigquery?ws=" + workspaceReference + "!4m3",
   "https://",
 ]) {
   resetTableInputs();

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
-import * as configurator from "../docs/configurator.mjs";
 import {
   buildDashboardUrl,
   buildSetupUrl,
-  validateConfiguration,
-  splitQualifiedTableId,
+  parseBigQueryConsoleTableUrl,
   parseQualifiedTableIdForInput,
+  parseTableReference,
+  parseTableReferenceForInput,
+  splitQualifiedTableId,
+  validateConfiguration,
 } from "../docs/configurator.mjs";
 import { REPORT_CONFIG } from "../docs/report-config.mjs";
 
@@ -117,24 +119,6 @@ const qualifiedTableId = {
   table: "my_table",
 };
 
-assert.equal(
-  typeof configurator.parseBigQueryConsoleTableUrl,
-  "function",
-  "the configurator exports a pure BigQuery Console URL parser",
-);
-
-assert.equal(
-  typeof configurator.parseTableReference,
-  "function",
-  "the configurator exports a unified paste parser",
-);
-
-assert.equal(
-  typeof configurator.parseTableReferenceForInput,
-  "function",
-  "the configurator exports a validated committed-input parser",
-);
-
 assert.deepEqual(
   splitQualifiedTableId("my-project.my_dataset.my_table"),
   qualifiedTableId,
@@ -209,17 +193,17 @@ for (const url of [
   encodedConsoleTableUrl,
 ]) {
   assert.deepEqual(
-    configurator.parseBigQueryConsoleTableUrl(url),
+    parseBigQueryConsoleTableUrl(url),
     consoleTableId,
     `${url} resolves to the copied BigQuery table`,
   );
   assert.deepEqual(
-    configurator.parseTableReference(url),
+    parseTableReference(url),
     consoleTableId,
     `${url} is accepted by the unified paste parser`,
   );
   assert.deepEqual(
-    configurator.parseTableReferenceForInput(url),
+    parseTableReferenceForInput(url),
     consoleTableId,
     `${url} is accepted by the committed-input parser`,
   );
@@ -251,12 +235,12 @@ for (const rejectedUrl of [
     "!2sbqaa_looker_demo!3stable$20260812",
 ]) {
   assert.equal(
-    configurator.parseBigQueryConsoleTableUrl(rejectedUrl),
+    parseBigQueryConsoleTableUrl(rejectedUrl),
     null,
     `${rejectedUrl} is rejected without extracting identifiers`,
   );
   assert.equal(
-    configurator.parseTableReference(rejectedUrl),
+    parseTableReference(rejectedUrl),
     null,
     `${rejectedUrl} cannot fall through to qualified-ID parsing`,
   );

--- a/docs/superpowers/plans/2026-08-12-bigquery-console-url-paste.md
+++ b/docs/superpowers/plans/2026-08-12-bigquery-console-url-paste.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - Accept only HTTPS URLs on `pantheon.corp.google.com` or `console.cloud.google.com` with exact path `/bigquery`.
-- Require exactly one `ws` parameter and exactly one complete `!1m5!1m4!4m3!1sPROJECT!2sDATASET!3sTABLE` reference.
+- Require exactly one `ws` parameter and at least one complete `!4m3!1sPROJECT!2sDATASET!3sTABLE` reference, all naming the same table (the enclosing group counts vary with Console UI-state fields, so they are not matched).
 - Apply `PROJECT_RE`, `DATASET_RE`, and `TABLE_RE` to URL-derived components before recognizing the URL.
 - Rejected URLs must not fill any other identifier field.
 - Preserve all merged #405 qualified-ID, validation, and fallback behavior.

--- a/docs/superpowers/plans/2026-08-12-bigquery-console-url-paste.md
+++ b/docs/superpowers/plans/2026-08-12-bigquery-console-url-paste.md
@@ -1,0 +1,163 @@
+# BigQuery Console URL Paste Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept strict BigQuery table URLs from Pantheon and public Google Cloud Console in the existing Looker Studio configurator paste flow.
+
+**Architecture:** Add a pure allowlisted URL parser beside the existing qualified-ID parser, then route the existing paste and committed-input handlers through one table-reference boundary. Reuse all existing field assignment and validation behavior; add no network calls or dependencies.
+
+**Tech Stack:** Browser-native JavaScript modules, `URL`, `URLSearchParams`, Node `assert`, static HTML.
+
+## Global Constraints
+
+- Accept only HTTPS URLs on `pantheon.corp.google.com` or `console.cloud.google.com` with exact path `/bigquery`.
+- Require exactly one `ws` parameter and exactly one complete `!1m5!1m4!4m3!1sPROJECT!2sDATASET!3sTABLE` reference.
+- Apply `PROJECT_RE`, `DATASET_RE`, and `TABLE_RE` to URL-derived components before recognizing the URL.
+- Rejected URLs must not fill any other identifier field.
+- Preserve all merged #405 qualified-ID, validation, and fallback behavior.
+- Add no fetch, navigation, external dependency, or BigQuery Console URL decoding beyond the approved workspace pattern.
+
+---
+
+### Task 1: Pure BigQuery Console URL parsing
+
+**Files:**
+- Modify: `dashboard/looker_studio/tools/test_web_configurator.mjs`
+- Modify: `dashboard/looker_studio/docs/configurator.mjs`
+
+**Interfaces:**
+- Consumes: `PROJECT_RE`, `DATASET_RE`, `TABLE_RE`, and `splitQualifiedTableId(value)`.
+- Produces: `parseBigQueryConsoleTableUrl(value)`, `parseTableReference(value)`, and `parseTableReferenceForInput(value)`, each returning `{ project, dataset, table } | null`.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add literal assertions for the reported Pantheon URL, the equivalent public
+Console URL, encoded `ws` markers, and rejection of HTTP, foreign host,
+userinfo, non-default port, wrong path, missing/duplicate `ws`, incomplete or
+duplicate marker sequences, and invalid components.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node dashboard/looker_studio/tools/test_web_configurator.mjs
+```
+
+Expected: failure because `parseBigQueryConsoleTableUrl` and the unified
+table-reference functions are not exported.
+
+- [ ] **Step 3: Implement the minimal pure parser**
+
+Use `new URL()` in a `try` block, exact protocol/host/path checks,
+`searchParams.getAll("ws")`, one global match of the approved workspace
+pattern, and the three existing identifier regexes. Route URL-shaped input
+only through this parser; route non-URL input through
+`splitQualifiedTableId()`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+node dashboard/looker_studio/tools/test_web_configurator.mjs
+```
+
+Expected: all existing and new parser assertions pass.
+
+### Task 2: Browser paste and committed-input integration
+
+**Files:**
+- Modify: `dashboard/looker_studio/tools/test_web_configurator.mjs`
+- Modify: `dashboard/looker_studio/docs/app.mjs`
+
+**Interfaces:**
+- Consumes: `parseTableReference(value)` and `parseTableReferenceForInput(value)` from Task 1.
+- Produces: existing UI behavior extended to recognized Console URLs, with no new DOM API.
+
+- [ ] **Step 1: Write failing DOM behavior tests**
+
+For both allowed hosts, paste a literal table URL into each of `project`,
+`dataset`, and `table`; assert all three fields and the ready status. Add a
+committed-input case and rejected-URL cases asserting that no other field is
+changed and the paste is not intercepted.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node dashboard/looker_studio/tools/test_web_configurator.mjs
+```
+
+Expected: URL paste is not intercepted and the fields are not distributed.
+
+- [ ] **Step 3: Route handlers through the unified parser**
+
+Replace the paste handler's `splitQualifiedTableId(text)` call with
+`parseTableReference(text)`. Replace the change handler's
+`parseQualifiedTableIdForInput(value)` call with
+`parseTableReferenceForInput(value)`. Keep `afterQualifiedTableId()` as the
+single mutation and refresh path.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+node dashboard/looker_studio/tools/test_web_configurator.mjs
+```
+
+Expected: URL and existing qualified-ID UI cases pass.
+
+### Task 3: User guidance and final verification
+
+**Files:**
+- Modify: `dashboard/looker_studio/docs/index.html`
+- Modify: `tests/test_looker_studio_dashboard.py`
+
+**Interfaces:**
+- Consumes: the supported paste contract from Tasks 1 and 2.
+- Produces: visible configurator guidance pinned by the existing dashboard test suite.
+
+- [ ] **Step 1: Write the failing guidance assertion**
+
+Add a behavioral source assertion that the project-field hint tells users they
+may paste a fully qualified table ID or BigQuery Console table link into any
+identifier field.
+
+- [ ] **Step 2: Run the dashboard test and verify RED**
+
+Run:
+
+```bash
+pytest -q tests/test_looker_studio_dashboard.py
+```
+
+Expected: failure because the guidance is absent.
+
+- [ ] **Step 3: Add concise guidance**
+
+Update `project-hint` in `docs/index.html` with one sentence describing both
+accepted paste forms and the any-field behavior, without changing the three
+fields as the source of truth.
+
+- [ ] **Step 4: Run complete verification**
+
+Run:
+
+```bash
+node dashboard/looker_studio/tools/test_web_configurator.mjs
+pytest -q tests/test_looker_studio_dashboard.py
+bash autoformat.sh
+git diff --check
+```
+
+Expected: every command exits 0 with no failing test or formatting error.
+
+- [ ] **Step 5: Commit and publish**
+
+Stage only the design, plan, parser, browser integration, guidance, and tests;
+commit as `feat: accept BigQuery Console table links`, push
+`agent/403-console-url-paste` to the upstream repository, and open a draft PR
+against `GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK:main` linking #403.

--- a/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
+++ b/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
@@ -25,7 +25,9 @@ An accepted URL must:
    `!4m3` core (for example `!1m5!1m4` or `!1m6!1m5`) vary with UI-state
    fields the Console appends, such as `!23sRESOURCE_LIST`, so they are not
    part of the contract. A workspace naming two different tables is
-   ambiguous and is rejected.
+   ambiguous and is rejected, as is one holding a truncated `!4m3` table
+   marker or a coexisting `!3m2` dataset-view resource — in either case
+   the active selection cannot be proved from the undocumented encoding.
 
 `URL` and `URLSearchParams` perform percent-decoding before the workspace
 reference is parsed. The extracted components must satisfy the existing

--- a/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
+++ b/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
@@ -1,0 +1,65 @@
+# BigQuery Console URL Paste Design
+
+## Goal
+
+Extend the Looker Studio configurator's merged #405 paste behavior so a user
+can paste a BigQuery table URL copied from either Google Console host and have
+the project, dataset, and table fields populated.
+
+Supported hosts are exactly:
+
+- `pantheon.corp.google.com`
+- `console.cloud.google.com`
+
+## Accepted URL contract
+
+An accepted URL must:
+
+1. be an absolute HTTPS URL without user information or a non-default port;
+2. use one of the two exact hostnames above;
+3. use the exact `/bigquery` path;
+4. contain exactly one `ws` query parameter; and
+5. contain exactly one complete decoded
+   `!1m5!1m4!4m3!1sPROJECT!2sDATASET!3sTABLE` table reference in `ws`.
+
+`URL` and `URLSearchParams` perform percent-decoding before the workspace
+reference is parsed. The extracted components must satisfy the existing
+`PROJECT_RE`, `DATASET_RE`, and `TABLE_RE` validators.
+
+Foreign hosts, HTTP URLs, unrelated paths, missing or repeated `ws`
+parameters, incomplete or repeated table-reference markers, and invalid
+identifiers are not recognized. An unrecognized URL follows ordinary browser
+paste behavior and never fills the other identifier fields.
+
+## Code structure
+
+`docs/configurator.mjs` owns parsing. A pure
+`parseBigQueryConsoleTableUrl(value)` function recognizes the URL contract.
+`parseTableReference(value)` selects the URL parser for URL-shaped input and
+otherwise delegates to the existing `splitQualifiedTableId(value)` behavior.
+`parseTableReferenceForInput(value)` applies the existing stricter validation
+used by the committed-input fallback.
+
+`docs/app.mjs` uses the unified table-reference functions in the existing
+paste and change handlers. Successful URL parsing therefore reuses the same
+field assignment, validation, dashboard-link refresh, and success status as a
+qualified ID. No fetch, navigation, or new dependency is introduced.
+
+`docs/index.html` tells users that a fully qualified ID or BigQuery Console
+table link can be pasted into any of the three identifier fields.
+
+## Verification
+
+`tools/test_web_configurator.mjs` covers:
+
+- the reported Pantheon URL and the public Console equivalent;
+- percent-encoded workspace markers;
+- paste into each of the three identifier fields;
+- the committed-input fallback;
+- exact host, protocol, port, path, `ws`, marker, and identifier rejection;
+- no partial field mutation for rejected URLs; and
+- preservation of every existing qualified-ID and plain-input case.
+
+The focused Node test and `tests/test_looker_studio_dashboard.py` must pass,
+followed by the repository formatter/check script relevant to the touched
+JavaScript and HTML files.

--- a/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
+++ b/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
@@ -34,9 +34,11 @@ reference is parsed. The extracted components must satisfy the existing
 `PROJECT_RE`, `DATASET_RE`, and `TABLE_RE` validators.
 
 Foreign hosts, HTTP URLs, unrelated paths, missing or repeated `ws`
-parameters, incomplete or repeated table-reference markers, and invalid
-identifiers are not recognized. An unrecognized URL follows ordinary browser
-paste behavior and never fills the other identifier fields.
+parameters, incomplete table-reference markers, complete references naming
+different tables, and invalid identifiers are not recognized. Repeated
+complete references that all name the same table remain supported, per the
+rules above. An unrecognized URL follows ordinary browser paste behavior and
+never fills the other identifier fields.
 
 ## Code structure
 

--- a/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
+++ b/docs/superpowers/specs/2026-08-12-bigquery-console-url-paste-design.md
@@ -19,8 +19,13 @@ An accepted URL must:
 2. use one of the two exact hostnames above;
 3. use the exact `/bigquery` path;
 4. contain exactly one `ws` query parameter; and
-5. contain exactly one complete decoded
-   `!1m5!1m4!4m3!1sPROJECT!2sDATASET!3sTABLE` table reference in `ws`.
+5. contain at least one complete decoded
+   `!4m3!1sPROJECT!2sDATASET!3sTABLE` table reference in `ws`, with every
+   such reference naming the same table. The group counts that precede the
+   `!4m3` core (for example `!1m5!1m4` or `!1m6!1m5`) vary with UI-state
+   fields the Console appends, such as `!23sRESOURCE_LIST`, so they are not
+   part of the contract. A workspace naming two different tables is
+   ambiguous and is rejected.
 
 `URL` and `URLSearchParams` perform percent-decoding before the workspace
 reference is parsed. The extracted components must satisfy the existing

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -701,6 +701,9 @@ def test_googlecloudplatform_pages_configuration():
   assert 'name="twitter:card"' in page
   assert "Copy security checklist" in page
   assert "billing-project-hint" in page
+  assert (
+      "Paste a fully qualified table ID or BigQuery Console table link" in page
+  )
   assert "Designed for desktop screens at least 1280 px wide" in page
   assert "allow up to 90 seconds" in page
   assert "@media (prefers-color-scheme: dark)" in styles


### PR DESCRIPTION
## Summary

- accept copied BigQuery table links from both console.cloud.google.com and pantheon.corp.google.com
- strictly validate HTTPS host, path, workspace parameter cardinality, marker shape, and extracted identifiers before autofilling
- preserve the existing fully qualified table-ID paste/change flow and leave rejected URLs to ordinary browser paste behavior without partial autofill
- document the new input affordance in the configurator

## Testing

- uv run --isolated --extra dev pytest --tb=short -q (3991 passed, 72 skipped)
- node dashboard/looker_studio/tools/test_web_configurator.mjs
- bash dashboard/looker_studio/tools/browser_smoke.sh --self-test
- bash dashboard/looker_studio/tools/browser_smoke.sh
- bash autoformat.sh
- git diff --check upstream/main...HEAD

Follow-up to #403.
