### PR TITLE
fix(examples): read BQ_LOCATION and make the dataset location discoverable

### DIFF
--- a/examples/dashboard_v2.ipynb
+++ b/examples/dashboard_v2.ipynb
@@ -81,7 +81,13 @@
     "**Source-of-truth hierarchy**:\n",
     "1. ADK plugin schema (`bigquery_agent_analytics_plugin.py`) — columns, types, JSON structure\n",
     "2. SDK semantic mirrors (`views.py`, `event_semantics.py`) — per-event extraction, event families\n",
-    "3. SDK aggregation patterns (`evaluators.py`) — session rollups, token COALESCE"
+    "3. SDK aggregation patterns (`evaluators.py`) — session rollups, token COALESCE\n",
+    "\n",
+    "**Before you run**: fill in your BigQuery target in *Cell 1: Configuration* —\n",
+    "`PROJECT_ID`, `DATASET_ID`, `TABLE_ID` and `LOCATION`. `LOCATION` is the one that\n",
+    "is easy to overlook: leave it as `None` for a US multi-region dataset, but set it\n",
+    "(or export `BQ_LOCATION`) to your dataset's region — e.g. `us-central1` — when the\n",
+    "dataset is single-region, or every query will fail to find the table."
    ]
   },
   {
@@ -186,7 +192,12 @@
     "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"<Your Dataset Id>\")\n",
     "TABLE_ID   = os.environ.get(\"BQ_TABLE\", \"<Your Table Id>\")\n",
     "TABLE_REF  = f\"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`\"\n",
-    "LOCATION   = os.environ.get(\"<Your Dataset Location>\") or None  # e.g., \"us-central1\", None = auto\n",
+    "\n",
+    "# Dataset location — also user-provided, and easy to miss. None auto-detects\n",
+    "# and is correct for a US multi-region dataset. If your dataset lives in a\n",
+    "# single region, set it here or export BQ_LOCATION (e.g. \"us-central1\",\n",
+    "# \"europe-west4\") — otherwise BigQuery will not find the dataset.\n",
+    "LOCATION   = os.environ.get(\"BQ_LOCATION\") or None\n",
     "\n",
     "# ---------- Required filters (top-level, every query) ----------\n",
     "TIME_RANGE_HOURS   = 720         # default: last 30 days\n",

--- a/examples/dashboard_v2_bigframes.ipynb
+++ b/examples/dashboard_v2_bigframes.ipynb
@@ -76,7 +76,13 @@
     "2. SDK semantic mirrors (`views.py`, `event_semantics.py`)\n",
     "3. SDK aggregation patterns (`evaluators.py`)\n",
     "\n",
-    "For the canonical pure-SQL reference, see `dashboard_v2.ipynb`."
+    "For the canonical pure-SQL reference, see `dashboard_v2.ipynb`.\n",
+    "\n",
+    "**Before you run**: fill in your BigQuery target in *Cell 1: Configuration* —\n",
+    "`PROJECT_ID`, `DATASET_ID`, `TABLE_ID` and `LOCATION`. `LOCATION` is the one that\n",
+    "is easy to overlook: leave it as `None` for a US multi-region dataset, but set it\n",
+    "(or export `BQ_LOCATION`) to your dataset's region — e.g. `us-central1` — when the\n",
+    "dataset is single-region, or every query will fail to find the table."
    ]
   },
   {
@@ -167,6 +173,11 @@
     "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"test-project-0728-467323\")\n",
     "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
     "TABLE_ID   = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
+    "\n",
+    "# Dataset location — also user-provided, and easy to miss. None auto-detects\n",
+    "# and is correct for a US multi-region dataset. If your dataset lives in a\n",
+    "# single region, set it here or export BQ_LOCATION (e.g. \"us-central1\",\n",
+    "# \"europe-west4\") — otherwise BigQuery will not find the dataset.\n",
     "LOCATION   = os.environ.get(\"BQ_LOCATION\") or None\n",
     "TABLE_REF  = f\"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`\"\n",
     "\n",


### PR DESCRIPTION
Follow-up to #426, from review feedback on the Dashboard V2 notebooks.

## Problem 1 — the env var lookup can never hit

`examples/dashboard_v2.ipynb` `cell-1-config` reads the location from an environment variable literally named `<Your Dataset Location>`:

```python
LOCATION   = os.environ.get("<Your Dataset Location>") or None  # e.g., "us-central1", None = auto
```

The placeholder landed in the *key* position instead of the default. Nothing ever exports a variable by that name, so `LOCATION` was unconditionally `None`, and exporting `BQ_LOCATION` — the name every other field in the block uses (`GOOGLE_CLOUD_PROJECT`, `BQ_DATASET`, `BQ_TABLE`), and the name `dashboard_v2_bigframes.ipynb` already reads — silently did nothing.

It looked fine in testing because `None` means auto-detect, which is right for a US multi-region dataset. A user with a single-region dataset had no working way to set the location.

## Problem 2 — it doesn't read as a field you're meant to edit

The other three targets announce themselves with `<Your ...>` placeholders:

```python
PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "<Your BQAA Project Id>")
DATASET_ID = os.environ.get("BQ_DATASET", "<Your Dataset Id>")
TABLE_ID   = os.environ.get("BQ_TABLE", "<Your Table Id>")
```

The location hid behind a trailing inline comment, so it doesn't register as something you may need to change — which is exactly how it got reported.

## Fix

Read `BQ_LOCATION`, and give the line its own comment block:

```python
# Dataset location — also user-provided, and easy to miss. None auto-detects
# and is correct for a US multi-region dataset. If your dataset lives in a
# single region, set it here or export BQ_LOCATION (e.g. "us-central1",
# "europe-west4") — otherwise BigQuery will not find the dataset.
LOCATION   = os.environ.get("BQ_LOCATION") or None
```

`None` stays the default rather than becoming a `<Your Dataset Location>` placeholder: auto-detect is correct for US multi-region, so the common path keeps running with no edit at all, and only regional users have to act.

Same wording added to the markdown header of both notebooks, so it's visible before anyone starts executing cells:

> **Before you run**: fill in your BigQuery target in *Cell 1: Configuration* — `PROJECT_ID`, `DATASET_ID`, `TABLE_ID` and `LOCATION`. `LOCATION` is the one that is easy to overlook: leave it as `None` for a US multi-region dataset, but set it (or export `BQ_LOCATION`) to your dataset's region — e.g. `us-central1` — when the dataset is single-region, or every query will fail to find the table.

Applied to both notebooks so the pair stays consistent. `dashboard_v2_bigframes.ipynb` already read the correct variable and only gains the comment and the header note.

## Scope

```
 examples/dashboard_v2.ipynb           | 15 +++++++++++++--
 examples/dashboard_v2_bigframes.ipynb | 13 ++++++++++++-
 2 files changed, 25 insertions(+), 3 deletions(-)
```

The three deletions are the old `<Your Dataset Location>` line and two markdown lines that gained a trailing newline. No reordering, no re-execution, existing cell outputs and cell IDs preserved.

## Verification

- Both files still parse as `nbformat` 4 with unchanged cell counts (63 and 36); both edited code cells pass `ast.parse`.
- Asserted `os.environ.get("BQ_LOCATION")` is present and `<Your Dataset Location>` is gone in both.
- JSON round-trips byte-identically outside the changed lines, which is why the diff is this small.
- **Not done**: an end-to-end run against a single-region dataset. The change is a variable rename plus comments, and `None` behaviour is unchanged, but say the word if you want that run before merge.

## Related, deliberately left alone

`dashboard_v2_bigframes.ipynb` still defaults to concrete values (`test-project-0728-467323`, `agent_analytics`, `agent_events`) where `dashboard_v2.ipynb` uses `<Your ...>` placeholders. Worth aligning, but it is a separate change from the location fix — happy to send it as a follow-up.