### PR TITLE
feat(evalbench): add BigQuery run reader and trace mapping

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -2491,6 +2491,33 @@ LangSmith data or provide a real-time streaming surface.
 
 ---
 
+## 24. EvalBench Import Reader
+
+The optional `bigquery_agent_analytics.evalbench` submodule reads one
+EvalBench `job_id` from its BigQuery `configs`, `results`, and `scores` tables
+and maps each scenario to BQAA-compatible synthetic trace rows. Source queries
+filter by a parameterized `job_id`; agentic and NL2SQL result aliases are both
+supported.
+
+```python
+from bigquery_agent_analytics.evalbench import EvalBenchRun
+
+run = EvalBenchRun.from_bigquery(
+    project_id="benchmark-project",
+    evalbench_dataset="evalbench",
+    job_id="abc123",
+    location="US",
+)
+rows = run.to_agent_event_rows()
+```
+
+This reader phase performs no writes. See
+[docs/evalbench.md](docs/evalbench.md) for the mapping contract, schema
+caveats, and the remaining materialization and CLI phases tracked by issue
+#97.
+
+---
+
 ## Module Architecture
 
 ```
@@ -2502,6 +2529,7 @@ bigquery_agent_analytics/
 │   └── evaluators.py          ← SystemEvaluator + LLMAsJudge + SQL templates
 │
 │   Evaluation Harness
+│   ├── evalbench.py           ← EvalBench BigQuery reader + event mapping
 │   ├── trace_evaluator.py     ← BigQueryTraceEvaluator, trajectory matching, replay
 │   ├── multi_trial.py         ← TrialRunner, pass@k, pass^k
 │   ├── grader_pipeline.py     ← GraderPipeline + scoring strategies

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ architecture, rationale, and implementation plans behind key SDK features.
 | Document | Description |
 |----------|-------------|
 | [hatteras_evaluation.md](hatteras_evaluation.md) | Hatteras-style categorical evaluation design |
+| [evalbench.md](evalbench.md) | EvalBench BigQuery run reader and synthetic BQAA event mapping (issue #97, reader phase) |
 
 ## Agent Context Graph
 

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -1,0 +1,115 @@
+# EvalBench Import Bridge
+
+`bigquery_agent_analytics.evalbench` reads one EvalBench BigQuery job and
+converts its result rows into the BQAA `agent_events` shape. This is a
+pull-only bridge: EvalBench remains the source of truth for benchmark results,
+and the SDK does not write into the ADK plugin's production `agent_events`
+table.
+
+This first implementation phase provides the reader and deterministic row
+mapping. Mirror-table materialization, idempotent replacement, score-table
+writes, CLI commands, and live integration tests remain later phases of
+[issue #97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97).
+
+## Data Flow
+
+```text
+EvalBench BigQuery dataset                    In-memory BQAA mapping
+
+configs  -- job_id = @job_id --+             agent identity + run time
+results  -- job_id = @job_id --+--> EvalBenchRun --> synthetic event rows
+scores   -- job_id = @job_id --+         |          USER_MESSAGE_RECEIVED
+                                           |          TOOL_* (when present)
+                                           |          AGENT_COMPLETED (when present)
+                                           +--> source score rows (unchanged)
+```
+
+All three source queries filter by the parameterized `job_id` in SQL. The
+reader currently loads that single run into memory.
+
+## Read And Map A Run
+
+```python
+from bigquery_agent_analytics.evalbench import EvalBenchRun
+
+run = EvalBenchRun.from_bigquery(
+    project_id="benchmark-project",
+    evalbench_dataset="evalbench",
+    job_id="abc123",
+    location="US",
+)
+
+event_rows = run.to_agent_event_rows()
+print(f"Mapped {len(run.results)} scenarios and loaded {len(run.scores)} scores")
+```
+
+The reader accepts both major EvalBench result shapes:
+
+| Meaning | NL2SQL fields | Agentic fields |
+|---|---|---|
+| Scenario | `id` | `eval_id` |
+| Prompt | `nl_prompt` | `prompt` or `scenario.starting_prompt` |
+| Final output | `generated_sql` | `stdout.response` |
+| Tool calls | optional | `stdout.tool_calls` or `accumulated_tools` |
+
+EvalBench's DataFrame writer can store nested objects as JSON or Python-literal
+strings. The mapper parses both structured encodings and leaves ordinary text
+unchanged.
+
+## Event Mapping
+
+Each scenario uses this identity:
+
+```text
+session_id = trace_id = evalbench:{job_id}:{scenario_id}
+agent      = evalbench:{orchestrator}:{generator}
+```
+
+`orchestrator`, `generator`, and the run timestamp come from EvalBench's
+flattened `configs` rows. If a historical run lacks config metadata, the agent
+components become `unknown`; if no timestamp is available, the mapper uses the
+Unix epoch and sets `attributes.evalbench_run_time_missing = true` rather than
+inventing a current timestamp.
+
+| Source data | Synthetic event | Required content |
+|---|---|---|
+| Prompt | `USER_MESSAGE_RECEIVED` | `text`, `text_summary` |
+| Tool call | `TOOL_STARTING` | `tool`, `args`, `text_summary` |
+| Tool result | `TOOL_COMPLETED` | `tool`, `result`, `text_summary` |
+| Final response or generated SQL | `AGENT_COMPLETED` | `response`, `text_summary` |
+
+Missing tool data emits no `TOOL_*` rows. Missing final output omits
+`AGENT_COMPLETED`. Missing `nl_prompt`/`prompt` is a hard error because a valid
+scenario trace cannot be built without the user message.
+
+Every row includes `attributes.experiment_id = job_id` and
+`attributes.evalbench_scenario_id = scenario_id`. Agentic token and latency
+metadata found in `stdout.stats.models` is normalized onto the terminal row as
+`usage_metadata`, `input_tokens`, `output_tokens`, and `latency_ms.total_ms`.
+
+## Why These Fields Matter
+
+The mapping follows the SDK queries that consume the future mirror table:
+
+- `client.py:138-158` projects the complete trace row contract in
+  `_GET_TRACE_QUERY`.
+- `trace.py:758-768` reads `attributes.experiment_id` for `TraceFilter`.
+- `evaluators.py:923-1076` reads latency and token counters in
+  `SESSION_SUMMARY_QUERY`.
+- `evaluators.py:1079-1102` builds judge text from `content.text_summary`,
+  selects `content.response`, and drops traces whose assembled text is not
+  longer than ten characters.
+
+The last constraint is easy to miss: a row can satisfy the BigQuery schema but
+remain invisible to `LLMAsJudge` when `text_summary` is absent. The mapper
+therefore populates it on every emitted event.
+
+## Current Boundaries
+
+- No BigQuery writes are performed by `to_agent_event_rows()`.
+- No `evalbench-import` or `evalbench-score` command exists yet.
+- `run.scores` preserves source score rows in memory; the
+  `evalbench_scores_imported` writer belongs to the materialization phase.
+- The future writer must target a BQAA-owned mirror table, accept a distinct
+  target project, and delete an existing `experiment_id` before append so a
+  repeated import cannot duplicate a run.

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -75,17 +75,22 @@ inventing a current timestamp.
 |---|---|---|
 | Prompt | `USER_MESSAGE_RECEIVED` | `text`, `text_summary` |
 | Tool call | `TOOL_STARTING` | `tool`, `args`, `text_summary` |
-| Tool result | `TOOL_COMPLETED` | `tool`, `result`, `text_summary` |
+| Tool result | `TOOL_COMPLETED` or `TOOL_ERROR` | `tool`, `result`, `text_summary` |
 | Final response or generated SQL | `AGENT_COMPLETED` | `response`, `text_summary` |
 
 Missing tool data emits no `TOOL_*` rows. Missing final output omits
 `AGENT_COMPLETED`. Missing `nl_prompt`/`prompt` is a hard error because a valid
-scenario trace cannot be built without the user message.
+scenario trace cannot be built without the user message. Duplicate scenario IDs
+are also rejected because they would otherwise produce colliding trace and span
+identifiers.
 
 Every row includes `attributes.experiment_id = job_id` and
 `attributes.evalbench_scenario_id = scenario_id`. Agentic token and latency
 metadata found in `stdout.stats.models` is normalized onto the terminal row as
 `usage_metadata`, `input_tokens`, `output_tokens`, and `latency_ms.total_ms`.
+Token counts are summed across model entries. Latency uses the maximum reported
+model duration because some EvalBench producers repeat one run-level duration
+for every model used by the run.
 
 ## Why These Fields Matter
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -1,0 +1,840 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Read EvalBench BigQuery runs and map them to BQAA event rows.
+
+The reader is deliberately pull-only: EvalBench keeps ownership of its
+``configs``, ``results``, and ``scores`` tables, while BQAA converts one
+``job_id`` at a time into the mirror-table row contract tracked by issue #97.
+Writing those rows is a separate phase so idempotency and table ownership can
+be reviewed independently from source-schema normalization.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+import dataclasses
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import hashlib
+import json
+import re
+from typing import Any, Optional
+
+from google.cloud import bigquery
+
+from ._telemetry import make_bq_client
+from ._telemetry import with_sdk_labels
+
+_SOURCE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_MISSING_TEXT = frozenset({"", "<na>", "nan", "none", "null"})
+_NO_GENERATED_OUTPUT = frozenset({"skipped"})
+_UNKNOWN_RUN_TIME = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+_READ_SOURCE_TABLE_QUERY = """\
+SELECT *
+FROM `{table_id}`
+WHERE job_id = @job_id
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalBenchRun:
+  """One EvalBench job loaded for conversion to BQAA trace rows.
+
+  ``results`` and ``scores`` retain the source rows as plain Python mappings.
+  ``config_rows`` carries EvalBench's flattened experiment/model settings,
+  which provide the run timestamp and agent identity for synthetic events.
+  """
+
+  project_id: str
+  evalbench_dataset: str
+  job_id: str
+  location: Optional[str] = None
+  results: tuple[dict[str, Any], ...] = dataclasses.field(
+      default_factory=tuple, repr=False
+  )
+  scores: tuple[dict[str, Any], ...] = dataclasses.field(
+      default_factory=tuple, repr=False
+  )
+  config_rows: tuple[dict[str, Any], ...] = dataclasses.field(
+      default_factory=tuple, repr=False
+  )
+
+  @classmethod
+  def from_bigquery(
+      cls,
+      *,
+      project_id: str,
+      evalbench_dataset: str,
+      job_id: str,
+      location: Optional[str] = None,
+      bq_client: Optional[Any] = None,
+  ) -> "EvalBenchRun":
+    """Load one EvalBench run's configs, results, and scores.
+
+    Every source query filters on ``job_id`` in BigQuery rather than loading
+    a whole table and filtering in Python. The current contract intentionally
+    loads one run into memory; paging very large runs is a future extension.
+
+    Args:
+      project_id: Project containing the EvalBench tables.
+      evalbench_dataset: Dataset containing ``configs``, ``results``, and
+        ``scores``.
+      job_id: EvalBench job identifier to load.
+      location: Optional BigQuery location.
+      bq_client: Optional test-compatible or caller-configured BigQuery client.
+
+    Returns:
+      An ``EvalBenchRun`` containing plain in-memory source rows.
+    """
+    _validate_source_segment("project_id", project_id)
+    _validate_source_segment("evalbench_dataset", evalbench_dataset)
+    if not isinstance(job_id, str) or not job_id:
+      raise ValueError("job_id must be a non-empty string")
+
+    client = bq_client or make_bq_client(project_id, location=location)
+    table_prefix = f"{project_id}.{evalbench_dataset}"
+    return cls(
+        project_id=project_id,
+        evalbench_dataset=evalbench_dataset,
+        job_id=job_id,
+        location=location,
+        results=_read_source_rows(
+            client,
+            table_id=f"{table_prefix}.results",
+            job_id=job_id,
+            location=location,
+        ),
+        scores=_read_source_rows(
+            client,
+            table_id=f"{table_prefix}.scores",
+            job_id=job_id,
+            location=location,
+        ),
+        config_rows=_read_source_rows(
+            client,
+            table_id=f"{table_prefix}.configs",
+            job_id=job_id,
+            location=location,
+        ),
+    )
+
+  def to_agent_event_rows(self) -> list[dict[str, Any]]:
+    """Convert loaded results to BQAA-compatible synthetic event rows.
+
+    Supports both EvalBench's NL2SQL field names
+    (``id``/``nl_prompt``/``generated_sql``) and its current agentic names
+    (``eval_id``/``prompt``/``stdout``). Missing tool calls emit no tool rows;
+    missing final output omits ``AGENT_COMPLETED``. A missing prompt or
+    scenario identifier is a hard error because no valid session can be
+    constructed without them.
+    """
+    config = _config_values(self.config_rows)
+    agent = _agent_name(config)
+    config_run_time = _first_run_time(self.config_rows)
+
+    prepared: list[tuple[str, int, dict[str, Any]]] = []
+    for source_index, result in enumerate(self.results):
+      scenario_id = _scenario_id(result)
+      prepared.append((scenario_id, source_index, result))
+
+    rows: list[dict[str, Any]] = []
+    for scenario_id, _, result in sorted(
+        prepared, key=lambda item: (item[0], item[1])
+    ):
+      prompt = _prompt(result)
+      if prompt is None:
+        raise ValueError(
+            f"EvalBench scenario {scenario_id!r} is missing nl_prompt/prompt"
+        )
+
+      run_time = _result_run_time(result) or config_run_time
+      missing_run_time = run_time is None
+      run_time = run_time or _UNKNOWN_RUN_TIME
+      session_id = f"evalbench:{self.job_id}:{scenario_id}"
+      invocation_id = _stable_id(session_id, "invocation", length=32)
+      root_span_id = _stable_id(session_id, "user", length=16)
+      attributes = _base_attributes(
+          result=result,
+          project_id=self.project_id,
+          dataset_id=self.evalbench_dataset,
+          job_id=self.job_id,
+          scenario_id=scenario_id,
+          agent=agent,
+      )
+      if missing_run_time:
+        attributes["evalbench_run_time_missing"] = True
+
+      error_fields = _source_error_fields(result)
+      if error_fields:
+        attributes["evalbench_error_fields"] = error_fields
+      source_error = _source_error_message(result, error_fields)
+      source_status = "ERROR" if source_error else "OK"
+      final_response = _final_response(result)
+      usage, response_latency = _usage_and_latency(result)
+      prompt_attributes = dict(attributes)
+      if final_response is None:
+        prompt_attributes.update(usage)
+
+      rows.append(
+          _event_row(
+              event_type="USER_MESSAGE_RECEIVED",
+              timestamp=run_time,
+              agent=agent,
+              session_id=session_id,
+              invocation_id=invocation_id,
+              span_id=root_span_id,
+              parent_span_id=None,
+              content={"text": prompt, "text_summary": prompt},
+              attributes=prompt_attributes,
+              latency_ms=(response_latency if final_response is None else None),
+              status=source_status if final_response is None else "OK",
+              error_message=source_error if final_response is None else None,
+          )
+      )
+
+      sequence = 1
+      for tool_index, tool_call in enumerate(_tool_calls(result)):
+        tool_name = tool_call["tool_name"]
+        tool_args = tool_call.get("args") or {}
+        tool_result = tool_call.get("result")
+        tool_error = _usable_text(tool_call.get("error"))
+        tool_status = "ERROR" if tool_error else "OK"
+        tool_span_id = _stable_id(
+            session_id, "tool", str(tool_index), length=16
+        )
+        start_summary = f"{tool_name}({_compact_json(tool_args)})"
+        rows.append(
+            _event_row(
+                event_type="TOOL_STARTING",
+                timestamp=run_time + timedelta(microseconds=sequence),
+                agent=agent,
+                session_id=session_id,
+                invocation_id=invocation_id,
+                span_id=tool_span_id,
+                parent_span_id=root_span_id,
+                content={
+                    "tool": tool_name,
+                    "args": _json_safe(tool_args),
+                    "text_summary": start_summary,
+                },
+                attributes=attributes,
+            )
+        )
+        sequence += 1
+
+        rendered_result = tool_result if tool_result is not None else tool_error
+        result_summary = f"{tool_name} -> {_one_line(rendered_result)}"
+        rows.append(
+            _event_row(
+                event_type="TOOL_COMPLETED",
+                timestamp=run_time + timedelta(microseconds=sequence),
+                agent=agent,
+                session_id=session_id,
+                invocation_id=invocation_id,
+                span_id=tool_span_id,
+                parent_span_id=root_span_id,
+                content={
+                    "tool": tool_name,
+                    "result": _json_safe(rendered_result),
+                    "text_summary": result_summary,
+                },
+                attributes=attributes,
+                latency_ms=_tool_latency(tool_call),
+                status=tool_status,
+                error_message=tool_error,
+            )
+        )
+        sequence += 1
+
+      if final_response is None:
+        continue
+
+      response_attributes = dict(attributes)
+      response_attributes.update(usage)
+      rows.append(
+          _event_row(
+              event_type="AGENT_COMPLETED",
+              timestamp=run_time + timedelta(microseconds=sequence),
+              agent=agent,
+              session_id=session_id,
+              invocation_id=invocation_id,
+              span_id=_stable_id(session_id, "agent-completed", length=16),
+              parent_span_id=root_span_id,
+              content={
+                  "response": final_response,
+                  "text_summary": final_response,
+              },
+              attributes=response_attributes,
+              latency_ms=response_latency,
+              status=source_status,
+              error_message=source_error,
+          )
+      )
+
+    return rows
+
+
+def _read_source_rows(
+    client: Any,
+    *,
+    table_id: str,
+    job_id: str,
+    location: Optional[str],
+) -> tuple[dict[str, Any], ...]:
+  query = _READ_SOURCE_TABLE_QUERY.format(table_id=table_id)
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("job_id", "STRING", job_id)
+      ]
+  )
+  job_config = with_sdk_labels(job_config, feature="evalbench-import")
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  result = client.query(query, **query_args).result()
+  return tuple(_plain_row(row) for row in result)
+
+
+def _plain_row(row: Any) -> dict[str, Any]:
+  if isinstance(row, Mapping):
+    items = row.items()
+  elif hasattr(row, "items"):
+    items = row.items()
+  else:
+    items = dict(row).items()
+  return {str(key): _plain_value(value) for key, value in items}
+
+
+def _plain_value(value: Any) -> Any:
+  if isinstance(value, Mapping):
+    return {str(key): _plain_value(item) for key, item in value.items()}
+  if isinstance(value, (list, tuple)):
+    return [_plain_value(item) for item in value]
+  return value
+
+
+def _validate_source_segment(name: str, value: Any) -> None:
+  if not isinstance(value, str) or not _SOURCE_SEGMENT_PATTERN.fullmatch(value):
+    raise ValueError(
+        f"{name} must contain only ASCII letters, digits, '_' or '-'"
+    )
+
+
+def _scenario_id(result: Mapping[str, Any]) -> str:
+  scenario = _as_mapping(_structured(result.get("scenario")))
+  nested_result = _as_mapping(_structured(result.get("eval_results")))
+  nested_scenario = _as_mapping(_structured(nested_result.get("scenario")))
+  for value in (
+      result.get("id"),
+      result.get("eval_id"),
+      scenario.get("id"),
+      nested_result.get("eval_id"),
+      nested_result.get("id"),
+      nested_scenario.get("id"),
+      result.get("prompt_id"),
+  ):
+    text = _usable_text(value)
+    if text is not None:
+      return text
+  raise ValueError("EvalBench result is missing id/eval_id")
+
+
+def _prompt(result: Mapping[str, Any]) -> Optional[str]:
+  scenario = _as_mapping(_structured(result.get("scenario")))
+  nested_result = _as_mapping(_structured(result.get("eval_results")))
+  nested_scenario = _as_mapping(_structured(nested_result.get("scenario")))
+  for value in (
+      result.get("nl_prompt"),
+      result.get("prompt"),
+      scenario.get("starting_prompt"),
+      nested_result.get("nl_prompt"),
+      nested_result.get("prompt"),
+      nested_scenario.get("starting_prompt"),
+  ):
+    text = _usable_text(value)
+    if text is not None:
+      return text
+  return None
+
+
+def _final_response(result: Mapping[str, Any]) -> Optional[str]:
+  for key in ("final_response", "response", "generated_output", "output"):
+    text = _usable_text(result.get(key))
+    if text is not None:
+      return text
+
+  stdout = result.get("stdout")
+  stdout_value = _structured(stdout)
+  if isinstance(stdout_value, Mapping):
+    for key in ("response", "final_response", "output"):
+      text = _usable_text(stdout_value.get(key))
+      if text is not None:
+        return text
+  else:
+    text = _usable_text(stdout)
+    if text is not None:
+      return text
+
+  nested_result = _as_mapping(_structured(result.get("eval_results")))
+  for key in ("final_response", "response", "generated_output", "output"):
+    text = _usable_text(nested_result.get(key))
+    if text is not None:
+      return text
+  nested_stdout = nested_result.get("stdout")
+  nested_stdout_value = _structured(nested_stdout)
+  if isinstance(nested_stdout_value, Mapping):
+    for key in ("response", "final_response", "output"):
+      text = _usable_text(nested_stdout_value.get(key))
+      if text is not None:
+        return text
+  else:
+    text = _usable_text(nested_stdout)
+    if text is not None:
+      return text
+
+  generated_sql = _usable_text(
+      result.get("generated_sql"), rejected=_NO_GENERATED_OUTPUT
+  )
+  if generated_sql is not None:
+    return generated_sql
+  return _usable_text(
+      nested_result.get("generated_sql"), rejected=_NO_GENERATED_OUTPUT
+  )
+
+
+def _tool_calls(result: Mapping[str, Any]) -> list[dict[str, Any]]:
+  nested_result = _as_mapping(_structured(result.get("eval_results")))
+  stdout_payload = _as_mapping(_structured(result.get("stdout")))
+  nested_stdout_payload = _as_mapping(_structured(nested_result.get("stdout")))
+  for value in (
+      result.get("tool_calls"),
+      stdout_payload.get("tool_calls"),
+      nested_result.get("tool_calls"),
+      nested_stdout_payload.get("tool_calls"),
+      result.get("accumulated_tools"),
+      nested_result.get("accumulated_tools"),
+  ):
+    calls = _normalize_tool_calls(value)
+    if calls:
+      return calls
+  return []
+
+
+def _normalize_tool_calls(value: Any) -> list[dict[str, Any]]:
+  value = _structured(value)
+  if not isinstance(value, (list, tuple)):
+    return []
+
+  calls: list[dict[str, Any]] = []
+  for item in value:
+    if isinstance(item, str):
+      name = _usable_text(item)
+      if name is not None:
+        calls.append({"tool_name": name, "args": {}, "result": None})
+      continue
+    call = _as_mapping(_structured(item))
+    name = None
+    for key in ("tool_name", "name", "tool"):
+      name = _usable_text(call.get(key))
+      if name is not None:
+        break
+    if name is None:
+      continue
+    args = call.get("parameters", call.get("args", call.get("arguments", {})))
+    result = call.get("response", call.get("result", call.get("output")))
+    error = call.get("error")
+    status = _usable_text(call.get("status"))
+    if (
+        error is None
+        and status is not None
+        and status.lower()
+        not in {
+            "completed",
+            "ok",
+            "success",
+        }
+    ):
+      error = status
+    calls.append(
+        {
+            "tool_name": name,
+            "args": _json_safe(_structured(args)) or {},
+            "result": _json_safe(_structured(result)),
+            "error": _json_safe(_structured(error)),
+            "timestamp": call.get("timestamp"),
+            "result_timestamp": call.get("result_timestamp"),
+            "duration_ms": call.get("duration_ms", call.get("latency_ms")),
+        }
+    )
+  return calls
+
+
+def _result_run_time(result: Mapping[str, Any]) -> Optional[datetime]:
+  nested_result = _as_mapping(_structured(result.get("eval_results")))
+  for value in (result.get("run_time"), nested_result.get("run_time")):
+    parsed = _parse_timestamp(value)
+    if parsed is not None:
+      return parsed
+  return None
+
+
+def _first_run_time(
+    config_rows: tuple[dict[str, Any], ...],
+) -> Optional[datetime]:
+  for row in config_rows:
+    parsed = _parse_timestamp(row.get("run_time"))
+    if parsed is not None:
+      return parsed
+  return None
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+  if isinstance(value, datetime):
+    return (
+        value
+        if value.tzinfo is not None
+        else value.replace(tzinfo=timezone.utc)
+    )
+  if isinstance(value, date):
+    return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+  if not isinstance(value, str):
+    return None
+  text = value.strip()
+  if not text or text.lower() in _MISSING_TEXT:
+    return None
+  if text.endswith("Z"):
+    text = text[:-1] + "+00:00"
+  try:
+    parsed = datetime.fromisoformat(text)
+  except ValueError:
+    return None
+  return (
+      parsed
+      if parsed.tzinfo is not None
+      else parsed.replace(tzinfo=timezone.utc)
+  )
+
+
+def _config_values(config_rows: tuple[dict[str, Any], ...]) -> dict[str, Any]:
+  values: dict[str, Any] = {}
+  for row in config_rows:
+    key = _usable_text(row.get("config"))
+    if key is not None:
+      values[key] = row.get("value")
+  return values
+
+
+def _agent_name(config: Mapping[str, Any]) -> str:
+  orchestrator = _usable_text(config.get("experiment_config.orchestrator"))
+  generator = _usable_text(config.get("model_config.generator"))
+  return f"evalbench:{orchestrator or 'unknown'}:{generator or 'unknown'}"
+
+
+def _base_attributes(
+    *,
+    result: Mapping[str, Any],
+    project_id: str,
+    dataset_id: str,
+    job_id: str,
+    scenario_id: str,
+    agent: str,
+) -> dict[str, Any]:
+  attributes: dict[str, Any] = {
+      "experiment_id": job_id,
+      "evalbench_scenario_id": scenario_id,
+      "evalbench_source_project": project_id,
+      "evalbench_source_dataset": dataset_id,
+      "root_agent_name": agent,
+  }
+  for source_key, target_key in (
+      ("database", "evalbench_database"),
+      ("dialects", "evalbench_dialects"),
+      ("query_type", "evalbench_query_type"),
+  ):
+    value = result.get(source_key)
+    if _usable_text(value) is not None or isinstance(
+        value, (list, tuple, dict)
+    ):
+      attributes[target_key] = _json_safe(_structured(value))
+  return attributes
+
+
+def _source_error_fields(result: Mapping[str, Any]) -> dict[str, Any]:
+  fields: dict[str, Any] = {}
+  for key in (
+      "prompt_generator_error",
+      "sql_generator_error",
+      "generated_error",
+      "golden_error",
+      "error",
+      "stderr",
+      "returncode",
+  ):
+    value = result.get(key)
+    if _usable_text(value) is not None:
+      fields[key] = _json_safe(_structured(value))
+  return fields
+
+
+def _source_error_message(
+    result: Mapping[str, Any], error_fields: Mapping[str, Any]
+) -> Optional[str]:
+  parts: list[str] = []
+  for key in (
+      "prompt_generator_error",
+      "sql_generator_error",
+      "generated_error",
+      "golden_error",
+      "error",
+  ):
+    text = _usable_text(error_fields.get(key))
+    if text is not None:
+      parts.append(f"{key}: {text}")
+
+  returncode = result.get("returncode")
+  try:
+    failed_returncode = returncode is not None and int(returncode) != 0
+  except (TypeError, ValueError):
+    failed_returncode = _usable_text(returncode) is not None
+  if failed_returncode:
+    parts.append(f"returncode: {returncode}")
+    stderr = _usable_text(error_fields.get("stderr"))
+    if stderr is not None:
+      parts.append(f"stderr: {stderr}")
+  return "; ".join(parts) if parts else None
+
+
+def _usage_and_latency(
+    result: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+  payload = _as_mapping(_structured(result.get("stdout")))
+  if not payload:
+    nested_result = _as_mapping(_structured(result.get("eval_results")))
+    payload = _as_mapping(_structured(nested_result.get("stdout")))
+
+  stats = _as_mapping(payload.get("stats"))
+  models = _as_mapping(stats.get("models"))
+  token_totals = {
+      "input": 0,
+      "output": 0,
+      "total": 0,
+      "cached": 0,
+  }
+  found_tokens = {key: False for key in token_totals}
+  total_latency_ms = 0
+  found_latency = False
+
+  for model_data_value in models.values():
+    model_data = _as_mapping(_structured(model_data_value))
+    tokens = _as_mapping(_structured(model_data.get("tokens")))
+    for target, aliases in (
+        ("input", ("input", "prompt", "input_tokens")),
+        ("output", ("candidates", "output", "output_tokens")),
+        ("total", ("total", "total_tokens")),
+        ("cached", ("cached", "cached_tokens")),
+    ):
+      number = _first_int(tokens, aliases)
+      if number is not None:
+        token_totals[target] += number
+        found_tokens[target] = True
+    api = _as_mapping(_structured(model_data.get("api")))
+    latency_value = _first_int(api, ("totalLatencyMs", "total_latency_ms"))
+    if latency_value is not None:
+      total_latency_ms += latency_value
+      found_latency = True
+
+  direct_values = {
+      "input": _first_int(
+          result, ("input_tokens", "prompt_tokens", "prompt_token_count")
+      ),
+      "output": _first_int(
+          result,
+          ("output_tokens", "completion_tokens", "candidates_token_count"),
+      ),
+      "total": _first_int(result, ("total_tokens", "total_token_count")),
+      "cached": _first_int(
+          result, ("cached_tokens", "cached_content_token_count")
+      ),
+  }
+  for key, value in direct_values.items():
+    if not found_tokens[key] and value is not None:
+      token_totals[key] = value
+      found_tokens[key] = True
+
+  if not found_tokens["total"] and (
+      found_tokens["input"] or found_tokens["output"]
+  ):
+    token_totals["total"] = token_totals["input"] + token_totals["output"]
+    found_tokens["total"] = True
+
+  usage: dict[str, Any] = {}
+  metadata: dict[str, int] = {}
+  if found_tokens["input"]:
+    usage["input_tokens"] = token_totals["input"]
+    metadata["prompt_token_count"] = token_totals["input"]
+  if found_tokens["output"]:
+    usage["output_tokens"] = token_totals["output"]
+    metadata["candidates_token_count"] = token_totals["output"]
+  if found_tokens["total"]:
+    metadata["total_token_count"] = token_totals["total"]
+  if found_tokens["cached"]:
+    metadata["cached_content_token_count"] = token_totals["cached"]
+  if metadata:
+    usage["usage_metadata"] = metadata
+
+  latency: dict[str, Any] = {}
+  if found_latency:
+    latency["total_ms"] = total_latency_ms
+  return usage, latency
+
+
+def _first_int(
+    mapping: Mapping[str, Any], keys: tuple[str, ...]
+) -> Optional[int]:
+  for key in keys:
+    value = mapping.get(key)
+    if value is None or isinstance(value, bool):
+      continue
+    try:
+      return int(value)
+    except (TypeError, ValueError):
+      continue
+  return None
+
+
+def _tool_latency(tool_call: Mapping[str, Any]) -> dict[str, Any]:
+  duration = tool_call.get("duration_ms")
+  if duration is not None:
+    try:
+      return {"total_ms": int(duration)}
+    except (TypeError, ValueError):
+      pass
+  started = _parse_timestamp(tool_call.get("timestamp"))
+  completed = _parse_timestamp(tool_call.get("result_timestamp"))
+  if started is not None and completed is not None:
+    return {
+        "total_ms": max(0, int((completed - started).total_seconds() * 1000))
+    }
+  return {}
+
+
+def _event_row(
+    *,
+    event_type: str,
+    timestamp: datetime,
+    agent: str,
+    session_id: str,
+    invocation_id: str,
+    span_id: str,
+    parent_span_id: Optional[str],
+    content: Mapping[str, Any],
+    attributes: Mapping[str, Any],
+    latency_ms: Optional[Mapping[str, Any]] = None,
+    status: str = "OK",
+    error_message: Optional[str] = None,
+) -> dict[str, Any]:
+  return {
+      "session_id": session_id,
+      "event_type": event_type,
+      "timestamp": timestamp.isoformat(),
+      "agent": agent,
+      "invocation_id": invocation_id,
+      "trace_id": session_id,
+      "span_id": span_id,
+      "parent_span_id": parent_span_id,
+      "user_id": None,
+      "content": _json_safe(content),
+      "content_parts": [],
+      "attributes": _json_safe(attributes),
+      "latency_ms": _json_safe(latency_ms or {}),
+      "status": status,
+      "error_message": error_message,
+      "is_truncated": False,
+  }
+
+
+def _stable_id(*parts: str, length: int) -> str:
+  digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+  return digest[:length]
+
+
+def _structured(value: Any) -> Any:
+  if not isinstance(value, str):
+    return _plain_value(value)
+  text = value.strip()
+  if not text or text[0] not in "[{(" or text[-1] not in "]})":
+    return value
+  try:
+    return _plain_value(json.loads(text))
+  except (json.JSONDecodeError, TypeError):
+    pass
+  try:
+    return _plain_value(ast.literal_eval(text))
+  except (SyntaxError, ValueError, TypeError):
+    return value
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+  if isinstance(value, Mapping):
+    return {str(key): item for key, item in value.items()}
+  return {}
+
+
+def _usable_text(
+    value: Any, *, rejected: frozenset[str] = frozenset()
+) -> Optional[str]:
+  if value is None:
+    return None
+  if isinstance(value, str):
+    if value.strip().lower() in _MISSING_TEXT | rejected:
+      return None
+    return value
+  if isinstance(value, (Mapping, list, tuple)):
+    return json.dumps(_json_safe(value), sort_keys=True, separators=(",", ":"))
+  text = str(value)
+  if text.strip().lower() in _MISSING_TEXT | rejected:
+    return None
+  return text
+
+
+def _json_safe(value: Any) -> Any:
+  if isinstance(value, Mapping):
+    return {str(key): _json_safe(item) for key, item in value.items()}
+  if isinstance(value, (list, tuple)):
+    return [_json_safe(item) for item in value]
+  if isinstance(value, datetime):
+    return value.isoformat()
+  if isinstance(value, date):
+    return value.isoformat()
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  return str(value)
+
+
+def _compact_json(value: Any) -> str:
+  safe = _json_safe(value)
+  if safe in ({}, [], None):
+    return ""
+  return json.dumps(safe, sort_keys=True, separators=(",", ":"))
+
+
+def _one_line(value: Any) -> str:
+  text = _usable_text(value)
+  if text is None:
+    return ""
+  return " ".join(text.splitlines())

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -148,8 +148,17 @@ class EvalBenchRun:
     config_run_time = _first_run_time(self.config_rows)
 
     prepared: list[tuple[str, int, dict[str, Any]]] = []
+    scenario_indexes: dict[str, int] = {}
     for source_index, result in enumerate(self.results):
       scenario_id = _scenario_id(result)
+      previous_index = scenario_indexes.get(scenario_id)
+      if previous_index is not None:
+        raise ValueError(
+            f"EvalBench job {self.job_id!r} contains duplicate scenario id "
+            f"{scenario_id!r} at result indexes {previous_index} and "
+            f"{source_index}"
+        )
+      scenario_indexes[scenario_id] = source_index
       prepared.append((scenario_id, source_index, result))
 
     rows: list[dict[str, Any]] = []
@@ -241,7 +250,7 @@ class EvalBenchRun:
         result_summary = f"{tool_name} -> {_one_line(rendered_result)}"
         rows.append(
             _event_row(
-                event_type="TOOL_COMPLETED",
+                event_type="TOOL_ERROR" if tool_error else "TOOL_COMPLETED",
                 timestamp=run_time + timedelta(microseconds=sequence),
                 agent=agent,
                 session_id=session_id,
@@ -583,11 +592,13 @@ def _source_error_fields(result: Mapping[str, Any]) -> dict[str, Any]:
       "golden_error",
       "error",
       "stderr",
-      "returncode",
   ):
     value = result.get(key)
     if _usable_text(value) is not None:
       fields[key] = _json_safe(_structured(value))
+  returncode = result.get("returncode")
+  if _failed_returncode(returncode):
+    fields["returncode"] = _json_safe(_structured(returncode))
   return fields
 
 
@@ -607,16 +618,19 @@ def _source_error_message(
       parts.append(f"{key}: {text}")
 
   returncode = result.get("returncode")
-  try:
-    failed_returncode = returncode is not None and int(returncode) != 0
-  except (TypeError, ValueError):
-    failed_returncode = _usable_text(returncode) is not None
-  if failed_returncode:
+  if _failed_returncode(returncode):
     parts.append(f"returncode: {returncode}")
     stderr = _usable_text(error_fields.get("stderr"))
     if stderr is not None:
       parts.append(f"stderr: {stderr}")
   return "; ".join(parts) if parts else None
+
+
+def _failed_returncode(returncode: Any) -> bool:
+  try:
+    return returncode is not None and int(returncode) != 0
+  except (TypeError, ValueError):
+    return _usable_text(returncode) is not None
 
 
 def _usage_and_latency(
@@ -655,7 +669,8 @@ def _usage_and_latency(
     api = _as_mapping(_structured(model_data.get("api")))
     latency_value = _first_int(api, ("totalLatencyMs", "total_latency_ms"))
     if latency_value is not None:
-      total_latency_ms += latency_value
+      # Some EvalBench producers repeat one run-level duration for each model.
+      total_latency_ms = max(total_latency_ms, latency_value)
       found_latency = True
 
   direct_values = {

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the EvalBench BigQuery reader and event-row mapper (#97)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+import pytest
+
+from bigquery_agent_analytics.evalbench import EvalBenchRun
+
+_RUN_TIME = datetime(2026, 4, 29, 12, 30, tzinfo=timezone.utc)
+_EXPECTED_EVENT_COLUMNS = {
+    "session_id",
+    "event_type",
+    "timestamp",
+    "agent",
+    "invocation_id",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "user_id",
+    "content",
+    "content_parts",
+    "attributes",
+    "latency_ms",
+    "status",
+    "error_message",
+    "is_truncated",
+}
+
+
+class _FakeQueryJob:
+
+  def __init__(self, rows: list[dict]) -> None:
+    self._rows = rows
+
+  def result(self) -> list[dict]:
+    return self._rows
+
+
+class _FakeBigQueryClient:
+
+  def __init__(self, tables: dict[str, list[dict]]) -> None:
+    self.tables = tables
+    self.calls: list[tuple[str, dict]] = []
+
+  def query(self, query: str, **kwargs) -> _FakeQueryJob:
+    self.calls.append((query, kwargs))
+    for table_name, rows in self.tables.items():
+      if f".{table_name}`" in query:
+        return _FakeQueryJob(rows)
+    raise AssertionError(f"unexpected query: {query}")
+
+
+def _run(*results: dict, config_rows: tuple[dict, ...] | None = None):
+  if config_rows is None:
+    config_rows = (
+        {
+            "config": "experiment_config.orchestrator",
+            "value": "geminicli",
+            "run_time": _RUN_TIME,
+        },
+        {
+            "config": "model_config.generator",
+            "value": "gemini_cli",
+            "run_time": _RUN_TIME,
+        },
+    )
+  return EvalBenchRun(
+      project_id="source-project",
+      evalbench_dataset="evalbench",
+      job_id="job-123",
+      location="US",
+      results=tuple(results),
+      config_rows=config_rows,
+  )
+
+
+def test_from_bigquery_filters_every_source_query_by_job_id() -> None:
+  fake = _FakeBigQueryClient(
+      {
+          "results": [{"id": "scenario-1", "job_id": "job-123"}],
+          "scores": [
+              {
+                  "id": "scenario-1",
+                  "job_id": "job-123",
+                  "comparator": "goal_completion",
+                  "score": 1,
+              }
+          ],
+          "configs": [
+              {
+                  "job_id": "job-123",
+                  "config": "experiment_config.orchestrator",
+                  "value": "geminicli",
+              }
+          ],
+      }
+  )
+
+  run = EvalBenchRun.from_bigquery(
+      project_id="source-project",
+      evalbench_dataset="evalbench",
+      job_id="job-123",
+      location="EU",
+      bq_client=fake,
+  )
+
+  assert len(run.results) == 1
+  assert len(run.scores) == 1
+  assert len(run.config_rows) == 1
+  assert len(fake.calls) == 3
+  for query, kwargs in fake.calls:
+    assert "WHERE job_id = @job_id" in query
+    assert "job-123" not in query
+    assert kwargs["location"] == "EU"
+    job_config = kwargs["job_config"]
+    assert job_config.labels["sdk_feature"] == "evalbench-import"
+    parameter = job_config.query_parameters[0]
+    assert parameter.name == "job_id"
+    assert parameter.value == "job-123"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("project_id", "source-project`; DROP TABLE x; --"),
+        ("evalbench_dataset", "evalbench.bad"),
+    ],
+)
+def test_from_bigquery_rejects_unsafe_source_identifiers(
+    field: str, value: str
+) -> None:
+  kwargs = {
+      "project_id": "source-project",
+      "evalbench_dataset": "evalbench",
+      "job_id": "job-123",
+      "bq_client": _FakeBigQueryClient({}),
+  }
+  kwargs[field] = value
+  with pytest.raises(ValueError, match=field):
+    EvalBenchRun.from_bigquery(**kwargs)
+
+
+def test_current_agentic_row_maps_prompt_tools_response_and_identity() -> None:
+  stdout = json.dumps(
+      {
+          "response": "The customer qualifies for a refund.",
+          "tool_calls": [
+              {
+                  "tool_name": "orders__lookup",
+                  "parameters": {"order_id": "A-1"},
+                  "response": {"status": "delivered"},
+                  "status": "success",
+                  "timestamp": "2026-04-29T12:30:00Z",
+                  "result_timestamp": "2026-04-29T12:30:00.125Z",
+              }
+          ],
+      }
+  )
+  rows = _run(
+      {
+          "eval_id": "refund-1",
+          "prompt": "Can order A-1 be refunded?",
+          "stdout": stdout,
+          "returncode": 0,
+      }
+  ).to_agent_event_rows()
+
+  assert [row["event_type"] for row in rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "TOOL_STARTING",
+      "TOOL_COMPLETED",
+      "AGENT_COMPLETED",
+  ]
+  assert all(set(row) == _EXPECTED_EVENT_COLUMNS for row in rows)
+  assert all(row["session_id"] == "evalbench:job-123:refund-1" for row in rows)
+  assert all(row["trace_id"] == row["session_id"] for row in rows)
+  assert all(row["agent"] == "evalbench:geminicli:gemini_cli" for row in rows)
+  assert rows[0]["content"] == {
+      "text": "Can order A-1 be refunded?",
+      "text_summary": "Can order A-1 be refunded?",
+  }
+  assert rows[1]["content"]["args"] == {"order_id": "A-1"}
+  assert rows[2]["content"]["result"] == {"status": "delivered"}
+  assert rows[2]["latency_ms"] == {"total_ms": 125}
+  assert rows[-1]["content"]["response"] == (
+      "The customer qualifies for a refund."
+  )
+
+
+def test_synthetic_rows_satisfy_judge_text_and_response_contracts() -> None:
+  rows = _run(
+      {
+          "id": "sql-1",
+          "nl_prompt": "List the five newest orders.",
+          "generated_sql": "SELECT * FROM orders ORDER BY created_at DESC LIMIT 5",
+          "run_time": _RUN_TIME,
+      }
+  ).to_agent_event_rows()
+
+  trace_text = "\n".join(
+      f"{row['event_type']}: {row['content'].get('text_summary', '')}"
+      for row in rows
+  )
+  assert len(trace_text) > 10
+  assert all(row["content"]["text_summary"] for row in rows)
+  completed = [row for row in rows if row["event_type"] == "AGENT_COMPLETED"]
+  assert len(completed) == 1
+  assert completed[0]["content"]["response"].startswith("SELECT")
+  assert completed[0]["attributes"]["experiment_id"] == "job-123"
+  assert completed[0]["attributes"]["evalbench_scenario_id"] == "sql-1"
+
+
+def test_missing_tools_and_final_response_are_non_fatal() -> None:
+  rows = _run(
+      {
+          "id": "sql-without-output",
+          "nl_prompt": "A valid prompt remains importable.",
+          "generated_sql": "skipped",
+          "input_tokens": 25,
+          "output_tokens": 5,
+      },
+      config_rows=(),
+  ).to_agent_event_rows()
+
+  assert len(rows) == 1
+  assert rows[0]["event_type"] == "USER_MESSAGE_RECEIVED"
+  assert rows[0]["timestamp"] == "1970-01-01T00:00:00+00:00"
+  assert rows[0]["attributes"]["evalbench_run_time_missing"] is True
+  assert rows[0]["attributes"]["usage_metadata"]["total_token_count"] == 30
+
+
+def test_missing_nl_prompt_is_a_hard_failure() -> None:
+  run = _run({"id": "missing-prompt", "generated_sql": "SELECT 1"})
+  with pytest.raises(ValueError, match="missing nl_prompt/prompt"):
+    run.to_agent_event_rows()
+
+
+def test_missing_scenario_id_is_a_hard_failure() -> None:
+  run = _run({"nl_prompt": "No identifier", "generated_sql": "SELECT 1"})
+  with pytest.raises(ValueError, match="missing id/eval_id"):
+    run.to_agent_event_rows()
+
+
+def test_agentic_token_and_latency_stats_map_to_bqaa_fields() -> None:
+  stdout = json.dumps(
+      {
+          "response": "Done",
+          "stats": {
+              "models": {
+                  "gemini-2.5-flash": {
+                      "api": {"totalLatencyMs": 850},
+                      "tokens": {
+                          "input": 120,
+                          "candidates": 30,
+                          "total": 150,
+                          "cached": 20,
+                      },
+                  }
+              }
+          },
+      }
+  )
+  rows = _run(
+      {"eval_id": "token-1", "prompt": "Run the task", "stdout": stdout}
+  ).to_agent_event_rows()
+  completed = rows[-1]
+
+  assert completed["latency_ms"] == {"total_ms": 850}
+  assert completed["attributes"]["input_tokens"] == 120
+  assert completed["attributes"]["output_tokens"] == 30
+  assert completed["attributes"]["usage_metadata"] == {
+      "prompt_token_count": 120,
+      "candidates_token_count": 30,
+      "total_token_count": 150,
+      "cached_content_token_count": 20,
+  }
+
+
+def test_error_fields_are_preserved_without_inventing_a_final_response() -> (
+    None
+):
+  rows = _run(
+      {
+          "eval_id": "failed-1",
+          "prompt": "Run a failing command",
+          "stdout": "",
+          "stderr": "command failed",
+          "returncode": 2,
+      }
+  ).to_agent_event_rows()
+
+  assert len(rows) == 1
+  assert rows[0]["status"] == "ERROR"
+  assert "returncode: 2" in rows[0]["error_message"]
+  assert "stderr: command failed" in rows[0]["error_message"]
+  assert rows[0]["attributes"]["evalbench_error_fields"] == {
+      "stderr": "command failed",
+      "returncode": 2,
+  }
+
+
+def test_python_literal_nested_result_shape_is_supported() -> None:
+  rows = _run(
+      {
+          "eval_results": repr(
+              {
+                  "eval_id": "legacy-agent-1",
+                  "prompt": "Inspect the repository",
+                  "stdout": json.dumps({"response": "Inspection complete"}),
+                  "accumulated_tools": ["read_file"],
+              }
+          )
+      }
+  ).to_agent_event_rows()
+
+  assert rows[0]["session_id"] == "evalbench:job-123:legacy-agent-1"
+  assert [row["event_type"] for row in rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "TOOL_STARTING",
+      "TOOL_COMPLETED",
+      "AGENT_COMPLETED",
+  ]
+  assert rows[-1]["content"]["response"] == "Inspection complete"
+
+
+def test_mapping_is_deterministic_and_sorts_unique_scenarios() -> None:
+  run = _run(
+      {"id": "b", "nl_prompt": "Prompt B", "generated_sql": "SELECT 2"},
+      {"id": "a", "nl_prompt": "Prompt A", "generated_sql": "SELECT 1"},
+  )
+  first = run.to_agent_event_rows()
+  second = run.to_agent_event_rows()
+
+  assert first == second
+  assert first[0]["session_id"] == "evalbench:job-123:a"
+  assert first[2]["session_id"] == "evalbench:job-123:b"

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -202,6 +202,36 @@ def test_current_agentic_row_maps_prompt_tools_response_and_identity() -> None:
   assert rows[-1]["content"]["response"] == (
       "The customer qualifies for a refund."
   )
+  assert "evalbench_error_fields" not in rows[0]["attributes"]
+
+
+def test_failed_tool_emits_tool_error_for_session_summary() -> None:
+  stdout = json.dumps(
+      {
+          "response": "The lookup failed.",
+          "tool_calls": [
+              {
+                  "tool_name": "orders__lookup",
+                  "parameters": {"order_id": "missing"},
+                  "error": "order not found",
+              }
+          ],
+      }
+  )
+
+  rows = _run(
+      {"eval_id": "tool-error-1", "prompt": "Find the order", "stdout": stdout}
+  ).to_agent_event_rows()
+
+  assert [row["event_type"] for row in rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "TOOL_STARTING",
+      "TOOL_ERROR",
+      "AGENT_COMPLETED",
+  ]
+  tool_error = rows[2]
+  assert tool_error["status"] == "ERROR"
+  assert tool_error["error_message"] == "order not found"
 
 
 def test_synthetic_rows_satisfy_judge_text_and_response_contracts() -> None:
@@ -258,7 +288,7 @@ def test_missing_scenario_id_is_a_hard_failure() -> None:
     run.to_agent_event_rows()
 
 
-def test_agentic_token_and_latency_stats_map_to_bqaa_fields() -> None:
+def test_agentic_multimodel_tokens_sum_without_multiplying_latency() -> None:
   stdout = json.dumps(
       {
           "response": "Done",
@@ -272,7 +302,16 @@ def test_agentic_token_and_latency_stats_map_to_bqaa_fields() -> None:
                           "total": 150,
                           "cached": 20,
                       },
-                  }
+                  },
+                  "gemini-2.5-pro": {
+                      "api": {"totalLatencyMs": 850},
+                      "tokens": {
+                          "input": 20,
+                          "candidates": 10,
+                          "total": 30,
+                          "cached": 5,
+                      },
+                  },
               }
           },
       }
@@ -283,13 +322,13 @@ def test_agentic_token_and_latency_stats_map_to_bqaa_fields() -> None:
   completed = rows[-1]
 
   assert completed["latency_ms"] == {"total_ms": 850}
-  assert completed["attributes"]["input_tokens"] == 120
-  assert completed["attributes"]["output_tokens"] == 30
+  assert completed["attributes"]["input_tokens"] == 140
+  assert completed["attributes"]["output_tokens"] == 40
   assert completed["attributes"]["usage_metadata"] == {
-      "prompt_token_count": 120,
-      "candidates_token_count": 30,
-      "total_token_count": 150,
-      "cached_content_token_count": 20,
+      "prompt_token_count": 140,
+      "candidates_token_count": 40,
+      "total_token_count": 180,
+      "cached_content_token_count": 25,
   }
 
 
@@ -351,3 +390,13 @@ def test_mapping_is_deterministic_and_sorts_unique_scenarios() -> None:
   assert first == second
   assert first[0]["session_id"] == "evalbench:job-123:a"
   assert first[2]["session_id"] == "evalbench:job-123:b"
+
+
+def test_duplicate_scenario_ids_are_rejected() -> None:
+  run = _run(
+      {"id": "duplicate", "nl_prompt": "First", "generated_sql": "SELECT 1"},
+      {"id": "duplicate", "nl_prompt": "Retry", "generated_sql": "SELECT 2"},
+  )
+
+  with pytest.raises(ValueError, match="duplicate scenario id 'duplicate'"):
+    run.to_agent_event_rows()


### PR DESCRIPTION
## Summary

- add the optional `bigquery_agent_analytics.evalbench` module with `EvalBenchRun`
- read one EvalBench job from `configs`, `results`, and `scores`
- filter every source query in BigQuery with the parameterized `job_id`
- normalize both current agentic and NL2SQL result shapes
- map scenarios into deterministic, BQAA-compatible synthetic event rows
- document the mapping contract, schema caveats, and remaining implementation phases

## Issue status

Tracking issue: #97.

This is the first implementation phase only. Issue #97 should remain open after
this PR merges.

Completed here:

- `EvalBenchRun.from_bigquery(...)`
- SQL-level `job_id` filtering
- EvalBench source-schema normalization
- synthetic BQAA event-row mapping
- focused unit tests
- mapping documentation

Still required under #97:

- BQAA-owned mirror-table DDL and writer
- cross-project materialization
- idempotent replacement under `WRITE_APPEND`
- `evalbench_scores_imported` materialization
- `evalbench-import` and `evalbench-score` CLI commands
- live `Client.get_session_trace(...)` and `LLMAsJudge` integration tests
- end-to-end EvalBench example

## Why

EvalBench owns benchmark execution and its existing BigQuery output, while BQAA
owns trace reconstruction and semantic evaluation. This reader establishes the
pull-based normalization boundary without coupling EvalBench to the ADK
plugin's production `agent_events` table.

Keeping the reader and pure row mapping separate from materialization also
allows the mirror-table ownership, idempotency, and write-disposition behavior
to be reviewed independently.

## Source compatibility

The mapper supports both major EvalBench result shapes:

| Meaning | NL2SQL | Agentic |
|---|---|---|
| Scenario ID | `id` | `eval_id` |
| Prompt | `nl_prompt` | `prompt` or `scenario.starting_prompt` |
| Final output | `generated_sql` | `stdout.response` |
| Tool calls | optional | `stdout.tool_calls` or `accumulated_tools` |

Nested values may arrive as JSON or Python-literal strings because of
EvalBench's DataFrame reporting path. Both structured encodings are normalized
without interpreting ordinary text as structured data.

## Event mapping

Each scenario maps to:

```text
USER_MESSAGE_RECEIVED
  |-- TOOL_STARTING / TOOL_COMPLETED, when tool data exists
  `-- AGENT_COMPLETED, when a usable final response exists
```

All emitted rows:

- use `session_id = trace_id = evalbench:{job_id}:{scenario_id}`
- set `attributes.experiment_id = job_id`
- set `attributes.evalbench_scenario_id = scenario_id`
- populate `content.text_summary` for the LLM judge trace-text query
- use deterministic invocation and span IDs
- preserve source error fields
- normalize available token and latency telemetry

Missing tool data emits no tool rows. Missing final output omits
`AGENT_COMPLETED`. Missing `nl_prompt`/`prompt` is a hard error.

## Scope boundaries

This PR performs no BigQuery writes and never targets the ADK plugin's
production `agent_events` table.

`run.scores` retains source score rows in memory, but writing
`evalbench_scores_imported` belongs to the materialization phase.

When historical data has no run timestamp, the mapper uses the Unix epoch and
marks `attributes.evalbench_run_time_missing = true` instead of inventing the
current time.

## Validation

- `pytest -q tests/test_evalbench_importer.py`
  - 12 passed
- complete repository suite on Python 3.13
  - 4082 passed, 73 skipped
- `pyink --check`
- `isort --check-only`
- `git diff --check`

The tests use a stubbed BigQuery client. Live BigQuery materialization and
evaluation validation remain part of the later #97 phases.
