### PR TITLE
docs(dashboard): add end-user manual for the Looker Studio dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ with a runnable ADK agent.
 |----------|-------------|
 | [SDK Feature Reference](SDK.md) | Complete API walkthrough with working code examples |
 | [Looker Studio Dashboard](dashboard/looker_studio/README.md) | Published 37-chart BQAA observability template with project/dataset/table configurator |
+| [Dashboard User Manual](dashboard/looker_studio/USER_MANUAL.md) | End-user guide to the Looker Studio dashboard: setup in three steps, page guide, sharing, troubleshooting |
 | [Agent Context Graph Codelab](docs/codelabs/periodic_materialization.md) | Extract decision traces from your agent's context graph, end to end (~35 min) |
 | [Scheduled Deploy Runbook](docs/guides/scheduled-context-graph-deploy.md) | Keep the context graph fresh on a Cloud Run + Cloud Scheduler cron |
 | [Design Documents](docs/README.md) | Architecture decisions and design rationale |

--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -6,6 +6,11 @@ built directly on the event table populated by the
 [ADK BigQuery Agent Analytics plugin](https://adk.dev/observability/bigquery-agent-analytics/).
 For teams that run BQAA but do not run Looker.
 
+**Just want to use the dashboard?** Read the
+[User Manual](USER_MANUAL.md) — prerequisites, three-step setup, page guide,
+and troubleshooting, written for dashboard users rather than contributors.
+This README is the contributor and operations reference.
+
 The implementation and acceptance contract is tracked in
 [issue #365](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/365).
 This directory is self-contained and has no dependency on the SDK runtime.

--- a/dashboard/looker_studio/USER_MANUAL.md
+++ b/dashboard/looker_studio/USER_MANUAL.md
@@ -7,9 +7,9 @@ the rest of this repository. If you want to change or validate the dashboard
 itself, see the [contributor README](README.md) instead.
 
 **What you get:** your own copy of an 8-page Looker Studio dashboard — token
-consumption, sessions, tool usage, LLM calls, user analytics, latency, errors,
-and a trace inspector — built on the `agent_events` table your agents already
-write. Your copy is private, reads your data with your credentials, and bills
+consumption, sessions, tool usage, LLM calls, user analytics, latency, tool
+errors, and a trace inspector — built on the `agent_events` table your agents
+already write. Your copy is private, reads your data with your credentials, and bills
 your project. Setting it up takes about five minutes.
 
 ---
@@ -98,17 +98,24 @@ In Looker Studio:
    until every step below is done.
 3. Open **Resource → Manage added data sources → Edit**.
 4. Set **Data credentials** to **Viewer**.
-5. Before sharing widely, **test the report with an account that has only
-   viewer access** — it should see charts only if that account can read the
-   BigQuery table.
+5. Before sharing widely, run **both** of these tests:
+   - Share with an account that has **no access to the BigQuery table**. It
+     must see errors or empty charts, **not data**. If it sees data, the
+     report is still on Owner's credentials — go back to step 4.
+   - Share with an account that **should** have access (table read plus
+     permission to run BigQuery jobs in the billing project — the same two
+     permissions from [Before you start](#before-you-start)). It must render
+     charts.
 
 Step 4 is the one that matters most: with Viewer's credentials, every person
-you share the report with sees data only if *they* can read the underlying
-BigQuery table. With Owner's credentials (which the creation dialog may
-default to), everyone you share with would see the data using **your**
-access. Step 5 is how you prove it worked. The configurator page has a
-**Copy security checklist** button with these same five steps, ready to paste
-into a handoff note.
+you share the report with sees data only through *their own* BigQuery access.
+With Owner's credentials (which the creation dialog may default to), everyone
+you share with would see the data using **your** access — which is exactly why
+a viewer test that shows data can be a *failure*, not a success. Step 5's two
+checks prove both halves: no-access accounts are locked out, authorized
+viewers get charts. The configurator page has a **Copy security checklist**
+button with a compact version of these steps, ready to paste into a handoff
+note.
 
 That's it — you now have your own dashboard.
 
@@ -126,7 +133,7 @@ That's it — you now have your own dashboard.
 | **LLM Interactions** | How many model calls, and how are they trending? |
 | **User Analytics** | Who uses the agents most — events, sessions, tokens, traces per user? |
 | **Latency** | How slow are LLM and tool calls — averages, p50/p75/p90/p99, trends? |
-| **Errors** | How many errors, and which agents and tools produce them? |
+| **Errors** | How many **tool** errors, and which agents and tools produce them? (LLM errors are not charted in v1.) |
 | **Trace Inspector** | Drill into individual events: timestamp, type, agent, user, trace, span, status. |
 
 ### The date control
@@ -186,7 +193,17 @@ date window you select and how much you interact:
 ### Check compatibility before creating (optional, needs a terminal)
 
 If you'd like a preflight — for a non-standard setup, or to validate the table
-before rolling the dashboard out — clone this repository and run:
+before rolling the dashboard out — you need the `bq` CLI installed and
+authenticated, plus one Python package. Install the package first:
+
+```sh
+python3 -m pip install pyyaml
+```
+
+Then clone this repository and run the helper, using your dataset's actual
+location (shown in the dataset's **Details** panel in the BigQuery console —
+for example `US`, `EU`, or `us-central1`; a mismatched location makes
+BigQuery reject the job):
 
 ```sh
 cd dashboard/looker_studio
@@ -194,16 +211,11 @@ python3 tools/hydrate_dashboard.py \
   --project YOUR_PROJECT_ID \
   --dataset YOUR_DATASET_ID \
   --table agent_events \
-  --location US
+  --location YOUR_DATASET_LOCATION
 ```
 
 It verifies the required columns and prints the same kind of creation URL the
-configurator produces. Requires the `bq` CLI, authenticated, plus one Python
-package:
-
-```sh
-python3 -m pip install pyyaml
-```
+configurator produces.
 
 ---
 
@@ -220,7 +232,7 @@ python3 -m pip install pyyaml
 | Looker Studio asks me to sign in or authorize | Expected. The dashboard uses your credentials to read your data. Authorize BigQuery access on your own account. |
 | "Not found: Table …" in Looker Studio | One of the three identifiers is wrong, or your account can't read the table. Open the table in the BigQuery console to confirm the exact IDs and your access, then re-create from the configurator. |
 | Permission errors on charts | Your account needs to read the table *and* run BigQuery jobs in the billing project (see [Before you start](#before-you-start) for how to check each). If you set an Advanced billing project, you need the **BigQuery Job User** role there. |
-| Quota or reservation errors on charts | The billing project has hit a BigQuery limit — the error names which one. Quotas reset on their own schedule (daily quotas at midnight Pacific), so shortening the date range and waiting can be enough; otherwise ask the billing project's administrator to raise the quota or adjust reservations. Granting more IAM access will not fix a quota error. |
+| Quota or reservation errors on charts | The billing project has hit a BigQuery limit — the error names which one, and the reset behavior depends on that specific limit (many daily quotas replenish at intervals throughout the day; custom query quotas reset at midnight Pacific). Shortening the date range reduces what each chart scans. If the limit keeps biting, ask the billing project's administrator to raise that quota; if the project uses reservations, capacity is the administrator's dial, not a quota reset. Granting more IAM access will not fix a quota error. |
 | Numbers look stale | Check the date range includes today, then use Looker Studio's refresh. Ignore the footer's "Data Last Updated" — it's a connector timestamp, not your latest event. |
 | A colleague I shared with sees an error instead of data | Working as intended if they lack BigQuery access — the report uses Viewer's credentials (see Step 3), so each viewer needs read access to the table *and* permission to run BigQuery jobs in the billing project. Grant those, or don't. |
 
@@ -236,6 +248,7 @@ Still stuck? Open an issue:
   and bills your project. The template owner cannot see your data.
 - **Viewers bring their own access.** With the Step 3 credentials setting,
   sharing the report never shares the data — each viewer needs their own
-  BigQuery read access.
+  BigQuery table read access and their own permission to run BigQuery jobs
+  in the billing project.
 - **You pay only for BigQuery queries your charts run.** No services are
   installed, and the dashboard creates no BigQuery objects in your project.

--- a/dashboard/looker_studio/USER_MANUAL.md
+++ b/dashboard/looker_studio/USER_MANUAL.md
@@ -1,0 +1,219 @@
+# BigQuery Agent Analytics Dashboard — User Manual
+
+This guide is for people who **use** the dashboard: you run agents that log to
+BigQuery through the [ADK BigQuery Agent Analytics plugin](https://adk.dev/observability/bigquery-agent-analytics/),
+and you want charts. You do not need to install anything, write SQL, or read
+the rest of this repository. If you want to change or validate the dashboard
+itself, see the [contributor README](README.md) instead.
+
+**What you get:** your own copy of an 8-page Looker Studio dashboard — token
+consumption, sessions, tool usage, LLM calls, user analytics, latency, errors,
+and a trace inspector — built on the `agent_events` table your agents already
+write. Your copy is private, reads your data with your credentials, and bills
+your project. Setting it up takes about five minutes.
+
+---
+
+## Before you start
+
+You need three things:
+
+1. **A BQAA table with data in it.** If your agents run with the ADK BigQuery
+   Agent Analytics plugin, this already exists — it is the table the plugin
+   writes to, normally named `agent_events`.
+2. **A Google account that can read that table and run BigQuery jobs** in the
+   project that will pay for queries. If you can open the table in the
+   [BigQuery console](https://console.cloud.google.com/bigquery) and click
+   **Preview**, you are set.
+3. **A desktop browser window at least 1280 pixels wide.** The dashboard is a
+   desktop layout; phones and narrow tablets are not supported.
+
+You will be asked to know three identifiers: your **project ID**, **dataset
+ID**, and **table ID**. If you don't know them offhand, open your table in the
+BigQuery console — the breadcrumb at the top reads
+`project / dataset / table`, and the table header has a copy control for the
+full ID.
+
+---
+
+## Create your dashboard in three steps
+
+### Step 1 — Fill in the configurator
+
+Open the configurator:
+**<https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/>**
+
+You can fill the three fields by hand, or let one paste do it. Paste **any of
+these into any of the three fields** and all three fill at once:
+
+| What you paste | Example | Where to copy it |
+|---|---|---|
+| Fully qualified table ID | `my-project.my_dataset.agent_events` | BigQuery console table header → copy table ID |
+| The same, with backticks or a trailing `;` | `` `my-project.my_dataset.agent_events`; `` | Copied out of a SQL editor |
+| Legacy colon form | `my-project:my_dataset.agent_events` | Older tools and docs |
+| BigQuery Console table link | `https://console.cloud.google.com/bigquery?ws=…` | Your browser's address bar while viewing the table |
+
+For the console link: open your table in the BigQuery console so it is the
+table you're looking at, then copy the address-bar URL and paste it. The
+configurator reads the project, dataset, and table out of the link and fills
+the fields — you'll see a confirmation like *Split
+"my-project.my_dataset.agent_events" into the three fields.*
+
+A link is only accepted when it clearly names exactly one table. If it
+doesn't — for example your workspace has several different tables open — the
+paste lands as ordinary text in the one field and shows a validation error.
+Nothing else is overwritten; close the extra tabs in the BigQuery console (or
+type the IDs by hand) and try again.
+
+When every field is valid, the status line reads
+**Ready for `project.dataset.table`.**
+
+### Step 2 — Click "Create my dashboard"
+
+The button opens Looker Studio with your copy of the dashboard template,
+already pointed at your table. When Looker Studio asks, **authorize BigQuery
+access** — this is Google asking for your consent, on your account; nothing is
+shared with the template's owner.
+
+The first screen can take a moment. Allow up to 90 seconds on a cold load
+before every chart is painted.
+
+### Step 3 — Save your copy, then secure it
+
+In Looker Studio:
+
+1. Select **Edit and share** to save the report to your account.
+2. Keep the new report **private** for now.
+3. Open **Resource → Manage added data sources → Edit**.
+4. Set **Data credentials** to **Viewer** before you share the report with
+   anyone.
+
+That last step matters: with Viewer's credentials, every person you share the
+report with sees data only if *they* can read the underlying BigQuery table.
+With Owner's credentials (which the creation dialog may default to), everyone
+you share with would see the data using **your** access. The configurator page
+has a **Copy security checklist** button with these same steps, ready to paste
+into a handoff note.
+
+That's it — you now have your own dashboard.
+
+---
+
+## Reading the dashboard
+
+### The eight pages
+
+| Page | What it answers |
+|---|---|
+| **Token Consumption** | How many tokens are my agents using, over time and by agent? |
+| **Agent & Sessions** | How many sessions and traces, and which agents are busiest? |
+| **Tool Usage** | Which tools are called, how often, completed by which agent? |
+| **LLM Interactions** | How many model calls, and how are they trending? |
+| **User Analytics** | Who uses the agents most — events, sessions, tokens, traces per user? |
+| **Latency** | How slow are LLM and tool calls — averages, p50/p75/p90/p99, trends? |
+| **Errors** | How many errors, and which agents and tools produce them? |
+| **Trace Inspector** | Drill into individual events: timestamp, type, agent, user, trace, span, status. |
+
+### The date control
+
+All eight pages share **one date range control**. It defaults to a rolling
+90-day window including today, and a change on any page follows you to every
+other page, including the Trace Inspector. Shorter windows are cheaper and
+faster — pick the shortest range that answers your question.
+
+### Three things worth knowing
+
+- **First paint is not instant.** A cold load or page switch can take up to 90
+  seconds before every chart on the page is drawn. The report controls appear
+  first; the charts catch up.
+- **Collapse the left navigation drawer.** At the 1280-pixel minimum width,
+  Looker Studio's expanded drawer overlays the report's left edge. Collapse it
+  to see the full page.
+- **"Data Last Updated" in the footer is not your data's freshness.** It is
+  Looker Studio's connector refresh time. Your newest events may be newer or
+  older than that stamp.
+
+---
+
+## Everyday tasks
+
+### Share a ready-to-use setup link with your team
+
+The configurator accepts prefilled identifiers in the URL:
+
+```text
+https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/?project=PROJECT_ID&dataset=DATASET_ID&table=agent_events
+```
+
+Fill in your values, or click **Copy setup link** on the configurator after
+entering them. Teammates open the link, click **Create my dashboard**, and get
+their own private copy over the same table — no identifiers to retype.
+
+### Bill queries to a different project
+
+If your team separates data storage from query billing, expand **Advanced
+settings** on the configurator and enter a **Billing project ID**. Dashboard
+queries then run (and are billed) in that project. You need permission to run
+BigQuery jobs there.
+
+### Keep query costs predictable
+
+Every chart reads one date-pruned query over your table, so cost tracks the
+date window you select and how much you interact:
+
+- Prefer short date ranges; the 90-day default is a get-started view, not a
+  recommendation.
+- Keep the table partitioned on its event timestamp (the ADK plugin's default
+  setup does this) so the date control prunes what BigQuery scans.
+- If costs matter to your team at scale, your admins can find deeper operating
+  guidance in the [contributor README](README.md#large-table-operating-guidance).
+
+### Check compatibility before creating (optional, needs a terminal)
+
+If you'd like a preflight — for a non-standard setup, or to validate the table
+before rolling the dashboard out — clone this repository and run:
+
+```sh
+cd dashboard/looker_studio
+python3 tools/hydrate_dashboard.py \
+  --project YOUR_PROJECT_ID \
+  --dataset YOUR_DATASET_ID \
+  --table agent_events \
+  --location US
+```
+
+It verifies the required columns and prints the same kind of creation URL the
+configurator produces. Requires the `bq` CLI, authenticated.
+
+---
+
+## Troubleshooting
+
+| What you see | What's happening and what to do |
+|---|---|
+| Charts blank or trickling in after opening a page | Normal on a cold load — allow up to 90 seconds. If a chart is still empty after that, widen the date range: your table may have no events in the selected window. |
+| Layout looks cut off on the left | Collapse the Looker Studio navigation drawer, and make the window at least 1280 px wide. Phones and narrow tablets aren't supported. |
+| Bottom charts clipped on Token Consumption or Latency | You're on a copy created before 2026-07-29, which keeps the old page geometry. Create a fresh copy from the configurator. |
+| Pasted a console link but the fields didn't fill | The link must name exactly one table. Open the table itself in the BigQuery console (close other table tabs), copy the address-bar URL, and paste again — or just paste the dotted `project.dataset.table` ID from the table header's copy control. |
+| A field shows a red validation error | Fix just that field: project IDs are 6–30 lowercase characters; dataset IDs allow letters, digits, and underscores (no hyphens — that's a BigQuery rule); table IDs also allow hyphens. |
+| Looker Studio asks me to sign in or authorize | Expected. The dashboard uses your credentials to read your data. Authorize BigQuery access on your own account. |
+| "Not found: Table …" in Looker Studio | One of the three identifiers is wrong, or your account can't read the table. Open the table in the BigQuery console to confirm the exact IDs and your access, then re-create from the configurator. |
+| Permission or quota errors on charts | Your account needs to read the table *and* run BigQuery jobs in the billing project. If you set an Advanced billing project, check your access there. |
+| Numbers look stale | Check the date range includes today, then use Looker Studio's refresh. Ignore the footer's "Data Last Updated" — it's a connector timestamp, not your latest event. |
+| A colleague I shared with sees an error instead of data | Working as intended if they lack BigQuery access to the table — the report uses Viewer's credentials (see Step 3). Grant them read access to the table, or don't. |
+
+Still stuck? Open an issue:
+<https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues>.
+
+---
+
+## Privacy and cost, in plain terms
+
+- **Your data never leaves your control.** The template is public, but your
+  copy creates its own data source with your credentials, reads your table,
+  and bills your project. The template owner cannot see your data.
+- **Viewers bring their own access.** With the Step 3 credentials setting,
+  sharing the report never shares the data — each viewer needs their own
+  BigQuery read access.
+- **You pay only for BigQuery queries your charts run.** No services are
+  installed, and the dashboard creates no BigQuery objects in your project.

--- a/dashboard/looker_studio/USER_MANUAL.md
+++ b/dashboard/looker_studio/USER_MANUAL.md
@@ -21,10 +21,16 @@ You need three things:
 1. **A BQAA table with data in it.** If your agents run with the ADK BigQuery
    Agent Analytics plugin, this already exists — it is the table the plugin
    writes to, normally named `agent_events`.
-2. **A Google account that can read that table and run BigQuery jobs** in the
-   project that will pay for queries. If you can open the table in the
-   [BigQuery console](https://console.cloud.google.com/bigquery) and click
-   **Preview**, you are set.
+2. **A Google account that can read that table _and_ run BigQuery jobs** in
+   the project that will pay for queries. These are two separate permissions:
+   - *Read:* open the table in the
+     [BigQuery console](https://console.cloud.google.com/bigquery) and click
+     **Preview**. Seeing rows proves read access — and only read access.
+   - *Run jobs:* in that same console window, run a tiny query such as
+     `SELECT COUNT(*)` on the table. If it completes, you can run jobs in the
+     selected project. If it fails with a permission error, ask your admin
+     for the **BigQuery Job User** role in the project that will pay for
+     queries.
 3. **A desktop browser window at least 1280 pixels wide.** The dashboard is a
    desktop layout; phones and narrow tablets are not supported.
 
@@ -70,29 +76,38 @@ When every field is valid, the status line reads
 
 ### Step 2 — Click "Create my dashboard"
 
-The button opens Looker Studio with your copy of the dashboard template,
-already pointed at your table. When Looker Studio asks, **authorize BigQuery
-access** — this is Google asking for your consent, on your account; nothing is
-shared with the template's owner.
+The button opens Looker Studio in a new tab with your copy of the dashboard
+template, already pointed at your table. **Building your copy can take about
+10 seconds, and the tab may briefly show a loading, not-found, or error page
+while Google provisions the report — don't close it.** It resolves on its
+own.
 
-The first screen can take a moment. Allow up to 90 seconds on a cold load
-before every chart is painted.
+When Looker Studio asks, **authorize BigQuery access** — this is Google
+asking for your consent, on your account; nothing is shared with the
+template's owner.
+
+Once the report itself appears, the charts take longer than the controls.
+Allow up to 90 seconds on a cold load before every chart is painted.
 
 ### Step 3 — Save your copy, then secure it
 
 In Looker Studio:
 
 1. Select **Edit and share** to save the report to your account.
-2. Keep the new report **private** for now.
+2. Keep the new report **private** while you configure its data source — and
+   until every step below is done.
 3. Open **Resource → Manage added data sources → Edit**.
-4. Set **Data credentials** to **Viewer** before you share the report with
-   anyone.
+4. Set **Data credentials** to **Viewer**.
+5. Before sharing widely, **test the report with an account that has only
+   viewer access** — it should see charts only if that account can read the
+   BigQuery table.
 
-That last step matters: with Viewer's credentials, every person you share the
-report with sees data only if *they* can read the underlying BigQuery table.
-With Owner's credentials (which the creation dialog may default to), everyone
-you share with would see the data using **your** access. The configurator page
-has a **Copy security checklist** button with these same steps, ready to paste
+Step 4 is the one that matters most: with Viewer's credentials, every person
+you share the report with sees data only if *they* can read the underlying
+BigQuery table. With Owner's credentials (which the creation dialog may
+default to), everyone you share with would see the data using **your**
+access. Step 5 is how you prove it worked. The configurator page has a
+**Copy security checklist** button with these same five steps, ready to paste
 into a handoff note.
 
 That's it — you now have your own dashboard.
@@ -183,7 +198,12 @@ python3 tools/hydrate_dashboard.py \
 ```
 
 It verifies the required columns and prints the same kind of creation URL the
-configurator produces. Requires the `bq` CLI, authenticated.
+configurator produces. Requires the `bq` CLI, authenticated, plus one Python
+package:
+
+```sh
+python3 -m pip install pyyaml
+```
 
 ---
 
@@ -191,6 +211,7 @@ configurator produces. Requires the `bq` CLI, authenticated.
 
 | What you see | What's happening and what to do |
 |---|---|
+| The new tab shows loading, not-found, or an error page right after clicking **Create my dashboard** | Google is still provisioning your report copy — this resolves within about 10 seconds. Don't close the tab. If it's still broken after a minute, close it and click the button again. |
 | Charts blank or trickling in after opening a page | Normal on a cold load — allow up to 90 seconds. If a chart is still empty after that, widen the date range: your table may have no events in the selected window. |
 | Layout looks cut off on the left | Collapse the Looker Studio navigation drawer, and make the window at least 1280 px wide. Phones and narrow tablets aren't supported. |
 | Bottom charts clipped on Token Consumption or Latency | You're on a copy created before 2026-07-29, which keeps the old page geometry. Create a fresh copy from the configurator. |
@@ -198,9 +219,10 @@ configurator produces. Requires the `bq` CLI, authenticated.
 | A field shows a red validation error | Fix just that field: project IDs are 6–30 lowercase characters; dataset IDs allow letters, digits, and underscores (no hyphens — that's a BigQuery rule); table IDs also allow hyphens. |
 | Looker Studio asks me to sign in or authorize | Expected. The dashboard uses your credentials to read your data. Authorize BigQuery access on your own account. |
 | "Not found: Table …" in Looker Studio | One of the three identifiers is wrong, or your account can't read the table. Open the table in the BigQuery console to confirm the exact IDs and your access, then re-create from the configurator. |
-| Permission or quota errors on charts | Your account needs to read the table *and* run BigQuery jobs in the billing project. If you set an Advanced billing project, check your access there. |
+| Permission errors on charts | Your account needs to read the table *and* run BigQuery jobs in the billing project (see [Before you start](#before-you-start) for how to check each). If you set an Advanced billing project, you need the **BigQuery Job User** role there. |
+| Quota or reservation errors on charts | The billing project has hit a BigQuery limit — the error names which one. Quotas reset on their own schedule (daily quotas at midnight Pacific), so shortening the date range and waiting can be enough; otherwise ask the billing project's administrator to raise the quota or adjust reservations. Granting more IAM access will not fix a quota error. |
 | Numbers look stale | Check the date range includes today, then use Looker Studio's refresh. Ignore the footer's "Data Last Updated" — it's a connector timestamp, not your latest event. |
-| A colleague I shared with sees an error instead of data | Working as intended if they lack BigQuery access to the table — the report uses Viewer's credentials (see Step 3). Grant them read access to the table, or don't. |
+| A colleague I shared with sees an error instead of data | Working as intended if they lack BigQuery access — the report uses Viewer's credentials (see Step 3), so each viewer needs read access to the table *and* permission to run BigQuery jobs in the billing project. Grant those, or don't. |
 
 Still stuck? Open an issue:
 <https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues>.


### PR DESCRIPTION
## Summary

- add `dashboard/looker_studio/USER_MANUAL.md`, an end-user guide to the Looker Studio dashboard, kept separate from the contributor README
- link it from the dashboard README ("Just want to use the dashboard?") and the repository README's documentation table

## Documentation Generated

| File | Diataxis quadrant | Description |
|------|----------|-------------|
| dashboard/looker_studio/USER_MANUAL.md | Tutorial + How-to + Reference + Troubleshooting | Prerequisites, three-step setup, page-by-page reading guide, everyday tasks, troubleshooting table, plain-language privacy/cost summary |
| dashboard/looker_studio/README.md | (link) | One-paragraph pointer separating user docs from contributor docs |
| README.md | (link) | Documentation-table row for the manual |

## Notes for review

- Every UI string in the manual was verified against `docs/index.html` / `app.mjs` at head ("Create my dashboard", "Copy setup link", "Copy security checklist", the `Ready for …` and `Split …` status lines).
- The "paste a BigQuery Console table link" rows describe the behavior added in #424; if this lands first, that table documents a feature that arrives with #424. Suggest merging #424 first (it is CI-green and finding-free).
- Facts sourced from the contributor README and `docs/dashboard-implementation.md`: 8 pages / 37 parity charts, shared rolling-90-day date control, 90-second cold-load allowance, 1280 px minimum viewport with collapsed drawer, the 2026-07-29 clipped-page republish, and the Viewer's-Credentials sharing steps.

## Testing

- `python3 -m pytest tests/test_looker_studio_dashboard.py` — 26 passed
- Link check: relative links (`README.md`, `README.md#large-table-operating-guidance`, `USER_MANUAL.md`) resolve at their committed paths
