### PR TITLE
feat(looker-studio): collapse the configurator to a single fully-qualified table-ID input

### DIFF
--- a/dashboard/looker_studio/README.md
+++ b/dashboard/looker_studio/README.md
@@ -121,12 +121,13 @@ own snapshot of the old geometry — create a fresh copy from the configurator
 to pick up the fix.
 
 For the standard BQAA layout, open the
-[three-field dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)
-and enter only:
-
-1. GCP project ID;
-2. BigQuery dataset ID;
-3. BQAA table ID (normally `agent_events`).
+[dashboard configurator](https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/)
+and enter only the **fully qualified BQAA table ID** —
+`project.dataset.table`, one value naming all three identifiers (the
+standard table segment is `agent_events`). Paste it straight from the
+BigQuery console's copy-table-ID control or paste the console table link;
+backticks, a legacy colon after the project, and a trailing `;` or `,` are
+cleaned up automatically (#448).
 
 For portable Linking API substitution, table IDs may use ASCII letters, digits,
 underscores, and hyphens, such as `events_agent_cur-phenix`. Dataset IDs retain

--- a/dashboard/looker_studio/USER_MANUAL.md
+++ b/dashboard/looker_studio/USER_MANUAL.md
@@ -34,10 +34,9 @@ You need three things:
 3. **A desktop browser window at least 1280 pixels wide.** The dashboard is a
    desktop layout; phones and narrow tablets are not supported.
 
-You will be asked to know three identifiers: your **project ID**, **dataset
-ID**, and **table ID**. If you don't know them offhand, open your table in the
-BigQuery console — the breadcrumb at the top reads
-`project / dataset / table`, and the table header has a copy control for the
+You will be asked for one identifier: the **fully qualified table ID**,
+`project.dataset.table`. If you don't know it offhand, open your table in
+the BigQuery console — the table header has a copy control for exactly that
 full ID.
 
 ---
@@ -49,30 +48,31 @@ full ID.
 Open the configurator:
 **<https://googlecloudplatform.github.io/BigQuery-Agent-Analytics-SDK/>**
 
-You can fill the three fields by hand, or let one paste do it. Paste **any of
-these into any of the three fields** and all three fill at once:
+There is one field: the **fully qualified BQAA table ID**. Type it as
+`project.dataset.table`, or let one paste do it — paste **any of these**
+and the field fills itself:
 
 | What you paste | Example | Where to copy it |
 |---|---|---|
 | Fully qualified table ID | `my-project.my_dataset.agent_events` | BigQuery console table header → copy table ID |
-| The same, with backticks or a trailing `;` | `` `my-project.my_dataset.agent_events`; `` | Copied out of a SQL editor |
+| The same, with backticks or a trailing `;` or `,` | `` `my-project.my_dataset.agent_events`; `` | Copied out of a SQL editor or an ID list |
 | Legacy colon form | `my-project:my_dataset.agent_events` | Older tools and docs |
 | BigQuery Console table link | `https://console.cloud.google.com/bigquery?ws=…` | Your browser's address bar while viewing the table |
 
 For the console link: open your table in the BigQuery console so it is the
 table you're looking at, then copy the address-bar URL and paste it. The
-configurator reads the project, dataset, and table out of the link and fills
-the fields — you'll see a confirmation like *Split
-"my-project.my_dataset.agent_events" into the three fields.*
+configurator reads the project, dataset, and table out of the link and
+shows the clean dotted ID in the field.
 
 A link is only accepted when it clearly names exactly one table. If it
 doesn't — for example your workspace has several different tables open — the
-paste lands as ordinary text in the one field and shows a validation error.
-Nothing else is overwritten; close the extra tabs in the BigQuery console (or
-type the IDs by hand) and try again.
+pasted text stays in the field with an error explaining the problem, and
+the **Create** and **Copy** buttons stay disabled. Close the extra tabs in
+the BigQuery console (or type the dotted ID by hand) and try again.
 
-When every field is valid, the status line reads
-**Ready for `project.dataset.table`.**
+When the ID is valid, the status line reads
+**Ready for `project.dataset.table`.** Editing the value in any way switches
+the buttons off again until the new value validates.
 
 ### Step 2 — Click "Create my dashboard"
 
@@ -236,10 +236,10 @@ configurator produces.
 | Charts blank or trickling in after opening a page | Normal on a cold load — allow up to 90 seconds. If a chart is still empty after that, widen the date range: your table may have no events in the selected window. |
 | Layout looks cut off on the left | Collapse the Looker Studio navigation drawer, and make the window at least 1280 px wide. Phones and narrow tablets aren't supported. |
 | Bottom charts clipped on Token Consumption or Latency | You're on a copy created before 2026-07-29, which keeps the old page geometry. Create a fresh copy from the configurator. |
-| Pasted a console link but the fields didn't fill | The link must name exactly one table. Open the table itself in the BigQuery console (close other table tabs), copy the address-bar URL, and paste again — or just paste the dotted `project.dataset.table` ID from the table header's copy control. |
-| A field shows a red validation error | Fix just that field: project IDs are 6–30 lowercase characters; dataset IDs allow letters, digits, and underscores (no hyphens — that's a BigQuery rule); table IDs also allow hyphens. |
+| Pasted a console link but the field shows an error instead of the dotted ID | The link must name exactly one table. Open the table itself in the BigQuery console (close other table tabs), copy the address-bar URL, and paste again — or just paste the dotted `project.dataset.table` ID from the table header's copy control. |
+| The table-ID field shows a red validation error | The error names what to fix. A *segment* error points at one part of `project.dataset.table`: project segments are 6–30 lowercase characters; dataset segments allow letters, digits, and underscores (no hyphens — that's a BigQuery rule); table segments also allow hyphens. Otherwise the value isn't three dot-separated segments — check for a missing dot or an extra one. |
 | Looker Studio asks me to sign in or authorize | Expected. The dashboard uses your credentials to read your data. Authorize BigQuery access on your own account. |
-| "Not found: Table …" in Looker Studio | One of the three identifiers is wrong, or your account can't read the table. Open the table in the BigQuery console to confirm the exact IDs and your access, then re-create from the configurator. |
+| "Not found: Table …" in Looker Studio | One of the ID's three segments is wrong, or your account can't read the table. Open the table in the BigQuery console to confirm the exact ID and your access, then re-create from the configurator. |
 | Permission errors on charts | Your account needs to read the table *and* run BigQuery jobs in the billing project (see [Before you start](#before-you-start) for how to check each). If you set an Advanced billing project, you need the **BigQuery Job User** role there. |
 | Quota or reservation errors on charts | The billing project has hit a BigQuery limit — the error names which one, and the reset behavior depends on that specific limit (many daily quotas replenish at intervals throughout the day; custom query quotas reset at midnight Pacific). Shortening the date range reduces what each chart scans. If the limit keeps biting, ask the billing project's administrator to raise that quota; if the project uses reservations, capacity is the administrator's dial, not a quota reset. Granting more IAM access will not fix a quota error. |
 | Numbers look stale | Check the date range includes today, then use Looker Studio's refresh. Ignore the footer's "Data Last Updated" — it's a connector timestamp, not your latest event. |

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -157,23 +157,27 @@ tableIdInput.addEventListener("change", () => {
 tableIdInput.addEventListener("paste", (event) => {
   const text = event.clipboardData.getData("text");
   revealTableErrors = true;
-  // Normalize the displayed value only after FULL validation succeeds; any
-  // invalid paste — unparseable, bad segment, or sentinel collision — must
-  // land as the exact clipboard text so the raw invalid input is retained
-  // alongside its immediate error (#448 decision 2, #449 review).
+  // The default paste inserts at the selection, so an invalid fragment
+  // could merge with a previous Ready value into a DIFFERENT valid ID and
+  // silently retarget the dashboard (#449 review). Always take over: the
+  // field becomes either the normalized valid ID or the complete raw
+  // clipboard text — never a splice — and validates immediately.
+  event.preventDefault();
   let parsed = null;
   try {
     parsed = validateQualifiedTableId(text);
   } catch {
     parsed = null;
   }
-  if (parsed) {
-    event.preventDefault();
-    tableIdInput.value = `${parsed.project}.${parsed.dataset}.${parsed.table}`;
-    refresh();
+  tableIdInput.value = parsed
+    ? `${parsed.project}.${parsed.dataset}.${parsed.table}`
+    : text;
+  if (tableIdInput.value !== lastValidRaw) {
+    derived = null;
+    disableActions();
+    setStatus("");
   }
-  // An invalid paste lands in the field; its input event validates it
-  // immediately because revealTableErrors is already set.
+  refresh();
 });
 
 billingInput.addEventListener("input", refresh);
@@ -193,6 +197,10 @@ function attemptCreate() {
   revealTableErrors = true;
   refresh();
   if (createLink.href) {
+    // Invalidate any pending clipboard completion: the provisioning
+    // warning must not be overwritten by an older copy resolving late
+    // (#449 review).
+    statusEpoch += 1;
     setStatus(WAITING_MESSAGE, "waiting");
     window.open(createLink.href, "_blank", "noopener,noreferrer");
   }
@@ -205,10 +213,20 @@ form.addEventListener("submit", (event) => {
 
 for (const input of [tableIdInput, billingInput]) {
   input.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      attemptCreate();
+    // Only a discrete, non-composing Enter is an attempted action: a held
+    // key repeat must not open tab after tab, and Enter committing an IME
+    // composition (isComposing, or legacy keyCode 229) is text entry, not
+    // activation (#449 review).
+    if (
+      event.key !== "Enter" ||
+      event.repeat ||
+      event.isComposing ||
+      event.keyCode === 229
+    ) {
+      return;
     }
+    event.preventDefault();
+    attemptCreate();
   });
 }
 
@@ -219,6 +237,7 @@ createLink.addEventListener("click", (event) => {
     refresh();
     return;
   }
+  statusEpoch += 1;
   setStatus(WAITING_MESSAGE, "waiting");
 });
 

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -3,7 +3,6 @@ import {
   PROJECT_RE,
   buildDashboardUrl,
   buildSetupUrl,
-  parseTableReference,
   validateQualifiedTableId,
 } from "./configurator.mjs";
 
@@ -15,6 +14,7 @@ const checklist = document.querySelector("#security-checklist");
 const status = document.querySelector("#form-status");
 const tableIdInput = document.querySelector("#table-id");
 const tableIdError = document.querySelector("#table-id-error");
+const advancedSettings = document.querySelector("#advanced-settings");
 const billingInput = document.querySelector("#billing-project");
 const billingError = document.querySelector("#billing-project-error");
 
@@ -27,6 +27,10 @@ const billingError = document.querySelector("#billing-project-error");
 let derived = null;
 let lastValidRaw = null;
 let revealTableErrors = false;
+// Bumped on every state mutation and at the start of every async copy, so a
+// clipboard completion that is no longer current cannot restore a stale
+// status over what the user's later edit cleared (#449 review).
+let statusEpoch = 0;
 
 function setStatus(message, kind = "") {
   status.textContent = message;
@@ -57,12 +61,23 @@ function clearBillingError() {
 function showBillingError(message) {
   billingInput.setAttribute("aria-invalid", "true");
   billingError.textContent = message;
+  // The override lives inside the Advanced disclosure: an error written
+  // into a closed <details> would leave both actions disabled with no
+  // visible explanation, so surface it. Correction never auto-closes.
+  advancedSettings.open = true;
+}
+
+// The single normalization both validation and URL construction consume: a
+// whitespace-only override must behave exactly like blank (billing the
+// project segment), never reach validateConfiguration as truthy text.
+function billingOverride() {
+  return billingInput.value.trim();
 }
 
 // A blank override bills the project segment of the fully qualified ID, so
 // blank is always valid; anything else must be a project ID.
 function billingOverrideIsValid() {
-  const value = billingInput.value.trim();
+  const value = billingOverride();
   if (!value || PROJECT_RE.test(value)) {
     clearBillingError();
     return true;
@@ -72,6 +87,7 @@ function billingOverrideIsValid() {
 }
 
 function refresh() {
+  statusEpoch += 1;
   let parsed;
   try {
     parsed = validateQualifiedTableId(tableIdInput.value);
@@ -102,7 +118,7 @@ function refresh() {
   try {
     createLink.href = buildDashboardUrl({
       ...derived,
-      billingProject: billingInput.value,
+      billingProject: billingOverride(),
     });
     createLink.removeAttribute("aria-disabled");
     copyButton.disabled = false;
@@ -141,13 +157,22 @@ tableIdInput.addEventListener("change", () => {
 tableIdInput.addEventListener("paste", (event) => {
   const text = event.clipboardData.getData("text");
   revealTableErrors = true;
-  const parsed = parseTableReference(text);
+  // Normalize the displayed value only after FULL validation succeeds; any
+  // invalid paste — unparseable, bad segment, or sentinel collision — must
+  // land as the exact clipboard text so the raw invalid input is retained
+  // alongside its immediate error (#448 decision 2, #449 review).
+  let parsed = null;
+  try {
+    parsed = validateQualifiedTableId(text);
+  } catch {
+    parsed = null;
+  }
   if (parsed) {
     event.preventDefault();
     tableIdInput.value = `${parsed.project}.${parsed.dataset}.${parsed.table}`;
     refresh();
   }
-  // An unparseable paste lands in the field; its input event validates it
+  // An invalid paste lands in the field; its input event validates it
   // immediately because revealTableErrors is already set.
 });
 
@@ -159,15 +184,33 @@ const WAITING_MESSAGE =
   "One exception: “This report isn’t shared with you” will not resolve by " +
   "waiting — see the note under the Create button.";
 
-form.addEventListener("submit", (event) => {
-  event.preventDefault();
+// The attempted-action path (#448 decision 1): reveal deferred errors,
+// revalidate, and open exactly one tab when actionable. Reached by the
+// form's submit event and — because this form has two text inputs and no
+// native submit control, so browsers never run implicit submission — by an
+// explicit Enter bridge on both fields (#449 review, P1).
+function attemptCreate() {
   revealTableErrors = true;
   refresh();
   if (createLink.href) {
     setStatus(WAITING_MESSAGE, "waiting");
     window.open(createLink.href, "_blank", "noopener,noreferrer");
   }
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  attemptCreate();
 });
+
+for (const input of [tableIdInput, billingInput]) {
+  input.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      attemptCreate();
+    }
+  });
+}
 
 createLink.addEventListener("click", (event) => {
   if (!createLink.href) {
@@ -183,27 +226,37 @@ copyButton.addEventListener("click", async () => {
   if (!derived) {
     return;
   }
+  const epoch = ++statusEpoch;
   try {
     const setupUrl = buildSetupUrl(
-      { ...derived, billingProject: billingInput.value },
+      { ...derived, billingProject: billingOverride() },
       window.location.href,
     );
     await navigator.clipboard.writeText(setupUrl);
-    setStatus("Setup link copied. It contains identifiers, never credentials.", "ready");
+    if (epoch === statusEpoch) {
+      setStatus("Setup link copied. It contains identifiers, never credentials.", "ready");
+    }
   } catch (error) {
-    setStatus(error.message || "Could not copy the setup link.", "error");
+    if (epoch === statusEpoch) {
+      setStatus(error.message || "Could not copy the setup link.", "error");
+    }
   }
 });
 
 checklistButton.addEventListener("click", async () => {
+  const epoch = ++statusEpoch;
   const text = [...checklist.querySelectorAll("li")]
     .map((item, index) => `${index + 1}. ${item.textContent.trim()}`)
     .join("\n");
   try {
     await navigator.clipboard.writeText(text);
-    setStatus("Security checklist copied.", "ready");
+    if (epoch === statusEpoch) {
+      setStatus("Security checklist copied.", "ready");
+    }
   } catch {
-    setStatus("Could not copy the security checklist.", "error");
+    if (epoch === statusEpoch) {
+      setStatus("Could not copy the security checklist.", "error");
+    }
   }
 });
 

--- a/dashboard/looker_studio/docs/app.mjs
+++ b/dashboard/looker_studio/docs/app.mjs
@@ -1,11 +1,11 @@
 import {
+  BILLING_PROJECT_MESSAGE,
+  PROJECT_RE,
   buildDashboardUrl,
   buildSetupUrl,
-  validateConfiguration,
   parseTableReference,
-  parseTableReferenceForInput,
+  validateQualifiedTableId,
 } from "./configurator.mjs";
-import { REPORT_CONFIG } from "./report-config.mjs";
 
 const form = document.querySelector("#configurator");
 const createLink = document.querySelector("#create-dashboard");
@@ -13,120 +13,145 @@ const copyButton = document.querySelector("#copy-link");
 const checklistButton = document.querySelector("#copy-checklist");
 const checklist = document.querySelector("#security-checklist");
 const status = document.querySelector("#form-status");
-const inputs = {
-  project: document.querySelector("#project"),
-  dataset: document.querySelector("#dataset"),
-  table: document.querySelector("#table"),
-  billingProject: document.querySelector("#billing-project"),
-};
-const tableInputs = [
-  inputs.project,
-  inputs.dataset,
-  inputs.table,
-];
-const errors = {
-  project: document.querySelector("#project-error"),
-  dataset: document.querySelector("#dataset-error"),
-  table: document.querySelector("#table-error"),
-  billingProject: document.querySelector("#billing-project-error"),
-};
+const tableIdInput = document.querySelector("#table-id");
+const tableIdError = document.querySelector("#table-id-error");
+const billingInput = document.querySelector("#billing-project");
+const billingError = document.querySelector("#billing-project-error");
 
-function currentValues() {
-  return Object.fromEntries(
-    Object.entries(inputs).map(([name, input]) => [name, input.value]),
-  );
-}
+// #448 field state. `derived` is the parsed triple behind the last valid
+// field value; `lastValidRaw` is that value verbatim, so any mutation away
+// from it is detected synchronously. `revealTableErrors` implements the
+// validation-timing contract: paste and setup-link prefill validate
+// immediately; manual entry first reports errors on blur or an attempted
+// action; once touched or invalid, every input revalidates.
+let derived = null;
+let lastValidRaw = null;
+let revealTableErrors = false;
 
 function setStatus(message, kind = "") {
   status.textContent = message;
   status.dataset.kind = kind;
 }
 
-function clearFieldErrors() {
-  for (const [name, input] of Object.entries(inputs)) {
-    input.removeAttribute("aria-invalid");
-    errors[name].textContent = "";
+function disableActions() {
+  createLink.removeAttribute("href");
+  createLink.setAttribute("aria-disabled", "true");
+  copyButton.disabled = true;
+}
+
+function clearTableError() {
+  tableIdInput.removeAttribute("aria-invalid");
+  tableIdError.textContent = "";
+}
+
+function showTableError(message) {
+  tableIdInput.setAttribute("aria-invalid", "true");
+  tableIdError.textContent = message;
+}
+
+function clearBillingError() {
+  billingInput.removeAttribute("aria-invalid");
+  billingError.textContent = "";
+}
+
+function showBillingError(message) {
+  billingInput.setAttribute("aria-invalid", "true");
+  billingError.textContent = message;
+}
+
+// A blank override bills the project segment of the fully qualified ID, so
+// blank is always valid; anything else must be a project ID.
+function billingOverrideIsValid() {
+  const value = billingInput.value.trim();
+  if (!value || PROJECT_RE.test(value)) {
+    clearBillingError();
+    return true;
   }
+  showBillingError(BILLING_PROJECT_MESSAGE);
+  return false;
 }
 
 function refresh() {
-  clearFieldErrors();
+  let parsed;
   try {
-    const values = validateConfiguration(currentValues());
-    createLink.href = buildDashboardUrl(values);
+    parsed = validateQualifiedTableId(tableIdInput.value);
+    clearTableError();
+  } catch (error) {
+    derived = null;
+    lastValidRaw = null;
+    disableActions();
+    setStatus("");
+    if (revealTableErrors) {
+      showTableError(error.message);
+    } else {
+      clearTableError();
+    }
+    billingOverrideIsValid();
+    return;
+  }
+  derived = parsed;
+  lastValidRaw = tableIdInput.value;
+  // #448 decision 3: a valid table ID alone is not actionable — the billing
+  // override must be blank or valid too, and an invalid override keeps the
+  // parsed triple while disabling both actions.
+  if (!billingOverrideIsValid()) {
+    disableActions();
+    setStatus("");
+    return;
+  }
+  try {
+    createLink.href = buildDashboardUrl({
+      ...derived,
+      billingProject: billingInput.value,
+    });
     createLink.removeAttribute("aria-disabled");
     copyButton.disabled = false;
     setStatus(
-      `Ready for ${values.project}.${values.dataset}.${values.table}.`,
+      `Ready for ${derived.project}.${derived.dataset}.${derived.table}.`,
       "ready",
     );
   } catch (error) {
-    createLink.removeAttribute("href");
-    createLink.setAttribute("aria-disabled", "true");
-    copyButton.disabled = true;
-    const hasFieldError = Boolean(error.field && inputs[error.field]);
-    if (hasFieldError) {
-      inputs[error.field].setAttribute("aria-invalid", "true");
-      errors[error.field].textContent = error.message;
-      setStatus("");
-    } else {
-      setStatus(error.message, "error");
-    }
+    // Unreachable through the field validators; keep the page honest if
+    // the template configuration itself is broken.
+    derived = null;
+    lastValidRaw = null;
+    disableActions();
+    setStatus(error.message, "error");
   }
 }
 
-function handleQualifiedTableId(parsed) {
-  inputs.project.value = parsed.project;
-  inputs.dataset.value = parsed.dataset;
-  inputs.table.value = parsed.table;
-}
-
-function afterQualifiedTableId(parsed) {
-  handleQualifiedTableId(parsed);
+tableIdInput.addEventListener("input", () => {
+  if (tableIdInput.value !== lastValidRaw) {
+    // Fail closed on every mutation away from the last valid value: the
+    // derived triple, both actions, and any prior Ready/status announcement
+    // are revoked immediately; only error *presentation* may wait for the
+    // validation trigger below.
+    derived = null;
+    disableActions();
+    setStatus("");
+  }
   refresh();
-  if (createLink.href) {
-    setStatus(
-      `Split "${parsed.project}.${parsed.dataset}.${parsed.table}" into the three fields.`,
-      "ready",
-    );
+});
+
+tableIdInput.addEventListener("change", () => {
+  revealTableErrors = true;
+  refresh();
+});
+
+tableIdInput.addEventListener("paste", (event) => {
+  const text = event.clipboardData.getData("text");
+  revealTableErrors = true;
+  const parsed = parseTableReference(text);
+  if (parsed) {
+    event.preventDefault();
+    tableIdInput.value = `${parsed.project}.${parsed.dataset}.${parsed.table}`;
+    refresh();
   }
-}
+  // An unparseable paste lands in the field; its input event validates it
+  // immediately because revealTableErrors is already set.
+});
 
-const query = new URLSearchParams(window.location.search);
-for (const [name, input] of Object.entries(inputs)) {
-  if (query.has(name)) {
-    input.value = query.get(name);
-  }
-}
-if (!inputs.table.value) {
-  inputs.table.value = REPORT_CONFIG.defaultTable;
-}
-for (const input of tableInputs) {
-  input.addEventListener("input", refresh);
-  input.addEventListener("change", (event) => {
-    const parsed = parseTableReferenceForInput(event.target.value);
-
-    if (parsed) {
-      afterQualifiedTableId(parsed);
-    } else {
-      refresh();
-    }
-  });
-}
-
-for (const input of tableInputs) {
-  input.addEventListener("paste", (event) => {
-    const text = event.clipboardData.getData("text");
-    const parsed = parseTableReference(text);
-
-    if (parsed) {
-      event.preventDefault();
-      afterQualifiedTableId(parsed);
-    }
-  });
-}
-
-inputs.billingProject.addEventListener("input", refresh);
+billingInput.addEventListener("input", refresh);
 
 const WAITING_MESSAGE =
   "Opening Looker Studio in a new tab. Building your report copy can take " +
@@ -136,6 +161,7 @@ const WAITING_MESSAGE =
 
 form.addEventListener("submit", (event) => {
   event.preventDefault();
+  revealTableErrors = true;
   refresh();
   if (createLink.href) {
     setStatus(WAITING_MESSAGE, "waiting");
@@ -146,6 +172,7 @@ form.addEventListener("submit", (event) => {
 createLink.addEventListener("click", (event) => {
   if (!createLink.href) {
     event.preventDefault();
+    revealTableErrors = true;
     refresh();
     return;
   }
@@ -153,8 +180,14 @@ createLink.addEventListener("click", (event) => {
 });
 
 copyButton.addEventListener("click", async () => {
+  if (!derived) {
+    return;
+  }
   try {
-    const setupUrl = buildSetupUrl(currentValues(), window.location.href);
+    const setupUrl = buildSetupUrl(
+      { ...derived, billingProject: billingInput.value },
+      window.location.href,
+    );
     await navigator.clipboard.writeText(setupUrl);
     setStatus("Setup link copied. It contains identifiers, never credentials.", "ready");
   } catch (error) {
@@ -174,4 +207,25 @@ checklistButton.addEventListener("click", async () => {
   }
 });
 
-refresh();
+// Setup-link prefill keeps the existing three-parameter contract: all three
+// identifier parameters compose the fully qualified ID and validate
+// immediately; anything less leaves the field pristine.
+const query = new URLSearchParams(window.location.search);
+if (query.has("billingProject")) {
+  billingInput.value = query.get("billingProject");
+}
+const prefill = ["project", "dataset", "table"].map((name) => query.get(name));
+if (prefill.every((part) => part)) {
+  tableIdInput.value = prefill.join(".");
+  revealTableErrors = true;
+  refresh();
+} else {
+  // Pristine: empty field, no error, actions disabled, no status.
+  disableActions();
+}
+
+// Written only at runtime; the browser smoke test asserts its presence in
+// the live DOM and its absence from the static HTML, proving this module
+// actually executed (the pre-#448 proof — an initial validation error — no
+// longer exists in the pristine state).
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -41,11 +41,35 @@ const VALIDATION_MESSAGES = Object.freeze({
     "Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit.",
 });
 
+export const BILLING_PROJECT_MESSAGE = VALIDATION_MESSAGES.billingProject;
+
+// Whole-field errors for the combined table-ID input: input with no truthful
+// project/dataset/table segments to blame (#448 decision 2). Segment-level
+// errors are built from VALIDATION_MESSAGES with the segment named up front.
+const TABLE_ID_MESSAGES = Object.freeze({
+  empty:
+    "Enter the fully qualified BQAA table ID as project.dataset.table.",
+  unparseable:
+    "Enter the fully qualified ID as project.dataset.table — exactly three dot-separated segments.",
+  link:
+    "That link doesn’t clearly name exactly one BigQuery table. Open the table itself in the BigQuery console (close other table tabs) and copy the address-bar URL again — or paste the dotted project.dataset.table ID instead.",
+});
+
+const SEGMENT_LABELS = Object.freeze({
+  project: "Project",
+  dataset: "Dataset",
+  table: "Table",
+});
+
 export class ConfigurationError extends Error {
-  constructor(field, message) {
+  // `segment` distinguishes the two #448 error classes for the combined
+  // table-ID field: a segment-level error names the offending
+  // project/dataset/table segment; a whole-field error carries null.
+  constructor(field, message, segment = null) {
     super(message);
     this.name = "ConfigurationError";
     this.field = field;
+    this.segment = segment;
   }
 }
 
@@ -69,8 +93,13 @@ function rejectSentinelCollisions(values, config) {
   for (const [index, name] of order.entries()) {
     const value = values[name];
     if (sentinels.slice(index + 1).some((sentinel) => value.includes(sentinel))) {
-      throw new Error(
-        `The ${name} contains a later reserved dashboard template value.`,
+      // Attributed to the offending segment so the single-field UI can
+      // report it in the segment-level error class (#448 decision 2); the
+      // collision logic itself and the Linking API output are unchanged.
+      throw new ConfigurationError(
+        "tableId",
+        `${SEGMENT_LABELS[name]} segment: contains a later reserved dashboard template value.`,
+        name,
       );
     }
   }
@@ -233,4 +262,44 @@ export function parseTableReference(value) {
 export function parseTableReferenceForInput(value) {
   const parsed = parseTableReference(value);
   return hasValidTableIdentifiers(parsed) ? parsed : null;
+}
+
+// Validates the combined table-ID field (#448) and returns the parsed
+// triple, or throws a ConfigurationError in one of the two error classes:
+// whole-field (empty, unparseable, or a link that names no single table —
+// `segment: null`) or segment-level (exactly three segments, one violating
+// its rule or a sentinel collision — `segment` names the offender). The
+// sentinel check runs here so a colliding value never reaches the Ready
+// state only to fail at URL construction.
+export function validateQualifiedTableId(value, config = REPORT_CONFIG) {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    throw new ConfigurationError("tableId", TABLE_ID_MESSAGES.empty);
+  }
+  const parsed = URL_SHAPED_RE.test(raw)
+    ? parseBigQueryConsoleTableUrl(raw)
+    : splitQualifiedTableId(raw);
+  if (!parsed) {
+    throw new ConfigurationError(
+      "tableId",
+      URL_SHAPED_RE.test(raw)
+        ? TABLE_ID_MESSAGES.link
+        : TABLE_ID_MESSAGES.unparseable,
+    );
+  }
+  for (const [segment, pattern] of [
+    ["project", PROJECT_RE],
+    ["dataset", DATASET_RE],
+    ["table", TABLE_RE],
+  ]) {
+    if (!pattern.test(parsed[segment])) {
+      throw new ConfigurationError(
+        "tableId",
+        `${SEGMENT_LABELS[segment]} segment: ${VALIDATION_MESSAGES[segment]}`,
+        segment,
+      );
+    }
+  }
+  rejectSentinelCollisions(parsed, config);
+  return Object.freeze({ ...parsed });
 }

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -162,11 +162,16 @@ export function buildSetupUrl(input, pageUrl) {
 }
 
 export function splitQualifiedTableId(value) {
+  // SQL-copy punctuation is one enclosing whole-ID backtick pair plus
+  // trailing statement/list punctuation. Only that pair is stripped: an
+  // embedded backtick stays in its segment and fails segment validation
+  // rather than being silently deleted into a different normalized ID
+  // (#449 review).
   const normalized = String(value ?? "")
   .trim()
-  .replace(/`/g, "")
-  .replace(/^([^.:]+):/, "$1.")
-  .replace(/[;,]+$/, "");
+  .replace(/[;,]+$/, "")
+  .replace(/^`(.*)`$/s, "$1")
+  .replace(/^([^.:]+):/, "$1.");
 
   const parts = normalized.split(".");
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {

--- a/dashboard/looker_studio/docs/configurator.mjs
+++ b/dashboard/looker_studio/docs/configurator.mjs
@@ -195,7 +195,11 @@ function hasValidTableIdentifiers(parsed) {
   );
 }
 
-export function parseBigQueryConsoleTableUrl(value) {
+// Structural extraction only: returns the project/dataset/table tuple of an
+// unambiguous supported-host Console link without judging the identifiers,
+// so validateQualifiedTableId can attribute a bad segment to its segment
+// (#449 review). The public parser below stays strict.
+function extractBigQueryConsoleTableReference(value) {
   let url;
   try {
     url = new URL(String(value ?? "").trim());
@@ -247,7 +251,11 @@ export function parseBigQueryConsoleTableUrl(value) {
   }
 
   const [, project, dataset, table] = matches[0];
-  const parsed = { project, dataset, table };
+  return { project, dataset, table };
+}
+
+export function parseBigQueryConsoleTableUrl(value) {
+  const parsed = extractBigQueryConsoleTableReference(value);
   return hasValidTableIdentifiers(parsed) ? parsed : null;
 }
 
@@ -276,8 +284,13 @@ export function validateQualifiedTableId(value, config = REPORT_CONFIG) {
   if (!raw) {
     throw new ConfigurationError("tableId", TABLE_ID_MESSAGES.empty);
   }
+  // The URL branch uses the structural extractor, not the strict public
+  // parser: a supported-host link that unambiguously names one table but
+  // carries an invalid identifier has three identifiable segments, so it
+  // must reach the segment loop below rather than collapse into the
+  // whole-field link error.
   const parsed = URL_SHAPED_RE.test(raw)
-    ? parseBigQueryConsoleTableUrl(raw)
+    ? extractBigQueryConsoleTableReference(raw)
     : splitQualifiedTableId(raw);
   if (!parsed) {
     throw new ConfigurationError(

--- a/dashboard/looker_studio/docs/dashboard-implementation.md
+++ b/dashboard/looker_studio/docs/dashboard-implementation.md
@@ -29,18 +29,27 @@ credentials: Viewer**. This manual share gate cannot be encoded in a Linking
 API parameter.
 
 `docs/index.html` provides the standard-installation path without requiring a
-local CLI. It accepts project, dataset, and table IDs, assumes the standard
-`agent_events` table and uses the project as the billing project by default,
-with an optional billing-project override, then constructs the same Linking
-API URL entirely in the browser. URL query
-parameters can prefill the three inputs, but the page never opens the report
+local CLI. It accepts a single **fully qualified BQAA table ID**
+(`project.dataset.table` — one input naming all three identifiers, #448),
+uses the ID's project segment as the billing project by default with an
+optional billing-project override, then constructs the same Linking API URL
+entirely in the browser. Setup links keep the existing
+`?project=…&dataset=…&table=…` query-parameter contract: all three
+parameters compose the field's prefill, but the page never opens the report
 without a user click.
 
-Dataset and table IDs use separate validators. Dataset IDs allow the established
-ASCII letter/digit/underscore subset. Table IDs additionally allow hyphens,
-which BigQuery supports and which remain safe inside the report's backticked
-table path. Commas and backticks stay invalid because they would change the
-Linking API replacement list or SQL identifier boundary.
+The combined field reports two error classes: whole-field errors for input
+with no truthful segments to blame (unparseable text, an ambiguous or
+unsupported Console link, wrong arity), and segment-level errors — the
+project, dataset, or table segment named inline — when exactly three
+segments exist and one violates its rule or collides with a template
+sentinel. The segment validators are unchanged: dataset segments allow the
+established ASCII letter/digit/underscore subset; table segments
+additionally allow hyphens, which BigQuery supports and which remain safe
+inside the report's backticked table path. Commas and backticks stay invalid
+inside a segment because they would change the Linking API replacement list
+or SQL identifier boundary — as paste *punctuation* (backticks around the
+whole ID, a trailing `;` or `,`) they are stripped before parsing.
 
 Looker Studio report parameters are not the binding mechanism. They can pass
 scalar values to BigQuery custom SQL, but BigQuery query parameters cannot

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -39,9 +39,9 @@
           <div class="eyebrow">BigQuery Agent Analytics</div>
           <h1>Your telemetry. Your dashboard.</h1>
           <p class="lede">
-            Enter three BigQuery identifiers. We’ll prepare a private copy of
-            the published Looker Studio dashboard, connected with your Google
-            credentials.
+            Enter your fully qualified BQAA table ID. We’ll prepare a private
+            copy of the published Looker Studio dashboard, connected with
+            your Google credentials.
           </p>
           <ul class="facts" aria-label="Dashboard facts">
             <li>37 parity charts</li>
@@ -77,7 +77,7 @@
           </span>
           <span class="field-error" id="table-id-error" aria-live="polite"></span>
 
-          <details>
+          <details id="advanced-settings">
             <summary>Advanced settings</summary>
             <label for="billing-project">Billing project ID</label>
             <input

--- a/dashboard/looker_studio/docs/index.html
+++ b/dashboard/looker_studio/docs/index.html
@@ -57,54 +57,25 @@
             used.
           </p>
 
-          <label for="project">Project ID</label>
+          <label for="table-id">Fully qualified BQAA table ID</label>
           <input
-            id="project"
-            name="project"
+            id="table-id"
+            name="tableId"
             autocomplete="off"
-            placeholder="my-gcp-project"
-            aria-describedby="project-hint project-error"
+            placeholder="my-project.my_dataset.agent_events"
+            aria-describedby="table-id-hint table-id-error"
             required
           >
-          <span class="field-hint" id="project-hint">
-            6–30 characters: lowercase letters, digits, and hyphens. Start
-            with a letter and end with a letter or digit.
-            Paste a fully qualified table ID or BigQuery Console table link
-            into any identifier field to fill all three.
+          <span class="field-hint" id="table-id-hint">
+            <code>project.dataset.table</code> — one ID names all three.
+            The plugin’s standard table is <code>agent_events</code>. Paste
+            a fully qualified table ID or a BigQuery Console table link;
+            backticks, a legacy colon after the project, and a trailing
+            <code>;</code> or <code>,</code> are cleaned up automatically.
+            Charts read this table directly and extract reporting fields
+            from its JSON columns.
           </span>
-          <span class="field-error" id="project-error" aria-live="polite"></span>
-
-          <label for="dataset">Dataset ID</label>
-          <input
-            id="dataset"
-            name="dataset"
-            autocomplete="off"
-            placeholder="agent_analytics"
-            aria-describedby="dataset-hint dataset-error"
-            required
-          >
-          <span class="field-hint" id="dataset-hint">
-            Start with a letter or underscore; then use letters, digits, or
-            underscores.
-          </span>
-          <span class="field-error" id="dataset-error" aria-live="polite"></span>
-
-          <label for="table">BQAA table ID</label>
-          <input
-            id="table"
-            name="table"
-            autocomplete="off"
-            value="agent_events"
-            aria-describedby="table-hint table-error"
-            required
-          >
-          <span class="field-hint" id="table-hint">
-            Charts read this table directly and extract reporting fields from
-            its JSON columns. The standard BQAA table is
-            <code>agent_events</code>. Custom table IDs may use ASCII letters,
-            digits, underscores, and hyphens.
-          </span>
-          <span class="field-error" id="table-error" aria-live="polite"></span>
+          <span class="field-error" id="table-id-error" aria-live="polite"></span>
 
           <details>
             <summary>Advanced settings</summary>
@@ -162,10 +133,11 @@
       <section class="how" aria-label="How setup works">
         <article class="step">
           <span class="step-number">01</span>
-          <h3>Enter identifiers</h3>
+          <h3>Enter your table ID</h3>
           <p>
-            Use the project, dataset, and base table configured for the ADK
-            BigQuery Agent Analytics plugin.
+            Paste or type the fully qualified ID of the base table configured
+            for the ADK BigQuery Agent Analytics plugin —
+            <code>project.dataset.table</code>, one value naming all three.
           </p>
         </article>
         <article class="step">

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -22,7 +22,10 @@
 #                                 marker's creation, a page that never
 #                                 writes the app-initialized marker, and a
 #                                 page whose live field value is mutated
-#                                 without a serialized value attribute
+#                                 without a serialized value attribute, a
+#                                 delayed live-value mutation after marker
+#                                 creation, and a decoy zero-error element
+#                                 beside a marker recording a real error
 #
 # Every fixture except the missing-initialization one satisfies the full
 # healthy baseline (#448): the runtime data-bqaa-app-initialized marker (set
@@ -207,6 +210,56 @@ HTML
   fi
   echo "self-test 7 OK: non-pristine live field value is detected"
 
+  # 8. A page that is pristine at marker creation (400 ms) but mutates the
+  #    live field value at 900 ms. Only a periodically restamped snapshot —
+  #    not a one-shot at creation — reflects the final state.
+  DELAYED_VALUE="$OUT_DIR/fixture-delayed-live-value"
+  mkdir -p "$DELAYED_VALUE"
+  cat > "$DELAYED_VALUE/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
+<script>
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
+window.addEventListener("load", function () {
+  setTimeout(function () {
+    document.getElementById("table-id").value = "late-mutation";
+  }, 900);
+});
+</script>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$DELAYED_VALUE" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 8 FAILED: a delayed live-value mutation passed as pristine"
+  fi
+  echo "self-test 8 OK: delayed live-value mutation is detected"
+
+  # 9. A page carrying an unrelated data-errors="0" element while the real
+  #    instrumentation marker records an error. An unscoped whole-DOM grep
+  #    would be satisfied by the decoy; only the marker-scoped assertion
+  #    catches the real count.
+  MASKING="$OUT_DIR/fixture-masking-element"
+  mkdir -p "$MASKING"
+  cat > "$MASKING/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
+<div data-errors="0" data-detail=""></div>
+<script>
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
+console.error("masked boom");
+</script>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$MASKING" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 9 FAILED: a decoy data-errors element masked a real error"
+  fi
+  echo "self-test 9 OK: decoy zero-error element cannot mask the marker"
+
   echo "browser smoke self-test OK: all negative fixtures fail as required"
   exit 0
 fi
@@ -285,6 +338,10 @@ window.__smokeErrors = [];
       marker.id = "smoke-result";
       document.body.appendChild(marker);
       stamp();
+      // Restamp periodically until the DOM dump: a one-time snapshot would
+      // miss a live-state mutation after marker creation (#449 review), the
+      // same way the error count is kept live rather than one-shot.
+      setInterval(stamp, 100);
     }, 400);
   });
 })();
@@ -358,12 +415,20 @@ if [ -z "$TIMED_OUT_KILL" ] && [ "$CHROME_STATUS" -ne 0 ]; then
   fail "browser exited with status $CHROME_STATUS"
 fi
 
-grep -q 'id="smoke-result"' "$OUT_DIR/dom.html" \
+# Extract THE instrumentation marker first and scope every marker-borne
+# assertion to that one tag: an unrelated element carrying data-errors="0"
+# must never mask a nonzero count on the real marker (#449 review).
+FLAT_DOM="$(tr '\n' ' ' < "$OUT_DIR/dom.html")"
+MARKER_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<div[^>]*id="smoke-result"[^>]*>' | head -1)"
+[ -n "$MARKER_TAG" ] \
   || fail "instrumentation marker missing — the page never finished loading"
-if ! grep -q 'data-errors="0"' "$OUT_DIR/dom.html"; then
-  DETAIL="$(grep -o 'data-detail="[^"]*"' "$OUT_DIR/dom.html" | head -1)"
-  fail "page-level errors recorded: ${DETAIL:-unknown}"
-fi
+case "$MARKER_TAG" in
+  *'data-errors="0"'*) : ;;
+  *)
+    DETAIL="$(printf '%s' "$MARKER_TAG" | grep -o 'data-detail="[^"]*"' | head -1)"
+    fail "page-level errors recorded: ${DETAIL:-unknown}"
+    ;;
+esac
 # The app-initialized marker is written only at runtime by the module, so
 # its presence in the live DOM — and its absence from the static source —
 # proves app.mjs executed (#448; replaces the pre-#448 initial-error proof).
@@ -378,9 +443,6 @@ grep -q 'data-bqaa-app-initialized="true"' "$OUT_DIR/dom.html" \
 # assert the exact LIVE states via the instrumentation snapshot — Chrome's
 # dump-dom does not reflect the value property into a value attribute, so
 # serialized-markup checks cannot prove the field is empty (#449 review).
-FLAT_DOM="$(tr '\n' ' ' < "$OUT_DIR/dom.html")"
-MARKER_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<div[^>]*id="smoke-result"[^>]*>' | head -1)"
-[ -n "$MARKER_TAG" ] || fail "instrumentation marker tag not found"
 case "$MARKER_TAG" in
   *'data-table-value=""'*) : ;;
   *) fail "pristine table-id field must have an empty live value" ;;

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -19,8 +19,10 @@
 #                                 occupied port, a failing browser binary, a
 #                                 browser that writes healthy DOM then exits
 #                                 nonzero, a console error delayed past the
-#                                 marker's creation, and a page that never
-#                                 writes the app-initialized marker
+#                                 marker's creation, a page that never
+#                                 writes the app-initialized marker, and a
+#                                 page whose live field value is mutated
+#                                 without a serialized value attribute
 #
 # Every fixture except the missing-initialization one satisfies the full
 # healthy baseline (#448): the runtime data-bqaa-app-initialized marker (set
@@ -127,7 +129,7 @@ cat <<'DOM'
 <input id="table-id">
 <a id="create-dashboard" aria-disabled="true"></a>
 <button id="copy-link" disabled></button>
-<div id="smoke-result" data-errors="0" data-detail=""></div>
+<div id="smoke-result" data-errors="0" data-detail="" data-table-value="" data-create-aria-disabled="true" data-create-has-href="false" data-copy-disabled="true"></div>
 </body></html>
 DOM
 sleep 1
@@ -182,6 +184,29 @@ HTML
   fi
   echo "self-test 6 OK: missing app initialization is detected"
 
+  # 7. A page whose live table-id value PROPERTY is set to a non-empty
+  #    string (no value attribute ever appears in the markup). Serialized
+  #    tag checks false-pass this state; only the live-state snapshot on
+  #    the instrumentation marker can catch it.
+  MUTATED="$OUT_DIR/fixture-live-value"
+  mkdir -p "$MUTATED"
+  cat > "$MUTATED/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
+<script>
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
+document.getElementById("table-id").value = "not-pristine";
+</script>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$MUTATED" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 7 FAILED: a mutated live field value passed as pristine"
+  fi
+  echo "self-test 7 OK: non-pristine live field value is detected"
+
   echo "browser smoke self-test OK: all negative fixtures fail as required"
   exit 0
 fi
@@ -216,6 +241,28 @@ window.__smokeErrors = [];
     }
     marker.setAttribute("data-errors", String(window.__smokeErrors.length));
     marker.setAttribute("data-detail", window.__smokeErrors.join(" | ").slice(0, 500));
+    // Live-state snapshot (#449 review): dump-dom does not reflect the
+    // value PROPERTY into a value attribute, so the pristine assertions
+    // must read the live properties, not the serialized markup.
+    var table = document.querySelector("#table-id");
+    var create = document.querySelector("#create-dashboard");
+    var copy = document.querySelector("#copy-link");
+    marker.setAttribute(
+      "data-table-value",
+      table ? String(table.value) : "MISSING"
+    );
+    marker.setAttribute(
+      "data-create-aria-disabled",
+      create ? String(create.getAttribute("aria-disabled")) : "MISSING"
+    );
+    marker.setAttribute(
+      "data-create-has-href",
+      create ? String(create.hasAttribute("href")) : "MISSING"
+    );
+    marker.setAttribute(
+      "data-copy-disabled",
+      copy ? String(copy.disabled) : "MISSING"
+    );
   };
   var record = function (message) {
     window.__smokeErrors.push(String(message));
@@ -328,32 +375,27 @@ fi
 grep -q 'data-bqaa-app-initialized="true"' "$OUT_DIR/dom.html" \
   || fail "app-initialized marker missing — app.mjs did not execute in the browser"
 # With no query parameters the first load is the pristine state (#448):
-# assert the exact elements and states, not generic attribute greps — a
-# generic aria-disabled search is already satisfied by the static markup
-# and would prove nothing about the runtime state (#449 review).
+# assert the exact LIVE states via the instrumentation snapshot — Chrome's
+# dump-dom does not reflect the value property into a value attribute, so
+# serialized-markup checks cannot prove the field is empty (#449 review).
 FLAT_DOM="$(tr '\n' ' ' < "$OUT_DIR/dom.html")"
-TABLE_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<input[^>]*id="table-id"[^>]*>' | head -1)"
-[ -n "$TABLE_TAG" ] || fail "pristine first load must render the table-id field"
-case "$TABLE_TAG" in
-  *aria-invalid*) fail "pristine table-id field must not be marked invalid" ;;
+MARKER_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<div[^>]*id="smoke-result"[^>]*>' | head -1)"
+[ -n "$MARKER_TAG" ] || fail "instrumentation marker tag not found"
+case "$MARKER_TAG" in
+  *'data-table-value=""'*) : ;;
+  *) fail "pristine table-id field must have an empty live value" ;;
 esac
-case "$TABLE_TAG" in
-  *value=*) fail "pristine table-id field must be empty" ;;
-esac
-CREATE_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<a[^>]*id="create-dashboard"[^>]*>' | head -1)"
-[ -n "$CREATE_TAG" ] || fail "pristine first load must render the create link"
-case "$CREATE_TAG" in
-  *'aria-disabled="true"'*) : ;;
+case "$MARKER_TAG" in
+  *'data-create-aria-disabled="true"'*) : ;;
   *) fail "pristine create link must be aria-disabled" ;;
 esac
-case "$CREATE_TAG" in
-  *href=*) fail "pristine create link must carry no URL" ;;
+case "$MARKER_TAG" in
+  *'data-create-has-href="false"'*) : ;;
+  *) fail "pristine create link must carry no URL" ;;
 esac
-COPY_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<button[^>]*id="copy-link"[^>]*>' | head -1)"
-[ -n "$COPY_TAG" ] || fail "pristine first load must render the copy button"
-case "$COPY_TAG" in
-  *disabled*) : ;;
-  *) fail "pristine copy button must be disabled" ;;
+case "$MARKER_TAG" in
+  *'data-copy-disabled="true"'*) : ;;
+  *) fail "pristine copy button must be disabled (live property)" ;;
 esac
 if printf '%s' "$FLAT_DOM" | grep -q 'aria-invalid='; then
   fail "pristine first load must not mark any field invalid"

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -79,7 +79,9 @@ if [ "${1:-}" = "--self-test" ]; then
   cat > "$FIXTURE/index.html" <<'HTML'
 <!doctype html>
 <html><body>
-<a aria-disabled="true"></a>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
 <script>
 document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
 console.error("generic boom");
@@ -122,7 +124,9 @@ HTML
 #!/usr/bin/env bash
 cat <<'DOM'
 <html data-bqaa-app-initialized="true"><body>
-<a aria-disabled="true"></a>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
 <div id="smoke-result" data-errors="0" data-detail=""></div>
 </body></html>
 DOM
@@ -143,7 +147,9 @@ FAKE
   cat > "$DELAYED/index.html" <<'HTML'
 <!doctype html>
 <html><body>
-<a aria-disabled="true"></a>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
 <script>
 document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
 window.addEventListener("load", function () {
@@ -166,7 +172,9 @@ HTML
   cat > "$UNINITIALIZED/index.html" <<'HTML'
 <!doctype html>
 <html><body>
-<a aria-disabled="true"></a>
+<input id="table-id">
+<a id="create-dashboard" aria-disabled="true"></a>
+<button id="copy-link" disabled></button>
 </body></html>
 HTML
   if SMOKE_DOCS_DIR="$UNINITIALIZED" "$SCRIPT_PATH" >/dev/null 2>&1; then
@@ -320,12 +328,36 @@ fi
 grep -q 'data-bqaa-app-initialized="true"' "$OUT_DIR/dom.html" \
   || fail "app-initialized marker missing — app.mjs did not execute in the browser"
 # With no query parameters the first load is the pristine state (#448):
-# the empty field carries no error and both actions are disabled.
-if grep -q 'aria-invalid=' "$OUT_DIR/dom.html"; then
+# assert the exact elements and states, not generic attribute greps — a
+# generic aria-disabled search is already satisfied by the static markup
+# and would prove nothing about the runtime state (#449 review).
+FLAT_DOM="$(tr '\n' ' ' < "$OUT_DIR/dom.html")"
+TABLE_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<input[^>]*id="table-id"[^>]*>' | head -1)"
+[ -n "$TABLE_TAG" ] || fail "pristine first load must render the table-id field"
+case "$TABLE_TAG" in
+  *aria-invalid*) fail "pristine table-id field must not be marked invalid" ;;
+esac
+case "$TABLE_TAG" in
+  *value=*) fail "pristine table-id field must be empty" ;;
+esac
+CREATE_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<a[^>]*id="create-dashboard"[^>]*>' | head -1)"
+[ -n "$CREATE_TAG" ] || fail "pristine first load must render the create link"
+case "$CREATE_TAG" in
+  *'aria-disabled="true"'*) : ;;
+  *) fail "pristine create link must be aria-disabled" ;;
+esac
+case "$CREATE_TAG" in
+  *href=*) fail "pristine create link must carry no URL" ;;
+esac
+COPY_TAG="$(printf '%s' "$FLAT_DOM" | grep -o '<button[^>]*id="copy-link"[^>]*>' | head -1)"
+[ -n "$COPY_TAG" ] || fail "pristine first load must render the copy button"
+case "$COPY_TAG" in
+  *disabled*) : ;;
+  *) fail "pristine copy button must be disabled" ;;
+esac
+if printf '%s' "$FLAT_DOM" | grep -q 'aria-invalid='; then
   fail "pristine first load must not mark any field invalid"
 fi
-grep -q 'aria-disabled="true"' "$OUT_DIR/dom.html" \
-  || fail "pristine first load must keep the create action disabled"
 # Belt and braces: anything Chrome itself logs as an error still fails.
 if grep -Eiq 'CONSOLE.*\b(error|blocked|failed|uncaught)\b' "$OUT_DIR/console.log"; then
   fail "browser stderr reported console errors"

--- a/dashboard/looker_studio/tools/browser_smoke.sh
+++ b/dashboard/looker_studio/tools/browser_smoke.sh
@@ -18,8 +18,14 @@
 #                                 to fail: an immediate console error, an
 #                                 occupied port, a failing browser binary, a
 #                                 browser that writes healthy DOM then exits
-#                                 nonzero, and a console error delayed past
-#                                 the marker's creation
+#                                 nonzero, a console error delayed past the
+#                                 marker's creation, and a page that never
+#                                 writes the app-initialized marker
+#
+# Every fixture except the missing-initialization one satisfies the full
+# healthy baseline (#448): the runtime data-bqaa-app-initialized marker (set
+# by script, never static), an aria-disabled action, and no aria-invalid
+# anywhere — so each fixture's injected fault is the sole reason it fails.
 #
 # Env: CHROME_BIN, SMOKE_PORT, SMOKE_DOCS_DIR override discovery.
 set -euo pipefail
@@ -66,15 +72,18 @@ if [ "${1:-}" = "--self-test" ]; then
   [ -n "$CHROME" ] || fail "no Chrome/Chromium binary found (set CHROME_BIN)"
 
   # 1. A page that reports a generic console error (no keyword the old
-  #    grep would have matched) but otherwise looks healthy, including the
-  #    aria-invalid marker.
+  #    grep would have matched) but otherwise satisfies the full healthy
+  #    baseline: runtime marker, pristine field, disabled action.
   FIXTURE="$OUT_DIR/fixture-console-error"
   mkdir -p "$FIXTURE"
   cat > "$FIXTURE/index.html" <<'HTML'
 <!doctype html>
 <html><body>
-<input aria-invalid="true">
-<script>console.error("generic boom");</script>
+<a aria-disabled="true"></a>
+<script>
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
+console.error("generic boom");
+</script>
 </body></html>
 HTML
   if SMOKE_DOCS_DIR="$FIXTURE" "$SCRIPT_PATH" >/dev/null 2>&1; then
@@ -112,8 +121,8 @@ HTML
   cat > "$FAKE_CHROME" <<'FAKE'
 #!/usr/bin/env bash
 cat <<'DOM'
-<html><body>
-<input aria-invalid="true">
+<html data-bqaa-app-initialized="true"><body>
+<a aria-disabled="true"></a>
 <div id="smoke-result" data-errors="0" data-detail=""></div>
 </body></html>
 DOM
@@ -134,8 +143,9 @@ FAKE
   cat > "$DELAYED/index.html" <<'HTML'
 <!doctype html>
 <html><body>
-<input aria-invalid="true">
+<a aria-disabled="true"></a>
 <script>
+document.documentElement.setAttribute("data-bqaa-app-initialized", "true");
 window.addEventListener("load", function () {
   setTimeout(function () { console.error("generic delayed boom"); }, 900);
 });
@@ -146,6 +156,23 @@ HTML
     fail "self-test 5 FAILED: a delayed console error passed"
   fi
   echo "self-test 5 OK: post-snapshot delayed error is detected"
+
+  # 6. A page that looks completely healthy — no errors, pristine field,
+  #    disabled action — but never writes the runtime app-initialized
+  #    marker. Only the marker assertion catches a module that silently
+  #    failed to execute.
+  UNINITIALIZED="$OUT_DIR/fixture-missing-initialization"
+  mkdir -p "$UNINITIALIZED"
+  cat > "$UNINITIALIZED/index.html" <<'HTML'
+<!doctype html>
+<html><body>
+<a aria-disabled="true"></a>
+</body></html>
+HTML
+  if SMOKE_DOCS_DIR="$UNINITIALIZED" "$SCRIPT_PATH" >/dev/null 2>&1; then
+    fail "self-test 6 FAILED: a page without the app-initialized marker passed"
+  fi
+  echo "self-test 6 OK: missing app initialization is detected"
 
   echo "browser smoke self-test OK: all negative fixtures fail as required"
   exit 0
@@ -282,14 +309,26 @@ if ! grep -q 'data-errors="0"' "$OUT_DIR/dom.html"; then
   DETAIL="$(grep -o 'data-detail="[^"]*"' "$OUT_DIR/dom.html" | head -1)"
   fail "page-level errors recorded: ${DETAIL:-unknown}"
 fi
-# With no query parameters the project field is empty, so a successfully
-# loaded module runs refresh() and marks the field invalid. Static HTML
-# never contains this attribute; its presence proves app.mjs executed.
-grep -q 'aria-invalid="true"' "$OUT_DIR/dom.html" \
-  || fail "validation never ran — app.mjs did not execute in the browser"
+# The app-initialized marker is written only at runtime by the module, so
+# its presence in the live DOM — and its absence from the static source —
+# proves app.mjs executed (#448; replaces the pre-#448 initial-error proof).
+# Match the marker only as a static tag attribute: a fixture's inline
+# script may name it in setAttribute() without shipping it statically.
+if grep -Eq '<[A-Za-z!][^>]*data-bqaa-app-initialized' "$DOCS_DIR/index.html"; then
+  fail "the app-initialized marker must not appear in static HTML"
+fi
+grep -q 'data-bqaa-app-initialized="true"' "$OUT_DIR/dom.html" \
+  || fail "app-initialized marker missing — app.mjs did not execute in the browser"
+# With no query parameters the first load is the pristine state (#448):
+# the empty field carries no error and both actions are disabled.
+if grep -q 'aria-invalid=' "$OUT_DIR/dom.html"; then
+  fail "pristine first load must not mark any field invalid"
+fi
+grep -q 'aria-disabled="true"' "$OUT_DIR/dom.html" \
+  || fail "pristine first load must keep the create action disabled"
 # Belt and braces: anything Chrome itself logs as an error still fails.
 if grep -Eiq 'CONSOLE.*\b(error|blocked|failed|uncaught)\b' "$OUT_DIR/console.log"; then
   fail "browser stderr reported console errors"
 fi
 
-echo "browser smoke OK: module loaded, zero page-level errors, validation ran"
+echo "browser smoke OK: module initialized, zero page-level errors, pristine first load"

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -9,6 +9,7 @@ import {
   parseTableReferenceForInput,
   splitQualifiedTableId,
   validateConfiguration,
+  validateQualifiedTableId,
 } from "../docs/configurator.mjs";
 import { REPORT_CONFIG } from "../docs/report-config.mjs";
 
@@ -440,7 +441,114 @@ for (const collision of [
 ]) {
   assert.throws(
     () => buildDashboardUrl(collision),
-    /reserved dashboard template value/,
+    // #448: the collision is attributed to the offending segment so the
+    // single-field UI reports it in the segment-level error class; the
+    // collision logic and Linking API output are unchanged.
+    (error) =>
+      error.field === "tableId" &&
+      ["project", "dataset"].includes(error.segment) &&
+      /reserved dashboard template value/.test(error.message),
+  );
+}
+
+// #448: the combined-field validator returns the parsed triple and throws
+// in exactly two error classes: whole-field (segment: null) for input with
+// no truthful segments to blame, and segment-level (segment named) when
+// exactly three segments exist and one violates its rule — including
+// sentinel collisions, which must fail here and never after Ready.
+assert.deepEqual(
+  validateQualifiedTableId("my-project.my_dataset.my_table"),
+  qualifiedTableId,
+);
+assert.deepEqual(
+  validateQualifiedTableId("`my-project.my_dataset.my_table`;"),
+  qualifiedTableId,
+  "SQL-copy punctuation is normalized by the combined-field validator",
+);
+assert.throws(
+  () => validateQualifiedTableId(""),
+  (error) =>
+    error.field === "tableId" &&
+    error.segment === null &&
+    /project\.dataset\.table/.test(error.message),
+  "empty input is a whole-field error",
+);
+assert.throws(
+  () => validateQualifiedTableId("a.b.c.d"),
+  (error) =>
+    error.field === "tableId" &&
+    error.segment === null &&
+    /three dot-separated segments/.test(error.message),
+  "wrong arity is a whole-field error",
+);
+assert.throws(
+  () => validateQualifiedTableId("BADPROJECT.dataset.table"),
+  (error) =>
+    error.field === "tableId" &&
+    error.segment === "project" &&
+    /^Project segment: /.test(error.message),
+  "an invalid project is a segment-level error naming the segment",
+);
+assert.throws(
+  () => validateQualifiedTableId("my-project.bad-dataset.table"),
+  (error) =>
+    error.segment === "dataset" && /^Dataset segment: /.test(error.message),
+);
+assert.throws(
+  () => validateQualifiedTableId("my-project.my_dataset.table$20260807"),
+  (error) =>
+    error.segment === "table" && /^Table segment: /.test(error.message),
+);
+assert.throws(
+  () => validateQualifiedTableId("xsentinelbqaaevents.my_dataset.my_table"),
+  (error) =>
+    error.segment === "project" &&
+    /reserved dashboard template value/.test(error.message),
+  "a sentinel collision fails segment-attributed before Ready",
+);
+assert.deepEqual(
+  validateQualifiedTableId(publicConsoleTableUrl),
+  consoleTableId,
+  "a supported Console link validates through the combined field",
+);
+assert.deepEqual(
+  validateQualifiedTableId(pantheonTableUrl),
+  consoleTableId,
+  "both supported Console hosts validate through the combined field",
+);
+assert.throws(
+  () =>
+    validateQualifiedTableId(
+      "https://console.cloud.google.com/bigquery?ws=" +
+        workspaceReference +
+        "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+        "!2sbqaa_looker_demo!3sother_table",
+    ),
+  (error) =>
+    error.segment === null &&
+    /clearly name exactly one BigQuery table/.test(error.message),
+  "an ambiguous Console link is a whole-field error",
+);
+
+// #448: a generated setup link round-trips through the single field while
+// retaining the existing three-parameter query format.
+{
+  const roundTripSetup = new URL(
+    buildSetupUrl(values, "https://example.test/configure"),
+  );
+  const prefillId = [
+    roundTripSetup.searchParams.get("project"),
+    roundTripSetup.searchParams.get("dataset"),
+    roundTripSetup.searchParams.get("table"),
+  ].join(".");
+  const reparsed = validateQualifiedTableId(prefillId);
+  assert.equal(
+    buildSetupUrl(
+      { ...reparsed, billingProject: "" },
+      "https://example.test/configure",
+    ),
+    roundTripSetup.toString(),
+    "the setup link survives a field round-trip byte-for-byte",
   );
 }
 
@@ -489,16 +597,14 @@ const fakeElements = new Map([
   ["#copy-checklist", new FakeElement()],
   ["#security-checklist", new FakeElement()],
   ["#form-status", new FakeElement()],
-  ["#project", new FakeElement(values.project)],
-  ["#dataset", new FakeElement(values.dataset)],
-  ["#table", new FakeElement(values.table)],
+  ["#table-id", new FakeElement("")],
+  ["#table-id-error", new FakeElement()],
   ["#billing-project", new FakeElement("")],
-  ["#project-error", new FakeElement()],
-  ["#dataset-error", new FakeElement()],
-  ["#table-error", new FakeElement()],
   ["#billing-project-error", new FakeElement()],
 ]);
+const fakeDocumentElement = new FakeElement();
 globalThis.document = {
+  documentElement: fakeDocumentElement,
   querySelector(selector) {
     return fakeElements.get(selector);
   },
@@ -510,33 +616,57 @@ globalThis.window = {
   },
   open() {},
 };
+let copiedText = "";
 Object.defineProperty(globalThis, "navigator", {
   configurable: true,
   value: {
     clipboard: {
-      async writeText() {},
+      async writeText(text) {
+        copiedText = text;
+      },
     },
   },
 });
 
-await import("../docs/app.mjs");
+const field = fakeElements.get("#table-id");
+const fieldError = fakeElements.get("#table-id-error");
+const billing = fakeElements.get("#billing-project");
+const billingErrorEl = fakeElements.get("#billing-project-error");
+const createLink = fakeElements.get("#create-dashboard");
+const copyButton = fakeElements.get("#copy-link");
+const formStatus = fakeElements.get("#form-status");
 
-function resetTableInputs() {
-  fakeElements.get("#project").value = values.project;
-  fakeElements.get("#dataset").value = values.dataset;
-  fakeElements.get("#table").value = values.table;
-
-  fakeElements.get("#form-status").textContent = "";
-  fakeElements.get("#form-status").dataset.kind = "";
-
-  fakeElements.get("#project-error").textContent = "";
-  fakeElements.get("#dataset-error").textContent = "";
-  fakeElements.get("#table-error").textContent = "";
+function assertActionsDisabled(context) {
+  assert.equal(createLink.href, "", `${context}: create link has no URL`);
+  assert.equal(
+    createLink.attributes.get("aria-disabled"),
+    "true",
+    `${context}: create link is aria-disabled`,
+  );
+  assert.equal(copyButton.disabled, true, `${context}: copy is disabled`);
 }
 
-function pasteIntoProject(name, text) {
+function assertFieldClean(context) {
+  assert.equal(
+    field.attributes.has("aria-invalid"),
+    false,
+    `${context}: field is not marked invalid`,
+  );
+  assert.equal(fieldError.textContent, "", `${context}: no field error`);
+}
+
+function typeIntoField(value) {
+  field.value = value;
+  field.listeners.input({ target: field });
+}
+
+function commitField() {
+  field.listeners.change({ target: field });
+}
+
+function pasteIntoField(text) {
   let prevented = false;
-  fakeElements.get(`#${name}`).listeners.paste({
+  field.listeners.paste({
     clipboardData: { getData: () => text },
     preventDefault() {
       prevented = true;
@@ -545,6 +675,106 @@ function pasteIntoProject(name, text) {
   return prevented;
 }
 
+await import("../docs/app.mjs");
+
+// #448 pristine first load: empty field, no error, both actions disabled,
+// no status — and the runtime app-initialized marker is set.
+assert.equal(field.value, "", "pristine: the field starts empty");
+assertFieldClean("pristine");
+assertActionsDisabled("pristine");
+assert.equal(formStatus.textContent, "", "pristine: no status");
+assert.equal(
+  fakeDocumentElement.attributes.get("data-bqaa-app-initialized"),
+  "true",
+  "app.mjs writes the runtime app-initialized marker",
+);
+
+// Manual typing stays partial: no error while incomplete, but a value that
+// becomes valid enables the actions without waiting for blur.
+typeIntoField("my-pro");
+assertFieldClean("partial typing");
+assertActionsDisabled("partial typing");
+assert.equal(formStatus.textContent, "", "partial typing: no status");
+
+typeIntoField("my-project.my_dataset.my_table");
+assert.match(
+  formStatus.textContent,
+  /^Ready for my-project\.my_dataset\.my_table\./,
+  "a hand-typed valid ID reaches Ready",
+);
+assert.equal(formStatus.dataset.kind, "ready");
+assert.ok(createLink.href, "Ready enables the create link");
+assert.equal(copyButton.disabled, false, "Ready enables copy");
+assertFieldClean("valid");
+
+// #448 fail-closed mutation: editing the Ready value immediately revokes
+// the derived triple, both actions, and the Ready announcement — while the
+// error presentation stays deferred until blur (the field is untouched by
+// a validation trigger so far in this cycle).
+typeIntoField("my-project.my_dataset.");
+assertActionsDisabled("mutated away from valid");
+assert.equal(
+  formStatus.textContent,
+  "",
+  "mutation clears the prior Ready announcement",
+);
+assert.equal(formStatus.dataset.kind, "");
+assertFieldClean("mutated before blur");
+
+commitField();
+assert.equal(
+  field.attributes.get("aria-invalid"),
+  "true",
+  "blur reveals the deferred error",
+);
+assert.match(
+  fieldError.textContent,
+  /three dot-separated segments/,
+  "an incomplete ID is a whole-field error",
+);
+assertActionsDisabled("invalid after blur");
+
+// Corrected: once touched/invalid, revalidation happens on every input.
+typeIntoField("my-project.my_dataset.my_table");
+assert.match(formStatus.textContent, /^Ready for /, "corrected reaches Ready");
+assertFieldClean("corrected");
+assert.ok(createLink.href, "corrected re-enables the create link");
+
+// Segment-level error class: the offending segment is named inline.
+typeIntoField("BADPROJECT.dataset.table");
+assert.match(
+  fieldError.textContent,
+  /^Project segment: /,
+  "an invalid project segment is attributed inline",
+);
+assert.match(fieldError.textContent, /6–30 lowercase letters/);
+assertActionsDisabled("segment error");
+assert.equal(formStatus.textContent, "", "segment error keeps the status empty");
+
+// Sentinel collisions are segment-attributed and block Ready.
+typeIntoField("xsentinelbqaaevents.my_dataset.my_table");
+assert.match(
+  fieldError.textContent,
+  /^Project segment: .*reserved dashboard template value/,
+  "a sentinel collision reports as a segment-level error before Ready",
+);
+assertActionsDisabled("sentinel collision");
+
+// Whole-field error class for a link that names no single table.
+typeIntoField(
+  "https://console.cloud.google.com/bigquery?ws=" +
+    workspaceReference +
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+    "!2sbqaa_looker_demo!3sother_table",
+);
+assert.match(
+  fieldError.textContent,
+  /clearly name exactly one BigQuery table/,
+  "an ambiguous Console link is a whole-field error",
+);
+assertActionsDisabled("ambiguous link");
+
+// Every supported paste form normalizes into the field and reaches Ready.
 for (const [description, pastedId] of [
   ["normal dotted ID", "my-project.my_dataset.my_table"],
   ["backticked ID", "`my-project.my_dataset.my_table`"],
@@ -552,402 +782,167 @@ for (const [description, pastedId] of [
   ["semicolon-terminated ID", "my-project.my_dataset.my_table;"],
   ["comma-terminated ID", "my-project.my_dataset.my_table,"],
 ]) {
-  resetTableInputs();
-  assert.equal(pasteIntoProject("project", pastedId), true, `${description} is handled`);
-  assert.deepEqual(
-    {
-      project: fakeElements.get("#project").value,
-      dataset: fakeElements.get("#dataset").value,
-      table: fakeElements.get("#table").value,
-    },
-    qualifiedTableId,
-    `${description} fills all identifier fields`,
-  );
+  typeIntoField("");
+  assert.equal(pasteIntoField(pastedId), true, `${description} is handled`);
   assert.equal(
-    fakeElements.get("#form-status").textContent,
-    'Split "my-project.my_dataset.my_table" into the three fields.',
-    `${description} reports the split`,
+    field.value,
+    "my-project.my_dataset.my_table",
+    `${description} normalizes into the field`,
   );
-  assert.equal(fakeElements.get("#form-status").dataset.kind, "ready");
+  assert.match(
+    formStatus.textContent,
+    /^Ready for my-project\.my_dataset\.my_table\./,
+    `${description} reaches Ready`,
+  );
+  assert.equal(formStatus.dataset.kind, "ready");
+  assertFieldClean(description);
 }
 
-resetTableInputs();
-fakeElements.get("#dataset").value = "my-project.my_dataset.my_table";
-fakeElements.get("#dataset").listeners.change({
-  target: fakeElements.get("#dataset"),
-});
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  qualifiedTableId,
-  "the change fallback also splits a qualified ID",
-);
-assert.equal(
-  fakeElements.get("#form-status").textContent,
-  'Split "my-project.my_dataset.my_table" into the three fields.',
-);
-
-resetTableInputs();
-
-assert.equal(
-  pasteIntoProject("project", "BADPROJECT.dataset.table"),
-  true,
-  "a qualified identifier with an invalid project is still distributed",
-);
-
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  {
-    project: "BADPROJECT",
-    dataset: "dataset",
-    table: "table",
-  },
-  "the qualified identifier is distributed before validation",
-);
-
-assert.match(
-  fakeElements.get("#project-error").textContent,
-  /Use 6–30 lowercase letters, digits, or hyphens; start with a letter and end with a letter or digit/,
-  "the invalid project component is reported inline",
-);
-
-assert.equal(
-  fakeElements.get("#form-status").textContent,
-  "",
-  "an invalid split does not replace the inline field error with a success status",
-);
-
-assert.equal(
-  fakeElements.get("#form-status").dataset.kind,
-  "",
-  "an invalid split does not leave the form in a ready state",
-);
-
-resetTableInputs();
-assert.equal(
-  pasteIntoProject("project", "customers"),
-  false,
-  "an unqualified ID retains normal paste behavior",
-);
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  {
-    project: values.project,
-    dataset: values.dataset,
-    table: values.table,
-  },
-  "an unqualified paste does not distribute values to the other fields",
-);
-
-// Simulate the browser applying the unhandled paste and dispatching its input event.
-fakeElements.get("#project").value = "customers";
-fakeElements.get("#project").listeners.input({
-  target: fakeElements.get("#project"),
-});
-assert.equal(fakeElements.get("#project").value, "customers");
-assert.equal(fakeElements.get("#dataset").value, values.dataset);
-assert.equal(fakeElements.get("#table").value, values.table);
-
-fakeElements.get("#table").value = "table,other";
-fakeElements.get("#table").listeners.input({
-  target: fakeElements.get("#table"),
-});
-assert.match(
-  fakeElements.get("#table-error").textContent,
-  /letters, digits/,
-);
-assert.equal(
-  fakeElements.get("#form-status").textContent,
-  "",
-  "field validation must not repeat the inline error in the form status",
-);
-
-resetTableInputs();
-
-assert.equal(
-  pasteIntoProject("project", "a.b.c.d"),
-  false,
-  "extra-dot identifiers should not be parsed",
-);
-
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  {
-    project: values.project,
-    dataset: values.dataset,
-    table: values.table,
-  },
-);
-
-fakeElements.get("#project").value = "a.b.c.d";
-fakeElements.get("#project").listeners.input({
-  target: fakeElements.get("#project"),
-});
-
-assert.match(
-  fakeElements.get("#project-error").textContent,
-  /6–30 lowercase letters/,
-);
-
-resetTableInputs();
-
-assert.equal(
-  pasteIntoProject("project", "my-project.my_dataset.table$20260807"),
-  true,
-);
-
-assert.equal(
-  fakeElements.get("#project").value,
-  "my-project",
-);
-
-assert.equal(
-  fakeElements.get("#dataset").value,
-  "my_dataset",
-);
-
-assert.equal(
-  fakeElements.get("#table").value,
-  "table$20260807",
-);
-
-assert.match(
-  fakeElements.get("#table-error").textContent,
-  /letters, digits/,
-);
-
-assert.equal(
-  fakeElements.get("#form-status").textContent,
-  "",
-  "invalid table should keep the form status empty",
-);
-
-resetTableInputs();
-
-assert.equal(
-  pasteIntoProject("project", "my-project.my_dataset.table@1234"),
-  true,
-);
-
-assert.equal(
-  fakeElements.get("#table").value,
-  "table@1234",
-);
-
-assert.match(
-  fakeElements.get("#table-error").textContent,
-  /letters, digits/,
-);
-
-assert.equal(
-  fakeElements.get("#form-status").textContent,
-  "",
-);
-
-resetTableInputs();
-
-assert.equal(
-  pasteIntoProject("project", "my-project.my_dataset."),
-  false,
-  "identifiers with an empty part should not be parsed",
-);
-
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  {
-    project: values.project,
-    dataset: values.dataset,
-    table: values.table,
-  },
-);
-
-fakeElements.get("#project").value = "my-project.my_dataset.";
-fakeElements.get("#project").listeners.input({
-  target: fakeElements.get("#project"),
-});
-
-assert.match(
-  fakeElements.get("#project-error").textContent,
-  /6–30 lowercase letters/,
-);
-
-resetTableInputs();
-
-const typedQualifiedId = "my-project.my_dataset.my_table";
-
-for (let i = 1; i <= typedQualifiedId.length; i += 1) {
-  const prefix = typedQualifiedId.slice(0, i);
-
-  fakeElements.get("#project").value = prefix;
-  fakeElements.get("#project").listeners.input({
-    target: fakeElements.get("#project"),
-  });
-
-  assert.equal(
-    fakeElements.get("#project").value,
-    prefix,
-    `typing "${prefix}" must not distribute the qualified ID`,
-  );
-  assert.equal(
-    fakeElements.get("#dataset").value,
-    values.dataset,
-    `typing "${prefix}" must not change the dataset`,
-  );
-  assert.equal(
-    fakeElements.get("#table").value,
-    values.table,
-    `typing "${prefix}" must not change the table`,
-  );
-}
-
-fakeElements.get("#project").listeners.change({
-  target: fakeElements.get("#project"),
-});
-
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  qualifiedTableId,
-  "a committed qualified ID is distributed on change",
-);
-
-for (const field of ["project", "dataset", "table"]) {
-  resetTableInputs();
-
-  assert.equal(
-    pasteIntoProject(
-      field,
-      "my-project.my_dataset.my_table",
-    ),
-    true,
-    `qualified ID pasted into ${field} is handled`,
-  );
-
-  assert.deepEqual(
-    {
-      project: fakeElements.get("#project").value,
-      dataset: fakeElements.get("#dataset").value,
-      table: fakeElements.get("#table").value,
-    },
-    qualifiedTableId,
-    `qualified ID pasted into ${field} fills all identifier fields`,
-  );
-}
-
+// Both supported Console hosts parse through a paste into the single field.
 for (const [description, consoleUrl] of [
   ["Pantheon", pantheonTableUrl],
   ["public Console", publicConsoleTableUrl],
   ["clicked-table", clickedTableUrl],
+  ["encoded", encodedConsoleTableUrl],
 ]) {
-  for (const field of ["project", "dataset", "table"]) {
-    resetTableInputs();
-
-    assert.equal(
-      pasteIntoProject(field, consoleUrl),
-      true,
-      `${description} URL pasted into ${field} is handled`,
-    );
-    assert.deepEqual(
-      {
-        project: fakeElements.get("#project").value,
-        dataset: fakeElements.get("#dataset").value,
-        table: fakeElements.get("#table").value,
-      },
-      consoleTableId,
-      `${description} URL pasted into ${field} fills all identifier fields`,
-    );
-    assert.equal(
-      fakeElements.get("#form-status").textContent,
-      'Split "haiyuan-anarres-dev-806843.bqaa_looker_demo.agent_events" into the three fields.',
-      `${description} URL reports the extracted table`,
-    );
-    assert.equal(fakeElements.get("#form-status").dataset.kind, "ready");
-  }
+  typeIntoField("");
+  assert.equal(
+    pasteIntoField(consoleUrl),
+    true,
+    `${description} URL paste is handled`,
+  );
+  assert.equal(
+    field.value,
+    "haiyuan-anarres-dev-806843.bqaa_looker_demo.agent_events",
+    `${description} URL normalizes to the dotted ID`,
+  );
+  assert.match(formStatus.textContent, /^Ready for /);
 }
 
-resetTableInputs();
-fakeElements.get("#dataset").value = encodedConsoleTableUrl;
-fakeElements.get("#dataset").listeners.change({
-  target: fakeElements.get("#dataset"),
-});
-assert.deepEqual(
-  {
-    project: fakeElements.get("#project").value,
-    dataset: fakeElements.get("#dataset").value,
-    table: fakeElements.get("#table").value,
-  },
-  consoleTableId,
-  "the committed-input fallback recognizes an encoded Console URL",
+// A paste that parses but carries an invalid segment reports immediately:
+// paste is a validation trigger, no blur needed.
+typeIntoField("");
+assert.equal(pasteIntoField("BADPROJECT.dataset.table"), true);
+assert.equal(field.value, "BADPROJECT.dataset.table");
+assert.match(
+  fieldError.textContent,
+  /^Project segment: /,
+  "a pasted invalid segment reports without waiting for blur",
 );
+assertActionsDisabled("pasted segment error");
 
+// An unparseable paste lands as raw text; its input event validates it
+// immediately because paste is a validation trigger.
+typeIntoField("");
+assert.equal(
+  pasteIntoField("a.b.c.d"),
+  false,
+  "wrong-arity paste retains ordinary paste behavior",
+);
+typeIntoField("a.b.c.d");
+assert.match(
+  fieldError.textContent,
+  /three dot-separated segments/,
+  "the landed unparseable paste reports a whole-field error immediately",
+);
+assert.equal(field.value, "a.b.c.d", "the raw invalid text is retained");
+assertActionsDisabled("unparseable paste");
+
+// A rejected Console link lands as raw text and reports the link error.
 for (const rejectedUrl of [
   "https://evil.example/bigquery?ws=" + workspaceReference,
   "https://console.cloud.google.com/bigquery?ws=" +
-    "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events",
-  "https://console.cloud.google.com/bigquery?ws=" +
     "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
-  "https://console.cloud.google.com/bigquery?ws=" +
-    workspaceReference +
-    "!1m5!1m4!3m2!1shaiyuan-anarres-dev-806843" +
-    "!2sother_dataset!23sRESOURCE_LIST",
-  "https://console.cloud.google.com/bigquery?ws=" +
-    workspaceReference +
-    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbqaa_looker_demo",
-  "https://console.cloud.google.com/bigquery?ws=" + workspaceReference + "!4m3",
   "https://",
   "https:evil.example",
 ]) {
-  resetTableInputs();
+  typeIntoField("");
   assert.equal(
-    pasteIntoProject("dataset", rejectedUrl),
+    pasteIntoField(rejectedUrl),
     false,
     "a rejected Console URL retains ordinary paste behavior",
   );
-  assert.equal(fakeElements.get("#project").value, values.project);
-  assert.equal(fakeElements.get("#dataset").value, values.dataset);
-  assert.equal(fakeElements.get("#table").value, values.table);
+  typeIntoField(rejectedUrl);
+  assert.match(
+    fieldError.textContent,
+    /clearly name exactly one BigQuery table/,
+    `${rejectedUrl} reports the whole-field link error`,
+  );
+  assert.equal(field.value, rejectedUrl, "the raw link text is retained");
+  assertActionsDisabled("rejected link");
+}
 
-  // Simulate the browser applying the unintercepted paste to its target.
-  fakeElements.get("#dataset").value = rejectedUrl;
-  fakeElements.get("#dataset").listeners.input({
-    target: fakeElements.get("#dataset"),
+// #448 decision 3: actionability requires the billing override too. An
+// invalid override keeps the parsed table triple (the field stays clean and
+// its value survives) while both actions disable; correcting the override
+// restores Ready without touching the table field.
+typeIntoField("my-project.my_dataset.my_table");
+assert.match(formStatus.textContent, /^Ready for /);
+billing.value = "UPPERCASE";
+billing.listeners.input({ target: billing });
+assertActionsDisabled("invalid billing override");
+assert.match(
+  billingErrorEl.textContent,
+  /6–30 lowercase letters/,
+  "the billing field shows its own error",
+);
+assert.equal(
+  billing.attributes.get("aria-invalid"),
+  "true",
+  "the billing field is marked invalid",
+);
+assertFieldClean("table field during billing error");
+assert.equal(
+  field.value,
+  "my-project.my_dataset.my_table",
+  "the parsed table value is retained during a billing error",
+);
+
+billing.value = "billing-project-123";
+billing.listeners.input({ target: billing });
+assert.match(formStatus.textContent, /^Ready for /, "corrected billing restores Ready");
+assert.equal(billingErrorEl.textContent, "", "the billing error clears");
+assert.equal(billing.attributes.has("aria-invalid"), false);
+assert.match(
+  createLink.href,
+  /billingProjectId%5D=billing-project-123|billingProjectId=billing-project-123|ds\.ds230\.billingProjectId/,
+  "the explicit override reaches the Linking API URL",
+);
+{
+  const linkParams = new URL(createLink.href).searchParams;
+  assert.equal(
+    linkParams.get("ds.ds230.billingProjectId"),
+    "billing-project-123",
+  );
+}
+billing.value = "";
+billing.listeners.input({ target: billing });
+{
+  const linkParams = new URL(createLink.href).searchParams;
+  assert.equal(
+    linkParams.get("ds.ds230.billingProjectId"),
+    "my-project",
+    "a blank override bills the project segment of the fully qualified ID",
+  );
+}
+
+// Copy produces the unchanged three-parameter setup link from the current
+// derived triple.
+copiedText = "";
+await copyButton.listeners.click();
+{
+  const copied = new URL(copiedText);
+  assert.deepEqual(Object.fromEntries(copied.searchParams), {
+    project: "my-project",
+    dataset: "my_dataset",
+    table: "my_table",
   });
-  assert.equal(fakeElements.get("#project").value, values.project);
-  assert.equal(fakeElements.get("#table").value, values.table);
 }
 
 // #398: clicking the enabled create link sets the provisioning expectation
 // without blocking navigation, and the message clears on the next change.
-resetTableInputs();
-fakeElements.get("#project").listeners.input({
-  target: fakeElements.get("#project"),
-});
-assert.match(fakeElements.get("#form-status").textContent, /^Ready for /);
-
 let navigationPrevented = false;
-fakeElements.get("#create-dashboard").listeners.click({
+createLink.listeners.click({
   preventDefault() {
     navigationPrevented = true;
   },
@@ -958,31 +953,31 @@ assert.equal(
   "an enabled create link must still navigate",
 );
 assert.match(
-  fakeElements.get("#form-status").textContent,
+  formStatus.textContent,
   /may briefly show an error page/,
   "clicking the enabled link warns about the provisioning delay",
 );
-assert.equal(fakeElements.get("#form-status").dataset.kind, "waiting");
+assert.equal(formStatus.dataset.kind, "waiting");
 
-fakeElements.get("#project").listeners.input({
-  target: fakeElements.get("#project"),
-});
+typeIntoField(field.value);
 assert.doesNotMatch(
-  fakeElements.get("#form-status").textContent,
+  formStatus.textContent,
   /error page/,
   "the waiting message clears on the next valid state change",
 );
 
 fakeElements.get("#configurator").listeners.submit({ preventDefault() {} });
 assert.equal(
-  fakeElements.get("#form-status").dataset.kind,
+  formStatus.dataset.kind,
   "waiting",
   "submitting the form sets the same provisioning expectation",
 );
 
-fakeElements.get("#create-dashboard").href = "";
+// A disabled create link must not navigate; the attempted action is a
+// validation trigger that reveals the field error.
+typeIntoField("a.b.c.d");
 navigationPrevented = false;
-fakeElements.get("#create-dashboard").listeners.click({
+createLink.listeners.click({
   preventDefault() {
     navigationPrevented = true;
   },
@@ -992,7 +987,36 @@ assert.equal(
   true,
   "a disabled create link must not navigate",
 );
+assert.match(
+  fieldError.textContent,
+  /three dot-separated segments/,
+  "the attempted action reveals the field error",
+);
+
+// #448: an existing three-parameter setup link prefills the single field
+// and validates immediately; the regenerated link is identical.
+window.location.search =
+  "?project=my-project&dataset=my_dataset&table=my_table";
+billing.value = "";
+await import("../docs/app.mjs?prefill=three-parameter");
+assert.equal(
+  field.value,
+  "my-project.my_dataset.my_table",
+  "a legacy setup link composes the fully qualified ID",
+);
+assert.match(
+  formStatus.textContent,
+  /^Ready for my-project\.my_dataset\.my_table\./,
+  "a prefilled link validates immediately",
+);
+copiedText = "";
+await copyButton.listeners.click();
+assert.equal(
+  new URL(copiedText).search,
+  "?project=my-project&dataset=my_dataset&table=my_table",
+  "the regenerated setup link retains the three-parameter format",
+);
 
 console.log(
-  "web configurator OK: identifiers and sentinels validated; Linking API URL deterministic",
+  "web configurator OK: single-field states, error classes, and Linking API URL deterministic",
 );

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -529,6 +529,34 @@ assert.throws(
     /clearly name exactly one BigQuery table/.test(error.message),
   "an ambiguous Console link is a whole-field error",
 );
+// #449 review: a structurally unambiguous supported-host link with an
+// invalid identifier has three identifiable segments, so it gets segment
+// attribution — while the strict public parser still returns null for it.
+for (const [segment, badWorkspace] of [
+  ["project", "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events"],
+  [
+    "dataset",
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843!2sbad-dataset!3sagent_events",
+  ],
+  [
+    "table",
+    "!1m5!1m4!4m3!1shaiyuan-anarres-dev-806843" +
+      "!2sbqaa_looker_demo!3stable$20260812",
+  ],
+]) {
+  const badSegmentUrl =
+    "https://console.cloud.google.com/bigquery?ws=" + badWorkspace;
+  assert.throws(
+    () => validateQualifiedTableId(badSegmentUrl),
+    (error) => error.segment === segment,
+    `a Console link with a bad ${segment} reports that segment`,
+  );
+  assert.equal(
+    parseBigQueryConsoleTableUrl(badSegmentUrl),
+    null,
+    "the strict public Console parser still rejects invalid identifiers",
+  );
+}
 
 // #448: a generated setup link round-trips through the single field while
 // retaining the existing three-parameter query format.
@@ -599,6 +627,7 @@ const fakeElements = new Map([
   ["#form-status", new FakeElement()],
   ["#table-id", new FakeElement("")],
   ["#table-id-error", new FakeElement()],
+  ["#advanced-settings", new FakeElement()],
   ["#billing-project", new FakeElement("")],
   ["#billing-project-error", new FakeElement()],
 ]);
@@ -609,20 +638,36 @@ globalThis.document = {
     return fakeElements.get(selector);
   },
 };
+let openedUrls = [];
 globalThis.window = {
   location: {
     href: "https://example.test/configure",
     search: "",
   },
-  open() {},
+  open(url) {
+    openedUrls.push(url);
+  },
 };
 let copiedText = "";
+// Controllable clipboard: tests can hold a write pending to exercise the
+// stale-completion guard, or let it resolve immediately.
+let pendingWrites = [];
+let holdClipboard = false;
 Object.defineProperty(globalThis, "navigator", {
   configurable: true,
   value: {
     clipboard: {
-      async writeText(text) {
-        copiedText = text;
+      writeText(text) {
+        if (!holdClipboard) {
+          copiedText = text;
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+          pendingWrites.push(() => {
+            copiedText = text;
+            resolve();
+          });
+        });
       },
     },
   },
@@ -819,10 +864,16 @@ for (const [description, consoleUrl] of [
   assert.match(formStatus.textContent, /^Ready for /);
 }
 
-// A paste that parses but carries an invalid segment reports immediately:
-// paste is a validation trigger, no blur needed.
+// #449 review (P3): a paste that parses structurally but fails validation
+// must NOT be normalized — the exact clipboard text lands and the error
+// reports immediately, because paste is a validation trigger.
 typeIntoField("");
-assert.equal(pasteIntoField("BADPROJECT.dataset.table"), true);
+assert.equal(
+  pasteIntoField("BADPROJECT.dataset.table"),
+  false,
+  "an invalid-segment paste retains ordinary paste behavior",
+);
+typeIntoField("BADPROJECT.dataset.table");
 assert.equal(field.value, "BADPROJECT.dataset.table");
 assert.match(
   fieldError.textContent,
@@ -830,6 +881,46 @@ assert.match(
   "a pasted invalid segment reports without waiting for blur",
 );
 assertActionsDisabled("pasted segment error");
+
+// Normalization-changing invalid paste: the wrapped raw form is preserved
+// verbatim rather than rewritten to dotted form before rejection.
+typeIntoField("");
+assert.equal(pasteIntoField("`BADPROJECT.dataset.table`;"), false);
+typeIntoField("`BADPROJECT.dataset.table`;");
+assert.equal(
+  field.value,
+  "`BADPROJECT.dataset.table`;",
+  "the exact clipboard text is retained for an invalid wrapped paste",
+);
+assert.match(fieldError.textContent, /^Project segment: /);
+assertActionsDisabled("wrapped invalid paste");
+
+// A sentinel-colliding paste is invalid too, so it also lands raw.
+typeIntoField("");
+assert.equal(
+  pasteIntoField("xsentinelbqaaevents.my_dataset.my_table"),
+  false,
+  "a sentinel-colliding paste retains ordinary paste behavior",
+);
+typeIntoField("xsentinelbqaaevents.my_dataset.my_table");
+assert.match(fieldError.textContent, /reserved dashboard template value/);
+
+// A supported-host Console link with an invalid identifier has three
+// identifiable segments: it lands raw and reports the segment, not the
+// whole-link error (#449 review, taxonomy).
+typeIntoField("");
+const badProjectConsoleUrl =
+  "https://console.cloud.google.com/bigquery?ws=" +
+  "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events";
+assert.equal(pasteIntoField(badProjectConsoleUrl), false);
+typeIntoField(badProjectConsoleUrl);
+assert.match(
+  fieldError.textContent,
+  /^Project segment: /,
+  "a Console link with a bad project reports the segment, not the link",
+);
+assert.equal(field.value, badProjectConsoleUrl, "the raw link is retained");
+assertActionsDisabled("console segment error");
 
 // An unparseable paste lands as raw text; its input event validates it
 // immediately because paste is a validation trigger.
@@ -993,6 +1084,112 @@ assert.match(
   "the attempted action reveals the field error",
 );
 
+// #449 review (P1): Enter is a real attempted action on both fields. The
+// form has two text inputs and no native submit control, so browsers never
+// run implicit submission — the explicit keydown bridge is the mechanism,
+// and these tests drive that exact listener.
+openedUrls = [];
+field.listeners.keydown({ key: "Enter", preventDefault() {} });
+assert.equal(openedUrls.length, 0, "Enter on invalid input opens nothing");
+assert.match(
+  fieldError.textContent,
+  /three dot-separated segments/,
+  "Enter on invalid input reveals the validation error",
+);
+
+typeIntoField("my-project.my_dataset.my_table");
+openedUrls = [];
+field.listeners.keydown({ key: "Enter", preventDefault() {} });
+assert.equal(
+  openedUrls.length,
+  1,
+  "Enter on a valid ID opens exactly one tab",
+);
+assert.equal(formStatus.dataset.kind, "waiting");
+
+openedUrls = [];
+billing.listeners.keydown({ key: "Enter", preventDefault() {} });
+assert.equal(
+  openedUrls.length,
+  1,
+  "Enter in the billing field is the same attempted action",
+);
+
+openedUrls = [];
+field.listeners.keydown({ key: "a", preventDefault() {} });
+assert.equal(openedUrls.length, 0, "other keys are not attempted actions");
+
+// #449 review (P2): a whitespace-only billing override behaves exactly
+// like blank input — same validity, same billed project.
+billing.value = "   ";
+billing.listeners.input({ target: billing });
+assert.match(
+  formStatus.textContent,
+  /^Ready for /,
+  "whitespace-only billing behaves like blank",
+);
+assert.equal(billingErrorEl.textContent, "");
+{
+  const linkParams = new URL(createLink.href).searchParams;
+  assert.equal(
+    linkParams.get("ds.ds230.billingProjectId"),
+    "my-project",
+    "a whitespace-only override bills the ID's project segment",
+  );
+}
+
+// #449 review (P2): a billing error opens the Advanced disclosure so the
+// only visible explanation is not hidden; correction never auto-closes it.
+const advancedDisclosure = fakeElements.get("#advanced-settings");
+advancedDisclosure.open = false;
+billing.value = "UPPERCASE";
+billing.listeners.input({ target: billing });
+assert.equal(
+  advancedDisclosure.open,
+  true,
+  "a billing error opens the disclosure",
+);
+billing.value = "";
+billing.listeners.input({ target: billing });
+assert.equal(
+  advancedDisclosure.open,
+  true,
+  "correction does not auto-close the disclosure",
+);
+
+// #449 review (P2): a clipboard completion that is no longer current must
+// not restore a stale status over a later edit.
+typeIntoField("my-project.my_dataset.my_table");
+holdClipboard = true;
+const staleCopy = copyButton.listeners.click();
+typeIntoField("my-project.my_dataset.");
+pendingWrites.splice(0).forEach((complete) => complete());
+await staleCopy;
+assert.equal(
+  formStatus.textContent,
+  "",
+  "a stale copy completion cannot restore the copied status",
+);
+
+// Reversed completions: the last-started operation owns the status.
+typeIntoField("my-project.my_dataset.my_table");
+const earlierCopy = copyButton.listeners.click();
+const laterChecklistCopy = fakeElements.get("#copy-checklist").listeners.click();
+{
+  const writers = pendingWrites.splice(0);
+  writers[1]();
+  await laterChecklistCopy;
+  assert.equal(formStatus.textContent, "Security checklist copied.");
+  writers[0]();
+  await earlierCopy;
+  assert.equal(
+    formStatus.textContent,
+    "Security checklist copied.",
+    "an out-of-order completion cannot overwrite the current status",
+  );
+}
+holdClipboard = false;
+
 // #448: an existing three-parameter setup link prefills the single field
 // and validates immediately; the regenerated link is identical.
 window.location.search =
@@ -1016,6 +1213,31 @@ assert.equal(
   "?project=my-project&dataset=my_dataset&table=my_table",
   "the regenerated setup link retains the three-parameter format",
 );
+
+// #449 review (P2): an invalid billing prefill must not hide the only
+// explanation inside the closed Advanced disclosure.
+window.location.search =
+  "?project=my-project&dataset=my_dataset&table=my_table" +
+  "&billingProject=UPPERCASE";
+advancedDisclosure.open = false;
+await import("../docs/app.mjs?prefill=invalid-billing");
+assert.equal(
+  field.value,
+  "my-project.my_dataset.my_table",
+  "the table prefill still composes with an invalid billing parameter",
+);
+assert.match(
+  billingErrorEl.textContent,
+  /6–30 lowercase letters/,
+  "the invalid billing prefill reports the billing error",
+);
+assert.equal(
+  advancedDisclosure.open,
+  true,
+  "the disclosure opens so the billing error is visible",
+);
+assertActionsDisabled("invalid billing prefill");
+assertFieldClean("table field during invalid billing prefill");
 
 console.log(
   "web configurator OK: single-field states, error classes, and Linking API URL deterministic",

--- a/dashboard/looker_studio/tools/test_web_configurator.mjs
+++ b/dashboard/looker_studio/tools/test_web_configurator.mjs
@@ -494,6 +494,24 @@ assert.throws(
   (error) =>
     error.segment === "dataset" && /^Dataset segment: /.test(error.message),
 );
+// #449 review round 2: only one enclosing whole-ID backtick pair is
+// punctuation; an embedded backtick stays in its segment and fails there
+// instead of being silently deleted into a different normalized ID.
+assert.deepEqual(
+  splitQualifiedTableId("my-project.my_da`taset.my_table"),
+  { project: "my-project", dataset: "my_da`taset", table: "my_table" },
+  "an embedded backtick is preserved for segment validation",
+);
+assert.equal(
+  parseQualifiedTableIdForInput("my-project.my_da`taset.my_table"),
+  null,
+);
+assert.throws(
+  () => validateQualifiedTableId("my-project.my_da`taset.my_table"),
+  (error) =>
+    error.segment === "dataset" && /^Dataset segment: /.test(error.message),
+  "an embedded backtick is a dataset-segment error, not silently accepted",
+);
 assert.throws(
   () => validateQualifiedTableId("my-project.my_dataset.table$20260807"),
   (error) =>
@@ -870,10 +888,9 @@ for (const [description, consoleUrl] of [
 typeIntoField("");
 assert.equal(
   pasteIntoField("BADPROJECT.dataset.table"),
-  false,
-  "an invalid-segment paste retains ordinary paste behavior",
+  true,
+  "every paste is intercepted so it can never splice into the field",
 );
-typeIntoField("BADPROJECT.dataset.table");
 assert.equal(field.value, "BADPROJECT.dataset.table");
 assert.match(
   fieldError.textContent,
@@ -885,8 +902,7 @@ assertActionsDisabled("pasted segment error");
 // Normalization-changing invalid paste: the wrapped raw form is preserved
 // verbatim rather than rewritten to dotted form before rejection.
 typeIntoField("");
-assert.equal(pasteIntoField("`BADPROJECT.dataset.table`;"), false);
-typeIntoField("`BADPROJECT.dataset.table`;");
+assert.equal(pasteIntoField("`BADPROJECT.dataset.table`;"), true);
 assert.equal(
   field.value,
   "`BADPROJECT.dataset.table`;",
@@ -899,10 +915,10 @@ assertActionsDisabled("wrapped invalid paste");
 typeIntoField("");
 assert.equal(
   pasteIntoField("xsentinelbqaaevents.my_dataset.my_table"),
-  false,
-  "a sentinel-colliding paste retains ordinary paste behavior",
+  true,
+  "a sentinel-colliding paste is intercepted and lands raw",
 );
-typeIntoField("xsentinelbqaaevents.my_dataset.my_table");
+assert.equal(field.value, "xsentinelbqaaevents.my_dataset.my_table");
 assert.match(fieldError.textContent, /reserved dashboard template value/);
 
 // A supported-host Console link with an invalid identifier has three
@@ -912,8 +928,7 @@ typeIntoField("");
 const badProjectConsoleUrl =
   "https://console.cloud.google.com/bigquery?ws=" +
   "!1m5!1m4!4m3!1sBADPROJECT!2sbqaa_looker_demo!3sagent_events";
-assert.equal(pasteIntoField(badProjectConsoleUrl), false);
-typeIntoField(badProjectConsoleUrl);
+assert.equal(pasteIntoField(badProjectConsoleUrl), true);
 assert.match(
   fieldError.textContent,
   /^Project segment: /,
@@ -922,15 +937,39 @@ assert.match(
 assert.equal(field.value, badProjectConsoleUrl, "the raw link is retained");
 assertActionsDisabled("console segment error");
 
+// #449 review round 2 (P2): starting from Ready, an invalid pasted
+// fragment must REPLACE the field with the raw clipboard text — never
+// splice into the previous valid ID and silently retarget another table.
+typeIntoField("my-project.my_dataset.my_table");
+assert.match(formStatus.textContent, /^Ready for /);
+assert.equal(pasteIntoField("x"), true, "fragment paste is intercepted");
+assert.equal(
+  field.value,
+  "x",
+  "the raw clipboard text replaces the field instead of merging",
+);
+assertActionsDisabled("fragment paste over Ready");
+assert.equal(formStatus.textContent, "", "the stale Ready status is cleared");
+assert.match(fieldError.textContent, /project\.dataset\.table/);
+
+// Embedded backtick: manual entry and paste both land raw with the
+// dataset-segment error.
+typeIntoField("my-project.my_da`taset.my_table");
+assert.match(fieldError.textContent, /^Dataset segment: /);
+assertActionsDisabled("embedded backtick typed");
+typeIntoField("");
+assert.equal(pasteIntoField("my-project.my_da`taset.my_table"), true);
+assert.equal(field.value, "my-project.my_da`taset.my_table");
+assert.match(fieldError.textContent, /^Dataset segment: /);
+
 // An unparseable paste lands as raw text; its input event validates it
 // immediately because paste is a validation trigger.
 typeIntoField("");
 assert.equal(
   pasteIntoField("a.b.c.d"),
-  false,
-  "wrong-arity paste retains ordinary paste behavior",
+  true,
+  "wrong-arity paste is intercepted and lands raw",
 );
-typeIntoField("a.b.c.d");
 assert.match(
   fieldError.textContent,
   /three dot-separated segments/,
@@ -950,10 +989,9 @@ for (const rejectedUrl of [
   typeIntoField("");
   assert.equal(
     pasteIntoField(rejectedUrl),
-    false,
-    "a rejected Console URL retains ordinary paste behavior",
+    true,
+    "a rejected Console URL is intercepted and lands raw",
   );
-  typeIntoField(rejectedUrl);
   assert.match(
     fieldError.textContent,
     /clearly name exactly one BigQuery table/,
@@ -1119,6 +1157,20 @@ openedUrls = [];
 field.listeners.keydown({ key: "a", preventDefault() {} });
 assert.equal(openedUrls.length, 0, "other keys are not attempted actions");
 
+// #449 review round 2 (P3): held-key repeats and IME-composition commits
+// are not attempted actions.
+openedUrls = [];
+field.listeners.keydown({ key: "Enter", repeat: true, preventDefault() {} });
+assert.equal(openedUrls.length, 0, "a held Enter repeat opens nothing");
+field.listeners.keydown({
+  key: "Enter",
+  isComposing: true,
+  preventDefault() {},
+});
+assert.equal(openedUrls.length, 0, "a composing Enter opens nothing");
+field.listeners.keydown({ key: "Enter", keyCode: 229, preventDefault() {} });
+assert.equal(openedUrls.length, 0, "a legacy 229 Enter opens nothing");
+
 // #449 review (P2): a whitespace-only billing override behaves exactly
 // like blank input — same validity, same billed project.
 billing.value = "   ";
@@ -1188,6 +1240,31 @@ const laterChecklistCopy = fakeElements.get("#copy-checklist").listeners.click()
     "an out-of-order completion cannot overwrite the current status",
   );
 }
+// #449 review round 2 (P2): starting Create invalidates pending copy
+// completions, so the provisioning warning is never overwritten by an
+// older copy resolving late — for either copy path.
+typeIntoField("my-project.my_dataset.my_table");
+const copyBeforeCreate = copyButton.listeners.click();
+createLink.listeners.click({ preventDefault() {} });
+assert.equal(formStatus.dataset.kind, "waiting");
+pendingWrites.splice(0).forEach((complete) => complete());
+await copyBeforeCreate;
+assert.equal(
+  formStatus.dataset.kind,
+  "waiting",
+  "a held setup-link copy cannot overwrite the provisioning warning",
+);
+const checklistBeforeCreate =
+  fakeElements.get("#copy-checklist").listeners.click();
+fakeElements.get("#configurator").listeners.submit({ preventDefault() {} });
+assert.equal(formStatus.dataset.kind, "waiting");
+pendingWrites.splice(0).forEach((complete) => complete());
+await checklistBeforeCreate;
+assert.equal(
+  formStatus.dataset.kind,
+  "waiting",
+  "a held checklist copy cannot overwrite the provisioning warning",
+);
 holdClipboard = false;
 
 // #448: an existing three-parameter setup link prefills the single field

--- a/tests/test_looker_studio_dashboard.py
+++ b/tests/test_looker_studio_dashboard.py
@@ -1062,8 +1062,14 @@ def test_googlecloudplatform_pages_configuration():
   assert 'name="twitter:card"' in page
   assert "Copy security checklist" in page
   assert "billing-project-hint" in page
+  # #448: one fully-qualified-table-ID entrance, no separate project or
+  # dataset fields, and the paste affordance stays advertised.
+  assert 'id="table-id"' in page
+  assert 'id="project"' not in page
+  assert 'id="dataset"' not in page
   assert (
-      "Paste a fully qualified table ID or BigQuery Console table link" in page
+      "Paste a fully qualified table ID or a BigQuery Console table link"
+      in " ".join(page.split())
   )
   assert "Designed for desktop screens at least 1280 px wide" in page
   assert "allow up to 90 seconds" in page


### PR DESCRIPTION
Implements #448 against its three-round review contract (decisions 1–8, twelve acceptance criteria). One entrance — the **fully qualified BQAA table ID** (`project.dataset.table`) — replaces the three identifier fields, with every previously supported paste form intact.

## Acceptance criteria — status

1. **Single entrance, no separate project/dataset fields** — done; the Python page pin asserts `id="table-id"` exists and `id="project"` / `id="dataset"` do not. Advanced billing override unchanged.
2. **All paste forms + both Console hosts (positive)** — the node suite drives all five dotted forms (comma fixture retained) and four Console-URL variants including Pantheon through the field; each normalizes to the dotted ID and reaches Ready.
3. **Rejection matrix (separate)** — ambiguous/unsupported links and wrong-arity input covered at both the validator and DOM layers.
4. **Fail-closed mutation** — editing a Ready value immediately revokes the derived triple, disables Create/Copy, and clears the Ready announcement (error presentation defers per the trigger contract); the `valid → partial → invalid → corrected` interaction test asserts all three including status behavior.
5. **Two error classes** — whole-field (`segment: null`) vs segment-level (segment named inline, e.g. "Project segment: …"), both retaining raw input, clearing derived state, disabling actions; **sentinel collisions now gate entry to Ready** and are attributed to their segment (`rejectSentinelCollisions` throws a `ConfigurationError` with `field: "tableId"` and `segment` — logic and Linking API output unchanged).
6. **Billing actionability** — `valid table → invalid billing → corrected billing` test passes with the table triple retained throughout; blank override bills the ID's project segment.
7. **Setup-link compatibility** — existing `?project=&dataset=&table=` links prefill the field and validate immediately (tested via a second module instance); regenerated links keep the format and round-trip byte-for-byte.
8. **Byte-identical Linking API URLs** — `buildDashboardUrl` / `buildSetupUrl` / `validateConfiguration` are untouched; the node suite's pinned `sqlReplace` / `billingProjectId` literals pass unchanged for blank and explicit overrides.
9. **Accessibility** — label, `aria-describedby` hint/error associations, `aria-invalid` management, `aria-live` error/status regions preserved on the combined field; validation timing per decision 1.
10. **Browser smoke** — the app-executed proof is now a runtime `data-bqaa-app-initialized` marker (asserted absent from static HTML as a tag attribute), plus an error-free pristine first-load assertion (no `aria-invalid`, Create disabled). All negative fixtures updated to the new healthy baseline (marker set by script, disabled action, no `aria-invalid`) so each injected fault is the sole failure cause, and a sixth **missing-initialization** fixture fails as required.
11. **Suites green** — node contract (rewritten for the single-field DOM), `browser_smoke.sh` main + `--self-test` (6/6 fixtures), and the Python dashboard suite (29/29) all pass locally; pyink/isort clean.
12. **Docs** — `USER_MANUAL.md` (Before-you-start, Step 1, troubleshooting rows), `README.md` (configurator section), `docs/dashboard-implementation.md` (data-source contract now describes the combined field and both error classes), and the page copy (field hint, step 01) updated.

Supersedes #403's separate-fields decision while preserving its rationale (precise diagnostics) through segment-level attribution, per the issue record.
