### PR TITLE
feat(evalbench): materialize versioned EvalBench snapshots and failed-session contract (#435)

### DIFF
--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -99,6 +99,14 @@ share a trace or session in the mirror table: a reader that filters only by
 score rows use the same identity, so score joins stay aligned. Published rows
 also carry `attributes.evalbench_import_version`.
 
+The identity encodes the `(job_id, import_version, scenario_id)` tuple
+unambiguously: a literal `:` or `\` inside a component is escaped as `\:` /
+`\\`, so `(import_version="release:1", scenario_id="case")` and
+`(import_version="release", scenario_id="1:case")` get different
+`session_id`s (`…:release\:1:case` vs `…:release:1\:case`), and a plain read
+of a scenario named `v1:case` never aliases published version `v1`. Components
+without those characters (the common case) render verbatim.
+
 `orchestrator`, `generator`, and the run timestamp come from EvalBench's
 flattened `configs` rows. If a historical run lacks config metadata, the agent
 components become `unknown`; if no timestamp is available, the mapper uses the
@@ -156,7 +164,7 @@ must already exist; the tables are created on first use):
 |---|---|---|
 | Events | `evalbench_agent_events` | `agent_events` columns plus `job_id`, `import_version`; partitioned by `timestamp`, clustered by `job_id, import_version, session_id` |
 | Scores | `evalbench_scores_imported` | `job_id`, `import_version`, `scenario_id`, `session_id`, `comparator`, `score FLOAT64`, `source_row JSON` (the verbatim EvalBench score row) |
-| Manifest | `evalbench_import_manifest` | one row per `(job_id, import_version)` — see below |
+| Manifest | `evalbench_import_manifest` (fixed) | one row per `(job_id, import_version)` — see below |
 
 The extra event columns are appended after the `agent_events` contract, so
 `Client.get_session_trace` and the other explicit-column readers work
@@ -227,6 +235,12 @@ order-independent fingerprints of the source `results`, `scores`, and
 
 A given `(job_id, import_version)` therefore never accumulates duplicates, and
 a published version stays bound to the destination tables in its manifest.
+The manifest is the single import registry of the target dataset; its name is
+fixed (`evalbench_import_manifest`, `evalbench.MANIFEST_TABLE`) rather than a
+`materialize` argument, so every import into the dataset — whatever
+`events_table`/`scores_table` it writes — checks the same registry before
+deleting published rows. A second manifest cannot be used to re-publish
+changed source under an existing version around the first manifest row.
 An `unchanged` result always refers to the tables that were actually written;
 to publish the same version elsewhere, choose a new `import_version` (moving
 rows between tables is not supported, so `replace=True` cannot orphan them).

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -85,9 +85,19 @@ rather than silently reproducing the first one.
 Each scenario uses this identity:
 
 ```text
+# plain read (to_agent_event_rows())
 session_id = trace_id = evalbench:{job_id}:{scenario_id}
+# published snapshot (materialize / to_agent_event_rows(import_version=...))
+session_id = trace_id = evalbench:{job_id}:{import_version}:{scenario_id}
 agent      = evalbench:{orchestrator}:{generator}
 ```
+
+Published identities are version-specific, and every synthetic span and
+invocation id derives from them, so retained import versions of one job never
+share a trace or session in the mirror table: a reader that filters only by
+`trace_id` (such as `Client.get_trace`) sees exactly one version. Imported
+score rows use the same identity, so score joins stay aligned. Published rows
+also carry `attributes.evalbench_import_version`.
 
 `orchestrator`, `generator`, and the run timestamp come from EvalBench's
 flattened `configs` rows. If a historical run lacks config metadata, the agent
@@ -121,7 +131,13 @@ for every model used by the run.
 
 Source failures surface as `status = 'ERROR'` plus `error_message`: a
 non-zero (or non-numeric) `returncode`, `stderr`, and the `*_error` columns
-are collected into `attributes.evalbench_error_fields`.
+are collected into `attributes.evalbench_error_fields`. Usable `stderr` is a
+process failure on its own, independent of `returncode`: a scenario that
+exited `0` and produced a final response but also wrote to `stderr` is
+published with `status = 'ERROR'` on its terminal row, never as a clean `OK`.
+
+The destination table names are validated before any BigQuery call, and the
+ADK plugin's production table name `agent_events` is rejected outright.
 
 ## Materialize A Snapshot
 
@@ -153,20 +169,45 @@ Event, score, and manifest rows are loaded into per-import staging tables
 multi-statement transaction:
 
 ```sql
-BEGIN TRANSACTION;
-DELETE FROM `…evalbench_agent_events`     WHERE job_id = @job_id AND import_version = @import_version;
-DELETE FROM `…evalbench_scores_imported`  WHERE job_id = @job_id AND import_version = @import_version;
-DELETE FROM `…evalbench_import_manifest`  WHERE job_id = @job_id AND import_version = @import_version;
-INSERT INTO `…evalbench_agent_events`    (…) SELECT … FROM `…evalbench_agent_events_staging_…`;
-INSERT INTO `…evalbench_scores_imported` (…) SELECT … FROM `…evalbench_scores_imported_staging_…`;
-INSERT INTO `…evalbench_import_manifest` (…) SELECT … FROM `…evalbench_import_manifest_staging_…`;
-COMMIT TRANSACTION;
+DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
+BEGIN
+  BEGIN TRANSACTION;
+  -- Compare-and-swap: re-check the manifest *inside* the transaction.
+  SET conflicting_manifest_rows = (
+    SELECT COUNT(*) FROM `…evalbench_import_manifest`
+    WHERE job_id = @job_id AND import_version = @import_version
+      AND (results_fingerprint != @results_fingerprint OR …   -- omitted with replace=True
+           OR events_table != @events_table OR scores_table != @scores_table)
+  );
+  IF conflicting_manifest_rows > 0 THEN RAISE USING MESSAGE = '…'; END IF;
+  DELETE FROM `…evalbench_agent_events`     WHERE job_id = @job_id AND import_version = @import_version;
+  DELETE FROM `…evalbench_scores_imported`  WHERE job_id = @job_id AND import_version = @import_version;
+  DELETE FROM `…evalbench_import_manifest`  WHERE job_id = @job_id AND import_version = @import_version;
+  INSERT INTO `…evalbench_agent_events`    (…) SELECT … FROM `…evalbench_agent_events_staging_…`;
+  INSERT INTO `…evalbench_scores_imported` (…) SELECT … FROM `…evalbench_scores_imported_staging_…`;
+  INSERT INTO `…evalbench_import_manifest` (…) SELECT … FROM `…evalbench_import_manifest_staging_…`;
+  COMMIT TRANSACTION;
+EXCEPTION WHEN ERROR THEN
+  ROLLBACK TRANSACTION;
+  RAISE;
+END;
 ```
 
 There is no delete-then-append window: a failure before `COMMIT` leaves the
-previously published version (or nothing) in place, and staging tables are
-always dropped. Mapping errors (missing prompt, duplicate scenario ids) are
-raised before any BigQuery write.
+previously published version (or nothing) in place. Mapping errors (missing
+prompt, duplicate scenario ids) are raised before any BigQuery write.
+
+The manifest check runs both before staging (so an unchanged source is a
+cheap no-op) and again inside the transaction. Two importers that both saw no
+manifest row for the same explicit `import_version` therefore cannot both
+commit different content: BigQuery serializes conflicting DML on the manifest
+table, the later transaction re-reads the earlier row, and the guard raises
+(`ValueError` in Python, nothing written). Re-running that importer then
+reports `unchanged` or the fingerprint error as usual.
+
+Staging tables are created with a six-hour expiration and dropped after
+`COMMIT` on a best-effort basis; a failed drop is logged and never turns a
+committed publish into an error.
 
 ### Import versions and idempotency
 
@@ -180,9 +221,15 @@ order-independent fingerprints of the source `results`, `scores`, and
 | Manifest row exists with identical fingerprints | nothing written, `status = "unchanged"` |
 | Same as above with `replace=True` | atomically re-published, `status = "replaced"` |
 | Explicit `import_version` whose fingerprints changed | `ValueError` (pass a new version, omit it to derive one, or `replace=True`) |
+| Manifest row exists but records other `events_table`/`scores_table` | `ValueError`, even with `replace=True`; nothing written |
+| Two importers race on a first-time version with different content | the first commit wins; the second raises `ValueError` from the in-transaction guard |
 | Derived version and the source changed | a new `import_version`; earlier versions are retained |
 
-A given `(job_id, import_version)` therefore never accumulates duplicates.
+A given `(job_id, import_version)` therefore never accumulates duplicates, and
+a published version stays bound to the destination tables in its manifest.
+An `unchanged` result always refers to the tables that were actually written;
+to publish the same version elsewhere, choose a new `import_version` (moving
+rows between tables is not supported, so `replace=True` cannot orphan them).
 
 ### Manifest
 
@@ -206,7 +253,8 @@ The manifest row binds every published version to its source:
 scenario **passed**. A session is *failed* when any of the following holds:
 
 - **process failure** — any event has `status = 'ERROR'` (non-zero
-  `returncode`, `stderr`, or a source `*_error` column);
+  `returncode`, usable `stderr` regardless of `returncode`, or a source
+  `*_error` column);
 - **missing completion** — the session has no `AGENT_COMPLETED` event;
 - **score failure** — the per-benchmark `EvalScorePolicy` is not met.
 
@@ -261,8 +309,10 @@ bq-agent-sdk evalbench-import \
 
 The command prints the `EvalBenchImportResult` (including the manifest) and
 exits `0` for `imported`, `replaced`, or `unchanged`, and `2` on invalid
-input, a changed source under an explicit `--import-version`, or a BigQuery
-error. There is no `evalbench-score` command.
+input (including `--events-table agent_events`, which is rejected before any
+BigQuery call), a changed source under an explicit `--import-version`, a
+version already bound to other destination tables, or a BigQuery error. There
+is no `evalbench-score` command.
 
 ## Why These Fields Matter
 

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -85,27 +85,36 @@ rather than silently reproducing the first one.
 Each scenario uses this identity:
 
 ```text
-# plain read (to_agent_event_rows())
+# plain read (to_agent_event_rows()) -- the v0.5.1 contract, unchanged
 session_id = trace_id = evalbench:{job_id}:{scenario_id}
 # published snapshot (materialize / to_agent_event_rows(import_version=...))
-session_id = trace_id = evalbench:{job_id}:{import_version}:{scenario_id}
+session_id = trace_id = evalbench-import:{job_id}:{import_version}:{scenario_id}
 agent      = evalbench:{orchestrator}:{generator}
 ```
 
-Published identities are version-specific, and every synthetic span and
-invocation id derives from them, so retained import versions of one job never
-share a trace or session in the mirror table: a reader that filters only by
-`trace_id` (such as `Client.get_trace`) sees exactly one version. Imported
-score rows use the same identity, so score joins stay aligned. Published rows
-also carry `attributes.evalbench_import_version`.
+The plain-read identity is frozen: `session_id`/`trace_id` are the unescaped
+`evalbench:{job_id}:{scenario_id}` and the synthetic `invocation_id`,
+`span_id`, and `parent_span_id` values are the same SHA-256-derived ids v0.5.1
+produced (the unit tests pin golden vectors), so re-mapping an existing run
+after an upgrade keeps its stored trace references.
 
-The identity encodes the `(job_id, import_version, scenario_id)` tuple
-unambiguously: a literal `:` or `\` inside a component is escaped as `\:` /
-`\\`, so `(import_version="release:1", scenario_id="case")` and
+Published identities live in a separate `evalbench-import:` namespace, are
+version-specific, and every synthetic span and invocation id derives from
+them with injective framing, so retained import versions of one job never
+share a trace or session in the mirror table — and never share one with a
+plain read either: a reader that filters only by `trace_id` (such as
+`Client.get_trace`) sees exactly one version. Imported score rows use the
+same identity, so score joins stay aligned. Published rows also carry
+`attributes.evalbench_import_version`.
+
+The published identity encodes the `(job_id, import_version, scenario_id)`
+tuple unambiguously: a literal `:` or `\` inside a component is escaped as
+`\:` / `\\`, so `(import_version="release:1", scenario_id="case")` and
 `(import_version="release", scenario_id="1:case")` get different
-`session_id`s (`…:release\:1:case` vs `…:release:1\:case`), and a plain read
-of a scenario named `v1:case` never aliases published version `v1`. Components
-without those characters (the common case) render verbatim.
+`session_id`s (`…:release\:1:case` vs `…:release:1\:case`). Components
+without those characters (the common case) render verbatim. A plain read of a
+scenario named `v1:case` (`evalbench:job:v1:case`) cannot alias published
+version `v1` (`evalbench-import:job:v1:case`) because the prefixes differ.
 
 `orchestrator`, `generator`, and the run timestamp come from EvalBench's
 flattened `configs` rows. If a historical run lacks config metadata, the agent
@@ -158,13 +167,15 @@ print(result.status, result.import_version, result.events_table)
 ```
 
 `materialize()` writes three BQAA-owned tables in the target dataset (which
-must already exist; the tables are created on first use):
+must already exist; the tables are created on first use) and serializes
+publishes through a fourth, fixed lock table:
 
 | Table | Default name | Contents |
 |---|---|---|
 | Events | `evalbench_agent_events` | `agent_events` columns plus `job_id`, `import_version`; partitioned by `timestamp`, clustered by `job_id, import_version, session_id` |
 | Scores | `evalbench_scores_imported` | `job_id`, `import_version`, `scenario_id`, `session_id`, `comparator`, `score FLOAT64`, `source_row JSON` (the verbatim EvalBench score row) |
 | Manifest | `evalbench_import_manifest` (fixed) | one row per `(job_id, import_version)` — see below |
+| Lock | `evalbench_import_lock` (fixed) | one sentinel row (`lock_id = 'evalbench-import'`, `claim_count`, `claimed_at`, `claimed_job_id`, `claimed_import_version`) that every publish transaction updates first |
 
 The extra event columns are appended after the `agent_events` contract, so
 `Client.get_session_trace` and the other explicit-column readers work
@@ -173,14 +184,22 @@ unchanged when pointed at the mirror table.
 ### Atomic publish
 
 Event, score, and manifest rows are loaded into per-import staging tables
-(`<table>_staging_<hex>`) and then published by **one** BigQuery
-multi-statement transaction:
+(`<table>_staging_<hex>`). The lock sentinel is then seeded by its own
+committed DML job (`INSERT … WHERE NOT EXISTS`, a no-op once it exists) so
+that it is part of the snapshot of the transaction that follows, and the rows
+are published by **one** BigQuery multi-statement transaction:
 
 ```sql
 DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
 BEGIN
   BEGIN TRANSACTION;
-  -- Compare-and-swap: re-check the manifest *inside* the transaction.
+  -- Claim the dataset lock: the only statement guaranteed to mutate a row.
+  UPDATE `…evalbench_import_lock`
+  SET claim_count = claim_count + 1, claimed_at = CURRENT_TIMESTAMP(),
+      claimed_job_id = @job_id, claimed_import_version = @import_version
+  WHERE lock_id = 'evalbench-import';
+  IF @@row_count = 0 THEN RAISE USING MESSAGE = '…sentinel is missing…'; END IF;
+  -- Defence in depth: re-check the manifest *inside* the transaction.
   SET conflicting_manifest_rows = (
     SELECT COUNT(*) FROM `…evalbench_import_manifest`
     WHERE job_id = @job_id AND import_version = @import_version
@@ -205,13 +224,31 @@ There is no delete-then-append window: a failure before `COMMIT` leaves the
 previously published version (or nothing) in place. Mapping errors (missing
 prompt, duplicate scenario ids) are raised before any BigQuery write.
 
+Why a lock row: BigQuery transactions use snapshot isolation, and
+[concurrent transactions are cancelled only when they mutate rows in the
+same table](https://cloud.google.com/bigquery/docs/transactions#transaction_concurrency)
+— reads and appends run concurrently, and [`INSERT` never conflicts with
+other DML](https://cloud.google.com/bigquery/docs/data-manipulation-language#dml_statement_conflicts).
+Two first-time imports of one `(job_id, import_version)` that both began
+before either committed would therefore both see no manifest row, both run
+keyed `DELETE`s that match nothing, and both `INSERT` — two manifests and a
+mixed corpus under one supposedly immutable version. The claim `UPDATE`
+always mutates the pre-existing sentinel, so at most one of the two
+transactions commits; BigQuery cancels the other with a "concurrent update"
+error, which `materialize()` reports as `ValueError` (nothing written).
+Re-running that importer then reports `unchanged` or the fingerprint error as
+usual. The same claim also serializes replace/re-import publishes into the
+dataset.
+
 The manifest check runs both before staging (so an unchanged source is a
-cheap no-op) and again inside the transaction. Two importers that both saw no
-manifest row for the same explicit `import_version` therefore cannot both
-commit different content: BigQuery serializes conflicting DML on the manifest
-table, the later transaction re-reads the earlier row, and the guard raises
-(`ValueError` in Python, nothing written). Re-running that importer then
-reports `unchanged` or the fingerprint error as usual.
+cheap no-op) and again inside the transaction, after the claim. An importer
+whose pre-publish read was stale but whose transaction started after another
+commit sees the committed row there and the guard raises (`ValueError` in
+Python, nothing written) before any `DELETE` runs.
+
+The unit tests exercise this with a stub that models the snapshot-isolation
+rules above (both transactions start from one snapshot, only a mutation of
+the sentinel conflicts); they do not run against live BigQuery.
 
 Staging tables are created with a six-hour expiration and dropped after
 `COMMIT` on a best-effort basis; a failed drop is logged and never turns a
@@ -230,7 +267,7 @@ order-independent fingerprints of the source `results`, `scores`, and
 | Same as above with `replace=True` | atomically re-published, `status = "replaced"` |
 | Explicit `import_version` whose fingerprints changed | `ValueError` (pass a new version, omit it to derive one, or `replace=True`) |
 | Manifest row exists but records other `events_table`/`scores_table` | `ValueError`, even with `replace=True`; nothing written |
-| Two importers race on a first-time version with different content | the first commit wins; the second raises `ValueError` from the in-transaction guard |
+| Two importers race on a first-time version with different content | the first to commit wins; the second is cancelled on the lock claim (or, if its transaction started later, refused by the in-transaction guard) and raises `ValueError` |
 | Derived version and the source changed | a new `import_version`; earlier versions are retained |
 
 A given `(job_id, import_version)` therefore never accumulates duplicates, and
@@ -239,7 +276,8 @@ The manifest is the single import registry of the target dataset; its name is
 fixed (`evalbench_import_manifest`, `evalbench.MANIFEST_TABLE`) rather than a
 `materialize` argument, so every import into the dataset — whatever
 `events_table`/`scores_table` it writes — checks the same registry before
-deleting published rows. A second manifest cannot be used to re-publish
+deleting published rows. The lock table (`evalbench_import_lock`,
+`evalbench.LOCK_TABLE`) is fixed for the same reason. A second manifest cannot be used to re-publish
 changed source under an existing version around the first manifest row.
 An `unchanged` result always refers to the tables that were actually written;
 to publish the same version elsewhere, choose a new `import_version` (moving
@@ -346,9 +384,10 @@ therefore populates it on every emitted event.
 ## Current Boundaries
 
 - Runs are imported one `job_id` at a time and held in memory.
-- The target dataset must exist; only the three tables are auto-created.
-- Concurrent imports of the same `(job_id, import_version)` serialize on
-  BigQuery's transaction locks; a conflicting import fails rather than
-  corrupting the corpus.
+- The target dataset must exist; only the four tables are auto-created.
+- Concurrent publishes into one dataset serialize on the lock sentinel
+  (coarse: one publish at a time per dataset); the loser fails with
+  `ValueError` and nothing written rather than corrupting the corpus, and
+  can simply be re-run.
 - Live BigQuery integration coverage for `materialize()` is not yet gated
   into the test suite; the unit tests use a stubbed client.

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -1,31 +1,32 @@
 # EvalBench Import Bridge
 
-`bigquery_agent_analytics.evalbench` reads one EvalBench BigQuery job and
-converts its result rows into the BQAA `agent_events` shape. This is a
-pull-only bridge: EvalBench remains the source of truth for benchmark results,
-and the SDK does not write into the ADK plugin's production `agent_events`
-table.
+`bigquery_agent_analytics.evalbench` reads one EvalBench BigQuery job,
+converts its result rows into the BQAA `agent_events` shape, and publishes
+that mapping as an immutable, versioned snapshot in BQAA-owned tables.
+EvalBench remains the source of truth for benchmark results, and the SDK
+never writes into the ADK plugin's production `agent_events` table.
 
-This first implementation phase provides the reader and deterministic row
-mapping. Mirror-table materialization, idempotent replacement, score-table
-writes, CLI commands, and live integration tests remain later phases of
-[issue #97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97).
+This covers the reader and deterministic row mapping from
+[issue #97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97)
+and the MVP snapshot + failed-session denominator from
+[issue #435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435).
+Localization, failure taxonomy, and other harnesses are later slices.
 
 ## Data Flow
 
 ```text
-EvalBench BigQuery dataset                    In-memory BQAA mapping
+EvalBench BigQuery dataset                BQAA-owned target dataset
 
-configs  -- job_id = @job_id --+             agent identity + run time
-results  -- job_id = @job_id --+--> EvalBenchRun --> synthetic event rows
-scores   -- job_id = @job_id --+         |          USER_MESSAGE_RECEIVED
-                                           |          TOOL_* (when present)
-                                           |          AGENT_COMPLETED (when present)
-                                           +--> source score rows (unchanged)
+configs  -- job_id = @job_id --+          evalbench_agent_events
+results  -- job_id = @job_id --+--> EvalBenchRun --> evalbench_scores_imported
+scores   -- job_id = @job_id --+   (in memory)      evalbench_import_manifest
+                                                     ^
+                              one transaction per (job_id, import_version)
 ```
 
 All three source queries filter by the parameterized `job_id` in SQL. The
-reader currently loads that single run into memory.
+reader loads that single run into memory; `materialize()` stages the mapped
+rows and publishes them atomically.
 
 ## Read And Map A Run
 
@@ -56,6 +57,29 @@ EvalBench's DataFrame writer can store nested objects as JSON or Python-literal
 strings. The mapper parses both structured encodings and leaves ordinary text
 unchanged.
 
+### Reading a job that may still be running
+
+`from_bigquery` reads `results`, `scores`, and `configs` sequentially. If the
+EvalBench job is still writing, the three reads can observe different moments
+and mix versions. Either import only after the job has completed, or pass
+`snapshot_at` so every read uses BigQuery time travel
+(`FOR SYSTEM_TIME AS OF @snapshot_at`) at the same instant:
+
+```python
+from datetime import datetime, timezone
+
+run = EvalBenchRun.from_bigquery(
+    project_id="benchmark-project",
+    evalbench_dataset="evalbench",
+    job_id="abc123",
+    snapshot_at=datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc),
+)
+```
+
+The manifest records `source_snapshot_at` and content fingerprints either
+way, so a source that changed after import becomes a new `import_version`
+rather than silently reproducing the first one.
+
 ## Event Mapping
 
 Each scenario uses this identity:
@@ -78,6 +102,9 @@ inventing a current timestamp.
 | Tool result | `TOOL_COMPLETED` or `TOOL_ERROR` | `tool`, `result`, `text_summary` |
 | Final response or generated SQL | `AGENT_COMPLETED` | `response`, `text_summary` |
 
+Span identifiers are synthetic (`sha256` of the session identity and role);
+they are not EvalBench's original OpenTelemetry spans.
+
 Missing tool data emits no `TOOL_*` rows. Missing final output omits
 `AGENT_COMPLETED`. Missing `nl_prompt`/`prompt` is a hard error because a valid
 scenario trace cannot be built without the user message. Duplicate scenario IDs
@@ -92,18 +119,161 @@ Token counts are summed across model entries. Latency uses the maximum reported
 model duration because some EvalBench producers repeat one run-level duration
 for every model used by the run.
 
+Source failures surface as `status = 'ERROR'` plus `error_message`: a
+non-zero (or non-numeric) `returncode`, `stderr`, and the `*_error` columns
+are collected into `attributes.evalbench_error_fields`.
+
+## Materialize A Snapshot
+
+```python
+result = run.materialize(
+    target_project="analytics-project",   # may differ from the source project
+    target_dataset="bqaa",
+)
+print(result.status, result.import_version, result.events_table)
+```
+
+`materialize()` writes three BQAA-owned tables in the target dataset (which
+must already exist; the tables are created on first use):
+
+| Table | Default name | Contents |
+|---|---|---|
+| Events | `evalbench_agent_events` | `agent_events` columns plus `job_id`, `import_version`; partitioned by `timestamp`, clustered by `job_id, import_version, session_id` |
+| Scores | `evalbench_scores_imported` | `job_id`, `import_version`, `scenario_id`, `session_id`, `comparator`, `score FLOAT64`, `source_row JSON` (the verbatim EvalBench score row) |
+| Manifest | `evalbench_import_manifest` | one row per `(job_id, import_version)` — see below |
+
+The extra event columns are appended after the `agent_events` contract, so
+`Client.get_session_trace` and the other explicit-column readers work
+unchanged when pointed at the mirror table.
+
+### Atomic publish
+
+Event, score, and manifest rows are loaded into per-import staging tables
+(`<table>_staging_<hex>`) and then published by **one** BigQuery
+multi-statement transaction:
+
+```sql
+BEGIN TRANSACTION;
+DELETE FROM `…evalbench_agent_events`     WHERE job_id = @job_id AND import_version = @import_version;
+DELETE FROM `…evalbench_scores_imported`  WHERE job_id = @job_id AND import_version = @import_version;
+DELETE FROM `…evalbench_import_manifest`  WHERE job_id = @job_id AND import_version = @import_version;
+INSERT INTO `…evalbench_agent_events`    (…) SELECT … FROM `…evalbench_agent_events_staging_…`;
+INSERT INTO `…evalbench_scores_imported` (…) SELECT … FROM `…evalbench_scores_imported_staging_…`;
+INSERT INTO `…evalbench_import_manifest` (…) SELECT … FROM `…evalbench_import_manifest_staging_…`;
+COMMIT TRANSACTION;
+```
+
+There is no delete-then-append window: a failure before `COMMIT` leaves the
+previously published version (or nothing) in place, and staging tables are
+always dropped. Mapping errors (missing prompt, duplicate scenario ids) are
+raised before any BigQuery write.
+
+### Import versions and idempotency
+
+`import_version` defaults to the first 16 hex digits of a SHA-256 over the
+order-independent fingerprints of the source `results`, `scores`, and
+`configs` rows. The manifest drives idempotency:
+
+| Situation | Outcome |
+|---|---|
+| No manifest row for `(job_id, import_version)` | rows published, `status = "imported"` |
+| Manifest row exists with identical fingerprints | nothing written, `status = "unchanged"` |
+| Same as above with `replace=True` | atomically re-published, `status = "replaced"` |
+| Explicit `import_version` whose fingerprints changed | `ValueError` (pass a new version, omit it to derive one, or `replace=True`) |
+| Derived version and the source changed | a new `import_version`; earlier versions are retained |
+
+A given `(job_id, import_version)` therefore never accumulates duplicates.
+
+### Manifest
+
+The manifest row binds every published version to its source:
+
+| Column | Meaning |
+|---|---|
+| `job_id`, `import_version` | the published version |
+| `source_project`, `source_dataset`, `source_snapshot_at` | where and (if pinned) when the source was read |
+| `results_count`, `scores_count`, `configs_count` | source row counts |
+| `results_fingerprint`, `scores_fingerprint`, `configs_fingerprint` | SHA-256 content fingerprints |
+| `events_table`, `scores_table` | fully-qualified published tables |
+| `event_row_count`, `score_row_count` | rows published |
+| `imported_at` | publish timestamp (UTC) |
+
+`EvalBenchImportResult.manifest` returns the same row in memory.
+
+## Failed-Session Contract (W0.4)
+
+`returncode == 0` means the EvalBench process **completed**, not that the
+scenario **passed**. A session is *failed* when any of the following holds:
+
+- **process failure** — any event has `status = 'ERROR'` (non-zero
+  `returncode`, `stderr`, or a source `*_error` column);
+- **missing completion** — the session has no `AGENT_COMPLETED` event;
+- **score failure** — the per-benchmark `EvalScorePolicy` is not met.
+
+`EvalScorePolicy(min_scores={comparator: min_score}, missing_score_fails=True)`
+is the policy hook. A session fails the score gate if any listed comparator
+scores below its threshold. By default a missing or `NULL` score for a listed
+comparator also fails, because a run that completed without being scored is
+not evidence of success; set `missing_score_fails=False` to relax that.
+
+`failed_sessions_sql()` returns the denominator query for one pinned import;
+it takes `@job_id` and `@import_version` parameters and never reads
+`returncode` directly:
+
+```python
+from google.cloud import bigquery
+from bigquery_agent_analytics.evalbench import (
+    EvalScorePolicy,
+    failed_sessions_sql,
+    import_query_parameters,
+)
+
+sql = failed_sessions_sql(
+    target_project="analytics-project",
+    target_dataset="bqaa",
+    policy=EvalScorePolicy({"goal_completion": 0.5}),
+)
+job_config = bigquery.QueryJobConfig(
+    query_parameters=import_query_parameters("abc123", result.import_version)
+)
+rows = client.query(sql, job_config=job_config).result()
+```
+
+Each returned row carries `session_id`, `scenario_id`, `started_at`,
+`process_failed`, `missing_completion`, `score_failed`, the combined
+`failed` flag, and `failing_scores` (the comparators that missed their
+threshold, with the offending score or `NULL`).
+
+`classify_sessions(event_rows, score_rows, policy)` is the in-memory
+reference implementation of the same contract over `to_agent_event_rows()`
+and `to_score_rows()` output; the unit tests pin the two to each other.
+
+## CLI
+
+```bash
+bq-agent-sdk evalbench-import \
+  --project-id benchmark-project --evalbench-dataset evalbench --job-id abc123 \
+  --target-project analytics-project --target-dataset bqaa \
+  [--import-version v1] [--replace] [--snapshot-at 2026-05-01T08:00:00Z] \
+  [--events-table evalbench_agent_events] [--scores-table evalbench_scores_imported] \
+  [--location US] [--format json|text|table]
+```
+
+The command prints the `EvalBenchImportResult` (including the manifest) and
+exits `0` for `imported`, `replaced`, or `unchanged`, and `2` on invalid
+input, a changed source under an explicit `--import-version`, or a BigQuery
+error. There is no `evalbench-score` command.
+
 ## Why These Fields Matter
 
-The mapping follows the SDK queries that consume the future mirror table:
+The mapping follows the SDK queries that consume the mirror table:
 
-- `client.py:138-158` projects the complete trace row contract in
-  `_GET_TRACE_QUERY`.
-- `trace.py:758-768` reads `attributes.experiment_id` for `TraceFilter`.
-- `evaluators.py:923-1076` reads latency and token counters in
-  `SESSION_SUMMARY_QUERY`.
-- `evaluators.py:1079-1102` builds judge text from `content.text_summary`,
-  selects `content.response`, and drops traces whose assembled text is not
-  longer than ten characters.
+- `client.py` projects the complete trace row contract in `_GET_TRACE_QUERY`.
+- `trace.py` reads `attributes.experiment_id` for `TraceFilter`.
+- `evaluators.py` reads latency and token counters in `SESSION_SUMMARY_QUERY`.
+- `evaluators.py` builds judge text from `content.text_summary`, selects
+  `content.response`, and drops traces whose assembled text is not longer
+  than ten characters.
 
 The last constraint is easy to miss: a row can satisfy the BigQuery schema but
 remain invisible to `LLMAsJudge` when `text_summary` is absent. The mapper
@@ -111,10 +281,10 @@ therefore populates it on every emitted event.
 
 ## Current Boundaries
 
-- No BigQuery writes are performed by `to_agent_event_rows()`.
-- No `evalbench-import` or `evalbench-score` command exists yet.
-- `run.scores` preserves source score rows in memory; the
-  `evalbench_scores_imported` writer belongs to the materialization phase.
-- The future writer must target a BQAA-owned mirror table, accept a distinct
-  target project, and delete an existing `experiment_id` before append so a
-  repeated import cannot duplicate a run.
+- Runs are imported one `job_id` at a time and held in memory.
+- The target dataset must exist; only the three tables are auto-created.
+- Concurrent imports of the same `(job_id, import_version)` serialize on
+  BigQuery's transaction locks; a conflicting import fails rather than
+  corrupting the corpus.
+- Live BigQuery integration coverage for `materialize()` is not yet gated
+  into the test suite; the unit tests use a stubbed client.

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2245,6 +2245,116 @@ bqaa_app.command(
 )(materialize_window)
 
 
+@app.command("evalbench-import")
+def evalbench_import(
+    project_id: str = typer.Option(
+        ...,
+        envvar="BQ_AGENT_PROJECT",
+        help="Project containing the EvalBench source tables.",
+    ),
+    evalbench_dataset: str = typer.Option(
+        ...,
+        "--evalbench-dataset",
+        help="Dataset containing EvalBench configs, results, and scores.",
+    ),
+    job_id: str = typer.Option(
+        ..., "--job-id", help="EvalBench job_id to import."
+    ),
+    target_dataset: str = typer.Option(
+        ...,
+        "--target-dataset",
+        help="BQAA-owned dataset that receives the mirror tables.",
+    ),
+    target_project: Optional[str] = typer.Option(
+        None,
+        "--target-project",
+        help="Target project (defaults to --project-id).",
+    ),
+    events_table: str = typer.Option(
+        "evalbench_agent_events",
+        "--events-table",
+        help="Mirror event table name in --target-dataset.",
+    ),
+    scores_table: str = typer.Option(
+        "evalbench_scores_imported",
+        "--scores-table",
+        help="Imported score table name in --target-dataset.",
+    ),
+    import_version: Optional[str] = typer.Option(
+        None,
+        "--import-version",
+        help=(
+            "Version label for this import. Defaults to a fingerprint of the"
+            " source rows so an unchanged source is a no-op."
+        ),
+    ),
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help="Atomically overwrite an existing import version.",
+    ),
+    snapshot_at: Optional[str] = typer.Option(
+        None,
+        "--snapshot-at",
+        help=(
+            "ISO-8601 timestamp; read all three source tables FOR SYSTEM_TIME"
+            " AS OF this instant so a still-running job cannot mix versions."
+        ),
+    ),
+    location: Optional[str] = typer.Option(
+        None, "--location", help="BigQuery location."
+    ),
+    fmt: str = typer.Option(
+        "json", "--format", help="Output format: json|text|table."
+    ),
+) -> None:
+  """Snapshot one EvalBench job into BQAA-owned mirror tables.
+
+  Reads the job's configs/results/scores, maps them to synthetic agent
+  events, and publishes events, scores, and a manifest row as one immutable
+  import version via a single BigQuery transaction. The ADK plugin's
+  production ``agent_events`` table is never written.
+
+  Exit codes:
+      0 — imported, replaced, or unchanged (see ``status`` in the output).
+      2 — invalid input, a changed source under an explicit
+          --import-version, or a BigQuery error.
+  """
+  try:
+    from .evalbench import _parse_timestamp
+    from .evalbench import EvalBenchRun
+
+    parsed_snapshot = None
+    if snapshot_at is not None:
+      parsed_snapshot = _parse_timestamp(snapshot_at)
+      if parsed_snapshot is None:
+        raise ValueError(
+            f"--snapshot-at must be an ISO-8601 timestamp, got {snapshot_at!r}"
+        )
+
+    run = EvalBenchRun.from_bigquery(
+        project_id=project_id,
+        evalbench_dataset=evalbench_dataset,
+        job_id=job_id,
+        location=location,
+        snapshot_at=parsed_snapshot,
+    )
+    result = run.materialize(
+        target_project=target_project,
+        target_dataset=target_dataset,
+        events_table=events_table,
+        scores_table=scores_table,
+        import_version=import_version,
+        replace=replace,
+    )
+    typer.echo(format_output(result.to_dict(), fmt))
+  except typer.Exit:
+    raise
+  except Exception as exc:  # noqa: BLE001
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
 @bqaa_app.command("seed-events")
 def seed_events(
     project_id: str = typer.Option(

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2317,12 +2317,19 @@ def evalbench_import(
 
   Exit codes:
       0 — imported, replaced, or unchanged (see ``status`` in the output).
-      2 — invalid input, a changed source under an explicit
-          --import-version, or a BigQuery error.
+      2 — invalid input (including the reserved ``agent_events`` table
+          name), a changed source under an explicit --import-version, a
+          version already bound to other destination tables, or a BigQuery
+          error.
   """
   try:
     from .evalbench import _parse_timestamp
+    from .evalbench import _validate_destination_table
     from .evalbench import EvalBenchRun
+
+    # Reject the reserved ADK plugin table before any BigQuery read or write.
+    _validate_destination_table("events_table", events_table)
+    _validate_destination_table("scores_table", scores_table)
 
     parsed_snapshot = None
     if snapshot_at is not None:

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -21,10 +21,12 @@ time into the mirror-table row contract tracked by issue #97.
 immutable, versioned snapshot into BQAA-owned tables -- never the ADK
 plugin's production ``agent_events`` table. Events, imported scores, and a
 manifest row are staged with load jobs and then published by one BigQuery
-multi-statement transaction, so a failed re-import cannot leave a partial
-corpus behind. ``failed_sessions_sql`` reads one pinned ``import_version`` and
-implements the W0.4 contract: ``returncode == 0`` means *completed*, and only
-the per-benchmark score policy decides *passed*.
+multi-statement transaction that first claims a pre-existing lock row, so a
+failed re-import cannot leave a partial corpus behind and two first-time
+imports of one version cannot both commit. ``failed_sessions_sql`` reads one
+pinned ``import_version`` and implements the W0.4 contract:
+``returncode == 0`` means *completed*, and only the per-benchmark score
+policy decides *passed*.
 """
 
 from __future__ import annotations
@@ -74,6 +76,16 @@ DEFAULT_SCORES_TABLE = "evalbench_scores_imported"
 # that dataset, so a second manifest can never route around the version
 # immutability guard of the first.
 MANIFEST_TABLE = "evalbench_import_manifest"
+# The dataset's publish lock. It holds one sentinel row that every publish
+# transaction UPDATEs before touching the manifest, events, or scores.
+# BigQuery cancels a transaction that mutates rows another concurrent
+# transaction has already mutated, but reads, appends, and keyed DELETEs that
+# match nothing never conflict -- so under snapshot isolation two first-time
+# imports that both began before either committed would otherwise both
+# observe "no manifest row" and both commit. Like the manifest, the lock
+# table is fixed per dataset and never caller-selectable.
+LOCK_TABLE = "evalbench_import_lock"
+_IMPORT_LOCK_ID = "evalbench-import"
 # The ADK plugin's production table. EvalBench imports publish only to
 # BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
 _RESERVED_DESTINATION_TABLES = frozenset({"agent_events"})
@@ -133,6 +145,13 @@ _MANIFEST_SCHEMA_FIELDS = (
     ("score_row_count", "INT64", "REQUIRED"),
     ("imported_at", "TIMESTAMP", "REQUIRED"),
 )
+_LOCK_SCHEMA_FIELDS = (
+    ("lock_id", "STRING", "REQUIRED"),
+    ("claim_count", "INT64", "REQUIRED"),
+    ("claimed_at", "TIMESTAMP", "NULLABLE"),
+    ("claimed_job_id", "STRING", "NULLABLE"),
+    ("claimed_import_version", "STRING", "NULLABLE"),
+)
 _FINGERPRINT_KEYS = (
     "results_fingerprint",
     "scores_fingerprint",
@@ -145,18 +164,43 @@ FROM `{manifest_table}`
 WHERE job_id = @job_id AND import_version = @import_version
 """
 
+# Seeds the lock sentinel outside the publish transaction. Two importers that
+# both find the table empty may each insert a sentinel (INSERTs never
+# conflict); that is harmless because the claim UPDATE below matches every
+# sentinel row, so both transactions still mutate the same row(s).
+_SEED_LOCK_QUERY = """\
+INSERT INTO `{lock_table}` (lock_id, claim_count)
+SELECT '{lock_id}', 0
+FROM UNNEST([1])
+WHERE NOT EXISTS (
+  SELECT 1 FROM `{lock_table}` WHERE lock_id = '{lock_id}'
+)
+"""
+
 # One multi-statement script publishes events, scores, and the manifest
-# together. The manifest guard runs *inside* the transaction: two importers
-# that both observed no manifest row before publishing cannot both commit a
-# different corpus under one immutable version, because BigQuery serializes
-# conflicting DML on the manifest table and the later transaction re-reads the
-# earlier row and raises. DML inside BEGIN/COMMIT is all-or-nothing, so a
-# failure anywhere (including the guard) leaves the previously published
-# version (or nothing) in place.
+# together. Its first statement claims the dataset lock by UPDATE-ing the
+# pre-existing sentinel row. Per BigQuery's transaction concurrency contract
+# ("if a transaction mutates rows in a table, other transactions that mutate
+# rows in the same table cannot run concurrently; conflicting transactions
+# are cancelled") at most one of two concurrent publishes survives, even when
+# both began from a snapshot that showed no manifest row. The manifest guard
+# then runs inside the same transaction as defence in depth: an importer
+# whose *pre-publish* read was stale but whose transaction started after the
+# other commit sees the committed row and raises before deleting anything.
+# DML inside BEGIN/COMMIT is all-or-nothing, so a failure anywhere leaves the
+# previously published version (or nothing) in place.
 _PUBLISH_CONFLICT_MESSAGE = (
     "evalbench import conflict: this import_version was already published"
     " with different source fingerprints or destination tables"
 )
+_LOCK_MISSING_MESSAGE = (
+    "evalbench import lock sentinel is missing; the publish transaction"
+    " cannot serialize against concurrent imports"
+)
+# Substring of the error BigQuery raises for the transaction it cancels when
+# two transactions mutate the same rows ("Transaction is aborted due to
+# concurrent update against table ...").
+_CONCURRENT_UPDATE_MARKER = "concurrent update"
 _DESTINATION_CONFLICT_PREDICATE = (
     "events_table != @events_table OR scores_table != @scores_table"
 )
@@ -169,6 +213,15 @@ _PUBLISH_SCRIPT = """\
 DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
 BEGIN
   BEGIN TRANSACTION;
+  UPDATE `{lock_table}`
+  SET claim_count = claim_count + 1,
+      claimed_at = CURRENT_TIMESTAMP(),
+      claimed_job_id = @job_id,
+      claimed_import_version = @import_version
+  WHERE lock_id = '{lock_id}';
+  IF @@row_count = 0 THEN
+    RAISE USING MESSAGE = '{lock_missing_message}';
+  END IF;
   SET conflicting_manifest_rows = (
     SELECT COUNT(*)
     FROM `{manifest_table}`
@@ -392,17 +445,24 @@ class EvalBenchRun:
     constructed without them.
 
     ``session_id``/``trace_id`` are ``evalbench:{job_id}:{scenario_id}`` for
-    a plain read. When ``import_version`` is given (as ``materialize`` does)
-    the identity becomes ``evalbench:{job_id}:{import_version}:{scenario_id}``
-    and every synthetic span id derives from it, so retained import versions
-    of one job never share a trace or session in the mirror table and
-    readers that filter only by ``trace_id`` see exactly one version. Each
-    component is escaped (see ``_session_identity``) so a ``:`` inside
-    ``import_version`` or ``scenario_id`` cannot make two different
-    ``(job_id, import_version, scenario_id)`` tuples share an identity.
+    a plain read, and the invocation/span ids hash that identity exactly as
+    v0.5.1 did, so re-mapping an existing run keeps its stored trace
+    references. When ``import_version`` is given (as ``materialize`` does)
+    the identity moves to the distinct published namespace
+    ``evalbench-import:{job_id}:{import_version}:{scenario_id}`` and every
+    synthetic span id derives from it with injective framing, so retained
+    import versions of one job never share a trace or session in the mirror
+    table and readers that filter only by ``trace_id`` see exactly one
+    version. Each published component is escaped (see ``_session_identity``)
+    so a ``:`` inside ``import_version`` or ``scenario_id`` cannot make two
+    different ``(job_id, import_version, scenario_id)`` tuples share an
+    identity, and no published identity can equal a plain-read one.
     """
     if import_version is not None:
       _validate_import_version(import_version)
+      stable_id = _published_stable_id
+    else:
+      stable_id = _stable_id
     config = _config_values(self.config_rows)
     agent = _agent_name(config)
     config_run_time = _first_run_time(self.config_rows)
@@ -437,8 +497,8 @@ class EvalBenchRun:
       session_id = _session_identity(
           self.job_id, scenario_id, import_version=import_version
       )
-      invocation_id = _stable_id(session_id, "invocation", length=32)
-      root_span_id = _stable_id(session_id, "user", length=16)
+      invocation_id = stable_id(session_id, "invocation", length=32)
+      root_span_id = stable_id(session_id, "user", length=16)
       attributes = _base_attributes(
           result=result,
           project_id=self.project_id,
@@ -487,9 +547,7 @@ class EvalBenchRun:
         tool_result = tool_call.get("result")
         tool_error = _usable_text(tool_call.get("error"))
         tool_status = "ERROR" if tool_error else "OK"
-        tool_span_id = _stable_id(
-            session_id, "tool", str(tool_index), length=16
-        )
+        tool_span_id = stable_id(session_id, "tool", str(tool_index), length=16)
         start_summary = f"{tool_name}({_compact_json(tool_args)})"
         rows.append(
             _event_row(
@@ -546,7 +604,7 @@ class EvalBenchRun:
               agent=agent,
               session_id=session_id,
               invocation_id=invocation_id,
-              span_id=_stable_id(session_id, "agent-completed", length=16),
+              span_id=stable_id(session_id, "agent-completed", length=16),
               parent_span_id=root_span_id,
               content={
                   "response": final_response,
@@ -633,7 +691,8 @@ class EvalBenchRun:
     caller-selectable: every import into the dataset, whatever
     ``events_table``/``scores_table`` it writes, checks the same registry
     before deleting any published rows, so one version cannot be
-    re-published around an earlier manifest row.
+    re-published around an earlier manifest row. The dataset's publish lock
+    (``LOCK_TABLE``, ``evalbench_import_lock``) is fixed for the same reason.
 
     Publishing is atomic: event, score, and manifest rows are loaded into
     per-import staging tables, then a single multi-statement transaction
@@ -646,9 +705,12 @@ class EvalBenchRun:
     no-op (``status == "unchanged"``) and a changed source becomes a new
     version. An explicit ``import_version`` whose stored fingerprints no
     longer match the source raises ``ValueError`` unless ``replace=True``.
-    The same check is repeated inside the publish transaction, so two
-    importers racing on a first-time version cannot both commit different
-    content. A published version is bound to the ``events_table`` /
+    The publish transaction first claims the dataset lock by updating its
+    pre-existing sentinel row, so two importers racing on a first-time
+    version cannot both commit: BigQuery cancels the second transaction that
+    mutates the same row, and the cancelled importer raises ``ValueError``
+    with nothing written. The fingerprint check is repeated inside the same
+    transaction as well. A published version is bound to the ``events_table`` /
     ``scores_table`` recorded in its manifest: re-importing it with other
     destination tables raises (even with ``replace=True``) instead of
     reporting a no-op against tables that were never written or orphaning
@@ -690,6 +752,7 @@ class EvalBenchRun:
     events_ref = f"{prefix}.{events_table}"
     scores_ref = f"{prefix}.{scores_table}"
     manifest_ref = f"{prefix}.{MANIFEST_TABLE}"
+    lock_ref = f"{prefix}.{LOCK_TABLE}"
 
     # Map before touching BigQuery so mapping errors never leave staging
     # tables behind or partially created targets.
@@ -723,6 +786,7 @@ class EvalBenchRun:
         events_ref=events_ref,
         scores_ref=scores_ref,
         manifest_ref=manifest_ref,
+        lock_ref=lock_ref,
     )
 
     existing = _read_manifest(
@@ -780,10 +844,14 @@ class EvalBenchRun:
           [manifest],
           _schema(_MANIFEST_SCHEMA_FIELDS),
       )
+      # The sentinel must exist *before* the transaction starts so the
+      # claim UPDATE mutates a row visible in the transaction snapshot.
+      _seed_import_lock(client, lock_ref=lock_ref, location=self.location)
       script = _publish_script(
           events_ref=events_ref,
           scores_ref=scores_ref,
           manifest_ref=manifest_ref,
+          lock_ref=lock_ref,
           events_staging=events_staging,
           scores_staging=scores_staging,
           manifest_staging=manifest_staging,
@@ -814,6 +882,15 @@ class EvalBenchRun:
               "source fingerprints or destination tables; nothing was "
               "written. Re-run to get status 'unchanged', or pass a new "
               "import_version (or omit it to derive one from the source)"
+          ) from exc
+        if _CONCURRENT_UPDATE_MARKER in str(exc).lower():
+          raise ValueError(
+              f"EvalBench job {self.job_id!r} import_version "
+              f"{import_version!r}: BigQuery cancelled this publish because a "
+              f"concurrent import into {prefix!r} claimed the import lock "
+              f"({lock_ref!r}) first; nothing was written. Re-run: the "
+              "result is 'unchanged' if the other import published identical "
+              "content, otherwise the fingerprint conflict is reported"
           ) from exc
         raise
     finally:
@@ -1082,17 +1159,21 @@ def _publish_script(
     events_ref: str,
     scores_ref: str,
     manifest_ref: str,
+    lock_ref: str,
     events_staging: str,
     scores_staging: str,
     manifest_staging: str,
     replace: bool,
 ) -> str:
-  """Render the publish transaction with its in-transaction manifest guard.
+  """Render the publish transaction: lock claim, manifest guard, DML.
 
-  Without ``replace`` the guard rejects an existing manifest row whose
-  fingerprints *or* destination tables differ from this import; with
-  ``replace`` fingerprints may drift but the destination binding still
-  holds, so a version can never be silently relocated.
+  The transaction always starts by UPDATE-ing the lock sentinel, which is
+  the only statement guaranteed to mutate an existing row (the keyed DELETEs
+  match nothing on a first import and INSERTs never conflict). Without
+  ``replace`` the guard rejects an existing manifest row whose fingerprints
+  *or* destination tables differ from this import; with ``replace``
+  fingerprints may drift but the destination binding still holds, so a
+  version can never be silently relocated.
   """
   if replace:
     conflict_predicate = _DESTINATION_CONFLICT_PREDICATE
@@ -1106,6 +1187,9 @@ def _publish_script(
       events_table=events_ref,
       scores_table=scores_ref,
       manifest_table=manifest_ref,
+      lock_table=lock_ref,
+      lock_id=_IMPORT_LOCK_ID,
+      lock_missing_message=_LOCK_MISSING_MESSAGE,
       events_staging=events_staging,
       scores_staging=scores_staging,
       manifest_staging=manifest_staging,
@@ -1141,12 +1225,24 @@ def _check_destination_binding(
   )
 
 
-# Identity components are joined with ":"; a literal ":" or "\" inside a
-# component is escaped ("\:" and "\\") so the join is injective and decodes
-# back to the original tuple. ``import_version`` admits ":" and ``scenario_id``
-# is arbitrary source text, so without escaping
-# ``(import_version="release:1", scenario_id="case")`` and
-# ``(import_version="release", scenario_id="1:case")`` would collide.
+# Two identity families, deliberately kept apart:
+#
+# * Plain reads (``to_agent_event_rows()`` without ``import_version``) keep
+#   the v0.5.1 public contract verbatim: ``evalbench:{job_id}:{scenario_id}``
+#   with no escaping, and span/invocation ids hashed by the legacy
+#   ``_stable_id``. Changing either would break stored trace references of
+#   runs mapped before this release.
+# * Published versions use the ``evalbench-import`` namespace, whose
+#   components are joined with ":" and escaped ("\:" and "\\") so the join
+#   is injective and decodes back to the original tuple. ``import_version``
+#   admits ":" and ``scenario_id`` is arbitrary source text, so without
+#   escaping ``(import_version="release:1", scenario_id="case")`` and
+#   ``(import_version="release", scenario_id="1:case")`` would collide.
+#
+# The namespaces cannot alias each other: every plain identity starts with
+# ``evalbench:`` and every published one with ``evalbench-import:``.
+_LEGACY_IDENTITY_PREFIX = "evalbench"
+_PUBLISHED_IDENTITY_PREFIX = "evalbench-import"
 _IDENTITY_SEPARATOR = ":"
 _IDENTITY_ESCAPES = str.maketrans({"\\": "\\\\", _IDENTITY_SEPARATOR: "\\:"})
 
@@ -1160,18 +1256,22 @@ def _session_identity(
 ) -> str:
   """Session/trace identity shared by event rows and score rows.
 
-  ``evalbench:{job_id}:{scenario_id}`` for a plain read and
-  ``evalbench:{job_id}:{import_version}:{scenario_id}`` for a published
-  version, with every component escaped so the encoding of the tuple is
-  unambiguous. Components without ``:`` or ``\\`` (the common case) render
-  verbatim. The two forms differ in component count, so a plain read of a
-  scenario named ``v1:case`` can never alias published version ``v1``.
+  ``evalbench:{job_id}:{scenario_id}`` (unescaped, the v0.5.1 contract) for
+  a plain read and ``evalbench-import:{job_id}:{import_version}:{scenario_id}``
+  with every component escaped for a published version. Published
+  components without ``:`` or ``\\`` (the common case) render verbatim.
   """
-  parts = ["evalbench", job_id]
-  if import_version is not None:
-    parts.append(import_version)
-  parts.append(scenario_id)
-  return _IDENTITY_SEPARATOR.join(_identity_component(part) for part in parts)
+  if import_version is None:
+    return _IDENTITY_SEPARATOR.join(
+        (_LEGACY_IDENTITY_PREFIX, job_id, scenario_id)
+    )
+  return _IDENTITY_SEPARATOR.join(
+      [_PUBLISHED_IDENTITY_PREFIX]
+      + [
+          _identity_component(part)
+          for part in (job_id, import_version, scenario_id)
+      ]
+  )
 
 
 def _validate_import_version(import_version: Any) -> None:
@@ -1281,7 +1381,12 @@ def _event_schema() -> list:
 
 
 def _ensure_import_tables(
-    client: Any, *, events_ref: str, scores_ref: str, manifest_ref: str
+    client: Any,
+    *,
+    events_ref: str,
+    scores_ref: str,
+    manifest_ref: str,
+    lock_ref: str,
 ) -> None:
   events = bigquery.Table(events_ref, schema=_event_schema())
   events.time_partitioning = bigquery.TimePartitioning(field="timestamp")
@@ -1296,6 +1401,27 @@ def _ensure_import_tables(
       manifest_ref, schema=_schema(_MANIFEST_SCHEMA_FIELDS)
   )
   client.create_table(manifest, exists_ok=True)
+
+  lock = bigquery.Table(lock_ref, schema=_schema(_LOCK_SCHEMA_FIELDS))
+  client.create_table(lock, exists_ok=True)
+
+
+def _seed_import_lock(
+    client: Any, *, lock_ref: str, location: Optional[str]
+) -> None:
+  """Insert the lock sentinel if the dataset does not have one yet.
+
+  Runs as its own committed DML job before the publish transaction, so the
+  transaction's snapshot contains the row its claim UPDATE mutates.
+  """
+  job_config = with_sdk_labels(
+      bigquery.QueryJobConfig(), feature=_IMPORT_FEATURE
+  )
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _SEED_LOCK_QUERY.format(lock_table=lock_ref, lock_id=_IMPORT_LOCK_ID)
+  client.query(query, **query_args).result()
 
 
 def _drop_staging_tables(client: Any, staging_refs: tuple[str, ...]) -> None:
@@ -1884,14 +2010,27 @@ def _event_row(
 
 
 def _stable_id(*parts: str, length: int) -> str:
-  """Deterministic hex id of a tuple of strings.
+  """Legacy (v0.5.1) deterministic hex id used by plain-read identities.
+
+  Frozen on purpose: ``to_agent_event_rows()`` without ``import_version``
+  must keep producing the invocation/span ids it produced in v0.5.1.
+  """
+  digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+  return digest[:length]
+
+
+def _published_stable_id(*parts: str, length: int) -> str:
+  """Deterministic hex id for published (versioned) identities.
 
   Parts are length-prefixed before hashing so the encoding is injective even
   when a part (such as a session id built from arbitrary scenario text)
   contains the joiner: ``("a\\x1fb", "c")`` and ``("a", "b\\x1fc")`` hash
-  differently.
+  differently. The framing is tagged with the published namespace so it can
+  never reproduce a legacy digest either.
   """
-  encoded = "\x1f".join(f"{len(part)}:{part}" for part in parts)
+  encoded = "\x1f".join(
+      [_PUBLISHED_IDENTITY_PREFIX] + [f"{len(part)}:{part}" for part in parts]
+  )
   digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
   return digest[:length]
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -11,13 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Read EvalBench BigQuery runs and map them to BQAA event rows.
+"""Read EvalBench BigQuery runs, map them to BQAA event rows, and snapshot them.
 
-The reader is deliberately pull-only: EvalBench keeps ownership of its
-``configs``, ``results``, and ``scores`` tables, while BQAA converts one
-``job_id`` at a time into the mirror-table row contract tracked by issue #97.
-Writing those rows is a separate phase so idempotency and table ownership can
-be reviewed independently from source-schema normalization.
+The reader is pull-only: EvalBench keeps ownership of its ``configs``,
+``results``, and ``scores`` tables, while BQAA converts one ``job_id`` at a
+time into the mirror-table row contract tracked by issue #97.
+
+``EvalBenchRun.materialize`` (issue #435) publishes that mapping as an
+immutable, versioned snapshot into BQAA-owned tables -- never the ADK
+plugin's production ``agent_events`` table. Events, imported scores, and a
+manifest row are staged with load jobs and then published by one BigQuery
+multi-statement transaction, so a failed re-import cannot leave a partial
+corpus behind. ``failed_sessions_sql`` reads one pinned ``import_version`` and
+implements the W0.4 contract: ``returncode == 0`` means *completed*, and only
+the per-benchmark score policy decides *passed*.
 """
 
 from __future__ import annotations
@@ -31,8 +38,10 @@ from datetime import timedelta
 from datetime import timezone
 import hashlib
 import json
+import math
 import re
 from typing import Any, Optional
+import uuid
 
 from google.cloud import bigquery
 
@@ -50,6 +59,174 @@ FROM `{table_id}`
 WHERE job_id = @job_id
 """
 
+_READ_SOURCE_TABLE_SNAPSHOT_QUERY = """\
+SELECT *
+FROM `{table_id}` FOR SYSTEM_TIME AS OF @snapshot_at
+WHERE job_id = @job_id
+"""
+
+DEFAULT_EVENTS_TABLE = "evalbench_agent_events"
+DEFAULT_SCORES_TABLE = "evalbench_scores_imported"
+DEFAULT_MANIFEST_TABLE = "evalbench_import_manifest"
+_IMPORT_FEATURE = "evalbench-import"
+_IMPORT_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+_COMPARATOR_PATTERN = re.compile(r"^[A-Za-z0-9_.:/-]{1,128}$")
+
+# Mirror of the ADK plugin ``agent_events`` shape (see ``_GET_TRACE_QUERY`` in
+# client.py) plus the two import-binding columns BQAA owns. The extra columns
+# are appended last so explicit-column consumers keep working unchanged.
+_EVENT_COLUMNS = (
+    "timestamp",
+    "event_type",
+    "agent",
+    "session_id",
+    "invocation_id",
+    "user_id",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "content",
+    "content_parts",
+    "attributes",
+    "latency_ms",
+    "status",
+    "error_message",
+    "is_truncated",
+    "job_id",
+    "import_version",
+)
+_SCORE_SCHEMA_FIELDS = (
+    ("job_id", "STRING", "REQUIRED"),
+    ("import_version", "STRING", "REQUIRED"),
+    ("scenario_id", "STRING", "NULLABLE"),
+    ("session_id", "STRING", "NULLABLE"),
+    ("comparator", "STRING", "NULLABLE"),
+    ("score", "FLOAT64", "NULLABLE"),
+    ("source_row", "JSON", "NULLABLE"),
+)
+_MANIFEST_SCHEMA_FIELDS = (
+    ("job_id", "STRING", "REQUIRED"),
+    ("import_version", "STRING", "REQUIRED"),
+    ("source_project", "STRING", "REQUIRED"),
+    ("source_dataset", "STRING", "REQUIRED"),
+    ("source_snapshot_at", "TIMESTAMP", "NULLABLE"),
+    ("results_count", "INT64", "REQUIRED"),
+    ("scores_count", "INT64", "REQUIRED"),
+    ("configs_count", "INT64", "REQUIRED"),
+    ("results_fingerprint", "STRING", "REQUIRED"),
+    ("scores_fingerprint", "STRING", "REQUIRED"),
+    ("configs_fingerprint", "STRING", "REQUIRED"),
+    ("events_table", "STRING", "REQUIRED"),
+    ("scores_table", "STRING", "REQUIRED"),
+    ("event_row_count", "INT64", "REQUIRED"),
+    ("score_row_count", "INT64", "REQUIRED"),
+    ("imported_at", "TIMESTAMP", "REQUIRED"),
+)
+_FINGERPRINT_KEYS = (
+    "results_fingerprint",
+    "scores_fingerprint",
+    "configs_fingerprint",
+)
+
+_READ_MANIFEST_QUERY = """\
+SELECT *
+FROM `{manifest_table}`
+WHERE job_id = @job_id AND import_version = @import_version
+"""
+
+# One multi-statement transaction publishes events, scores, and the manifest
+# together. DML inside BEGIN/COMMIT is all-or-nothing, so a failure anywhere
+# leaves the previously published version (or nothing) in place.
+_PUBLISH_SCRIPT = """\
+BEGIN TRANSACTION;
+DELETE FROM `{events_table}`
+WHERE job_id = @job_id AND import_version = @import_version;
+DELETE FROM `{scores_table}`
+WHERE job_id = @job_id AND import_version = @import_version;
+DELETE FROM `{manifest_table}`
+WHERE job_id = @job_id AND import_version = @import_version;
+INSERT INTO `{events_table}` ({event_columns})
+SELECT {event_columns} FROM `{events_staging}`;
+INSERT INTO `{scores_table}` ({score_columns})
+SELECT {score_columns} FROM `{scores_staging}`;
+INSERT INTO `{manifest_table}` ({manifest_columns})
+SELECT {manifest_columns} FROM `{manifest_staging}`;
+COMMIT TRANSACTION;
+"""
+
+_FAILED_SESSIONS_BASE = """\
+WITH sessions AS (
+  SELECT
+    session_id,
+    ANY_VALUE(JSON_VALUE(attributes, '$.evalbench_scenario_id')) AS scenario_id,
+    MIN(timestamp) AS started_at,
+    LOGICAL_OR(status = 'ERROR') AS process_failed,
+    NOT LOGICAL_OR(event_type = 'AGENT_COMPLETED') AS missing_completion
+  FROM `{events_table}`
+  WHERE job_id = @job_id AND import_version = @import_version
+  GROUP BY session_id
+)"""
+
+_FAILED_SESSIONS_POLICY = """,
+policy AS (
+  SELECT comparator, min_score
+  FROM UNNEST([
+{policy_rows}
+  ])
+),
+score_gate AS (
+  SELECT
+    s.session_id,
+    COUNTIF({fail_predicate}) AS failing_score_count,
+    ARRAY_AGG(
+      IF(
+        {fail_predicate},
+        STRUCT(p.comparator AS comparator, sc.score AS score),
+        NULL
+      )
+      IGNORE NULLS
+    ) AS failing_scores
+  FROM sessions AS s
+  CROSS JOIN policy AS p
+  LEFT JOIN `{scores_table}` AS sc
+    ON sc.job_id = @job_id
+    AND sc.import_version = @import_version
+    AND sc.session_id = s.session_id
+    AND sc.comparator = p.comparator
+  GROUP BY s.session_id
+)
+SELECT
+  s.session_id,
+  s.scenario_id,
+  s.started_at,
+  s.process_failed,
+  s.missing_completion,
+  COALESCE(g.failing_score_count, 0) > 0 AS score_failed,
+  (
+    s.process_failed
+    OR s.missing_completion
+    OR COALESCE(g.failing_score_count, 0) > 0
+  ) AS failed,
+  g.failing_scores
+FROM sessions AS s
+LEFT JOIN score_gate AS g USING (session_id)
+ORDER BY s.session_id
+"""
+
+_FAILED_SESSIONS_NO_POLICY = """
+SELECT
+  session_id,
+  scenario_id,
+  started_at,
+  process_failed,
+  missing_completion,
+  FALSE AS score_failed,
+  (process_failed OR missing_completion) AS failed,
+  ARRAY<STRUCT<comparator STRING, score FLOAT64>>[] AS failing_scores
+FROM sessions
+ORDER BY session_id
+"""
+
 
 @dataclasses.dataclass(frozen=True)
 class EvalBenchRun:
@@ -58,12 +235,15 @@ class EvalBenchRun:
   ``results`` and ``scores`` retain the source rows as plain Python mappings.
   ``config_rows`` carries EvalBench's flattened experiment/model settings,
   which provide the run timestamp and agent identity for synthetic events.
+  ``snapshot_at`` records the BigQuery time-travel timestamp the three source
+  tables were read at, when the caller pinned one.
   """
 
   project_id: str
   evalbench_dataset: str
   job_id: str
   location: Optional[str] = None
+  snapshot_at: Optional[datetime] = None
   results: tuple[dict[str, Any], ...] = dataclasses.field(
       default_factory=tuple, repr=False
   )
@@ -82,6 +262,7 @@ class EvalBenchRun:
       evalbench_dataset: str,
       job_id: str,
       location: Optional[str] = None,
+      snapshot_at: Optional[datetime] = None,
       bq_client: Optional[Any] = None,
   ) -> "EvalBenchRun":
     """Load one EvalBench run's configs, results, and scores.
@@ -90,12 +271,22 @@ class EvalBenchRun:
     a whole table and filtering in Python. The current contract intentionally
     loads one run into memory; paging very large runs is a future extension.
 
+    The three tables are read sequentially. If the EvalBench job is still
+    writing, results, scores, and configs can come from different moments;
+    either wait for the job to complete before importing or pass
+    ``snapshot_at`` so every read uses ``FOR SYSTEM_TIME AS OF`` the same
+    instant. ``materialize`` records the content fingerprints either way, so
+    a source that changed after import produces a new ``import_version``
+    rather than silently reproducing the first one.
+
     Args:
       project_id: Project containing the EvalBench tables.
       evalbench_dataset: Dataset containing ``configs``, ``results``, and
         ``scores``.
       job_id: EvalBench job identifier to load.
       location: Optional BigQuery location.
+      snapshot_at: Optional timezone-aware timestamp; when set, all three
+        source reads use BigQuery time travel as of this instant.
       bq_client: Optional test-compatible or caller-configured BigQuery client.
 
     Returns:
@@ -105,31 +296,32 @@ class EvalBenchRun:
     _validate_source_segment("evalbench_dataset", evalbench_dataset)
     if not isinstance(job_id, str) or not job_id:
       raise ValueError("job_id must be a non-empty string")
+    if snapshot_at is not None and (
+        not isinstance(snapshot_at, datetime) or snapshot_at.tzinfo is None
+    ):
+      raise ValueError("snapshot_at must be a timezone-aware datetime")
 
     client = bq_client or make_bq_client(project_id, location=location)
     table_prefix = f"{project_id}.{evalbench_dataset}"
+    read_args: dict[str, Any] = {
+        "job_id": job_id,
+        "location": location,
+        "snapshot_at": snapshot_at,
+    }
     return cls(
         project_id=project_id,
         evalbench_dataset=evalbench_dataset,
         job_id=job_id,
         location=location,
+        snapshot_at=snapshot_at,
         results=_read_source_rows(
-            client,
-            table_id=f"{table_prefix}.results",
-            job_id=job_id,
-            location=location,
+            client, table_id=f"{table_prefix}.results", **read_args
         ),
         scores=_read_source_rows(
-            client,
-            table_id=f"{table_prefix}.scores",
-            job_id=job_id,
-            location=location,
+            client, table_id=f"{table_prefix}.scores", **read_args
         ),
         config_rows=_read_source_rows(
-            client,
-            table_id=f"{table_prefix}.configs",
-            job_id=job_id,
-            location=location,
+            client, table_id=f"{table_prefix}.configs", **read_args
         ),
     )
 
@@ -297,6 +489,638 @@ class EvalBenchRun:
 
     return rows
 
+  def to_score_rows(self, *, import_version: str) -> list[dict[str, Any]]:
+    """Normalize loaded EvalBench score rows for ``evalbench_scores_imported``.
+
+    Each source row is preserved verbatim in ``source_row``; ``scenario_id``,
+    ``session_id``, ``comparator``, and a float ``score`` are lifted out so the
+    failed-session view can join scores to events without parsing JSON.
+    Unparseable scores become ``NULL`` rather than being dropped.
+    """
+    _validate_import_version(import_version)
+    prepared: list[tuple[tuple[str, str, str], dict[str, Any]]] = []
+    for score in self.scores:
+      scenario_id = _score_scenario_id(score)
+      comparator = _score_comparator(score)
+      source_row = _json_safe(score)
+      row = {
+          "job_id": self.job_id,
+          "import_version": import_version,
+          "scenario_id": scenario_id,
+          "session_id": (
+              f"evalbench:{self.job_id}:{scenario_id}"
+              if scenario_id is not None
+              else None
+          ),
+          "comparator": comparator,
+          "score": _score_value(score.get("score")),
+          "source_row": source_row,
+      }
+      sort_key = (
+          scenario_id or "",
+          comparator or "",
+          _canonical_json(source_row),
+      )
+      prepared.append((sort_key, row))
+    return [row for _, row in sorted(prepared, key=lambda item: item[0])]
+
+  def fingerprints(self) -> dict[str, str]:
+    """Order-independent SHA-256 fingerprints of the loaded source rows."""
+    return {
+        "results_fingerprint": _fingerprint_rows(self.results),
+        "scores_fingerprint": _fingerprint_rows(self.scores),
+        "configs_fingerprint": _fingerprint_rows(self.config_rows),
+    }
+
+  def materialize(
+      self,
+      *,
+      target_dataset: str,
+      target_project: Optional[str] = None,
+      events_table: str = DEFAULT_EVENTS_TABLE,
+      scores_table: str = DEFAULT_SCORES_TABLE,
+      manifest_table: str = DEFAULT_MANIFEST_TABLE,
+      import_version: Optional[str] = None,
+      replace: bool = False,
+      imported_at: Optional[datetime] = None,
+      bq_client: Optional[Any] = None,
+  ) -> "EvalBenchImportResult":
+    """Publish this run as one immutable import version in BQAA-owned tables.
+
+    The target is always a BQAA-owned mirror (default
+    ``evalbench_agent_events`` / ``evalbench_scores_imported`` /
+    ``evalbench_import_manifest``); the ADK plugin's production
+    ``agent_events`` table is never written. ``target_project`` may differ
+    from the source ``project_id``. The target dataset must already exist;
+    the three tables are created on first use.
+
+    Publishing is atomic: event, score, and manifest rows are loaded into
+    per-import staging tables, then a single multi-statement transaction
+    deletes any prior rows for ``(job_id, import_version)`` and inserts the
+    staged rows. A failure before ``COMMIT`` leaves the target untouched, and
+    staging tables are always dropped.
+
+    Idempotency is driven by the manifest. ``import_version`` defaults to a
+    content fingerprint of the source rows, so an unchanged source is a
+    no-op (``status == "unchanged"``) and a changed source becomes a new
+    version. An explicit ``import_version`` whose stored fingerprints no
+    longer match the source raises ``ValueError`` unless ``replace=True``.
+
+    Args:
+      target_dataset: BQAA-owned dataset that receives the mirror tables.
+      target_project: Target project; defaults to the source ``project_id``.
+      events_table: Mirror event table name in ``target_dataset``.
+      scores_table: Imported score table name in ``target_dataset``.
+      manifest_table: Manifest table name in ``target_dataset``.
+      import_version: Optional caller-chosen version label. Defaults to the
+        first 16 hex digits of the combined source fingerprint.
+      replace: Re-publish even when an identical version already exists
+        (``status == "replaced"``), or when an explicit version's source
+        fingerprints changed.
+      imported_at: Manifest timestamp; defaults to now (UTC).
+      bq_client: Optional test-compatible or caller-configured BigQuery
+        client for the target project.
+
+    Returns:
+      An ``EvalBenchImportResult`` with the published version and manifest.
+    """
+    target_project = target_project or self.project_id
+    _validate_source_segment("target_project", target_project)
+    _validate_source_segment("target_dataset", target_dataset)
+    _validate_source_segment("events_table", events_table)
+    _validate_source_segment("scores_table", scores_table)
+    _validate_source_segment("manifest_table", manifest_table)
+    if imported_at is None:
+      imported_at = datetime.now(timezone.utc)
+    elif imported_at.tzinfo is None:
+      raise ValueError("imported_at must be a timezone-aware datetime")
+
+    fingerprints = self.fingerprints()
+    if import_version is None:
+      import_version = _derived_import_version(fingerprints)
+    _validate_import_version(import_version)
+
+    prefix = f"{target_project}.{target_dataset}"
+    events_ref = f"{prefix}.{events_table}"
+    scores_ref = f"{prefix}.{scores_table}"
+    manifest_ref = f"{prefix}.{manifest_table}"
+
+    # Map before touching BigQuery so mapping errors never leave staging
+    # tables behind or partially created targets.
+    event_rows = [
+        {**row, "job_id": self.job_id, "import_version": import_version}
+        for row in self.to_agent_event_rows()
+    ]
+    score_rows = self.to_score_rows(import_version=import_version)
+    manifest = {
+        "job_id": self.job_id,
+        "import_version": import_version,
+        "source_project": self.project_id,
+        "source_dataset": self.evalbench_dataset,
+        "source_snapshot_at": (
+            self.snapshot_at.isoformat() if self.snapshot_at else None
+        ),
+        "results_count": len(self.results),
+        "scores_count": len(self.scores),
+        "configs_count": len(self.config_rows),
+        **fingerprints,
+        "events_table": events_ref,
+        "scores_table": scores_ref,
+        "event_row_count": len(event_rows),
+        "score_row_count": len(score_rows),
+        "imported_at": imported_at.isoformat(),
+    }
+
+    client = bq_client or make_bq_client(target_project, location=self.location)
+    _ensure_import_tables(
+        client,
+        events_ref=events_ref,
+        scores_ref=scores_ref,
+        manifest_ref=manifest_ref,
+    )
+
+    existing = _read_manifest(
+        client,
+        manifest_ref=manifest_ref,
+        job_id=self.job_id,
+        import_version=import_version,
+        location=self.location,
+    )
+    status = "imported"
+    if existing is not None:
+      unchanged = all(
+          existing.get(key) == fingerprints[key] for key in _FINGERPRINT_KEYS
+      )
+      if not unchanged and not replace:
+        raise ValueError(
+            f"EvalBench job {self.job_id!r} import_version "
+            f"{import_version!r} already exists with different source "
+            "fingerprints; pass a new import_version (or omit it to derive "
+            "one from the source content), or replace=True to overwrite it"
+        )
+      if unchanged and not replace:
+        return EvalBenchImportResult(
+            job_id=self.job_id,
+            import_version=import_version,
+            status="unchanged",
+            events_table=events_ref,
+            scores_table=scores_ref,
+            manifest_table=manifest_ref,
+            event_row_count=int(existing.get("event_row_count") or 0),
+            score_row_count=int(existing.get("score_row_count") or 0),
+            manifest=existing,
+        )
+      status = "replaced"
+
+    staging_suffix = f"_staging_{uuid.uuid4().hex[:8]}"
+    events_staging = events_ref + staging_suffix
+    scores_staging = scores_ref + staging_suffix
+    manifest_staging = manifest_ref + staging_suffix
+    try:
+      _load_staging(client, events_staging, event_rows, _event_schema())
+      _load_staging(
+          client, scores_staging, score_rows, _schema(_SCORE_SCHEMA_FIELDS)
+      )
+      _load_staging(
+          client,
+          manifest_staging,
+          [manifest],
+          _schema(_MANIFEST_SCHEMA_FIELDS),
+      )
+      script = _PUBLISH_SCRIPT.format(
+          events_table=events_ref,
+          scores_table=scores_ref,
+          manifest_table=manifest_ref,
+          events_staging=events_staging,
+          scores_staging=scores_staging,
+          manifest_staging=manifest_staging,
+          event_columns=", ".join(_EVENT_COLUMNS),
+          score_columns=", ".join(name for name, _, _ in _SCORE_SCHEMA_FIELDS),
+          manifest_columns=", ".join(
+              name for name, _, _ in _MANIFEST_SCHEMA_FIELDS
+          ),
+      )
+      job_config = bigquery.QueryJobConfig(
+          query_parameters=_import_parameters(self.job_id, import_version)
+      )
+      job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
+      query_args: dict[str, Any] = {"job_config": job_config}
+      if self.location is not None:
+        query_args["location"] = self.location
+      client.query(script, **query_args).result()
+    finally:
+      for staging_ref in (events_staging, scores_staging, manifest_staging):
+        client.delete_table(staging_ref, not_found_ok=True)
+
+    return EvalBenchImportResult(
+        job_id=self.job_id,
+        import_version=import_version,
+        status=status,
+        events_table=events_ref,
+        scores_table=scores_ref,
+        manifest_table=manifest_ref,
+        event_row_count=len(event_rows),
+        score_row_count=len(score_rows),
+        manifest=manifest,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalBenchImportResult:
+  """Outcome of ``EvalBenchRun.materialize``.
+
+  ``status`` is ``"imported"`` for a new version, ``"replaced"`` when an
+  existing version was atomically overwritten, and ``"unchanged"`` when the
+  manifest already recorded this version with identical fingerprints and
+  nothing was written.
+  """
+
+  job_id: str
+  import_version: str
+  status: str
+  events_table: str
+  scores_table: str
+  manifest_table: str
+  event_row_count: int
+  score_row_count: int
+  manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    return _json_safe(dataclasses.asdict(self))
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalScorePolicy:
+  """Per-benchmark pass policy over imported EvalBench scores.
+
+  ``min_scores`` maps a score ``comparator`` name to the minimum score a
+  session must reach on that comparator to pass. A session fails the score
+  gate when any listed comparator scores below its threshold. With
+  ``missing_score_fails`` (the default) a session with no score row for a
+  listed comparator, or a ``NULL`` score, also fails: an EvalBench run that
+  completed without being scored is not evidence of success.
+  """
+
+  min_scores: Mapping[str, float] = dataclasses.field(default_factory=dict)
+  missing_score_fails: bool = True
+
+  def __post_init__(self) -> None:
+    normalized: dict[str, float] = {}
+    for comparator, min_score in self.min_scores.items():
+      if not isinstance(comparator, str) or not _COMPARATOR_PATTERN.fullmatch(
+          comparator
+      ):
+        raise ValueError(
+            f"comparator name {comparator!r} must match "
+            f"{_COMPARATOR_PATTERN.pattern}"
+        )
+      if isinstance(min_score, bool) or not isinstance(min_score, (int, float)):
+        raise ValueError(f"min_score for {comparator!r} must be a number")
+      value = float(min_score)
+      if not math.isfinite(value):
+        raise ValueError(f"min_score for {comparator!r} must be finite")
+      normalized[comparator] = value
+    object.__setattr__(self, "min_scores", normalized)
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionVerdict:
+  """Failed-session classification for one imported EvalBench session.
+
+  ``failed`` is true when the process failed (any ``ERROR`` event, which is
+  how non-zero ``returncode`` and source error fields surface), when no
+  ``AGENT_COMPLETED`` event exists, or when the score policy is not met.
+  ``returncode == 0`` on its own never makes a session pass.
+  """
+
+  session_id: str
+  scenario_id: Optional[str]
+  process_failed: bool
+  missing_completion: bool
+  score_failed: bool
+  failing_scores: dict[str, Optional[float]]
+  failed: bool
+
+
+def classify_sessions(
+    event_rows: list[dict[str, Any]],
+    score_rows: list[dict[str, Any]],
+    policy: Optional[EvalScorePolicy] = None,
+) -> list[SessionVerdict]:
+  """In-memory reference implementation of ``failed_sessions_sql``.
+
+  ``event_rows`` are ``to_agent_event_rows()`` rows and ``score_rows`` are
+  ``to_score_rows()`` rows for one ``(job_id, import_version)``. The SQL and
+  this function must agree; tests pin the contract here.
+  """
+  policy = policy or EvalScorePolicy()
+  sessions: dict[str, dict[str, Any]] = {}
+  for row in event_rows:
+    session_id = row.get("session_id")
+    if not session_id:
+      continue
+    state = sessions.setdefault(
+        session_id,
+        {
+            "scenario_id": None,
+            "process_failed": False,
+            "missing_completion": True,
+        },
+    )
+    attributes = _as_mapping(_structured(row.get("attributes")))
+    scenario_id = _usable_text(attributes.get("evalbench_scenario_id"))
+    if state["scenario_id"] is None and scenario_id is not None:
+      state["scenario_id"] = scenario_id
+    if row.get("status") == "ERROR":
+      state["process_failed"] = True
+    if row.get("event_type") == "AGENT_COMPLETED":
+      state["missing_completion"] = False
+
+  scores: dict[str, dict[str, list[Optional[float]]]] = {}
+  for row in score_rows:
+    session_id = row.get("session_id")
+    comparator = row.get("comparator")
+    if not session_id or comparator is None:
+      continue
+    scores.setdefault(session_id, {}).setdefault(comparator, []).append(
+        _score_value(row.get("score"))
+    )
+
+  verdicts: list[SessionVerdict] = []
+  for session_id in sorted(sessions):
+    state = sessions[session_id]
+    failing_scores: dict[str, Optional[float]] = {}
+    for comparator, min_score in policy.min_scores.items():
+      values = scores.get(session_id, {}).get(comparator, [])
+      if not values:
+        if policy.missing_score_fails:
+          failing_scores[comparator] = None
+        continue
+      failing = [
+          value for value in values if value is not None and value < min_score
+      ]
+      if failing:
+        failing_scores[comparator] = min(failing)
+      elif policy.missing_score_fails and any(v is None for v in values):
+        failing_scores[comparator] = None
+    score_failed = bool(failing_scores)
+    verdicts.append(
+        SessionVerdict(
+            session_id=session_id,
+            scenario_id=state["scenario_id"],
+            process_failed=state["process_failed"],
+            missing_completion=state["missing_completion"],
+            score_failed=score_failed,
+            failing_scores=failing_scores,
+            failed=(
+                state["process_failed"]
+                or state["missing_completion"]
+                or score_failed
+            ),
+        )
+    )
+  return verdicts
+
+
+def failed_sessions_sql(
+    *,
+    target_project: str,
+    target_dataset: str,
+    events_table: str = DEFAULT_EVENTS_TABLE,
+    scores_table: str = DEFAULT_SCORES_TABLE,
+    policy: Optional[EvalScorePolicy] = None,
+) -> str:
+  """Return the failed-session denominator query for one pinned import.
+
+  The query takes two parameters, ``@job_id`` and ``@import_version``
+  (see ``import_query_parameters``), and returns one row per session with
+  ``process_failed``, ``missing_completion``, ``score_failed``, and the
+  combined ``failed`` flag plus the offending ``failing_scores``. Sessions
+  whose EvalBench process exited with ``returncode == 0`` are *completed*;
+  they count as passed only when ``policy`` is satisfied. Without a policy
+  only process failures and missing completions are counted.
+  """
+  _validate_source_segment("target_project", target_project)
+  _validate_source_segment("target_dataset", target_dataset)
+  _validate_source_segment("events_table", events_table)
+  _validate_source_segment("scores_table", scores_table)
+  policy = policy or EvalScorePolicy()
+  sql = _FAILED_SESSIONS_BASE.format(
+      events_table=f"{target_project}.{target_dataset}.{events_table}"
+  )
+  if not policy.min_scores:
+    return sql + _FAILED_SESSIONS_NO_POLICY
+  policy_rows = ",\n".join(
+      f"    STRUCT('{comparator}' AS comparator, {min_score!r} AS min_score)"
+      for comparator, min_score in policy.min_scores.items()
+  )
+  if policy.missing_score_fails:
+    fail_predicate = "(sc.score IS NULL OR sc.score < p.min_score)"
+  else:
+    fail_predicate = "(sc.score IS NOT NULL AND sc.score < p.min_score)"
+  return sql + _FAILED_SESSIONS_POLICY.format(
+      policy_rows=policy_rows,
+      fail_predicate=fail_predicate,
+      scores_table=f"{target_project}.{target_dataset}.{scores_table}",
+  )
+
+
+def import_query_parameters(
+    job_id: str, import_version: str
+) -> list[bigquery.ScalarQueryParameter]:
+  """Query parameters that pin ``failed_sessions_sql`` to one import."""
+  _validate_import_version(import_version)
+  return _import_parameters(job_id, import_version)
+
+
+def _import_parameters(
+    job_id: str, import_version: str
+) -> list[bigquery.ScalarQueryParameter]:
+  return [
+      bigquery.ScalarQueryParameter("job_id", "STRING", job_id),
+      bigquery.ScalarQueryParameter("import_version", "STRING", import_version),
+  ]
+
+
+def _validate_import_version(import_version: Any) -> None:
+  if not isinstance(
+      import_version, str
+  ) or not _IMPORT_VERSION_PATTERN.fullmatch(import_version):
+    raise ValueError(
+        f"import_version must match {_IMPORT_VERSION_PATTERN.pattern}"
+    )
+
+
+def _derived_import_version(fingerprints: Mapping[str, str]) -> str:
+  combined = "\x1f".join(fingerprints[key] for key in _FINGERPRINT_KEYS)
+  return hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+
+
+def _canonical_json(value: Any) -> str:
+  return json.dumps(
+      _json_safe(value), sort_keys=True, separators=(",", ":"), default=str
+  )
+
+
+def _fingerprint_rows(rows: tuple[dict[str, Any], ...]) -> str:
+  digests = sorted(
+      hashlib.sha256(_canonical_json(row).encode("utf-8")).hexdigest()
+      for row in rows
+  )
+  return hashlib.sha256("\n".join(digests).encode("utf-8")).hexdigest()
+
+
+def _score_scenario_id(score: Mapping[str, Any]) -> Optional[str]:
+  for key in ("id", "eval_id", "scenario_id", "prompt_id"):
+    text = _usable_text(score.get(key))
+    if text is not None:
+      return text
+  return None
+
+
+def _score_comparator(score: Mapping[str, Any]) -> Optional[str]:
+  for key in ("comparator", "scorer", "metric", "evaluator"):
+    text = _usable_text(score.get(key))
+    if text is not None:
+      return text
+  return None
+
+
+def _score_value(value: Any) -> Optional[float]:
+  """Coerce an EvalBench score to a finite float; anything else is NULL."""
+  if value is None:
+    return None
+  if isinstance(value, bool):
+    return 1.0 if value else 0.0
+  try:
+    number = float(value)
+  except (TypeError, ValueError):
+    return None
+  return number if math.isfinite(number) else None
+
+
+def _schema(fields: tuple[tuple[str, str, str], ...]) -> list:
+  return [
+      bigquery.SchemaField(name, field_type, mode=mode)
+      for name, field_type, mode in fields
+  ]
+
+
+def _event_schema() -> list:
+  """Mirror of the ADK plugin ``agent_events`` schema plus import binding."""
+  return [
+      bigquery.SchemaField("timestamp", "TIMESTAMP", mode="REQUIRED"),
+      bigquery.SchemaField("event_type", "STRING"),
+      bigquery.SchemaField("agent", "STRING"),
+      bigquery.SchemaField("session_id", "STRING"),
+      bigquery.SchemaField("invocation_id", "STRING"),
+      bigquery.SchemaField("user_id", "STRING"),
+      bigquery.SchemaField("trace_id", "STRING"),
+      bigquery.SchemaField("span_id", "STRING"),
+      bigquery.SchemaField("parent_span_id", "STRING"),
+      bigquery.SchemaField("content", "JSON"),
+      bigquery.SchemaField(
+          "content_parts",
+          "RECORD",
+          mode="REPEATED",
+          fields=[
+              bigquery.SchemaField("mime_type", "STRING"),
+              bigquery.SchemaField("uri", "STRING"),
+              bigquery.SchemaField(
+                  "object_ref",
+                  "RECORD",
+                  fields=[
+                      bigquery.SchemaField("uri", "STRING"),
+                      bigquery.SchemaField("version", "STRING"),
+                      bigquery.SchemaField("authorizer", "STRING"),
+                      bigquery.SchemaField("details", "JSON"),
+                  ],
+              ),
+              bigquery.SchemaField("text", "STRING"),
+              bigquery.SchemaField("part_index", "INTEGER"),
+              bigquery.SchemaField("part_attributes", "STRING"),
+              bigquery.SchemaField("storage_mode", "STRING"),
+          ],
+      ),
+      bigquery.SchemaField("attributes", "JSON"),
+      bigquery.SchemaField("latency_ms", "JSON"),
+      bigquery.SchemaField("status", "STRING"),
+      bigquery.SchemaField("error_message", "STRING"),
+      bigquery.SchemaField("is_truncated", "BOOLEAN"),
+      bigquery.SchemaField("job_id", "STRING", mode="REQUIRED"),
+      bigquery.SchemaField("import_version", "STRING", mode="REQUIRED"),
+  ]
+
+
+def _ensure_import_tables(
+    client: Any, *, events_ref: str, scores_ref: str, manifest_ref: str
+) -> None:
+  events = bigquery.Table(events_ref, schema=_event_schema())
+  events.time_partitioning = bigquery.TimePartitioning(field="timestamp")
+  events.clustering_fields = ["job_id", "import_version", "session_id"]
+  client.create_table(events, exists_ok=True)
+
+  scores = bigquery.Table(scores_ref, schema=_schema(_SCORE_SCHEMA_FIELDS))
+  scores.clustering_fields = ["job_id", "import_version", "session_id"]
+  client.create_table(scores, exists_ok=True)
+
+  manifest = bigquery.Table(
+      manifest_ref, schema=_schema(_MANIFEST_SCHEMA_FIELDS)
+  )
+  client.create_table(manifest, exists_ok=True)
+
+
+def _read_manifest(
+    client: Any,
+    *,
+    manifest_ref: str,
+    job_id: str,
+    import_version: str,
+    location: Optional[str],
+) -> Optional[dict[str, Any]]:
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=_import_parameters(job_id, import_version)
+  )
+  job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _READ_MANIFEST_QUERY.format(manifest_table=manifest_ref)
+  rows = [_plain_row(row) for row in client.query(query, **query_args).result()]
+  if not rows:
+    return None
+  if len(rows) > 1:
+    raise ValueError(
+        f"manifest table {manifest_ref!r} has {len(rows)} rows for job "
+        f"{job_id!r} import_version {import_version!r}; expected at most one"
+    )
+  return rows[0]
+
+
+def _load_staging(
+    client: Any, staging_ref: str, rows: list[dict[str, Any]], schema: list
+) -> None:
+  """Load ``rows`` into a fresh staging table with an explicit schema.
+
+  Load jobs write to managed storage, so the publish transaction that runs
+  next sees every row (streaming inserts would sit in a buffer the DML
+  cannot read). Nested ``content``/``attributes`` objects are loaded as JSON
+  values via newline-delimited JSON.
+  """
+  if not rows:
+    client.create_table(
+        bigquery.Table(staging_ref, schema=schema), exists_ok=True
+    )
+    return
+  job_config = bigquery.LoadJobConfig(
+      write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+      source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+      autodetect=False,
+      schema=schema,
+  )
+  job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
+  client.load_table_from_json(rows, staging_ref, job_config=job_config).result()
+
 
 def _read_source_rows(
     client: Any,
@@ -304,14 +1128,18 @@ def _read_source_rows(
     table_id: str,
     job_id: str,
     location: Optional[str],
+    snapshot_at: Optional[datetime] = None,
 ) -> tuple[dict[str, Any], ...]:
-  query = _READ_SOURCE_TABLE_QUERY.format(table_id=table_id)
-  job_config = bigquery.QueryJobConfig(
-      query_parameters=[
-          bigquery.ScalarQueryParameter("job_id", "STRING", job_id)
-      ]
-  )
-  job_config = with_sdk_labels(job_config, feature="evalbench-import")
+  parameters = [bigquery.ScalarQueryParameter("job_id", "STRING", job_id)]
+  if snapshot_at is None:
+    query = _READ_SOURCE_TABLE_QUERY.format(table_id=table_id)
+  else:
+    query = _READ_SOURCE_TABLE_SNAPSHOT_QUERY.format(table_id=table_id)
+    parameters.append(
+        bigquery.ScalarQueryParameter("snapshot_at", "TIMESTAMP", snapshot_at)
+    )
+  job_config = bigquery.QueryJobConfig(query_parameters=parameters)
+  job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
   query_args: dict[str, Any] = {"job_config": job_config}
   if location is not None:
     query_args["location"] = location

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -350,7 +350,6 @@ class EvalBenchRun:
   evalbench_dataset: str
   job_id: str
   location: Optional[str] = None
-  snapshot_at: Optional[datetime] = None
   results: tuple[dict[str, Any], ...] = dataclasses.field(
       default_factory=tuple, repr=False
   )
@@ -360,6 +359,9 @@ class EvalBenchRun:
   config_rows: tuple[dict[str, Any], ...] = dataclasses.field(
       default_factory=tuple, repr=False
   )
+  # Declared last so the v0.5.1 positional order
+  # (project, dataset, job, location, results, scores, config_rows) is stable.
+  snapshot_at: Optional[datetime] = None
 
   @classmethod
   def from_bigquery(

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -38,6 +38,7 @@ from datetime import timedelta
 from datetime import timezone
 import hashlib
 import json
+import logging
 import math
 import re
 from typing import Any, Optional
@@ -68,7 +69,12 @@ WHERE job_id = @job_id
 DEFAULT_EVENTS_TABLE = "evalbench_agent_events"
 DEFAULT_SCORES_TABLE = "evalbench_scores_imported"
 DEFAULT_MANIFEST_TABLE = "evalbench_import_manifest"
+# The ADK plugin's production table. EvalBench imports publish only to
+# BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
+_RESERVED_DESTINATION_TABLES = frozenset({"agent_events"})
 _IMPORT_FEATURE = "evalbench-import"
+_STAGING_TABLE_TTL = timedelta(hours=6)
+_LOGGER = logging.getLogger(__name__)
 _IMPORT_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 _COMPARATOR_PATTERN = re.compile(r"^[A-Za-z0-9_.:/-]{1,128}$")
 
@@ -134,24 +140,57 @@ FROM `{manifest_table}`
 WHERE job_id = @job_id AND import_version = @import_version
 """
 
-# One multi-statement transaction publishes events, scores, and the manifest
-# together. DML inside BEGIN/COMMIT is all-or-nothing, so a failure anywhere
-# leaves the previously published version (or nothing) in place.
+# One multi-statement script publishes events, scores, and the manifest
+# together. The manifest guard runs *inside* the transaction: two importers
+# that both observed no manifest row before publishing cannot both commit a
+# different corpus under one immutable version, because BigQuery serializes
+# conflicting DML on the manifest table and the later transaction re-reads the
+# earlier row and raises. DML inside BEGIN/COMMIT is all-or-nothing, so a
+# failure anywhere (including the guard) leaves the previously published
+# version (or nothing) in place.
+_PUBLISH_CONFLICT_MESSAGE = (
+    "evalbench import conflict: this import_version was already published"
+    " with different source fingerprints or destination tables"
+)
+_DESTINATION_CONFLICT_PREDICATE = (
+    "events_table != @events_table OR scores_table != @scores_table"
+)
+_FINGERPRINT_CONFLICT_PREDICATE = (
+    "results_fingerprint != @results_fingerprint"
+    " OR scores_fingerprint != @scores_fingerprint"
+    " OR configs_fingerprint != @configs_fingerprint"
+)
 _PUBLISH_SCRIPT = """\
-BEGIN TRANSACTION;
-DELETE FROM `{events_table}`
-WHERE job_id = @job_id AND import_version = @import_version;
-DELETE FROM `{scores_table}`
-WHERE job_id = @job_id AND import_version = @import_version;
-DELETE FROM `{manifest_table}`
-WHERE job_id = @job_id AND import_version = @import_version;
-INSERT INTO `{events_table}` ({event_columns})
-SELECT {event_columns} FROM `{events_staging}`;
-INSERT INTO `{scores_table}` ({score_columns})
-SELECT {score_columns} FROM `{scores_staging}`;
-INSERT INTO `{manifest_table}` ({manifest_columns})
-SELECT {manifest_columns} FROM `{manifest_staging}`;
-COMMIT TRANSACTION;
+DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
+BEGIN
+  BEGIN TRANSACTION;
+  SET conflicting_manifest_rows = (
+    SELECT COUNT(*)
+    FROM `{manifest_table}`
+    WHERE job_id = @job_id
+      AND import_version = @import_version
+      AND ({conflict_predicate})
+  );
+  IF conflicting_manifest_rows > 0 THEN
+    RAISE USING MESSAGE = '{conflict_message}';
+  END IF;
+  DELETE FROM `{events_table}`
+  WHERE job_id = @job_id AND import_version = @import_version;
+  DELETE FROM `{scores_table}`
+  WHERE job_id = @job_id AND import_version = @import_version;
+  DELETE FROM `{manifest_table}`
+  WHERE job_id = @job_id AND import_version = @import_version;
+  INSERT INTO `{events_table}` ({event_columns})
+  SELECT {event_columns} FROM `{events_staging}`;
+  INSERT INTO `{scores_table}` ({score_columns})
+  SELECT {score_columns} FROM `{scores_staging}`;
+  INSERT INTO `{manifest_table}` ({manifest_columns})
+  SELECT {manifest_columns} FROM `{manifest_staging}`;
+  COMMIT TRANSACTION;
+EXCEPTION WHEN ERROR THEN
+  ROLLBACK TRANSACTION;
+  RAISE;
+END;
 """
 
 _FAILED_SESSIONS_BASE = """\
@@ -174,18 +213,12 @@ policy AS (
 {policy_rows}
   ])
 ),
-score_gate AS (
+comparator_gate AS (
   SELECT
     s.session_id,
-    COUNTIF({fail_predicate}) AS failing_score_count,
-    ARRAY_AGG(
-      IF(
-        {fail_predicate},
-        STRUCT(p.comparator AS comparator, sc.score AS score),
-        NULL
-      )
-      IGNORE NULLS
-    ) AS failing_scores
+    p.comparator,
+    LOGICAL_OR({fail_predicate}) AS failing,
+    MIN(IF(sc.score < p.min_score, sc.score, NULL)) AS failing_score
   FROM sessions AS s
   CROSS JOIN policy AS p
   LEFT JOIN `{scores_table}` AS sc
@@ -193,7 +226,23 @@ score_gate AS (
     AND sc.import_version = @import_version
     AND sc.session_id = s.session_id
     AND sc.comparator = p.comparator
-  GROUP BY s.session_id
+  GROUP BY s.session_id, p.comparator
+),
+score_gate AS (
+  SELECT
+    session_id,
+    COUNTIF(failing) AS failing_score_count,
+    ARRAY_AGG(
+      IF(
+        failing,
+        STRUCT(comparator AS comparator, failing_score AS score),
+        NULL
+      )
+      IGNORE NULLS
+      ORDER BY comparator
+    ) AS failing_scores
+  FROM comparator_gate
+  GROUP BY session_id
 )
 SELECT
   s.session_id,
@@ -325,7 +374,9 @@ class EvalBenchRun:
         ),
     )
 
-  def to_agent_event_rows(self) -> list[dict[str, Any]]:
+  def to_agent_event_rows(
+      self, *, import_version: Optional[str] = None
+  ) -> list[dict[str, Any]]:
     """Convert loaded results to BQAA-compatible synthetic event rows.
 
     Supports both EvalBench's NL2SQL field names
@@ -334,7 +385,16 @@ class EvalBenchRun:
     missing final output omits ``AGENT_COMPLETED``. A missing prompt or
     scenario identifier is a hard error because no valid session can be
     constructed without them.
+
+    ``session_id``/``trace_id`` are ``evalbench:{job_id}:{scenario_id}`` for
+    a plain read. When ``import_version`` is given (as ``materialize`` does)
+    the identity becomes ``evalbench:{job_id}:{import_version}:{scenario_id}``
+    and every synthetic span id derives from it, so retained import versions
+    of one job never share a trace or session in the mirror table and
+    readers that filter only by ``trace_id`` see exactly one version.
     """
+    if import_version is not None:
+      _validate_import_version(import_version)
     config = _config_values(self.config_rows)
     agent = _agent_name(config)
     config_run_time = _first_run_time(self.config_rows)
@@ -366,7 +426,9 @@ class EvalBenchRun:
       run_time = _result_run_time(result) or config_run_time
       missing_run_time = run_time is None
       run_time = run_time or _UNKNOWN_RUN_TIME
-      session_id = f"evalbench:{self.job_id}:{scenario_id}"
+      session_id = _session_identity(
+          self.job_id, scenario_id, import_version=import_version
+      )
       invocation_id = _stable_id(session_id, "invocation", length=32)
       root_span_id = _stable_id(session_id, "user", length=16)
       attributes = _base_attributes(
@@ -377,6 +439,8 @@ class EvalBenchRun:
           scenario_id=scenario_id,
           agent=agent,
       )
+      if import_version is not None:
+        attributes["evalbench_import_version"] = import_version
       if missing_run_time:
         attributes["evalbench_run_time_missing"] = True
 
@@ -495,6 +559,8 @@ class EvalBenchRun:
     Each source row is preserved verbatim in ``source_row``; ``scenario_id``,
     ``session_id``, ``comparator``, and a float ``score`` are lifted out so the
     failed-session view can join scores to events without parsing JSON.
+    ``session_id`` uses the same version-specific identity as
+    ``to_agent_event_rows(import_version=...)`` so score joins stay aligned.
     Unparseable scores become ``NULL`` rather than being dropped.
     """
     _validate_import_version(import_version)
@@ -508,7 +574,9 @@ class EvalBenchRun:
           "import_version": import_version,
           "scenario_id": scenario_id,
           "session_id": (
-              f"evalbench:{self.job_id}:{scenario_id}"
+              _session_identity(
+                  self.job_id, scenario_id, import_version=import_version
+              )
               if scenario_id is not None
               else None
           ),
@@ -565,6 +633,13 @@ class EvalBenchRun:
     no-op (``status == "unchanged"``) and a changed source becomes a new
     version. An explicit ``import_version`` whose stored fingerprints no
     longer match the source raises ``ValueError`` unless ``replace=True``.
+    The same check is repeated inside the publish transaction, so two
+    importers racing on a first-time version cannot both commit different
+    content. A published version is bound to the ``events_table`` /
+    ``scores_table`` recorded in its manifest: re-importing it with other
+    destination tables raises (even with ``replace=True``) instead of
+    reporting a no-op against tables that were never written or orphaning
+    the old rows; use a new ``import_version`` to publish elsewhere.
 
     Args:
       target_dataset: BQAA-owned dataset that receives the mirror tables.
@@ -587,9 +662,9 @@ class EvalBenchRun:
     target_project = target_project or self.project_id
     _validate_source_segment("target_project", target_project)
     _validate_source_segment("target_dataset", target_dataset)
-    _validate_source_segment("events_table", events_table)
-    _validate_source_segment("scores_table", scores_table)
-    _validate_source_segment("manifest_table", manifest_table)
+    _validate_destination_table("events_table", events_table)
+    _validate_destination_table("scores_table", scores_table)
+    _validate_destination_table("manifest_table", manifest_table)
     if imported_at is None:
       imported_at = datetime.now(timezone.utc)
     elif imported_at.tzinfo is None:
@@ -609,7 +684,7 @@ class EvalBenchRun:
     # tables behind or partially created targets.
     event_rows = [
         {**row, "job_id": self.job_id, "import_version": import_version}
-        for row in self.to_agent_event_rows()
+        for row in self.to_agent_event_rows(import_version=import_version)
     ]
     score_rows = self.to_score_rows(import_version=import_version)
     manifest = {
@@ -648,6 +723,13 @@ class EvalBenchRun:
     )
     status = "imported"
     if existing is not None:
+      _check_destination_binding(
+          existing,
+          job_id=self.job_id,
+          import_version=import_version,
+          events_ref=events_ref,
+          scores_ref=scores_ref,
+      )
       unchanged = all(
           existing.get(key) == fingerprints[key] for key in _FINGERPRINT_KEYS
       )
@@ -687,30 +769,49 @@ class EvalBenchRun:
           [manifest],
           _schema(_MANIFEST_SCHEMA_FIELDS),
       )
-      script = _PUBLISH_SCRIPT.format(
-          events_table=events_ref,
-          scores_table=scores_ref,
-          manifest_table=manifest_ref,
+      script = _publish_script(
+          events_ref=events_ref,
+          scores_ref=scores_ref,
+          manifest_ref=manifest_ref,
           events_staging=events_staging,
           scores_staging=scores_staging,
           manifest_staging=manifest_staging,
-          event_columns=", ".join(_EVENT_COLUMNS),
-          score_columns=", ".join(name for name, _, _ in _SCORE_SCHEMA_FIELDS),
-          manifest_columns=", ".join(
-              name for name, _, _ in _MANIFEST_SCHEMA_FIELDS
-          ),
+          replace=replace,
       )
       job_config = bigquery.QueryJobConfig(
-          query_parameters=_import_parameters(self.job_id, import_version)
+          query_parameters=_publish_parameters(
+              job_id=self.job_id,
+              import_version=import_version,
+              fingerprints=fingerprints,
+              events_ref=events_ref,
+              scores_ref=scores_ref,
+          )
       )
       job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
       query_args: dict[str, Any] = {"job_config": job_config}
       if self.location is not None:
         query_args["location"] = self.location
-      client.query(script, **query_args).result()
+      try:
+        client.query(script, **query_args).result()
+      except ValueError:
+        raise
+      except Exception as exc:  # noqa: BLE001
+        if _PUBLISH_CONFLICT_MESSAGE in str(exc):
+          raise ValueError(
+              f"EvalBench job {self.job_id!r} import_version "
+              f"{import_version!r} was published concurrently with different "
+              "source fingerprints or destination tables; nothing was "
+              "written. Re-run to get status 'unchanged', or pass a new "
+              "import_version (or omit it to derive one from the source)"
+          ) from exc
+        raise
     finally:
-      for staging_ref in (events_staging, scores_staging, manifest_staging):
-        client.delete_table(staging_ref, not_found_ok=True)
+      # Staging cleanup is best-effort: a failed DROP must not turn a
+      # committed publish into an error (or mask the real failure), and the
+      # staging tables carry an expiration so leftovers cannot accumulate.
+      _drop_staging_tables(
+          client, (events_staging, scores_staging, manifest_staging)
+      )
 
     return EvalBenchImportResult(
         job_id=self.job_id,
@@ -942,6 +1043,102 @@ def _import_parameters(
   ]
 
 
+def _publish_parameters(
+    *,
+    job_id: str,
+    import_version: str,
+    fingerprints: Mapping[str, str],
+    events_ref: str,
+    scores_ref: str,
+) -> list[bigquery.ScalarQueryParameter]:
+  """``_import_parameters`` plus the values the transaction guard compares."""
+  parameters = _import_parameters(job_id, import_version)
+  for key in _FINGERPRINT_KEYS:
+    parameters.append(
+        bigquery.ScalarQueryParameter(key, "STRING", fingerprints[key])
+    )
+  parameters.append(
+      bigquery.ScalarQueryParameter("events_table", "STRING", events_ref)
+  )
+  parameters.append(
+      bigquery.ScalarQueryParameter("scores_table", "STRING", scores_ref)
+  )
+  return parameters
+
+
+def _publish_script(
+    *,
+    events_ref: str,
+    scores_ref: str,
+    manifest_ref: str,
+    events_staging: str,
+    scores_staging: str,
+    manifest_staging: str,
+    replace: bool,
+) -> str:
+  """Render the publish transaction with its in-transaction manifest guard.
+
+  Without ``replace`` the guard rejects an existing manifest row whose
+  fingerprints *or* destination tables differ from this import; with
+  ``replace`` fingerprints may drift but the destination binding still
+  holds, so a version can never be silently relocated.
+  """
+  if replace:
+    conflict_predicate = _DESTINATION_CONFLICT_PREDICATE
+  else:
+    conflict_predicate = (
+        _FINGERPRINT_CONFLICT_PREDICATE
+        + " OR "
+        + _DESTINATION_CONFLICT_PREDICATE
+    )
+  return _PUBLISH_SCRIPT.format(
+      events_table=events_ref,
+      scores_table=scores_ref,
+      manifest_table=manifest_ref,
+      events_staging=events_staging,
+      scores_staging=scores_staging,
+      manifest_staging=manifest_staging,
+      conflict_predicate=conflict_predicate,
+      conflict_message=_PUBLISH_CONFLICT_MESSAGE,
+      event_columns=", ".join(_EVENT_COLUMNS),
+      score_columns=", ".join(name for name, _, _ in _SCORE_SCHEMA_FIELDS),
+      manifest_columns=", ".join(
+          name for name, _, _ in _MANIFEST_SCHEMA_FIELDS
+      ),
+  )
+
+
+def _check_destination_binding(
+    existing: Mapping[str, Any],
+    *,
+    job_id: str,
+    import_version: str,
+    events_ref: str,
+    scores_ref: str,
+) -> None:
+  """Reject a re-import whose destination tables differ from the manifest."""
+  stored = (existing.get("events_table"), existing.get("scores_table"))
+  if stored == (events_ref, scores_ref):
+    return
+  raise ValueError(
+      f"EvalBench job {job_id!r} import_version {import_version!r} is "
+      f"published in events_table={stored[0]!r} scores_table={stored[1]!r}, "
+      f"not the requested events_table={events_ref!r} "
+      f"scores_table={scores_ref!r}; a version stays bound to the tables in "
+      "its manifest. Point at those tables, or publish to the new tables "
+      "under a new import_version"
+  )
+
+
+def _session_identity(
+    job_id: str, scenario_id: str, *, import_version: Optional[str]
+) -> str:
+  """Session/trace identity shared by event rows and score rows."""
+  if import_version is None:
+    return f"evalbench:{job_id}:{scenario_id}"
+  return f"evalbench:{job_id}:{import_version}:{scenario_id}"
+
+
 def _validate_import_version(import_version: Any) -> None:
   if not isinstance(
       import_version, str
@@ -971,11 +1168,7 @@ def _fingerprint_rows(rows: tuple[dict[str, Any], ...]) -> str:
 
 
 def _score_scenario_id(score: Mapping[str, Any]) -> Optional[str]:
-  for key in ("id", "eval_id", "scenario_id", "prompt_id"):
-    text = _usable_text(score.get(key))
-    if text is not None:
-      return text
-  return None
+  return _find_scenario_id(score)
 
 
 def _score_comparator(score: Mapping[str, Any]) -> Optional[str]:
@@ -1070,6 +1263,20 @@ def _ensure_import_tables(
   client.create_table(manifest, exists_ok=True)
 
 
+def _drop_staging_tables(client: Any, staging_refs: tuple[str, ...]) -> None:
+  for staging_ref in staging_refs:
+    try:
+      client.delete_table(staging_ref, not_found_ok=True)
+    except Exception as exc:  # noqa: BLE001
+      _LOGGER.warning(
+          "evalbench import: could not drop staging table %s (%s); it expires"
+          " automatically after %s",
+          staging_ref,
+          exc,
+          _STAGING_TABLE_TTL,
+      )
+
+
 def _read_manifest(
     client: Any,
     *,
@@ -1105,15 +1312,17 @@ def _load_staging(
   Load jobs write to managed storage, so the publish transaction that runs
   next sees every row (streaming inserts would sit in a buffer the DML
   cannot read). Nested ``content``/``attributes`` objects are loaded as JSON
-  values via newline-delimited JSON.
+  values via newline-delimited JSON. The staging table is created with an
+  expiration first, so a staging table that outlives a crashed import (or a
+  failed cleanup) is garbage-collected by BigQuery.
   """
+  table = bigquery.Table(staging_ref, schema=schema)
+  table.expires = datetime.now(timezone.utc) + _STAGING_TABLE_TTL
+  client.create_table(table, exists_ok=True)
   if not rows:
-    client.create_table(
-        bigquery.Table(staging_ref, schema=schema), exists_ok=True
-    )
     return
   job_config = bigquery.LoadJobConfig(
-      write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+      write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
       source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
       autodetect=False,
       schema=schema,
@@ -1172,23 +1381,48 @@ def _validate_source_segment(name: str, value: Any) -> None:
     )
 
 
-def _scenario_id(result: Mapping[str, Any]) -> str:
-  scenario = _as_mapping(_structured(result.get("scenario")))
-  nested_result = _as_mapping(_structured(result.get("eval_results")))
+def _validate_destination_table(name: str, value: Any) -> None:
+  """Validate a mirror table name and reject the ADK plugin's ``agent_events``.
+
+  Runs before any BigQuery operation so the production telemetry table can
+  never be created, staged into, or published to by an EvalBench import.
+  """
+  _validate_source_segment(name, value)
+  if value.lower() in _RESERVED_DESTINATION_TABLES:
+    raise ValueError(
+        f"{name} must not be the reserved ADK plugin table {value!r}; "
+        "EvalBench imports publish only to BQAA-owned mirror tables such as "
+        f"{DEFAULT_EVENTS_TABLE!r}"
+    )
+
+
+def _find_scenario_id(row: Mapping[str, Any]) -> Optional[str]:
+  """Locate the scenario id in a result or score row (same lookup order)."""
+  scenario = _as_mapping(_structured(row.get("scenario")))
+  nested_result = _as_mapping(_structured(row.get("eval_results")))
   nested_scenario = _as_mapping(_structured(nested_result.get("scenario")))
   for value in (
-      result.get("id"),
-      result.get("eval_id"),
+      row.get("id"),
+      row.get("eval_id"),
+      row.get("scenario_id"),
       scenario.get("id"),
       nested_result.get("eval_id"),
       nested_result.get("id"),
+      nested_result.get("scenario_id"),
       nested_scenario.get("id"),
-      result.get("prompt_id"),
+      row.get("prompt_id"),
   ):
     text = _usable_text(value)
     if text is not None:
       return text
-  raise ValueError("EvalBench result is missing id/eval_id")
+  return None
+
+
+def _scenario_id(result: Mapping[str, Any]) -> str:
+  scenario_id = _find_scenario_id(result)
+  if scenario_id is None:
+    raise ValueError("EvalBench result is missing id/eval_id")
+  return scenario_id
 
 
 def _prompt(result: Mapping[str, Any]) -> Optional[str]:
@@ -1448,9 +1682,12 @@ def _source_error_message(
   returncode = result.get("returncode")
   if _failed_returncode(returncode):
     parts.append(f"returncode: {returncode}")
-    stderr = _usable_text(error_fields.get("stderr"))
-    if stderr is not None:
-      parts.append(f"stderr: {stderr}")
+  # stderr is a process failure in its own right: a process that exited 0
+  # and produced a final response but also wrote to stderr is still not a
+  # clean completion, so it must not be published as status OK.
+  stderr = _usable_text(error_fields.get("stderr"))
+  if stderr is not None:
+    parts.append(f"stderr: {stderr}")
   return "; ".join(parts) if parts else None
 
 
@@ -1664,6 +1901,12 @@ def _json_safe(value: Any) -> Any:
     return value.isoformat()
   if isinstance(value, date):
     return value.isoformat()
+  if isinstance(value, float) and not math.isfinite(value):
+    # JSON has no NaN/Infinity; BigQuery's NDJSON loader rejects the Python
+    # extensions, so keep the value as text rather than failing the load.
+    if math.isnan(value):
+      return "NaN"
+    return "Infinity" if value > 0 else "-Infinity"
   if value is None or isinstance(value, (str, int, float, bool)):
     return value
   return str(value)

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -68,7 +68,12 @@ WHERE job_id = @job_id
 
 DEFAULT_EVENTS_TABLE = "evalbench_agent_events"
 DEFAULT_SCORES_TABLE = "evalbench_scores_imported"
-DEFAULT_MANIFEST_TABLE = "evalbench_import_manifest"
+# The one import registry per target dataset. It is deliberately not
+# caller-selectable: every import into ``{target_project}.{target_dataset}``
+# consults this table before deleting rows from *any* events/scores table in
+# that dataset, so a second manifest can never route around the version
+# immutability guard of the first.
+MANIFEST_TABLE = "evalbench_import_manifest"
 # The ADK plugin's production table. EvalBench imports publish only to
 # BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
 _RESERVED_DESTINATION_TABLES = frozenset({"agent_events"})
@@ -391,7 +396,10 @@ class EvalBenchRun:
     the identity becomes ``evalbench:{job_id}:{import_version}:{scenario_id}``
     and every synthetic span id derives from it, so retained import versions
     of one job never share a trace or session in the mirror table and
-    readers that filter only by ``trace_id`` see exactly one version.
+    readers that filter only by ``trace_id`` see exactly one version. Each
+    component is escaped (see ``_session_identity``) so a ``:`` inside
+    ``import_version`` or ``scenario_id`` cannot make two different
+    ``(job_id, import_version, scenario_id)`` tuples share an identity.
     """
     if import_version is not None:
       _validate_import_version(import_version)
@@ -607,7 +615,6 @@ class EvalBenchRun:
       target_project: Optional[str] = None,
       events_table: str = DEFAULT_EVENTS_TABLE,
       scores_table: str = DEFAULT_SCORES_TABLE,
-      manifest_table: str = DEFAULT_MANIFEST_TABLE,
       import_version: Optional[str] = None,
       replace: bool = False,
       imported_at: Optional[datetime] = None,
@@ -616,11 +623,17 @@ class EvalBenchRun:
     """Publish this run as one immutable import version in BQAA-owned tables.
 
     The target is always a BQAA-owned mirror (default
-    ``evalbench_agent_events`` / ``evalbench_scores_imported`` /
-    ``evalbench_import_manifest``); the ADK plugin's production
-    ``agent_events`` table is never written. ``target_project`` may differ
-    from the source ``project_id``. The target dataset must already exist;
-    the three tables are created on first use.
+    ``evalbench_agent_events`` / ``evalbench_scores_imported``); the ADK
+    plugin's production ``agent_events`` table is never written.
+    ``target_project`` may differ from the source ``project_id``. The target
+    dataset must already exist; the three tables are created on first use.
+
+    The manifest is the single import registry of the target dataset
+    (``MANIFEST_TABLE``, ``evalbench_import_manifest``) and is not
+    caller-selectable: every import into the dataset, whatever
+    ``events_table``/``scores_table`` it writes, checks the same registry
+    before deleting any published rows, so one version cannot be
+    re-published around an earlier manifest row.
 
     Publishing is atomic: event, score, and manifest rows are loaded into
     per-import staging tables, then a single multi-statement transaction
@@ -646,7 +659,6 @@ class EvalBenchRun:
       target_project: Target project; defaults to the source ``project_id``.
       events_table: Mirror event table name in ``target_dataset``.
       scores_table: Imported score table name in ``target_dataset``.
-      manifest_table: Manifest table name in ``target_dataset``.
       import_version: Optional caller-chosen version label. Defaults to the
         first 16 hex digits of the combined source fingerprint.
       replace: Re-publish even when an identical version already exists
@@ -664,7 +676,6 @@ class EvalBenchRun:
     _validate_source_segment("target_dataset", target_dataset)
     _validate_destination_table("events_table", events_table)
     _validate_destination_table("scores_table", scores_table)
-    _validate_destination_table("manifest_table", manifest_table)
     if imported_at is None:
       imported_at = datetime.now(timezone.utc)
     elif imported_at.tzinfo is None:
@@ -678,7 +689,7 @@ class EvalBenchRun:
     prefix = f"{target_project}.{target_dataset}"
     events_ref = f"{prefix}.{events_table}"
     scores_ref = f"{prefix}.{scores_table}"
-    manifest_ref = f"{prefix}.{manifest_table}"
+    manifest_ref = f"{prefix}.{MANIFEST_TABLE}"
 
     # Map before touching BigQuery so mapping errors never leave staging
     # tables behind or partially created targets.
@@ -1130,13 +1141,37 @@ def _check_destination_binding(
   )
 
 
+# Identity components are joined with ":"; a literal ":" or "\" inside a
+# component is escaped ("\:" and "\\") so the join is injective and decodes
+# back to the original tuple. ``import_version`` admits ":" and ``scenario_id``
+# is arbitrary source text, so without escaping
+# ``(import_version="release:1", scenario_id="case")`` and
+# ``(import_version="release", scenario_id="1:case")`` would collide.
+_IDENTITY_SEPARATOR = ":"
+_IDENTITY_ESCAPES = str.maketrans({"\\": "\\\\", _IDENTITY_SEPARATOR: "\\:"})
+
+
+def _identity_component(value: str) -> str:
+  return value.translate(_IDENTITY_ESCAPES)
+
+
 def _session_identity(
     job_id: str, scenario_id: str, *, import_version: Optional[str]
 ) -> str:
-  """Session/trace identity shared by event rows and score rows."""
-  if import_version is None:
-    return f"evalbench:{job_id}:{scenario_id}"
-  return f"evalbench:{job_id}:{import_version}:{scenario_id}"
+  """Session/trace identity shared by event rows and score rows.
+
+  ``evalbench:{job_id}:{scenario_id}`` for a plain read and
+  ``evalbench:{job_id}:{import_version}:{scenario_id}`` for a published
+  version, with every component escaped so the encoding of the tuple is
+  unambiguous. Components without ``:`` or ``\\`` (the common case) render
+  verbatim. The two forms differ in component count, so a plain read of a
+  scenario named ``v1:case`` can never alias published version ``v1``.
+  """
+  parts = ["evalbench", job_id]
+  if import_version is not None:
+    parts.append(import_version)
+  parts.append(scenario_id)
+  return _IDENTITY_SEPARATOR.join(_identity_component(part) for part in parts)
 
 
 def _validate_import_version(import_version: Any) -> None:
@@ -1849,7 +1884,15 @@ def _event_row(
 
 
 def _stable_id(*parts: str, length: int) -> str:
-  digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+  """Deterministic hex id of a tuple of strings.
+
+  Parts are length-prefixed before hashing so the encoding is injective even
+  when a part (such as a session id built from arbitrary scenario text)
+  contains the joiner: ``("a\\x1fb", "c")`` and ``("a", "b\\x1fc")`` hash
+  differently.
+  """
+  encoded = "\x1f".join(f"{len(part)}:{part}" for part in parts)
+  digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
   return digest[:length]
 
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -21,10 +21,12 @@ time into the mirror-table row contract tracked by issue #97.
 immutable, versioned snapshot into BQAA-owned tables -- never the ADK
 plugin's production ``agent_events`` table. Events, imported scores, and a
 manifest row are staged with load jobs and then published by one BigQuery
-multi-statement transaction that first claims a pre-existing lock row, so a
-failed re-import cannot leave a partial corpus behind and two first-time
-imports of one version cannot both commit. ``failed_sessions_sql`` reads one
-pinned ``import_version`` and implements the W0.4 contract:
+multi-statement transaction that first claims a pre-existing lock row and
+then decides, against its own snapshot, whether the version is *absent*
+(publish), *identical* (leave the first publish in place) or *conflicting*
+(raise), so a failed re-import cannot leave a partial corpus behind and two
+first-time imports of one version cannot both commit. ``failed_sessions_sql``
+reads one pinned ``import_version`` and implements the W0.4 contract:
 ``returncode == 0`` means *completed*, and only the per-benchmark score
 policy decides *passed*.
 """
@@ -157,6 +159,15 @@ _FINGERPRINT_KEYS = (
     "scores_fingerprint",
     "configs_fingerprint",
 )
+# Manifest columns that, together with the fingerprints and destination
+# refs, fully determine what a published version contains: the source
+# project/dataset land in the manifest and in every event row's
+# ``attributes.evalbench_source_project`` / ``evalbench_source_dataset``, so
+# equal source rows read from another source are a *different* version.
+# ``source_snapshot_at`` and ``imported_at`` are read-time bookkeeping that
+# do not change any published row, and the counts are derived from the
+# fingerprinted rows, so none of them takes part in the identity decision.
+_PROVENANCE_KEYS = ("source_project", "source_dataset")
 
 _READ_MANIFEST_QUERY = """\
 SELECT *
@@ -184,14 +195,31 @@ WHERE NOT EXISTS (
 # rows in the same table cannot run concurrently; conflicting transactions
 # are cancelled") at most one of two concurrent publishes survives, even when
 # both began from a snapshot that showed no manifest row. The manifest guard
-# then runs inside the same transaction as defence in depth: an importer
+# then runs inside the same transaction as defence in depth for an importer
 # whose *pre-publish* read was stale but whose transaction started after the
-# other commit sees the committed row and raises before deleting anything.
+# other commit. It classifies the committed manifest row for this
+# ``(job_id, import_version)`` as one of three cases:
+#
+# * absent      -- publish the staged rows;
+# * conflicting -- fingerprints, source provenance (without ``replace``) or
+#                  destination tables differ: RAISE, nothing is written;
+# * identical   -- without ``replace`` the first publish is left exactly as
+#                  it is: RAISE ``_PUBLISH_UNCHANGED_MESSAGE`` so the script
+#                  rolls back (including the lock claim) and the caller
+#                  reports ``unchanged`` instead of deleting and re-inserting
+#                  equal rows under a new ``imported_at``.
+#
 # DML inside BEGIN/COMMIT is all-or-nothing, so a failure anywhere leaves the
 # previously published version (or nothing) in place.
 _PUBLISH_CONFLICT_MESSAGE = (
     "evalbench import conflict: this import_version was already published"
-    " with different source fingerprints or destination tables"
+    " with different source fingerprints, source project/dataset, or"
+    " destination tables"
+)
+_PUBLISH_UNCHANGED_MESSAGE = (
+    "evalbench import unchanged: this import_version is already published"
+    " with identical source fingerprints, source project/dataset, and"
+    " destination tables"
 )
 _LOCK_MISSING_MESSAGE = (
     "evalbench import lock sentinel is missing; the publish transaction"
@@ -209,7 +237,21 @@ _FINGERPRINT_CONFLICT_PREDICATE = (
     " OR scores_fingerprint != @scores_fingerprint"
     " OR configs_fingerprint != @configs_fingerprint"
 )
+_PROVENANCE_CONFLICT_PREDICATE = (
+    "source_project != @source_project OR source_dataset != @source_dataset"
+)
+# Rendered into ``_PUBLISH_SCRIPT`` without ``replace``: an identical,
+# already-published version must not be rewritten.
+_IDENTICAL_GUARD = """\
+  IF existing_manifest_rows > 0 THEN
+    RAISE USING MESSAGE = '{unchanged_message}';
+  END IF;
+"""
+_REPLACE_IDENTICAL_NOTE = (
+    "  -- replace=True: an identical version is re-published in place.\n"
+)
 _PUBLISH_SCRIPT = """\
+DECLARE existing_manifest_rows INT64 DEFAULT 0;
 DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
 BEGIN
   BEGIN TRANSACTION;
@@ -222,6 +264,12 @@ BEGIN
   IF @@row_count = 0 THEN
     RAISE USING MESSAGE = '{lock_missing_message}';
   END IF;
+  SET existing_manifest_rows = (
+    SELECT COUNT(*)
+    FROM `{manifest_table}`
+    WHERE job_id = @job_id
+      AND import_version = @import_version
+  );
   SET conflicting_manifest_rows = (
     SELECT COUNT(*)
     FROM `{manifest_table}`
@@ -232,6 +280,7 @@ BEGIN
   IF conflicting_manifest_rows > 0 THEN
     RAISE USING MESSAGE = '{conflict_message}';
   END IF;
+{identical_guard}\
   DELETE FROM `{events_table}`
   WHERE job_id = @job_id AND import_version = @import_version;
   DELETE FROM `{scores_table}`
@@ -705,14 +754,21 @@ class EvalBenchRun:
     Idempotency is driven by the manifest. ``import_version`` defaults to a
     content fingerprint of the source rows, so an unchanged source is a
     no-op (``status == "unchanged"``) and a changed source becomes a new
-    version. An explicit ``import_version`` whose stored fingerprints no
-    longer match the source raises ``ValueError`` unless ``replace=True``.
-    The publish transaction first claims the dataset lock by updating its
-    pre-existing sentinel row, so two importers racing on a first-time
-    version cannot both commit: BigQuery cancels the second transaction that
-    mutates the same row, and the cancelled importer raises ``ValueError``
-    with nothing written. The fingerprint check is repeated inside the same
-    transaction as well. A published version is bound to the ``events_table`` /
+    version. An explicit ``import_version`` whose stored fingerprints, or
+    whose stored source project/dataset, no longer match this run raises
+    ``ValueError`` unless ``replace=True``: equal rows read from another
+    EvalBench project or dataset publish different
+    ``attributes.evalbench_source_*`` values, so they are a different
+    version, not the same one. The publish transaction first claims the
+    dataset lock by updating its pre-existing sentinel row, so two importers
+    racing on a first-time version cannot both commit: BigQuery cancels the
+    second transaction that mutates the same row, and the cancelled importer
+    raises ``ValueError`` with nothing written. The same
+    absent/identical/conflicting decision is then repeated inside the
+    transaction against its own snapshot, so an importer whose pre-read was
+    stale still reports ``unchanged`` for an identical version (leaving the
+    first publish untouched) and raises for a conflicting one. A published
+    version is bound to the ``events_table`` /
     ``scores_table`` recorded in its manifest: re-importing it with other
     destination tables raises (even with ``replace=True``) instead of
     reporting a no-op against tables that were never written or orphaning
@@ -807,27 +863,22 @@ class EvalBenchRun:
           events_ref=events_ref,
           scores_ref=scores_ref,
       )
-      unchanged = all(
-          existing.get(key) == fingerprints[key] for key in _FINGERPRINT_KEYS
-      )
-      if not unchanged and not replace:
+      drift = _manifest_drift(existing, manifest)
+      if drift and not replace:
         raise ValueError(
             f"EvalBench job {self.job_id!r} import_version "
-            f"{import_version!r} already exists with different source "
-            "fingerprints; pass a new import_version (or omit it to derive "
-            "one from the source content), or replace=True to overwrite it"
+            f"{import_version!r} already exists with different "
+            f"{' and '.join(drift)}; pass a new import_version (or omit it "
+            "to derive one from the source content), or replace=True to "
+            "overwrite it"
         )
-      if unchanged and not replace:
-        return EvalBenchImportResult(
-            job_id=self.job_id,
+      if not drift and not replace:
+        return self._unchanged_result(
+            existing,
             import_version=import_version,
-            status="unchanged",
-            events_table=events_ref,
-            scores_table=scores_ref,
-            manifest_table=manifest_ref,
-            event_row_count=int(existing.get("event_row_count") or 0),
-            score_row_count=int(existing.get("score_row_count") or 0),
-            manifest=existing,
+            events_ref=events_ref,
+            scores_ref=scores_ref,
+            manifest_ref=manifest_ref,
         )
       status = "replaced"
 
@@ -864,6 +915,8 @@ class EvalBenchRun:
               job_id=self.job_id,
               import_version=import_version,
               fingerprints=fingerprints,
+              source_project=self.project_id,
+              source_dataset=self.evalbench_dataset,
               events_ref=events_ref,
               scores_ref=scores_ref,
           )
@@ -877,13 +930,34 @@ class EvalBenchRun:
       except ValueError:
         raise
       except Exception as exc:  # noqa: BLE001
+        if _PUBLISH_UNCHANGED_MESSAGE in str(exc):
+          # The transaction found an identical committed version that the
+          # stale pre-read missed and rolled itself back. Report the
+          # version that is actually published; the manifest row cannot
+          # have vanished since (nothing deletes manifest rows), so the
+          # local copy is only a defensive fallback.
+          committed = _read_manifest(
+              client,
+              manifest_ref=manifest_ref,
+              job_id=self.job_id,
+              import_version=import_version,
+              location=self.location,
+          )
+          return self._unchanged_result(
+              committed if committed is not None else manifest,
+              import_version=import_version,
+              events_ref=events_ref,
+              scores_ref=scores_ref,
+              manifest_ref=manifest_ref,
+          )
         if _PUBLISH_CONFLICT_MESSAGE in str(exc):
           raise ValueError(
               f"EvalBench job {self.job_id!r} import_version "
               f"{import_version!r} was published concurrently with different "
-              "source fingerprints or destination tables; nothing was "
-              "written. Re-run to get status 'unchanged', or pass a new "
-              "import_version (or omit it to derive one from the source)"
+              "source fingerprints, source project/dataset, or destination "
+              "tables; nothing was written. Re-run to get status "
+              "'unchanged', or pass a new import_version (or omit it to "
+              "derive one from the source)"
           ) from exc
         if _CONCURRENT_UPDATE_MARKER in str(exc).lower():
           raise ValueError(
@@ -913,6 +987,28 @@ class EvalBenchRun:
         event_row_count=len(event_rows),
         score_row_count=len(score_rows),
         manifest=manifest,
+    )
+
+  def _unchanged_result(
+      self,
+      existing: Mapping[str, Any],
+      *,
+      import_version: str,
+      events_ref: str,
+      scores_ref: str,
+      manifest_ref: str,
+  ) -> "EvalBenchImportResult":
+    """The ``unchanged`` outcome for an already-published identical version."""
+    return EvalBenchImportResult(
+        job_id=self.job_id,
+        import_version=import_version,
+        status="unchanged",
+        events_table=events_ref,
+        scores_table=scores_ref,
+        manifest_table=manifest_ref,
+        event_row_count=int(existing.get("event_row_count") or 0),
+        score_row_count=int(existing.get("score_row_count") or 0),
+        manifest=dict(existing),
     )
 
 
@@ -1138,6 +1234,8 @@ def _publish_parameters(
     job_id: str,
     import_version: str,
     fingerprints: Mapping[str, str],
+    source_project: str,
+    source_dataset: str,
     events_ref: str,
     scores_ref: str,
 ) -> list[bigquery.ScalarQueryParameter]:
@@ -1153,7 +1251,33 @@ def _publish_parameters(
   parameters.append(
       bigquery.ScalarQueryParameter("scores_table", "STRING", scores_ref)
   )
+  parameters.append(
+      bigquery.ScalarQueryParameter("source_project", "STRING", source_project)
+  )
+  parameters.append(
+      bigquery.ScalarQueryParameter("source_dataset", "STRING", source_dataset)
+  )
   return parameters
+
+
+def _manifest_drift(
+    existing: Mapping[str, Any], manifest: Mapping[str, Any]
+) -> list[str]:
+  """Describe how a stored manifest row differs from this import's manifest.
+
+  Compares exactly the inputs the publish transaction's guard compares
+  without ``replace`` (fingerprints and ``_PROVENANCE_KEYS``); destination
+  refs are checked separately by ``_check_destination_binding`` because they
+  are enforced even with ``replace``. Returns an empty list when the stored
+  version is identical.
+  """
+  drift: list[str] = []
+  if any(existing.get(key) != manifest[key] for key in _FINGERPRINT_KEYS):
+    drift.append("source fingerprints")
+  for key in _PROVENANCE_KEYS:
+    if existing.get(key) != manifest[key]:
+      drift.append(f"{key} ({existing.get(key)!r} vs {manifest[key]!r})")
+  return drift
 
 
 def _publish_script(
@@ -1172,18 +1296,26 @@ def _publish_script(
   The transaction always starts by UPDATE-ing the lock sentinel, which is
   the only statement guaranteed to mutate an existing row (the keyed DELETEs
   match nothing on a first import and INSERTs never conflict). Without
-  ``replace`` the guard rejects an existing manifest row whose fingerprints
-  *or* destination tables differ from this import; with ``replace``
-  fingerprints may drift but the destination binding still holds, so a
-  version can never be silently relocated.
+  ``replace`` the guard rejects an existing manifest row whose fingerprints,
+  source project/dataset, *or* destination tables differ from this import,
+  and leaves an identical row untouched (``_PUBLISH_UNCHANGED_MESSAGE``
+  rolls the transaction back); with ``replace`` fingerprints and provenance
+  may drift and an identical version is re-published, but the destination
+  binding still holds, so a version can never be silently relocated.
   """
   if replace:
     conflict_predicate = _DESTINATION_CONFLICT_PREDICATE
+    identical_guard = _REPLACE_IDENTICAL_NOTE
   else:
-    conflict_predicate = (
-        _FINGERPRINT_CONFLICT_PREDICATE
-        + " OR "
-        + _DESTINATION_CONFLICT_PREDICATE
+    conflict_predicate = " OR ".join(
+        (
+            _FINGERPRINT_CONFLICT_PREDICATE,
+            _PROVENANCE_CONFLICT_PREDICATE,
+            _DESTINATION_CONFLICT_PREDICATE,
+        )
+    )
+    identical_guard = _IDENTICAL_GUARD.format(
+        unchanged_message=_PUBLISH_UNCHANGED_MESSAGE
     )
   return _PUBLISH_SCRIPT.format(
       events_table=events_ref,
@@ -1197,6 +1329,7 @@ def _publish_script(
       manifest_staging=manifest_staging,
       conflict_predicate=conflict_predicate,
       conflict_message=_PUBLISH_CONFLICT_MESSAGE,
+      identical_guard=identical_guard,
       event_columns=", ".join(_EVENT_COLUMNS),
       score_columns=", ".join(name for name, _, _ in _SCORE_SCHEMA_FIELDS),
       manifest_columns=", ".join(

--- a/tests/test_cli_evalbench_import.py
+++ b/tests/test_cli_evalbench_import.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``bq-agent-sdk evalbench-import`` (#435)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics import evalbench
+from bigquery_agent_analytics.cli import app
+
+runner = CliRunner()
+
+
+class _RecordingRun:
+
+  def __init__(self, calls: list[dict]) -> None:
+    self._calls = calls
+
+  def materialize(self, **kwargs) -> evalbench.EvalBenchImportResult:
+    self._calls.append({"materialize": kwargs})
+    return evalbench.EvalBenchImportResult(
+        job_id="job-123",
+        import_version=kwargs.get("import_version") or "abc123",
+        status="imported",
+        events_table="analytics-project.bqaa.evalbench_agent_events",
+        scores_table="analytics-project.bqaa.evalbench_scores_imported",
+        manifest_table="analytics-project.bqaa.evalbench_import_manifest",
+        event_row_count=4,
+        score_row_count=2,
+        manifest={"job_id": "job-123"},
+    )
+
+
+def _patch_from_bigquery(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+  calls: list[dict] = []
+
+  def fake_from_bigquery(cls, **kwargs):
+    calls.append({"from_bigquery": kwargs})
+    return _RecordingRun(calls)
+
+  monkeypatch.setattr(
+      evalbench.EvalBenchRun,
+      "from_bigquery",
+      classmethod(fake_from_bigquery),
+  )
+  return calls
+
+
+def test_evalbench_import_reads_source_and_materializes_to_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--location",
+          "US",
+          "--snapshot-at",
+          "2026-05-01T08:00:00Z",
+          "--target-project",
+          "analytics-project",
+          "--target-dataset",
+          "bqaa",
+          "--import-version",
+          "v1",
+          "--replace",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  assert calls[0]["from_bigquery"] == {
+      "project_id": "source-project",
+      "evalbench_dataset": "evalbench",
+      "job_id": "job-123",
+      "location": "US",
+      "snapshot_at": datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc),
+  }
+  materialize = calls[1]["materialize"]
+  assert materialize["target_project"] == "analytics-project"
+  assert materialize["target_dataset"] == "bqaa"
+  assert materialize["events_table"] == "evalbench_agent_events"
+  assert materialize["scores_table"] == "evalbench_scores_imported"
+  assert materialize["import_version"] == "v1"
+  assert materialize["replace"] is True
+  payload = json.loads(result.output)
+  assert payload["status"] == "imported"
+  assert payload["import_version"] == "v1"
+  assert payload["event_row_count"] == 4
+
+
+def test_evalbench_import_defaults_target_to_source_and_derived_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  assert calls[0]["from_bigquery"]["snapshot_at"] is None
+  materialize = calls[1]["materialize"]
+  assert materialize["target_project"] is None
+  assert materialize["import_version"] is None
+  assert materialize["replace"] is False
+
+
+def test_evalbench_import_rejects_bad_snapshot_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+          "--snapshot-at",
+          "yesterday",
+      ],
+  )
+  assert result.exit_code == 2
+  assert "snapshot-at" in result.output
+  assert calls == []
+
+
+def test_evalbench_import_surfaces_materialize_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  def failing_from_bigquery(cls, **kwargs):
+    raise ValueError(
+        "import_version 'v1' already exists with different fingerprints"
+    )
+
+  monkeypatch.setattr(
+      evalbench.EvalBenchRun,
+      "from_bigquery",
+      classmethod(failing_from_bigquery),
+  )
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+      ],
+  )
+  assert result.exit_code == 2
+  assert "different fingerprints" in result.output

--- a/tests/test_cli_evalbench_import.py
+++ b/tests/test_cli_evalbench_import.py
@@ -166,6 +166,33 @@ def test_evalbench_import_rejects_bad_snapshot_timestamp(
   assert calls == []
 
 
+@pytest.mark.parametrize("option", ["--events-table", "--scores-table"])
+def test_evalbench_import_rejects_reserved_agent_events_table(
+    monkeypatch: pytest.MonkeyPatch, option: str
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+          option,
+          "agent_events",
+      ],
+  )
+  assert result.exit_code == 2, result.output
+  assert "reserved ADK plugin table 'agent_events'" in result.output
+  # Rejected before any BigQuery read or write.
+  assert calls == []
+
+
 def test_evalbench_import_surfaces_materialize_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -98,6 +98,54 @@ def _run(*results: dict, config_rows: tuple[dict, ...] | None = None):
   )
 
 
+def test_evalbench_run_keeps_v051_positional_argument_order() -> None:
+  """``snapshot_at`` must not shift the v0.5.1 positional fields.
+
+  v0.5.1 callers construct ``EvalBenchRun(project, dataset, job, location,
+  results, scores, config_rows)``; inserting ``snapshot_at`` ahead of
+  ``results`` would silently swallow ``results`` into ``snapshot_at``.
+  """
+  results = ({"eval_id": "e-1", "scenario_id": "s-1"},)
+  scores = ({"eval_id": "e-1", "comparator": "goal_completion", "score": 1},)
+  config_rows = (
+      {"config": "experiment_config.orchestrator", "value": "geminicli"},
+  )
+
+  run = EvalBenchRun(
+      "source-project",
+      "evalbench",
+      "job-123",
+      "US",
+      results,
+      scores,
+      config_rows,
+  )
+
+  assert run.project_id == "source-project"
+  assert run.evalbench_dataset == "evalbench"
+  assert run.job_id == "job-123"
+  assert run.location == "US"
+  assert run.results == results
+  assert run.scores == scores
+  assert run.config_rows == config_rows
+  assert run.snapshot_at is None
+  assert not isinstance(run.snapshot_at, tuple)
+
+  snapshot_at = datetime(2026, 8, 29, tzinfo=timezone.utc)
+  pinned = EvalBenchRun(
+      "source-project",
+      "evalbench",
+      "job-123",
+      "US",
+      results,
+      scores,
+      config_rows,
+      snapshot_at,
+  )
+  assert pinned.results == results
+  assert pinned.snapshot_at == snapshot_at
+
+
 def test_from_bigquery_filters_every_source_query_by_job_id() -> None:
   fake = _FakeBigQueryClient(
       {

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -19,9 +19,12 @@ import dataclasses
 from datetime import datetime
 from datetime import timezone
 import json
+import math
+import re
 
 import pytest
 
+from bigquery_agent_analytics import evalbench
 from bigquery_agent_analytics.evalbench import classify_sessions
 from bigquery_agent_analytics.evalbench import EvalBenchRun
 from bigquery_agent_analytics.evalbench import EvalScorePolicy
@@ -423,36 +426,120 @@ class _FakeJob:
     return self._rows
 
 
+class _FakeManifestStore:
+  """Committed manifest rows shared by several fake clients (one BigQuery)."""
+
+  def __init__(self, rows: list[dict] | None = None) -> None:
+    self.rows: list[dict] = list(rows or [])
+
+
+_RAISE_MESSAGE = re.compile(r"RAISE USING MESSAGE = '([^']*)'")
+
+
 class _FakeWriteClient:
-  """Records loads, queries, and table DDL issued by ``materialize``."""
+  """Records loads, queries, and table DDL issued by ``materialize``.
+
+  The publish transaction is emulated against a ``_FakeManifestStore``: the
+  guard predicate rendered in the script is evaluated against the committed
+  rows with the query parameters, the script's own ``RAISE`` message is
+  surfaced on conflict, and otherwise the staged manifest row replaces the
+  committed one. ``stale_manifest_reads`` makes the pre-publish manifest read
+  return nothing, which is how two importers that both observed no row are
+  interleaved deterministically.
+  """
 
   def __init__(
       self,
       *,
       manifest_rows: list[dict] | None = None,
+      store: _FakeManifestStore | None = None,
+      stale_manifest_reads: bool = False,
       load_error: Exception | None = None,
       transaction_error: Exception | None = None,
+      delete_error: Exception | None = None,
   ) -> None:
-    self.manifest_rows = list(manifest_rows or [])
+    self.store = store or _FakeManifestStore(manifest_rows)
+    self.stale_manifest_reads = stale_manifest_reads
     self.load_error = load_error
     self.transaction_error = transaction_error
+    self.delete_error = delete_error
     self.loads: list[tuple[str, list[dict], object]] = []
     self.queries: list[tuple[str, dict]] = []
     self.created: list[str] = []
+    self.created_tables: list[object] = []
     self.deleted: list[str] = []
+
+  @property
+  def manifest_rows(self) -> list[dict]:
+    return self.store.rows
 
   def create_table(self, table, exists_ok: bool = False):
     assert exists_ok is True
     self.created.append(f"{table.project}.{table.dataset_id}.{table.table_id}")
+    self.created_tables.append(table)
     return table
 
   def query(self, query: str, **kwargs) -> _FakeJob:
     self.queries.append((query, kwargs))
+    params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
     if "BEGIN TRANSACTION" in query:
-      return _FakeJob(error=self.transaction_error)
+      if self.transaction_error is not None:
+        return _FakeJob(error=self.transaction_error)
+      return self._publish(query, params)
     if ".evalbench_import_manifest`" in query:
-      return _FakeJob(self.manifest_rows)
+      if self.stale_manifest_reads:
+        return _FakeJob([])
+      return _FakeJob(
+          [
+              row
+              for row in self.store.rows
+              if row["job_id"] == params["job_id"]
+              and row["import_version"] == params["import_version"]
+          ]
+      )
     raise AssertionError(f"unexpected query: {query}")
+
+  def _publish(self, script: str, params: dict) -> _FakeJob:
+    def same_version(row: dict) -> bool:
+      return (
+          row["job_id"] == params["job_id"]
+          and row["import_version"] == params["import_version"]
+      )
+
+    predicates = []
+    if "results_fingerprint != @results_fingerprint" in script:
+      predicates.append(
+          lambda row: any(
+              row[key] != params[key]
+              for key in (
+                  "results_fingerprint",
+                  "scores_fingerprint",
+                  "configs_fingerprint",
+              )
+          )
+      )
+    if "events_table != @events_table" in script:
+      predicates.append(
+          lambda row: row["events_table"] != params["events_table"]
+          or row["scores_table"] != params["scores_table"]
+      )
+    conflicts = [
+        row
+        for row in self.store.rows
+        if same_version(row) and any(pred(row) for pred in predicates)
+    ]
+    if conflicts:
+      message = _RAISE_MESSAGE.search(script).group(1)
+      return _FakeJob(error=RuntimeError(f"400 {message}"))
+    staged_manifest = next(
+        rows
+        for dest, rows, _ in self.loads
+        if "evalbench_import_manifest" in dest
+    )
+    self.store.rows = [
+        row for row in self.store.rows if not same_version(row)
+    ] + list(staged_manifest)
+    return _FakeJob()
 
   def load_table_from_json(self, rows, destination, job_config=None):
     self.loads.append((destination, list(rows), job_config))
@@ -461,6 +548,8 @@ class _FakeWriteClient:
   def delete_table(self, table_ref: str, not_found_ok: bool = False) -> None:
     assert not_found_ok is True
     self.deleted.append(table_ref)
+    if self.delete_error is not None:
+      raise self.delete_error
 
 
 def _scored_run(*, extra_result: dict | None = None, scores=None):
@@ -555,10 +644,8 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
       (sql, kw) for sql, kw in fake.queries if "BEGIN TRANSACTION" in sql
   )
   params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
-  assert params == {
-      "job_id": "job-123",
-      "import_version": result.import_version,
-  }
+  assert params["job_id"] == "job-123"
+  assert params["import_version"] == result.import_version
   assert kwargs["job_config"].labels["sdk_feature"] == "evalbench-import"
   assert kwargs["location"] == "US"
 
@@ -579,9 +666,14 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
       for dest, rows, _ in fake.loads
       if "evalbench_scores_imported" in dest
   )
+  version = result.import_version
   assert {row["session_id"] for row in score_rows} == {
-      "evalbench:job-123:ok-1",
-      "evalbench:job-123:crash-1",
+      f"evalbench:job-123:{version}:ok-1",
+      f"evalbench:job-123:{version}:crash-1",
+  }
+  # Score joins stay aligned with the version-specific event identity.
+  assert {row["session_id"] for row in score_rows} == {
+      row["session_id"] for row in event_rows
   }
   assert {row["comparator"] for row in score_rows} == {"goal_completion"}
   manifest_rows = next(
@@ -630,6 +722,61 @@ def test_materialize_same_job_and_version_is_a_noop() -> None:
   assert again.import_version == imported.import_version
   assert second.loads == []
   assert _transaction_queries(second) == []
+
+
+def test_materialize_unchanged_source_rejects_other_destination_tables() -> (
+    None
+):
+  """A no-op must never report tables that were never written (#451 P1)."""
+  run = _scored_run()
+  imported = run.materialize(
+      target_dataset="bqaa", bq_client=_FakeWriteClient()
+  )
+  assert imported.events_table == "source-project.bqaa.evalbench_agent_events"
+
+  second = _FakeWriteClient(manifest_rows=[imported.manifest])
+  with pytest.raises(ValueError) as excinfo:
+    run.materialize(
+        target_dataset="bqaa",
+        events_table="evalbench_agent_events_v2",
+        bq_client=second,
+    )
+  message = str(excinfo.value)
+  assert "source-project.bqaa.evalbench_agent_events'" in message
+  assert "evalbench_agent_events_v2" in message
+  assert "new import_version" in message
+  assert second.loads == []
+  assert _transaction_queries(second) == []
+
+
+def test_materialize_replace_cannot_relocate_a_version() -> None:
+  """``replace=True`` must not orphan rows in the manifest's tables."""
+  run = _scored_run()
+  imported = run.materialize(
+      target_dataset="bqaa", bq_client=_FakeWriteClient()
+  )
+
+  second = _FakeWriteClient(manifest_rows=[imported.manifest])
+  with pytest.raises(ValueError, match="bound to the tables in its manifest"):
+    run.materialize(
+        target_dataset="bqaa",
+        scores_table="evalbench_scores_imported_v2",
+        replace=True,
+        bq_client=second,
+    )
+  assert second.loads == []
+  assert _transaction_queries(second) == []
+  # The transaction guard enforces the same binding even when the pre-read
+  # missed the manifest row.
+  stale = _FakeWriteClient(store=second.store, stale_manifest_reads=True)
+  with pytest.raises(ValueError, match="published concurrently"):
+    run.materialize(
+        target_dataset="bqaa",
+        scores_table="evalbench_scores_imported_v2",
+        replace=True,
+        bq_client=stale,
+    )
+  assert stale.store.rows == [imported.manifest]
 
 
 def test_materialize_replace_republishes_identical_version() -> None:
@@ -740,6 +887,226 @@ def test_materialize_rejects_unsafe_target_identifiers(
     _scored_run().materialize(**kwargs)
 
 
+@pytest.mark.parametrize(
+    "field", ["events_table", "scores_table", "manifest_table"]
+)
+@pytest.mark.parametrize("value", ["agent_events", "AGENT_EVENTS"])
+def test_materialize_rejects_reserved_agent_events_table(
+    field: str, value: str
+) -> None:
+  fake = _FakeWriteClient()
+  kwargs = {"target_dataset": "bqaa", "bq_client": fake}
+  kwargs[field] = value
+  with pytest.raises(ValueError, match=f"{field} must not be the reserved"):
+    _scored_run().materialize(**kwargs)
+  # Rejected before any BigQuery operation.
+  assert fake.created == []
+  assert fake.queries == []
+  assert fake.loads == []
+
+
+def test_publish_script_guards_manifest_inside_the_transaction() -> None:
+  fake = _FakeWriteClient()
+  result = _scored_run().materialize(
+      target_dataset="bqaa", import_version="v1", bq_client=fake
+  )
+  script = _transaction_queries(fake)[0]
+
+  guard = script.index("conflicting_manifest_rows = (")
+  assert script.index("BEGIN TRANSACTION") < guard < script.index("DELETE FROM")
+  assert "RAISE USING MESSAGE" in script
+  assert script.index("RAISE USING MESSAGE") < script.index("DELETE FROM")
+  assert "results_fingerprint != @results_fingerprint" in script
+  assert "scores_fingerprint != @scores_fingerprint" in script
+  assert "configs_fingerprint != @configs_fingerprint" in script
+  assert "events_table != @events_table" in script
+  assert "scores_table != @scores_table" in script
+  assert "EXCEPTION WHEN ERROR THEN" in script
+  assert script.index("ROLLBACK TRANSACTION") > script.index(
+      "COMMIT TRANSACTION"
+  )
+  _, kwargs = next(
+      (sql, kw) for sql, kw in fake.queries if "BEGIN TRANSACTION" in sql
+  )
+  params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
+  assert params == {
+      "job_id": "job-123",
+      "import_version": "v1",
+      "results_fingerprint": result.manifest["results_fingerprint"],
+      "scores_fingerprint": result.manifest["scores_fingerprint"],
+      "configs_fingerprint": result.manifest["configs_fingerprint"],
+      "events_table": result.events_table,
+      "scores_table": result.scores_table,
+  }
+
+
+def test_publish_script_replace_skips_fingerprint_guard_only() -> None:
+  fake = _FakeWriteClient()
+  _scored_run().materialize(
+      target_dataset="bqaa", import_version="v1", replace=True, bq_client=fake
+  )
+  script = _transaction_queries(fake)[0]
+  assert "results_fingerprint != @results_fingerprint" not in script
+  assert "events_table != @events_table" in script
+
+
+def test_materialize_concurrent_first_imports_cannot_overwrite_version() -> (
+    None
+):
+  """Two importers both see no manifest row; only the first may commit."""
+  store = _FakeManifestStore()
+  importer_a = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  importer_b = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  run_a = _scored_run()
+  run_b = _scored_run(
+      extra_result={
+          "eval_id": "late-1",
+          "prompt": "Different content under the same explicit version",
+          "stdout": json.dumps({"response": "late"}),
+      }
+  )
+
+  first = run_a.materialize(
+      target_dataset="bqaa", import_version="v1", bq_client=importer_a
+  )
+  assert first.status == "imported"
+  assert store.rows == [first.manifest]
+
+  # Importer B's pre-read observed nothing, so it reaches the transaction;
+  # the in-transaction guard sees A's committed row and refuses.
+  with pytest.raises(ValueError, match="published concurrently"):
+    run_b.materialize(
+        target_dataset="bqaa", import_version="v1", bq_client=importer_b
+    )
+  assert store.rows == [first.manifest]
+  assert len(_transaction_queries(importer_b)) == 1
+  staged = {destination for destination, _, _ in importer_b.loads}
+  assert set(importer_b.deleted) == staged
+
+  # replace=True is the explicit override and wins the same race.
+  importer_c = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  replaced = run_b.materialize(
+      target_dataset="bqaa",
+      import_version="v1",
+      replace=True,
+      bq_client=importer_c,
+  )
+  assert store.rows == [replaced.manifest]
+
+
+def test_materialize_publishes_version_specific_identities() -> None:
+  run = _scored_run()
+  fake_v1 = _FakeWriteClient()
+  fake_v2 = _FakeWriteClient()
+  run.materialize(target_dataset="bqaa", import_version="v1", bq_client=fake_v1)
+  run.materialize(target_dataset="bqaa", import_version="v2", bq_client=fake_v2)
+
+  def published_events(fake):
+    return next(
+        rows for dest, rows, _ in fake.loads if "evalbench_agent_events" in dest
+    )
+
+  v1 = published_events(fake_v1)
+  v2 = published_events(fake_v2)
+  assert {row["trace_id"] for row in v1} == {
+      "evalbench:job-123:v1:ok-1",
+      "evalbench:job-123:v1:crash-1",
+  }
+  assert all(row["session_id"] == row["trace_id"] for row in v1)
+  # A reader that filters only by trace_id (Client.get_trace /
+  # _GET_TRACE_QUERY) can never merge two retained versions into one trace.
+  assert {row["trace_id"] for row in v1}.isdisjoint(
+      row["trace_id"] for row in v2
+  )
+  assert {row["span_id"] for row in v1}.isdisjoint(row["span_id"] for row in v2)
+  assert {row["invocation_id"] for row in v1}.isdisjoint(
+      row["invocation_id"] for row in v2
+  )
+  assert all(
+      row["attributes"]["evalbench_import_version"] == "v1" for row in v1
+  )
+  assert all(
+      row["attributes"]["evalbench_scenario_id"] in {"ok-1", "crash-1"}
+      for row in v1
+  )
+
+
+def test_unversioned_reader_identity_is_unchanged() -> None:
+  rows = _scored_run().to_agent_event_rows()
+  assert {row["session_id"] for row in rows} == {
+      "evalbench:job-123:ok-1",
+      "evalbench:job-123:crash-1",
+  }
+  assert all(
+      "evalbench_import_version" not in row["attributes"] for row in rows
+  )
+
+
+def test_staging_tables_expire_and_cleanup_failure_does_not_mask_publish() -> (
+    None
+):
+  fake = _FakeWriteClient(delete_error=RuntimeError("drop denied"))
+  result = _scored_run().materialize(target_dataset="bqaa", bq_client=fake)
+
+  assert result.status == "imported"
+  assert len(fake.manifest_rows) == 1
+  staging = [t for t in fake.created_tables if "_staging_" in t.table_id]
+  assert len(staging) == 3
+  assert all(table.expires is not None for table in staging)
+  assert all(
+      config.write_disposition == "WRITE_APPEND" for _, _, config in fake.loads
+  )
+  assert len(fake.deleted) == 3
+
+  # A failed publish still surfaces its own error, not the cleanup's.
+  failing = _FakeWriteClient(
+      transaction_error=RuntimeError("commit failed"),
+      delete_error=RuntimeError("drop denied"),
+  )
+  with pytest.raises(RuntimeError, match="commit failed"):
+    _scored_run().materialize(target_dataset="bqaa", bq_client=failing)
+
+
+def test_json_safe_keeps_non_finite_floats_loadable() -> None:
+  assert evalbench._json_safe(
+      {"nan": math.nan, "inf": math.inf, "ninf": -math.inf, "ok": 1.5}
+  ) == {"nan": "NaN", "inf": "Infinity", "ninf": "-Infinity", "ok": 1.5}
+  rows = _scored_run(
+      scores=(
+          {
+              "eval_id": "ok-1",
+              "comparator": "goal_completion",
+              "score": math.nan,
+          },
+      )
+  ).to_score_rows(import_version="v1")
+  assert rows[0]["score"] is None
+  assert rows[0]["source_row"]["score"] == "NaN"
+  json.dumps(rows[0], allow_nan=False)
+
+
+def test_score_rows_resolve_nested_scenario_ids_like_results() -> None:
+  rows = _scored_run(
+      scores=(
+          {
+              "eval_results": json.dumps({"eval_id": "ok-1"}),
+              "comparator": "goal_completion",
+              "score": 1,
+          },
+          {
+              "scenario": {"id": "crash-1"},
+              "comparator": "goal_completion",
+              "score": 0,
+          },
+      )
+  ).to_score_rows(import_version="v1")
+  assert [row["scenario_id"] for row in rows] == ["crash-1", "ok-1"]
+  assert [row["session_id"] for row in rows] == [
+      "evalbench:job-123:v1:crash-1",
+      "evalbench:job-123:v1:ok-1",
+  ]
+
+
 def test_from_bigquery_snapshot_reads_all_sources_as_of_one_timestamp() -> None:
   fake = _FakeBigQueryClient({"results": [], "scores": [], "configs": []})
   snapshot = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
@@ -776,7 +1143,7 @@ def _verdicts(run: EvalBenchRun, policy: EvalScorePolicy):
   return {
       verdict.session_id: verdict
       for verdict in classify_sessions(
-          run.to_agent_event_rows(),
+          run.to_agent_event_rows(import_version="v1"),
           run.to_score_rows(import_version="v1"),
           policy,
       )
@@ -802,21 +1169,21 @@ def test_classify_sessions_counts_low_scoring_completed_runs_as_failed() -> (
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
 
   assert set(verdicts) == {
-      "evalbench:job-123:ok-1",
-      "evalbench:job-123:crash-1",
-      "evalbench:job-123:wrong-1",
+      "evalbench:job-123:v1:ok-1",
+      "evalbench:job-123:v1:crash-1",
+      "evalbench:job-123:v1:wrong-1",
   }
-  passed = verdicts["evalbench:job-123:ok-1"]
+  passed = verdicts["evalbench:job-123:v1:ok-1"]
   assert passed.failed is False
   assert passed.process_failed is False
   assert passed.score_failed is False
 
-  crashed = verdicts["evalbench:job-123:crash-1"]
+  crashed = verdicts["evalbench:job-123:v1:crash-1"]
   assert crashed.failed is True
   assert crashed.process_failed is True
   assert crashed.missing_completion is True
 
-  wrong = verdicts["evalbench:job-123:wrong-1"]
+  wrong = verdicts["evalbench:job-123:v1:wrong-1"]
   assert wrong.failed is True
   assert wrong.process_failed is False
   assert wrong.missing_completion is False
@@ -824,7 +1191,10 @@ def test_classify_sessions_counts_low_scoring_completed_runs_as_failed() -> (
   assert wrong.failing_scores == {"goal_completion": 0.2}
 
   failed = sorted(v.session_id for v in verdicts.values() if v.failed)
-  assert failed == ["evalbench:job-123:crash-1", "evalbench:job-123:wrong-1"]
+  assert failed == [
+      "evalbench:job-123:v1:crash-1",
+      "evalbench:job-123:v1:wrong-1",
+  ]
 
 
 def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
@@ -832,7 +1202,7 @@ def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
 ):
   run = _scored_run(scores=())
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
-  completed = verdicts["evalbench:job-123:ok-1"]
+  completed = verdicts["evalbench:job-123:v1:ok-1"]
   assert completed.process_failed is False
   assert completed.score_failed is True
   assert completed.failed is True
@@ -841,13 +1211,98 @@ def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
   lenient = _verdicts(
       run, EvalScorePolicy({"goal_completion": 0.5}, missing_score_fails=False)
   )
-  assert lenient["evalbench:job-123:ok-1"].failed is False
+  assert lenient["evalbench:job-123:v1:ok-1"].failed is False
+
+
+def test_stderr_is_a_process_failure_even_when_returncode_is_zero() -> None:
+  """returncode 0 + final response + stderr must not publish as OK (#451)."""
+  run = _scored_run(
+      extra_result={
+          "eval_id": "noisy-1",
+          "prompt": "Completed with a traceback on stderr",
+          "stdout": json.dumps({"response": "done"}),
+          "stderr": "Traceback (most recent call last): boom",
+          "returncode": 0,
+          "run_time": _RUN_TIME,
+      },
+      scores=(
+          {"eval_id": "ok-1", "comparator": "goal_completion", "score": 1},
+          {"eval_id": "crash-1", "comparator": "goal_completion", "score": 0},
+          {"eval_id": "noisy-1", "comparator": "goal_completion", "score": 1},
+      ),
+  )
+  rows = [
+      row
+      for row in run.to_agent_event_rows(import_version="v1")
+      if row["session_id"].endswith(":noisy-1")
+  ]
+  assert [row["event_type"] for row in rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "AGENT_COMPLETED",
+  ]
+  completed = rows[-1]
+  assert completed["status"] == "ERROR"
+  assert completed["error_message"] == (
+      "stderr: Traceback (most recent call last): boom"
+  )
+  assert "returncode" not in completed["error_message"]
+  assert completed["attributes"]["evalbench_error_fields"] == {
+      "stderr": "Traceback (most recent call last): boom"
+  }
+  assert any(row["status"] == "ERROR" for row in rows)
+
+  # Python reference: a process failure despite a passing score.
+  verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
+  noisy = verdicts["evalbench:job-123:v1:noisy-1"]
+  assert noisy.process_failed is True
+  assert noisy.missing_completion is False
+  assert noisy.score_failed is False
+  assert noisy.failed is True
+  assert verdicts["evalbench:job-123:v1:ok-1"].failed is False
+
+  # SQL path: process failure is any ERROR event in the session, never the
+  # exit code, so the published ERROR row above fails the denominator.
+  sql = failed_sessions_sql(
+      target_project="p",
+      target_dataset="d",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+  )
+  assert "LOGICAL_OR(status = 'ERROR') AS process_failed" in sql
+  assert "s.process_failed\n    OR s.missing_completion" in sql
+  assert "returncode" not in sql
+
+
+def test_classify_sessions_and_sql_collapse_duplicate_comparator_rows() -> None:
+  run = _scored_run(
+      scores=(
+          {"eval_id": "ok-1", "comparator": "goal_completion", "score": 0.9},
+          {"eval_id": "ok-1", "comparator": "goal_completion", "score": 0.1},
+          {"eval_id": "ok-1", "comparator": "goal_completion", "score": 0.3},
+      )
+  )
+  verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
+  # One entry per comparator carrying the lowest failing score.
+  assert verdicts["evalbench:job-123:v1:ok-1"].failing_scores == {
+      "goal_completion": 0.1
+  }
+
+  sql = failed_sessions_sql(
+      target_project="p",
+      target_dataset="d",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+  )
+  assert "GROUP BY s.session_id, p.comparator" in sql
+  assert (
+      "MIN(IF(sc.score < p.min_score, sc.score, NULL)) AS failing_score" in sql
+  )
+  assert "COUNTIF(failing) AS failing_score_count" in sql
+  assert "STRUCT(comparator AS comparator, failing_score AS score)" in sql
 
 
 def test_classify_sessions_without_policy_only_uses_process_signals() -> None:
   verdicts = _verdicts(_scored_run(), EvalScorePolicy())
-  assert verdicts["evalbench:job-123:ok-1"].failed is False
-  assert verdicts["evalbench:job-123:crash-1"].failed is True
+  assert verdicts["evalbench:job-123:v1:ok-1"].failed is False
+  assert verdicts["evalbench:job-123:v1:crash-1"].failed is True
 
 
 def test_failed_sessions_sql_pins_import_version_and_renders_policy() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -508,6 +508,8 @@ class _FakeManifestStore:
 
 
 _RAISE_MESSAGE = re.compile(r"RAISE USING MESSAGE = '([^']*)'")
+# The RAISE message of one ``IF <guard> > 0 THEN`` block of the publish script.
+_GUARD_MESSAGE = r"IF {guard} > 0 THEN\s*RAISE USING MESSAGE = '([^']*)'"
 _CONCURRENT_UPDATE_ERROR = (
     "400 Transaction is aborted due to concurrent update against table"
     " {lock_table}. Transaction ID: fake"
@@ -538,11 +540,12 @@ class _FakeWriteClient:
     transaction with the "concurrent update" error, which is what the fake
     raises. Only one of two concurrent publishes can therefore commit.
 
-  ``stale_manifest_reads`` makes the pre-publish manifest read return
-  nothing; ``transaction_snapshot`` pins the snapshot the transaction itself
-  starts from (default: the committed state when ``BEGIN TRANSACTION`` runs).
-  Passing one snapshot to two clients models two transactions that both
-  began before either committed.
+  ``stale_manifest_reads`` makes every manifest read *before* this client's
+  first publish transaction return nothing (a stale pre-read); reads after
+  the transaction see committed state. ``transaction_snapshot`` pins the
+  snapshot the transaction itself starts from (default: the committed state
+  when ``BEGIN TRANSACTION`` runs). Passing one snapshot to two clients
+  models two transactions that both began before either committed.
   """
 
   def __init__(
@@ -558,6 +561,7 @@ class _FakeWriteClient:
   ) -> None:
     self.store = store or _FakeManifestStore(manifest_rows)
     self.stale_manifest_reads = stale_manifest_reads
+    self.transaction_attempted = False
     self.transaction_snapshot = transaction_snapshot
     self.load_error = load_error
     self.transaction_error = transaction_error
@@ -582,6 +586,7 @@ class _FakeWriteClient:
     self.queries.append((query, kwargs))
     params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
     if "BEGIN TRANSACTION" in query:
+      self.transaction_attempted = True
       if self.transaction_error is not None:
         return _FakeJob(error=self.transaction_error)
       snapshot = self.transaction_snapshot or self.store.snapshot()
@@ -593,7 +598,7 @@ class _FakeWriteClient:
         self.store.lock_rows = 1
       return _FakeJob()
     if ".evalbench_import_manifest`" in query:
-      if self.stale_manifest_reads:
+      if self.stale_manifest_reads and not self.transaction_attempted:
         return _FakeJob([])
       return _FakeJob(
           [row for row in self.store.rows if _same_version(row, params)]
@@ -621,7 +626,9 @@ class _FakeWriteClient:
           )
       )
 
-    # 2. Manifest guard, evaluated against the transaction's snapshot.
+    # 2. Manifest guard, evaluated against the transaction's snapshot:
+    #    absent -> publish, conflicting -> RAISE, identical -> RAISE the
+    #    "unchanged" message (without replace) so nothing is rewritten.
     predicates = []
     if "results_fingerprint != @results_fingerprint" in script:
       predicates.append(
@@ -634,19 +641,30 @@ class _FakeWriteClient:
               )
           )
       )
+    if "source_project != @source_project" in script:
+      predicates.append(
+          lambda row: row["source_project"] != params["source_project"]
+          or row["source_dataset"] != params["source_dataset"]
+      )
     if "events_table != @events_table" in script:
       predicates.append(
           lambda row: row["events_table"] != params["events_table"]
           or row["scores_table"] != params["scores_table"]
       )
+    existing = [row for row in snapshot.rows if _same_version(row, params)]
     conflicts = [
-        row
-        for row in snapshot.rows
-        if _same_version(row, params) and any(pred(row) for pred in predicates)
+        row for row in existing if any(pred(row) for pred in predicates)
     ]
     if conflicts:
-      message = _RAISE_MESSAGE.findall(script)[-1]
-      return _FakeJob(error=RuntimeError(f"400 {message}"))
+      message = _GUARD_MESSAGE.format(guard="conflicting_manifest_rows")
+      return _FakeJob(
+          error=RuntimeError(f"400 {re.search(message, script).group(1)}")
+      )
+    identical_guard = re.search(
+        _GUARD_MESSAGE.format(guard="existing_manifest_rows"), script
+    )
+    if existing and identical_guard is not None:
+      return _FakeJob(error=RuntimeError(f"400 {identical_guard.group(1)}"))
 
     # 3. Commit: keyed DELETEs then INSERTs from staging, plus the claim.
     def staged(table: str) -> list[dict]:
@@ -1070,6 +1088,17 @@ def test_publish_script_guards_manifest_inside_the_transaction() -> None:
   assert "configs_fingerprint != @configs_fingerprint" in script
   assert "events_table != @events_table" in script
   assert "scores_table != @scores_table" in script
+  assert "source_project != @source_project" in script
+  assert "source_dataset != @source_dataset" in script
+  # Absent / identical / conflicting: an identical manifest row is left in
+  # place (RAISE -> ROLLBACK) rather than deleted and re-inserted.
+  assert evalbench._PUBLISH_CONFLICT_MESSAGE in script
+  assert evalbench._PUBLISH_UNCHANGED_MESSAGE in script
+  assert (
+      script.index("IF conflicting_manifest_rows > 0 THEN")
+      < script.index("IF existing_manifest_rows > 0 THEN")
+      < script.index("DELETE FROM")
+  )
   assert "EXCEPTION WHEN ERROR THEN" in script
   assert script.index("ROLLBACK TRANSACTION") > script.index(
       "COMMIT TRANSACTION"
@@ -1086,6 +1115,8 @@ def test_publish_script_guards_manifest_inside_the_transaction() -> None:
       "configs_fingerprint": result.manifest["configs_fingerprint"],
       "events_table": result.events_table,
       "scores_table": result.scores_table,
+      "source_project": "source-project",
+      "source_dataset": "evalbench",
   }
 
 
@@ -1096,6 +1127,9 @@ def test_publish_script_replace_skips_fingerprint_guard_only() -> None:
   )
   script = _transaction_queries(fake)[0]
   assert "results_fingerprint != @results_fingerprint" not in script
+  assert "source_project != @source_project" not in script
+  assert "IF existing_manifest_rows > 0 THEN" not in script
+  assert evalbench._PUBLISH_UNCHANGED_MESSAGE not in script
   assert "events_table != @events_table" in script
 
 
@@ -1144,6 +1178,114 @@ def test_materialize_stale_pre_read_is_caught_by_transaction_guard() -> None:
 
 def _published_rows(fake: _FakeWriteClient, table: str) -> list[dict]:
   return next(rows for dest, rows, _ in fake.loads if table in dest)
+
+
+def test_materialize_stale_pre_read_identical_publish_is_unchanged() -> None:
+  """Stale pre-read, identical content *and* provenance: the transaction
+  distinguishes an identical manifest from an absent one, preserves A's
+  rows and manifest, and reports ``unchanged`` instead of re-publishing."""
+  store = _FakeManifestStore()
+  importer_a = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  first = _scored_run().materialize(
+      target_dataset="bqaa",
+      import_version="v1",
+      imported_at=datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc),
+      bq_client=importer_a,
+  )
+  assert first.status == "imported"
+  assert store.lock_claims == 1
+  published_events = _published_rows(importer_a, "evalbench_agent_events")
+
+  importer_b = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  same = _scored_run().materialize(
+      target_dataset="bqaa",
+      import_version="v1",
+      imported_at=datetime(2026, 5, 2, 8, 0, tzinfo=timezone.utc),
+      bq_client=importer_b,
+  )
+  assert same.status == "unchanged"
+  assert same.manifest == first.manifest
+  assert same.event_row_count == first.event_row_count
+  assert same.score_row_count == first.score_row_count
+  # B reached the transaction (its pre-read saw nothing) but was rolled
+  # back: A's manifest (with A's imported_at), rows, and lock claim survive.
+  assert len(_transaction_queries(importer_b)) == 1
+  assert store.rows == [first.manifest]
+  assert store.events == published_events
+  assert store.lock_claims == 1
+  staged = {destination for destination, _, _ in importer_b.loads}
+  assert set(importer_b.deleted) == staged
+
+
+@pytest.mark.parametrize(
+    "field, other_value",
+    [("project_id", "other-project"), ("evalbench_dataset", "evalbench_copy")],
+)
+def test_materialize_stale_pre_read_provenance_drift_is_a_conflict(
+    field: str, other_value: str
+) -> None:
+  """Codex P1 on a8e8b5c: equal source rows read from another source
+  project/dataset produce equal fingerprints, but ``source_project`` /
+  ``source_dataset`` change the manifest and the published
+  ``attributes.evalbench_source_*`` values. A stale-pre-read importer whose
+  transaction starts after the first commit must treat that as a
+  conflicting version, not as absent, and must not rewrite it without
+  ``replace=True``."""
+  store = _FakeManifestStore()
+  importer_a = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  first = _scored_run().materialize(
+      target_dataset="bqaa", import_version="v1", bq_client=importer_a
+  )
+  assert first.status == "imported"
+  published_events = _published_rows(importer_a, "evalbench_agent_events")
+
+  other_source = dataclasses.replace(_scored_run(), **{field: other_value})
+  assert other_source.fingerprints() == _scored_run().fingerprints()
+  # Same destination tables as A, so only provenance differs.
+  target = {"target_project": "source-project", "target_dataset": "bqaa"}
+
+  importer_b = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  with pytest.raises(ValueError, match="published concurrently"):
+    other_source.materialize(
+        **target, import_version="v1", bq_client=importer_b
+    )
+  assert len(_transaction_queries(importer_b)) == 1
+  assert store.rows == [first.manifest]
+  assert store.events == published_events
+  assert store.lock_claims == 1
+  assert all(
+      row["attributes"]["evalbench_source_project"] == "source-project"
+      and row["attributes"]["evalbench_source_dataset"] == "evalbench"
+      for row in store.events
+  )
+  staged = {destination for destination, _, _ in importer_b.loads}
+  assert set(importer_b.deleted) == staged
+
+  # A fresh pre-read reports the same drift before staging anything.
+  fresh = _FakeWriteClient(store=store)
+  with pytest.raises(ValueError, match="already exists with different") as info:
+    other_source.materialize(**target, import_version="v1", bq_client=fresh)
+  assert other_value in str(info.value)
+  assert "new import_version" in str(info.value)
+  assert fresh.loads == []
+  assert _transaction_queries(fresh) == []
+  assert store.rows == [first.manifest]
+
+  # replace=True is the explicit override: the version is re-published from
+  # the new source and the manifest records the new provenance.
+  importer_c = _FakeWriteClient(store=store)
+  replaced = other_source.materialize(
+      **target, import_version="v1", replace=True, bq_client=importer_c
+  )
+  assert replaced.status == "replaced"
+  assert store.rows == [replaced.manifest]
+  manifest_key = "source_project" if field == "project_id" else "source_dataset"
+  assert replaced.manifest[manifest_key] == other_value
+  attribute_key = "evalbench_" + manifest_key
+  assert all(
+      row["attributes"][attribute_key] == other_value for row in store.events
+  )
+  assert store.lock_claims == 2
 
 
 def test_materialize_concurrent_first_imports_serialize_on_lock_sentinel() -> (

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -887,9 +887,7 @@ def test_materialize_rejects_unsafe_target_identifiers(
     _scored_run().materialize(**kwargs)
 
 
-@pytest.mark.parametrize(
-    "field", ["events_table", "scores_table", "manifest_table"]
-)
+@pytest.mark.parametrize("field", ["events_table", "scores_table"])
 @pytest.mark.parametrize("value", ["agent_events", "AGENT_EVENTS"])
 def test_materialize_rejects_reserved_agent_events_table(
     field: str, value: str
@@ -1039,6 +1037,209 @@ def test_unversioned_reader_identity_is_unchanged() -> None:
   }
   assert all(
       "evalbench_import_version" not in row["attributes"] for row in rows
+  )
+
+
+def test_materialize_rejects_caller_selected_manifest_table() -> None:
+  """The manifest registry is fixed per dataset and cannot be redirected."""
+  fake = _FakeWriteClient()
+  with pytest.raises(TypeError, match="manifest_table"):
+    _scored_run().materialize(
+        target_dataset="bqaa",
+        manifest_table="other_manifest",
+        bq_client=fake,
+    )
+  assert fake.created == []
+  assert fake.queries == []
+  assert fake.loads == []
+
+
+def test_materialize_consults_canonical_registry_for_custom_tables() -> None:
+  """Every import checks ``<target>.evalbench_import_manifest`` regardless of
+  which events/scores tables it writes."""
+  fake = _FakeWriteClient()
+  result = _scored_run().materialize(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      events_table="custom_events",
+      scores_table="custom_scores",
+      import_version="v1",
+      bq_client=fake,
+  )
+  registry = "analytics-project.bqaa.evalbench_import_manifest"
+  assert result.manifest_table == registry
+  assert evalbench.MANIFEST_TABLE == "evalbench_import_manifest"
+  pre_reads = [sql for sql, _ in fake.queries if "BEGIN TRANSACTION" not in sql]
+  assert pre_reads and all(f"`{registry}`" in sql for sql in pre_reads)
+  script = _transaction_queries(fake)[0]
+  assert f"FROM `{registry}`" in script
+  assert f"DELETE FROM `{registry}`" in script
+  assert f"INSERT INTO `{registry}`" in script
+  # The manifest staging table derives from the registry name as well.
+  assert any(f"{registry}_staging_" in dest for dest, _, _ in fake.loads)
+
+
+def test_changed_source_cannot_replace_shared_rows_via_second_manifest() -> (
+    None
+):
+  """Codex P1 regression: publish ``job/v1``, then publish *changed* source
+  for the same ``job/v1`` into the same events/scores tables. With one
+  canonical registry the second import cannot route around the first
+  manifest row, so the shared rows are never deleted or replaced."""
+  store = _FakeManifestStore()
+  first_client = _FakeWriteClient(store=store)
+  first = _scored_run().materialize(
+      target_dataset="bqaa",
+      events_table="shared_events",
+      scores_table="shared_scores",
+      import_version="v1",
+      bq_client=first_client,
+  )
+  assert first.status == "imported"
+  assert store.rows == [first.manifest]
+
+  changed = _scored_run(
+      extra_result={
+          "eval_id": "late-1",
+          "prompt": "Changed content under the same version",
+          "stdout": json.dumps({"response": "late"}),
+      }
+  )
+  # The pre-read sees the registry row and refuses before staging anything.
+  second_client = _FakeWriteClient(store=store)
+  with pytest.raises(ValueError, match="different source fingerprints"):
+    changed.materialize(
+        target_dataset="bqaa",
+        events_table="shared_events",
+        scores_table="shared_scores",
+        import_version="v1",
+        bq_client=second_client,
+    )
+  assert store.rows == [first.manifest]
+  assert second_client.loads == []
+  assert _transaction_queries(second_client) == []
+
+  # Even an importer whose pre-read is stale hits the same registry inside
+  # the transaction and is rolled back; nothing is deleted from the shared
+  # tables.
+  stale_client = _FakeWriteClient(store=store, stale_manifest_reads=True)
+  with pytest.raises(ValueError, match="published concurrently"):
+    changed.materialize(
+        target_dataset="bqaa",
+        events_table="shared_events",
+        scores_table="shared_scores",
+        import_version="v1",
+        bq_client=stale_client,
+    )
+  assert store.rows == [first.manifest]
+
+
+def _colliding_runs() -> (
+    tuple[tuple[EvalBenchRun, str], tuple[EvalBenchRun, str]]
+):
+  """Two ``(run, import_version)`` pairs whose naive ``:``-joined identity
+  would both read ``evalbench:job-123:release:1:case``."""
+
+  def run_for(scenario_id: str) -> EvalBenchRun:
+    return _scored_run(
+        extra_result={
+            "eval_id": scenario_id,
+            "prompt": "Prompt",
+            "stdout": json.dumps(
+                {
+                    "response": "done",
+                    "tool_calls": [
+                        {"tool_name": "search", "args": {}, "result": "x"}
+                    ],
+                }
+            ),
+            "run_time": _RUN_TIME,
+        },
+        scores=({"eval_id": scenario_id, "comparator": "goal", "score": 1},),
+    )
+
+  return (run_for("case"), "release:1"), (run_for("1:case"), "release")
+
+
+def test_session_identity_escapes_delimiters() -> None:
+  left = evalbench._session_identity(
+      "job-123", "case", import_version="release:1"
+  )
+  right = evalbench._session_identity(
+      "job-123", "1:case", import_version="release"
+  )
+  assert left != right
+  assert left == "evalbench:job-123:release\\:1:case"
+  assert right == "evalbench:job-123:release:1\\:case"
+  # Backslashes in a component are escaped too, so escaping is reversible.
+  assert (
+      evalbench._session_identity("job-123", "a\\:b", import_version=None)
+      == "evalbench:job-123:a\\\\\\:b"
+  )
+  # A plain read of scenario ``v1:case`` never aliases published ``v1``.
+  assert evalbench._session_identity(
+      "job-123", "v1:case", import_version=None
+  ) != evalbench._session_identity("job-123", "case", import_version="v1")
+  # Common case (no delimiters) keeps the documented readable form.
+  assert (
+      evalbench._session_identity("job-123", "ok-1", import_version="v1")
+      == "evalbench:job-123:v1:ok-1"
+  )
+
+
+@pytest.mark.parametrize(
+    "column", ["session_id", "trace_id", "invocation_id", "span_id"]
+)
+def test_versioned_event_identities_are_collision_safe(column: str) -> None:
+  (run_a, version_a), (run_b, version_b) = _colliding_runs()
+  rows_a = [
+      row
+      for row in run_a.to_agent_event_rows(import_version=version_a)
+      if row["attributes"]["evalbench_scenario_id"] == "case"
+  ]
+  rows_b = [
+      row
+      for row in run_b.to_agent_event_rows(import_version=version_b)
+      if row["attributes"]["evalbench_scenario_id"] == "1:case"
+  ]
+  assert rows_a and rows_b
+  # Same shape (user + tool start/end + completed) so the ids line up 1:1.
+  assert [row["event_type"] for row in rows_a] == [
+      row["event_type"] for row in rows_b
+  ]
+  ids_a = {row[column] for row in rows_a}
+  ids_b = {row[column] for row in rows_b}
+  assert ids_a.isdisjoint(ids_b), column
+  parents_a = {row["parent_span_id"] for row in rows_a} - {None}
+  parents_b = {row["parent_span_id"] for row in rows_b} - {None}
+  assert parents_a.isdisjoint(parents_b)
+
+
+def test_versioned_score_identities_are_collision_safe() -> None:
+  (run_a, version_a), (run_b, version_b) = _colliding_runs()
+  scores_a = {
+      row["session_id"] for row in run_a.to_score_rows(import_version=version_a)
+  }
+  scores_b = {
+      row["session_id"] for row in run_b.to_score_rows(import_version=version_b)
+  }
+  assert scores_a.isdisjoint(scores_b)
+  # Scores still join their own version's events (only the extra scenario
+  # is scored in ``_colliding_runs``).
+  events_a = {
+      row["session_id"]
+      for row in run_a.to_agent_event_rows(import_version=version_a)
+  }
+  assert scores_a == {"evalbench:job-123:release\\:1:case"}
+  assert scores_a <= events_a
+
+
+def test_stable_id_is_not_ambiguous_across_part_boundaries() -> None:
+  assert evalbench._stable_id("a\x1fb", "c", length=16) != evalbench._stable_id(
+      "a", "b\x1fc", length=16
+  )
+  assert evalbench._stable_id("ab", "c", length=16) != evalbench._stable_id(
+      "a", "bc", length=16
   )
 
 

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -426,26 +426,75 @@ class _FakeJob:
     return self._rows
 
 
+class _FakeSnapshot:
+  """What one BigQuery transaction sees: the committed state at its start."""
+
+  def __init__(self, rows: list[dict], lock_rows: int, lock_claims: int):
+    self.rows = rows
+    self.lock_rows = lock_rows
+    self.lock_claims = lock_claims
+
+
 class _FakeManifestStore:
-  """Committed manifest rows shared by several fake clients (one BigQuery)."""
+  """Committed state of one target dataset shared by several fake clients.
+
+  ``rows`` is the manifest registry; ``events``/``scores`` are the published
+  mirror tables; ``lock_rows`` counts sentinel rows in
+  ``evalbench_import_lock`` and ``lock_claims`` is the sentinel's
+  ``claim_count`` (every committed publish mutates it).
+  """
 
   def __init__(self, rows: list[dict] | None = None) -> None:
     self.rows: list[dict] = list(rows or [])
+    self.events: list[dict] = []
+    self.scores: list[dict] = []
+    self.lock_rows = 0
+    self.lock_claims = 0
+
+  def snapshot(self) -> _FakeSnapshot:
+    return _FakeSnapshot(
+        rows=[dict(row) for row in self.rows],
+        lock_rows=self.lock_rows,
+        lock_claims=self.lock_claims,
+    )
 
 
 _RAISE_MESSAGE = re.compile(r"RAISE USING MESSAGE = '([^']*)'")
+_CONCURRENT_UPDATE_ERROR = (
+    "400 Transaction is aborted due to concurrent update against table"
+    " {lock_table}. Transaction ID: fake"
+)
+
+
+def _same_version(row: dict, params: dict) -> bool:
+  return (
+      row["job_id"] == params["job_id"]
+      and row["import_version"] == params["import_version"]
+  )
 
 
 class _FakeWriteClient:
   """Records loads, queries, and table DDL issued by ``materialize``.
 
-  The publish transaction is emulated against a ``_FakeManifestStore``: the
-  guard predicate rendered in the script is evaluated against the committed
-  rows with the query parameters, the script's own ``RAISE`` message is
-  surfaced on conflict, and otherwise the staged manifest row replaces the
-  committed one. ``stale_manifest_reads`` makes the pre-publish manifest read
-  return nothing, which is how two importers that both observed no row are
-  interleaved deterministically.
+  The publish transaction is emulated against a ``_FakeManifestStore`` with
+  BigQuery's snapshot-isolation rules
+  (https://cloud.google.com/bigquery/docs/transactions#transaction_concurrency):
+
+  * every read inside the transaction (the manifest guard) sees the
+    ``_FakeSnapshot`` taken when the transaction began, never later commits;
+  * appends never conflict, and a keyed ``DELETE`` that matches nothing
+    mutates nothing, so neither can fail a concurrent transaction;
+  * the lock claim ``UPDATE`` mutates the pre-existing sentinel row. If a
+    concurrent transaction committed a mutation of that row after this
+    transaction's snapshot (``lock_claims`` moved), BigQuery cancels this
+    transaction with the "concurrent update" error, which is what the fake
+    raises. Only one of two concurrent publishes can therefore commit.
+
+  ``stale_manifest_reads`` makes the pre-publish manifest read return
+  nothing; ``transaction_snapshot`` pins the snapshot the transaction itself
+  starts from (default: the committed state when ``BEGIN TRANSACTION`` runs).
+  Passing one snapshot to two clients models two transactions that both
+  began before either committed.
   """
 
   def __init__(
@@ -454,12 +503,14 @@ class _FakeWriteClient:
       manifest_rows: list[dict] | None = None,
       store: _FakeManifestStore | None = None,
       stale_manifest_reads: bool = False,
+      transaction_snapshot: _FakeSnapshot | None = None,
       load_error: Exception | None = None,
       transaction_error: Exception | None = None,
       delete_error: Exception | None = None,
   ) -> None:
     self.store = store or _FakeManifestStore(manifest_rows)
     self.stale_manifest_reads = stale_manifest_reads
+    self.transaction_snapshot = transaction_snapshot
     self.load_error = load_error
     self.transaction_error = transaction_error
     self.delete_error = delete_error
@@ -485,27 +536,44 @@ class _FakeWriteClient:
     if "BEGIN TRANSACTION" in query:
       if self.transaction_error is not None:
         return _FakeJob(error=self.transaction_error)
-      return self._publish(query, params)
+      snapshot = self.transaction_snapshot or self.store.snapshot()
+      return self._publish(query, params, snapshot)
+    if ".evalbench_import_lock`" in query and query.startswith("INSERT INTO"):
+      # Seeding is INSERT-only, so it never conflicts and may run twice.
+      assert params == {}
+      if self.store.lock_rows == 0:
+        self.store.lock_rows = 1
+      return _FakeJob()
     if ".evalbench_import_manifest`" in query:
       if self.stale_manifest_reads:
         return _FakeJob([])
       return _FakeJob(
-          [
-              row
-              for row in self.store.rows
-              if row["job_id"] == params["job_id"]
-              and row["import_version"] == params["import_version"]
-          ]
+          [row for row in self.store.rows if _same_version(row, params)]
       )
     raise AssertionError(f"unexpected query: {query}")
 
-  def _publish(self, script: str, params: dict) -> _FakeJob:
-    def same_version(row: dict) -> bool:
-      return (
-          row["job_id"] == params["job_id"]
-          and row["import_version"] == params["import_version"]
+  def _publish(
+      self, script: str, params: dict, snapshot: _FakeSnapshot
+  ) -> _FakeJob:
+    # 1. Lock claim: the script's first statement after BEGIN TRANSACTION.
+    lock_table = re.search(r"UPDATE `([^`]+)`", script).group(1)
+    assert lock_table.endswith(".evalbench_import_lock")
+    assert script.index("UPDATE `") < script.index(
+        "conflicting_manifest_rows ="
+    )
+    if snapshot.lock_rows == 0:
+      # ``IF @@row_count = 0 THEN RAISE``: nothing was mutated.
+      message = _RAISE_MESSAGE.findall(script)[0]
+      return _FakeJob(error=RuntimeError(f"400 {message}"))
+    if snapshot.lock_claims != self.store.lock_claims:
+      # Another transaction mutated the sentinel after this snapshot.
+      return _FakeJob(
+          error=RuntimeError(
+              _CONCURRENT_UPDATE_ERROR.format(lock_table=lock_table)
+          )
       )
 
+    # 2. Manifest guard, evaluated against the transaction's snapshot.
     predicates = []
     if "results_fingerprint != @results_fingerprint" in script:
       predicates.append(
@@ -525,20 +593,28 @@ class _FakeWriteClient:
       )
     conflicts = [
         row
-        for row in self.store.rows
-        if same_version(row) and any(pred(row) for pred in predicates)
+        for row in snapshot.rows
+        if _same_version(row, params) and any(pred(row) for pred in predicates)
     ]
     if conflicts:
-      message = _RAISE_MESSAGE.search(script).group(1)
+      message = _RAISE_MESSAGE.findall(script)[-1]
       return _FakeJob(error=RuntimeError(f"400 {message}"))
-    staged_manifest = next(
-        rows
-        for dest, rows, _ in self.loads
-        if "evalbench_import_manifest" in dest
-    )
-    self.store.rows = [
-        row for row in self.store.rows if not same_version(row)
-    ] + list(staged_manifest)
+
+    # 3. Commit: keyed DELETEs then INSERTs from staging, plus the claim.
+    def staged(table: str) -> list[dict]:
+      return next(rows for dest, rows, _ in self.loads if table in dest)
+
+    store = self.store
+    store.lock_claims += 1
+    store.events = [
+        row for row in store.events if not _same_version(row, params)
+    ] + staged(params["events_table"] + "_staging_")
+    store.scores = [
+        row for row in store.scores if not _same_version(row, params)
+    ] + staged(params["scores_table"] + "_staging_")
+    store.rows = [
+        row for row in store.rows if not _same_version(row, params)
+    ] + staged("evalbench_import_manifest")
     return _FakeJob()
 
   def load_table_from_json(self, rows, destination, job_config=None):
@@ -598,6 +674,14 @@ def _transaction_queries(fake: _FakeWriteClient) -> list[str]:
   return [sql for sql, _ in fake.queries if "BEGIN TRANSACTION" in sql]
 
 
+def _lock_seed_queries(fake: _FakeWriteClient) -> list[str]:
+  return [
+      sql
+      for sql, _ in fake.queries
+      if sql.startswith("INSERT INTO") and ".evalbench_import_lock`" in sql
+  ]
+
+
 def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
   fake = _FakeWriteClient()
   run = _scored_run()
@@ -631,6 +715,9 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
   assert all("_staging_" in ref for ref in staged)
   assert set(fake.deleted) == staged
 
+  # The fixed lock table is created alongside the three mirror tables.
+  assert "analytics-project.bqaa.evalbench_import_lock" in fake.created
+
   # Exactly one transaction publishes all three tables; no delete-then-append.
   transactions = _transaction_queries(fake)
   assert len(transactions) == 1
@@ -638,6 +725,13 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
   assert script.count("DELETE FROM") == 3
   assert script.count("INSERT INTO") == 3
   assert script.index("BEGIN TRANSACTION") < script.index("DELETE FROM")
+  # The lock sentinel is seeded by its own committed job before the
+  # transaction begins, so the claim UPDATE has a row to mutate.
+  seeds = _lock_seed_queries(fake)
+  assert len(seeds) == 1
+  order = [sql for sql, _ in fake.queries]
+  assert order.index(seeds[0]) < order.index(script)
+  assert "WHERE NOT EXISTS" in seeds[0]
   assert script.index("INSERT INTO") < script.index("COMMIT TRANSACTION")
   assert "job-123" not in script
   _, kwargs = next(
@@ -668,8 +762,8 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
   )
   version = result.import_version
   assert {row["session_id"] for row in score_rows} == {
-      f"evalbench:job-123:{version}:ok-1",
-      f"evalbench:job-123:{version}:crash-1",
+      f"evalbench-import:job-123:{version}:ok-1",
+      f"evalbench-import:job-123:{version}:crash-1",
   }
   # Score joins stay aligned with the version-specific event identity.
   assert {row["session_id"] for row in score_rows} == {
@@ -910,8 +1004,17 @@ def test_publish_script_guards_manifest_inside_the_transaction() -> None:
   )
   script = _transaction_queries(fake)[0]
 
+  # The claim UPDATE of the pre-existing sentinel is the first statement of
+  # the transaction: it is the only statement guaranteed to mutate a row, so
+  # it is what BigQuery serializes concurrent publishes on.
+  claim = script.index("UPDATE `source-project.bqaa.evalbench_import_lock`")
   guard = script.index("conflicting_manifest_rows = (")
-  assert script.index("BEGIN TRANSACTION") < guard < script.index("DELETE FROM")
+  assert script.index("BEGIN TRANSACTION") < claim < guard
+  assert guard < script.index("DELETE FROM")
+  assert "SET claim_count = claim_count + 1" in script
+  assert f"WHERE lock_id = '{evalbench._IMPORT_LOCK_ID}'" in script
+  assert script.index("IF @@row_count = 0 THEN") < guard
+  assert evalbench._LOCK_MISSING_MESSAGE in script
   assert "RAISE USING MESSAGE" in script
   assert script.index("RAISE USING MESSAGE") < script.index("DELETE FROM")
   assert "results_fingerprint != @results_fingerprint" in script
@@ -948,10 +1051,9 @@ def test_publish_script_replace_skips_fingerprint_guard_only() -> None:
   assert "events_table != @events_table" in script
 
 
-def test_materialize_concurrent_first_imports_cannot_overwrite_version() -> (
-    None
-):
-  """Two importers both see no manifest row; only the first may commit."""
+def test_materialize_stale_pre_read_is_caught_by_transaction_guard() -> None:
+  """Importer B's pre-read is stale but its transaction starts after A
+  committed, so the in-transaction manifest guard refuses it."""
   store = _FakeManifestStore()
   importer_a = _FakeWriteClient(store=store, stale_manifest_reads=True)
   importer_b = _FakeWriteClient(store=store, stale_manifest_reads=True)
@@ -992,6 +1094,112 @@ def test_materialize_concurrent_first_imports_cannot_overwrite_version() -> (
   assert store.rows == [replaced.manifest]
 
 
+def _published_rows(fake: _FakeWriteClient, table: str) -> list[dict]:
+  return next(rows for dest, rows, _ in fake.loads if table in dest)
+
+
+def test_materialize_concurrent_first_imports_serialize_on_lock_sentinel() -> (
+    None
+):
+  """Codex P1: two *truly concurrent* first imports of one version.
+
+  Both transactions begin from the same snapshot, before either commits, so
+  under BigQuery snapshot isolation both guards see no manifest row and both
+  keyed DELETEs match nothing; INSERTs never conflict. Without a real claim
+  both would commit and the version would hold two manifests and a mixed
+  corpus. The claim UPDATE of the pre-existing sentinel is a row mutation,
+  so BigQuery cancels the second transaction that performs it
+  (transactions#transaction_concurrency: "conflicting transactions are
+  cancelled"). The fake models exactly that rule; it is not a live BigQuery
+  test.
+  """
+  store = _FakeManifestStore()
+  store.lock_rows = 1  # sentinel seeded by an earlier import into the dataset
+  shared_snapshot = store.snapshot()  # both transactions begin here
+  importer_a = _FakeWriteClient(
+      store=store,
+      stale_manifest_reads=True,
+      transaction_snapshot=shared_snapshot,
+  )
+  importer_b = _FakeWriteClient(
+      store=store,
+      stale_manifest_reads=True,
+      transaction_snapshot=shared_snapshot,
+  )
+  run_a = _scored_run()
+  run_b = _scored_run(
+      extra_result={
+          "eval_id": "late-1",
+          "prompt": "Different content under the same explicit version",
+          "stdout": json.dumps({"response": "late"}),
+      }
+  )
+
+  first = run_a.materialize(
+      target_dataset="bqaa", import_version="v1", bq_client=importer_a
+  )
+  assert first.status == "imported"
+  assert store.lock_claims == 1
+  assert store.rows == [first.manifest]
+
+  # B's snapshot predates A's commit: its guard sees nothing, but its claim
+  # UPDATE conflicts with A's committed mutation of the sentinel, so BigQuery
+  # cancels B. Nothing B staged reaches the published tables.
+  with pytest.raises(ValueError, match="claimed the import lock") as info:
+    run_b.materialize(
+        target_dataset="bqaa", import_version="v1", bq_client=importer_b
+    )
+  assert "concurrent update" in str(info.value.__cause__)
+  assert len(_transaction_queries(importer_b)) == 1
+  assert store.lock_claims == 1
+  assert store.rows == [first.manifest]
+  assert store.events == _published_rows(importer_a, "evalbench_agent_events")
+  assert store.scores == _published_rows(
+      importer_a, "evalbench_scores_imported"
+  )
+  # No mixed corpus: B's extra scenario never landed.
+  assert all(
+      row["attributes"]["evalbench_scenario_id"] != "late-1"
+      for row in store.events
+  )
+  staged = {destination for destination, _, _ in importer_b.loads}
+  assert set(importer_b.deleted) == staged
+
+  # Re-running B against the committed state reports the real conflict
+  # before staging anything; identical content would report "unchanged".
+  retry = _FakeWriteClient(store=store)
+  with pytest.raises(ValueError, match="different source fingerprints"):
+    run_b.materialize(
+        target_dataset="bqaa", import_version="v1", bq_client=retry
+    )
+  assert retry.loads == []
+  same = run_a.materialize(
+      target_dataset="bqaa",
+      import_version="v1",
+      bq_client=_FakeWriteClient(store=store),
+  )
+  assert same.status == "unchanged"
+  assert store.lock_claims == 1
+
+
+def test_materialize_lock_claim_requires_seeded_sentinel() -> None:
+  """If the sentinel is not in the transaction snapshot the claim mutates
+  nothing, and the ``@@row_count`` guard aborts rather than publishing
+  without serialization."""
+  store = _FakeManifestStore()
+  fake = _FakeWriteClient(
+      store=store, transaction_snapshot=store.snapshot()  # lock_rows == 0
+  )
+  with pytest.raises(RuntimeError, match="lock sentinel is missing"):
+    _scored_run().materialize(
+        target_dataset="bqaa", import_version="v1", bq_client=fake
+    )
+  assert store.rows == []
+  assert store.events == []
+  staged = {destination for destination, _, _ in fake.loads}
+  assert set(fake.deleted) == staged
+
+
 def test_materialize_publishes_version_specific_identities() -> None:
   run = _scored_run()
   fake_v1 = _FakeWriteClient()
@@ -1007,8 +1215,8 @@ def test_materialize_publishes_version_specific_identities() -> None:
   v1 = published_events(fake_v1)
   v2 = published_events(fake_v2)
   assert {row["trace_id"] for row in v1} == {
-      "evalbench:job-123:v1:ok-1",
-      "evalbench:job-123:v1:crash-1",
+      "evalbench-import:job-123:v1:ok-1",
+      "evalbench-import:job-123:v1:crash-1",
   }
   assert all(row["session_id"] == row["trace_id"] for row in v1)
   # A reader that filters only by trace_id (Client.get_trace /
@@ -1069,8 +1277,17 @@ def test_materialize_consults_canonical_registry_for_custom_tables() -> None:
   registry = "analytics-project.bqaa.evalbench_import_manifest"
   assert result.manifest_table == registry
   assert evalbench.MANIFEST_TABLE == "evalbench_import_manifest"
-  pre_reads = [sql for sql, _ in fake.queries if "BEGIN TRANSACTION" not in sql]
+  pre_reads = [
+      sql
+      for sql, _ in fake.queries
+      if "BEGIN TRANSACTION" not in sql and sql not in _lock_seed_queries(fake)
+  ]
   assert pre_reads and all(f"`{registry}`" in sql for sql in pre_reads)
+  # The lock is the dataset's fixed lock table as well, never a custom one.
+  assert all(
+      "`analytics-project.bqaa.evalbench_import_lock`" in sql
+      for sql in _lock_seed_queries(fake)
+  )
   script = _transaction_queries(fake)[0]
   assert f"FROM `{registry}`" in script
   assert f"DELETE FROM `{registry}`" in script
@@ -1138,7 +1355,7 @@ def _colliding_runs() -> (
     tuple[tuple[EvalBenchRun, str], tuple[EvalBenchRun, str]]
 ):
   """Two ``(run, import_version)`` pairs whose naive ``:``-joined identity
-  would both read ``evalbench:job-123:release:1:case``."""
+  would both read ``evalbench-import:job-123:release:1:case``."""
 
   def run_for(scenario_id: str) -> EvalBenchRun:
     return _scored_run(
@@ -1169,22 +1386,37 @@ def test_session_identity_escapes_delimiters() -> None:
       "job-123", "1:case", import_version="release"
   )
   assert left != right
-  assert left == "evalbench:job-123:release\\:1:case"
-  assert right == "evalbench:job-123:release:1\\:case"
-  # Backslashes in a component are escaped too, so escaping is reversible.
+  assert left == "evalbench-import:job-123:release\\:1:case"
+  assert right == "evalbench-import:job-123:release:1\\:case"
+  # Backslashes in a published component are escaped too, so escaping is
+  # reversible.
   assert (
-      evalbench._session_identity("job-123", "a\\:b", import_version=None)
-      == "evalbench:job-123:a\\\\\\:b"
+      evalbench._session_identity("job-123", "a\\:b", import_version="v1")
+      == "evalbench-import:job-123:v1:a\\\\\\:b"
   )
-  # A plain read of scenario ``v1:case`` never aliases published ``v1``.
-  assert evalbench._session_identity(
-      "job-123", "v1:case", import_version=None
-  ) != evalbench._session_identity("job-123", "case", import_version="v1")
   # Common case (no delimiters) keeps the documented readable form.
   assert (
       evalbench._session_identity("job-123", "ok-1", import_version="v1")
-      == "evalbench:job-123:v1:ok-1"
+      == "evalbench-import:job-123:v1:ok-1"
   )
+
+
+def test_published_identities_never_alias_plain_reads() -> None:
+  """The two families live in disjoint namespaces: every plain identity
+  starts with ``evalbench:`` and every published one with
+  ``evalbench-import:``, whatever the (unescaped) plain components contain."""
+  plain = evalbench._session_identity("job-123", "v1:case", import_version=None)
+  assert plain == "evalbench:job-123:v1:case"  # v0.5.1 form, unescaped
+  assert plain != evalbench._session_identity(
+      "job-123", "case", import_version="v1"
+  )
+  # Even a scenario id that spells out the published namespace cannot alias
+  # it, because the plain prefix is fixed and differs.
+  contrived = evalbench._session_identity(
+      "job-123", "import:job-123:v1:case", import_version=None
+  )
+  assert contrived.startswith("evalbench:")
+  assert not contrived.startswith("evalbench-import:")
 
 
 @pytest.mark.parametrize(
@@ -1230,16 +1462,125 @@ def test_versioned_score_identities_are_collision_safe() -> None:
       row["session_id"]
       for row in run_a.to_agent_event_rows(import_version=version_a)
   }
-  assert scores_a == {"evalbench:job-123:release\\:1:case"}
+  assert scores_a == {"evalbench-import:job-123:release\\:1:case"}
   assert scores_a <= events_a
 
 
-def test_stable_id_is_not_ambiguous_across_part_boundaries() -> None:
-  assert evalbench._stable_id("a\x1fb", "c", length=16) != evalbench._stable_id(
+def test_published_stable_id_is_not_ambiguous_across_part_boundaries() -> None:
+  published = evalbench._published_stable_id
+  assert published("a\x1fb", "c", length=16) != published(
       "a", "b\x1fc", length=16
   )
-  assert evalbench._stable_id("ab", "c", length=16) != evalbench._stable_id(
-      "a", "bc", length=16
+  assert published("ab", "c", length=16) != published("a", "bc", length=16)
+  # Distinct framing from the legacy hash, so a published span id can never
+  # reproduce a v0.5.1 one for the same parts.
+  assert published("x", "user", length=16) != evalbench._stable_id(
+      "x", "user", length=16
+  )
+
+
+# Golden vectors produced by the v0.5.1 module (commit 3fb6a00,
+# ``to_agent_event_rows()`` without ``import_version``) for a single-tool
+# scenario. They pin the public unversioned identity contract: session/trace
+# ids are the unescaped ``evalbench:{job_id}:{scenario_id}`` and the
+# invocation/span ids come from the legacy ``_stable_id`` hash.
+_V051_IDENTITY_VECTORS = {
+    "case": {
+        "session_id": "evalbench:job-123:case",
+        "invocation_id": "f567e6f5a86a69f608edb2751cc3771c",
+        "root_span_id": "fe515c0a118b87b6",
+        "tool_span_id": "4bd7d835aaebbb51",
+        "completed_span_id": "0628e23feb7a53c8",
+    },
+    # A scenario id containing the delimiter stays verbatim (no escaping).
+    "v1:case": {
+        "session_id": "evalbench:job-123:v1:case",
+        "invocation_id": "1916bbd16e0d961e89622a612952e96a",
+        "root_span_id": "9bde893b313678b5",
+        "tool_span_id": "6ab0da7e7d3e8bd4",
+        "completed_span_id": "bd312c799fb82468",
+    },
+    "refund-1": {
+        "session_id": "evalbench:job-123:refund-1",
+        "invocation_id": "c89ad7e24957d27a83c903f2f1e2a372",
+        "root_span_id": "a8bcda92a6445014",
+        "tool_span_id": "0374231379db3981",
+        "completed_span_id": "7dac2cffcd509c0b",
+    },
+}
+
+
+def _golden_run(scenario_id: str) -> EvalBenchRun:
+  return _run(
+      {
+          "eval_id": scenario_id,
+          "prompt": "Prompt",
+          "stdout": json.dumps(
+              {
+                  "response": "done",
+                  "tool_calls": [
+                      {"tool_name": "search", "args": {"q": "x"}, "result": "r"}
+                  ],
+              }
+          ),
+          "returncode": 0,
+          "run_time": _RUN_TIME,
+      }
+  )
+
+
+@pytest.mark.parametrize("scenario_id", sorted(_V051_IDENTITY_VECTORS))
+def test_unversioned_identities_match_v051_golden_vectors(
+    scenario_id: str,
+) -> None:
+  expected = _V051_IDENTITY_VECTORS[scenario_id]
+  rows = _golden_run(scenario_id).to_agent_event_rows()
+  by_type = {row["event_type"]: row for row in rows}
+  assert set(by_type) == {
+      "USER_MESSAGE_RECEIVED",
+      "TOOL_STARTING",
+      "TOOL_COMPLETED",
+      "AGENT_COMPLETED",
+  }
+  assert {row["session_id"] for row in rows} == {expected["session_id"]}
+  assert {row["trace_id"] for row in rows} == {expected["session_id"]}
+  assert {row["invocation_id"] for row in rows} == {expected["invocation_id"]}
+  user = by_type["USER_MESSAGE_RECEIVED"]
+  assert (user["span_id"], user["parent_span_id"]) == (
+      expected["root_span_id"],
+      None,
+  )
+  for event_type in ("TOOL_STARTING", "TOOL_COMPLETED"):
+    assert by_type[event_type]["span_id"] == expected["tool_span_id"]
+    assert by_type[event_type]["parent_span_id"] == expected["root_span_id"]
+  completed = by_type["AGENT_COMPLETED"]
+  assert completed["span_id"] == expected["completed_span_id"]
+  assert completed["parent_span_id"] == expected["root_span_id"]
+
+
+def test_legacy_stable_id_hash_is_frozen() -> None:
+  assert (
+      evalbench._stable_id("evalbench:job-123:case", "invocation", length=32)
+      == _V051_IDENTITY_VECTORS["case"]["invocation_id"]
+  )
+  assert (
+      evalbench._stable_id("evalbench:job-123:case", "user", length=16)
+      == _V051_IDENTITY_VECTORS["case"]["root_span_id"]
+  )
+
+
+def test_published_identities_differ_from_unversioned_ones() -> None:
+  """Publishing a run under a version never reuses a plain-read id, so the
+  two families can coexist in one table without sharing traces or spans."""
+  run = _golden_run("case")
+  plain = run.to_agent_event_rows()
+  published = run.to_agent_event_rows(import_version="v1")
+  for column in ("session_id", "trace_id", "invocation_id", "span_id"):
+    assert {row[column] for row in plain}.isdisjoint(
+        row[column] for row in published
+    ), column
+  assert all(
+      row["session_id"].startswith("evalbench-import:") for row in published
   )
 
 
@@ -1303,8 +1644,8 @@ def test_score_rows_resolve_nested_scenario_ids_like_results() -> None:
   ).to_score_rows(import_version="v1")
   assert [row["scenario_id"] for row in rows] == ["crash-1", "ok-1"]
   assert [row["session_id"] for row in rows] == [
-      "evalbench:job-123:v1:crash-1",
-      "evalbench:job-123:v1:ok-1",
+      "evalbench-import:job-123:v1:crash-1",
+      "evalbench-import:job-123:v1:ok-1",
   ]
 
 
@@ -1370,21 +1711,21 @@ def test_classify_sessions_counts_low_scoring_completed_runs_as_failed() -> (
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
 
   assert set(verdicts) == {
-      "evalbench:job-123:v1:ok-1",
-      "evalbench:job-123:v1:crash-1",
-      "evalbench:job-123:v1:wrong-1",
+      "evalbench-import:job-123:v1:ok-1",
+      "evalbench-import:job-123:v1:crash-1",
+      "evalbench-import:job-123:v1:wrong-1",
   }
-  passed = verdicts["evalbench:job-123:v1:ok-1"]
+  passed = verdicts["evalbench-import:job-123:v1:ok-1"]
   assert passed.failed is False
   assert passed.process_failed is False
   assert passed.score_failed is False
 
-  crashed = verdicts["evalbench:job-123:v1:crash-1"]
+  crashed = verdicts["evalbench-import:job-123:v1:crash-1"]
   assert crashed.failed is True
   assert crashed.process_failed is True
   assert crashed.missing_completion is True
 
-  wrong = verdicts["evalbench:job-123:v1:wrong-1"]
+  wrong = verdicts["evalbench-import:job-123:v1:wrong-1"]
   assert wrong.failed is True
   assert wrong.process_failed is False
   assert wrong.missing_completion is False
@@ -1393,8 +1734,8 @@ def test_classify_sessions_counts_low_scoring_completed_runs_as_failed() -> (
 
   failed = sorted(v.session_id for v in verdicts.values() if v.failed)
   assert failed == [
-      "evalbench:job-123:v1:crash-1",
-      "evalbench:job-123:v1:wrong-1",
+      "evalbench-import:job-123:v1:crash-1",
+      "evalbench-import:job-123:v1:wrong-1",
   ]
 
 
@@ -1403,7 +1744,7 @@ def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
 ):
   run = _scored_run(scores=())
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
-  completed = verdicts["evalbench:job-123:v1:ok-1"]
+  completed = verdicts["evalbench-import:job-123:v1:ok-1"]
   assert completed.process_failed is False
   assert completed.score_failed is True
   assert completed.failed is True
@@ -1412,7 +1753,7 @@ def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
   lenient = _verdicts(
       run, EvalScorePolicy({"goal_completion": 0.5}, missing_score_fails=False)
   )
-  assert lenient["evalbench:job-123:v1:ok-1"].failed is False
+  assert lenient["evalbench-import:job-123:v1:ok-1"].failed is False
 
 
 def test_stderr_is_a_process_failure_even_when_returncode_is_zero() -> None:
@@ -1454,12 +1795,12 @@ def test_stderr_is_a_process_failure_even_when_returncode_is_zero() -> None:
 
   # Python reference: a process failure despite a passing score.
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
-  noisy = verdicts["evalbench:job-123:v1:noisy-1"]
+  noisy = verdicts["evalbench-import:job-123:v1:noisy-1"]
   assert noisy.process_failed is True
   assert noisy.missing_completion is False
   assert noisy.score_failed is False
   assert noisy.failed is True
-  assert verdicts["evalbench:job-123:v1:ok-1"].failed is False
+  assert verdicts["evalbench-import:job-123:v1:ok-1"].failed is False
 
   # SQL path: process failure is any ERROR event in the session, never the
   # exit code, so the published ERROR row above fails the denominator.
@@ -1483,7 +1824,7 @@ def test_classify_sessions_and_sql_collapse_duplicate_comparator_rows() -> None:
   )
   verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
   # One entry per comparator carrying the lowest failing score.
-  assert verdicts["evalbench:job-123:v1:ok-1"].failing_scores == {
+  assert verdicts["evalbench-import:job-123:v1:ok-1"].failing_scores == {
       "goal_completion": 0.1
   }
 
@@ -1502,8 +1843,8 @@ def test_classify_sessions_and_sql_collapse_duplicate_comparator_rows() -> None:
 
 def test_classify_sessions_without_policy_only_uses_process_signals() -> None:
   verdicts = _verdicts(_scored_run(), EvalScorePolicy())
-  assert verdicts["evalbench:job-123:v1:ok-1"].failed is False
-  assert verdicts["evalbench:job-123:v1:crash-1"].failed is True
+  assert verdicts["evalbench-import:job-123:v1:ok-1"].failed is False
+  assert verdicts["evalbench-import:job-123:v1:crash-1"].failed is True
 
 
 def test_failed_sessions_sql_pins_import_version_and_renders_policy() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the EvalBench BigQuery reader and event-row mapper (#97)."""
+"""Tests for the EvalBench reader/mapper (#97) and snapshot importer (#435)."""
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime
 from datetime import timezone
 import json
 
 import pytest
 
+from bigquery_agent_analytics.evalbench import classify_sessions
 from bigquery_agent_analytics.evalbench import EvalBenchRun
+from bigquery_agent_analytics.evalbench import EvalScorePolicy
+from bigquery_agent_analytics.evalbench import failed_sessions_sql
 
 _RUN_TIME = datetime(2026, 4, 29, 12, 30, tzinfo=timezone.utc)
 _EXPECTED_EVENT_COLUMNS = {
@@ -400,3 +404,483 @@ def test_duplicate_scenario_ids_are_rejected() -> None:
 
   with pytest.raises(ValueError, match="duplicate scenario id 'duplicate'"):
     run.to_agent_event_rows()
+
+
+# ---------------------------------------------------------------------------
+# materialize(): atomic, idempotent snapshot into BQAA-owned tables (#435)
+# ---------------------------------------------------------------------------
+
+
+class _FakeJob:
+
+  def __init__(self, rows=(), error: Exception | None = None) -> None:
+    self._rows = list(rows)
+    self._error = error
+
+  def result(self):
+    if self._error is not None:
+      raise self._error
+    return self._rows
+
+
+class _FakeWriteClient:
+  """Records loads, queries, and table DDL issued by ``materialize``."""
+
+  def __init__(
+      self,
+      *,
+      manifest_rows: list[dict] | None = None,
+      load_error: Exception | None = None,
+      transaction_error: Exception | None = None,
+  ) -> None:
+    self.manifest_rows = list(manifest_rows or [])
+    self.load_error = load_error
+    self.transaction_error = transaction_error
+    self.loads: list[tuple[str, list[dict], object]] = []
+    self.queries: list[tuple[str, dict]] = []
+    self.created: list[str] = []
+    self.deleted: list[str] = []
+
+  def create_table(self, table, exists_ok: bool = False):
+    assert exists_ok is True
+    self.created.append(f"{table.project}.{table.dataset_id}.{table.table_id}")
+    return table
+
+  def query(self, query: str, **kwargs) -> _FakeJob:
+    self.queries.append((query, kwargs))
+    if "BEGIN TRANSACTION" in query:
+      return _FakeJob(error=self.transaction_error)
+    if ".evalbench_import_manifest`" in query:
+      return _FakeJob(self.manifest_rows)
+    raise AssertionError(f"unexpected query: {query}")
+
+  def load_table_from_json(self, rows, destination, job_config=None):
+    self.loads.append((destination, list(rows), job_config))
+    return _FakeJob(error=self.load_error)
+
+  def delete_table(self, table_ref: str, not_found_ok: bool = False) -> None:
+    assert not_found_ok is True
+    self.deleted.append(table_ref)
+
+
+def _scored_run(*, extra_result: dict | None = None, scores=None):
+  results = [
+      {
+          "eval_id": "ok-1",
+          "prompt": "Passing scenario",
+          "stdout": json.dumps({"response": "done"}),
+          "returncode": 0,
+          "run_time": _RUN_TIME,
+      },
+      {
+          "eval_id": "crash-1",
+          "prompt": "Crashing scenario",
+          "stdout": "",
+          "stderr": "boom",
+          "returncode": 2,
+          "run_time": _RUN_TIME,
+      },
+  ]
+  if extra_result is not None:
+    results.append(extra_result)
+  if scores is None:
+    scores = (
+        {"eval_id": "ok-1", "comparator": "goal_completion", "score": 1},
+        {"eval_id": "crash-1", "comparator": "goal_completion", "score": 0},
+    )
+  return EvalBenchRun(
+      project_id="source-project",
+      evalbench_dataset="evalbench",
+      job_id="job-123",
+      location="US",
+      results=tuple(results),
+      scores=tuple(scores),
+      config_rows=(
+          {
+              "config": "experiment_config.orchestrator",
+              "value": "geminicli",
+              "run_time": _RUN_TIME,
+          },
+      ),
+  )
+
+
+def _transaction_queries(fake: _FakeWriteClient) -> list[str]:
+  return [sql for sql, _ in fake.queries if "BEGIN TRANSACTION" in sql]
+
+
+def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
+  fake = _FakeWriteClient()
+  run = _scored_run()
+
+  result = run.materialize(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      bq_client=fake,
+  )
+
+  assert result.status == "imported"
+  assert result.events_table == "analytics-project.bqaa.evalbench_agent_events"
+  assert result.scores_table == (
+      "analytics-project.bqaa.evalbench_scores_imported"
+  )
+  assert result.manifest_table == (
+      "analytics-project.bqaa.evalbench_import_manifest"
+  )
+  # Never the ADK plugin's production table, and never the source project.
+  for destination, _, _ in fake.loads:
+    assert destination.startswith("analytics-project.bqaa.evalbench_")
+    assert ".agent_events" not in destination
+  assert all(
+      ref.startswith("analytics-project.bqaa.evalbench_")
+      for ref in fake.created
+  )
+
+  # Every load targets a per-import staging table, not the published one.
+  staged = {destination for destination, _, _ in fake.loads}
+  assert len(staged) == 3
+  assert all("_staging_" in ref for ref in staged)
+  assert set(fake.deleted) == staged
+
+  # Exactly one transaction publishes all three tables; no delete-then-append.
+  transactions = _transaction_queries(fake)
+  assert len(transactions) == 1
+  script = transactions[0]
+  assert script.count("DELETE FROM") == 3
+  assert script.count("INSERT INTO") == 3
+  assert script.index("BEGIN TRANSACTION") < script.index("DELETE FROM")
+  assert script.index("INSERT INTO") < script.index("COMMIT TRANSACTION")
+  assert "job-123" not in script
+  _, kwargs = next(
+      (sql, kw) for sql, kw in fake.queries if "BEGIN TRANSACTION" in sql
+  )
+  params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
+  assert params == {
+      "job_id": "job-123",
+      "import_version": result.import_version,
+  }
+  assert kwargs["job_config"].labels["sdk_feature"] == "evalbench-import"
+  assert kwargs["location"] == "US"
+
+  # Rows are bound to the import version and keep the mapper's contract.
+  event_rows = next(
+      rows for dest, rows, _ in fake.loads if "evalbench_agent_events" in dest
+  )
+  assert {row["import_version"] for row in event_rows} == {
+      result.import_version
+  }
+  assert {row["job_id"] for row in event_rows} == {"job-123"}
+  assert all(row["content"]["text_summary"] for row in event_rows)
+  assert all(
+      row["attributes"]["experiment_id"] == "job-123" for row in event_rows
+  )
+  score_rows = next(
+      rows
+      for dest, rows, _ in fake.loads
+      if "evalbench_scores_imported" in dest
+  )
+  assert {row["session_id"] for row in score_rows} == {
+      "evalbench:job-123:ok-1",
+      "evalbench:job-123:crash-1",
+  }
+  assert {row["comparator"] for row in score_rows} == {"goal_completion"}
+  manifest_rows = next(
+      rows
+      for dest, rows, _ in fake.loads
+      if "evalbench_import_manifest" in dest
+  )
+  assert len(manifest_rows) == 1
+  manifest = manifest_rows[0]
+  assert manifest["job_id"] == "job-123"
+  assert manifest["import_version"] == result.import_version
+  assert manifest["source_project"] == "source-project"
+  assert manifest["source_dataset"] == "evalbench"
+  assert manifest["results_count"] == 2
+  assert manifest["scores_count"] == 2
+  assert manifest["configs_count"] == 1
+  assert manifest["event_row_count"] == len(event_rows)
+  assert manifest["score_row_count"] == len(score_rows)
+  assert manifest["events_table"] == result.events_table
+  assert manifest["scores_table"] == result.scores_table
+  for key in (
+      "results_fingerprint",
+      "scores_fingerprint",
+      "configs_fingerprint",
+  ):
+    assert len(manifest[key]) == 64
+  assert manifest["imported_at"]
+  assert result.manifest == manifest
+
+
+def test_materialize_defaults_target_project_to_source_project() -> None:
+  fake = _FakeWriteClient()
+  result = _scored_run().materialize(target_dataset="bqaa", bq_client=fake)
+  assert result.events_table == "source-project.bqaa.evalbench_agent_events"
+
+
+def test_materialize_same_job_and_version_is_a_noop() -> None:
+  first = _FakeWriteClient()
+  run = _scored_run()
+  imported = run.materialize(target_dataset="bqaa", bq_client=first)
+
+  second = _FakeWriteClient(manifest_rows=[imported.manifest])
+  again = run.materialize(target_dataset="bqaa", bq_client=second)
+
+  assert again.status == "unchanged"
+  assert again.import_version == imported.import_version
+  assert second.loads == []
+  assert _transaction_queries(second) == []
+
+
+def test_materialize_replace_republishes_identical_version() -> None:
+  first = _FakeWriteClient()
+  run = _scored_run()
+  imported = run.materialize(target_dataset="bqaa", bq_client=first)
+
+  second = _FakeWriteClient(manifest_rows=[imported.manifest])
+  again = run.materialize(target_dataset="bqaa", bq_client=second, replace=True)
+
+  assert again.status == "replaced"
+  assert again.import_version == imported.import_version
+  assert len(_transaction_queries(second)) == 1
+
+
+def test_materialize_derived_version_changes_when_source_changes() -> None:
+  base = _scored_run().materialize(
+      target_dataset="bqaa", bq_client=_FakeWriteClient()
+  )
+  changed = _scored_run(
+      extra_result={
+          "eval_id": "late-1",
+          "prompt": "A scenario appended after the first import",
+          "stdout": json.dumps({"response": "late"}),
+          "returncode": 0,
+      }
+  ).materialize(target_dataset="bqaa", bq_client=_FakeWriteClient())
+
+  assert changed.import_version != base.import_version
+  assert changed.manifest["results_fingerprint"] != (
+      base.manifest["results_fingerprint"]
+  )
+  assert changed.manifest["scores_fingerprint"] == (
+      base.manifest["scores_fingerprint"]
+  )
+
+
+def test_materialize_fingerprint_ignores_source_row_order() -> None:
+  run = _scored_run()
+  reordered = dataclasses.replace(
+      run,
+      results=tuple(reversed(run.results)),
+      scores=tuple(reversed(run.scores)),
+  )
+  first = run.materialize(target_dataset="bqaa", bq_client=_FakeWriteClient())
+  second = reordered.materialize(
+      target_dataset="bqaa", bq_client=_FakeWriteClient()
+  )
+  assert first.import_version == second.import_version
+
+
+def test_materialize_explicit_version_rejects_changed_source() -> None:
+  first = _FakeWriteClient()
+  imported = _scored_run().materialize(
+      target_dataset="bqaa", import_version="v1", bq_client=first
+  )
+  assert imported.import_version == "v1"
+
+  changed = _scored_run(
+      extra_result={
+          "eval_id": "late-1",
+          "prompt": "Appended after v1 was imported",
+          "stdout": json.dumps({"response": "late"}),
+      }
+  )
+  second = _FakeWriteClient(manifest_rows=[imported.manifest])
+  with pytest.raises(ValueError, match="fingerprint"):
+    changed.materialize(
+        target_dataset="bqaa", import_version="v1", bq_client=second
+    )
+  assert second.loads == []
+  assert _transaction_queries(second) == []
+
+
+def test_materialize_staging_failure_leaves_target_untouched() -> None:
+  fake = _FakeWriteClient(load_error=RuntimeError("load failed"))
+  with pytest.raises(RuntimeError, match="load failed"):
+    _scored_run().materialize(target_dataset="bqaa", bq_client=fake)
+
+  assert _transaction_queries(fake) == []
+  # Staging tables are always cleaned up.
+  assert fake.deleted
+
+
+def test_materialize_transaction_failure_drops_staging_and_raises() -> None:
+  fake = _FakeWriteClient(transaction_error=RuntimeError("commit failed"))
+  with pytest.raises(RuntimeError, match="commit failed"):
+    _scored_run().materialize(target_dataset="bqaa", bq_client=fake)
+  staged = {destination for destination, _, _ in fake.loads}
+  assert set(fake.deleted) == staged
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("target_project", "bad.project"),
+        ("target_dataset", "bqaa`; DROP TABLE x; --"),
+        ("events_table", "agent events"),
+        ("scores_table", "scores;"),
+    ],
+)
+def test_materialize_rejects_unsafe_target_identifiers(
+    field: str, value: str
+) -> None:
+  kwargs = {"target_dataset": "bqaa", "bq_client": _FakeWriteClient()}
+  kwargs[field] = value
+  with pytest.raises(ValueError, match=field):
+    _scored_run().materialize(**kwargs)
+
+
+def test_from_bigquery_snapshot_reads_all_sources_as_of_one_timestamp() -> None:
+  fake = _FakeBigQueryClient({"results": [], "scores": [], "configs": []})
+  snapshot = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+
+  run = EvalBenchRun.from_bigquery(
+      project_id="source-project",
+      evalbench_dataset="evalbench",
+      job_id="job-123",
+      snapshot_at=snapshot,
+      bq_client=fake,
+  )
+
+  assert run.snapshot_at == snapshot
+  assert len(fake.calls) == 3
+  for query, kwargs in fake.calls:
+    assert "FOR SYSTEM_TIME AS OF @snapshot_at" in query
+    params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
+    assert params["snapshot_at"] == snapshot
+
+
+def test_materialize_records_snapshot_timestamp_in_manifest() -> None:
+  snapshot = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+  run = dataclasses.replace(_scored_run(), snapshot_at=snapshot)
+  result = run.materialize(target_dataset="bqaa", bq_client=_FakeWriteClient())
+  assert result.manifest["source_snapshot_at"] == snapshot.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Failed-session denominator (W0.4): returncode 0 means completed, not passed
+# ---------------------------------------------------------------------------
+
+
+def _verdicts(run: EvalBenchRun, policy: EvalScorePolicy):
+  return {
+      verdict.session_id: verdict
+      for verdict in classify_sessions(
+          run.to_agent_event_rows(),
+          run.to_score_rows(import_version="v1"),
+          policy,
+      )
+  }
+
+
+def test_classify_sessions_counts_low_scoring_completed_runs_as_failed() -> (
+    None
+):
+  run = _scored_run(
+      extra_result={
+          "eval_id": "wrong-1",
+          "prompt": "Completed but wrong answer",
+          "stdout": json.dumps({"response": "42"}),
+          "returncode": 0,
+      },
+      scores=(
+          {"eval_id": "ok-1", "comparator": "goal_completion", "score": 1},
+          {"eval_id": "crash-1", "comparator": "goal_completion", "score": 0},
+          {"eval_id": "wrong-1", "comparator": "goal_completion", "score": 0.2},
+      ),
+  )
+  verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
+
+  assert set(verdicts) == {
+      "evalbench:job-123:ok-1",
+      "evalbench:job-123:crash-1",
+      "evalbench:job-123:wrong-1",
+  }
+  passed = verdicts["evalbench:job-123:ok-1"]
+  assert passed.failed is False
+  assert passed.process_failed is False
+  assert passed.score_failed is False
+
+  crashed = verdicts["evalbench:job-123:crash-1"]
+  assert crashed.failed is True
+  assert crashed.process_failed is True
+  assert crashed.missing_completion is True
+
+  wrong = verdicts["evalbench:job-123:wrong-1"]
+  assert wrong.failed is True
+  assert wrong.process_failed is False
+  assert wrong.missing_completion is False
+  assert wrong.score_failed is True
+  assert wrong.failing_scores == {"goal_completion": 0.2}
+
+  failed = sorted(v.session_id for v in verdicts.values() if v.failed)
+  assert failed == ["evalbench:job-123:crash-1", "evalbench:job-123:wrong-1"]
+
+
+def test_classify_sessions_returncode_zero_without_scores_is_not_a_pass() -> (
+    None
+):
+  run = _scored_run(scores=())
+  verdicts = _verdicts(run, EvalScorePolicy({"goal_completion": 0.5}))
+  completed = verdicts["evalbench:job-123:ok-1"]
+  assert completed.process_failed is False
+  assert completed.score_failed is True
+  assert completed.failed is True
+  assert completed.failing_scores == {"goal_completion": None}
+
+  lenient = _verdicts(
+      run, EvalScorePolicy({"goal_completion": 0.5}, missing_score_fails=False)
+  )
+  assert lenient["evalbench:job-123:ok-1"].failed is False
+
+
+def test_classify_sessions_without_policy_only_uses_process_signals() -> None:
+  verdicts = _verdicts(_scored_run(), EvalScorePolicy())
+  assert verdicts["evalbench:job-123:ok-1"].failed is False
+  assert verdicts["evalbench:job-123:crash-1"].failed is True
+
+
+def test_failed_sessions_sql_pins_import_version_and_renders_policy() -> None:
+  sql = failed_sessions_sql(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      policy=EvalScorePolicy({"goal_completion": 0.5, "sql_correctness": 1.0}),
+  )
+
+  assert "`analytics-project.bqaa.evalbench_agent_events`" in sql
+  assert "`analytics-project.bqaa.evalbench_scores_imported`" in sql
+  assert sql.count("import_version = @import_version") >= 2
+  assert sql.count("job_id = @job_id") >= 2
+  assert "STRUCT('goal_completion' AS comparator, 0.5 AS min_score)" in sql
+  assert "STRUCT('sql_correctness' AS comparator, 1.0 AS min_score)" in sql
+  assert "status = 'ERROR'" in sql
+  assert "event_type = 'AGENT_COMPLETED'" in sql
+  # Completion is never inferred from the process exit code.
+  assert "returncode" not in sql
+
+
+def test_failed_sessions_sql_rejects_unsafe_comparator_names() -> None:
+  with pytest.raises(ValueError, match="comparator"):
+    failed_sessions_sql(
+        target_project="p",
+        target_dataset="d",
+        policy=EvalScorePolicy({"x' OR 1=1 --": 0.5}),
+    )
+
+
+def test_failed_sessions_sql_without_policy_still_counts_process_failures() -> (
+    None
+):
+  sql = failed_sessions_sql(target_project="p", target_dataset="d")
+  assert "status = 'ERROR'" in sql
+  assert "min_score" not in sql


### PR DESCRIPTION
## Summary
Slice 1 of #435: BQAA-owned EvalBench snapshot writer + failed-session contract (#97 subset).

- `EvalBenchRun.materialize()` writes versioned `evalbench_agent_events`, `evalbench_scores_imported`, and `evalbench_import_manifest` (never the default ADK `agent_events` table).
- Atomic publish via staging tables + a single transaction keyed on `(job_id, import_version)`.
- Failed-session contract: `EvalScorePolicy`, `classify_sessions()`, `failed_sessions_sql()`. `returncode==0` means completed, not passed.
- CLI: `bq-agent-sdk evalbench-import`.

## Out of scope (deliberate)
Taxonomy, localization/#429, KramaBench/LakeQA/Spider harnesses, dashboards, D4, live-trace smoke (`BQAA_LIVE`).

## Test plan
- [x] 39 new unit tests in `tests/test_evalbench_importer.py` and `tests/test_cli_evalbench_import.py`
- [ ] Reviewers (Codex, Kimi) review this PR on GitHub
- [ ] Human: partner job / D4 still blocked; do not start the 6-week clock

Closes nothing yet. Progress on #435 / #97.