### PR TITLE
ci: pin pyink below 26 to unbreak the Format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install formatting tools
-        run: pip install "pyink>=24.3.0" "isort>=5.0"
+        run: pip install "pyink>=24.3.0,<26" "isort>=5.0"
 
       - name: Run autoformat and check for changes
         run: |


### PR DESCRIPTION
The Format check is currently red on every new PR: pyink 26.5.1 shipped after `main` last ran CI (2026-08-23, green) and its new style reformats **30 pre-existing files** across `src/`, `tests/`, `examples/`, and `scripts/` (−608/+282 lines), so the unpinned `pip install "pyink>=24.3.0"` in `ci.yml` fails `git diff --exit-code` no matter what a PR contains. First observed on #446, whose own files are format-clean under both 25.x and 26.5.1.

Verified locally:
- `pyink 25.12.0` + `bash autoformat.sh` → **289 files left unchanged** (tree clean);
- `pyink 26.5.1` + `bash autoformat.sh` → **30 files reformatted**, none of them touched by any open PR.

This pins `pyink>=24.3.0,<26`, restoring the gate to the style the repository is actually formatted in. If maintainers prefer to adopt the pyink 26 style instead, that should be a deliberate repo-wide reformat commit, after which this pin can be raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)