### PR TITLE
feat(evalbench): failed_sessions view and version-pinned consumer (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **EvalBench failed-session view and version-pinned consumer (#435, slice 2)**
+  — `EvalBenchRun.materialize()` now keeps an `evalbench_failed_sessions`
+  view in the target dataset pinned (as literals) to the job's latest
+  successful import, so SQL consumers never scan another `import_version`;
+  `failed_sessions()` / `bq-agent-sdk evalbench-failed-sessions` list the
+  failed sessions of exactly one published version, resolving the version
+  from the manifest before reading events, and each row's versioned
+  `session_id`/`trace_id` (`EvalBenchSession.trace_selector()`) drills into
+  `Client.get_session_trace` without mixing versions. `failed_sessions_sql()`
+  accepts `job_id=`/`import_version=` to render the pin as literals.
+
 ## [0.5.1] - 2026-08-29
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `session_id`/`trace_id` (`EvalBenchSession.trace_selector()`) drills into
   `Client.get_session_trace` without mixing versions. `failed_sessions_sql()`
   accepts `job_id=`/`import_version=` to render the pin as literals. The
-  view's pin comment carries the rendered score policy and a hash of the
-  query below it, so ownership is proven by the definition (a copied pin
-  over other SQL, or an edited managed view, is refused, never replaced),
-  a same-version re-import that adds, changes, or drops the policy
-  re-renders the gate, and the view is written with create-if-absent plus
-  ETag-conditional replace after re-reading the view and latest manifest,
-  so concurrent imports cannot overwrite a newer pin.
+  view's pin comment carries the manifest generation (`imported_at`) and
+  the rendered score policy, and ownership is proven by re-rendering the
+  definition from the committed manifest row and comparing byte-for-byte
+  (a copied pin over other SQL, or an edited or reformatted managed view,
+  is refused, never replaced); a same-version re-import that adds,
+  changes, or drops the policy re-renders the gate, only the import that
+  committed the latest generation decides it, and the view is written with
+  create-if-absent plus ETag-conditional replace after re-reading the view
+  and latest manifest, so concurrent imports cannot overwrite a newer pin
+  or attach an older caller's policy to a newer generation.
 
 ## [0.5.1] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `session_id`/`trace_id` (`EvalBenchSession.trace_selector()`) drills into
   `Client.get_session_trace` without mixing versions. `failed_sessions_sql()`
   accepts `job_id=`/`import_version=` to render the pin as literals. The
-  view's pin comment carries the manifest generation (`imported_at`) and
-  the rendered score policy, and ownership is proven by re-rendering the
-  definition from the committed manifest row and comparing byte-for-byte
-  (a copied pin over other SQL, or an edited or reformatted managed view,
-  is refused, never replaced); a same-version re-import that adds,
-  changes, or drops the policy re-renders the gate, only the import that
-  committed the latest generation decides it, and the view is written with
-  create-if-absent plus ETag-conditional replace after re-reading the view
-  and latest manifest, so concurrent imports cannot overwrite a newer pin
-  or attach an older caller's policy to a newer generation.
+  gate and generation are committed manifest state: every publish mints
+  an opaque `generation_id` (caller-supplied `imported_at` may repeat and
+  is not the generation) and records the score policy as `view_policy`,
+  a same-version `unchanged` re-import that adds, changes, or drops the
+  policy commits it to the row it found under a new generation, and the
+  view is always rendered from the latest manifest row. The view's pin
+  comment names the generation and the rendered policy, and ownership is
+  proven by re-rendering the definition from the committed manifest row
+  and comparing byte-for-byte (a copied pin over other SQL, an edited or
+  reformatted managed view, or a canonical rendering of the current
+  generation under a gate the manifest does not record, is refused, never
+  replaced). The view is written with create-if-absent plus
+  ETag-conditional replace after re-reading the view and latest manifest,
+  so concurrent imports cannot overwrite a newer pin or attach an older
+  caller's policy to a newer generation.
 
 ## [0.5.1] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the manifest before reading events, and each row's versioned
   `session_id`/`trace_id` (`EvalBenchSession.trace_selector()`) drills into
   `Client.get_session_trace` without mixing versions. `failed_sessions_sql()`
-  accepts `job_id=`/`import_version=` to render the pin as literals.
+  accepts `job_id=`/`import_version=` to render the pin as literals. The
+  view's pin comment carries the rendered score policy and a hash of the
+  query below it, so ownership is proven by the definition (a copied pin
+  over other SQL, or an edited managed view, is refused, never replaced),
+  a same-version re-import that adds, changes, or drops the policy
+  re-renders the gate, and the view is written with create-if-absent plus
+  ETag-conditional replace after re-reading the view and latest manifest,
+  so concurrent imports cannot overwrite a newer pin.
 
 ## [0.5.1] - 2026-08-29
 

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -301,7 +301,9 @@ The manifest row binds every published version to its source:
 | `results_fingerprint`, `scores_fingerprint`, `configs_fingerprint` | SHA-256 content fingerprints |
 | `events_table`, `scores_table` | fully-qualified published tables |
 | `event_row_count`, `score_row_count` | rows published |
-| `imported_at` | publish timestamp (UTC) |
+| `imported_at` | publish timestamp (UTC; caller-supplied via `imported_at=`, so two publishes may share it) |
+| `generation_id` | opaque id of this committed generation of the row: minted by every publish (a `replace=True` of the same version label included) and by every committed change of `view_policy`; never shared |
+| `view_policy` | the score gate the failed-session view renders for this version (canonical JSON of the `EvalScorePolicy`, `NULL` for none) — committed manifest state, never taken from the view |
 
 `EvalBenchImportResult.manifest` returns the same row in memory.
 
@@ -367,7 +369,7 @@ the definition itself, and the view can never scan another version. The
 view's query text (its description names the pinned version too) is:
 
 ```sql
--- evalbench_failed_sessions pin: {"import_version": "v2", "imported_at": "2026-08-30T17:04:11.512034+00:00", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}}
+-- evalbench_failed_sessions pin: {"generation_id": "3f9c2c1e0b7a4d6e9a1b5c8d7e6f4a2b", "import_version": "v2", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}}
 WITH sessions AS (
   SELECT ...
   FROM `analytics-project.bqaa.evalbench_agent_events`
@@ -376,13 +378,22 @@ WITH sessions AS (
 ```
 
 The pin records the job, the version, the manifest generation it renders
-(`imported_at`, in UTC with microseconds — a `replace=True` of the same
-version label is a new generation), and the score policy rendered into
-the view (`null` without one). Nothing the view says about itself proves
-ownership: the importer treats a view as its own only when the pin names
-a version that job committed to the manifest *and* the body is
-byte-for-byte what the importer renders for that manifest row, generation
-and policy. The comparison is exact — BigQuery returns a view's query text
+(`generation_id`, the row's opaque id — a `replace=True` of the same
+version label is a new generation, and so is a committed policy change;
+`imported_at` is caller-chosen and may repeat, so it is not the
+generation), and the score policy rendered into the view (`null` without
+one). The view body is a pure function of the latest manifest row: the
+gate it renders is the row's committed `view_policy`, never something the
+view says about itself. Nothing in the pin proves ownership: the importer
+treats a view as its own only when the pin names a version that job
+committed to the manifest *and* the body is byte-for-byte what the
+importer renders for that manifest row — with the row's own `view_policy`
+when the pin names the row's current `generation_id`, so a canonical
+rendering of the current generation under any other gate is foreign; or,
+for a view a superseded generation left behind, the pinned generation and
+policy over the row's own tables, in which case the view is only ever
+advanced to the committed rendering, so whatever gate it carries is never
+preserved. The comparison is exact — BigQuery returns a view's query text
 verbatim, and whitespace inside a rendered literal (`job_id = "job  x"`
 versus `"job x"`) changes which rows the view reads, so no whitespace
 normalization is applied. A pin copied or forged onto other SQL (however
@@ -401,9 +412,10 @@ Pinning rules:
 | New `import_version` of the same job | replaced, pinned to the new version (the job's latest `imported_at` in the manifest) |
 | No-op re-import (`unchanged`) | untouched; created only if it does not exist yet (corpora published before views existed) |
 | `replace=True` of an older version | re-pinned to it — the replace refreshed `imported_at`, so it *is* the latest successful import |
-| `policy=` / `--min-score` given, changed, or dropped | the score gate is part of the pin: the view is re-rendered whenever the policy differs from the one it carries (including a later same-version call *without* a policy, which removes the gate), and left alone when version and policy both match |
-| `policy=` on a call whose version is **not** the latest import | the gate is decided by the import of the version the view pins: a view already pinned to the latest version is left exactly as it is, and a view that is absent or behind is created or advanced carrying the gate it already had (none for a new view), never this call's |
-| `policy=` on a call whose *generation* is not the one the manifest holds (a concurrent `replace=True` of the same version committed a newer `imported_at`) | as above: the version label does not decide, the generation does. Every generation is rendered into the pin, so the newer replacement always rewrites the view (bumping its ETag) even when version, gate and SQL are otherwise identical; a delayed older caller's conditional replace then fails, re-reads, and leaves the newer generation's gate in place |
+| `policy=` / `--min-score` given, changed, or dropped | the gate is committed to the manifest row (`view_policy`): a publish records it with the row, and an `unchanged` re-import that names another gate commits it to the row it found — under a new `generation_id`, and only if that row is still the generation it found — before the view is re-rendered from the row (including a later same-version call *without* a policy, which removes the gate); nothing is written when version and policy both match |
+| `policy=` on a call whose version is **not** the latest import | the gate is recorded on that version's own row; the view renders the latest version's row, so a view already pinned to the latest generation is left exactly as it is, and a view that is absent or behind is created or advanced carrying the latest row's committed gate (never this call's, and never the gate the stale view happened to carry) |
+| `policy=` on a call whose *generation* is not the one the manifest holds (a concurrent `replace=True` of the same version — even with the same `imported_at` — committed a newer `generation_id`) | as above: neither the version label nor the timestamp decides, the committed generation does. Every generation is rendered into the pin, so the newer replacement always rewrites the view (bumping its ETag) even when version, gate and SQL are otherwise identical; a delayed older caller's conditional replace then fails, re-reads, and renders the newer generation's committed gate |
+| A view at that name that *is* the importer's rendering of the current generation, but under a gate the manifest row does not record | `ValueError` before anything is written, from every later call (an older version's unchanged re-import included): the view cannot vouch for its own gate, only the manifest can |
 | View at that name pinned to **another job** | `ValueError` before anything is written; use one `failed_sessions_view` name per job |
 | A table, a view the importer did not create, a copied pin over other SQL, or a managed view whose query was edited, at that name | `ValueError` before anything is written (before the import tables are even created); the importer never replaces objects whose definition it cannot vouch for — drop the object or pick another name |
 | Two imports of one job race on the view | the loser of the create race (`409`) or ETag check (`412`) re-reads the view and the latest manifest and re-decides, up to three times, so a delayed writer never overwrites a newer pin — nor re-renders it with its own (older) policy; a race against **another job's** view fails closed with the import already published |

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -363,19 +363,27 @@ overridable with `failed_sessions_view=` / `--failed-sessions-view`, or
 `None` / `--skip-failed-sessions-view` to manage no view — whose body is
 `failed_sessions_sql()` with `@job_id` and `@import_version` rendered as
 string literals. Views cannot take query parameters, so the pin lives in
-the definition itself, and the view can never scan another version:
+the definition itself, and the view can never scan another version. The
+view's query text (its description names the pinned version too) is:
 
 ```sql
-CREATE OR REPLACE VIEW `analytics-project.bqaa.evalbench_failed_sessions`
-OPTIONS (description = "EvalBench failed sessions (W0.4 contract) pinned to job_id 'abc123' import_version 'v2'; ...")
-AS
--- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123"}
+-- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}, "query_sha256": "…"}
 WITH sessions AS (
   SELECT ...
   FROM `analytics-project.bqaa.evalbench_agent_events`
   WHERE job_id = "abc123" AND import_version = "v2"
   ...
 ```
+
+The pin records the job, the version, the score policy rendered into the
+view (`null` without one), and the SHA-256 of the query below it. The
+comment alone never proves ownership: the importer treats a view as its
+own only when the query hashes to what the pin says — a pin copied onto
+other SQL, or a managed view whose body somebody edited, is a foreign
+object and is refused. The importer never uses `CREATE OR REPLACE VIEW`;
+it creates the view with create-if-absent and replaces it with an
+ETag-conditional update, after re-reading both the view and the latest
+manifest row immediately before writing.
 
 Pinning rules:
 
@@ -385,18 +393,21 @@ Pinning rules:
 | New `import_version` of the same job | replaced, pinned to the new version (the job's latest `imported_at` in the manifest) |
 | No-op re-import (`unchanged`) | untouched; created only if it does not exist yet (corpora published before views existed) |
 | `replace=True` of an older version | re-pinned to it — the replace refreshed `imported_at`, so it *is* the latest successful import |
-| `policy=` / `--min-score` given | the score gate is rendered into the view (and re-rendered on every call, since the policy is not part of the pin); a later call *without* a policy leaves the rendered gate in place when the pin is unchanged |
+| `policy=` / `--min-score` given, changed, or dropped | the score gate is part of the pin: the view is re-rendered whenever the policy differs from the one it carries (including a later same-version call *without* a policy, which removes the gate), and left alone when version and policy both match |
 | View at that name pinned to **another job** | `ValueError` before anything is written; use one `failed_sessions_view` name per job |
-| A table, or a view the importer did not create, at that name | `ValueError` before anything is written; the importer never replaces objects it does not own |
+| A table, a view the importer did not create, a copied pin over other SQL, or a managed view whose query was edited, at that name | `ValueError` before anything is written (before the import tables are even created); the importer never replaces objects whose definition it cannot vouch for — drop the object or pick another name |
+| Two imports of one job race on the view | the loser of the create race (`409`) or ETag check (`412`) re-reads the view and the latest manifest and re-decides, up to three times, so a delayed writer never overwrites a newer pin; a race against **another job's** view fails closed with the import already published |
 
 "Latest successful import" is the manifest row with the newest
 `imported_at` (ties broken by `import_version`), which is also what the
 Python consumer below resolves when no version is pinned, so the two agree.
-The view is rewritten only when its pin or policy changes and is issued
-after the publish transaction committed; if the DDL fails (for example a
-missing `bigquery.tables.update` permission) `materialize()` raises a
-`ValueError` naming the published version, and simply re-running it retries
-the view (`status == "unchanged"`). A specific older version is queried
+The view is rewritten only when its rendered definition (pinned version,
+policy, or SQL) would change, and is written after the publish transaction
+committed; if the write fails (for example a missing
+`bigquery.tables.update` permission, or a view that kept changing
+underneath the conditional replace) `materialize()` raises a `ValueError`
+naming the published version, and simply re-running it retries the view
+(`status == "unchanged"`). A specific older version is queried
 with the parameterized `failed_sessions_sql()` shown above or with
 `failed_sessions(import_version=...)`.
 

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -367,7 +367,7 @@ the definition itself, and the view can never scan another version. The
 view's query text (its description names the pinned version too) is:
 
 ```sql
--- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}, "query_sha256": "…"}
+-- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}}
 WITH sessions AS (
   SELECT ...
   FROM `analytics-project.bqaa.evalbench_agent_events`
@@ -375,15 +375,18 @@ WITH sessions AS (
   ...
 ```
 
-The pin records the job, the version, the score policy rendered into the
-view (`null` without one), and the SHA-256 of the query below it. The
-comment alone never proves ownership: the importer treats a view as its
-own only when the query hashes to what the pin says — a pin copied onto
-other SQL, or a managed view whose body somebody edited, is a foreign
-object and is refused. The importer never uses `CREATE OR REPLACE VIEW`;
-it creates the view with create-if-absent and replaces it with an
-ETag-conditional update, after re-reading both the view and the latest
-manifest row immediately before writing.
+The pin records the job, the version, and the score policy rendered into
+the view (`null` without one). Nothing the view says about itself proves
+ownership: the importer treats a view as its own only when the pin names
+a version that job committed to the manifest *and* the body is exactly
+(modulo whitespace) what the importer renders for that manifest row and
+policy. A pin copied or forged onto other SQL (however self-consistent), a
+contract-shaped body for an unpublished version or over other tables, or
+a managed view whose body somebody edited, is a foreign object and is
+refused. The importer never uses `CREATE OR REPLACE VIEW`; it creates the
+view with create-if-absent and replaces it with an ETag-conditional
+update, after re-reading both the view and the latest manifest row
+immediately before writing.
 
 Pinning rules:
 
@@ -394,9 +397,10 @@ Pinning rules:
 | No-op re-import (`unchanged`) | untouched; created only if it does not exist yet (corpora published before views existed) |
 | `replace=True` of an older version | re-pinned to it — the replace refreshed `imported_at`, so it *is* the latest successful import |
 | `policy=` / `--min-score` given, changed, or dropped | the score gate is part of the pin: the view is re-rendered whenever the policy differs from the one it carries (including a later same-version call *without* a policy, which removes the gate), and left alone when version and policy both match |
+| `policy=` on a call whose version is **not** the latest import | the gate is decided by the import of the version the view pins: a view already pinned to the latest version is left exactly as it is, and a view that is absent or behind is created or advanced carrying the gate it already had (none for a new view), never this call's |
 | View at that name pinned to **another job** | `ValueError` before anything is written; use one `failed_sessions_view` name per job |
 | A table, a view the importer did not create, a copied pin over other SQL, or a managed view whose query was edited, at that name | `ValueError` before anything is written (before the import tables are even created); the importer never replaces objects whose definition it cannot vouch for — drop the object or pick another name |
-| Two imports of one job race on the view | the loser of the create race (`409`) or ETag check (`412`) re-reads the view and the latest manifest and re-decides, up to three times, so a delayed writer never overwrites a newer pin; a race against **another job's** view fails closed with the import already published |
+| Two imports of one job race on the view | the loser of the create race (`409`) or ETag check (`412`) re-reads the view and the latest manifest and re-decides, up to three times, so a delayed writer never overwrites a newer pin — nor re-renders it with its own (older) policy; a race against **another job's** view fails closed with the import already published |
 
 "Latest successful import" is the manifest row with the newest
 `imported_at` (ties broken by `import_version`), which is also what the

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -9,8 +9,10 @@ never writes into the ADK plugin's production `agent_events` table.
 This covers the reader and deterministic row mapping from
 [issue #97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97)
 and the MVP snapshot + failed-session denominator from
-[issue #435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435).
-Localization, failure taxonomy, and other harnesses are later slices.
+[issue #435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435):
+the versioned writer (slice 1) and the queryable `evalbench_failed_sessions`
+view plus version-pinned consumer (slice 2). Localization, failure taxonomy,
+and other harnesses are later slices.
 
 ## Data Flow
 
@@ -20,8 +22,11 @@ EvalBench BigQuery dataset                BQAA-owned target dataset
 configs  -- job_id = @job_id --+          evalbench_agent_events
 results  -- job_id = @job_id --+--> EvalBenchRun --> evalbench_scores_imported
 scores   -- job_id = @job_id --+   (in memory)      evalbench_import_manifest
-                                                     ^
+                                                     ^         |
                               one transaction per (job_id, import_version)
+                                                               v
+                                          evalbench_failed_sessions (VIEW,
+                                          pinned to the job's latest import)
 ```
 
 All three source queries filter by the parameterized `job_id` in SQL. The
@@ -176,6 +181,7 @@ publishes through a fourth, fixed lock table:
 | Scores | `evalbench_scores_imported` | `job_id`, `import_version`, `scenario_id`, `session_id`, `comparator`, `score FLOAT64`, `source_row JSON` (the verbatim EvalBench score row) |
 | Manifest | `evalbench_import_manifest` (fixed) | one row per `(job_id, import_version)` — see below |
 | Lock | `evalbench_import_lock` (fixed) | one sentinel row (`lock_id = 'evalbench-import'`, `claim_count`, `claimed_at`, `claimed_job_id`, `claimed_import_version`) that every publish transaction updates first |
+| Failed sessions | `evalbench_failed_sessions` (view) | `failed_sessions_sql()` pinned to the job's latest successful import — see [Queryable view](#queryable-view) |
 
 The extra event columns are appended after the `agent_events` contract, so
 `Client.get_session_trace` and the other explicit-column readers work
@@ -348,6 +354,113 @@ threshold, with the offending score or `NULL`).
 reference implementation of the same contract over `to_agent_event_rows()`
 and `to_score_rows()` output; the unit tests pin the two to each other.
 
+### Queryable view
+
+Every successful `materialize()` call (`imported`, `replaced`, *and*
+`unchanged`) also keeps one view in the target dataset — default name
+`evalbench_failed_sessions` (`evalbench.DEFAULT_FAILED_SESSIONS_VIEW`),
+overridable with `failed_sessions_view=` / `--failed-sessions-view`, or
+`None` / `--skip-failed-sessions-view` to manage no view — whose body is
+`failed_sessions_sql()` with `@job_id` and `@import_version` rendered as
+string literals. Views cannot take query parameters, so the pin lives in
+the definition itself, and the view can never scan another version:
+
+```sql
+CREATE OR REPLACE VIEW `analytics-project.bqaa.evalbench_failed_sessions`
+OPTIONS (description = "EvalBench failed sessions (W0.4 contract) pinned to job_id 'abc123' import_version 'v2'; ...")
+AS
+-- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123"}
+WITH sessions AS (
+  SELECT ...
+  FROM `analytics-project.bqaa.evalbench_agent_events`
+  WHERE job_id = "abc123" AND import_version = "v2"
+  ...
+```
+
+Pinning rules:
+
+| Situation | View |
+|---|---|
+| First import of a job | created, pinned to that version |
+| New `import_version` of the same job | replaced, pinned to the new version (the job's latest `imported_at` in the manifest) |
+| No-op re-import (`unchanged`) | untouched; created only if it does not exist yet (corpora published before views existed) |
+| `replace=True` of an older version | re-pinned to it — the replace refreshed `imported_at`, so it *is* the latest successful import |
+| `policy=` / `--min-score` given | the score gate is rendered into the view (and re-rendered on every call, since the policy is not part of the pin); a later call *without* a policy leaves the rendered gate in place when the pin is unchanged |
+| View at that name pinned to **another job** | `ValueError` before anything is written; use one `failed_sessions_view` name per job |
+| A table, or a view the importer did not create, at that name | `ValueError` before anything is written; the importer never replaces objects it does not own |
+
+"Latest successful import" is the manifest row with the newest
+`imported_at` (ties broken by `import_version`), which is also what the
+Python consumer below resolves when no version is pinned, so the two agree.
+The view is rewritten only when its pin or policy changes and is issued
+after the publish transaction committed; if the DDL fails (for example a
+missing `bigquery.tables.update` permission) `materialize()` raises a
+`ValueError` naming the published version, and simply re-running it retries
+the view (`status == "unchanged"`). A specific older version is queried
+with the parameterized `failed_sessions_sql()` shown above or with
+`failed_sessions(import_version=...)`.
+
+### Version-pinned consumer
+
+`failed_sessions()` lists the failed sessions of exactly one published
+version and never mixes two:
+
+```python
+from bigquery_agent_analytics.evalbench import EvalScorePolicy, failed_sessions
+
+listing = failed_sessions(
+    target_project="analytics-project",
+    target_dataset="bqaa",
+    job_id="abc123",
+    # import_version="v1",   # pin one version; default: latest successful import
+    policy=EvalScorePolicy({"goal_completion": 0.5}),
+)
+print(listing.import_version, listing.failed_count, "of", listing.session_count)
+for session in listing.sessions:
+    print(session.session_id, session.scenario_id, session.failing_scores)
+```
+
+The version is resolved from the manifest *before* any event row is read:
+an explicit `import_version` must have a manifest row (otherwise
+`ValueError`), and the default is the job's latest successful import. The
+query is `failed_sessions_sql()` over the `events_table`/`scores_table`
+recorded in that manifest row (a version stays bound to the tables it was
+published to), executed with `import_query_parameters(job_id,
+import_version)`. `EvalBenchFailedSessions.sessions` holds the failed rows
+(`include_passed=True` returns every session); each `EvalBenchSession`
+carries `job_id`, `import_version`, the versioned `session_id`/`trace_id`,
+`scenario_id`, `started_at`, the four flags, and `failing_scores`.
+`EvalBenchSession.verdict()` is the matching `SessionVerdict`, so the
+listing is interchangeable with `classify_sessions()` output.
+
+### Drill-down without mixing versions
+
+Published rows use the version-specific identity
+`evalbench-import:{job_id}:{import_version}:{scenario_id}` for both
+`session_id` and `trace_id`, so a `Client` pointed at the mirror table
+resolves one version by construction — there is no other version under
+that identity to merge:
+
+```python
+from bigquery_agent_analytics import Client
+
+client = Client(
+    project_id="analytics-project",
+    dataset_id="bqaa",
+    table_id="evalbench_agent_events",   # the mirror table, never agent_events
+)
+for session in listing.sessions:
+    trace = client.get_session_trace(**session.trace_selector())
+    # equivalently: trace = session.get_trace(client)
+```
+
+`trace_selector()` returns `{"session_id": ..., "experiment_id": job_id}`:
+the session id already pins the import version, and the `experiment_id`
+pin matches `attributes.experiment_id` on every published row, so the
+selector is unambiguous for the identity-resolving reader. Extra
+`get_session_trace` keyword arguments (for example `event_types=`) pass
+through `session.get_trace(client, ...)`.
+
 ## CLI
 
 ```bash
@@ -359,12 +472,32 @@ bq-agent-sdk evalbench-import \
   [--location US] [--format json|text|table]
 ```
 
-The command prints the `EvalBenchImportResult` (including the manifest) and
-exits `0` for `imported`, `replaced`, or `unchanged`, and `2` on invalid
-input (including `--events-table agent_events`, which is rejected before any
-BigQuery call), a changed source under an explicit `--import-version`, a
-version already bound to other destination tables, or a BigQuery error. There
-is no `evalbench-score` command.
+The command prints the `EvalBenchImportResult` (including the manifest and
+the `failed_sessions_view` it left pinned) and exits `0` for `imported`,
+`replaced`, or `unchanged`, and `2` on invalid input (including
+`--events-table agent_events` or a malformed `--min-score`, both rejected
+before any BigQuery call), a changed source under an explicit
+`--import-version`, a version already bound to other destination tables, a
+failed-session view at that name that belongs to another job, or a BigQuery
+error. `--failed-sessions-view NAME` picks the view name,
+`--skip-failed-sessions-view` manages none, and repeatable
+`--min-score COMPARATOR=MIN_SCORE` (with `--missing-score-passes` to relax
+the missing-score rule) renders an `EvalScorePolicy` into the view.
+
+```bash
+bq-agent-sdk evalbench-failed-sessions \
+  --project-id analytics-project --target-dataset bqaa --job-id abc123 \
+  [--import-version v1] [--min-score goal_completion=0.5]... \
+  [--missing-score-passes] [--include-passed] \
+  [--location US] [--format json|text|table]
+```
+
+Prints the `EvalBenchFailedSessions` listing (`--format table` prints one
+row per session) for exactly one published version — the job's latest
+successful import unless `--import-version` pins one — and exits `0` when
+the listing was produced (possibly empty) or `2` on invalid input, a job or
+version with no published import, or a BigQuery error. There is no
+`evalbench-score` command.
 
 ## Why These Fields Matter
 
@@ -384,7 +517,11 @@ therefore populates it on every emitted event.
 ## Current Boundaries
 
 - Runs are imported one `job_id` at a time and held in memory.
-- The target dataset must exist; only the four tables are auto-created.
+- The target dataset must exist; only the four tables and the
+  failed-session view are auto-created.
+- One `evalbench_failed_sessions` view is pinned to one job; datasets that
+  hold several jobs need one `--failed-sessions-view` name per job (the
+  importer refuses to re-point another job's view).
 - Concurrent publishes into one dataset serialize on the lock sentinel
   (coarse: one publish at a time per dataset); the loser fails with
   `ValueError` and nothing written rather than corrupting the corpus, and

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -367,7 +367,7 @@ the definition itself, and the view can never scan another version. The
 view's query text (its description names the pinned version too) is:
 
 ```sql
--- evalbench_failed_sessions pin: {"import_version": "v2", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}}
+-- evalbench_failed_sessions pin: {"import_version": "v2", "imported_at": "2026-08-30T17:04:11.512034+00:00", "job_id": "abc123", "policy": {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": true}}
 WITH sessions AS (
   SELECT ...
   FROM `analytics-project.bqaa.evalbench_agent_events`
@@ -375,18 +375,23 @@ WITH sessions AS (
   ...
 ```
 
-The pin records the job, the version, and the score policy rendered into
+The pin records the job, the version, the manifest generation it renders
+(`imported_at`, in UTC with microseconds — a `replace=True` of the same
+version label is a new generation), and the score policy rendered into
 the view (`null` without one). Nothing the view says about itself proves
 ownership: the importer treats a view as its own only when the pin names
-a version that job committed to the manifest *and* the body is exactly
-(modulo whitespace) what the importer renders for that manifest row and
-policy. A pin copied or forged onto other SQL (however self-consistent), a
-contract-shaped body for an unpublished version or over other tables, or
-a managed view whose body somebody edited, is a foreign object and is
-refused. The importer never uses `CREATE OR REPLACE VIEW`; it creates the
-view with create-if-absent and replaces it with an ETag-conditional
-update, after re-reading both the view and the latest manifest row
-immediately before writing.
+a version that job committed to the manifest *and* the body is
+byte-for-byte what the importer renders for that manifest row, generation
+and policy. The comparison is exact — BigQuery returns a view's query text
+verbatim, and whitespace inside a rendered literal (`job_id = "job  x"`
+versus `"job x"`) changes which rows the view reads, so no whitespace
+normalization is applied. A pin copied or forged onto other SQL (however
+self-consistent), a contract-shaped body for an unpublished version or
+over other tables, or a managed view whose body somebody edited or
+reformatted, is a foreign object and is refused. The importer never uses
+`CREATE OR REPLACE VIEW`; it creates the view with create-if-absent and
+replaces it with an ETag-conditional update, after re-reading both the
+view and the latest manifest row immediately before writing.
 
 Pinning rules:
 
@@ -398,6 +403,7 @@ Pinning rules:
 | `replace=True` of an older version | re-pinned to it — the replace refreshed `imported_at`, so it *is* the latest successful import |
 | `policy=` / `--min-score` given, changed, or dropped | the score gate is part of the pin: the view is re-rendered whenever the policy differs from the one it carries (including a later same-version call *without* a policy, which removes the gate), and left alone when version and policy both match |
 | `policy=` on a call whose version is **not** the latest import | the gate is decided by the import of the version the view pins: a view already pinned to the latest version is left exactly as it is, and a view that is absent or behind is created or advanced carrying the gate it already had (none for a new view), never this call's |
+| `policy=` on a call whose *generation* is not the one the manifest holds (a concurrent `replace=True` of the same version committed a newer `imported_at`) | as above: the version label does not decide, the generation does. Every generation is rendered into the pin, so the newer replacement always rewrites the view (bumping its ETag) even when version, gate and SQL are otherwise identical; a delayed older caller's conditional replace then fails, re-reads, and leaves the newer generation's gate in place |
 | View at that name pinned to **another job** | `ValueError` before anything is written; use one `failed_sessions_view` name per job |
 | A table, a view the importer did not create, a copied pin over other SQL, or a managed view whose query was edited, at that name | `ValueError` before anything is written (before the import tables are even created); the importer never replaces objects whose definition it cannot vouch for — drop the object or pick another name |
 | Two imports of one job race on the view | the loser of the create race (`409`) or ETag check (`412`) re-reads the view and the latest manifest and re-decides, up to three times, so a delayed writer never overwrites a newer pin — nor re-renders it with its own (older) policy; a race against **another job's** view fails closed with the import already published |

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 
@@ -2245,6 +2245,42 @@ bqaa_app.command(
 )(materialize_window)
 
 
+_MIN_SCORE_HELP = (
+    "COMPARATOR=MIN_SCORE score gate (repeatable): a session fails when the"
+    " comparator scores below MIN_SCORE, or has no score."
+)
+_MISSING_SCORE_PASSES_HELP = (
+    "Treat a missing or NULL score for a --min-score comparator as passing"
+    " instead of failing."
+)
+
+
+def _evalbench_score_policy(
+    min_scores: Optional[list[str]], missing_score_passes: bool
+) -> Optional[Any]:
+  """Build the ``EvalScorePolicy`` behind ``--min-score`` options."""
+  from .evalbench import EvalScorePolicy
+
+  thresholds: dict[str, float] = {}
+  for item in min_scores or []:
+    comparator, separator, value = item.rpartition("=")
+    if not separator or not comparator:
+      raise ValueError(
+          f"--min-score must be COMPARATOR=MIN_SCORE, got {item!r}"
+      )
+    try:
+      thresholds[comparator] = float(value)
+    except ValueError:
+      raise ValueError(
+          f"--min-score {item!r}: MIN_SCORE must be a number"
+      ) from None
+  if not thresholds:
+    return None
+  return EvalScorePolicy(
+      thresholds, missing_score_fails=not missing_score_passes
+  )
+
+
 @app.command("evalbench-import")
 def evalbench_import(
     project_id: str = typer.Option(
@@ -2301,6 +2337,27 @@ def evalbench_import(
             " AS OF this instant so a still-running job cannot mix versions."
         ),
     ),
+    failed_sessions_view: str = typer.Option(
+        "evalbench_failed_sessions",
+        "--failed-sessions-view",
+        help=(
+            "Failed-session view name in --target-dataset, kept pinned to"
+            " this job's latest successful import."
+        ),
+    ),
+    skip_failed_sessions_view: bool = typer.Option(
+        False,
+        "--skip-failed-sessions-view",
+        help="Do not create or update the failed-session view.",
+    ),
+    min_score: Optional[list[str]] = typer.Option(
+        None,
+        "--min-score",
+        help=_MIN_SCORE_HELP + " Rendered into the failed-session view.",
+    ),
+    missing_score_passes: bool = typer.Option(
+        False, "--missing-score-passes", help=_MISSING_SCORE_PASSES_HELP
+    ),
     location: Optional[str] = typer.Option(
         None, "--location", help="BigQuery location."
     ),
@@ -2313,14 +2370,17 @@ def evalbench_import(
   Reads the job's configs/results/scores, maps them to synthetic agent
   events, and publishes events, scores, and a manifest row as one immutable
   import version via a single BigQuery transaction. The ADK plugin's
-  production ``agent_events`` table is never written.
+  production ``agent_events`` table is never written. Every successful run
+  also keeps the ``--failed-sessions-view`` pinned to the job's latest
+  successful import (see ``evalbench-failed-sessions``).
 
   Exit codes:
       0 — imported, replaced, or unchanged (see ``status`` in the output).
       2 — invalid input (including the reserved ``agent_events`` table
           name), a changed source under an explicit --import-version, a
-          version already bound to other destination tables, or a BigQuery
-          error.
+          version already bound to other destination tables, a
+          failed-session view at that name that belongs to another job, or
+          a BigQuery error.
   """
   try:
     from .evalbench import _parse_timestamp
@@ -2330,6 +2390,9 @@ def evalbench_import(
     # Reject the reserved ADK plugin table before any BigQuery read or write.
     _validate_destination_table("events_table", events_table)
     _validate_destination_table("scores_table", scores_table)
+    if not skip_failed_sessions_view:
+      _validate_destination_table("failed_sessions_view", failed_sessions_view)
+    policy = _evalbench_score_policy(min_score, missing_score_passes)
 
     parsed_snapshot = None
     if snapshot_at is not None:
@@ -2353,8 +2416,90 @@ def evalbench_import(
         scores_table=scores_table,
         import_version=import_version,
         replace=replace,
+        failed_sessions_view=(
+            None if skip_failed_sessions_view else failed_sessions_view
+        ),
+        policy=policy,
     )
     typer.echo(format_output(result.to_dict(), fmt))
+  except typer.Exit:
+    raise
+  except Exception as exc:  # noqa: BLE001
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
+@app.command("evalbench-failed-sessions")
+def evalbench_failed_sessions(
+    project_id: str = typer.Option(
+        ...,
+        envvar="BQ_AGENT_PROJECT",
+        help="Project holding the BQAA-owned target dataset.",
+    ),
+    target_dataset: str = typer.Option(
+        ...,
+        "--target-dataset",
+        help="BQAA-owned dataset the EvalBench job was imported into.",
+    ),
+    job_id: str = typer.Option(
+        ..., "--job-id", help="EvalBench job_id whose failed sessions to list."
+    ),
+    import_version: Optional[str] = typer.Option(
+        None,
+        "--import-version",
+        help=(
+            "Pin one published import version. Defaults to the job's latest"
+            " successful import (the version the failed-session view tracks)."
+        ),
+    ),
+    min_score: Optional[list[str]] = typer.Option(
+        None, "--min-score", help=_MIN_SCORE_HELP
+    ),
+    missing_score_passes: bool = typer.Option(
+        False, "--missing-score-passes", help=_MISSING_SCORE_PASSES_HELP
+    ),
+    include_passed: bool = typer.Option(
+        False,
+        "--include-passed",
+        help="Also list the sessions that passed (failed = false).",
+    ),
+    location: Optional[str] = typer.Option(
+        None, "--location", help="BigQuery location."
+    ),
+    fmt: str = typer.Option(
+        "json", "--format", help="Output format: json|text|table."
+    ),
+) -> None:
+  """List the failed sessions of one published EvalBench import version.
+
+  Runs the W0.4 failed-session contract (``failed_sessions_sql``) against
+  exactly one ``(job_id, import_version)`` recorded in the import manifest,
+  so sessions of different import versions are never mixed. Each row's
+  ``session_id``/``trace_id`` is the version-specific identity that
+  ``Client.get_session_trace`` drills into.
+
+  Exit codes:
+      0 — the listing was produced (possibly empty).
+      2 — invalid input (including a malformed --min-score), a job or
+          version with no published import, or a BigQuery error.
+  """
+  try:
+    from .evalbench import failed_sessions
+
+    policy = _evalbench_score_policy(min_score, missing_score_passes)
+    result = failed_sessions(
+        target_project=project_id,
+        target_dataset=target_dataset,
+        job_id=job_id,
+        import_version=import_version,
+        policy=policy,
+        include_passed=include_passed,
+        location=location,
+    )
+    if fmt == "table":
+      typer.echo(format_output(result.sessions, fmt))
+    else:
+      typer.echo(format_output(result.to_dict(), fmt))
   except typer.Exit:
     raise
   except Exception as exc:  # noqa: BLE001

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -103,24 +103,29 @@ _IMPORT_LOCK_ID = "evalbench-import"
 # (``_LATEST_IMPORT_QUERY`` over the manifest). Its body is
 # ``failed_sessions_sql`` with ``@job_id``/``@import_version`` rendered as
 # string literals, so the view never scans another version. The pin is
-# recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that also carries
-# the manifest generation (``imported_at``) rendered and the rendered score
-# policy. Nothing the view says about itself proves ownership: a view is
-# the importer's only when the pin names a version this job committed to
-# the manifest and the body is byte-for-byte what the importer renders for
-# that manifest row, generation and policy (BigQuery returns a view's query
+# recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that also names
+# the manifest generation (``generation_id``) rendered and the rendered
+# score policy. Both are committed manifest state, never view state: every
+# publish (a ``replace`` of the same version label included) and every
+# committed policy change mints an opaque ``generation_id`` for the row,
+# and the row's ``view_policy`` is the gate the view renders. The view body
+# is a pure function of the latest manifest row. Nothing the view says
+# about itself proves ownership: a view is the importer's only when the
+# pin names a version this job committed to the manifest and the body is
+# byte-for-byte what the importer renders for that manifest row -- with
+# the row's own policy when the pin names the row's current generation, or
+# for a view left behind by a superseded generation, the pinned policy
+# over the row's tables, in which case it is only ever advanced to the
+# committed rendering, never preserved. (BigQuery returns a view's query
 # text verbatim, and whitespace inside a literal is significant, so no
-# normalization is applied). Anything else at that name -- a table, a
+# normalization is applied.) Anything else at that name -- a table, a
 # foreign view, a copied marker (however self-consistent) over other SQL, a
-# rendering for an unpublished version, or a managed view somebody edited
-# or reformatted -- is refused, never replaced. Writes go through the
-# tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent, and
-# ETag-conditional replace after re-reading the view and the latest
+# rendering for an unpublished version, a canonical rendering of the
+# current generation under another policy, or a managed view somebody
+# edited or reformatted -- is refused, never replaced. Writes go through
+# the tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent,
+# and ETag-conditional replace after re-reading the view and the latest
 # manifest, so two concurrent imports cannot overwrite each other's pin.
-# The policy rendered into the view is decided by the import that
-# committed the manifest generation the view pins -- a ``replace`` of the
-# same version label is a new generation -- and an import of any other
-# generation never rewrites a view already pinned to the latest one.
 DEFAULT_FAILED_SESSIONS_VIEW = "evalbench_failed_sessions"
 _VIEW_PIN_MARKER = "-- evalbench_failed_sessions pin: "
 # Bounded retries when the view changes underneath a conditional write.
@@ -184,6 +189,15 @@ _MANIFEST_SCHEMA_FIELDS = (
     ("event_row_count", "INT64", "REQUIRED"),
     ("score_row_count", "INT64", "REQUIRED"),
     ("imported_at", "TIMESTAMP", "REQUIRED"),
+    # Opaque id of this committed generation of the row: minted by every
+    # publish and by every committed change of ``view_policy``. Callers
+    # choose ``imported_at``, so two publishes may share it; nothing shares
+    # a ``generation_id``.
+    ("generation_id", "STRING", "REQUIRED"),
+    # The score gate the failed_sessions view renders for this version
+    # (canonical JSON of ``_policy_pin``, NULL for none). The view carries
+    # what this column says, never what the view itself claims.
+    ("view_policy", "STRING", "NULLABLE"),
 )
 _LOCK_SCHEMA_FIELDS = (
     ("lock_id", "STRING", "REQUIRED"),
@@ -223,6 +237,20 @@ FROM `{manifest_table}`
 WHERE job_id = @job_id
 ORDER BY imported_at DESC, import_version DESC
 LIMIT 1
+"""
+
+# Commits another score gate for an already-published, identical version
+# (an ``unchanged`` re-import that adds, changes, or drops the policy). The
+# change is conditional on the generation the caller found, so it can never
+# land on a row a concurrent ``replace`` has since re-published, and it
+# mints a new generation so the view pinned to the old one is recognized as
+# superseded and re-rendered from the row.
+_RECORD_VIEW_POLICY_QUERY = """\
+UPDATE `{manifest_table}`
+SET view_policy = @view_policy, generation_id = @generation_id
+WHERE job_id = @job_id
+  AND import_version = @import_version
+  AND generation_id = @expected_generation_id
 """
 
 # The managed view's query text (``Table.view_query``): the pin comment on
@@ -847,13 +875,17 @@ class EvalBenchRun:
     foreign view, a copied pin over other SQL, an edited or reformatted
     managed view), raises ``ValueError`` before anything is written -- pass
     a different ``failed_sessions_view`` per job, or ``None`` to manage no
-    view. The pin also records the manifest generation (``imported_at``)
-    the view renders, and only the import that committed the latest
-    generation decides the policy the view carries (a ``replace`` of the
-    same version is a new generation). The view is written with
-    create-if-absent and ETag-conditional replace after re-reading it and
-    the latest manifest, so concurrent imports of one job cannot leave a
-    stale pin or an older caller's policy behind.
+    view. The gate the view renders is committed manifest state, not view
+    state: every publish records ``policy`` in its manifest row
+    (``view_policy``) under a fresh opaque ``generation_id`` (a ``replace``
+    of the same version label is a new generation), an ``unchanged``
+    re-import with another policy commits it to the row it found -- only
+    if that row's generation is still the one it found -- under a new
+    generation, and the view is always rendered from the latest manifest
+    row. The view is written with create-if-absent and ETag-conditional
+    replace after re-reading it and the latest manifest, so concurrent
+    imports of one job cannot leave a stale pin or an older caller's
+    policy behind.
 
     Args:
       target_dataset: BQAA-owned dataset that receives the mirror tables.
@@ -902,6 +934,7 @@ class EvalBenchRun:
     if import_version is None:
       import_version = _derived_import_version(fingerprints)
     _validate_import_version(import_version)
+    generation_id = _new_generation_id()
 
     prefix = f"{target_project}.{target_dataset}"
     events_ref = f"{prefix}.{events_table}"
@@ -938,6 +971,8 @@ class EvalBenchRun:
         "event_row_count": len(event_rows),
         "score_row_count": len(score_rows),
         "imported_at": imported_at.isoformat(),
+        "generation_id": generation_id,
+        "view_policy": _policy_column(policy),
     }
 
     client = bq_client or make_bq_client(target_project, location=self.location)
@@ -978,9 +1013,9 @@ class EvalBenchRun:
               location=self.location,
               status=result.status,
               import_version=import_version,
-              # The generation this call handled: the row it committed, or
-              # for ``unchanged`` the committed row it found.
-              imported_at=result.manifest["imported_at"],
+              # The row this call handled: the one it committed, or for
+              # ``unchanged`` the committed row it found.
+              manifest=result.manifest,
           ),
       )
 
@@ -1474,43 +1509,71 @@ def _policy_from_pin(value: Any) -> Optional[EvalScorePolicy]:
   return policy
 
 
-def _pin_timestamp(value: Any) -> str:
-  """Canonical (UTC, microsecond) form of a manifest ``imported_at``.
+def _policy_column(policy: Optional[EvalScorePolicy]) -> Optional[str]:
+  """``view_policy`` manifest column: the canonical pin as JSON, or NULL."""
+  pin = _policy_pin(policy)
+  if pin is None:
+    return None
+  return json.dumps(pin, sort_keys=True)
 
-  The manifest row comes back from BigQuery as a datetime and is staged
-  as an ISO string; both must pin identically.
+
+def _policy_from_column(value: Any) -> Optional[EvalScorePolicy]:
+  """Parse a manifest row's ``view_policy`` strictly (it is trusted state)."""
+  if value is None:
+    return None
+  try:
+    if not isinstance(value, str):
+      raise ValueError("view_policy must be a string")
+    policy = _policy_from_pin(json.loads(value))
+  except (ValueError, TypeError) as exc:
+    raise ValueError(
+        f"manifest view_policy {value!r} is not a canonical score policy;"
+        " re-publish the version with replace=True"
+    ) from exc
+  if _policy_column(policy) != value:
+    raise ValueError(
+        f"manifest view_policy {value!r} is not canonical; re-publish the"
+        " version with replace=True"
+    )
+  return policy
+
+
+_GENERATION_ID_PATTERN = re.compile(r"[0-9a-f]{32}")
+
+
+def _new_generation_id() -> str:
+  return uuid.uuid4().hex
+
+
+def _manifest_generation_id(manifest: Mapping[str, Any]) -> str:
+  """The opaque id of one committed generation of a manifest row.
+
+  A ``replace`` re-publishes the same version label as a new generation,
+  and so does a committed policy change; ``imported_at`` is caller-chosen
+  and may repeat, so it never identifies the generation. Only this does.
   """
-  parsed = _parse_timestamp(value)
-  if parsed is None:
-    raise ValueError(f"imported_at {value!r} is not a timestamp")
-  return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds")
-
-
-def _manifest_generation(manifest: Mapping[str, Any]) -> tuple[str, str]:
-  """``(import_version, imported_at)``: one committed publish of a job.
-
-  A ``replace`` re-publishes the same version label under a new
-  ``imported_at``, so the version alone does not identify what the
-  manifest currently holds; the generation does.
-  """
-  return (
-      str(manifest["import_version"]),
-      _pin_timestamp(manifest["imported_at"]),
-  )
+  value = manifest.get("generation_id")
+  if not isinstance(value, str) or not _GENERATION_ID_PATTERN.fullmatch(value):
+    raise ValueError(
+        f"manifest row for job {manifest.get('job_id')!r} import_version "
+        f"{manifest.get('import_version')!r} has no generation_id;"
+        " re-publish the version with replace=True"
+    )
+  return value
 
 
 def _view_pin(
     job_id: str,
     import_version: str,
     *,
-    imported_at: Any,
+    generation_id: str,
     policy: Optional[EvalScorePolicy],
 ) -> dict[str, Any]:
   """The pin comment payload: what the view is bound to."""
   return {
       "job_id": job_id,
       "import_version": import_version,
-      "imported_at": _pin_timestamp(imported_at),
+      "generation_id": generation_id,
       "policy": _policy_pin(policy),
   }
 
@@ -1543,22 +1606,21 @@ def _parse_view_pin(
         isinstance(pin, dict)
         and isinstance(pin.get("job_id"), str)
         and isinstance(pin.get("import_version"), str)
-        and isinstance(pin.get("imported_at"), str)
+        and isinstance(pin.get("generation_id"), str)
+        # The generation must be in the one form the importer mints, or
+        # the re-rendered body could never match anyway.
+        and _GENERATION_ID_PATTERN.fullmatch(pin["generation_id"])
     ):
       return None
     try:
       policy = _policy_from_pin(pin.get("policy"))
-      # The generation must be in the one form the importer writes, or the
-      # re-rendered body could never match anyway.
-      if _pin_timestamp(pin["imported_at"]) != pin["imported_at"]:
-        return None
     except ValueError:
       return None
     return (
         {
             "job_id": pin["job_id"],
             "import_version": pin["import_version"],
-            "imported_at": pin["imported_at"],
+            "generation_id": pin["generation_id"],
             "policy": pin.get("policy"),
         },
         policy,
@@ -1578,10 +1640,6 @@ class _ManagedView:
   def view_query(self) -> str:
     return str(self.table.view_query)
 
-  @property
-  def generation(self) -> tuple[str, str]:
-    return _manifest_generation(self.pin)
-
 
 def _read_managed_view(
     client: Any,
@@ -1595,17 +1653,22 @@ def _read_managed_view(
   ``None`` means nothing exists at ``view_ref``. The view is the importer's
   only if its pin names a version the pinned job committed to the manifest
   *and* its body is byte-for-byte what the importer renders for that
-  manifest row and the pinned generation and policy. The comparison is
-  exact: BigQuery returns a view's query text verbatim, and whitespace
-  inside a rendered literal (a ``job_id``) changes which rows the view
-  reads, so no normalization is safe. Nothing the view carries about itself
-  is trusted: a table, a view somebody else wrote, a copied or forged
-  marker over other SQL, a rendering for an unpublished version or over
-  other tables, or an edited or reformatted body all raise. The importer
-  only ever replaces views whose definition it can vouch for. The pinned
-  generation and policy are view state (a replaced generation leaves no
-  other record), so they are taken from the pin and vouched for only
-  through the body that renders them.
+  manifest row. When the pin names the row's *current* generation the
+  rendering uses the row's committed ``view_policy`` -- the pin's own
+  policy claim is never the reference, so a canonical rendering of the
+  current generation under any other gate is foreign. When the pin names a
+  superseded generation (the row was re-published or its policy
+  re-committed after the view was written, and nothing else records that
+  generation) the body must be the rendering of the pinned generation and
+  policy over the row's own tables; such a view is only ever advanced to
+  the committed rendering by ``_reconcile_failed_sessions_view``, so
+  whatever gate it carries is never preserved. The comparison is exact:
+  BigQuery returns a view's query text verbatim, and whitespace inside a
+  rendered literal (a ``job_id``) changes which rows the view reads, so no
+  normalization is safe. A table, a view somebody else wrote, a copied or
+  forged marker over other SQL, a rendering for an unpublished version or
+  over other tables, or an edited or reformatted body all raise. The
+  importer only ever replaces views whose definition it can vouch for.
   """
   try:
     table = client.get_table(view_ref)
@@ -1628,10 +1691,17 @@ def _read_managed_view(
       # No manifest table: nothing was ever published here, so the view
       # cannot be one the importer wrote.
       pinned = None
-    if pinned is not None and view_query == _failed_sessions_view_body(
-        manifest=pinned, policy=policy, imported_at=pin["imported_at"]
-    ):
-      return _ManagedView(table=table, pin=pin, policy=policy)
+    if pinned is not None:
+      if pin["generation_id"] == _manifest_generation_id(pinned):
+        expected = _committed_view_body(pinned)
+      else:
+        expected = _failed_sessions_view_body(
+            manifest=pinned,
+            policy=policy,
+            generation_id=pin["generation_id"],
+        )
+      if view_query == expected:
+        return _ManagedView(table=table, pin=pin, policy=policy)
   raise ValueError(
       f"{view_ref!r} exists but is not an evalbench failed_sessions view"
       " created by materialize() (or its definition was changed); choose"
@@ -1662,16 +1732,29 @@ def _check_view_binding(
   return existing
 
 
+def _committed_view_body(manifest: Mapping[str, Any]) -> str:
+  """The view the manifest row says the importer renders for it.
+
+  Generation and policy come from the row (``generation_id``,
+  ``view_policy``): this is the only rendering the importer ever writes.
+  """
+  return _failed_sessions_view_body(
+      manifest=manifest,
+      policy=_policy_from_column(manifest.get("view_policy")),
+      generation_id=_manifest_generation_id(manifest),
+  )
+
+
 def _failed_sessions_view_body(
     *,
     manifest: Mapping[str, Any],
     policy: Optional[EvalScorePolicy],
-    imported_at: Any = None,
+    generation_id: Optional[str] = None,
 ) -> str:
   """The managed view's query text pinned to one manifest row's version.
 
-  A pure function of the manifest row, the generation (``imported_at``,
-  the row's own unless a pin's claim is being re-rendered) and the
+  A pure function of the manifest row's version and tables, the generation
+  (the row's own unless a pin's claim is being re-rendered) and the
   canonical policy, which is what lets ``_read_managed_view`` re-render
   and compare.
   """
@@ -1688,8 +1771,10 @@ def _failed_sessions_view_body(
   pin = _view_pin(
       job_id,
       import_version,
-      imported_at=(
-          manifest["imported_at"] if imported_at is None else imported_at
+      generation_id=(
+          _manifest_generation_id(manifest)
+          if generation_id is None
+          else generation_id
       ),
       policy=policy,
   )
@@ -1715,29 +1800,39 @@ def _sync_failed_sessions_view(
     location: Optional[str],
     status: str,
     import_version: str,
-    imported_at: Any,
+    manifest: Mapping[str, Any],
 ) -> str:
   """Point ``view_ref`` at the job's latest successful import.
 
-  Runs after the publish decision. The latest manifest row (not the version
-  just handled) is the pin, so an ``unchanged`` no-op on an old version does
-  not move the view backwards, and a ``replace`` of an old version -- which
-  refreshes ``imported_at`` -- does. The write is skipped when the existing
-  view's query already is what would be rendered (same generation, same
-  policy, same SQL), so a no-op re-import never rewrites the view, while
-  adding, changing, or dropping the policy does -- when the generation
-  this call handled (``import_version`` committed at ``imported_at``) *is*
-  the latest import. Only that generation's import decides the policy the
-  view carries; see ``_reconcile_failed_sessions_view``.
+  Runs after the publish decision. ``manifest`` is the row this call
+  handled: the one it committed (which already records ``policy`` under
+  its fresh generation), or for ``unchanged`` the committed row it found.
+  In the latter case a policy that differs from the row's is committed to
+  that row first (``_record_view_policy``), conditional on the row still
+  being the generation this call found, so an ``unchanged`` re-import can
+  add, change, or drop the gate of the version it names -- and nothing
+  else. The view itself is then reconciled from the latest manifest row
+  (not the version just handled), so an ``unchanged`` no-op on an old
+  version does not move the view backwards, and a ``replace`` of an old
+  version -- which refreshes ``imported_at`` -- does; see
+  ``_reconcile_failed_sessions_view``.
   """
   try:
+    if status == "unchanged" and _policy_column(policy) != manifest.get(
+        "view_policy"
+    ):
+      _record_view_policy(
+          client,
+          manifest_ref=manifest_ref,
+          manifest=manifest,
+          policy=policy,
+          location=location,
+      )
     _reconcile_failed_sessions_view(
         client,
         view_ref=view_ref,
         manifest_ref=manifest_ref,
         job_id=job_id,
-        generation=(import_version, _pin_timestamp(imported_at)),
-        policy=policy,
         location=location,
     )
   except Exception as exc:  # noqa: BLE001
@@ -1751,42 +1846,77 @@ def _sync_failed_sessions_view(
   return view_ref
 
 
+def _record_view_policy(
+    client: Any,
+    *,
+    manifest_ref: str,
+    manifest: Mapping[str, Any],
+    policy: Optional[EvalScorePolicy],
+    location: Optional[str],
+) -> None:
+  """Commit ``policy`` to the manifest row this call found, if unchanged.
+
+  The UPDATE is keyed on the row's ``generation_id`` as read, so it lands
+  on nothing when a concurrent ``replace`` (or another policy change)
+  re-published the row since -- that generation's own caller decided its
+  gate. It mints a new generation either way, so a view still pinned to
+  the old one is recognized as superseded and re-rendered from the row.
+  """
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "job_id", "STRING", str(manifest["job_id"])
+          ),
+          bigquery.ScalarQueryParameter(
+              "import_version", "STRING", str(manifest["import_version"])
+          ),
+          bigquery.ScalarQueryParameter(
+              "expected_generation_id",
+              "STRING",
+              _manifest_generation_id(manifest),
+          ),
+          bigquery.ScalarQueryParameter(
+              "generation_id", "STRING", _new_generation_id()
+          ),
+          bigquery.ScalarQueryParameter(
+              "view_policy", "STRING", _policy_column(policy)
+          ),
+      ]
+  )
+  job_config = with_sdk_labels(job_config, feature=_VIEW_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _RECORD_VIEW_POLICY_QUERY.format(manifest_table=manifest_ref)
+  client.query(query, **query_args).result()
+
+
 def _reconcile_failed_sessions_view(
     client: Any,
     *,
     view_ref: str,
     manifest_ref: str,
     job_id: str,
-    generation: tuple[str, str],
-    policy: Optional[EvalScorePolicy],
     location: Optional[str],
 ) -> None:
   """Create or conditionally replace the managed view, never blindly.
 
   Each attempt re-reads the view (ownership, job, ETag) and *then* the
   latest manifest row, so a version committed by a concurrent import after
-  the view was read is still seen. A missing view is created with
+  the view was read is still seen. What gets written is always the
+  rendering of that row -- its version, tables, ``generation_id`` and
+  ``view_policy`` -- and nothing this caller asked for: the caller's
+  policy is already committed manifest state (or was refused there) by the
+  time the view is reconciled. A missing view is created with
   create-if-absent (``Conflict`` if another import created it first); an
   existing one is replaced only if its ETag still matches
   (``PreconditionFailed`` otherwise). Either race re-reads and re-decides,
   a bounded number of times, then fails closed -- a stale pin is never
   written over a newer one, and success is never reported for a view that
-  was not verified.
-
-  ``policy`` is authoritative only while ``generation`` -- the
-  ``(import_version, imported_at)`` this invocation handled -- is the
-  latest import. The version label alone is not enough: two ``replace``
-  calls of one version publish two generations, and only the one the
-  manifest holds decides the gate. When the (re-)read latest generation is
-  another one, its own import decided the policy: a view already pinned to
-  it is left exactly as it is (so a delayed retry cannot attach an older
-  caller's gate to a newer generation), and a view that is absent or still
-  behind is created or advanced carrying the gate it already had (none for
-  a new view), not this caller's. Because the generation is rendered into
-  the pin, every new generation changes the view text, so the writer of a
-  newer generation always bumps the ETag under a delayed older caller --
-  that caller's conditional replace fails and re-decides instead of landing
-  its stale policy unchallenged.
+  was not verified. Because every generation is rendered into the pin, the
+  writer of a newer generation always bumps the ETag under a delayed older
+  caller, whose conditional replace then fails and re-decides from the
+  committed row instead of landing its stale rendering unchallenged.
   """
   for _ in range(_VIEW_SYNC_ATTEMPTS):
     existing = _check_view_binding(
@@ -1804,16 +1934,7 @@ def _reconcile_failed_sessions_view(
           f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
           " after publishing; cannot pin the failed_sessions view"
       )
-    latest_generation = _manifest_generation(latest)
-    if latest_generation == generation:
-      render_policy = policy
-    elif existing is None:
-      render_policy = None
-    elif existing.generation == latest_generation:
-      return
-    else:
-      render_policy = existing.policy
-    body = _failed_sessions_view_body(manifest=latest, policy=render_policy)
+    body = _committed_view_body(latest)
     description = _failed_sessions_view_description(latest)
     if existing is None:
       table = bigquery.Table(view_ref)

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -104,19 +104,23 @@ _IMPORT_LOCK_ID = "evalbench-import"
 # ``failed_sessions_sql`` with ``@job_id``/``@import_version`` rendered as
 # string literals, so the view never scans another version. The pin is
 # recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that also carries
-# the rendered score policy. Nothing the view says about itself proves
-# ownership: a view is the importer's only when the pin names a version
-# this job committed to the manifest and the body is byte-for-byte (modulo
-# whitespace) what the importer renders for that manifest row and policy.
-# Anything else at that name -- a table, a foreign view, a copied marker
-# (however self-consistent) over other SQL, a rendering for an unpublished
-# version, or a managed view somebody edited -- is refused, never replaced.
-# Writes go through the tables API rather than ``CREATE OR REPLACE VIEW``:
-# create-if-absent, and ETag-conditional replace after re-reading the view
-# and the latest manifest, so two concurrent imports cannot overwrite each
-# other's pin. The policy rendered into the view is decided by the import
-# of the version the view pins; an import of any other version never
-# rewrites a view already pinned to the latest one.
+# the manifest generation (``imported_at``) rendered and the rendered score
+# policy. Nothing the view says about itself proves ownership: a view is
+# the importer's only when the pin names a version this job committed to
+# the manifest and the body is byte-for-byte what the importer renders for
+# that manifest row, generation and policy (BigQuery returns a view's query
+# text verbatim, and whitespace inside a literal is significant, so no
+# normalization is applied). Anything else at that name -- a table, a
+# foreign view, a copied marker (however self-consistent) over other SQL, a
+# rendering for an unpublished version, or a managed view somebody edited
+# or reformatted -- is refused, never replaced. Writes go through the
+# tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent, and
+# ETag-conditional replace after re-reading the view and the latest
+# manifest, so two concurrent imports cannot overwrite each other's pin.
+# The policy rendered into the view is decided by the import that
+# committed the manifest generation the view pins -- a ``replace`` of the
+# same version label is a new generation -- and an import of any other
+# generation never rewrites a view already pinned to the latest one.
 DEFAULT_FAILED_SESSIONS_VIEW = "evalbench_failed_sessions"
 _VIEW_PIN_MARKER = "-- evalbench_failed_sessions pin: "
 # Bounded retries when the view changes underneath a conditional write.
@@ -839,13 +843,17 @@ class EvalBenchRun:
     created on the next call for corpora published before views existed.
     Ownership is proven by the definition, not by the pin comment alone: a
     view at that name pinned to *another* job, or any object there whose
-    query is not what the importer rendered (a table, a foreign view, a
-    copied pin over other SQL, an edited managed view), raises
-    ``ValueError`` before anything is written -- pass a different
-    ``failed_sessions_view`` per job, or ``None`` to manage no view. The
-    view is written with create-if-absent and ETag-conditional replace
-    after re-reading it and the latest manifest, so concurrent imports of
-    one job cannot leave a stale pin behind.
+    query is not byte-for-byte what the importer rendered (a table, a
+    foreign view, a copied pin over other SQL, an edited or reformatted
+    managed view), raises ``ValueError`` before anything is written -- pass
+    a different ``failed_sessions_view`` per job, or ``None`` to manage no
+    view. The pin also records the manifest generation (``imported_at``)
+    the view renders, and only the import that committed the latest
+    generation decides the policy the view carries (a ``replace`` of the
+    same version is a new generation). The view is written with
+    create-if-absent and ETag-conditional replace after re-reading it and
+    the latest manifest, so concurrent imports of one job cannot leave a
+    stale pin or an older caller's policy behind.
 
     Args:
       target_dataset: BQAA-owned dataset that receives the mirror tables.
@@ -970,6 +978,9 @@ class EvalBenchRun:
               location=self.location,
               status=result.status,
               import_version=import_version,
+              # The generation this call handled: the row it committed, or
+              # for ``unchanged`` the committed row it found.
+              imported_at=result.manifest["imported_at"],
           ),
       )
 
@@ -1463,22 +1474,43 @@ def _policy_from_pin(value: Any) -> Optional[EvalScorePolicy]:
   return policy
 
 
-def _normalize_sql(text: str) -> str:
-  # BigQuery stores a view's query text verbatim; collapsing whitespace only
-  # guards against incidental reformatting, never against changed SQL.
-  return " ".join(text.split())
+def _pin_timestamp(value: Any) -> str:
+  """Canonical (UTC, microsecond) form of a manifest ``imported_at``.
+
+  The manifest row comes back from BigQuery as a datetime and is staged
+  as an ISO string; both must pin identically.
+  """
+  parsed = _parse_timestamp(value)
+  if parsed is None:
+    raise ValueError(f"imported_at {value!r} is not a timestamp")
+  return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _manifest_generation(manifest: Mapping[str, Any]) -> tuple[str, str]:
+  """``(import_version, imported_at)``: one committed publish of a job.
+
+  A ``replace`` re-publishes the same version label under a new
+  ``imported_at``, so the version alone does not identify what the
+  manifest currently holds; the generation does.
+  """
+  return (
+      str(manifest["import_version"]),
+      _pin_timestamp(manifest["imported_at"]),
+  )
 
 
 def _view_pin(
     job_id: str,
     import_version: str,
     *,
+    imported_at: Any,
     policy: Optional[EvalScorePolicy],
 ) -> dict[str, Any]:
   """The pin comment payload: what the view is bound to."""
   return {
       "job_id": job_id,
       "import_version": import_version,
+      "imported_at": _pin_timestamp(imported_at),
       "policy": _policy_pin(policy),
   }
 
@@ -1511,16 +1543,22 @@ def _parse_view_pin(
         isinstance(pin, dict)
         and isinstance(pin.get("job_id"), str)
         and isinstance(pin.get("import_version"), str)
+        and isinstance(pin.get("imported_at"), str)
     ):
       return None
     try:
       policy = _policy_from_pin(pin.get("policy"))
+      # The generation must be in the one form the importer writes, or the
+      # re-rendered body could never match anyway.
+      if _pin_timestamp(pin["imported_at"]) != pin["imported_at"]:
+        return None
     except ValueError:
       return None
     return (
         {
             "job_id": pin["job_id"],
             "import_version": pin["import_version"],
+            "imported_at": pin["imported_at"],
             "policy": pin.get("policy"),
         },
         policy,
@@ -1540,6 +1578,10 @@ class _ManagedView:
   def view_query(self) -> str:
     return str(self.table.view_query)
 
+  @property
+  def generation(self) -> tuple[str, str]:
+    return _manifest_generation(self.pin)
+
 
 def _read_managed_view(
     client: Any,
@@ -1552,12 +1594,18 @@ def _read_managed_view(
 
   ``None`` means nothing exists at ``view_ref``. The view is the importer's
   only if its pin names a version the pinned job committed to the manifest
-  *and* its body is exactly (modulo whitespace) what the importer renders
-  for that manifest row and the pinned policy. Nothing the view carries
-  about itself is trusted: a table, a view somebody else wrote, a copied
-  or forged marker over other SQL, a rendering for an unpublished version
-  or over other tables, or an edited body all raise. The importer only ever
-  replaces views whose definition it can vouch for.
+  *and* its body is byte-for-byte what the importer renders for that
+  manifest row and the pinned generation and policy. The comparison is
+  exact: BigQuery returns a view's query text verbatim, and whitespace
+  inside a rendered literal (a ``job_id``) changes which rows the view
+  reads, so no normalization is safe. Nothing the view carries about itself
+  is trusted: a table, a view somebody else wrote, a copied or forged
+  marker over other SQL, a rendering for an unpublished version or over
+  other tables, or an edited or reformatted body all raise. The importer
+  only ever replaces views whose definition it can vouch for. The pinned
+  generation and policy are view state (a replaced generation leaves no
+  other record), so they are taken from the pin and vouched for only
+  through the body that renders them.
   """
   try:
     table = client.get_table(view_ref)
@@ -1580,8 +1628,8 @@ def _read_managed_view(
       # No manifest table: nothing was ever published here, so the view
       # cannot be one the importer wrote.
       pinned = None
-    if pinned is not None and _normalize_sql(view_query) == _normalize_sql(
-        _failed_sessions_view_body(manifest=pinned, policy=policy)
+    if pinned is not None and view_query == _failed_sessions_view_body(
+        manifest=pinned, policy=policy, imported_at=pin["imported_at"]
     ):
       return _ManagedView(table=table, pin=pin, policy=policy)
   raise ValueError(
@@ -1618,11 +1666,14 @@ def _failed_sessions_view_body(
     *,
     manifest: Mapping[str, Any],
     policy: Optional[EvalScorePolicy],
+    imported_at: Any = None,
 ) -> str:
   """The managed view's query text pinned to one manifest row's version.
 
-  A pure function of the manifest row and the canonical policy, which is
-  what lets ``_read_managed_view`` re-render and compare.
+  A pure function of the manifest row, the generation (``imported_at``,
+  the row's own unless a pin's claim is being re-rendered) and the
+  canonical policy, which is what lets ``_read_managed_view`` re-render
+  and compare.
   """
   job_id = str(manifest["job_id"])
   import_version = str(manifest["import_version"])
@@ -1634,7 +1685,14 @@ def _failed_sessions_view_body(
       job_id=job_id,
       import_version=import_version,
   )
-  pin = _view_pin(job_id, import_version, policy=policy)
+  pin = _view_pin(
+      job_id,
+      import_version,
+      imported_at=(
+          manifest["imported_at"] if imported_at is None else imported_at
+      ),
+      policy=policy,
+  )
   return _VIEW_BODY.format(pin_comment=_view_pin_comment(pin), query=query)
 
 
@@ -1657,6 +1715,7 @@ def _sync_failed_sessions_view(
     location: Optional[str],
     status: str,
     import_version: str,
+    imported_at: Any,
 ) -> str:
   """Point ``view_ref`` at the job's latest successful import.
 
@@ -1664,11 +1723,12 @@ def _sync_failed_sessions_view(
   just handled) is the pin, so an ``unchanged`` no-op on an old version does
   not move the view backwards, and a ``replace`` of an old version -- which
   refreshes ``imported_at`` -- does. The write is skipped when the existing
-  view's query already is what would be rendered (same version, same policy,
-  same SQL), so a no-op re-import never rewrites the view, while adding,
-  changing, or dropping the policy does -- when ``import_version`` *is* the
-  latest import. Only that version's import decides the policy the view
-  carries; see ``_reconcile_failed_sessions_view``.
+  view's query already is what would be rendered (same generation, same
+  policy, same SQL), so a no-op re-import never rewrites the view, while
+  adding, changing, or dropping the policy does -- when the generation
+  this call handled (``import_version`` committed at ``imported_at``) *is*
+  the latest import. Only that generation's import decides the policy the
+  view carries; see ``_reconcile_failed_sessions_view``.
   """
   try:
     _reconcile_failed_sessions_view(
@@ -1676,7 +1736,7 @@ def _sync_failed_sessions_view(
         view_ref=view_ref,
         manifest_ref=manifest_ref,
         job_id=job_id,
-        import_version=import_version,
+        generation=(import_version, _pin_timestamp(imported_at)),
         policy=policy,
         location=location,
     )
@@ -1697,7 +1757,7 @@ def _reconcile_failed_sessions_view(
     view_ref: str,
     manifest_ref: str,
     job_id: str,
-    import_version: str,
+    generation: tuple[str, str],
     policy: Optional[EvalScorePolicy],
     location: Optional[str],
 ) -> None:
@@ -1713,13 +1773,20 @@ def _reconcile_failed_sessions_view(
   written over a newer one, and success is never reported for a view that
   was not verified.
 
-  ``policy`` is authoritative only while ``import_version`` -- the version
-  this invocation handled -- is the latest import. When the (re-)read latest
-  version is another one, its own import decided the policy: a view
-  already pinned to it is left exactly as it is (so a delayed retry cannot
-  attach an older caller's gate to a newer version), and a view that is
-  absent or still behind is created or advanced carrying the gate it
-  already had (none for a new view), not this caller's.
+  ``policy`` is authoritative only while ``generation`` -- the
+  ``(import_version, imported_at)`` this invocation handled -- is the
+  latest import. The version label alone is not enough: two ``replace``
+  calls of one version publish two generations, and only the one the
+  manifest holds decides the gate. When the (re-)read latest generation is
+  another one, its own import decided the policy: a view already pinned to
+  it is left exactly as it is (so a delayed retry cannot attach an older
+  caller's gate to a newer generation), and a view that is absent or still
+  behind is created or advanced carrying the gate it already had (none for
+  a new view), not this caller's. Because the generation is rendered into
+  the pin, every new generation changes the view text, so the writer of a
+  newer generation always bumps the ETag under a delayed older caller --
+  that caller's conditional replace fails and re-decides instead of landing
+  its stale policy unchallenged.
   """
   for _ in range(_VIEW_SYNC_ATTEMPTS):
     existing = _check_view_binding(
@@ -1737,12 +1804,12 @@ def _reconcile_failed_sessions_view(
           f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
           " after publishing; cannot pin the failed_sessions view"
       )
-    latest_version = str(latest["import_version"])
-    if latest_version == import_version:
+    latest_generation = _manifest_generation(latest)
+    if latest_generation == generation:
       render_policy = policy
     elif existing is None:
       render_policy = None
-    elif existing.pin["import_version"] == latest_version:
+    elif existing.generation == latest_generation:
       return
     else:
       render_policy = existing.policy
@@ -1757,7 +1824,7 @@ def _reconcile_failed_sessions_view(
       except Conflict:
         continue
       return
-    if _normalize_sql(existing.view_query) == _normalize_sql(body):
+    if existing.view_query == body:
       return
     table = existing.table
     if not getattr(table, "etag", None):

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -112,17 +112,22 @@ _IMPORT_LOCK_ID = "evalbench-import"
 # is a pure function of the latest manifest row. Nothing the view says
 # about itself proves ownership: a view is the importer's only when the
 # pin names a version this job committed to the manifest and the body is
-# byte-for-byte what the importer renders for that manifest row -- with
-# the row's own policy when the pin names the row's current generation, or
-# for a view left behind by a superseded generation, the pinned policy
-# over the row's tables, in which case it is only ever advanced to the
-# committed rendering, never preserved. (BigQuery returns a view's query
-# text verbatim, and whitespace inside a literal is significant, so no
+# byte-for-byte what the importer renders for that manifest row from
+# committed metadata alone -- the row's own policy when the pin names the
+# row's current generation, or, for a view left behind by a superseded
+# generation, the policy the row's ``superseded_generations`` history
+# recorded for that generation when it was replaced (every publish and
+# policy change appends the generation it supersedes). A generation the
+# manifest never committed cannot be verified and is refused; a
+# superseded view that verifies is only ever advanced to the committed
+# rendering, never preserved. (BigQuery returns a view's query text
+# verbatim, and whitespace inside a literal is significant, so no
 # normalization is applied.) Anything else at that name -- a table, a
 # foreign view, a copied marker (however self-consistent) over other SQL, a
 # rendering for an unpublished version, a canonical rendering of the
-# current generation under another policy, or a managed view somebody
-# edited or reformatted -- is refused, never replaced. Writes go through
+# current generation under another policy, a rendering under a generation
+# or policy the manifest does not hold, or a managed view somebody edited
+# or reformatted -- is refused, never replaced. Writes go through
 # the tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent,
 # and ETag-conditional replace after re-reading the view and the latest
 # manifest, so two concurrent imports cannot overwrite each other's pin.
@@ -192,12 +197,30 @@ _MANIFEST_SCHEMA_FIELDS = (
     # Opaque id of this committed generation of the row: minted by every
     # publish and by every committed change of ``view_policy``. Callers
     # choose ``imported_at``, so two publishes may share it; nothing shares
-    # a ``generation_id``.
-    ("generation_id", "STRING", "REQUIRED"),
+    # a ``generation_id``. Declared NULLABLE only so the column can be
+    # added to a manifest created before generations existed (slice 1);
+    # ``_ensure_manifest_schema`` backfills every row, and every row the
+    # importer writes carries one.
+    ("generation_id", "STRING", "NULLABLE"),
     # The score gate the failed_sessions view renders for this version
     # (canonical JSON of ``_policy_pin``, NULL for none). The view carries
     # what this column says, never what the view itself claims.
     ("view_policy", "STRING", "NULLABLE"),
+    # Committed history of the generations this row has had, oldest first:
+    # one ``TO_JSON_STRING(STRUCT(generation_id, view_policy))`` per
+    # superseded generation, appended by the publish transaction (a
+    # ``replace``) and by ``_RECORD_VIEW_POLICY_QUERY``. It is what lets a
+    # view a superseded generation left behind be authenticated from
+    # committed metadata rather than from its own pin.
+    ("superseded_generations", "STRING", "REPEATED"),
+)
+# Manifest columns the importer stages and inserts verbatim; the history
+# column is computed inside the publish transaction from the row it
+# replaces (``_PUBLISH_SCRIPT``), never taken from the staged row.
+_STAGED_MANIFEST_COLUMNS = tuple(
+    name
+    for name, _, _ in _MANIFEST_SCHEMA_FIELDS
+    if name != "superseded_generations"
 )
 _LOCK_SCHEMA_FIELDS = (
     ("lock_id", "STRING", "REQUIRED"),
@@ -247,10 +270,28 @@ LIMIT 1
 # superseded and re-rendered from the row.
 _RECORD_VIEW_POLICY_QUERY = """\
 UPDATE `{manifest_table}`
-SET view_policy = @view_policy, generation_id = @generation_id
+SET view_policy = @view_policy,
+    generation_id = @generation_id,
+    superseded_generations = ARRAY_CONCAT(
+        IFNULL(superseded_generations, []),
+        [TO_JSON_STRING(STRUCT(
+            generation_id AS generation_id, view_policy AS view_policy))])
 WHERE job_id = @job_id
   AND import_version = @import_version
   AND generation_id = @expected_generation_id
+"""
+
+# Gives every manifest row published before generations existed (slice 1)
+# a ``generation_id``. The id is derived from the row key rather than
+# minted at random so that two importers upgrading one dataset at once
+# converge on the same value: the backfill is idempotent whichever of them
+# commits first (or both do). ``import_version`` cannot contain ``:``
+# (``_IMPORT_VERSION_PATTERN``), so the key is unambiguous.
+_BACKFILL_GENERATION_QUERY = """\
+UPDATE `{manifest_table}`
+SET generation_id = TO_HEX(MD5(CONCAT(
+    'evalbench-import-manifest:', import_version, ':', job_id)))
+WHERE generation_id IS NULL
 """
 
 # The managed view's query text (``Table.view_query``): the pin comment on
@@ -337,6 +378,7 @@ _REPLACE_IDENTICAL_NOTE = (
 _PUBLISH_SCRIPT = """\
 DECLARE existing_manifest_rows INT64 DEFAULT 0;
 DECLARE conflicting_manifest_rows INT64 DEFAULT 0;
+DECLARE prior_generations ARRAY<STRING> DEFAULT [];
 BEGIN
   BEGIN TRANSACTION;
   UPDATE `{lock_table}`
@@ -365,6 +407,16 @@ BEGIN
     RAISE USING MESSAGE = '{conflict_message}';
   END IF;
 {identical_guard}\
+  -- The generation this publish supersedes (if any) joins the row's
+  -- committed history, so a view still pinned to it stays verifiable.
+  SET prior_generations = IFNULL((
+    SELECT ARRAY_CONCAT(
+        IFNULL(superseded_generations, []),
+        [TO_JSON_STRING(STRUCT(
+            generation_id AS generation_id, view_policy AS view_policy))])
+    FROM `{manifest_table}`
+    WHERE job_id = @job_id AND import_version = @import_version
+  ), []);
   DELETE FROM `{events_table}`
   WHERE job_id = @job_id AND import_version = @import_version;
   DELETE FROM `{scores_table}`
@@ -375,8 +427,8 @@ BEGIN
   SELECT {event_columns} FROM `{events_staging}`;
   INSERT INTO `{scores_table}` ({score_columns})
   SELECT {score_columns} FROM `{scores_staging}`;
-  INSERT INTO `{manifest_table}` ({manifest_columns})
-  SELECT {manifest_columns} FROM `{manifest_staging}`;
+  INSERT INTO `{manifest_table}` ({manifest_columns}, superseded_generations)
+  SELECT {manifest_columns}, prior_generations FROM `{manifest_staging}`;
   COMMIT TRANSACTION;
 EXCEPTION WHEN ERROR THEN
   ROLLBACK TRANSACTION;
@@ -973,9 +1025,20 @@ class EvalBenchRun:
         "imported_at": imported_at.isoformat(),
         "generation_id": generation_id,
         "view_policy": _policy_column(policy),
+        # Staged as empty; the publish transaction carries the replaced
+        # row's history forward (``_PUBLISH_SCRIPT``).
+        "superseded_generations": [],
     }
 
     client = bq_client or make_bq_client(target_project, location=self.location)
+
+    # A manifest created by an earlier release (slice 1: no generations, no
+    # view policy, no history) is upgraded in place before anything reads
+    # or writes it, so an unchanged re-import finds a generation and a
+    # publish finds its columns. Nothing is created here.
+    _ensure_manifest_schema(
+        client, manifest_ref=manifest_ref, location=self.location
+    )
 
     # The view binding is checked before any table is created or written so
     # a name clash with another job's view (or a foreign object) aborts
@@ -1026,6 +1089,19 @@ class EvalBenchRun:
         import_version=import_version,
         location=self.location,
     )
+    if existing is not None and existing.get("generation_id") is None:
+      # An upgrade interrupted between the schema change and the backfill
+      # left this row without a generation; finish it (idempotently).
+      _backfill_generation_ids(
+          client, manifest_ref=manifest_ref, location=self.location
+      )
+      existing = _read_manifest(
+          client,
+          manifest_ref=manifest_ref,
+          job_id=self.job_id,
+          import_version=import_version,
+          location=self.location,
+      )
     status = "imported"
     if existing is not None:
       _check_destination_binding(
@@ -1153,6 +1229,17 @@ class EvalBenchRun:
           client, (events_staging, scores_staging, manifest_staging)
       )
 
+    # The committed row is what the result reports: the transaction adds
+    # the generation history a ``replace`` supersedes, which is not known
+    # from the (possibly stale) pre-read. Nothing deletes manifest rows, so
+    # the local copy is only a defensive fallback.
+    committed = _read_manifest(
+        client,
+        manifest_ref=manifest_ref,
+        job_id=self.job_id,
+        import_version=import_version,
+        location=self.location,
+    )
     return finish(
         EvalBenchImportResult(
             job_id=self.job_id,
@@ -1163,7 +1250,7 @@ class EvalBenchRun:
             manifest_table=manifest_ref,
             event_row_count=len(event_rows),
             score_row_count=len(score_rows),
-            manifest=manifest,
+            manifest=committed if committed is not None else manifest,
         )
     )
 
@@ -1557,9 +1644,52 @@ def _manifest_generation_id(manifest: Mapping[str, Any]) -> str:
     raise ValueError(
         f"manifest row for job {manifest.get('job_id')!r} import_version "
         f"{manifest.get('import_version')!r} has no generation_id;"
-        " re-publish the version with replace=True"
+        " re-run materialize() to upgrade the manifest, or re-publish the"
+        " version with replace=True"
     )
   return value
+
+
+def _superseded_generations(
+    manifest: Mapping[str, Any],
+) -> dict[str, Optional[str]]:
+  """The row's committed history: superseded ``generation_id`` -> policy.
+
+  Parsed strictly (it is trusted state written only by the publish
+  transaction and ``_record_view_policy``). Entries without a generation
+  (a legacy row replaced before its backfill) name nothing a view could
+  have been pinned to and are skipped.
+  """
+  history: dict[str, Optional[str]] = {}
+  for raw in manifest.get("superseded_generations") or ():
+    try:
+      entry = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+      raise ValueError(
+          f"manifest superseded_generations entry {raw!r} is not JSON"
+      ) from exc
+    if not isinstance(entry, Mapping):
+      raise ValueError(
+          f"manifest superseded_generations entry {raw!r} is malformed"
+      )
+    generation_id = entry.get("generation_id")
+    if generation_id is None:
+      continue
+    if not isinstance(
+        generation_id, str
+    ) or not _GENERATION_ID_PATTERN.fullmatch(generation_id):
+      raise ValueError(
+          f"manifest superseded_generations entry {raw!r} has a malformed"
+          " generation_id"
+      )
+    policy = entry.get("view_policy")
+    if policy is not None and not isinstance(policy, str):
+      raise ValueError(
+          f"manifest superseded_generations entry {raw!r} has a malformed"
+          " view_policy"
+      )
+    history[generation_id] = policy
+  return history
 
 
 def _view_pin(
@@ -1630,11 +1760,15 @@ def _parse_view_pin(
 
 @dataclasses.dataclass(frozen=True)
 class _ManagedView:
-  """A view at the managed name that the importer recognizes as its own."""
+  """A view at the managed name that the importer recognizes as its own.
+
+  ``pin`` is what the view claims, verified against the manifest; the gate
+  it renders was checked against committed state and is not carried here,
+  since nothing downstream may act on a view's own policy claim.
+  """
 
   table: Any
   pin: dict[str, Any]
-  policy: Optional[EvalScorePolicy]
 
   @property
   def view_query(self) -> str:
@@ -1653,22 +1787,25 @@ def _read_managed_view(
   ``None`` means nothing exists at ``view_ref``. The view is the importer's
   only if its pin names a version the pinned job committed to the manifest
   *and* its body is byte-for-byte what the importer renders for that
-  manifest row. When the pin names the row's *current* generation the
-  rendering uses the row's committed ``view_policy`` -- the pin's own
-  policy claim is never the reference, so a canonical rendering of the
-  current generation under any other gate is foreign. When the pin names a
-  superseded generation (the row was re-published or its policy
-  re-committed after the view was written, and nothing else records that
-  generation) the body must be the rendering of the pinned generation and
-  policy over the row's own tables; such a view is only ever advanced to
-  the committed rendering by ``_reconcile_failed_sessions_view``, so
-  whatever gate it carries is never preserved. The comparison is exact:
-  BigQuery returns a view's query text verbatim, and whitespace inside a
-  rendered literal (a ``job_id``) changes which rows the view reads, so no
-  normalization is safe. A table, a view somebody else wrote, a copied or
-  forged marker over other SQL, a rendering for an unpublished version or
-  over other tables, or an edited or reformatted body all raise. The
-  importer only ever replaces views whose definition it can vouch for.
+  manifest row from committed metadata alone. When the pin names the row's
+  *current* generation the rendering uses the row's committed
+  ``view_policy``; when it names a generation the row's
+  ``superseded_generations`` history records (the row was re-published or
+  its policy re-committed after the view was written) the rendering uses
+  the policy that history committed for that generation. The pin's own
+  policy claim is never the reference, so a canonical rendering of any
+  generation under another gate is foreign -- and so is a rendering under
+  a generation the manifest never committed, however well-formed: nothing
+  trusted can vouch for it. A view of a superseded generation that does
+  verify is only ever advanced to the committed rendering by
+  ``_reconcile_failed_sessions_view``, so whatever gate it carries is
+  never preserved. The comparison is exact: BigQuery returns a view's
+  query text verbatim, and whitespace inside a rendered literal (a
+  ``job_id``) changes which rows the view reads, so no normalization is
+  safe. A table, a view somebody else wrote, a copied or forged marker
+  over other SQL, a rendering for an unpublished version or over other
+  tables, or an edited or reformatted body all raise. The importer only
+  ever replaces views whose definition it can vouch for.
   """
   try:
     table = client.get_table(view_ref)
@@ -1677,7 +1814,7 @@ def _read_managed_view(
   view_query = getattr(table, "view_query", None)
   parsed = _parse_view_pin(view_query) if isinstance(view_query, str) else None
   if parsed is not None:
-    pin, policy = parsed
+    pin, _ = parsed
     try:
       pinned = _read_manifest(
           client,
@@ -1692,16 +1829,9 @@ def _read_managed_view(
       # cannot be one the importer wrote.
       pinned = None
     if pinned is not None:
-      if pin["generation_id"] == _manifest_generation_id(pinned):
-        expected = _committed_view_body(pinned)
-      else:
-        expected = _failed_sessions_view_body(
-            manifest=pinned,
-            policy=policy,
-            generation_id=pin["generation_id"],
-        )
-      if view_query == expected:
-        return _ManagedView(table=table, pin=pin, policy=policy)
+      expected = _committed_generation_view_body(pinned, pin["generation_id"])
+      if expected is not None and view_query == expected:
+        return _ManagedView(table=table, pin=pin)
   raise ValueError(
       f"{view_ref!r} exists but is not an evalbench failed_sessions view"
       " created by materialize() (or its definition was changed); choose"
@@ -1742,6 +1872,31 @@ def _committed_view_body(manifest: Mapping[str, Any]) -> str:
       manifest=manifest,
       policy=_policy_from_column(manifest.get("view_policy")),
       generation_id=_manifest_generation_id(manifest),
+  )
+
+
+def _committed_generation_view_body(
+    manifest: Mapping[str, Any], generation_id: str
+) -> Optional[str]:
+  """The rendering the importer wrote for ``generation_id`` of this row.
+
+  The row's current generation renders with its ``view_policy``; a
+  generation in the row's ``superseded_generations`` history renders with
+  the policy committed for it there, over the row's tables (a version's
+  destination never changes). ``None`` for a generation the manifest never
+  committed -- including a row that has no generation yet, which no view
+  was ever written for -- so the caller cannot vouch for it.
+  """
+  current = manifest.get("generation_id")
+  if isinstance(current, str) and generation_id == current:
+    return _committed_view_body(manifest)
+  history = _superseded_generations(manifest)
+  if generation_id not in history:
+    return None
+  return _failed_sessions_view_body(
+      manifest=manifest,
+      policy=_policy_from_column(history[generation_id]),
+      generation_id=generation_id,
   )
 
 
@@ -1934,6 +2089,13 @@ def _reconcile_failed_sessions_view(
           f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
           " after publishing; cannot pin the failed_sessions view"
       )
+    if latest.get("generation_id") is None:
+      # The latest row predates generations and its backfill was
+      # interrupted; finish it and re-decide.
+      _backfill_generation_ids(
+          client, manifest_ref=manifest_ref, location=location
+      )
+      continue
     body = _committed_view_body(latest)
     description = _failed_sessions_view_description(latest)
     if existing is None:
@@ -2310,9 +2472,7 @@ def _publish_script(
       identical_guard=identical_guard,
       event_columns=", ".join(_EVENT_COLUMNS),
       score_columns=", ".join(name for name, _, _ in _SCORE_SCHEMA_FIELDS),
-      manifest_columns=", ".join(
-          name for name, _, _ in _MANIFEST_SCHEMA_FIELDS
-      ),
+      manifest_columns=", ".join(_STAGED_MANIFEST_COLUMNS),
   )
 
 
@@ -2491,6 +2651,66 @@ def _event_schema() -> list:
       bigquery.SchemaField("job_id", "STRING", mode="REQUIRED"),
       bigquery.SchemaField("import_version", "STRING", mode="REQUIRED"),
   ]
+
+
+_SCHEMA_UPGRADE_ATTEMPTS = 3
+
+
+def _ensure_manifest_schema(
+    client: Any, *, manifest_ref: str, location: Optional[str]
+) -> None:
+  """Upgrade a manifest table an earlier release created, idempotently.
+
+  Slice 1 (#451) created ``evalbench_import_manifest`` without
+  ``generation_id``, ``view_policy`` and ``superseded_generations``;
+  ``create_table(exists_ok=True)`` returns such a table unchanged. Any
+  column of ``_MANIFEST_SCHEMA_FIELDS`` the live table lacks is added
+  through the tables API (ETag-conditional, re-read and retried when a
+  concurrent upgrade lands first), then every row without a generation is
+  given one (``_BACKFILL_GENERATION_QUERY``). A table that already has the
+  full schema costs one metadata read and nothing else; a manifest that
+  does not exist yet is left for ``_ensure_import_tables`` to create with
+  the full schema.
+  """
+  try:
+    table = client.get_table(manifest_ref)
+  except NotFound:
+    return
+  wanted = _schema(_MANIFEST_SCHEMA_FIELDS)
+  for _ in range(_SCHEMA_UPGRADE_ATTEMPTS):
+    present = {field.name for field in table.schema}
+    missing = [field for field in wanted if field.name not in present]
+    if not missing:
+      return
+    table.schema = list(table.schema) + missing
+    try:
+      client.update_table(table, ["schema"])
+    except PreconditionFailed:
+      table = client.get_table(manifest_ref)
+      continue
+    _backfill_generation_ids(
+        client, manifest_ref=manifest_ref, location=location
+    )
+    return
+  raise ValueError(
+      f"manifest table {manifest_ref!r} changed concurrently"
+      f" {_SCHEMA_UPGRADE_ATTEMPTS} times while adding"
+      f" {[field.name for field in missing]}; re-run materialize()"
+  )
+
+
+def _backfill_generation_ids(
+    client: Any, *, manifest_ref: str, location: Optional[str]
+) -> None:
+  """Give every manifest row without a ``generation_id`` its derived one."""
+  job_config = with_sdk_labels(
+      bigquery.QueryJobConfig(), feature=_IMPORT_FEATURE
+  )
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _BACKFILL_GENERATION_QUERY.format(manifest_table=manifest_ref)
+  client.query(query, **query_args).result()
 
 
 def _ensure_import_tables(

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -104,15 +104,19 @@ _IMPORT_LOCK_ID = "evalbench-import"
 # ``failed_sessions_sql`` with ``@job_id``/``@import_version`` rendered as
 # string literals, so the view never scans another version. The pin is
 # recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that also carries
-# the rendered score policy and a hash of the canonical query below it, so
-# the marker alone never proves ownership: a view is the importer's only
-# when its body is byte-for-byte (modulo whitespace) what the importer
-# renders for that pin. Anything else at that name -- a table, a foreign
-# view, a view carrying a copied marker over other SQL, or a managed view
-# somebody edited -- is refused, never replaced. Writes go through the
-# tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent, and
-# ETag-conditional replace after re-reading the view and the latest
-# manifest, so two concurrent imports cannot overwrite each other's pin.
+# the rendered score policy. Nothing the view says about itself proves
+# ownership: a view is the importer's only when the pin names a version
+# this job committed to the manifest and the body is byte-for-byte (modulo
+# whitespace) what the importer renders for that manifest row and policy.
+# Anything else at that name -- a table, a foreign view, a copied marker
+# (however self-consistent) over other SQL, a rendering for an unpublished
+# version, or a managed view somebody edited -- is refused, never replaced.
+# Writes go through the tables API rather than ``CREATE OR REPLACE VIEW``:
+# create-if-absent, and ETag-conditional replace after re-reading the view
+# and the latest manifest, so two concurrent imports cannot overwrite each
+# other's pin. The policy rendered into the view is decided by the import
+# of the version the view pins; an import of any other version never
+# rewrites a view already pinned to the latest one.
 DEFAULT_FAILED_SESSIONS_VIEW = "evalbench_failed_sessions"
 _VIEW_PIN_MARKER = "-- evalbench_failed_sessions pin: "
 # Bounded retries when the view changes underneath a conditional write.
@@ -936,7 +940,13 @@ class EvalBenchRun:
     # re-reads it right before writing; this early read is the fail-fast
     # path, not the authority.
     if view_ref is not None:
-      _check_view_binding(client, view_ref=view_ref, job_id=self.job_id)
+      _check_view_binding(
+          client,
+          view_ref=view_ref,
+          manifest_ref=manifest_ref,
+          job_id=self.job_id,
+          location=self.location,
+      )
 
     _ensure_import_tables(
         client,
@@ -1403,14 +1413,60 @@ def _policy_pin(policy: Optional[EvalScorePolicy]) -> Optional[dict[str, Any]]:
   }
 
 
+def _canonical_policy(
+    policy: Optional[EvalScorePolicy],
+) -> Optional[EvalScorePolicy]:
+  """``policy`` in the one form the view renders (sorted, float, or none).
+
+  Rendering from the canonical form makes the view body a pure function of
+  (manifest row, policy pin), whatever key order the caller used.
+  """
+  pin = _policy_pin(policy)
+  if pin is None:
+    return None
+  return EvalScorePolicy(
+      pin["min_scores"], missing_score_fails=pin["missing_score_fails"]
+  )
+
+
+def _policy_from_pin(value: Any) -> Optional[EvalScorePolicy]:
+  """Parse a pin's ``policy`` strictly; ``ValueError`` if it is not one.
+
+  Only exactly what ``_policy_pin`` emits is accepted (and it must
+  round-trip), so a view carrying anything else is not the importer's.
+  """
+  if value is None:
+    return None
+  if not isinstance(value, dict) or set(value) != {
+      "min_scores",
+      "missing_score_fails",
+  }:
+    raise ValueError("policy pin must have min_scores and missing_score_fails")
+  min_scores = value["min_scores"]
+  missing_score_fails = value["missing_score_fails"]
+  if (
+      not isinstance(min_scores, dict)
+      or not min_scores
+      or not isinstance(missing_score_fails, bool)
+  ):
+    raise ValueError("policy pin is malformed")
+  for comparator, min_score in min_scores.items():
+    if (
+        not isinstance(comparator, str)
+        or isinstance(min_score, bool)
+        or not isinstance(min_score, (int, float))
+    ):
+      raise ValueError("policy pin min_scores is malformed")
+  policy = EvalScorePolicy(min_scores, missing_score_fails=missing_score_fails)
+  if _policy_pin(policy) != value:
+    raise ValueError("policy pin is not canonical")
+  return policy
+
+
 def _normalize_sql(text: str) -> str:
   # BigQuery stores a view's query text verbatim; collapsing whitespace only
   # guards against incidental reformatting, never against changed SQL.
   return " ".join(text.split())
-
-
-def _sql_digest(query: str) -> str:
-  return hashlib.sha256(_normalize_sql(query).encode("utf-8")).hexdigest()
 
 
 def _view_pin(
@@ -1418,14 +1474,12 @@ def _view_pin(
     import_version: str,
     *,
     policy: Optional[EvalScorePolicy],
-    query: str,
 ) -> dict[str, Any]:
-  """The pin comment payload: what the view is bound to, and to what SQL."""
+  """The pin comment payload: what the view is bound to."""
   return {
       "job_id": job_id,
       "import_version": import_version,
       "policy": _policy_pin(policy),
-      "query_sha256": _sql_digest(query),
   }
 
 
@@ -1434,16 +1488,16 @@ def _view_pin_comment(pin: Mapping[str, Any]) -> str:
   return _VIEW_PIN_MARKER + json.dumps(pin, sort_keys=True, ensure_ascii=True)
 
 
-def _parse_view_pin(view_query: str) -> Optional[dict[str, Any]]:
-  """Return the pin a managed view carries, or ``None`` if it is not ours.
+def _parse_view_pin(
+    view_query: str,
+) -> Optional[tuple[dict[str, Any], Optional[EvalScorePolicy]]]:
+  """Parse the pin comment a view starts with: what it *claims* to be.
 
-  Ours means: the first nonblank line is a well-formed pin comment *and*
-  the query below it hashes to the ``query_sha256`` the pin records. A
-  copied marker over other SQL, or a managed view whose body was edited,
-  fails the second half and is treated as foreign.
+  Returns the pin and its policy, or ``None`` when the first nonblank line
+  is not a well-formed pin. This is a claim only; ``_read_managed_view``
+  decides ownership by re-rendering the claimed definition.
   """
-  lines = view_query.splitlines()
-  for index, raw in enumerate(lines):
+  for raw in view_query.splitlines():
     line = raw.strip()
     if not line:
       continue
@@ -1457,18 +1511,20 @@ def _parse_view_pin(view_query: str) -> Optional[dict[str, Any]]:
         isinstance(pin, dict)
         and isinstance(pin.get("job_id"), str)
         and isinstance(pin.get("import_version"), str)
-        and isinstance(pin.get("query_sha256"), str)
     ):
       return None
-    query = "\n".join(lines[index + 1 :])
-    if not query.strip() or _sql_digest(query) != pin["query_sha256"]:
+    try:
+      policy = _policy_from_pin(pin.get("policy"))
+    except ValueError:
       return None
-    return {
-        "job_id": pin["job_id"],
-        "import_version": pin["import_version"],
-        "policy": pin.get("policy"),
-        "query_sha256": pin["query_sha256"],
-    }
+    return (
+        {
+            "job_id": pin["job_id"],
+            "import_version": pin["import_version"],
+            "policy": pin.get("policy"),
+        },
+        policy,
+    )
   return None
 
 
@@ -1478,42 +1534,76 @@ class _ManagedView:
 
   table: Any
   pin: dict[str, Any]
+  policy: Optional[EvalScorePolicy]
 
   @property
   def view_query(self) -> str:
     return str(self.table.view_query)
 
 
-def _read_managed_view(client: Any, *, view_ref: str) -> Optional[_ManagedView]:
+def _read_managed_view(
+    client: Any,
+    *,
+    view_ref: str,
+    manifest_ref: str,
+    location: Optional[str],
+) -> Optional[_ManagedView]:
   """Return the managed view at ``view_ref`` with its pin and ETag.
 
-  ``None`` means nothing exists at ``view_ref``. Anything else that is not a
-  view carrying the importer's pin *over the query that pin hashes* (a
-  table, a view somebody else wrote, a copied marker, an edited body)
-  raises: the importer only ever replaces views whose definition it can
-  vouch for.
+  ``None`` means nothing exists at ``view_ref``. The view is the importer's
+  only if its pin names a version the pinned job committed to the manifest
+  *and* its body is exactly (modulo whitespace) what the importer renders
+  for that manifest row and the pinned policy. Nothing the view carries
+  about itself is trusted: a table, a view somebody else wrote, a copied
+  or forged marker over other SQL, a rendering for an unpublished version
+  or over other tables, or an edited body all raise. The importer only ever
+  replaces views whose definition it can vouch for.
   """
   try:
     table = client.get_table(view_ref)
   except NotFound:
     return None
   view_query = getattr(table, "view_query", None)
-  pin = _parse_view_pin(view_query) if isinstance(view_query, str) else None
-  if pin is None:
-    raise ValueError(
-        f"{view_ref!r} exists but is not an evalbench failed_sessions view"
-        " created by materialize() (or its definition was changed); choose"
-        " another failed_sessions_view name (or None to skip the view)"
-        " rather than replacing it"
-    )
-  return _ManagedView(table=table, pin=pin)
+  parsed = _parse_view_pin(view_query) if isinstance(view_query, str) else None
+  if parsed is not None:
+    pin, policy = parsed
+    try:
+      pinned = _read_manifest(
+          client,
+          manifest_ref=manifest_ref,
+          job_id=pin["job_id"],
+          import_version=pin["import_version"],
+          location=location,
+          feature=_VIEW_FEATURE,
+      )
+    except NotFound:
+      # No manifest table: nothing was ever published here, so the view
+      # cannot be one the importer wrote.
+      pinned = None
+    if pinned is not None and _normalize_sql(view_query) == _normalize_sql(
+        _failed_sessions_view_body(manifest=pinned, policy=policy)
+    ):
+      return _ManagedView(table=table, pin=pin, policy=policy)
+  raise ValueError(
+      f"{view_ref!r} exists but is not an evalbench failed_sessions view"
+      " created by materialize() (or its definition was changed); choose"
+      " another failed_sessions_view name (or None to skip the view)"
+      " rather than replacing it"
+  )
 
 
 def _check_view_binding(
-    client: Any, *, view_ref: str, job_id: str
+    client: Any,
+    *,
+    view_ref: str,
+    manifest_ref: str,
+    job_id: str,
+    location: Optional[str],
 ) -> Optional[_ManagedView]:
   """Refuse a view the importer does not own or that belongs to another job."""
-  existing = _read_managed_view(client, view_ref=view_ref)
+  existing = _read_managed_view(
+      client, view_ref=view_ref, manifest_ref=manifest_ref, location=location
+  )
   if existing is not None and existing.pin["job_id"] != job_id:
     raise ValueError(
         f"failed_sessions view {view_ref!r} is pinned to EvalBench job "
@@ -1529,9 +1619,14 @@ def _failed_sessions_view_body(
     manifest: Mapping[str, Any],
     policy: Optional[EvalScorePolicy],
 ) -> str:
-  """The managed view's query text pinned to one manifest row's version."""
+  """The managed view's query text pinned to one manifest row's version.
+
+  A pure function of the manifest row and the canonical policy, which is
+  what lets ``_read_managed_view`` re-render and compare.
+  """
   job_id = str(manifest["job_id"])
   import_version = str(manifest["import_version"])
+  policy = _canonical_policy(policy)
   query = _failed_sessions_sql_for_refs(
       events_ref=str(manifest["events_table"]),
       scores_ref=str(manifest["scores_table"]),
@@ -1539,7 +1634,7 @@ def _failed_sessions_view_body(
       job_id=job_id,
       import_version=import_version,
   )
-  pin = _view_pin(job_id, import_version, policy=policy, query=query)
+  pin = _view_pin(job_id, import_version, policy=policy)
   return _VIEW_BODY.format(pin_comment=_view_pin_comment(pin), query=query)
 
 
@@ -1571,7 +1666,9 @@ def _sync_failed_sessions_view(
   refreshes ``imported_at`` -- does. The write is skipped when the existing
   view's query already is what would be rendered (same version, same policy,
   same SQL), so a no-op re-import never rewrites the view, while adding,
-  changing, or dropping the policy does.
+  changing, or dropping the policy does -- when ``import_version`` *is* the
+  latest import. Only that version's import decides the policy the view
+  carries; see ``_reconcile_failed_sessions_view``.
   """
   try:
     _reconcile_failed_sessions_view(
@@ -1579,6 +1676,7 @@ def _sync_failed_sessions_view(
         view_ref=view_ref,
         manifest_ref=manifest_ref,
         job_id=job_id,
+        import_version=import_version,
         policy=policy,
         location=location,
     )
@@ -1599,6 +1697,7 @@ def _reconcile_failed_sessions_view(
     view_ref: str,
     manifest_ref: str,
     job_id: str,
+    import_version: str,
     policy: Optional[EvalScorePolicy],
     location: Optional[str],
 ) -> None:
@@ -1613,9 +1712,23 @@ def _reconcile_failed_sessions_view(
   a bounded number of times, then fails closed -- a stale pin is never
   written over a newer one, and success is never reported for a view that
   was not verified.
+
+  ``policy`` is authoritative only while ``import_version`` -- the version
+  this invocation handled -- is the latest import. When the (re-)read latest
+  version is another one, its own import decided the policy: a view
+  already pinned to it is left exactly as it is (so a delayed retry cannot
+  attach an older caller's gate to a newer version), and a view that is
+  absent or still behind is created or advanced carrying the gate it
+  already had (none for a new view), not this caller's.
   """
   for _ in range(_VIEW_SYNC_ATTEMPTS):
-    existing = _check_view_binding(client, view_ref=view_ref, job_id=job_id)
+    existing = _check_view_binding(
+        client,
+        view_ref=view_ref,
+        manifest_ref=manifest_ref,
+        job_id=job_id,
+        location=location,
+    )
     latest = _read_latest_manifest(
         client, manifest_ref=manifest_ref, job_id=job_id, location=location
     )
@@ -1624,7 +1737,16 @@ def _reconcile_failed_sessions_view(
           f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
           " after publishing; cannot pin the failed_sessions view"
       )
-    body = _failed_sessions_view_body(manifest=latest, policy=policy)
+    latest_version = str(latest["import_version"])
+    if latest_version == import_version:
+      render_policy = policy
+    elif existing is None:
+      render_policy = None
+    elif existing.pin["import_version"] == latest_version:
+      return
+    else:
+      render_policy = existing.policy
+    body = _failed_sessions_view_body(manifest=latest, policy=render_policy)
     description = _failed_sessions_view_description(latest)
     if existing is None:
       table = bigquery.Table(view_ref)
@@ -2248,11 +2370,12 @@ def _read_manifest(
     job_id: str,
     import_version: str,
     location: Optional[str],
+    feature: str = _IMPORT_FEATURE,
 ) -> Optional[dict[str, Any]]:
   job_config = bigquery.QueryJobConfig(
       query_parameters=_import_parameters(job_id, import_version)
   )
-  job_config = with_sdk_labels(job_config, feature=_IMPORT_FEATURE)
+  job_config = with_sdk_labels(job_config, feature=feature)
   query_args: dict[str, Any] = {"job_config": job_config}
   if location is not None:
     query_args["location"] = location

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -29,6 +29,13 @@ first-time imports of one version cannot both commit. ``failed_sessions_sql``
 reads one pinned ``import_version`` and implements the W0.4 contract:
 ``returncode == 0`` means *completed*, and only the per-benchmark score
 policy decides *passed*.
+
+Slice 2 of #435 makes that denominator queryable without mixing versions:
+``materialize`` also maintains one ``evalbench_failed_sessions`` VIEW per
+target dataset whose body is ``failed_sessions_sql`` with the job's latest
+successful import rendered as literals, and ``failed_sessions`` is the
+version-pinned Python consumer whose rows carry the versioned
+``session_id`` that ``Client.get_session_trace`` drills into.
 """
 
 from __future__ import annotations
@@ -48,6 +55,7 @@ import re
 from typing import Any, Optional
 import uuid
 
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 
 from ._telemetry import make_bq_client
@@ -88,6 +96,17 @@ MANIFEST_TABLE = "evalbench_import_manifest"
 # table is fixed per dataset and never caller-selectable.
 LOCK_TABLE = "evalbench_import_lock"
 _IMPORT_LOCK_ID = "evalbench-import"
+# The queryable failed-session denominator (#435 slice 2): one VIEW per
+# target dataset, pinned to the *latest successful import* of one job_id
+# (``_LATEST_IMPORT_QUERY`` over the manifest). Its body is
+# ``failed_sessions_sql`` with ``@job_id``/``@import_version`` rendered as
+# string literals, so the view never scans another version. The pin is
+# recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that
+# ``materialize`` reads back before publishing: a view bound to another job,
+# or any object at that name the importer did not create, is never replaced.
+DEFAULT_FAILED_SESSIONS_VIEW = "evalbench_failed_sessions"
+_VIEW_PIN_MARKER = "-- evalbench_failed_sessions pin: "
+_VIEW_FEATURE = "evalbench-failed-sessions"
 # The ADK plugin's production table. EvalBench imports publish only to
 # BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
 _RESERVED_DESTINATION_TABLES = frozenset({"agent_events"})
@@ -174,6 +193,25 @@ SELECT *
 FROM `{manifest_table}`
 WHERE job_id = @job_id AND import_version = @import_version
 """
+
+# "Latest successful import" of one job: the manifest holds only committed
+# publishes, so the newest ``imported_at`` (ties broken by version label for
+# determinism) is the version the failed_sessions view tracks and the
+# version ``failed_sessions()`` resolves when none is pinned.
+_LATEST_IMPORT_QUERY = """\
+SELECT *
+FROM `{manifest_table}`
+WHERE job_id = @job_id
+ORDER BY imported_at DESC, import_version DESC
+LIMIT 1
+"""
+
+_CREATE_VIEW_DDL = """\
+CREATE OR REPLACE VIEW `{view_ref}`
+OPTIONS (description = {description})
+AS
+{pin_comment}
+{query}"""
 
 # Seeds the lock sentinel outside the publish transaction. Two importers that
 # both find the table empty may each insert a sentinel (INSERTs never
@@ -727,6 +765,8 @@ class EvalBenchRun:
       import_version: Optional[str] = None,
       replace: bool = False,
       imported_at: Optional[datetime] = None,
+      failed_sessions_view: Optional[str] = DEFAULT_FAILED_SESSIONS_VIEW,
+      policy: Optional["EvalScorePolicy"] = None,
       bq_client: Optional[Any] = None,
   ) -> "EvalBenchImportResult":
     """Publish this run as one immutable import version in BQAA-owned tables.
@@ -774,6 +814,19 @@ class EvalBenchRun:
     reporting a no-op against tables that were never written or orphaning
     the old rows; use a new ``import_version`` to publish elsewhere.
 
+    Every successful call (``imported``, ``replaced`` *and* ``unchanged``)
+    also keeps the dataset's failed-session VIEW (``failed_sessions_view``,
+    default ``evalbench_failed_sessions``) pinned to this job's latest
+    successful import: ``failed_sessions_sql`` rendered with the
+    ``(job_id, import_version)`` of the newest manifest row as literals, so
+    SQL consumers never scan another version. The view is only rewritten
+    when that pin (or ``policy``) changes, so a no-op re-import leaves it
+    untouched, and it is created on the next call for corpora published
+    before views existed. A view at that name pinned to *another* job, or
+    any object there the importer did not create, raises ``ValueError``
+    before anything is written -- pass a different ``failed_sessions_view``
+    per job, or ``None`` to manage no view.
+
     Args:
       target_dataset: BQAA-owned dataset that receives the mirror tables.
       target_project: Target project; defaults to the source ``project_id``.
@@ -785,6 +838,10 @@ class EvalBenchRun:
         (``status == "replaced"``), or when an explicit version's source
         fingerprints changed.
       imported_at: Manifest timestamp; defaults to now (UTC).
+      failed_sessions_view: Name of the failed-session view kept in
+        ``target_dataset`` (see above); ``None`` skips view maintenance.
+      policy: Optional ``EvalScorePolicy`` rendered into the view so that
+        score failures count alongside process failures.
       bq_client: Optional test-compatible or caller-configured BigQuery
         client for the target project.
 
@@ -796,6 +853,18 @@ class EvalBenchRun:
     _validate_source_segment("target_dataset", target_dataset)
     _validate_destination_table("events_table", events_table)
     _validate_destination_table("scores_table", scores_table)
+    if failed_sessions_view is not None:
+      _validate_destination_table("failed_sessions_view", failed_sessions_view)
+      if failed_sessions_view in (
+          events_table,
+          scores_table,
+          MANIFEST_TABLE,
+          LOCK_TABLE,
+      ):
+        raise ValueError(
+            f"failed_sessions_view {failed_sessions_view!r} must not name an"
+            " import table"
+        )
     if imported_at is None:
       imported_at = datetime.now(timezone.utc)
     elif imported_at.tzinfo is None:
@@ -811,6 +880,11 @@ class EvalBenchRun:
     scores_ref = f"{prefix}.{scores_table}"
     manifest_ref = f"{prefix}.{MANIFEST_TABLE}"
     lock_ref = f"{prefix}.{LOCK_TABLE}"
+    view_ref = (
+        f"{prefix}.{failed_sessions_view}"
+        if failed_sessions_view is not None
+        else None
+    )
 
     # Map before touching BigQuery so mapping errors never leave staging
     # tables behind or partially created targets.
@@ -847,6 +921,37 @@ class EvalBenchRun:
         lock_ref=lock_ref,
     )
 
+    # The view binding is checked before the manifest so a name clash with
+    # another job's view (or a foreign object) aborts before any write.
+    existing_pin: Optional[dict[str, str]] = None
+    if view_ref is not None:
+      existing_pin = _read_view_pin(client, view_ref=view_ref)
+      if existing_pin is not None and existing_pin["job_id"] != self.job_id:
+        raise ValueError(
+            f"failed_sessions view {view_ref!r} is pinned to EvalBench job "
+            f"{existing_pin['job_id']!r}, not {self.job_id!r}; pass a "
+            "different failed_sessions_view for this job, or None to skip"
+            " the view"
+        )
+
+    def finish(result: "EvalBenchImportResult") -> "EvalBenchImportResult":
+      if view_ref is None:
+        return result
+      return dataclasses.replace(
+          result,
+          failed_sessions_view=_sync_failed_sessions_view(
+              client,
+              view_ref=view_ref,
+              manifest_ref=manifest_ref,
+              job_id=self.job_id,
+              existing_pin=existing_pin,
+              policy=policy,
+              location=self.location,
+              status=result.status,
+              import_version=import_version,
+          ),
+      )
+
     existing = _read_manifest(
         client,
         manifest_ref=manifest_ref,
@@ -873,12 +978,14 @@ class EvalBenchRun:
             "overwrite it"
         )
       if not drift and not replace:
-        return self._unchanged_result(
-            existing,
-            import_version=import_version,
-            events_ref=events_ref,
-            scores_ref=scores_ref,
-            manifest_ref=manifest_ref,
+        return finish(
+            self._unchanged_result(
+                existing,
+                import_version=import_version,
+                events_ref=events_ref,
+                scores_ref=scores_ref,
+                manifest_ref=manifest_ref,
+            )
         )
       status = "replaced"
 
@@ -943,12 +1050,14 @@ class EvalBenchRun:
               import_version=import_version,
               location=self.location,
           )
-          return self._unchanged_result(
-              committed if committed is not None else manifest,
-              import_version=import_version,
-              events_ref=events_ref,
-              scores_ref=scores_ref,
-              manifest_ref=manifest_ref,
+          return finish(
+              self._unchanged_result(
+                  committed if committed is not None else manifest,
+                  import_version=import_version,
+                  events_ref=events_ref,
+                  scores_ref=scores_ref,
+                  manifest_ref=manifest_ref,
+              )
           )
         if _PUBLISH_CONFLICT_MESSAGE in str(exc):
           raise ValueError(
@@ -977,16 +1086,18 @@ class EvalBenchRun:
           client, (events_staging, scores_staging, manifest_staging)
       )
 
-    return EvalBenchImportResult(
-        job_id=self.job_id,
-        import_version=import_version,
-        status=status,
-        events_table=events_ref,
-        scores_table=scores_ref,
-        manifest_table=manifest_ref,
-        event_row_count=len(event_rows),
-        score_row_count=len(score_rows),
-        manifest=manifest,
+    return finish(
+        EvalBenchImportResult(
+            job_id=self.job_id,
+            import_version=import_version,
+            status=status,
+            events_table=events_ref,
+            scores_table=scores_ref,
+            manifest_table=manifest_ref,
+            event_row_count=len(event_rows),
+            score_row_count=len(score_rows),
+            manifest=manifest,
+        )
     )
 
   def _unchanged_result(
@@ -1020,6 +1131,10 @@ class EvalBenchImportResult:
   existing version was atomically overwritten, and ``"unchanged"`` when the
   manifest already recorded this version with identical fingerprints and
   nothing was written.
+
+  ``failed_sessions_view`` is the fully-qualified failed-session view the
+  call left pinned to this job's latest successful import, or ``None`` when
+  view maintenance was disabled.
   """
 
   job_id: str
@@ -1031,6 +1146,7 @@ class EvalBenchImportResult:
   event_row_count: int
   score_row_count: int
   manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
+  failed_sessions_view: Optional[str] = None
 
   def to_dict(self) -> dict[str, Any]:
     return _json_safe(dataclasses.asdict(self))
@@ -1176,40 +1292,450 @@ def failed_sessions_sql(
     events_table: str = DEFAULT_EVENTS_TABLE,
     scores_table: str = DEFAULT_SCORES_TABLE,
     policy: Optional[EvalScorePolicy] = None,
+    job_id: Optional[str] = None,
+    import_version: Optional[str] = None,
 ) -> str:
   """Return the failed-session denominator query for one pinned import.
 
-  The query takes two parameters, ``@job_id`` and ``@import_version``
-  (see ``import_query_parameters``), and returns one row per session with
-  ``process_failed``, ``missing_completion``, ``score_failed``, and the
-  combined ``failed`` flag plus the offending ``failing_scores``. Sessions
-  whose EvalBench process exited with ``returncode == 0`` are *completed*;
-  they count as passed only when ``policy`` is satisfied. Without a policy
-  only process failures and missing completions are counted.
+  By default the query takes two parameters, ``@job_id`` and
+  ``@import_version`` (see ``import_query_parameters``). Passing both
+  ``job_id`` and ``import_version`` renders them as string literals instead,
+  which is the form a BigQuery VIEW (no query parameters) needs; passing
+  only one of them is an error, so a query can never be half-pinned.
+
+  Each returned row is one session with ``process_failed``,
+  ``missing_completion``, ``score_failed``, and the combined ``failed``
+  flag plus the offending ``failing_scores``. Sessions whose EvalBench
+  process exited with ``returncode == 0`` are *completed*; they count as
+  passed only when ``policy`` is satisfied. Without a policy only process
+  failures and missing completions are counted.
   """
   _validate_source_segment("target_project", target_project)
   _validate_source_segment("target_dataset", target_dataset)
   _validate_source_segment("events_table", events_table)
   _validate_source_segment("scores_table", scores_table)
+  return _failed_sessions_sql_for_refs(
+      events_ref=f"{target_project}.{target_dataset}.{events_table}",
+      scores_ref=f"{target_project}.{target_dataset}.{scores_table}",
+      policy=policy,
+      job_id=job_id,
+      import_version=import_version,
+  )
+
+
+def _failed_sessions_sql_for_refs(
+    *,
+    events_ref: str,
+    scores_ref: str,
+    policy: Optional[EvalScorePolicy],
+    job_id: Optional[str] = None,
+    import_version: Optional[str] = None,
+) -> str:
+  """``failed_sessions_sql`` over fully-qualified (manifest-bound) refs."""
+  if (job_id is None) != (import_version is None):
+    raise ValueError(
+        "job_id and import_version must be pinned together (or both omitted"
+        " to use @job_id/@import_version query parameters)"
+    )
   policy = policy or EvalScorePolicy()
-  sql = _FAILED_SESSIONS_BASE.format(
-      events_table=f"{target_project}.{target_dataset}.{events_table}"
-  )
+  sql = _FAILED_SESSIONS_BASE.format(events_table=events_ref)
   if not policy.min_scores:
-    return sql + _FAILED_SESSIONS_NO_POLICY
-  policy_rows = ",\n".join(
-      f"    STRUCT('{comparator}' AS comparator, {min_score!r} AS min_score)"
-      for comparator, min_score in policy.min_scores.items()
-  )
-  if policy.missing_score_fails:
-    fail_predicate = "(sc.score IS NULL OR sc.score < p.min_score)"
+    sql += _FAILED_SESSIONS_NO_POLICY
   else:
-    fail_predicate = "(sc.score IS NOT NULL AND sc.score < p.min_score)"
-  return sql + _FAILED_SESSIONS_POLICY.format(
-      policy_rows=policy_rows,
-      fail_predicate=fail_predicate,
-      scores_table=f"{target_project}.{target_dataset}.{scores_table}",
+    policy_rows = ",\n".join(
+        f"    STRUCT('{comparator}' AS comparator, {min_score!r} AS min_score)"
+        for comparator, min_score in policy.min_scores.items()
+    )
+    if policy.missing_score_fails:
+      fail_predicate = "(sc.score IS NULL OR sc.score < p.min_score)"
+    else:
+      fail_predicate = "(sc.score IS NOT NULL AND sc.score < p.min_score)"
+    sql += _FAILED_SESSIONS_POLICY.format(
+        policy_rows=policy_rows,
+        fail_predicate=fail_predicate,
+        scores_table=scores_ref,
+    )
+  if job_id is None:
+    return sql
+  if not isinstance(job_id, str) or not job_id:
+    raise ValueError("job_id must be a non-empty string")
+  _validate_import_version(import_version)
+  return sql.replace("@job_id", _sql_string_literal(job_id)).replace(
+      "@import_version", _sql_string_literal(import_version)
   )
+
+
+def _sql_string_literal(value: str) -> str:
+  """Render ``value`` as a GoogleSQL double-quoted string literal.
+
+  JSON string escaping (backslash, double quote, newline, and ``\\u``
+  escapes for the other control characters) is a subset of GoogleSQL's,
+  and non-ASCII text is emitted verbatim rather than as ``\\u`` surrogate
+  pairs, which GoogleSQL rejects. The result is always a single line.
+  """
+  return json.dumps(value, ensure_ascii=False)
+
+
+# --- Failed-session view and version-pinned consumer (#435 slice 2) ---
+
+
+def _view_pin(job_id: str, import_version: str) -> dict[str, str]:
+  return {"job_id": job_id, "import_version": import_version}
+
+
+def _view_pin_comment(pin: Mapping[str, str]) -> str:
+  # ``ensure_ascii`` keeps the comment on one line whatever the job_id holds.
+  return _VIEW_PIN_MARKER + json.dumps(pin, sort_keys=True, ensure_ascii=True)
+
+
+def _parse_view_pin(view_query: str) -> Optional[dict[str, str]]:
+  for line in view_query.splitlines():
+    line = line.strip()
+    if not line:
+      continue
+    if not line.startswith(_VIEW_PIN_MARKER):
+      return None
+    try:
+      pin = json.loads(line[len(_VIEW_PIN_MARKER) :])
+    except json.JSONDecodeError:
+      return None
+    if (
+        isinstance(pin, dict)
+        and isinstance(pin.get("job_id"), str)
+        and isinstance(pin.get("import_version"), str)
+    ):
+      return _view_pin(pin["job_id"], pin["import_version"])
+    return None
+  return None
+
+
+def _read_view_pin(client: Any, *, view_ref: str) -> Optional[dict[str, str]]:
+  """Return the ``(job_id, import_version)`` a managed view is pinned to.
+
+  ``None`` means nothing exists at ``view_ref``. Anything else that is not a
+  view carrying the importer's pin comment (a table, or a view somebody else
+  wrote) raises: the importer only ever replaces views it created.
+  """
+  try:
+    table = client.get_table(view_ref)
+  except NotFound:
+    return None
+  view_query = getattr(table, "view_query", None)
+  pin = _parse_view_pin(view_query) if isinstance(view_query, str) else None
+  if pin is None:
+    raise ValueError(
+        f"{view_ref!r} exists but is not an evalbench failed_sessions view"
+        " created by materialize(); choose another failed_sessions_view"
+        " name (or None to skip the view) rather than replacing it"
+    )
+  return pin
+
+
+def _failed_sessions_view_ddl(
+    *,
+    view_ref: str,
+    manifest: Mapping[str, Any],
+    policy: Optional[EvalScorePolicy],
+) -> str:
+  """``CREATE OR REPLACE VIEW`` pinned to one manifest row's version."""
+  job_id = str(manifest["job_id"])
+  import_version = str(manifest["import_version"])
+  pin = _view_pin(job_id, import_version)
+  description = (
+      "EvalBench failed sessions (W0.4 contract) pinned to job_id "
+      f"{job_id!r} import_version {import_version!r}; maintained by"
+      " bigquery_agent_analytics.evalbench.EvalBenchRun.materialize"
+  )
+  return _CREATE_VIEW_DDL.format(
+      view_ref=view_ref,
+      description=_sql_string_literal(description),
+      pin_comment=_view_pin_comment(pin),
+      query=_failed_sessions_sql_for_refs(
+          events_ref=str(manifest["events_table"]),
+          scores_ref=str(manifest["scores_table"]),
+          policy=policy,
+          job_id=job_id,
+          import_version=import_version,
+      ),
+  )
+
+
+def _sync_failed_sessions_view(
+    client: Any,
+    *,
+    view_ref: str,
+    manifest_ref: str,
+    job_id: str,
+    existing_pin: Optional[Mapping[str, str]],
+    policy: Optional[EvalScorePolicy],
+    location: Optional[str],
+    status: str,
+    import_version: str,
+) -> str:
+  """Point ``view_ref`` at the job's latest successful import.
+
+  Runs after the publish decision. The latest manifest row (not the version
+  just handled) is the pin, so an ``unchanged`` no-op on an old version does
+  not move the view backwards, and a ``replace`` of an old version -- which
+  refreshes ``imported_at`` -- does. The DDL is skipped when the existing
+  pin already matches and no policy is requested, so a no-op re-import
+  never rewrites the view; a policy is re-rendered because it is not part
+  of the pin.
+  """
+  latest = _read_latest_manifest(
+      client, manifest_ref=manifest_ref, job_id=job_id, location=location
+  )
+  if latest is None:
+    raise ValueError(
+        f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
+        " after publishing; cannot pin the failed_sessions view"
+    )
+  pin = _view_pin(str(latest["job_id"]), str(latest["import_version"]))
+  policy_requested = policy is not None and bool(policy.min_scores)
+  if existing_pin == pin and not policy_requested:
+    return view_ref
+  ddl = _failed_sessions_view_ddl(
+      view_ref=view_ref, manifest=latest, policy=policy
+  )
+  job_config = with_sdk_labels(bigquery.QueryJobConfig(), feature=_VIEW_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  try:
+    client.query(ddl, **query_args).result()
+  except Exception as exc:  # noqa: BLE001
+    raise ValueError(
+        f"EvalBench job {job_id!r} import_version {import_version!r} is"
+        f" published (status {status!r}) but the failed_sessions view"
+        f" {view_ref!r} could not be created or updated: {exc}. Re-run"
+        " materialize() to retry the view; the import itself then reports"
+        " 'unchanged'"
+    ) from exc
+  return view_ref
+
+
+def _read_latest_manifest(
+    client: Any,
+    *,
+    manifest_ref: str,
+    job_id: str,
+    location: Optional[str],
+) -> Optional[dict[str, Any]]:
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("job_id", "STRING", job_id)
+      ]
+  )
+  job_config = with_sdk_labels(job_config, feature=_VIEW_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _LATEST_IMPORT_QUERY.format(manifest_table=manifest_ref)
+  rows = [_plain_row(row) for row in client.query(query, **query_args).result()]
+  return rows[0] if rows else None
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalBenchSession:
+  """One session of a pinned EvalBench import, as ``failed_sessions`` returns.
+
+  The classification fields mirror ``SessionVerdict`` (and therefore
+  ``failed_sessions_sql``). ``session_id`` and ``trace_id`` are the
+  version-specific published identity
+  ``evalbench-import:{job_id}:{import_version}:{scenario_id}``, so handing
+  them to ``Client.get_session_trace`` (see ``trace_selector``) can only
+  ever return rows of this ``import_version``.
+  """
+
+  job_id: str
+  import_version: str
+  session_id: str
+  trace_id: str
+  scenario_id: Optional[str]
+  started_at: Optional[datetime]
+  process_failed: bool
+  missing_completion: bool
+  score_failed: bool
+  failed: bool
+  failing_scores: dict[str, Optional[float]] = dataclasses.field(
+      default_factory=dict
+  )
+
+  def trace_selector(self) -> dict[str, Any]:
+    """Keyword arguments that drill this session into ``get_session_trace``.
+
+    ``session_id`` alone already pins the import version (it is part of the
+    identity); ``experiment_id`` additionally pins the job scope, matching
+    ``attributes.experiment_id`` that every published row carries. Use with
+    a ``Client`` whose ``table_id`` is the mirror events table::
+
+        client.get_session_trace(**session.trace_selector())
+    """
+    return {"session_id": self.session_id, "experiment_id": self.job_id}
+
+  def get_trace(self, client: Any, **overrides: Any) -> Any:
+    """Thin wrapper: ``client.get_session_trace(**trace_selector())``."""
+    return client.get_session_trace(**{**self.trace_selector(), **overrides})
+
+  def verdict(self) -> SessionVerdict:
+    return SessionVerdict(
+        session_id=self.session_id,
+        scenario_id=self.scenario_id,
+        process_failed=self.process_failed,
+        missing_completion=self.missing_completion,
+        score_failed=self.score_failed,
+        failing_scores=dict(self.failing_scores),
+        failed=self.failed,
+    )
+
+  def to_dict(self) -> dict[str, Any]:
+    return _json_safe(dataclasses.asdict(self))
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalBenchFailedSessions:
+  """Outcome of ``failed_sessions``: one pinned import and its session rows.
+
+  ``sessions`` holds the failed sessions only unless ``include_passed`` was
+  requested; ``failed_count``/``session_count`` are computed over the same
+  pinned version regardless.
+  """
+
+  job_id: str
+  import_version: str
+  events_table: str
+  scores_table: str
+  sessions: list[EvalBenchSession]
+  session_count: int
+  failed_count: int
+  manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    return _json_safe(dataclasses.asdict(self))
+
+
+def failed_sessions(
+    *,
+    target_project: str,
+    target_dataset: str,
+    job_id: str,
+    import_version: Optional[str] = None,
+    policy: Optional[EvalScorePolicy] = None,
+    include_passed: bool = False,
+    location: Optional[str] = None,
+    bq_client: Optional[Any] = None,
+) -> EvalBenchFailedSessions:
+  """List the failed sessions of exactly one published import version.
+
+  The version is pinned before any event row is read: an explicit
+  ``import_version`` must have a manifest row, and when omitted the job's
+  latest successful import (newest ``imported_at``, the same pin the
+  ``evalbench_failed_sessions`` view tracks) is used. The query is
+  ``failed_sessions_sql`` over the events/scores tables recorded in that
+  manifest row -- a version stays bound to the tables it was published to
+  -- executed with ``import_query_parameters``, so rows of another version
+  can never be mixed in. ``policy`` applies the per-benchmark score gate;
+  without it only process failures and missing completions count.
+
+  Returns an ``EvalBenchFailedSessions`` whose ``sessions`` are the failed
+  rows (all rows with ``include_passed=True``), each carrying the versioned
+  ``session_id``/``trace_id`` for ``Client.get_session_trace``.
+  """
+  _validate_source_segment("target_project", target_project)
+  _validate_source_segment("target_dataset", target_dataset)
+  if not isinstance(job_id, str) or not job_id:
+    raise ValueError("job_id must be a non-empty string")
+  manifest_ref = f"{target_project}.{target_dataset}.{MANIFEST_TABLE}"
+  client = bq_client or make_bq_client(target_project, location=location)
+  if import_version is None:
+    manifest = _read_latest_manifest(
+        client, manifest_ref=manifest_ref, job_id=job_id, location=location
+    )
+    if manifest is None:
+      raise ValueError(
+          f"EvalBench job {job_id!r} has no published import in"
+          f" {manifest_ref!r}; run materialize() first"
+      )
+    import_version = str(manifest["import_version"])
+  else:
+    _validate_import_version(import_version)
+    manifest = _read_manifest(
+        client,
+        manifest_ref=manifest_ref,
+        job_id=job_id,
+        import_version=import_version,
+        location=location,
+    )
+    if manifest is None:
+      raise ValueError(
+          f"EvalBench job {job_id!r} import_version {import_version!r} is not"
+          f" published in {manifest_ref!r}"
+      )
+  events_ref = str(manifest["events_table"])
+  scores_ref = str(manifest["scores_table"])
+  sql = _failed_sessions_sql_for_refs(
+      events_ref=events_ref, scores_ref=scores_ref, policy=policy
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=import_query_parameters(job_id, import_version)
+  )
+  job_config = with_sdk_labels(job_config, feature=_VIEW_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  rows = [
+      _session_from_row(
+          _plain_row(row), job_id=job_id, import_version=import_version
+      )
+      for row in client.query(sql, **query_args).result()
+  ]
+  failed = [row for row in rows if row.failed]
+  return EvalBenchFailedSessions(
+      job_id=job_id,
+      import_version=import_version,
+      events_table=events_ref,
+      scores_table=scores_ref,
+      sessions=rows if include_passed else failed,
+      session_count=len(rows),
+      failed_count=len(failed),
+      manifest=dict(manifest),
+  )
+
+
+def _session_from_row(
+    row: Mapping[str, Any], *, job_id: str, import_version: str
+) -> EvalBenchSession:
+  """Build an ``EvalBenchSession`` from one ``failed_sessions_sql`` row."""
+  failing_scores: dict[str, Optional[float]] = {}
+  for item in row.get("failing_scores") or ():
+    entry = _as_mapping(item) if isinstance(item, Mapping) else _row_items(item)
+    comparator = entry.get("comparator")
+    if isinstance(comparator, str):
+      failing_scores[comparator] = _score_value(entry.get("score"))
+  started_at = row.get("started_at")
+  if started_at is not None and not isinstance(started_at, datetime):
+    started_at = _parse_timestamp(started_at)
+  session_id = str(row["session_id"])
+  return EvalBenchSession(
+      job_id=job_id,
+      import_version=import_version,
+      session_id=session_id,
+      trace_id=session_id,
+      scenario_id=_usable_text(row.get("scenario_id")),
+      started_at=started_at,
+      process_failed=bool(row.get("process_failed")),
+      missing_completion=bool(row.get("missing_completion")),
+      score_failed=bool(row.get("score_failed")),
+      failed=bool(row.get("failed")),
+      failing_scores=failing_scores,
+  )
+
+
+def _row_items(value: Any) -> dict[str, Any]:
+  """``bigquery.Row``-like STRUCT values expose ``items()`` without Mapping."""
+  if hasattr(value, "items"):
+    return {str(key): item for key, item in value.items()}
+  return {}
 
 
 def import_query_parameters(

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -55,7 +55,9 @@ import re
 from typing import Any, Optional
 import uuid
 
+from google.api_core.exceptions import Conflict
 from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import PreconditionFailed
 from google.cloud import bigquery
 
 from ._telemetry import make_bq_client
@@ -101,11 +103,20 @@ _IMPORT_LOCK_ID = "evalbench-import"
 # (``_LATEST_IMPORT_QUERY`` over the manifest). Its body is
 # ``failed_sessions_sql`` with ``@job_id``/``@import_version`` rendered as
 # string literals, so the view never scans another version. The pin is
-# recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that
-# ``materialize`` reads back before publishing: a view bound to another job,
-# or any object at that name the importer did not create, is never replaced.
+# recorded in a leading SQL comment (``_VIEW_PIN_MARKER``) that also carries
+# the rendered score policy and a hash of the canonical query below it, so
+# the marker alone never proves ownership: a view is the importer's only
+# when its body is byte-for-byte (modulo whitespace) what the importer
+# renders for that pin. Anything else at that name -- a table, a foreign
+# view, a view carrying a copied marker over other SQL, or a managed view
+# somebody edited -- is refused, never replaced. Writes go through the
+# tables API rather than ``CREATE OR REPLACE VIEW``: create-if-absent, and
+# ETag-conditional replace after re-reading the view and the latest
+# manifest, so two concurrent imports cannot overwrite each other's pin.
 DEFAULT_FAILED_SESSIONS_VIEW = "evalbench_failed_sessions"
 _VIEW_PIN_MARKER = "-- evalbench_failed_sessions pin: "
+# Bounded retries when the view changes underneath a conditional write.
+_VIEW_SYNC_ATTEMPTS = 3
 _VIEW_FEATURE = "evalbench-failed-sessions"
 # The ADK plugin's production table. EvalBench imports publish only to
 # BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
@@ -206,10 +217,9 @@ ORDER BY imported_at DESC, import_version DESC
 LIMIT 1
 """
 
-_CREATE_VIEW_DDL = """\
-CREATE OR REPLACE VIEW `{view_ref}`
-OPTIONS (description = {description})
-AS
+# The managed view's query text (``Table.view_query``): the pin comment on
+# the first line, the pinned ``failed_sessions_sql`` below it.
+_VIEW_BODY = """\
 {pin_comment}
 {query}"""
 
@@ -820,12 +830,18 @@ class EvalBenchRun:
     successful import: ``failed_sessions_sql`` rendered with the
     ``(job_id, import_version)`` of the newest manifest row as literals, so
     SQL consumers never scan another version. The view is only rewritten
-    when that pin (or ``policy``) changes, so a no-op re-import leaves it
-    untouched, and it is created on the next call for corpora published
-    before views existed. A view at that name pinned to *another* job, or
-    any object there the importer did not create, raises ``ValueError``
-    before anything is written -- pass a different ``failed_sessions_view``
-    per job, or ``None`` to manage no view.
+    when its rendered definition would change (pinned version, ``policy``,
+    or the SQL itself), so a no-op re-import leaves it untouched, and it is
+    created on the next call for corpora published before views existed.
+    Ownership is proven by the definition, not by the pin comment alone: a
+    view at that name pinned to *another* job, or any object there whose
+    query is not what the importer rendered (a table, a foreign view, a
+    copied pin over other SQL, an edited managed view), raises
+    ``ValueError`` before anything is written -- pass a different
+    ``failed_sessions_view`` per job, or ``None`` to manage no view. The
+    view is written with create-if-absent and ETag-conditional replace
+    after re-reading it and the latest manifest, so concurrent imports of
+    one job cannot leave a stale pin behind.
 
     Args:
       target_dataset: BQAA-owned dataset that receives the mirror tables.
@@ -913,6 +929,15 @@ class EvalBenchRun:
     }
 
     client = bq_client or make_bq_client(target_project, location=self.location)
+
+    # The view binding is checked before any table is created or written so
+    # a name clash with another job's view (or a foreign object) aborts
+    # before the importer touches the dataset. ``_sync_failed_sessions_view``
+    # re-reads it right before writing; this early read is the fail-fast
+    # path, not the authority.
+    if view_ref is not None:
+      _check_view_binding(client, view_ref=view_ref, job_id=self.job_id)
+
     _ensure_import_tables(
         client,
         events_ref=events_ref,
@@ -920,19 +945,6 @@ class EvalBenchRun:
         manifest_ref=manifest_ref,
         lock_ref=lock_ref,
     )
-
-    # The view binding is checked before the manifest so a name clash with
-    # another job's view (or a foreign object) aborts before any write.
-    existing_pin: Optional[dict[str, str]] = None
-    if view_ref is not None:
-      existing_pin = _read_view_pin(client, view_ref=view_ref)
-      if existing_pin is not None and existing_pin["job_id"] != self.job_id:
-        raise ValueError(
-            f"failed_sessions view {view_ref!r} is pinned to EvalBench job "
-            f"{existing_pin['job_id']!r}, not {self.job_id!r}; pass a "
-            "different failed_sessions_view for this job, or None to skip"
-            " the view"
-        )
 
     def finish(result: "EvalBenchImportResult") -> "EvalBenchImportResult":
       if view_ref is None:
@@ -944,7 +956,6 @@ class EvalBenchRun:
               view_ref=view_ref,
               manifest_ref=manifest_ref,
               job_id=self.job_id,
-              existing_pin=existing_pin,
               policy=policy,
               location=self.location,
               status=result.status,
@@ -1379,18 +1390,61 @@ def _sql_string_literal(value: str) -> str:
 # --- Failed-session view and version-pinned consumer (#435 slice 2) ---
 
 
-def _view_pin(job_id: str, import_version: str) -> dict[str, str]:
-  return {"job_id": job_id, "import_version": import_version}
+def _policy_pin(policy: Optional[EvalScorePolicy]) -> Optional[dict[str, Any]]:
+  """The score gate a view renders, in canonical form (``None`` = no gate)."""
+  if policy is None or not policy.min_scores:
+    return None
+  return {
+      "min_scores": {
+          comparator: float(min_score)
+          for comparator, min_score in sorted(policy.min_scores.items())
+      },
+      "missing_score_fails": bool(policy.missing_score_fails),
+  }
 
 
-def _view_pin_comment(pin: Mapping[str, str]) -> str:
+def _normalize_sql(text: str) -> str:
+  # BigQuery stores a view's query text verbatim; collapsing whitespace only
+  # guards against incidental reformatting, never against changed SQL.
+  return " ".join(text.split())
+
+
+def _sql_digest(query: str) -> str:
+  return hashlib.sha256(_normalize_sql(query).encode("utf-8")).hexdigest()
+
+
+def _view_pin(
+    job_id: str,
+    import_version: str,
+    *,
+    policy: Optional[EvalScorePolicy],
+    query: str,
+) -> dict[str, Any]:
+  """The pin comment payload: what the view is bound to, and to what SQL."""
+  return {
+      "job_id": job_id,
+      "import_version": import_version,
+      "policy": _policy_pin(policy),
+      "query_sha256": _sql_digest(query),
+  }
+
+
+def _view_pin_comment(pin: Mapping[str, Any]) -> str:
   # ``ensure_ascii`` keeps the comment on one line whatever the job_id holds.
   return _VIEW_PIN_MARKER + json.dumps(pin, sort_keys=True, ensure_ascii=True)
 
 
-def _parse_view_pin(view_query: str) -> Optional[dict[str, str]]:
-  for line in view_query.splitlines():
-    line = line.strip()
+def _parse_view_pin(view_query: str) -> Optional[dict[str, Any]]:
+  """Return the pin a managed view carries, or ``None`` if it is not ours.
+
+  Ours means: the first nonblank line is a well-formed pin comment *and*
+  the query below it hashes to the ``query_sha256`` the pin records. A
+  copied marker over other SQL, or a managed view whose body was edited,
+  fails the second half and is treated as foreign.
+  """
+  lines = view_query.splitlines()
+  for index, raw in enumerate(lines):
+    line = raw.strip()
     if not line:
       continue
     if not line.startswith(_VIEW_PIN_MARKER):
@@ -1399,22 +1453,45 @@ def _parse_view_pin(view_query: str) -> Optional[dict[str, str]]:
       pin = json.loads(line[len(_VIEW_PIN_MARKER) :])
     except json.JSONDecodeError:
       return None
-    if (
+    if not (
         isinstance(pin, dict)
         and isinstance(pin.get("job_id"), str)
         and isinstance(pin.get("import_version"), str)
+        and isinstance(pin.get("query_sha256"), str)
     ):
-      return _view_pin(pin["job_id"], pin["import_version"])
-    return None
+      return None
+    query = "\n".join(lines[index + 1 :])
+    if not query.strip() or _sql_digest(query) != pin["query_sha256"]:
+      return None
+    return {
+        "job_id": pin["job_id"],
+        "import_version": pin["import_version"],
+        "policy": pin.get("policy"),
+        "query_sha256": pin["query_sha256"],
+    }
   return None
 
 
-def _read_view_pin(client: Any, *, view_ref: str) -> Optional[dict[str, str]]:
-  """Return the ``(job_id, import_version)`` a managed view is pinned to.
+@dataclasses.dataclass(frozen=True)
+class _ManagedView:
+  """A view at the managed name that the importer recognizes as its own."""
+
+  table: Any
+  pin: dict[str, Any]
+
+  @property
+  def view_query(self) -> str:
+    return str(self.table.view_query)
+
+
+def _read_managed_view(client: Any, *, view_ref: str) -> Optional[_ManagedView]:
+  """Return the managed view at ``view_ref`` with its pin and ETag.
 
   ``None`` means nothing exists at ``view_ref``. Anything else that is not a
-  view carrying the importer's pin comment (a table, or a view somebody else
-  wrote) raises: the importer only ever replaces views it created.
+  view carrying the importer's pin *over the query that pin hashes* (a
+  table, a view somebody else wrote, a copied marker, an edited body)
+  raises: the importer only ever replaces views whose definition it can
+  vouch for.
   """
   try:
     table = client.get_table(view_ref)
@@ -1425,38 +1502,53 @@ def _read_view_pin(client: Any, *, view_ref: str) -> Optional[dict[str, str]]:
   if pin is None:
     raise ValueError(
         f"{view_ref!r} exists but is not an evalbench failed_sessions view"
-        " created by materialize(); choose another failed_sessions_view"
-        " name (or None to skip the view) rather than replacing it"
+        " created by materialize() (or its definition was changed); choose"
+        " another failed_sessions_view name (or None to skip the view)"
+        " rather than replacing it"
     )
-  return pin
+  return _ManagedView(table=table, pin=pin)
 
 
-def _failed_sessions_view_ddl(
+def _check_view_binding(
+    client: Any, *, view_ref: str, job_id: str
+) -> Optional[_ManagedView]:
+  """Refuse a view the importer does not own or that belongs to another job."""
+  existing = _read_managed_view(client, view_ref=view_ref)
+  if existing is not None and existing.pin["job_id"] != job_id:
+    raise ValueError(
+        f"failed_sessions view {view_ref!r} is pinned to EvalBench job "
+        f"{existing.pin['job_id']!r}, not {job_id!r}; pass a "
+        "different failed_sessions_view for this job, or None to skip"
+        " the view"
+    )
+  return existing
+
+
+def _failed_sessions_view_body(
     *,
-    view_ref: str,
     manifest: Mapping[str, Any],
     policy: Optional[EvalScorePolicy],
 ) -> str:
-  """``CREATE OR REPLACE VIEW`` pinned to one manifest row's version."""
+  """The managed view's query text pinned to one manifest row's version."""
   job_id = str(manifest["job_id"])
   import_version = str(manifest["import_version"])
-  pin = _view_pin(job_id, import_version)
-  description = (
-      "EvalBench failed sessions (W0.4 contract) pinned to job_id "
-      f"{job_id!r} import_version {import_version!r}; maintained by"
-      " bigquery_agent_analytics.evalbench.EvalBenchRun.materialize"
+  query = _failed_sessions_sql_for_refs(
+      events_ref=str(manifest["events_table"]),
+      scores_ref=str(manifest["scores_table"]),
+      policy=policy,
+      job_id=job_id,
+      import_version=import_version,
   )
-  return _CREATE_VIEW_DDL.format(
-      view_ref=view_ref,
-      description=_sql_string_literal(description),
-      pin_comment=_view_pin_comment(pin),
-      query=_failed_sessions_sql_for_refs(
-          events_ref=str(manifest["events_table"]),
-          scores_ref=str(manifest["scores_table"]),
-          policy=policy,
-          job_id=job_id,
-          import_version=import_version,
-      ),
+  pin = _view_pin(job_id, import_version, policy=policy, query=query)
+  return _VIEW_BODY.format(pin_comment=_view_pin_comment(pin), query=query)
+
+
+def _failed_sessions_view_description(manifest: Mapping[str, Any]) -> str:
+  return (
+      "EvalBench failed sessions (W0.4 contract) pinned to job_id "
+      f"{str(manifest['job_id'])!r} import_version "
+      f"{str(manifest['import_version'])!r}; maintained by"
+      " bigquery_agent_analytics.evalbench.EvalBenchRun.materialize"
   )
 
 
@@ -1466,7 +1558,6 @@ def _sync_failed_sessions_view(
     view_ref: str,
     manifest_ref: str,
     job_id: str,
-    existing_pin: Optional[Mapping[str, str]],
     policy: Optional[EvalScorePolicy],
     location: Optional[str],
     status: str,
@@ -1477,32 +1568,20 @@ def _sync_failed_sessions_view(
   Runs after the publish decision. The latest manifest row (not the version
   just handled) is the pin, so an ``unchanged`` no-op on an old version does
   not move the view backwards, and a ``replace`` of an old version -- which
-  refreshes ``imported_at`` -- does. The DDL is skipped when the existing
-  pin already matches and no policy is requested, so a no-op re-import
-  never rewrites the view; a policy is re-rendered because it is not part
-  of the pin.
+  refreshes ``imported_at`` -- does. The write is skipped when the existing
+  view's query already is what would be rendered (same version, same policy,
+  same SQL), so a no-op re-import never rewrites the view, while adding,
+  changing, or dropping the policy does.
   """
-  latest = _read_latest_manifest(
-      client, manifest_ref=manifest_ref, job_id=job_id, location=location
-  )
-  if latest is None:
-    raise ValueError(
-        f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
-        " after publishing; cannot pin the failed_sessions view"
-    )
-  pin = _view_pin(str(latest["job_id"]), str(latest["import_version"]))
-  policy_requested = policy is not None and bool(policy.min_scores)
-  if existing_pin == pin and not policy_requested:
-    return view_ref
-  ddl = _failed_sessions_view_ddl(
-      view_ref=view_ref, manifest=latest, policy=policy
-  )
-  job_config = with_sdk_labels(bigquery.QueryJobConfig(), feature=_VIEW_FEATURE)
-  query_args: dict[str, Any] = {"job_config": job_config}
-  if location is not None:
-    query_args["location"] = location
   try:
-    client.query(ddl, **query_args).result()
+    _reconcile_failed_sessions_view(
+        client,
+        view_ref=view_ref,
+        manifest_ref=manifest_ref,
+        job_id=job_id,
+        policy=policy,
+        location=location,
+    )
   except Exception as exc:  # noqa: BLE001
     raise ValueError(
         f"EvalBench job {job_id!r} import_version {import_version!r} is"
@@ -1512,6 +1591,69 @@ def _sync_failed_sessions_view(
         " 'unchanged'"
     ) from exc
   return view_ref
+
+
+def _reconcile_failed_sessions_view(
+    client: Any,
+    *,
+    view_ref: str,
+    manifest_ref: str,
+    job_id: str,
+    policy: Optional[EvalScorePolicy],
+    location: Optional[str],
+) -> None:
+  """Create or conditionally replace the managed view, never blindly.
+
+  Each attempt re-reads the view (ownership, job, ETag) and *then* the
+  latest manifest row, so a version committed by a concurrent import after
+  the view was read is still seen. A missing view is created with
+  create-if-absent (``Conflict`` if another import created it first); an
+  existing one is replaced only if its ETag still matches
+  (``PreconditionFailed`` otherwise). Either race re-reads and re-decides,
+  a bounded number of times, then fails closed -- a stale pin is never
+  written over a newer one, and success is never reported for a view that
+  was not verified.
+  """
+  for _ in range(_VIEW_SYNC_ATTEMPTS):
+    existing = _check_view_binding(client, view_ref=view_ref, job_id=job_id)
+    latest = _read_latest_manifest(
+        client, manifest_ref=manifest_ref, job_id=job_id, location=location
+    )
+    if latest is None:
+      raise ValueError(
+          f"EvalBench job {job_id!r} has no manifest row in {manifest_ref!r}"
+          " after publishing; cannot pin the failed_sessions view"
+      )
+    body = _failed_sessions_view_body(manifest=latest, policy=policy)
+    description = _failed_sessions_view_description(latest)
+    if existing is None:
+      table = bigquery.Table(view_ref)
+      table.view_query = body
+      table.description = description
+      try:
+        client.create_table(table, exists_ok=False)
+      except Conflict:
+        continue
+      return
+    if _normalize_sql(existing.view_query) == _normalize_sql(body):
+      return
+    table = existing.table
+    if not getattr(table, "etag", None):
+      raise ValueError(
+          f"failed_sessions view {view_ref!r} has no ETag; refusing an"
+          " unconditional replace"
+      )
+    table.view_query = body
+    table.description = description
+    try:
+      client.update_table(table, ["view_query", "description"])
+    except PreconditionFailed:
+      continue
+    return
+  raise ValueError(
+      f"failed_sessions view {view_ref!r} changed concurrently"
+      f" {_VIEW_SYNC_ATTEMPTS} times; re-run materialize() to retry"
+  )
 
 
 def _read_latest_manifest(

--- a/tests/test_cli_evalbench_failed_sessions.py
+++ b/tests/test_cli_evalbench_failed_sessions.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``bq-agent-sdk evalbench-failed-sessions`` (#435 slice 2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics import evalbench
+from bigquery_agent_analytics.cli import app
+
+runner = CliRunner()
+
+_SESSION = evalbench.EvalBenchSession(
+    job_id="job-123",
+    import_version="v1",
+    session_id="evalbench-import:job-123:v1:crash-1",
+    trace_id="evalbench-import:job-123:v1:crash-1",
+    scenario_id="crash-1",
+    started_at=datetime(2026, 4, 29, 12, 30, tzinfo=timezone.utc),
+    process_failed=True,
+    missing_completion=True,
+    score_failed=False,
+    failed=True,
+)
+_LISTING = evalbench.EvalBenchFailedSessions(
+    job_id="job-123",
+    import_version="v1",
+    events_table="analytics-project.bqaa.evalbench_agent_events",
+    scores_table="analytics-project.bqaa.evalbench_scores_imported",
+    sessions=[_SESSION],
+    session_count=2,
+    failed_count=1,
+    manifest={"job_id": "job-123", "import_version": "v1"},
+)
+_BASE_ARGS = [
+    "evalbench-failed-sessions",
+    "--project-id",
+    "analytics-project",
+    "--target-dataset",
+    "bqaa",
+    "--job-id",
+    "job-123",
+]
+
+
+def _patch_failed_sessions(
+    monkeypatch: pytest.MonkeyPatch, error: Exception | None = None
+) -> list[dict]:
+  calls: list[dict] = []
+
+  def fake_failed_sessions(**kwargs):
+    calls.append(kwargs)
+    if error is not None:
+      raise error
+    return _LISTING
+
+  monkeypatch.setattr(evalbench, "failed_sessions", fake_failed_sessions)
+  return calls
+
+
+def test_lists_latest_version_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_failed_sessions(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 0, result.output
+  assert calls == [
+      {
+          "target_project": "analytics-project",
+          "target_dataset": "bqaa",
+          "job_id": "job-123",
+          "import_version": None,
+          "policy": None,
+          "include_passed": False,
+          "location": None,
+      }
+  ]
+  payload = json.loads(result.output)
+  assert payload["import_version"] == "v1"
+  assert payload["failed_count"] == 1
+  assert payload["sessions"][0]["session_id"] == (
+      "evalbench-import:job-123:v1:crash-1"
+  )
+  assert (
+      payload["sessions"][0]["trace_id"] == payload["sessions"][0]["session_id"]
+  )
+
+
+def test_pins_version_and_policy_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_failed_sessions(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      _BASE_ARGS
+      + [
+          "--import-version",
+          "v1",
+          "--min-score",
+          "goal_completion=0.5",
+          "--min-score",
+          "sql_correctness=1",
+          "--missing-score-passes",
+          "--include-passed",
+          "--location",
+          "US",
+          "--format",
+          "table",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  (call,) = calls
+  assert call["import_version"] == "v1"
+  assert call["policy"] == evalbench.EvalScorePolicy(
+      {"goal_completion": 0.5, "sql_correctness": 1.0},
+      missing_score_fails=False,
+  )
+  assert call["include_passed"] is True
+  assert call["location"] == "US"
+  assert "session_id" in result.output
+  assert "evalbench-import:job-123:v1:crash-1" in result.output
+
+
+@pytest.mark.parametrize(
+    "option",
+    ["goal_completion", "=0.5", "goal_completion=high", "bad name=0.5"],
+)
+def test_rejects_malformed_min_score(
+    monkeypatch: pytest.MonkeyPatch, option: str
+) -> None:
+  calls = _patch_failed_sessions(monkeypatch)
+  result = runner.invoke(app, _BASE_ARGS + ["--min-score", option])
+  assert result.exit_code == 2, result.output
+  assert "min-score" in result.output or "comparator" in result.output
+  assert calls == []
+
+
+def test_surfaces_consumer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+  _patch_failed_sessions(
+      monkeypatch,
+      error=ValueError("EvalBench job 'job-123' has no published import"),
+  )
+  result = runner.invoke(app, _BASE_ARGS)
+  assert result.exit_code == 2
+  assert "no published import" in result.output

--- a/tests/test_cli_evalbench_import.py
+++ b/tests/test_cli_evalbench_import.py
@@ -107,6 +107,8 @@ def test_evalbench_import_reads_source_and_materializes_to_target(
   assert materialize["scores_table"] == "evalbench_scores_imported"
   assert materialize["import_version"] == "v1"
   assert materialize["replace"] is True
+  assert materialize["failed_sessions_view"] == "evalbench_failed_sessions"
+  assert materialize["policy"] is None
   payload = json.loads(result.output)
   assert payload["status"] == "imported"
   assert payload["import_version"] == "v1"
@@ -139,6 +141,93 @@ def test_evalbench_import_defaults_target_to_source_and_derived_version(
   assert materialize["target_project"] is None
   assert materialize["import_version"] is None
   assert materialize["replace"] is False
+  assert materialize["failed_sessions_view"] == "evalbench_failed_sessions"
+
+
+def test_evalbench_import_view_and_policy_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+          "--failed-sessions-view",
+          "failed_sessions_job_123",
+          "--min-score",
+          "goal_completion=0.5",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  materialize = calls[1]["materialize"]
+  assert materialize["failed_sessions_view"] == "failed_sessions_job_123"
+  assert materialize["policy"] == evalbench.EvalScorePolicy(
+      {"goal_completion": 0.5}
+  )
+
+
+def test_evalbench_import_can_skip_the_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+          "--skip-failed-sessions-view",
+      ],
+  )
+  assert result.exit_code == 0, result.output
+  assert calls[1]["materialize"]["failed_sessions_view"] is None
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--failed-sessions-view", "agent_events"),
+        ("--min-score", "goal_completion"),
+    ],
+)
+def test_evalbench_import_rejects_bad_view_or_policy_before_reading(
+    monkeypatch: pytest.MonkeyPatch, option: str, value: str
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-import",
+          "--project-id",
+          "source-project",
+          "--evalbench-dataset",
+          "evalbench",
+          "--job-id",
+          "job-123",
+          "--target-dataset",
+          "bqaa",
+          option,
+          value,
+      ],
+  )
+  assert result.exit_code == 2, result.output
+  assert calls == []
 
 
 def test_evalbench_import_rejects_bad_snapshot_timestamp(

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -15,16 +15,20 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import dataclasses
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+import hashlib
 import inspect
 import json
 import math
 import re
 
+from google.api_core.exceptions import Conflict
 from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import PreconditionFailed
 import pytest
 
 from bigquery_agent_analytics import evalbench
@@ -503,8 +507,15 @@ class _FakeManifestStore:
     self.scores: list[dict] = []
     self.lock_rows = 0
     self.lock_claims = 0
-    # view ref -> view body (the DDL text after ``AS``), like ``view_query``.
+    # view ref -> query text (``Table.view_query``) and its current ETag.
     self.views: dict[str, str] = {}
+    self.view_etags: dict[str, str] = {}
+    self._etag_counter = 0
+
+  def write_view(self, view_ref: str, view_query: str) -> None:
+    self._etag_counter += 1
+    self.views[view_ref] = view_query
+    self.view_etags[view_ref] = f"etag-{self._etag_counter}"
 
   def snapshot(self) -> _FakeSnapshot:
     return _FakeSnapshot(
@@ -531,12 +542,18 @@ def _same_version(row: dict, params: dict) -> bool:
 
 
 class _FakeView:
-  """What ``client.get_table`` returns for a view: its query text."""
+  """What ``client.get_table`` returns for a view: query text and ETag."""
 
   table_type = "VIEW"
 
-  def __init__(self, view_query: str) -> None:
+  def __init__(
+      self, view_query: str, etag: str | None = "etag-foreign", ref: str = ""
+  ) -> None:
     self.view_query = view_query
+    self.etag = etag
+    self.description = None
+    parts = ref.split(".") if ref else ["", "", ""]
+    self.project, self.dataset_id, self.table_id = parts
 
 
 _POLICY_ROW = re.compile(
@@ -581,6 +598,7 @@ class _FakeWriteClient:
       delete_error: Exception | None = None,
       view_error: Exception | None = None,
       foreign_objects: dict[str, object] | None = None,
+      before_view_write: Callable[[], None] | None = None,
   ) -> None:
     self.store = store or _FakeManifestStore(manifest_rows)
     self.stale_manifest_reads = stale_manifest_reads
@@ -590,8 +608,14 @@ class _FakeWriteClient:
     self.transaction_error = transaction_error
     self.delete_error = delete_error
     self.view_error = view_error
+    # Runs once, inside this client's first view write, *after* the importer
+    # read the view and the latest manifest and decided what to write: a
+    # concurrent import that lands in that window.
+    self.before_view_write = before_view_write
     # Objects that exist at a ref but were not created by the importer.
     self.foreign_objects = dict(foreign_objects or {})
+    # (kind, view ref, number of queries issued so far) per view write.
+    self.view_writes: list[tuple[str, str, int]] = []
     self.loads: list[tuple[str, list[dict], object]] = []
     self.queries: list[tuple[str, dict]] = []
     self.created: list[str] = []
@@ -604,17 +628,54 @@ class _FakeWriteClient:
     return self.store.rows
 
   def create_table(self, table, exists_ok: bool = False):
-    assert exists_ok is True
-    self.created.append(f"{table.project}.{table.dataset_id}.{table.table_id}")
-    self.created_tables.append(table)
+    ref = f"{table.project}.{table.dataset_id}.{table.table_id}"
+    if getattr(table, "view_query", None) is None:
+      assert exists_ok is True
+      self.created.append(ref)
+      self.created_tables.append(table)
+      return table
+    # Views: create-if-absent through the tables API, never exists_ok.
+    assert exists_ok is False
+    assert isinstance(table.view_query, str) and table.description
+    self._run_before_view_write()
+    if self.view_error is not None:
+      raise self.view_error
+    if ref in self.foreign_objects or ref in self.store.views:
+      raise Conflict(f"409 Already Exists: Table {ref}")
+    self.store.write_view(ref, table.view_query)
+    self.view_writes.append(("create", ref, len(self.queries)))
     return table
+
+  def update_table(self, table, fields):
+    ref = f"{table.project}.{table.dataset_id}.{table.table_id}"
+    assert "view_query" in fields
+    self._run_before_view_write()
+    if self.view_error is not None:
+      raise self.view_error
+    if ref not in self.store.views:
+      raise NotFound(ref)
+    # ``If-Match``: the write only lands if the ETag read is still current.
+    if table.etag != self.store.view_etags[ref]:
+      raise PreconditionFailed(f"412 Precondition Failed: {ref}")
+    self.store.write_view(ref, table.view_query)
+    self.view_writes.append(("update", ref, len(self.queries)))
+    return table
+
+  def _run_before_view_write(self) -> None:
+    hook, self.before_view_write = self.before_view_write, None
+    if hook is not None:
+      hook()
 
   def get_table(self, table_ref: str):
     self.get_table_calls.append(table_ref)
     if table_ref in self.foreign_objects:
       return self.foreign_objects[table_ref]
     if table_ref in self.store.views:
-      return _FakeView(self.store.views[table_ref])
+      return _FakeView(
+          self.store.views[table_ref],
+          etag=self.store.view_etags[table_ref],
+          ref=table_ref,
+      )
     raise NotFound(table_ref)
 
   def query(self, query: str, **kwargs) -> _FakeJob:
@@ -626,14 +687,7 @@ class _FakeWriteClient:
         return _FakeJob(error=self.transaction_error)
       snapshot = self.transaction_snapshot or self.store.snapshot()
       return self._publish(query, params, snapshot)
-    if query.startswith("CREATE OR REPLACE VIEW"):
-      # Views cannot take query parameters.
-      assert params == {}
-      if self.view_error is not None:
-        return _FakeJob(error=self.view_error)
-      view_ref = re.match(r"CREATE OR REPLACE VIEW `([^`]+)`", query).group(1)
-      self.store.views[view_ref] = query.split("\nAS\n", 1)[1]
-      return _FakeJob()
+    assert not query.startswith("CREATE"), "views are written via the API"
     if query.startswith("WITH sessions AS"):
       return _FakeJob(self._failed_sessions(query, params))
     if (
@@ -1579,9 +1633,7 @@ def test_materialize_consults_canonical_registry_for_custom_tables() -> None:
   pre_reads = [
       sql
       for sql, _ in fake.queries
-      if "BEGIN TRANSACTION" not in sql
-      and sql not in _lock_seed_queries(fake)
-      and not sql.startswith("CREATE OR REPLACE VIEW")
+      if "BEGIN TRANSACTION" not in sql and sql not in _lock_seed_queries(fake)
   ]
   assert pre_reads and all(f"`{registry}`" in sql for sql in pre_reads)
   # The lock is the dataset's fixed lock table as well, never a custom one.
@@ -2203,16 +2255,19 @@ _WRONG_SCORES = (
 )
 
 
-def _view_ddls(fake: _FakeWriteClient) -> list[str]:
-  return [
-      sql for sql, _ in fake.queries if sql.startswith("CREATE OR REPLACE VIEW")
-  ]
+def _view_writes(fake: _FakeWriteClient) -> list[tuple[str, str, int]]:
+  return fake.view_writes
 
 
-def _view_pin(fake: _FakeWriteClient, view_ref: str = _VIEW_REF) -> dict:
+def _full_pin(fake: _FakeWriteClient, view_ref: str = _VIEW_REF) -> dict:
   first_line = fake.store.views[view_ref].splitlines()[0]
   assert first_line.startswith(_PIN_LINE)
   return json.loads(first_line[len(_PIN_LINE) :])
+
+
+def _view_pin(fake: _FakeWriteClient, view_ref: str = _VIEW_REF) -> dict:
+  pin = _full_pin(fake, view_ref)
+  return {"job_id": pin["job_id"], "import_version": pin["import_version"]}
 
 
 def _listing_query(fake: _FakeWriteClient) -> tuple[str, dict]:
@@ -2235,16 +2290,25 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   )
 
   assert result.failed_sessions_view == _VIEW_REF
-  (ddl,) = _view_ddls(fake)
-  assert ddl.startswith(f"CREATE OR REPLACE VIEW `{_VIEW_REF}`")
-  assert "OPTIONS (description = " in ddl
-  # The view is created only after the publish transaction committed.
+  ((kind, ref, after_queries),) = _view_writes(fake)
+  assert (kind, ref) == ("create", _VIEW_REF)
+  # The view is created only after the publish transaction committed, and
+  # its pin was re-read (get_table) right before writing, not only up front.
   statements = [sql for sql, _ in fake.queries]
-  assert statements.index(ddl) > max(
+  assert after_queries > max(
       i for i, sql in enumerate(statements) if "BEGIN TRANSACTION" in sql
   )
+  assert fake.get_table_calls == [_VIEW_REF, _VIEW_REF]
   body = fake.store.views[_VIEW_REF]
   assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
+  pin = _full_pin(fake)
+  assert pin["policy"] is None
+  assert (
+      pin["query_sha256"]
+      == hashlib.sha256(
+          " ".join(body.split("\n", 1)[1].split()).encode()
+      ).hexdigest()
+  )
   # The body is failed_sessions_sql pinned as literals: no parameters, and
   # no other version can be read.
   assert body.endswith(
@@ -2268,24 +2332,28 @@ def test_materialize_renders_policy_into_the_view() -> None:
   assert "STRUCT('goal_completion' AS comparator, 0.5 AS min_score)" in body
   assert "`analytics-project.bqaa.evalbench_scores_imported`" in body
   assert body.count('import_version = "v1"') == 2
+  assert _full_pin(fake)["policy"] == {
+      "min_scores": {"goal_completion": 0.5},
+      "missing_score_fails": True,
+  }
 
 
 def test_materialize_unchanged_reimport_leaves_view_untouched() -> None:
   fake = _FakeWriteClient()
   run = _scored_run()
   run.materialize(**_TARGET, import_version="v1", bq_client=fake)
-  assert len(_view_ddls(fake)) == 1
+  assert len(_view_writes(fake)) == 1
 
   result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert result.status == "unchanged"
   assert result.failed_sessions_view == _VIEW_REF
-  assert len(_view_ddls(fake)) == 1
+  assert len(_view_writes(fake)) == 1
 
   # A corpus published before views existed gets its view on the next no-op.
   del fake.store.views[_VIEW_REF]
   result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert result.status == "unchanged"
-  assert len(_view_ddls(fake)) == 2
+  assert len(_view_writes(fake)) == 2
   assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
 
 
@@ -2312,7 +2380,7 @@ def test_materialize_view_tracks_the_latest_successful_import() -> None:
   )
   assert unchanged.status == "unchanged"
   assert _view_pin(fake)["import_version"] == "v2"
-  assert len(_view_ddls(fake)) == 2
+  assert len(_view_writes(fake)) == 2
 
   # Re-publishing the older version makes it the latest import again.
   replaced = run_v1.materialize(
@@ -2324,7 +2392,11 @@ def test_materialize_view_tracks_the_latest_successful_import() -> None:
   )
   assert replaced.status == "replaced"
   assert _view_pin(fake)["import_version"] == "v1"
-  assert len(_view_ddls(fake)) == 3
+  assert [kind for kind, _, _ in _view_writes(fake)] == [
+      "create",
+      "update",
+      "update",
+  ]
 
 
 def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
@@ -2362,6 +2434,37 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
         type("Table", (), {"table_type": "TABLE", "view_query": None})(),
         _FakeView("SELECT 1"),
         _FakeView("-- evalbench_failed_sessions pin: not json\nSELECT 1"),
+        # A syntactically valid pin (hash field and all) over foreign SQL.
+        _FakeView(
+            _PIN_LINE
+            + json.dumps(
+                {
+                    "import_version": "v1",
+                    "job_id": "job-123",
+                    "policy": None,
+                    "query_sha256": "0" * 64,
+                }
+            )
+            + "\nSELECT 1"
+        ),
+        # A pin without the query hash never proves ownership.
+        _FakeView(
+            _PIN_LINE
+            + json.dumps({"import_version": "v1", "job_id": "job-123"})
+            + "\nSELECT 1"
+        ),
+        # A pin comment and nothing else.
+        _FakeView(
+            _PIN_LINE
+            + json.dumps(
+                {
+                    "import_version": "v1",
+                    "job_id": "job-123",
+                    "policy": None,
+                    "query_sha256": hashlib.sha256(b"").hexdigest(),
+                }
+            )
+        ),
     ],
 )
 def test_materialize_never_replaces_objects_it_did_not_create(
@@ -2372,7 +2475,48 @@ def test_materialize_never_replaces_objects_it_did_not_create(
     _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert fake.loads == []
   assert fake.transaction_attempted is False
-  assert _view_ddls(fake) == []
+  # Refused before the import tables were even created (or touched).
+  assert fake.created == []
+  assert fake.queries == []
+  assert _view_writes(fake) == []
+
+
+def test_materialize_refuses_a_forged_marker_copied_from_a_managed_view() -> (
+    None
+):
+  """The pin comment is not the authority; the definition it hashes is."""
+  fake = _FakeWriteClient()
+  _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  genuine = fake.store.views[_VIEW_REF]
+  pin_line, query = genuine.split("\n", 1)
+
+  # The exact pin line, copied verbatim onto a user-managed view with its
+  # own SQL: same job, same version, matching everything but the query.
+  forged = pin_line + "\nSELECT 'not the contract' AS session_id"
+  fake.store.write_view(_VIEW_REF, forged)
+  before = list(fake.view_writes)
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v2", bq_client=fake)
+  assert fake.store.views[_VIEW_REF] == forged
+  assert fake.view_writes == before
+  assert not any(row["import_version"] == "v2" for row in fake.manifest_rows)
+
+  # Likewise a managed view whose body drifted (someone edited the query):
+  # the pin still parses, the hash no longer matches, so it is not ours.
+  fake.store.write_view(
+      _VIEW_REF, pin_line + "\n" + query.replace("session_id", "sid")
+  )
+  with pytest.raises(ValueError, match="definition was changed"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.view_writes == before
+
+  # Only whitespace differs: still the importer's definition.
+  fake.store.write_view(_VIEW_REF, pin_line + "\n  " + "  ".join(query.split()))
+  result = _scored_run().materialize(
+      **_TARGET, import_version="v1", bq_client=fake
+  )
+  assert result.status == "unchanged"
+  assert fake.view_writes == before
 
 
 @pytest.mark.parametrize(
@@ -2404,7 +2548,7 @@ def test_materialize_can_skip_the_view() -> None:
   assert result.status == "imported"
   assert result.failed_sessions_view is None
   assert fake.get_table_calls == []
-  assert _view_ddls(fake) == []
+  assert _view_writes(fake) == []
 
 
 def test_materialize_reports_a_view_failure_after_publishing() -> None:
@@ -2417,6 +2561,7 @@ def test_materialize_reports_a_view_failure_after_publishing() -> None:
     _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert "403 no bigquery.tables.update" in str(exc.value)
   assert len(fake.manifest_rows) == 1
+  assert _VIEW_REF not in fake.store.views
   # The retry path: the import is a no-op and the view gets created.
   fake.view_error = None
   result = _scored_run().materialize(
@@ -2424,6 +2569,180 @@ def test_materialize_reports_a_view_failure_after_publishing() -> None:
   )
   assert result.status == "unchanged"
   assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
+
+
+def test_materialize_policy_change_on_the_same_version_rerenders_the_view() -> (
+    None
+):
+  """The pin covers the policy: a later same-version call without a policy
+  must not leave the earlier score gate baked into the view."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  gate = "STRUCT('goal_completion' AS comparator, 0.9 AS min_score)"
+
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  assert gate in fake.store.views[_VIEW_REF]
+  assert len(_view_writes(fake)) == 1
+
+  # Same policy, same version: nothing to do.
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  assert result.status == "unchanged"
+  assert len(_view_writes(fake)) == 1
+
+  # No policy: the gate must go, even though (job_id, import_version) and
+  # the import itself are unchanged.
+  result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert result.status == "unchanged"
+  assert len(_view_writes(fake)) == 2
+  body = fake.store.views[_VIEW_REF]
+  assert gate not in body and "policy AS" not in body
+  assert _full_pin(fake)["policy"] is None
+  assert body.endswith(
+      failed_sessions_sql(**_TARGET, job_id="job-123", import_version="v1")
+  )
+
+  # Changed threshold, then the missing-score rule: each re-renders once.
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert len(_view_writes(fake)) == 3
+  assert "0.5 AS min_score" in fake.store.views[_VIEW_REF]
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy(
+          {"goal_completion": 0.5}, missing_score_fails=False
+      ),
+      bq_client=fake,
+  )
+  assert len(_view_writes(fake)) == 4
+  assert _full_pin(fake)["policy"]["missing_score_fails"] is False
+
+
+def test_materialize_same_job_create_race_keeps_the_newer_pin() -> None:
+  """Two first imports of one job: the loser of the create race must not
+  overwrite the winner's newer pin, and both must report success."""
+  store = _FakeManifestStore()
+  fake_v2 = _FakeWriteClient(store=store)
+  run_v2 = _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES)
+
+  def v2_lands_first() -> None:
+    # v1 has read "no view" and "latest = v1" and is about to create.
+    result = run_v2.materialize(
+        **_TARGET,
+        import_version="v2",
+        imported_at=_T1 + timedelta(hours=1),
+        bq_client=fake_v2,
+    )
+    assert result.status == "imported"
+    assert _view_pin(fake_v2)["import_version"] == "v2"
+
+  fake_v1 = _FakeWriteClient(store=store, before_view_write=v2_lands_first)
+  result = _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake_v1
+  )
+
+  assert result.status == "imported"
+  assert result.failed_sessions_view == _VIEW_REF
+  # v1's stale create hit Conflict; the retry re-read the view (v2) and the
+  # latest manifest (v2), found them in agreement, and wrote nothing.
+  assert _view_pin(fake_v1)["import_version"] == "v2"
+  assert fake_v1.view_writes == []
+  assert [kind for kind, _, _ in fake_v2.view_writes] == ["create"]
+  assert fake_v1.get_table_calls.count(_VIEW_REF) == 3
+
+
+def test_materialize_same_job_update_race_is_etag_guarded() -> None:
+  """An existing view: the delayed writer's replace must fail its ETag
+  check rather than clobber the newer pin another import just wrote."""
+  store = _FakeManifestStore()
+  setup = _FakeWriteClient(store=store)
+  _scored_run().materialize(
+      **_TARGET, import_version="v0", imported_at=_T1, bq_client=setup
+  )
+  stale_etag = store.view_etags[_VIEW_REF]
+
+  fake_v2 = _FakeWriteClient(store=store)
+  run_v2 = _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES)
+
+  def v2_lands_first() -> None:
+    run_v2.materialize(
+        **_TARGET,
+        import_version="v2",
+        imported_at=_T1 + timedelta(hours=2),
+        bq_client=fake_v2,
+    )
+    assert _view_pin(fake_v2)["import_version"] == "v2"
+    assert store.view_etags[_VIEW_REF] != stale_etag
+
+  fake_v1 = _FakeWriteClient(store=store, before_view_write=v2_lands_first)
+  result = _scored_run(extra_result=_WRONG_RESULT).materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1 + timedelta(hours=1),
+      bq_client=fake_v1,
+  )
+
+  assert result.status == "imported"
+  assert _view_pin(fake_v1)["import_version"] == "v2"
+  assert 'import_version = "v1"' not in store.views[_VIEW_REF]
+  assert fake_v1.view_writes == []
+  assert [kind for kind, _, _ in fake_v2.view_writes] == ["update"]
+
+
+def test_materialize_cross_job_view_race_fails_closed() -> None:
+  """Two jobs pass the up-front check (no view yet); the one that loses the
+  create race must refuse to replace the other job's view and say so."""
+  store = _FakeManifestStore()
+  fake_other = _FakeWriteClient(store=store)
+  other = dataclasses.replace(_scored_run(), job_id="job-other")
+
+  def other_job_lands_first() -> None:
+    other.materialize(**_TARGET, import_version="v1", bq_client=fake_other)
+
+  fake = _FakeWriteClient(store=store, before_view_write=other_job_lands_first)
+  with pytest.raises(ValueError) as exc:
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+
+  message = str(exc.value)
+  assert "is published (status 'imported')" in message
+  assert "pinned to EvalBench job 'job-other'" in message
+  assert _view_pin(fake)["job_id"] == "job-other"
+  assert fake.view_writes == []
+  # job-123's import itself is committed; only the view was refused.
+  assert {row["job_id"] for row in store.rows} == {"job-123", "job-other"}
+
+
+def test_materialize_view_sync_gives_up_after_bounded_retries() -> None:
+  store = _FakeManifestStore()
+
+  class _AlwaysRacing(_FakeWriteClient):
+
+    def create_table(self, table, exists_ok: bool = False):
+      if getattr(table, "view_query", None) is None:
+        return super().create_table(table, exists_ok=exists_ok)
+      self.view_writes.append(("create", "", len(self.queries)))
+      raise Conflict("409 Already Exists")
+
+  fake = _AlwaysRacing(store=store)
+  with pytest.raises(ValueError, match="changed concurrently 3 times") as exc:
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert "is published (status 'imported')" in str(exc.value)
+  assert len(fake.view_writes) == 3
+  assert _VIEW_REF not in store.views
 
 
 def test_failed_sessions_sql_pins_literals_with_escaping() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -701,6 +701,25 @@ class _FakeWriteClient:
           reverse=True,
       )
       return _FakeJob([dict(row) for row in latest[:1]])
+    if ".evalbench_import_manifest`" in query and query.startswith("UPDATE"):
+      # ``_RECORD_VIEW_POLICY_QUERY``: keyed on the generation the caller
+      # read, so it lands on nothing once the row was re-published.
+      assert set(params) == {
+          "job_id",
+          "import_version",
+          "expected_generation_id",
+          "generation_id",
+          "view_policy",
+      }
+      assert "generation_id = @expected_generation_id" in query
+      for row in self.store.rows:
+        if (
+            _same_version(row, params)
+            and row["generation_id"] == params["expected_generation_id"]
+        ):
+          row["view_policy"] = params["view_policy"]
+          row["generation_id"] = params["generation_id"]
+      return _FakeJob()
     if ".evalbench_import_lock`" in query and query.startswith("INSERT INTO"):
       # Seeding is INSERT-only, so it never conflicts and may run twice.
       assert params == {}
@@ -1033,6 +1052,9 @@ def test_materialize_publishes_events_scores_and_manifest_atomically() -> None:
   ):
     assert len(manifest[key]) == 64
   assert manifest["imported_at"]
+  # One opaque generation per publish; the gate is committed with the row.
+  assert re.fullmatch(r"[0-9a-f]{32}", manifest["generation_id"])
+  assert manifest["view_policy"] is None
   assert result.manifest == manifest
 
 
@@ -2253,9 +2275,28 @@ _PIN_LINE = "-- evalbench_failed_sessions pin: "
 _T1 = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
 
 
-def _pin_ts(moment: datetime) -> str:
-  """How the view pin records a manifest generation: UTC, microseconds."""
-  return moment.astimezone(timezone.utc).isoformat(timespec="microseconds")
+def _row(fake: _FakeWriteClient, import_version: str) -> dict:
+  (row,) = [
+      row
+      for row in fake.manifest_rows
+      if row["import_version"] == import_version
+  ]
+  return row
+
+
+def _generation(fake: _FakeWriteClient, import_version: str = "v1") -> str:
+  """The opaque generation the committed manifest row currently carries."""
+  return _row(fake, import_version)["generation_id"]
+
+
+def _policy_json(min_score: float) -> str:
+  return json.dumps(
+      {
+          "min_scores": {"goal_completion": min_score},
+          "missing_score_fails": True,
+      },
+      sort_keys=True,
+  )
 
 
 _WRONG_RESULT = {
@@ -2321,7 +2362,7 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   assert _full_pin(fake) == {
       "job_id": "job-123",
       "import_version": "v1",
-      "imported_at": _pin_ts(_T1),
+      "generation_id": _generation(fake, "v1"),
       "policy": None,
   }
   # The body is failed_sessions_sql pinned as literals: no parameters, and
@@ -2455,7 +2496,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
             + json.dumps(
                 {
                     "import_version": "v1",
-                    "imported_at": _pin_ts(_T1),
+                    "generation_id": "0" * 32,
                     "job_id": "job-123",
                     "policy": None,
                     "query_sha256": "0" * 64,
@@ -2469,7 +2510,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
             + json.dumps(
                 {
                     "import_version": "v1",
-                    "imported_at": _pin_ts(_T1),
+                    "generation_id": "0" * 32,
                     "job_id": "job-123",
                 }
             )
@@ -2489,7 +2530,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
             + json.dumps(
                 {
                     "import_version": "v1",
-                    "imported_at": _pin_ts(_T1),
+                    "generation_id": "0" * 32,
                     "job_id": "job-123",
                     "policy": None,
                 }
@@ -2639,11 +2680,18 @@ def test_materialize_policy_change_on_the_same_version_rerenders_the_view() -> (
   assert result.status == "unchanged"
   assert len(_view_writes(fake)) == 1
 
+  assert _row(fake, "v1")["view_policy"] == _policy_json(0.9)
+  first_generation = _generation(fake)
+
   # No policy: the gate must go, even though (job_id, import_version) and
-  # the import itself are unchanged.
+  # the import itself are unchanged. The change is committed to the
+  # manifest row as a new generation before the view is re-rendered.
   result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert result.status == "unchanged"
   assert len(_view_writes(fake)) == 2
+  assert _row(fake, "v1")["view_policy"] is None
+  assert _generation(fake) != first_generation
+  assert _full_pin(fake)["generation_id"] == _generation(fake)
   body = fake.store.views[_VIEW_REF]
   assert gate not in body and "policy AS" not in body
   assert _full_pin(fake)["policy"] is None
@@ -2958,7 +3006,7 @@ def test_materialize_etag_retry_never_applies_a_stale_policy_to_a_newer_version(
   assert [kind for kind, _, _ in fake_v2.view_writes] == ["update"]
   assert _full_pin(fake_v1) == {
       "import_version": "v2",
-      "imported_at": _pin_ts(_T1 + timedelta(hours=2)),
+      "generation_id": _generation(fake_v1, "v2"),
       "job_id": "job-123",
       "policy": None,
   }
@@ -2969,9 +3017,10 @@ def test_materialize_older_version_advances_a_stale_view_without_its_policy() ->
     None
 ):
   """A view left behind (the latest import managed no view) is still moved
-  to the latest version by a later, older-version call -- but the gate it
-  carries is view state that only the latest version's own import may
-  change, so the older call's policy is not rendered into it."""
+  to the latest version by a later, older-version call -- rendered with
+  the gate the latest version's manifest row committed (none here), not
+  the older call's policy and not the gate the stale view happened to
+  carry. The older call's policy is recorded on its own version's row."""
   fake = _FakeWriteClient()
   run_v1 = _scored_run()
   run_v1.materialize(
@@ -3000,14 +3049,14 @@ def test_materialize_older_version_advances_a_stale_view_without_its_policy() ->
   assert result.status == "unchanged"
   assert _full_pin(fake) == {
       "import_version": "v2",
-      "imported_at": _pin_ts(_T1 + timedelta(hours=1)),
+      "generation_id": _generation(fake, "v2"),
       "job_id": "job-123",
-      "policy": {
-          "min_scores": {"goal_completion": 0.9},
-          "missing_score_fails": True,
-      },
+      "policy": None,
   }
+  assert "min_score" not in fake.store.views[_VIEW_REF]
   assert [kind for kind, _, _ in _view_writes(fake)] == ["create", "update"]
+  assert _row(fake, "v1")["view_policy"] == _policy_json(0.5)
+  assert _row(fake, "v2")["view_policy"] is None
 
   # A re-run of the same older call is then a no-op.
   run_v1.materialize(
@@ -3047,7 +3096,7 @@ def test_materialize_older_version_creates_a_missing_view_without_a_gate() -> (
   assert result.failed_sessions_view == _VIEW_REF
   assert _full_pin(fake) == {
       "import_version": "v2",
-      "imported_at": _pin_ts(_T1 + timedelta(hours=1)),
+      "generation_id": _generation(fake, "v2"),
       "job_id": "job-123",
       "policy": None,
   }
@@ -3089,16 +3138,26 @@ def test_materialize_refuses_a_view_whose_literal_whitespace_changed() -> None:
   assert fake.view_writes == before
 
 
-def test_materialize_same_version_replace_race_keeps_the_newer_generations_policy() -> (
-    None
-):
+@pytest.mark.parametrize(
+    "older_imported_at",
+    [
+        pytest.param(_T1 + timedelta(hours=1), id="distinct-timestamps"),
+        # ``imported_at`` is caller-supplied: two replaces of one version
+        # may carry the very same timestamp, so it cannot be the
+        # generation. Only the opaque generation_id is.
+        pytest.param(_T1 + timedelta(hours=2), id="equal-timestamps"),
+    ],
+)
+def test_materialize_same_version_replace_race_keeps_the_newer_generations_policy(
+    older_imported_at: datetime,
+) -> None:
   """Two ``replace=True`` calls of one version label publish two manifest
   generations. The older generation's caller (gate 0.9) reads the view and
   pauses before its replace; the newer generation's caller (no gate) lands
-  and re-pins the view. The version string is the same for both, so
-  authority must be decided by the generation: the delayed caller's
-  replace must neither land its gate over the newer generation nor be
-  accepted on retry."""
+  and re-pins the view. The version string is the same for both -- and so
+  may be ``imported_at`` -- so authority must be decided by the committed
+  generation: the delayed caller's replace must neither land its gate over
+  the newer generation nor be accepted on retry."""
   store = _FakeManifestStore()
   setup = _FakeWriteClient(store=store)
   _scored_run().materialize(
@@ -3131,7 +3190,7 @@ def test_materialize_same_version_replace_race_keeps_the_newer_generations_polic
       **_TARGET,
       import_version="v1",
       replace=True,
-      imported_at=_T1 + timedelta(hours=1),
+      imported_at=older_imported_at,
       policy=EvalScorePolicy({"goal_completion": 0.9}),
       bq_client=fake_older,
   )
@@ -3141,18 +3200,22 @@ def test_materialize_same_version_replace_race_keeps_the_newer_generations_polic
   # The older caller's replace hit its ETag check; the retry found the view
   # pinned to the generation the manifest holds and left it alone.
   assert fake_older.view_writes == []
+  (row,) = store.rows
+  assert row["imported_at"] == (_T1 + timedelta(hours=2)).isoformat()
+  assert row["view_policy"] is None
+  newer_generation = row["generation_id"]
+  assert newer_generation != result.manifest["generation_id"]
   assert _full_pin(fake_older) == {
       "import_version": "v1",
-      "imported_at": _pin_ts(_T1 + timedelta(hours=2)),
+      "generation_id": newer_generation,
       "job_id": "job-123",
       "policy": None,
   }
   assert "0.9 AS min_score" not in store.views[_VIEW_REF]
-  (row,) = store.rows
-  assert row["imported_at"] == (_T1 + timedelta(hours=2)).isoformat()
 
-  # A later same-version call that finds this generation committed is its
-  # import and may set the gate; the delayed caller's gate stays gone.
+  # A later same-version call that finds this generation committed may set
+  # the gate -- committed to the row under a new generation, then rendered
+  # -- and the delayed caller's gate stays gone.
   result = _scored_run().materialize(
       **_TARGET,
       import_version="v1",
@@ -3160,33 +3223,35 @@ def test_materialize_same_version_replace_race_keeps_the_newer_generations_polic
       bq_client=fake_older,
   )
   assert result.status == "unchanged"
-  assert _full_pin(fake_older)["imported_at"] == _pin_ts(
-      _T1 + timedelta(hours=2)
-  )
+  (row,) = store.rows
+  assert row["view_policy"] == _policy_json(0.5)
+  assert row["generation_id"] != newer_generation
+  assert _full_pin(fake_older)["generation_id"] == row["generation_id"]
   assert "0.5 AS min_score" in store.views[_VIEW_REF]
 
 
 @pytest.mark.parametrize(
-    "imported_at",
+    "generation_id",
     [
-        "not a timestamp",
-        # Canonical form only: UTC with microseconds.
-        "2026-05-01T08:00:00+00:00",
-        "2026-05-01T10:00:00.000000+02:00",
-        "2026-05-01T08:00:00.000000Z",
+        "not a generation",
+        # Canonical form only: 32 lowercase hex digits.
+        "0" * 31,
+        "0" * 33,
+        "A" * 32,
+        "2026-05-01T08:00:00.000000+00:00",
         1777622400,
         None,
     ],
 )
 def test_materialize_refuses_a_pin_with_a_malformed_generation(
-    imported_at,
+    generation_id,
 ) -> None:
   fake = _FakeWriteClient()
   _scored_run().materialize(
       **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
   )
   _, query = fake.store.views[_VIEW_REF].split("\n", 1)
-  pin = {**_full_pin(fake), "imported_at": imported_at}
+  pin = {**_full_pin(fake), "generation_id": generation_id}
   fake.store.write_view(
       _VIEW_REF, _PIN_LINE + json.dumps(pin, sort_keys=True) + "\n" + query
   )
@@ -3194,6 +3259,87 @@ def test_materialize_refuses_a_pin_with_a_malformed_generation(
   with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
     _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert fake.view_writes == before
+
+
+def test_materialize_refuses_a_canonical_policy_forgery() -> None:
+  """The gate is committed manifest state, so the view cannot vouch for it.
+
+  A foreign writer takes a committed manifest row (the latest version,
+  published without a gate) and writes exactly what the importer would
+  render for it under ``goal_completion >= 0.9`` -- the canonical body,
+  the current generation, a matching policy pin. Nothing in that text is
+  wrong; only the manifest row says there is no gate. Every later call,
+  including an unchanged re-import of an *older* version (which must not
+  render its own gate anyway), has to fail closed rather than accept the
+  view as its own and leave the forged gate standing.
+  """
+  fake = _FakeWriteClient()
+  _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES).materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      bq_client=fake,
+  )
+  genuine = fake.store.views[_VIEW_REF]
+  assert _view_pin(fake)["import_version"] == "v2"
+  assert _row(fake, "v2")["view_policy"] is None
+
+  forged = evalbench._failed_sessions_view_body(
+      manifest=_row(fake, "v2"),
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+  )
+  assert forged != genuine
+  assert "0.9 AS min_score" in forged
+  assert _full_pin_of(forged)["generation_id"] == _generation(fake, "v2")
+  fake.store.write_view(_VIEW_REF, forged)
+  before = list(fake.view_writes)
+
+  # The non-latest version, unchanged: refused up front, nothing written.
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(
+        **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+    )
+  assert fake.store.views[_VIEW_REF] == forged
+  assert fake.view_writes == before
+  # The latest version itself, and a new version: likewise.
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES).materialize(
+        **_TARGET, import_version="v2", bq_client=fake
+    )
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v3", bq_client=fake)
+  assert fake.store.views[_VIEW_REF] == forged
+  assert fake.view_writes == before
+  assert {row["import_version"] for row in fake.manifest_rows} == {"v1", "v2"}
+  assert _row(fake, "v2")["view_policy"] is None
+
+  # The same forgery under a generation the manifest does not hold looks
+  # like a view a superseded generation left behind; that is never
+  # preserved either -- it is re-rendered from the committed row.
+  fake.store.write_view(
+      _VIEW_REF,
+      evalbench._failed_sessions_view_body(
+          manifest=_row(fake, "v2"),
+          policy=EvalScorePolicy({"goal_completion": 0.9}),
+          generation_id="f" * 32,
+      ),
+  )
+  result = _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  assert result.status == "unchanged"
+  assert fake.store.views[_VIEW_REF] == genuine
+  assert "min_score" not in fake.store.views[_VIEW_REF]
+  assert _full_pin(fake)["generation_id"] == _generation(fake, "v2")
+
+
+def _full_pin_of(view_query: str) -> dict:
+  first_line = view_query.splitlines()[0]
+  assert first_line.startswith(_PIN_LINE)
+  return json.loads(first_line[len(_PIN_LINE) :])
 
 
 def test_failed_sessions_sql_pins_literals_with_escaping() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -507,6 +507,12 @@ class _FakeManifestStore:
     self.scores: list[dict] = []
     self.lock_rows = 0
     self.lock_claims = 0
+    # The manifest table's live schema (``None`` until created) and ETag.
+    # Every DML the fake runs against the manifest is checked against it,
+    # as BigQuery would reject a column the table does not have.
+    self.manifest_schema: list | None = None
+    self.manifest_etag = "manifest-etag-0"
+    self.schema_updates = 0
     # view ref -> query text (``Table.view_query``) and its current ETag.
     self.views: dict[str, str] = {}
     self.view_etags: dict[str, str] = {}
@@ -516,6 +522,15 @@ class _FakeManifestStore:
     self._etag_counter += 1
     self.views[view_ref] = view_query
     self.view_etags[view_ref] = f"etag-{self._etag_counter}"
+
+  def set_manifest_schema(self, schema: list) -> None:
+    self.manifest_schema = list(schema)
+    self.schema_updates += 1
+    self.manifest_etag = f"manifest-etag-{self.schema_updates}"
+
+  def manifest_columns(self) -> set[str]:
+    assert self.manifest_schema is not None, "manifest table does not exist"
+    return {field.name for field in self.manifest_schema}
 
   def snapshot(self) -> _FakeSnapshot:
     return _FakeSnapshot(
@@ -539,6 +554,35 @@ def _same_version(row: dict, params: dict) -> bool:
       row["job_id"] == params["job_id"]
       and row["import_version"] == params["import_version"]
   )
+
+
+class _FakeTable:
+  """What ``client.get_table`` returns for the manifest: schema and ETag."""
+
+  table_type = "TABLE"
+  view_query = None
+
+  def __init__(self, ref: str, schema: list, etag: str) -> None:
+    self.schema = list(schema)
+    self.etag = etag
+    self.project, self.dataset_id, self.table_id = ref.split(".")
+
+
+def _history_entry(row: dict) -> str:
+  """``TO_JSON_STRING(STRUCT(generation_id, view_policy))`` of a row."""
+  return json.dumps(
+      {
+          "generation_id": row.get("generation_id"),
+          "view_policy": row.get("view_policy"),
+      },
+      separators=(",", ":"),
+  )
+
+
+def _legacy_generation(row: dict) -> str:
+  """``_BACKFILL_GENERATION_QUERY``'s derived id for a slice-1 row."""
+  key = f"evalbench-import-manifest:{row['import_version']}:{row['job_id']}"
+  return hashlib.md5(key.encode("utf-8")).hexdigest()
 
 
 class _FakeView:
@@ -599,8 +643,13 @@ class _FakeWriteClient:
       view_error: Exception | None = None,
       foreign_objects: dict[str, object] | None = None,
       before_view_write: Callable[[], None] | None = None,
+      before_schema_update: Callable[[], None] | None = None,
   ) -> None:
     self.store = store or _FakeManifestStore(manifest_rows)
+    # Runs inside every manifest schema update, *after* the importer read
+    # the table and decided which columns to add: a concurrent upgrade
+    # that lands in that window.
+    self.before_schema_update = before_schema_update
     self.stale_manifest_reads = stale_manifest_reads
     self.transaction_attempted = False
     self.transaction_snapshot = transaction_snapshot
@@ -633,6 +682,14 @@ class _FakeWriteClient:
       assert exists_ok is True
       self.created.append(ref)
       self.created_tables.append(table)
+      if ref.endswith(".evalbench_import_manifest"):
+        # ``exists_ok`` returns the existing table *unchanged*: its schema
+        # is whatever release created it, not what this caller passed.
+        if self.store.manifest_schema is None:
+          self.store.set_manifest_schema(table.schema)
+        return _FakeTable(
+            ref, self.store.manifest_schema, self.store.manifest_etag
+        )
       return table
     # Views: create-if-absent through the tables API, never exists_ok.
     assert exists_ok is False
@@ -648,6 +705,30 @@ class _FakeWriteClient:
 
   def update_table(self, table, fields):
     ref = f"{table.project}.{table.dataset_id}.{table.table_id}"
+    if fields == ["schema"]:
+      assert ref.endswith(".evalbench_import_manifest")
+      assert self.store.manifest_schema is not None
+      if self.before_schema_update is not None:
+        self.before_schema_update()
+      if table.etag != self.store.manifest_etag:
+        raise PreconditionFailed(f"412 Precondition Failed: {ref}")
+      # BigQuery only ever *adds* NULLABLE or REPEATED columns in place.
+      existing = {field.name for field in self.store.manifest_schema}
+      added = [field for field in table.schema if field.name not in existing]
+      assert added, "schema update that adds nothing"
+      assert [f.name for f in table.schema][: len(existing)] == [
+          f.name for f in self.store.manifest_schema
+      ]
+      assert all(field.mode in ("NULLABLE", "REPEATED") for field in added)
+      self.store.set_manifest_schema(table.schema)
+      # Existing rows read the new columns back as NULL (or an empty
+      # array for a REPEATED column); nothing is backfilled by the DDL.
+      for row in self.store.rows:
+        for field in added:
+          row.setdefault(field.name, [] if field.mode == "REPEATED" else None)
+      return _FakeTable(
+          ref, self.store.manifest_schema, self.store.manifest_etag
+      )
     assert "view_query" in fields
     self._run_before_view_write()
     if self.view_error is not None:
@@ -670,6 +751,12 @@ class _FakeWriteClient:
     self.get_table_calls.append(table_ref)
     if table_ref in self.foreign_objects:
       return self.foreign_objects[table_ref]
+    if table_ref.endswith(".evalbench_import_manifest"):
+      if self.store.manifest_schema is None:
+        raise NotFound(table_ref)
+      return _FakeTable(
+          table_ref, self.store.manifest_schema, self.store.manifest_etag
+      )
     if table_ref in self.store.views:
       return _FakeView(
           self.store.views[table_ref],
@@ -702,8 +789,19 @@ class _FakeWriteClient:
       )
       return _FakeJob([dict(row) for row in latest[:1]])
     if ".evalbench_import_manifest`" in query and query.startswith("UPDATE"):
+      columns = self.store.manifest_columns()
+      if "WHERE generation_id IS NULL" in query:
+        # ``_BACKFILL_GENERATION_QUERY``: derived, so idempotent.
+        assert params == {}
+        assert "generation_id" in columns
+        assert "TO_HEX(MD5(" in query
+        for row in self.store.rows:
+          if row.get("generation_id") is None:
+            row["generation_id"] = _legacy_generation(row)
+        return _FakeJob()
       # ``_RECORD_VIEW_POLICY_QUERY``: keyed on the generation the caller
-      # read, so it lands on nothing once the row was re-published.
+      # read, so it lands on nothing once the row was re-published; the
+      # generation it supersedes joins the row's committed history.
       assert set(params) == {
           "job_id",
           "import_version",
@@ -712,11 +810,18 @@ class _FakeWriteClient:
           "view_policy",
       }
       assert "generation_id = @expected_generation_id" in query
+      assert {"view_policy", "generation_id", "superseded_generations"} <= (
+          columns
+      )
+      assert "ARRAY_CONCAT(" in query and "TO_JSON_STRING(STRUCT(" in query
       for row in self.store.rows:
         if (
             _same_version(row, params)
-            and row["generation_id"] == params["expected_generation_id"]
+            and row.get("generation_id") == params["expected_generation_id"]
         ):
+          row["superseded_generations"] = list(
+              row.get("superseded_generations") or []
+          ) + [_history_entry(row)]
           row["view_policy"] = params["view_policy"]
           row["generation_id"] = params["generation_id"]
       return _FakeJob()
@@ -820,6 +925,37 @@ class _FakeWriteClient:
       return next(rows for dest, rows, _ in reversed(self.loads) if dest == ref)
 
     store = self.store
+    manifest_table = lock_table.rsplit(".", 1)[0] + ".evalbench_import_manifest"
+    # The manifest INSERT names its columns; every one must exist on the
+    # live table (a slice-1 manifest lacks the generation columns).
+    inserted = re.search(
+        r"INSERT INTO `" + re.escape(manifest_table) + r"` \(([^)]*)\)",
+        script,
+    ).group(1)
+    insert_columns = [name.strip() for name in inserted.split(",")]
+    missing = set(insert_columns) - store.manifest_columns()
+    assert not missing, f"manifest INSERT names absent columns {missing}"
+    assert "superseded_generations" in insert_columns
+    assert "SET prior_generations = IFNULL((" in script
+    assert script.index("SET prior_generations") < script.index(
+        f"DELETE FROM `{manifest_table}`"
+    )
+    # ``prior_generations``: the replaced row's history plus the generation
+    # this publish supersedes, read from the transaction's snapshot.
+    prior = [row for row in snapshot.rows if _same_version(row, params)]
+    history = [
+        entry
+        for row in prior
+        for entry in list(row.get("superseded_generations") or [])
+        + [_history_entry(row)]
+    ]
+    manifest_rows = []
+    for row in staged(manifest_table):
+      assert set(row) - {"superseded_generations"} == set(insert_columns) - {
+          "superseded_generations"
+      }
+      manifest_rows.append({**row, "superseded_generations": history})
+
     store.lock_claims += 1
     store.events = [
         row for row in store.events if not _same_version(row, params)
@@ -829,7 +965,7 @@ class _FakeWriteClient:
     ] + staged(params["scores_table"])
     store.rows = [
         row for row in store.rows if not _same_version(row, params)
-    ] + staged(lock_table.rsplit(".", 1)[0] + ".evalbench_import_manifest")
+    ] + manifest_rows
     return _FakeJob()
 
   def _failed_sessions(self, query: str, params: dict) -> list[dict]:
@@ -2355,7 +2491,10 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   assert after_queries > max(
       i for i, sql in enumerate(statements) if "BEGIN TRANSACTION" in sql
   )
-  assert fake.get_table_calls == [_VIEW_REF, _VIEW_REF]
+  assert [ref for ref in fake.get_table_calls if ref == _VIEW_REF] == [
+      _VIEW_REF,
+      _VIEW_REF,
+  ]
   body = fake.store.views[_VIEW_REF]
   # The pin says what the view is bound to; nothing in it (no digest) is
   # taken as proof of ownership -- see the forged-pin tests below.
@@ -2628,7 +2767,7 @@ def test_materialize_can_skip_the_view() -> None:
   )
   assert result.status == "imported"
   assert result.failed_sessions_view is None
-  assert fake.get_table_calls == []
+  assert _VIEW_REF not in fake.get_table_calls
   assert _view_writes(fake) == []
 
 
@@ -3316,24 +3455,434 @@ def test_materialize_refuses_a_canonical_policy_forgery() -> None:
   assert {row["import_version"] for row in fake.manifest_rows} == {"v1", "v2"}
   assert _row(fake, "v2")["view_policy"] is None
 
-  # The same forgery under a generation the manifest does not hold looks
-  # like a view a superseded generation left behind; that is never
-  # preserved either -- it is re-rendered from the committed row.
-  fake.store.write_view(
-      _VIEW_REF,
-      evalbench._failed_sessions_view_body(
-          manifest=_row(fake, "v2"),
-          policy=EvalScorePolicy({"goal_completion": 0.9}),
-          generation_id="f" * 32,
-      ),
+  # The same forgery under a well-formed generation the manifest never
+  # committed (neither current nor in the row's history) is exactly what a
+  # view a superseded generation left behind would look like -- but the
+  # only thing that says so is the view. Nothing committed can vouch for
+  # it, so it is refused rather than authenticated and replaced.
+  forged_stale = evalbench._failed_sessions_view_body(
+      manifest=_row(fake, "v2"),
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      generation_id="f" * 32,
   )
-  result = _scored_run().materialize(
+  assert _row(fake, "v2")["superseded_generations"] == []
+  fake.store.write_view(_VIEW_REF, forged_stale)
+  before = list(fake.view_writes)
+  for kwargs in (
+      {"import_version": "v1", "imported_at": _T1},
+      {"import_version": "v2", "replace": True},
+      {"import_version": "v3"},
+  ):
+    with pytest.raises(
+        ValueError, match="not an evalbench failed_sessions view"
+    ):
+      _scored_run().materialize(**_TARGET, **kwargs, bq_client=fake)
+    assert fake.store.views[_VIEW_REF] == forged_stale
+    assert fake.view_writes == before
+  assert {row["import_version"] for row in fake.manifest_rows} == {"v1", "v2"}
+  assert _generation(fake, "v2") == _full_pin_of(genuine)["generation_id"]
+
+
+def test_materialize_authenticates_a_superseded_view_from_committed_history() -> (
+    None
+):
+  """A view a superseded generation left behind is recognized only through
+  the manifest's own record of that generation: the row's
+  ``superseded_generations`` history names the generation and the gate it
+  carried, and that -- never the view's pin -- is what the body is checked
+  against. A pin naming a real superseded generation under any other gate
+  is a forgery and is refused."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  first_generation = _generation(fake)
+  stale_view = fake.store.views[_VIEW_REF]
+  assert _full_pin_of(stale_view)["generation_id"] == first_generation
+
+  # A policy change commits a new generation; the history records the one
+  # it supersedes together with the gate that generation rendered.
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  second_generation = _generation(fake)
+  assert second_generation != first_generation
+  assert [
+      json.loads(e) for e in _row(fake, "v1")["superseded_generations"]
+  ] == [{"generation_id": first_generation, "view_policy": _policy_json(0.9)}]
+  assert _full_pin(fake)["generation_id"] == second_generation
+
+  # Put the first generation's view back (as if the re-render had never
+  # landed): it verifies from the history and is advanced, not preserved.
+  fake.store.write_view(_VIEW_REF, stale_view)
+  writes = len(fake.view_writes)
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert result.status == "unchanged"
+  assert len(fake.view_writes) == writes + 1
+  assert _full_pin(fake)["generation_id"] == second_generation
+  assert "0.5 AS min_score" in fake.store.views[_VIEW_REF]
+  assert "0.9 AS min_score" not in fake.store.views[_VIEW_REF]
+
+  # The same superseded generation under a gate the history does not
+  # record for it -- the current gate, or none -- is not that view.
+  for policy in (EvalScorePolicy({"goal_completion": 0.5}), None):
+    forged = evalbench._failed_sessions_view_body(
+        manifest=_row(fake, "v1"),
+        policy=policy,
+        generation_id=first_generation,
+    )
+    assert forged != stale_view
+    fake.store.write_view(_VIEW_REF, forged)
+    writes = len(fake.view_writes)
+    with pytest.raises(
+        ValueError, match="not an evalbench failed_sessions view"
+    ):
+      run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+    assert fake.store.views[_VIEW_REF] == forged
+    assert len(fake.view_writes) == writes
+
+  # A ``replace`` supersedes a generation too, and the history keeps
+  # every generation the row ever had, oldest first.
+  fake.store.write_view(_VIEW_REF, stale_view)
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1 + timedelta(hours=1),
+      replace=True,
+      bq_client=fake,
+  )
+  assert result.status == "replaced"
+  third_generation = _generation(fake)
+  assert third_generation not in (first_generation, second_generation)
+  assert [
+      json.loads(e) for e in _row(fake, "v1")["superseded_generations"]
+  ] == [
+      {"generation_id": first_generation, "view_policy": _policy_json(0.9)},
+      {"generation_id": second_generation, "view_policy": _policy_json(0.5)},
+  ]
+  assert result.manifest["superseded_generations"] == (
+      _row(fake, "v1")["superseded_generations"]
+  )
+  assert _full_pin(fake)["generation_id"] == third_generation
+  assert "min_score" not in fake.store.views[_VIEW_REF]
+
+
+# The manifest schema slice 1 (#451) shipped: no generation, no committed
+# view policy, no generation history. Pinned by name so that a change to
+# ``_MANIFEST_SCHEMA_FIELDS`` that would alter what an upgrade has to add
+# fails here rather than on a live dataset.
+_SLICE_1_MANIFEST_COLUMNS = (
+    "job_id",
+    "import_version",
+    "source_project",
+    "source_dataset",
+    "source_snapshot_at",
+    "results_count",
+    "scores_count",
+    "configs_count",
+    "results_fingerprint",
+    "scores_fingerprint",
+    "configs_fingerprint",
+    "events_table",
+    "scores_table",
+    "event_row_count",
+    "score_row_count",
+    "imported_at",
+)
+_GENERATION_COLUMNS = ("generation_id", "view_policy", "superseded_generations")
+
+
+def _slice_1_schema() -> list:
+  fields = {name: field for name, *field in evalbench._MANIFEST_SCHEMA_FIELDS}
+  assert set(fields) == set(_SLICE_1_MANIFEST_COLUMNS) | set(
+      _GENERATION_COLUMNS
+  )
+  return evalbench._schema(
+      tuple((name, *fields[name]) for name in _SLICE_1_MANIFEST_COLUMNS)
+  )
+
+
+def _downgrade_to_slice_1(fake: _FakeWriteClient) -> None:
+  """Leave the fake's dataset as the slice-1 release left it.
+
+  The manifest has the slice-1 columns only, every row carries only those
+  columns, and there is no failed_sessions view (slice 1 wrote none).
+  """
+  fake.store.set_manifest_schema(_slice_1_schema())
+  for row in fake.store.rows:
+    for column in _GENERATION_COLUMNS:
+      row.pop(column, None)
+    assert set(row) == set(_SLICE_1_MANIFEST_COLUMNS)
+  fake.store.views.clear()
+  fake.store.view_etags.clear()
+  fake.view_writes.clear()
+  fake.queries.clear()
+
+
+def _backfill_queries(fake: _FakeWriteClient) -> list[int]:
+  return [
+      i
+      for i, (sql, _) in enumerate(fake.queries)
+      if sql.startswith("UPDATE") and "WHERE generation_id IS NULL" in sql
+  ]
+
+
+def _manifest_reads(fake: _FakeWriteClient) -> list[int]:
+  return [
+      i
+      for i, (sql, _) in enumerate(fake.queries)
+      if sql.startswith("SELECT *") and ".evalbench_import_manifest`" in sql
+  ]
+
+
+def test_materialize_upgrades_a_slice_1_manifest_in_place() -> None:
+  """A dataset published by slice 1 (#451) is upgraded before it is read:
+  the generation columns are added to the live manifest, every legacy row
+  gets a generation derived from its key, and only then does the import
+  proceed -- an unchanged re-import pins the view to the backfilled
+  generation, and a later replace supersedes that generation into the
+  row's committed history like any other."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _downgrade_to_slice_1(fake)
+  legacy = dict(_row(fake, "v1"))
+  upgrades_before = fake.store.schema_updates
+
+  result = run.materialize(
       **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
   )
   assert result.status == "unchanged"
-  assert fake.store.views[_VIEW_REF] == genuine
-  assert "min_score" not in fake.store.views[_VIEW_REF]
+  # One schema update: the three columns appended, in declared order,
+  # after the slice-1 columns, without touching what was there.
+  assert fake.store.schema_updates == upgrades_before + 1
+  assert tuple(f.name for f in fake.store.manifest_schema) == (
+      _SLICE_1_MANIFEST_COLUMNS + _GENERATION_COLUMNS
+  )
+  modes = {f.name: f.mode for f in fake.store.manifest_schema}
+  assert modes["generation_id"] == "NULLABLE"
+  assert modes["view_policy"] == "NULLABLE"
+  assert modes["superseded_generations"] == "REPEATED"
+  # The backfill ran once, before the first manifest read.
+  (backfill,) = _backfill_queries(fake)
+  assert backfill < min(_manifest_reads(fake))
+  row = _row(fake, "v1")
+  assert {k: v for k, v in row.items() if k in _SLICE_1_MANIFEST_COLUMNS} == (
+      legacy
+  )
+  assert row["generation_id"] == _legacy_generation(legacy)
+  assert evalbench._GENERATION_ID_PATTERN.fullmatch(row["generation_id"])
+  assert row["view_policy"] is None
+  assert row["superseded_generations"] == []
+  assert result.manifest == row
+  # The view is created from the upgraded row, pinned to the backfilled
+  # generation, and recognized as the importer's on the next read.
+  assert [kind for kind, _, _ in fake.view_writes] == ["create"]
+  assert _full_pin(fake)["generation_id"] == _legacy_generation(legacy)
+  assert fake.store.views[_VIEW_REF] == evalbench._committed_view_body(row)
+  assert evalbench._read_managed_view(
+      fake,
+      view_ref=_VIEW_REF,
+      manifest_ref=result.manifest_table,
+      location=None,
+  ).pin["generation_id"] == _legacy_generation(legacy)
+
+  # Idempotent: an upgraded manifest costs one metadata read and no DML.
+  fake.queries.clear()
+  result = run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  assert result.status == "unchanged"
+  assert fake.store.schema_updates == upgrades_before + 1
+  assert _backfill_queries(fake) == []
+  assert [kind for kind, _, _ in fake.view_writes] == ["create"]
+  assert _row(fake, "v1") == row
+
+  # The backfilled generation is a real one: a policy change supersedes it
+  # into the row's history, and the view pinned to it is authenticated
+  # from that history and advanced.
+  stale_view = fake.store.views[_VIEW_REF]
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  assert result.status == "unchanged"
+  assert _generation(fake) != _legacy_generation(legacy)
+  assert [
+      json.loads(e) for e in _row(fake, "v1")["superseded_generations"]
+  ] == [{"generation_id": _legacy_generation(legacy), "view_policy": None}]
+  assert _full_pin(fake)["generation_id"] == _generation(fake)
+  fake.store.write_view(_VIEW_REF, stale_view)
+  assert evalbench._read_managed_view(
+      fake,
+      view_ref=_VIEW_REF,
+      manifest_ref=result.manifest_table,
+      location=None,
+  ).pin["generation_id"] == _legacy_generation(legacy)
+
+  # A replace of the legacy version and a brand-new version both publish
+  # through the upgraded manifest (the INSERT names every column).
+  second_generation = _generation(fake)
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1 + timedelta(hours=1),
+      replace=True,
+      bq_client=fake,
+  )
+  assert result.status == "replaced"
+  assert _generation(fake) not in (
+      _legacy_generation(legacy),
+      second_generation,
+  )
+  assert [
+      json.loads(e) for e in _row(fake, "v1")["superseded_generations"]
+  ] == [
+      {"generation_id": _legacy_generation(legacy), "view_policy": None},
+      {"generation_id": second_generation, "view_policy": _policy_json(0.9)},
+  ]
+  result = run.materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=2),
+      bq_client=fake,
+  )
+  assert result.status == "imported"
+  assert _row(fake, "v2")["superseded_generations"] == []
+  assert evalbench._GENERATION_ID_PATTERN.fullmatch(_generation(fake, "v2"))
+  assert _view_pin(fake)["import_version"] == "v2"
+  assert fake.store.schema_updates == upgrades_before + 1
+
+
+def test_materialize_finishes_an_interrupted_manifest_upgrade() -> None:
+  """An upgrade that added the columns but died before the backfill leaves
+  rows without a generation under a complete schema. The next import finds
+  nothing to add, notices the row it handles has no generation, backfills,
+  and proceeds; the backfill is derived, so finishing it twice is safe."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  run.materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      bq_client=fake,
+  )
+  # Schema complete, every row as the DDL alone would leave it.
+  for row in fake.store.rows:
+    row["generation_id"] = None
+    row["view_policy"] = None
+    row["superseded_generations"] = []
+  fake.store.views.clear()
+  fake.store.view_etags.clear()
+  fake.view_writes.clear()
+  fake.queries.clear()
+  upgrades_before = fake.store.schema_updates
+
+  result = run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  assert result.status == "unchanged"
+  assert fake.store.schema_updates == upgrades_before
+  assert len(_backfill_queries(fake)) == 1
+  # The backfill is table-wide: the version this call did not touch got
+  # its generation too, so the view (which tracks the latest, v2) pins it.
+  for version in ("v1", "v2"):
+    assert _generation(fake, version) == _legacy_generation(_row(fake, version))
+  assert result.manifest["generation_id"] == _generation(fake, "v1")
+  assert _view_pin(fake)["import_version"] == "v2"
   assert _full_pin(fake)["generation_id"] == _generation(fake, "v2")
+  assert fake.store.views[_VIEW_REF] == evalbench._committed_view_body(
+      _row(fake, "v2")
+  )
+
+
+def test_materialize_tolerates_a_concurrent_manifest_upgrade() -> None:
+  """Two importers upgrading one slice-1 dataset at once: the schema update
+  is ETag-conditional, so the loser re-reads, finds the columns already
+  there, and continues -- finishing the backfill itself if the winner had
+  not yet -- and both converge on the same derived generation. A manifest
+  that keeps changing under the upgrade fails closed."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _downgrade_to_slice_1(fake)
+  legacy = dict(_row(fake, "v1"))
+  upgrades_before = fake.store.schema_updates
+
+  def other_importer_adds_the_columns() -> None:
+    fake.before_schema_update = None
+    fake.store.set_manifest_schema(
+        evalbench._schema(evalbench._MANIFEST_SCHEMA_FIELDS)
+    )
+    for row in fake.store.rows:
+      row.setdefault("generation_id", None)
+      row.setdefault("view_policy", None)
+      row.setdefault("superseded_generations", [])
+
+  fake.before_schema_update = other_importer_adds_the_columns
+  result = run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  assert result.status == "unchanged"
+  # Only the other importer's update landed; this one re-read and moved on.
+  assert fake.store.schema_updates == upgrades_before + 1
+  assert tuple(f.name for f in fake.store.manifest_schema) == (
+      _SLICE_1_MANIFEST_COLUMNS + _GENERATION_COLUMNS
+  )
+  assert len(_backfill_queries(fake)) == 1
+  assert _generation(fake) == _legacy_generation(legacy)
+  assert _full_pin(fake)["generation_id"] == _legacy_generation(legacy)
+
+  # A manifest whose ETag moves on every attempt without gaining the
+  # columns exhausts the bounded retry and is refused, untouched.
+  fake = _FakeWriteClient()
+  run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _downgrade_to_slice_1(fake)
+  upgrades_before = fake.store.schema_updates
+  fake.before_schema_update = lambda: fake.store.set_manifest_schema(
+      _slice_1_schema()
+  )
+  with pytest.raises(ValueError, match="changed concurrently"):
+    run.materialize(
+        **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+    )
+  assert (
+      fake.store.schema_updates
+      == upgrades_before + evalbench._SCHEMA_UPGRADE_ATTEMPTS
+  )
+  assert tuple(f.name for f in fake.store.manifest_schema) == (
+      _SLICE_1_MANIFEST_COLUMNS
+  )
+  assert _backfill_queries(fake) == []
+  assert fake.view_writes == []
+  assert "generation_id" not in _row(fake, "v1")
 
 
 def _full_pin_of(view_query: str) -> dict:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -2251,6 +2251,13 @@ _TARGET = {"target_project": "analytics-project", "target_dataset": "bqaa"}
 _VIEW_REF = "analytics-project.bqaa.evalbench_failed_sessions"
 _PIN_LINE = "-- evalbench_failed_sessions pin: "
 _T1 = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+
+
+def _pin_ts(moment: datetime) -> str:
+  """How the view pin records a manifest generation: UTC, microseconds."""
+  return moment.astimezone(timezone.utc).isoformat(timespec="microseconds")
+
+
 _WRONG_RESULT = {
     "eval_id": "wrong-1",
     "prompt": "Completed but wrong answer",
@@ -2295,7 +2302,7 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   fake = _FakeWriteClient()
 
   result = _scored_run().materialize(
-      **_TARGET, import_version="v1", bq_client=fake
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
   )
 
   assert result.failed_sessions_view == _VIEW_REF
@@ -2314,6 +2321,7 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   assert _full_pin(fake) == {
       "job_id": "job-123",
       "import_version": "v1",
+      "imported_at": _pin_ts(_T1),
       "policy": None,
   }
   # The body is failed_sessions_sql pinned as literals: no parameters, and
@@ -2447,6 +2455,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
             + json.dumps(
                 {
                     "import_version": "v1",
+                    "imported_at": _pin_ts(_T1),
                     "job_id": "job-123",
                     "policy": None,
                     "query_sha256": "0" * 64,
@@ -2457,14 +2466,33 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
         # A pin without a policy field over foreign SQL.
         _FakeView(
             _PIN_LINE
-            + json.dumps({"import_version": "v1", "job_id": "job-123"})
+            + json.dumps(
+                {
+                    "import_version": "v1",
+                    "imported_at": _pin_ts(_T1),
+                    "job_id": "job-123",
+                }
+            )
+            + "\nSELECT 1"
+        ),
+        # A pin without a generation over foreign SQL.
+        _FakeView(
+            _PIN_LINE
+            + json.dumps(
+                {"import_version": "v1", "job_id": "job-123", "policy": None}
+            )
             + "\nSELECT 1"
         ),
         # A pin comment and nothing else.
         _FakeView(
             _PIN_LINE
             + json.dumps(
-                {"import_version": "v1", "job_id": "job-123", "policy": None}
+                {
+                    "import_version": "v1",
+                    "imported_at": _pin_ts(_T1),
+                    "job_id": "job-123",
+                    "policy": None,
+                }
             )
         ),
     ],
@@ -2513,8 +2541,17 @@ def test_materialize_refuses_a_forged_marker_copied_from_a_managed_view() -> (
     _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert fake.view_writes == before
 
-  # Only whitespace differs: still the importer's definition.
+  # Reformatted whitespace is not the importer's text either: BigQuery
+  # returns view_query verbatim, and whitespace inside a rendered literal
+  # is significant (see the literal-whitespace test below), so the check
+  # is byte-for-byte.
   fake.store.write_view(_VIEW_REF, pin_line + "\n  " + "  ".join(query.split()))
+  with pytest.raises(ValueError, match="definition was changed"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.view_writes == before
+
+  # The genuine text is recognized, and a no-op re-import writes nothing.
+  fake.store.write_view(_VIEW_REF, genuine)
   result = _scored_run().materialize(
       **_TARGET, import_version="v1", bq_client=fake
   )
@@ -2846,7 +2883,7 @@ def test_materialize_refuses_a_pin_with_a_malformed_policy(policy) -> None:
   fake = _FakeWriteClient()
   _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   _, query = fake.store.views[_VIEW_REF].split("\n", 1)
-  pin = {"import_version": "v1", "job_id": "job-123", "policy": policy}
+  pin = {**_full_pin(fake), "policy": policy}
   fake.store.write_view(_VIEW_REF, _PIN_LINE + json.dumps(pin) + "\n" + query)
   before = list(fake.view_writes)
   with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
@@ -2921,6 +2958,7 @@ def test_materialize_etag_retry_never_applies_a_stale_policy_to_a_newer_version(
   assert [kind for kind, _, _ in fake_v2.view_writes] == ["update"]
   assert _full_pin(fake_v1) == {
       "import_version": "v2",
+      "imported_at": _pin_ts(_T1 + timedelta(hours=2)),
       "job_id": "job-123",
       "policy": None,
   }
@@ -2962,6 +3000,7 @@ def test_materialize_older_version_advances_a_stale_view_without_its_policy() ->
   assert result.status == "unchanged"
   assert _full_pin(fake) == {
       "import_version": "v2",
+      "imported_at": _pin_ts(_T1 + timedelta(hours=1)),
       "job_id": "job-123",
       "policy": {
           "min_scores": {"goal_completion": 0.9},
@@ -3008,11 +3047,153 @@ def test_materialize_older_version_creates_a_missing_view_without_a_gate() -> (
   assert result.failed_sessions_view == _VIEW_REF
   assert _full_pin(fake) == {
       "import_version": "v2",
+      "imported_at": _pin_ts(_T1 + timedelta(hours=1)),
       "job_id": "job-123",
       "policy": None,
   }
   assert "min_score" not in fake.store.views[_VIEW_REF]
   assert [kind for kind, _, _ in _view_writes(fake)] == ["create"]
+
+
+def test_materialize_refuses_a_view_whose_literal_whitespace_changed() -> None:
+  """Whitespace inside a rendered literal is significant: ``job_id =
+  "job  x"`` and ``job_id = "job x"`` read different rows. A foreign view
+  that keeps the genuine pin but collapses the literal is not the
+  importer's definition; it must be refused (and never accepted as an
+  ``unchanged`` no-op that leaves the wrong literal in place)."""
+  run = dataclasses.replace(_scored_run(), job_id="job  x")
+  fake = _FakeWriteClient()
+  run.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  genuine = fake.store.views[_VIEW_REF]
+  pin_line, query = genuine.split("\n", 1)
+  assert 'job_id = "job  x"' in query
+  before = list(fake.view_writes)
+
+  forged = pin_line + "\n" + query.replace('"job  x"', '"job x"')
+  assert forged != genuine
+  fake.store.write_view(_VIEW_REF, forged)
+  with pytest.raises(ValueError, match="definition was changed"):
+    run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  with pytest.raises(ValueError, match="definition was changed"):
+    run.materialize(**_TARGET, import_version="v2", bq_client=fake)
+  assert fake.store.views[_VIEW_REF] == forged
+  assert fake.view_writes == before
+  assert not any(row["import_version"] == "v2" for row in fake.manifest_rows)
+
+  # The genuine text is recognized, and the no-op writes nothing.
+  fake.store.write_view(_VIEW_REF, genuine)
+  result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert result.status == "unchanged"
+  assert fake.view_writes == before
+
+
+def test_materialize_same_version_replace_race_keeps_the_newer_generations_policy() -> (
+    None
+):
+  """Two ``replace=True`` calls of one version label publish two manifest
+  generations. The older generation's caller (gate 0.9) reads the view and
+  pauses before its replace; the newer generation's caller (no gate) lands
+  and re-pins the view. The version string is the same for both, so
+  authority must be decided by the generation: the delayed caller's
+  replace must neither land its gate over the newer generation nor be
+  accepted on retry."""
+  store = _FakeManifestStore()
+  setup = _FakeWriteClient(store=store)
+  _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=setup
+  )
+  stale_etag = store.view_etags[_VIEW_REF]
+
+  fake_newer = _FakeWriteClient(store=store)
+
+  def newer_generation_lands_first() -> None:
+    result = _scored_run().materialize(
+        **_TARGET,
+        import_version="v1",
+        replace=True,
+        imported_at=_T1 + timedelta(hours=2),
+        bq_client=fake_newer,
+    )
+    assert result.status == "replaced"
+    # Same version, same (absent) gate, same SQL as the view already
+    # carried -- yet a new generation is a new pin, so the view was
+    # rewritten and its ETag moved under the delayed older caller. Without
+    # that, the older caller's conditional replace would land unchallenged.
+    assert [kind for kind, _, _ in fake_newer.view_writes] == ["update"]
+    assert store.view_etags[_VIEW_REF] != stale_etag
+
+  fake_older = _FakeWriteClient(
+      store=store, before_view_write=newer_generation_lands_first
+  )
+  result = _scored_run().materialize(
+      **_TARGET,
+      import_version="v1",
+      replace=True,
+      imported_at=_T1 + timedelta(hours=1),
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake_older,
+  )
+
+  assert result.status == "replaced"
+  assert result.failed_sessions_view == _VIEW_REF
+  # The older caller's replace hit its ETag check; the retry found the view
+  # pinned to the generation the manifest holds and left it alone.
+  assert fake_older.view_writes == []
+  assert _full_pin(fake_older) == {
+      "import_version": "v1",
+      "imported_at": _pin_ts(_T1 + timedelta(hours=2)),
+      "job_id": "job-123",
+      "policy": None,
+  }
+  assert "0.9 AS min_score" not in store.views[_VIEW_REF]
+  (row,) = store.rows
+  assert row["imported_at"] == (_T1 + timedelta(hours=2)).isoformat()
+
+  # A later same-version call that finds this generation committed is its
+  # import and may set the gate; the delayed caller's gate stays gone.
+  result = _scored_run().materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake_older,
+  )
+  assert result.status == "unchanged"
+  assert _full_pin(fake_older)["imported_at"] == _pin_ts(
+      _T1 + timedelta(hours=2)
+  )
+  assert "0.5 AS min_score" in store.views[_VIEW_REF]
+
+
+@pytest.mark.parametrize(
+    "imported_at",
+    [
+        "not a timestamp",
+        # Canonical form only: UTC with microseconds.
+        "2026-05-01T08:00:00+00:00",
+        "2026-05-01T10:00:00.000000+02:00",
+        "2026-05-01T08:00:00.000000Z",
+        1777622400,
+        None,
+    ],
+)
+def test_materialize_refuses_a_pin_with_a_malformed_generation(
+    imported_at,
+) -> None:
+  fake = _FakeWriteClient()
+  _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _, query = fake.store.views[_VIEW_REF].split("\n", 1)
+  pin = {**_full_pin(fake), "imported_at": imported_at}
+  fake.store.write_view(
+      _VIEW_REF, _PIN_LINE + json.dumps(pin, sort_keys=True) + "\n" + query
+  )
+  before = list(fake.view_writes)
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.view_writes == before
 
 
 def test_failed_sessions_sql_pins_literals_with_escaping() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -708,7 +708,16 @@ class _FakeWriteClient:
         self.store.lock_rows = 1
       return _FakeJob()
     if ".evalbench_import_manifest`" in query:
-      if self.stale_manifest_reads and not self.transaction_attempted:
+      feature = kwargs["job_config"].labels["sdk_feature"]
+      if (
+          self.stale_manifest_reads
+          and not self.transaction_attempted
+          and feature == "evalbench-import"
+      ):
+        # Only the import's own pre-read of the version it is publishing
+        # can be stale (it raced another importer's commit). The view
+        # ownership lookup (labelled for the view feature) reads the row an
+        # existing view pins, which committed before that view was written.
         return _FakeJob([])
       return _FakeJob(
           [row for row in self.store.rows if _same_version(row, params)]
@@ -2300,15 +2309,13 @@ def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
   )
   assert fake.get_table_calls == [_VIEW_REF, _VIEW_REF]
   body = fake.store.views[_VIEW_REF]
-  assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
-  pin = _full_pin(fake)
-  assert pin["policy"] is None
-  assert (
-      pin["query_sha256"]
-      == hashlib.sha256(
-          " ".join(body.split("\n", 1)[1].split()).encode()
-      ).hexdigest()
-  )
+  # The pin says what the view is bound to; nothing in it (no digest) is
+  # taken as proof of ownership -- see the forged-pin tests below.
+  assert _full_pin(fake) == {
+      "job_id": "job-123",
+      "import_version": "v1",
+      "policy": None,
+  }
   # The body is failed_sessions_sql pinned as literals: no parameters, and
   # no other version can be read.
   assert body.endswith(
@@ -2434,7 +2441,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
         type("Table", (), {"table_type": "TABLE", "view_query": None})(),
         _FakeView("SELECT 1"),
         _FakeView("-- evalbench_failed_sessions pin: not json\nSELECT 1"),
-        # A syntactically valid pin (hash field and all) over foreign SQL.
+        # A well-formed pin (with a stray digest claim) over foreign SQL.
         _FakeView(
             _PIN_LINE
             + json.dumps(
@@ -2447,7 +2454,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
             )
             + "\nSELECT 1"
         ),
-        # A pin without the query hash never proves ownership.
+        # A pin without a policy field over foreign SQL.
         _FakeView(
             _PIN_LINE
             + json.dumps({"import_version": "v1", "job_id": "job-123"})
@@ -2457,12 +2464,7 @@ def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
         _FakeView(
             _PIN_LINE
             + json.dumps(
-                {
-                    "import_version": "v1",
-                    "job_id": "job-123",
-                    "policy": None,
-                    "query_sha256": hashlib.sha256(b"").hexdigest(),
-                }
+                {"import_version": "v1", "job_id": "job-123", "policy": None}
             )
         ),
     ],
@@ -2475,9 +2477,10 @@ def test_materialize_never_replaces_objects_it_did_not_create(
     _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
   assert fake.loads == []
   assert fake.transaction_attempted is False
-  # Refused before the import tables were even created (or touched).
+  # Refused before the import tables were even created (or touched); at
+  # most the manifest was consulted for the version the pin claims.
   assert fake.created == []
-  assert fake.queries == []
+  assert all(".evalbench_import_manifest`" in sql for sql, _ in fake.queries)
   assert _view_writes(fake) == []
 
 
@@ -2743,6 +2746,273 @@ def test_materialize_view_sync_gives_up_after_bounded_retries() -> None:
   assert "is published (status 'imported')" in str(exc.value)
   assert len(fake.view_writes) == 3
   assert _VIEW_REF not in store.views
+
+
+def _sql_sha256(query: str) -> str:
+  return hashlib.sha256(" ".join(query.split()).encode()).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        None,
+        # A structurally valid policy pin as well: still foreign.
+        {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": True},
+    ],
+)
+def test_materialize_refuses_a_foreign_view_with_a_self_consistent_pin(
+    policy: dict | None,
+) -> None:
+  """A digest the view supplies about itself is not proof of ownership.
+
+  A foreign view can carry a same-job pin over arbitrary SQL *and* a
+  correctly recomputed hash of that SQL. Ownership must instead be decided
+  against what the importer would render for a committed manifest row.
+  """
+  fake = _FakeWriteClient()
+  _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  before = list(fake.view_writes)
+
+  foreign_sql = "SELECT 'foreign-owned' AS session_id"
+  pin = {
+      "import_version": "v1",
+      "job_id": "job-123",
+      "policy": policy,
+      "query_sha256": _sql_sha256(foreign_sql),
+  }
+  forged = _PIN_LINE + json.dumps(pin, sort_keys=True) + "\n" + foreign_sql
+  fake.store.write_view(_VIEW_REF, forged)
+
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v2", bq_client=fake)
+  assert fake.store.views[_VIEW_REF] == forged
+  assert fake.view_writes == before
+  assert not any(row["import_version"] == "v2" for row in fake.manifest_rows)
+
+
+def test_materialize_refuses_a_contract_shaped_view_for_an_unpublished_version() -> (
+    None
+):
+  """Even a body that *is* the importer's rendering counts only for a
+  version this job actually committed to the manifest (and the tables that
+  row names): a pin to an unpublished version, or a rendering over other
+  tables, is foreign."""
+  fake = _FakeWriteClient()
+  _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  (published,) = fake.manifest_rows
+  before = list(fake.view_writes)
+
+  unpublished = {**published, "import_version": "v9"}
+  fake.store.write_view(
+      _VIEW_REF,
+      evalbench._failed_sessions_view_body(manifest=unpublished, policy=None),
+  )
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+
+  relocated = {
+      **published,
+      "events_table": "analytics-project.bqaa.somebody_elses_events",
+  }
+  fake.store.write_view(
+      _VIEW_REF,
+      evalbench._failed_sessions_view_body(manifest=relocated, policy=None),
+  )
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.view_writes == before
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        "not a mapping",
+        {"min_scores": {"goal_completion": 0.9}},
+        {"min_scores": {}, "missing_score_fails": True},
+        {"min_scores": {"goal_completion": "0.9"}, "missing_score_fails": True},
+        {"min_scores": {"goal_completion": True}, "missing_score_fails": True},
+        {"min_scores": {"goal_completion": 0.9}, "missing_score_fails": 1},
+        {"min_scores": {"bad name": 0.9}, "missing_score_fails": True},
+        {
+            "min_scores": {"goal_completion": 0.9},
+            "missing_score_fails": True,
+            "extra": 1,
+        },
+    ],
+)
+def test_materialize_refuses_a_pin_with_a_malformed_policy(policy) -> None:
+  fake = _FakeWriteClient()
+  _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  _, query = fake.store.views[_VIEW_REF].split("\n", 1)
+  pin = {"import_version": "v1", "job_id": "job-123", "policy": policy}
+  fake.store.write_view(_VIEW_REF, _PIN_LINE + json.dumps(pin) + "\n" + query)
+  before = list(fake.view_writes)
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.view_writes == before
+
+
+def test_materialize_view_policy_rendering_is_canonical() -> None:
+  """The same gate given in another key order (or as ints) renders the same
+  view, so the importer recognizes its own definition and writes nothing."""
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 1, "accuracy": 0.5}),
+      bq_client=fake,
+  )
+  assert len(_view_writes(fake)) == 1
+  result = run.materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"accuracy": 0.5, "goal_completion": 1.0}),
+      bq_client=fake,
+  )
+  assert result.status == "unchanged"
+  assert len(_view_writes(fake)) == 1
+  assert _full_pin(fake)["policy"]["min_scores"] == {
+      "accuracy": 0.5,
+      "goal_completion": 1.0,
+  }
+
+
+def test_materialize_etag_retry_never_applies_a_stale_policy_to_a_newer_version() -> (
+    None
+):
+  """v1 (gate 0.9) reads the view, pauses; v2 (no policy) lands and rewrites
+  the view; v1's replace fails its ETag check and retries. The retry sees
+  v2 as latest -- a version v1 did not publish -- so it must not re-render
+  v2 with v1's policy: v2's own import decided there is no gate."""
+  store = _FakeManifestStore()
+  setup = _FakeWriteClient(store=store)
+  _scored_run().materialize(
+      **_TARGET, import_version="v0", imported_at=_T1, bq_client=setup
+  )
+
+  fake_v2 = _FakeWriteClient(store=store)
+  run_v2 = _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES)
+
+  def v2_lands_first() -> None:
+    result = run_v2.materialize(
+        **_TARGET,
+        import_version="v2",
+        imported_at=_T1 + timedelta(hours=2),
+        bq_client=fake_v2,
+    )
+    assert result.status == "imported"
+    assert _full_pin(fake_v2)["policy"] is None
+
+  fake_v1 = _FakeWriteClient(store=store, before_view_write=v2_lands_first)
+  result = _scored_run(extra_result=_WRONG_RESULT).materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1 + timedelta(hours=1),
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake_v1,
+  )
+
+  assert result.status == "imported"
+  assert result.failed_sessions_view == _VIEW_REF
+  assert fake_v1.view_writes == []
+  assert [kind for kind, _, _ in fake_v2.view_writes] == ["update"]
+  assert _full_pin(fake_v1) == {
+      "import_version": "v2",
+      "job_id": "job-123",
+      "policy": None,
+  }
+  assert "0.9 AS min_score" not in store.views[_VIEW_REF]
+
+
+def test_materialize_older_version_advances_a_stale_view_without_its_policy() -> (
+    None
+):
+  """A view left behind (the latest import managed no view) is still moved
+  to the latest version by a later, older-version call -- but the gate it
+  carries is view state that only the latest version's own import may
+  change, so the older call's policy is not rendered into it."""
+  fake = _FakeWriteClient()
+  run_v1 = _scored_run()
+  run_v1.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES).materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      failed_sessions_view=None,
+      bq_client=fake,
+  )
+  assert _view_pin(fake)["import_version"] == "v1"
+
+  result = run_v1.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert result.status == "unchanged"
+  assert _full_pin(fake) == {
+      "import_version": "v2",
+      "job_id": "job-123",
+      "policy": {
+          "min_scores": {"goal_completion": 0.9},
+          "missing_score_fails": True,
+      },
+  }
+  assert [kind for kind, _, _ in _view_writes(fake)] == ["create", "update"]
+
+  # A re-run of the same older call is then a no-op.
+  run_v1.materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert len(_view_writes(fake)) == 2
+
+
+def test_materialize_older_version_creates_a_missing_view_without_a_gate() -> (
+    None
+):
+  """No view yet and the latest version's import managed none: an older
+  version's call still creates the view for the latest version, but with
+  no gate -- its policy is not that version's to set."""
+  fake = _FakeWriteClient()
+  _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES).materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      failed_sessions_view=None,
+      bq_client=fake,
+  )
+  assert _VIEW_REF not in fake.store.views
+
+  result = _scored_run().materialize(
+      **_TARGET,
+      import_version="v1",
+      imported_at=_T1,
+      policy=EvalScorePolicy({"goal_completion": 0.9}),
+      bq_client=fake,
+  )
+  assert result.status == "imported"
+  assert result.failed_sessions_view == _VIEW_REF
+  assert _full_pin(fake) == {
+      "import_version": "v2",
+      "job_id": "job-123",
+      "policy": None,
+  }
+  assert "min_score" not in fake.store.views[_VIEW_REF]
+  assert [kind for kind, _, _ in _view_writes(fake)] == ["create"]
 
 
 def test_failed_sessions_sql_pins_literals_with_escaping() -> None:

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -17,17 +17,22 @@ from __future__ import annotations
 
 import dataclasses
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
+import inspect
 import json
 import math
 import re
 
+from google.api_core.exceptions import NotFound
 import pytest
 
 from bigquery_agent_analytics import evalbench
 from bigquery_agent_analytics.evalbench import classify_sessions
 from bigquery_agent_analytics.evalbench import EvalBenchRun
+from bigquery_agent_analytics.evalbench import EvalBenchSession
 from bigquery_agent_analytics.evalbench import EvalScorePolicy
+from bigquery_agent_analytics.evalbench import failed_sessions
 from bigquery_agent_analytics.evalbench import failed_sessions_sql
 
 _RUN_TIME = datetime(2026, 4, 29, 12, 30, tzinfo=timezone.utc)
@@ -498,6 +503,8 @@ class _FakeManifestStore:
     self.scores: list[dict] = []
     self.lock_rows = 0
     self.lock_claims = 0
+    # view ref -> view body (the DDL text after ``AS``), like ``view_query``.
+    self.views: dict[str, str] = {}
 
   def snapshot(self) -> _FakeSnapshot:
     return _FakeSnapshot(
@@ -521,6 +528,20 @@ def _same_version(row: dict, params: dict) -> bool:
       row["job_id"] == params["job_id"]
       and row["import_version"] == params["import_version"]
   )
+
+
+class _FakeView:
+  """What ``client.get_table`` returns for a view: its query text."""
+
+  table_type = "VIEW"
+
+  def __init__(self, view_query: str) -> None:
+    self.view_query = view_query
+
+
+_POLICY_ROW = re.compile(
+    r"STRUCT\('([^']+)' AS comparator, ([-+0-9.eE]+) AS min_score\)"
+)
 
 
 class _FakeWriteClient:
@@ -558,6 +579,8 @@ class _FakeWriteClient:
       load_error: Exception | None = None,
       transaction_error: Exception | None = None,
       delete_error: Exception | None = None,
+      view_error: Exception | None = None,
+      foreign_objects: dict[str, object] | None = None,
   ) -> None:
     self.store = store or _FakeManifestStore(manifest_rows)
     self.stale_manifest_reads = stale_manifest_reads
@@ -566,11 +589,15 @@ class _FakeWriteClient:
     self.load_error = load_error
     self.transaction_error = transaction_error
     self.delete_error = delete_error
+    self.view_error = view_error
+    # Objects that exist at a ref but were not created by the importer.
+    self.foreign_objects = dict(foreign_objects or {})
     self.loads: list[tuple[str, list[dict], object]] = []
     self.queries: list[tuple[str, dict]] = []
     self.created: list[str] = []
     self.created_tables: list[object] = []
     self.deleted: list[str] = []
+    self.get_table_calls: list[str] = []
 
   @property
   def manifest_rows(self) -> list[dict]:
@@ -582,6 +609,14 @@ class _FakeWriteClient:
     self.created_tables.append(table)
     return table
 
+  def get_table(self, table_ref: str):
+    self.get_table_calls.append(table_ref)
+    if table_ref in self.foreign_objects:
+      return self.foreign_objects[table_ref]
+    if table_ref in self.store.views:
+      return _FakeView(self.store.views[table_ref])
+    raise NotFound(table_ref)
+
   def query(self, query: str, **kwargs) -> _FakeJob:
     self.queries.append((query, kwargs))
     params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
@@ -591,6 +626,27 @@ class _FakeWriteClient:
         return _FakeJob(error=self.transaction_error)
       snapshot = self.transaction_snapshot or self.store.snapshot()
       return self._publish(query, params, snapshot)
+    if query.startswith("CREATE OR REPLACE VIEW"):
+      # Views cannot take query parameters.
+      assert params == {}
+      if self.view_error is not None:
+        return _FakeJob(error=self.view_error)
+      view_ref = re.match(r"CREATE OR REPLACE VIEW `([^`]+)`", query).group(1)
+      self.store.views[view_ref] = query.split("\nAS\n", 1)[1]
+      return _FakeJob()
+    if query.startswith("WITH sessions AS"):
+      return _FakeJob(self._failed_sessions(query, params))
+    if (
+        ".evalbench_import_manifest`" in query
+        and "ORDER BY imported_at DESC" in query
+    ):
+      assert set(params) == {"job_id"}
+      latest = sorted(
+          (row for row in self.store.rows if row["job_id"] == params["job_id"]),
+          key=lambda row: (row["imported_at"], row["import_version"]),
+          reverse=True,
+      )
+      return _FakeJob([dict(row) for row in latest[:1]])
     if ".evalbench_import_lock`" in query and query.startswith("INSERT INTO"):
       # Seeding is INSERT-only, so it never conflicts and may run twice.
       assert params == {}
@@ -667,21 +723,74 @@ class _FakeWriteClient:
       return _FakeJob(error=RuntimeError(f"400 {identical_guard.group(1)}"))
 
     # 3. Commit: keyed DELETEs then INSERTs from staging, plus the claim.
+    #    The script names *this* publish's staging tables, so several
+    #    publishes through one fake (several versions) each insert their own
+    #    staged rows rather than the first load that matches a table name.
+    staging_refs = re.findall(
+        r"SELECT [^\n]+ FROM `([^`]+_staging_[0-9a-f]+)`", script
+    )
+    assert len(staging_refs) == 3, script
+
     def staged(table: str) -> list[dict]:
-      return next(rows for dest, rows, _ in self.loads if table in dest)
+      (ref,) = [
+          ref for ref in staging_refs if ref.startswith(table + "_staging_")
+      ]
+      return next(rows for dest, rows, _ in reversed(self.loads) if dest == ref)
 
     store = self.store
     store.lock_claims += 1
     store.events = [
         row for row in store.events if not _same_version(row, params)
-    ] + staged(params["events_table"] + "_staging_")
+    ] + staged(params["events_table"])
     store.scores = [
         row for row in store.scores if not _same_version(row, params)
-    ] + staged(params["scores_table"] + "_staging_")
+    ] + staged(params["scores_table"])
     store.rows = [
         row for row in store.rows if not _same_version(row, params)
-    ] + staged("evalbench_import_manifest")
+    ] + staged(lock_table.rsplit(".", 1)[0] + ".evalbench_import_manifest")
     return _FakeJob()
+
+  def _failed_sessions(self, query: str, params: dict) -> list[dict]:
+    """Emulate ``failed_sessions_sql`` with the reference implementation.
+
+    The policy is read back from the rendered SQL, and only the rows of the
+    parameterized ``(job_id, import_version)`` take part, which is exactly
+    the isolation the SQL's ``WHERE`` clauses provide.
+    """
+    assert set(params) == {"job_id", "import_version"}
+    thresholds = {
+        comparator: float(value)
+        for comparator, value in _POLICY_ROW.findall(query)
+    }
+    policy = EvalScorePolicy(
+        thresholds,
+        missing_score_fails=(
+            "sc.score IS NULL OR" in query if thresholds else True
+        ),
+    )
+    events = [row for row in self.store.events if _same_version(row, params)]
+    scores = [row for row in self.store.scores if _same_version(row, params)]
+    started_at: dict[str, str] = {}
+    for row in events:
+      started_at[row["session_id"]] = min(
+          started_at.get(row["session_id"], row["timestamp"]), row["timestamp"]
+      )
+    return [
+        {
+            "session_id": verdict.session_id,
+            "scenario_id": verdict.scenario_id,
+            "started_at": started_at[verdict.session_id],
+            "process_failed": verdict.process_failed,
+            "missing_completion": verdict.missing_completion,
+            "score_failed": verdict.score_failed,
+            "failed": verdict.failed,
+            "failing_scores": [
+                {"comparator": comparator, "score": score}
+                for comparator, score in sorted(verdict.failing_scores.items())
+            ],
+        }
+        for verdict in classify_sessions(events, scores, policy)
+    ]
 
   def load_table_from_json(self, rows, destination, job_config=None):
     self.loads.append((destination, list(rows), job_config))
@@ -1470,7 +1579,9 @@ def test_materialize_consults_canonical_registry_for_custom_tables() -> None:
   pre_reads = [
       sql
       for sql, _ in fake.queries
-      if "BEGIN TRANSACTION" not in sql and sql not in _lock_seed_queries(fake)
+      if "BEGIN TRANSACTION" not in sql
+      and sql not in _lock_seed_queries(fake)
+      and not sql.startswith("CREATE OR REPLACE VIEW")
   ]
   assert pre_reads and all(f"`{registry}`" in sql for sql in pre_reads)
   # The lock is the dataset's fixed lock table as well, never a custom one.
@@ -2071,3 +2182,447 @@ def test_failed_sessions_sql_without_policy_still_counts_process_failures() -> (
   sql = failed_sessions_sql(target_project="p", target_dataset="d")
   assert "status = 'ERROR'" in sql
   assert "min_score" not in sql
+
+
+# --- failed_sessions view and version-pinned consumer (#435 slice 2) ---
+
+_TARGET = {"target_project": "analytics-project", "target_dataset": "bqaa"}
+_VIEW_REF = "analytics-project.bqaa.evalbench_failed_sessions"
+_PIN_LINE = "-- evalbench_failed_sessions pin: "
+_T1 = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+_WRONG_RESULT = {
+    "eval_id": "wrong-1",
+    "prompt": "Completed but wrong answer",
+    "stdout": json.dumps({"response": "42"}),
+    "returncode": 0,
+}
+_WRONG_SCORES = (
+    {"eval_id": "ok-1", "comparator": "goal_completion", "score": 1},
+    {"eval_id": "crash-1", "comparator": "goal_completion", "score": 0},
+    {"eval_id": "wrong-1", "comparator": "goal_completion", "score": 0.2},
+)
+
+
+def _view_ddls(fake: _FakeWriteClient) -> list[str]:
+  return [
+      sql for sql, _ in fake.queries if sql.startswith("CREATE OR REPLACE VIEW")
+  ]
+
+
+def _view_pin(fake: _FakeWriteClient, view_ref: str = _VIEW_REF) -> dict:
+  first_line = fake.store.views[view_ref].splitlines()[0]
+  assert first_line.startswith(_PIN_LINE)
+  return json.loads(first_line[len(_PIN_LINE) :])
+
+
+def _listing_query(fake: _FakeWriteClient) -> tuple[str, dict]:
+  (query,) = [
+      (sql, kwargs)
+      for sql, kwargs in fake.queries
+      if sql.startswith("WITH sessions AS")
+  ]
+  sql, kwargs = query
+  return sql, {p.name: p.value for p in kwargs["job_config"].query_parameters}
+
+
+def test_materialize_pins_failed_sessions_view_to_the_published_version() -> (
+    None
+):
+  fake = _FakeWriteClient()
+
+  result = _scored_run().materialize(
+      **_TARGET, import_version="v1", bq_client=fake
+  )
+
+  assert result.failed_sessions_view == _VIEW_REF
+  (ddl,) = _view_ddls(fake)
+  assert ddl.startswith(f"CREATE OR REPLACE VIEW `{_VIEW_REF}`")
+  assert "OPTIONS (description = " in ddl
+  # The view is created only after the publish transaction committed.
+  statements = [sql for sql, _ in fake.queries]
+  assert statements.index(ddl) > max(
+      i for i, sql in enumerate(statements) if "BEGIN TRANSACTION" in sql
+  )
+  body = fake.store.views[_VIEW_REF]
+  assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
+  # The body is failed_sessions_sql pinned as literals: no parameters, and
+  # no other version can be read.
+  assert body.endswith(
+      failed_sessions_sql(**_TARGET, job_id="job-123", import_version="v1")
+  )
+  assert "@job_id" not in body and "@import_version" not in body
+  assert 'job_id = "job-123" AND import_version = "v1"' in body
+  assert "`analytics-project.bqaa.evalbench_agent_events`" in body
+  assert "returncode" not in body
+
+
+def test_materialize_renders_policy_into_the_view() -> None:
+  fake = _FakeWriteClient()
+  _scored_run().materialize(
+      **_TARGET,
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  body = fake.store.views[_VIEW_REF]
+  assert "STRUCT('goal_completion' AS comparator, 0.5 AS min_score)" in body
+  assert "`analytics-project.bqaa.evalbench_scores_imported`" in body
+  assert body.count('import_version = "v1"') == 2
+
+
+def test_materialize_unchanged_reimport_leaves_view_untouched() -> None:
+  fake = _FakeWriteClient()
+  run = _scored_run()
+  run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert len(_view_ddls(fake)) == 1
+
+  result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert result.status == "unchanged"
+  assert result.failed_sessions_view == _VIEW_REF
+  assert len(_view_ddls(fake)) == 1
+
+  # A corpus published before views existed gets its view on the next no-op.
+  del fake.store.views[_VIEW_REF]
+  result = run.materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert result.status == "unchanged"
+  assert len(_view_ddls(fake)) == 2
+  assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
+
+
+def test_materialize_view_tracks_the_latest_successful_import() -> None:
+  fake = _FakeWriteClient()
+  run_v1 = _scored_run()
+  run_v2 = _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES)
+
+  run_v1.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  run_v2.materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      bq_client=fake,
+  )
+  assert _view_pin(fake)["import_version"] == "v2"
+  assert 'import_version = "v1"' not in fake.store.views[_VIEW_REF]
+
+  # A no-op re-import of the older version does not move the view back.
+  unchanged = run_v1.materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  assert unchanged.status == "unchanged"
+  assert _view_pin(fake)["import_version"] == "v2"
+  assert len(_view_ddls(fake)) == 2
+
+  # Re-publishing the older version makes it the latest import again.
+  replaced = run_v1.materialize(
+      **_TARGET,
+      import_version="v1",
+      replace=True,
+      imported_at=_T1 + timedelta(hours=2),
+      bq_client=fake,
+  )
+  assert replaced.status == "replaced"
+  assert _view_pin(fake)["import_version"] == "v1"
+  assert len(_view_ddls(fake)) == 3
+
+
+def test_materialize_refuses_a_view_pinned_to_another_job() -> None:
+  fake = _FakeWriteClient()
+  other = dataclasses.replace(_scored_run(), job_id="job-other")
+  other.materialize(**_TARGET, import_version="v1", bq_client=fake)
+
+  with pytest.raises(ValueError, match="pinned to EvalBench job 'job-other'"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  # Refused before staging or publishing anything for job-123.
+  assert all(row["job_id"] == "job-other" for row in fake.manifest_rows)
+  assert all("job-other" in dest for dest, _, _ in fake.loads) or all(
+      "job-123" not in json.dumps(rows) for _, rows, _ in fake.loads
+  )
+  assert _view_pin(fake)["job_id"] == "job-other"
+
+  # A per-job view name resolves the clash.
+  result = _scored_run().materialize(
+      **_TARGET,
+      import_version="v1",
+      failed_sessions_view="evalbench_failed_sessions_job_123",
+      bq_client=fake,
+  )
+  assert result.status == "imported"
+  assert result.failed_sessions_view == (
+      "analytics-project.bqaa.evalbench_failed_sessions_job_123"
+  )
+  assert _view_pin(fake, result.failed_sessions_view)["job_id"] == "job-123"
+  assert _view_pin(fake)["job_id"] == "job-other"
+
+
+@pytest.mark.parametrize(
+    "foreign",
+    [
+        type("Table", (), {"table_type": "TABLE", "view_query": None})(),
+        _FakeView("SELECT 1"),
+        _FakeView("-- evalbench_failed_sessions pin: not json\nSELECT 1"),
+    ],
+)
+def test_materialize_never_replaces_objects_it_did_not_create(
+    foreign: object,
+) -> None:
+  fake = _FakeWriteClient(foreign_objects={_VIEW_REF: foreign})
+  with pytest.raises(ValueError, match="not an evalbench failed_sessions view"):
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert fake.loads == []
+  assert fake.transaction_attempted is False
+  assert _view_ddls(fake) == []
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "evalbench_agent_events",
+        "evalbench_scores_imported",
+        "evalbench_import_manifest",
+        "evalbench_import_lock",
+        "agent_events",
+        "bad name",
+    ],
+)
+def test_materialize_rejects_unsafe_view_names(name: str) -> None:
+  fake = _FakeWriteClient()
+  with pytest.raises(ValueError):
+    _scored_run().materialize(
+        **_TARGET, failed_sessions_view=name, bq_client=fake
+    )
+  assert fake.queries == []
+  assert fake.created == []
+
+
+def test_materialize_can_skip_the_view() -> None:
+  fake = _FakeWriteClient()
+  result = _scored_run().materialize(
+      **_TARGET, failed_sessions_view=None, bq_client=fake
+  )
+  assert result.status == "imported"
+  assert result.failed_sessions_view is None
+  assert fake.get_table_calls == []
+  assert _view_ddls(fake) == []
+
+
+def test_materialize_reports_a_view_failure_after_publishing() -> None:
+  fake = _FakeWriteClient(
+      view_error=RuntimeError("403 no bigquery.tables.update")
+  )
+  with pytest.raises(
+      ValueError, match="is published .status 'imported'."
+  ) as exc:
+    _scored_run().materialize(**_TARGET, import_version="v1", bq_client=fake)
+  assert "403 no bigquery.tables.update" in str(exc.value)
+  assert len(fake.manifest_rows) == 1
+  # The retry path: the import is a no-op and the view gets created.
+  fake.view_error = None
+  result = _scored_run().materialize(
+      **_TARGET, import_version="v1", bq_client=fake
+  )
+  assert result.status == "unchanged"
+  assert _view_pin(fake) == {"job_id": "job-123", "import_version": "v1"}
+
+
+def test_failed_sessions_sql_pins_literals_with_escaping() -> None:
+  job_id = 'job "q" \\ x\nnew'
+  sql = failed_sessions_sql(
+      target_project="p", target_dataset="d", job_id=job_id, import_version="v1"
+  )
+  assert "@" not in sql
+  assert 'job_id = "job \\"q\\" \\\\ x\\nnew" AND import_version = "v1"' in sql
+  # The literal never breaks the line the pin is on.
+  assert "x\nnew" not in sql
+
+  with pytest.raises(ValueError, match="pinned together"):
+    failed_sessions_sql(target_project="p", target_dataset="d", job_id="j")
+  with pytest.raises(ValueError, match="pinned together"):
+    failed_sessions_sql(
+        target_project="p", target_dataset="d", import_version="v1"
+    )
+  with pytest.raises(ValueError, match="import_version"):
+    failed_sessions_sql(
+        target_project="p",
+        target_dataset="d",
+        job_id="j",
+        import_version="not a version!",
+    )
+
+
+def test_failed_sessions_matches_classify_sessions_for_the_pinned_version() -> (
+    None
+):
+  fake = _FakeWriteClient()
+  run = _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES)
+  policy = EvalScorePolicy({"goal_completion": 0.5})
+  run.materialize(**_TARGET, import_version="v1", policy=policy, bq_client=fake)
+
+  listing = failed_sessions(
+      **_TARGET, job_id="job-123", policy=policy, bq_client=fake
+  )
+
+  assert listing.import_version == "v1"
+  assert listing.events_table == "analytics-project.bqaa.evalbench_agent_events"
+  assert listing.session_count == 3
+  assert listing.failed_count == 2
+  verdicts = classify_sessions(
+      run.to_agent_event_rows(import_version="v1"),
+      run.to_score_rows(import_version="v1"),
+      policy,
+  )
+  assert [s.verdict() for s in listing.sessions] == [
+      v for v in verdicts if v.failed
+  ]
+  assert [s.session_id for s in listing.sessions] == [
+      "evalbench-import:job-123:v1:crash-1",
+      "evalbench-import:job-123:v1:wrong-1",
+  ]
+  for session in listing.sessions:
+    assert session.trace_id == session.session_id
+    assert (session.job_id, session.import_version) == ("job-123", "v1")
+    assert isinstance(session.started_at, datetime)
+  assert listing.sessions[1].failing_scores == {"goal_completion": 0.2}
+  assert listing.to_dict()["sessions"][1]["failing_scores"] == {
+      "goal_completion": 0.2
+  }
+
+  # The contract query ran parameterized against the pinned version.
+  sql, params = _listing_query(fake)
+  assert params == {"job_id": "job-123", "import_version": "v1"}
+  assert "`analytics-project.bqaa.evalbench_agent_events`" in sql
+  assert "STRUCT('goal_completion' AS comparator, 0.5 AS min_score)" in sql
+
+  everything = failed_sessions(
+      **_TARGET,
+      job_id="job-123",
+      policy=policy,
+      include_passed=True,
+      bq_client=fake,
+  )
+  assert [s.verdict() for s in everything.sessions] == verdicts
+  assert (everything.session_count, everything.failed_count) == (3, 2)
+
+
+def test_failed_sessions_never_mixes_import_versions() -> None:
+  fake = _FakeWriteClient()
+  policy = EvalScorePolicy({"goal_completion": 0.5})
+  _scored_run().materialize(
+      **_TARGET, import_version="v1", imported_at=_T1, bq_client=fake
+  )
+  _scored_run(extra_result=_WRONG_RESULT, scores=_WRONG_SCORES).materialize(
+      **_TARGET,
+      import_version="v2",
+      imported_at=_T1 + timedelta(hours=1),
+      bq_client=fake,
+  )
+
+  latest = failed_sessions(
+      **_TARGET, job_id="job-123", policy=policy, bq_client=fake
+  )
+  assert latest.import_version == "v2"
+  assert {s.session_id for s in latest.sessions} == {
+      "evalbench-import:job-123:v2:crash-1",
+      "evalbench-import:job-123:v2:wrong-1",
+  }
+
+  pinned = failed_sessions(
+      **_TARGET,
+      job_id="job-123",
+      import_version="v1",
+      policy=policy,
+      bq_client=fake,
+  )
+  assert pinned.import_version == "v1"
+  assert {s.session_id for s in pinned.sessions} == {
+      "evalbench-import:job-123:v1:crash-1"
+  }
+  assert pinned.manifest["import_version"] == "v1"
+
+  with pytest.raises(ValueError, match="'v3' is not published"):
+    failed_sessions(
+        **_TARGET, job_id="job-123", import_version="v3", bq_client=fake
+    )
+  with pytest.raises(ValueError, match="no published import"):
+    failed_sessions(**_TARGET, job_id="job-none", bq_client=fake)
+  with pytest.raises(ValueError, match="import_version must match"):
+    failed_sessions(
+        **_TARGET,
+        job_id="job-123",
+        import_version="bad version!",
+        bq_client=fake,
+    )
+
+
+def test_failed_sessions_reads_the_tables_bound_in_the_manifest() -> None:
+  fake = _FakeWriteClient()
+  _scored_run().materialize(
+      **_TARGET,
+      events_table="evalbench_events_custom",
+      scores_table="evalbench_scores_custom",
+      import_version="v1",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert "`analytics-project.bqaa.evalbench_events_custom`" in (
+      fake.store.views[_VIEW_REF]
+  )
+  assert "`analytics-project.bqaa.evalbench_scores_custom`" in (
+      fake.store.views[_VIEW_REF]
+  )
+
+  listing = failed_sessions(
+      **_TARGET,
+      job_id="job-123",
+      policy=EvalScorePolicy({"goal_completion": 0.5}),
+      bq_client=fake,
+  )
+  assert (
+      listing.events_table == "analytics-project.bqaa.evalbench_events_custom"
+  )
+  assert (
+      listing.scores_table == "analytics-project.bqaa.evalbench_scores_custom"
+  )
+  sql, _ = _listing_query(fake)
+  assert "`analytics-project.bqaa.evalbench_events_custom`" in sql
+  assert "`analytics-project.bqaa.evalbench_scores_custom`" in sql
+  assert "evalbench_agent_events" not in sql
+
+
+def test_session_trace_selector_pins_the_versioned_identity() -> None:
+  from bigquery_agent_analytics.client import Client
+
+  session = EvalBenchSession(
+      job_id="job-123",
+      import_version="v1",
+      session_id="evalbench-import:job-123:v1:crash-1",
+      trace_id="evalbench-import:job-123:v1:crash-1",
+      scenario_id="crash-1",
+      started_at=None,
+      process_failed=True,
+      missing_completion=True,
+      score_failed=False,
+      failed=True,
+  )
+  selector = session.trace_selector()
+  assert selector == {
+      "session_id": "evalbench-import:job-123:v1:crash-1",
+      "experiment_id": "job-123",
+  }
+  # Accepted verbatim by the existing reader (no new client surface).
+  inspect.signature(Client.get_session_trace).bind(None, **selector)
+
+  class _Recorder:
+
+    def get_session_trace(self, **kwargs):
+      self.kwargs = kwargs
+      return "trace"
+
+  recorder = _Recorder()
+  assert session.get_trace(recorder, event_types=["AGENT_COMPLETED"]) == "trace"
+  assert recorder.kwargs == {**selector, "event_types": ["AGENT_COMPLETED"]}
+  # Another version of the same scenario is a different identity.
+  assert selector["session_id"] != evalbench._session_identity(
+      "job-123", "crash-1", import_version="v2"
+  )


### PR DESCRIPTION
## Summary
Slice 2 of #435, stacked on #451. Queryable `evalbench_failed_sessions` view + version-pinned consumer/CLI so the failed-session denominator can be listed and drilled into without mixing import versions.

- `materialize()` keeps `evalbench_failed_sessions` (or `failed_sessions_view=`) pinned to the job's **latest successful import**: `failed_sessions_sql()` rendered with `(job_id, import_version)` as literals, so the view never scans another version. Pin recorded in a leading SQL comment and read back before publishing — a view pinned to another job, or a table/view the importer did not create, is refused before any write. Unchanged re-imports leave the view alone; a missing view is created; a specific older version is queried with the parameterized SQL or `failed_sessions(import_version=...)`.
- `failed_sessions()` resolves one `(job_id, import_version)` from the manifest first (latest by default), runs the parameterized contract over the tables that version is bound to, and returns `EvalBenchSession` rows whose versioned `session_id`/`trace_id` + `trace_selector()` feed `Client.get_session_trace` (`session.get_trace(client)`).
- `failed_sessions_sql(job_id=, import_version=)` renders escaped literals for view bodies.
- CLI: `bq-agent-sdk evalbench-failed-sessions --job-id … [--import-version] [--min-score C=V]… [--include-passed]` (exit 0/2); `evalbench-import` gains `--failed-sessions-view`, `--skip-failed-sessions-view`, `--min-score`, `--missing-score-passes`.
- Docs (`docs/evalbench.md`: Queryable view / Version-pinned consumer / Drill-down) and CHANGELOG.

## Depends on
#451 (slice 1 writer). Merge after #451, or together.

## Out of scope
Taxonomy, localization, harnesses, dashboards, D4, live traces.

## Test plan
- [x] Unit tests for view DDL pin, classify_sessions parity, version isolation, CLI
- [x] `python3 -m pytest -q tests/test_evalbench_importer.py tests/test_cli_evalbench_import.py tests/test_cli_evalbench_failed_sessions.py` — 111 passed
- [x] Full suite: 4299 passed, 54 skipped; the only failures/collection errors (`test_cli_agent_tool`, `test_memory_service*`, 2 in `test_pr16_fixes`) are a local `opentelemetry-semconv` ↔ editable `adk-python` import mismatch that fails identically at the base commit
- [ ] Codex + Kimi review this PR on GitHub