### PR TITLE
fix(eval): support alternate token metadata keys

### DIFF
--- a/src/bigquery_agent_analytics/evaluators.py
+++ b/src/bigquery_agent_analytics/evaluators.py
@@ -954,25 +954,32 @@ SELECT
     OR error_message IS NOT NULL
     OR status = 'ERROR'
   ) > 0 AS has_error,
+  -- Keep token-key precedence aligned with the dashboard extraction contract.
   SUM(COALESCE(
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
       attributes, '$.usage_metadata.prompt_token_count'
     ) AS INT64),
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
+      attributes, '$.usage_metadata.prompt_tokens'
+    ) AS INT64),
+    SAFE_CAST(JSON_VALUE(
       content, '$.usage.prompt'
     ) AS INT64),
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
       attributes, '$.input_tokens'
     ) AS INT64)
   )) AS input_tokens,
   SUM(COALESCE(
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
       attributes, '$.usage_metadata.candidates_token_count'
     ) AS INT64),
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
+      attributes, '$.usage_metadata.completion_tokens'
+    ) AS INT64),
+    SAFE_CAST(JSON_VALUE(
       content, '$.usage.completion'
     ) AS INT64),
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
       attributes, '$.output_tokens'
     ) AS INT64)
   )) AS output_tokens,
@@ -1054,18 +1061,39 @@ SELECT
     )
   ) IS NOT NULL) AS cache_telemetry_events,
   SUM(COALESCE(
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
       attributes, '$.usage_metadata.total_token_count'
     ) AS INT64),
-    CAST(JSON_VALUE(
+    SAFE_CAST(JSON_VALUE(
+      attributes, '$.usage_metadata.total_tokens'
+    ) AS INT64),
+    SAFE_CAST(JSON_VALUE(
       content, '$.usage.total'
     ) AS INT64),
     COALESCE(
-      CAST(JSON_VALUE(
+      SAFE_CAST(JSON_VALUE(
+        attributes, '$.usage_metadata.prompt_token_count'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
+        attributes, '$.usage_metadata.prompt_tokens'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
+        content, '$.usage.prompt'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
         attributes, '$.input_tokens'
       ) AS INT64), 0
     ) + COALESCE(
-      CAST(JSON_VALUE(
+      SAFE_CAST(JSON_VALUE(
+        attributes, '$.usage_metadata.candidates_token_count'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
+        attributes, '$.usage_metadata.completion_tokens'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
+        content, '$.usage.completion'
+      ) AS INT64),
+      SAFE_CAST(JSON_VALUE(
         attributes, '$.output_tokens'
       ) AS INT64), 0
     )

--- a/tests/test_sdk_evaluators.py
+++ b/tests/test_sdk_evaluators.py
@@ -14,6 +14,7 @@
 
 """Tests for the SDK evaluators module."""
 
+import re
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -477,6 +478,16 @@ class TestAIGenerateJudgeBatchQuery:
 class TestSessionSummaryQuery:
   """Tests for SESSION_SUMMARY_QUERY token fields."""
 
+  @staticmethod
+  def _metric_sql(alias):
+    match = re.search(
+        rf"SUM\(COALESCE\((.*?)\)\) AS {alias}",
+        SESSION_SUMMARY_QUERY,
+        re.DOTALL,
+    )
+    assert match is not None
+    return " ".join(match.group(1).split())
+
   def test_contains_input_tokens(self):
     assert "input_tokens" in SESSION_SUMMARY_QUERY
 
@@ -492,6 +503,57 @@ class TestSessionSummaryQuery:
 
   def test_contains_cache_telemetry_events(self):
     assert "cache_telemetry_events" in SESSION_SUMMARY_QUERY
+
+  def test_usage_metadata_token_alias_precedence(self):
+    input_sql = self._metric_sql("input_tokens")
+    input_paths = (
+        "$.usage_metadata.prompt_token_count",
+        "$.usage_metadata.prompt_tokens",
+        "$.usage.prompt",
+        "$.input_tokens",
+    )
+    input_positions = [input_sql.index(path) for path in input_paths]
+    assert input_positions == sorted(input_positions)
+
+    output_sql = self._metric_sql("output_tokens")
+    output_paths = (
+        "$.usage_metadata.candidates_token_count",
+        "$.usage_metadata.completion_tokens",
+        "$.usage.completion",
+        "$.output_tokens",
+    )
+    output_positions = [output_sql.index(path) for path in output_paths]
+    assert output_positions == sorted(output_positions)
+
+    total_sql = self._metric_sql("total_tokens")
+    total_paths = (
+        "$.usage_metadata.total_token_count",
+        "$.usage_metadata.total_tokens",
+        "$.usage.total",
+    )
+    total_positions = [total_sql.index(path) for path in total_paths]
+    assert total_positions == sorted(total_positions)
+
+  def test_total_token_fallback_uses_input_and_output_aliases(self):
+    total_sql = self._metric_sql("total_tokens")
+    for path in (
+        "$.usage_metadata.prompt_token_count",
+        "$.usage_metadata.prompt_tokens",
+        "$.usage.prompt",
+        "$.input_tokens",
+        "$.usage_metadata.candidates_token_count",
+        "$.usage_metadata.completion_tokens",
+        "$.usage.completion",
+        "$.output_tokens",
+    ):
+      assert path in total_sql
+
+  @pytest.mark.parametrize(
+      "alias", ("input_tokens", "output_tokens", "total_tokens")
+  )
+  def test_token_extraction_uses_safe_cast(self, alias):
+    metric_sql = self._metric_sql(alias)
+    assert re.search(r"(?<!SAFE_)CAST\(JSON_VALUE\(", metric_sql) is None
 
 
 class TestTokenEfficiencyPrebuilt:


### PR DESCRIPTION
## Summary

- Align `SESSION_SUMMARY_QUERY` token extraction with the dashboard's supported `usage_metadata` field variants.
- Accept `prompt_tokens`, `completion_tokens`, and `total_tokens` after their canonical `*_token_count` counterparts.
- Use `SAFE_CAST` so malformed numeric telemetry falls through to the next supported source instead of failing the session-summary query.
- Make the total-token fallback use the same input/output sources as the individual token aggregates.

Provider-reported total tokens remain authoritative when present, including totals that contain thinking tokens. Input plus output is used only when no reported total is available.

This change affects evaluator session summaries only. It does not change the plugin, telemetry schema, dashboard extraction, or cached-token accounting.

Fixes #442.

## Testing

- `pytest -q tests/test_sdk_evaluators.py` - 87 passed
- `pytest --tb=short -q` - 4075 passed, 73 skipped
- Repository formatter
- `git diff --check`