### PR TITLE
docs: clarify thinking-token accounting

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -194,6 +194,18 @@ evaluator = SystemEvaluator.cost_per_session(
 )
 ```
 
+`token_efficiency()` uses the session's `total_tokens`. When source telemetry
+provides Gemini `usage_metadata.total_token_count`, that provider-reported
+total can include `usage_metadata.thoughts_token_count`; it is therefore not
+guaranteed to equal `prompt_token_count + candidates_token_count`. If no
+provider total exists, the session query falls back to input plus output
+tokens.
+
+`cost_per_session()` is a separate estimate based only on `input_tokens` and
+`output_tokens` plus the configured rates. It does not consume a separate
+`thoughts_token_count` field, so do not treat it as provider invoice
+reconciliation when thinking tokens are present.
+
 `context_cache_hit_rate()` requires source telemetry that includes
 Gemini `usage_metadata.cached_content_token_count`. Older plugin data
 may not contain that field. When cache telemetry is absent, the

--- a/SDK.md
+++ b/SDK.md
@@ -194,12 +194,15 @@ evaluator = SystemEvaluator.cost_per_session(
 )
 ```
 
-`token_efficiency()` uses the session's `total_tokens`. When source telemetry
-provides Gemini `usage_metadata.total_token_count`, that provider-reported
-total can include `usage_metadata.thoughts_token_count`; it is therefore not
-guaranteed to equal `prompt_token_count + candidates_token_count`. If no
-provider total exists, the session query falls back to input plus output
-tokens.
+`token_efficiency()` uses the session's `total_tokens`. The session query
+prefers an explicit provider total: Gemini
+`usage_metadata.total_token_count`, followed by `content.usage.total` from
+other telemetry shapes. Gemini's total can include
+`usage_metadata.thoughts_token_count`; it is therefore not guaranteed to equal
+`prompt_token_count + candidates_token_count`. If neither provider total
+exists, the query falls back specifically to the raw `attributes.input_tokens`
+plus `attributes.output_tokens` event fields. That fallback does not reuse all
+alternate paths recognized by the separate input and output counters.
 
 `cost_per_session()` is a separate estimate based only on `input_tokens` and
 `output_tokens` plus the configured rates. It does not consume a separate

--- a/dashboard/looker_studio/USER_MANUAL.md
+++ b/dashboard/looker_studio/USER_MANUAL.md
@@ -143,7 +143,7 @@ All eight pages share **one date range control**. It defaults to a rolling
 other page, including the Trace Inspector. Shorter windows are cheaper and
 faster — pick the shortest range that answers your question.
 
-### Three things worth knowing
+### Four things worth knowing
 
 - **First paint is not instant.** A cold load or page switch can take up to 90
   seconds before every chart on the page is drawn. The report controls appear
@@ -154,6 +154,11 @@ faster — pick the shortest range that answers your question.
 - **"Data Last Updated" in the footer is not your data's freshness.** It is
   Looker Studio's connector refresh time. Your newest events may be newer or
   older than that stamp.
+- **Total tokens can exceed prompt plus completion.** The dashboard uses the
+  provider-reported total token count. Gemini telemetry can include thinking
+  tokens in that total, so prompt and completion counts in the source data may
+  not add up to the displayed total. The dashboard does not chart thinking
+  tokens separately.
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -480,6 +480,16 @@ value strictly exceeds the budget.
 | `ttft(threshold_ms)` | `avg_ttft_ms` | `observed <= threshold_ms` |
 | `cost_per_session(max_cost_usd, ...)` | `(input_tokens/1K)*input_rate + (output_tokens/1K)*output_rate` | `observed <= max_cost_usd` |
 
+For `token_efficiency()`, `total_tokens` prefers the provider-reported
+`usage_metadata.total_token_count`. Gemini can include
+`usage_metadata.thoughts_token_count` in that total, so the value is not
+guaranteed to equal prompt plus completion tokens. When a provider total is
+absent, the session summary falls back to input plus output tokens.
+
+`cost_per_session()` does not consume a separate `thoughts_token_count` field;
+it remains an estimate over the extracted input and output counts and the
+caller-supplied rates.
+
 `context_cache_hit_rate()` treats missing cache telemetry as unknown,
 not as a cache miss. Older plugin rows without
 `usage_metadata.cached_content_token_count` report

--- a/docs/design.md
+++ b/docs/design.md
@@ -480,11 +480,14 @@ value strictly exceeds the budget.
 | `ttft(threshold_ms)` | `avg_ttft_ms` | `observed <= threshold_ms` |
 | `cost_per_session(max_cost_usd, ...)` | `(input_tokens/1K)*input_rate + (output_tokens/1K)*output_rate` | `observed <= max_cost_usd` |
 
-For `token_efficiency()`, `total_tokens` prefers the provider-reported
-`usage_metadata.total_token_count`. Gemini can include
-`usage_metadata.thoughts_token_count` in that total, so the value is not
-guaranteed to equal prompt plus completion tokens. When a provider total is
-absent, the session summary falls back to input plus output tokens.
+For `token_efficiency()`, `total_tokens` prefers an explicit provider total:
+`usage_metadata.total_token_count`, followed by `content.usage.total` from
+other telemetry shapes. Gemini can include `usage_metadata.thoughts_token_count`
+in its total, so the value is not guaranteed to equal prompt plus completion
+tokens. When neither provider total exists, the session summary falls back
+specifically to the raw `attributes.input_tokens` plus
+`attributes.output_tokens` event fields. That fallback does not reuse all
+alternate paths recognized by the separate input and output counters.
 
 `cost_per_session()` does not consume a separate `thoughts_token_count` field;
 it remains an estimate over the extracted input and output counts and the


### PR DESCRIPTION
## Summary

- Clarify that `SystemEvaluator.token_efficiency()` prefers an explicit
  provider-reported total token count, which can include Gemini thinking tokens
  and therefore may not equal prompt plus completion tokens.
- Document the exact fallback to raw `attributes.input_tokens` plus
  `attributes.output_tokens` when no explicit provider total is available.
- Distinguish that behavior from `cost_per_session()`, which estimates cost
  using extracted input/output tokens and caller-provided rates without
  consuming a separate `thoughts_token_count` field.
- Add the same accounting caveat to the Looker Studio user manual and state
  that thinking tokens are not charted separately.

This addresses the thinking-token documentation follow-up in #382. It does not
close #382 or change evaluator or dashboard behavior.

## Testing

- Targeted evaluator and dashboard tests: 108 passed
- `pytest --tb=short -q` (Python 3.13): 4070 passed, 73 skipped
- `git diff --check`
