### PR TITLE
feat(evalbench): evalbench-score CLI wrapping Client.evaluate (#435, #97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EvalBench LLM-judge scoring of one import version (#435 slice 3, #97)**
+  — new `bq-agent-sdk evalbench-score` command: a thin wrapper over the
+  existing `Client.evaluate` + `LLMAsJudge` (`correctness` |
+  `hallucination` | `sentiment`, `--threshold`, `--strict`, `--exit-code`
+  with the same exit codes and `FAIL` lines as `evaluate`) that points the
+  client at the mirror events table and scores exactly one published
+  version of `--job-id` — the latest successful import unless
+  `--import-version` pins one. `evalbench.import_sessions()` resolves the
+  version from the manifest and lists its session identities;
+  `EvalBenchImportSessions.trace_filter()` renders them as
+  `TraceFilter(experiment_id=job_id, session_ids=..., limit=...)`, so the
+  version pin reaches `Client.evaluate` without changing it. The report's
+  `details.evalbench` names the scored job, version, table, and pinned
+  session count. Reference in `docs/evalbench.md`; CI gate example in
+  `examples/evalbench_score_gate.sh`.
 - **EvalBench failed-session view and version-pinned consumer (#435, slice 2)**
   — `EvalBenchRun.materialize()` now keeps an `evalbench_failed_sessions`
   view in the target dataset pinned (as literals) to the job's latest

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -494,6 +494,48 @@ selector is unambiguous for the identity-resolving reader. Extra
 `get_session_trace` keyword arguments (for example `event_types=`) pass
 through `session.get_trace(client, ...)`.
 
+## Score An Import With The LLM Judge (#97)
+
+`bq-agent-sdk evalbench-score` is a thin wrapper over the existing
+`Client.evaluate` + `LLMAsJudge` path: nothing new is computed, the judge
+is simply pointed at one published import version of the mirror table.
+
+```python
+from bigquery_agent_analytics import Client
+from bigquery_agent_analytics.evalbench import import_sessions
+from bigquery_agent_analytics.evaluators import LLMAsJudge
+
+pinned = import_sessions(
+    target_project="analytics-project",
+    target_dataset="bqaa",
+    job_id="abc123",
+    # import_version="v1",   # pin one version; default: latest successful import
+)
+client = Client(
+    project_id="analytics-project",
+    dataset_id="bqaa",
+    table_id="evalbench_agent_events",   # must equal pinned.events_table
+)
+report = client.evaluate(
+    evaluator=LLMAsJudge.correctness(threshold=0.7),
+    filters=pinned.trace_filter(),
+)
+print(pinned.import_version, report.pass_rate, report.total_sessions)
+```
+
+`import_sessions()` resolves the version from the manifest exactly as
+`failed_sessions()` does (an explicit `import_version` must be published;
+the default is the job's latest successful import) and then reads that
+version's distinct `session_id` values from the `events_table` recorded in
+the manifest row. `EvalBenchImportSessions.trace_filter()` returns
+`TraceFilter(experiment_id=job_id, session_ids=<those ids>, limit=<count>)`:
+`TraceFilter` has no import-version dimension, so the version pin reaches
+`Client.evaluate` through the exact versioned session identities, which
+retained versions of one job never share. `trace_filter()` refuses an
+empty session set because `TraceFilter` treats "no `session_ids`" as
+unfiltered, which would silently widen the evaluation to every retained
+version of the job. `Client.evaluate` itself is unchanged.
+
 ## CLI
 
 ```bash
@@ -529,8 +571,35 @@ Prints the `EvalBenchFailedSessions` listing (`--format table` prints one
 row per session) for exactly one published version — the job's latest
 successful import unless `--import-version` pins one — and exits `0` when
 the listing was produced (possibly empty) or `2` on invalid input, a job or
-version with no published import, or a BigQuery error. There is no
-`evalbench-score` command.
+version with no published import, or a BigQuery error.
+
+```bash
+bq-agent-sdk evalbench-score \
+  --project-id analytics-project --dataset-id bqaa --job-id abc123 \
+  [--table-id evalbench_agent_events] [--import-version v1] \
+  [--evaluator correctness|hallucination|sentiment] [--threshold 0.7] \
+  [--strict] [--exit-code] [--endpoint gemini-2.5-flash] [--connection-id ID] \
+  [--location US] [--format json|text|table]
+```
+
+Runs the chosen `LLMAsJudge` (default `correctness`, judge default
+threshold `0.5`) through `Client.evaluate` over the mirror `--table-id`,
+narrowed to one published version of `--job-id` (the latest successful
+import unless `--import-version` pins one). The output is the ordinary
+`EvaluationReport` (`--format text` prints its summary) with
+`details.evalbench` naming the scored `job_id`, `import_version`,
+`events_table`, and `pinned_sessions`, so a scorecard can always be traced
+back to the version it judged. `--strict`, `--endpoint`, and
+`--connection-id` behave as they do for `bq-agent-sdk evaluate`.
+
+Exit codes match `evaluate`: `0` when the scorecard was produced (failing
+sessions included), `1` with `--exit-code` when at least one session failed
+the threshold (the same `FAIL session=... metric=... feedback="..."` lines
+are printed to stderr first), and `2` on invalid input — an unknown
+`--evaluator`, the reserved `agent_events` table, a job or version with no
+published import, a `--table-id` the version was not published to, or a
+version with no sessions — or a BigQuery error. `examples/evalbench_score_gate.sh`
+shows the CI gate form.
 
 ## Why These Fields Matter
 

--- a/examples/evalbench_score_gate.sh
+++ b/examples/evalbench_score_gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example: gate a build on the LLM-judge score of one EvalBench import.
+#
+# Scores exactly one published import version of an EvalBench job that was
+# mirrored with `bq-agent-sdk evalbench-import` (#435). The judge runs
+# through the ordinary `Client.evaluate` path over the mirror table; the
+# ADK plugin's production `agent_events` table is never read.
+#
+# Prerequisites:
+#   pip install bigquery-agent-analytics
+#   export BQ_AGENT_PROJECT=analytics-project   # project holding the mirror
+#   export BQ_AGENT_DATASET=bqaa                # BQAA-owned target dataset
+#   export EVALBENCH_JOB_ID=abc123              # job already imported
+#
+# Optional:
+#   export EVALBENCH_IMPORT_VERSION=v1          # default: latest successful import
+#   export EVALBENCH_JUDGE=correctness          # correctness|hallucination|sentiment
+#   export EVALBENCH_THRESHOLD=0.7              # judge default 0.5
+#
+# Usage:
+#   bash examples/evalbench_score_gate.sh
+#
+# Exit codes (same as `bq-agent-sdk evaluate`):
+#   0 every session passed the judge threshold
+#   1 at least one session failed (FAIL lines are printed to stderr)
+#   2 invalid input (unknown judge, unpublished job/version, wrong table)
+#     or a BigQuery error
+
+set -euo pipefail
+
+: "${BQ_AGENT_PROJECT:?set BQ_AGENT_PROJECT}"
+: "${BQ_AGENT_DATASET:?set BQ_AGENT_DATASET}"
+: "${EVALBENCH_JOB_ID:?set EVALBENCH_JOB_ID}"
+
+args=(
+  --job-id "${EVALBENCH_JOB_ID}"
+  --evaluator "${EVALBENCH_JUDGE:-correctness}"
+  --threshold "${EVALBENCH_THRESHOLD:-0.5}"
+  --exit-code
+  --format text
+)
+if [[ -n "${EVALBENCH_IMPORT_VERSION:-}" ]]; then
+  args+=(--import-version "${EVALBENCH_IMPORT_VERSION}")
+fi
+
+echo "=== EvalBench LLM-judge gate: job ${EVALBENCH_JOB_ID} ==="
+bq-agent-sdk evalbench-score "${args[@]}"

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -33,6 +33,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 import sys
 from typing import Any, Optional
@@ -2590,7 +2591,8 @@ def evalbench_score(
       0 — the scorecard was produced (failures included, without
           ``--exit-code``).
       1 — ``--exit-code`` and at least one session failed the threshold.
-      2 — invalid input (unknown ``--evaluator``, the reserved
+      2 — invalid input (unknown ``--evaluator``, a ``--threshold``
+          outside ``[0.0, 1.0]`` or non-finite, the reserved
           ``agent_events`` table, a job or version with no published
           import, a ``--table-id`` the version was not published to, a
           version with no sessions), or a BigQuery error.
@@ -2609,6 +2611,17 @@ def evalbench_score(
       raise typer.Exit(code=2)
     # Reject the reserved ADK plugin table before any BigQuery call.
     _validate_destination_table("table_id", table_id)
+    # Judge scores are 0-1; a NaN/inf or out-of-range threshold would
+    # otherwise reach the judge and, with --exit-code, green-gate CI.
+    if threshold is not None and not (
+        math.isfinite(threshold) and 0.0 <= threshold <= 1.0
+    ):
+      typer.echo(
+          "Error: --threshold must be a finite value in [0.0, 1.0], got"
+          f" {threshold!r}.",
+          err=True,
+      )
+      raise typer.Exit(code=2)
     with_t, without_t = entry
     judge = with_t(threshold) if threshold is not None else without_t()
 

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2507,6 +2507,156 @@ def evalbench_failed_sessions(
     raise typer.Exit(code=2)
 
 
+@app.command("evalbench-score")
+def evalbench_score(
+    project_id: str = typer.Option(
+        ...,
+        envvar="BQ_AGENT_PROJECT",
+        help="Project holding the BQAA-owned dataset the job was imported into.",
+    ),
+    dataset_id: str = typer.Option(
+        ...,
+        envvar="BQ_AGENT_DATASET",
+        help="BQAA-owned dataset holding the mirror tables and manifest.",
+    ),
+    table_id: str = typer.Option(
+        "evalbench_agent_events",
+        "--table-id",
+        help=(
+            "Mirror event table the version was published to (never the ADK"
+            " plugin's agent_events)."
+        ),
+    ),
+    job_id: str = typer.Option(
+        ..., "--job-id", help="EvalBench job_id to score."
+    ),
+    evaluator: str = typer.Option(
+        "correctness",
+        "--evaluator",
+        help="LLM judge: correctness|hallucination|sentiment.",
+    ),
+    threshold: Optional[float] = typer.Option(
+        None,
+        "--threshold",
+        help="Pass/fail threshold 0-1 (uses the judge default if omitted).",
+    ),
+    import_version: Optional[str] = typer.Option(
+        None,
+        "--import-version",
+        help=(
+            "Score one published import version. Defaults to the job's"
+            " latest successful import (the version the failed-session"
+            " view tracks)."
+        ),
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help=(
+            "Stamp parse-error metadata on judge rows with empty or NULL"
+            " typed output (same as `evaluate --strict`)."
+        ),
+    ),
+    exit_code: bool = typer.Option(
+        False,
+        "--exit-code",
+        help="Return exit code 1 when any session fails the judge threshold.",
+    ),
+    endpoint: Optional[str] = typer.Option(
+        None, "--endpoint", help="AI.GENERATE endpoint for the LLM judge."
+    ),
+    connection_id: Optional[str] = typer.Option(
+        None, "--connection-id", help="BQ connection ID for AI.GENERATE."
+    ),
+    location: Optional[str] = typer.Option(
+        None, "--location", help="BigQuery location."
+    ),
+    fmt: str = typer.Option(
+        "json", "--format", help="Output format: json|text|table."
+    ),
+) -> None:
+  """Score one published EvalBench import version with the LLM judge.
+
+  A thin wrapper over ``Client.evaluate`` + ``LLMAsJudge``: the client is
+  pointed at the mirror events table, the version is resolved from the
+  import manifest exactly as ``evalbench-failed-sessions`` does (latest
+  successful import unless ``--import-version`` pins one), and the judge
+  runs over ``TraceFilter(experiment_id=job_id)`` narrowed to that version's
+  session ids, so retained versions of one job are never mixed. The report
+  is the ordinary ``EvaluationReport`` with ``details.evalbench`` naming the
+  scored job, version, table, and pinned session count.
+
+  Exit codes:
+      0 — the scorecard was produced (failures included, without
+          ``--exit-code``).
+      1 — ``--exit-code`` and at least one session failed the threshold.
+      2 — invalid input (unknown ``--evaluator``, the reserved
+          ``agent_events`` table, a job or version with no published
+          import, a ``--table-id`` the version was not published to, a
+          version with no sessions), or a BigQuery error.
+  """
+  try:
+    from .evalbench import _validate_destination_table
+    from .evalbench import import_sessions
+
+    entry = _LLM_JUDGES.get(evaluator)
+    if not entry:
+      typer.echo(
+          f"Error: unknown evaluator: {evaluator!r}; expected"
+          " correctness|hallucination|sentiment.",
+          err=True,
+      )
+      raise typer.Exit(code=2)
+    # Reject the reserved ADK plugin table before any BigQuery call.
+    _validate_destination_table("table_id", table_id)
+    with_t, without_t = entry
+    judge = with_t(threshold) if threshold is not None else without_t()
+
+    client = _build_client(
+        project_id,
+        dataset_id,
+        table_id,
+        location,
+        endpoint=endpoint,
+        connection_id=connection_id,
+    )
+    pinned = import_sessions(
+        target_project=project_id,
+        target_dataset=dataset_id,
+        job_id=job_id,
+        import_version=import_version,
+        location=location,
+        bq_client=client.bq_client,
+    )
+    events_ref = f"{project_id}.{dataset_id}.{table_id}"
+    if pinned.events_table != events_ref:
+      raise ValueError(
+          f"EvalBench job {job_id!r} import_version"
+          f" {pinned.import_version!r} is published in"
+          f" {pinned.events_table!r}, not {events_ref!r}; pass the"
+          " --table-id it was published to"
+      )
+    report = client.evaluate(
+        evaluator=judge, filters=pinned.trace_filter(), strict=strict
+    )
+    report.details["evalbench"] = {
+        "job_id": pinned.job_id,
+        "import_version": pinned.import_version,
+        "events_table": pinned.events_table,
+        "pinned_sessions": pinned.session_count,
+    }
+    typer.echo(format_output(report, fmt))
+
+    if exit_code and report.pass_rate < 1.0:
+      _emit_evaluate_failures(report)
+      raise typer.Exit(code=1)
+  except typer.Exit:
+    raise
+  except Exception as exc:  # noqa: BLE001
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
 @bqaa_app.command("seed-events")
 def seed_events(
     project_id: str = typer.Option(

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2633,11 +2633,16 @@ def evalbench_score(
         endpoint=endpoint,
         connection_id=connection_id,
     )
+    # ``events_table`` makes ``import_sessions`` check the manifest's
+    # binding against --table-id (and re-validate the stored reference)
+    # before any events-table query is submitted; the comparison below is
+    # only a second line of defense on the returned pin.
     pinned = import_sessions(
         target_project=project_id,
         target_dataset=dataset_id,
         job_id=job_id,
         import_version=import_version,
+        events_table=table_id,
         location=location,
         bq_client=client.bq_client,
     )

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -52,7 +52,7 @@ import json
 import logging
 import math
 import re
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 import uuid
 
 from google.api_core.exceptions import Conflict
@@ -62,6 +62,9 @@ from google.cloud import bigquery
 
 from ._telemetry import make_bq_client
 from ._telemetry import with_sdk_labels
+
+if TYPE_CHECKING:
+  from .trace import TraceFilter
 
 _SOURCE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 _MISSING_TEXT = frozenset({"", "<na>", "nan", "none", "null"})
@@ -140,6 +143,7 @@ _VIEW_FEATURE = "evalbench-failed-sessions"
 # BQAA-owned mirror tables, so this name is rejected before any BigQuery call.
 _RESERVED_DESTINATION_TABLES = frozenset({"agent_events"})
 _IMPORT_FEATURE = "evalbench-import"
+_SCORE_FEATURE = "evalbench-score"
 _STAGING_TABLE_TTL = timedelta(hours=6)
 _LOGGER = logging.getLogger(__name__)
 _IMPORT_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
@@ -260,6 +264,19 @@ FROM `{manifest_table}`
 WHERE job_id = @job_id
 ORDER BY imported_at DESC, import_version DESC
 LIMIT 1
+"""
+
+# Session identities of one published import version, read from the events
+# table the manifest bound that version to. ``TraceFilter`` has no
+# import-version dimension, so ``Client.evaluate`` is pinned to a version
+# through these exact ``session_id`` values (plus the ``experiment_id`` job
+# pin); retained versions of one job never share a session id
+# (``_session_identity``), so the pin cannot admit another version's rows.
+_IMPORT_SESSIONS_QUERY = """\
+SELECT DISTINCT session_id
+FROM `{events_table}`
+WHERE job_id = @job_id AND import_version = @import_version
+ORDER BY session_id
 """
 
 # Commits another score gate for an already-published, identical version
@@ -2134,13 +2151,14 @@ def _read_latest_manifest(
     manifest_ref: str,
     job_id: str,
     location: Optional[str],
+    feature: str = _VIEW_FEATURE,
 ) -> Optional[dict[str, Any]]:
   job_config = bigquery.QueryJobConfig(
       query_parameters=[
           bigquery.ScalarQueryParameter("job_id", "STRING", job_id)
       ]
   )
-  job_config = with_sdk_labels(job_config, feature=_VIEW_FEATURE)
+  job_config = with_sdk_labels(job_config, feature=feature)
   query_args: dict[str, Any] = {"job_config": job_config}
   if location is not None:
     query_args["location"] = location
@@ -2312,6 +2330,164 @@ def failed_sessions(
       sessions=rows if include_passed else failed,
       session_count=len(rows),
       failed_count=len(failed),
+      manifest=dict(manifest),
+  )
+
+
+def _resolve_manifest(
+    client: Any,
+    *,
+    manifest_ref: str,
+    job_id: str,
+    import_version: Optional[str],
+    location: Optional[str],
+    feature: str,
+) -> tuple[str, dict[str, Any]]:
+  """Pin ``(job_id, import_version)`` to one committed manifest row.
+
+  An explicit ``import_version`` must have a manifest row; ``None`` resolves
+  the job's latest successful import (newest ``imported_at``, the same pin
+  the ``evalbench_failed_sessions`` view tracks). Raises ``ValueError``
+  before any event row is read when nothing is published.
+  """
+  if import_version is None:
+    manifest = _read_latest_manifest(
+        client,
+        manifest_ref=manifest_ref,
+        job_id=job_id,
+        location=location,
+        feature=feature,
+    )
+    if manifest is None:
+      raise ValueError(
+          f"EvalBench job {job_id!r} has no published import in"
+          f" {manifest_ref!r}; run materialize() first"
+      )
+    return str(manifest["import_version"]), manifest
+  _validate_import_version(import_version)
+  manifest = _read_manifest(
+      client,
+      manifest_ref=manifest_ref,
+      job_id=job_id,
+      import_version=import_version,
+      location=location,
+      feature=feature,
+  )
+  if manifest is None:
+    raise ValueError(
+        f"EvalBench job {job_id!r} import_version {import_version!r} is not"
+        f" published in {manifest_ref!r}"
+    )
+  return import_version, manifest
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalBenchImportSessions:
+  """The sessions of exactly one published EvalBench import version.
+
+  Returned by ``import_sessions``. ``session_ids`` are the versioned
+  identities (``evalbench-import:{job_id}:{import_version}:{scenario_id}``)
+  the mirror ``events_table`` holds for this version, in ``session_id``
+  order; ``manifest`` is the committed manifest row the version was
+  resolved from. ``trace_filter()`` turns the listing into the
+  ``TraceFilter`` that scores this version -- and only this version -- with
+  ``Client.evaluate``.
+  """
+
+  job_id: str
+  import_version: str
+  events_table: str
+  scores_table: str
+  session_ids: tuple[str, ...]
+  manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+  @property
+  def session_count(self) -> int:
+    return len(self.session_ids)
+
+  def trace_filter(self) -> "TraceFilter":
+    """``TraceFilter`` selecting exactly this version's sessions.
+
+    Pins ``experiment_id`` to the job and ``session_ids`` to the version's
+    identities, with ``limit`` raised to the session count so no session is
+    truncated. Refuses an empty session set: ``TraceFilter`` treats no
+    ``session_ids`` as "unfiltered", which would silently widen the
+    evaluation to every retained version of the job.
+    """
+    from .trace import TraceFilter  # local: keep evalbench import-light
+
+    if not self.session_ids:
+      raise ValueError(
+          f"EvalBench job {self.job_id!r} import_version"
+          f" {self.import_version!r} has no sessions in"
+          f" {self.events_table!r}; nothing to score"
+      )
+    return TraceFilter(
+        experiment_id=self.job_id,
+        session_ids=list(self.session_ids),
+        limit=len(self.session_ids),
+    )
+
+  def to_dict(self) -> dict[str, Any]:
+    return _json_safe(dataclasses.asdict(self))
+
+
+def import_sessions(
+    *,
+    target_project: str,
+    target_dataset: str,
+    job_id: str,
+    import_version: Optional[str] = None,
+    location: Optional[str] = None,
+    bq_client: Optional[Any] = None,
+) -> EvalBenchImportSessions:
+  """Resolve one published import version to its session identities.
+
+  The version is pinned from the manifest before any event row is read
+  (``failed_sessions`` semantics: an explicit ``import_version`` must be
+  published, ``None`` means the job's latest successful import), then the
+  version's distinct ``session_id`` values are read from the
+  ``events_table`` recorded in that manifest row, so a version stays bound
+  to the table it was published to. The result feeds ``Client.evaluate``
+  through ``EvalBenchImportSessions.trace_filter()`` -- the
+  ``bq-agent-sdk evalbench-score`` path (#97).
+  """
+  _validate_source_segment("target_project", target_project)
+  _validate_source_segment("target_dataset", target_dataset)
+  if not isinstance(job_id, str) or not job_id:
+    raise ValueError("job_id must be a non-empty string")
+  manifest_ref = f"{target_project}.{target_dataset}.{MANIFEST_TABLE}"
+  client = bq_client or make_bq_client(target_project, location=location)
+  import_version, manifest = _resolve_manifest(
+      client,
+      manifest_ref=manifest_ref,
+      job_id=job_id,
+      import_version=import_version,
+      location=location,
+      feature=_SCORE_FEATURE,
+  )
+  events_ref = str(manifest["events_table"])
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=_import_parameters(job_id, import_version)
+  )
+  job_config = with_sdk_labels(job_config, feature=_SCORE_FEATURE)
+  query_args: dict[str, Any] = {"job_config": job_config}
+  if location is not None:
+    query_args["location"] = location
+  query = _IMPORT_SESSIONS_QUERY.format(events_table=events_ref)
+  session_ids = tuple(
+      str(row["session_id"])
+      for row in (
+          _plain_row(raw) for raw in client.query(query, **query_args).result()
+      )
+      if row.get("session_id") is not None
+  )
+  return EvalBenchImportSessions(
+      job_id=job_id,
+      import_version=import_version,
+      events_table=events_ref,
+      scores_table=str(manifest["scores_table"]),
+      session_ids=session_ids,
       manifest=dict(manifest),
   )
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -2438,6 +2438,7 @@ def import_sessions(
     target_dataset: str,
     job_id: str,
     import_version: Optional[str] = None,
+    events_table: Optional[str] = None,
     location: Optional[str] = None,
     bq_client: Optional[Any] = None,
 ) -> EvalBenchImportSessions:
@@ -2451,11 +2452,30 @@ def import_sessions(
   to the table it was published to. The result feeds ``Client.evaluate``
   through ``EvalBenchImportSessions.trace_filter()`` -- the
   ``bq-agent-sdk evalbench-score`` path (#97).
+
+  The manifest is written by the importer and read here under the scorer's
+  identity, so the persisted ``events_table`` is never trusted as-is: it
+  must be the canonical ``target_project.target_dataset.<mirror table>``
+  reference (every segment re-validated, the ADK plugin's ``agent_events``
+  rejected) before it is formatted into the session query. When
+  ``events_table`` names the mirror table the caller expects (the CLI's
+  ``--table-id``), the stored binding must match it, again before any
+  events-table statement is submitted.
+
+  Args:
+      events_table: Optional mirror table name in ``target_dataset`` the
+        version is expected to be published in. Validated before any
+        BigQuery call; a mismatch with the manifest raises ``ValueError``
+        before the events table is read.
   """
   _validate_source_segment("target_project", target_project)
   _validate_source_segment("target_dataset", target_dataset)
   if not isinstance(job_id, str) or not job_id:
     raise ValueError("job_id must be a non-empty string")
+  expected_events_ref: Optional[str] = None
+  if events_table is not None:
+    _validate_destination_table("events_table", events_table)
+    expected_events_ref = f"{target_project}.{target_dataset}.{events_table}"
   manifest_ref = f"{target_project}.{target_dataset}.{MANIFEST_TABLE}"
   client = bq_client or make_bq_client(target_project, location=location)
   import_version, manifest = _resolve_manifest(
@@ -2466,7 +2486,19 @@ def import_sessions(
       location=location,
       feature=_SCORE_FEATURE,
   )
-  events_ref = str(manifest["events_table"])
+  events_ref = _validate_manifest_events_table(
+      manifest.get("events_table"),
+      target_project=target_project,
+      target_dataset=target_dataset,
+      job_id=job_id,
+      import_version=import_version,
+  )
+  if expected_events_ref is not None and events_ref != expected_events_ref:
+    raise ValueError(
+        f"EvalBench job {job_id!r} import_version {import_version!r} is"
+        f" published in {events_ref!r}, not {expected_events_ref!r}; pass"
+        " the events_table it was published to"
+    )
   job_config = bigquery.QueryJobConfig(
       query_parameters=_import_parameters(job_id, import_version)
   )
@@ -3065,6 +3097,50 @@ def _validate_destination_table(name: str, value: Any) -> None:
         "EvalBench imports publish only to BQAA-owned mirror tables such as "
         f"{DEFAULT_EVENTS_TABLE!r}"
     )
+
+
+def _validate_manifest_events_table(
+    value: Any,
+    *,
+    target_project: str,
+    target_dataset: str,
+    job_id: str,
+    import_version: str,
+) -> str:
+  """Re-validate a persisted manifest ``events_table`` before querying it.
+
+  The importer validates every segment before publishing, but the manifest
+  is read back under a different identity (the scorer), so the stored
+  value is treated as untrusted input: it must be exactly
+  ``target_project.target_dataset.<table>`` with the table segment passing
+  ``_validate_destination_table`` (segment charset, reserved
+  ``agent_events``). Anything else -- a closed backtick, a semicolon, a
+  reference into another project or dataset -- raises before the value can
+  be formatted into a statement.
+  """
+  context = (
+      f"EvalBench job {job_id!r} import_version {import_version!r} manifest"
+      " events_table"
+  )
+  if not isinstance(value, str) or not value:
+    raise ValueError(f"{context} must be a non-empty string, got {value!r}")
+  segments = value.split(".")
+  if len(segments) != 3:
+    raise ValueError(
+        f"{context} must be a canonical project.dataset.table reference,"
+        f" got {value!r}"
+    )
+  project, dataset, table = segments
+  try:
+    _validate_destination_table("events_table", table)
+  except ValueError as exc:
+    raise ValueError(f"{context} {value!r} is invalid: {exc}") from exc
+  if project != target_project or dataset != target_dataset:
+    raise ValueError(
+        f"{context} {value!r} is outside the scored dataset"
+        f" {target_project!r}.{target_dataset!r}"
+    )
+  return f"{project}.{dataset}.{table}"
 
 
 def _find_scenario_id(row: Mapping[str, Any]) -> Optional[str]:

--- a/tests/test_cli_evalbench_score.py
+++ b/tests/test_cli_evalbench_score.py
@@ -143,6 +143,7 @@ def test_scores_latest_version_with_correctness_judge_by_default(
           "job_id": "job-123",
           "import_version": None,
           "location": None,
+          "events_table": "evalbench_agent_events",
           "bq_client": client.bq_client,
       }
   ]
@@ -263,6 +264,79 @@ def test_table_not_bound_to_version_exits_2(
   assert result.exit_code == 2
   assert "analytics-project.bqaa.evalbench_agent_events" in result.output
   assert "analytics-project.bqaa.other_events" in result.output
+  client.evaluate.assert_not_called()
+
+
+def test_requested_table_is_handed_to_import_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """``--table-id`` reaches ``import_sessions`` so the binding is checked
+  there, before any events-table query (not only after the pin returns)."""
+  _, _, pin_calls = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--table-id", "other_events"])
+
+  assert result.exit_code == 2
+  assert [c["events_table"] for c in pin_calls] == ["other_events"]
+
+
+class _RecordingBQClient:
+  """Real ``import_sessions`` fake: answers the manifest, records calls."""
+
+  def __init__(self, manifest: dict) -> None:
+    self._manifest = manifest
+    self.calls: list[str] = []
+
+  def query(self, sql: str, **kwargs):
+    self.calls.append(sql)
+    result = MagicMock()
+    result.result.return_value = [dict(self._manifest)]
+    return result
+
+
+@pytest.mark.parametrize(
+    "stored_events_table",
+    [
+        "analytics-project.bqaa.evalbench_agent_events`; DROP TABLE"
+        " `analytics-project.bqaa.agent_events",
+        "analytics-project.bqaa.evalbench_agent_events; SELECT 1",
+        "other-project.bqaa.evalbench_agent_events",
+        "analytics-project.bqaa.agent_events",
+    ],
+)
+def test_hostile_manifest_events_table_exits_2_before_events_query(
+    monkeypatch: pytest.MonkeyPatch, stored_events_table: str
+) -> None:
+  """Regression for the confused-deputy manifest ``events_table``.
+
+  The manifest writer and the scorer are different identities. A stored
+  ``events_table`` that is not the canonical ``project.dataset.<table>``
+  the scorer requested must fail before any events-table statement is
+  submitted -- only the manifest lookup may run.
+  """
+  bq_client = _RecordingBQClient(
+      {
+          "job_id": "job-123",
+          "import_version": "v2",
+          "events_table": stored_events_table,
+          "scores_table": "analytics-project.bqaa.evalbench_scores_imported",
+          "imported_at": _NOW,
+          "generation_id": "gen-v2",
+      }
+  )
+  client = MagicMock()
+  client.bq_client = bq_client
+  monkeypatch.setattr(cli, "_build_client", lambda *a, **kw: client)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--import-version", "v2"])
+
+  assert result.exit_code == 2, result.output
+  assert "events_table" in result.output
+  assert len(bq_client.calls) == 1
+  assert "evalbench_import_manifest" in bq_client.calls[0]
+  assert not any(
+      sql.startswith("SELECT DISTINCT session_id") for sql in bq_client.calls
+  )
   client.evaluate.assert_not_called()
 
 

--- a/tests/test_cli_evalbench_score.py
+++ b/tests/test_cli_evalbench_score.py
@@ -348,3 +348,58 @@ def test_without_exit_code_flag_failures_still_exit_0(
 
   assert result.exit_code == 0, result.output
   assert json.loads(result.output)["failed_sessions"] == 2
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1.1", "nan", "inf", "-inf"])
+def test_invalid_threshold_exits_2_before_any_client(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+  client, build_calls, pin_calls = _patch(monkeypatch)
+  judge_calls: list[float] = []
+  with_t, without_t = cli._LLM_JUDGES["correctness"]
+
+  def spy_with_t(t):
+    judge_calls.append(t)
+    return with_t(t)
+
+  monkeypatch.setitem(cli._LLM_JUDGES, "correctness", (spy_with_t, without_t))
+
+  result = runner.invoke(app, _BASE_ARGS + ["--threshold", value])
+
+  assert result.exit_code == 2, result.output
+  assert "Error: --threshold must be a finite value in [0.0, 1.0]" in (
+      result.output
+  )
+  assert judge_calls == []
+  assert build_calls == []
+  assert pin_calls == []
+  client.evaluate.assert_not_called()
+
+
+def test_invalid_threshold_with_exit_code_still_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  # A negative threshold must not turn ``--exit-code`` into a green gate.
+  client, build_calls, _ = _patch(monkeypatch, report=_report(0, 2))
+
+  result = runner.invoke(
+      app, _BASE_ARGS + ["--threshold", "-0.1", "--exit-code"]
+  )
+
+  assert result.exit_code == 2, result.output
+  assert "FAIL session=" not in result.output
+  assert build_calls == []
+  client.evaluate.assert_not_called()
+
+
+@pytest.mark.parametrize("value", ["0.0", "1.0"])
+def test_boundary_thresholds_are_accepted(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+  client, _, _ = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--threshold", value])
+
+  assert result.exit_code == 0, result.output
+  judge = client.evaluate.call_args.kwargs["evaluator"]
+  assert [c.threshold for c in judge._criteria] == [float(value)]

--- a/tests/test_cli_evalbench_score.py
+++ b/tests/test_cli_evalbench_score.py
@@ -1,0 +1,350 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``bq-agent-sdk evalbench-score`` (#435 slice 3, #97)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics import cli
+from bigquery_agent_analytics import evalbench
+from bigquery_agent_analytics.cli import app
+from bigquery_agent_analytics.evaluators import EvaluationReport
+from bigquery_agent_analytics.evaluators import LLMAsJudge
+from bigquery_agent_analytics.evaluators import SessionScore
+from bigquery_agent_analytics.trace import TraceFilter
+
+runner = CliRunner()
+
+_NOW = datetime(2026, 4, 29, 12, 30, tzinfo=timezone.utc)
+_SESSION_IDS = (
+    "evalbench-import:job-123:v2:scenario-a",
+    "evalbench-import:job-123:v2:scenario-b",
+)
+_PINNED = evalbench.EvalBenchImportSessions(
+    job_id="job-123",
+    import_version="v2",
+    events_table="analytics-project.bqaa.evalbench_agent_events",
+    scores_table="analytics-project.bqaa.evalbench_scores_imported",
+    session_ids=_SESSION_IDS,
+    manifest={"job_id": "job-123", "import_version": "v2"},
+)
+_BASE_ARGS = [
+    "evalbench-score",
+    "--project-id",
+    "analytics-project",
+    "--dataset-id",
+    "bqaa",
+    "--job-id",
+    "job-123",
+]
+
+
+def _report(passed: int, total: int) -> EvaluationReport:
+  return EvaluationReport(
+      dataset="test",
+      evaluator_name="correctness_judge",
+      total_sessions=total,
+      passed_sessions=passed,
+      failed_sessions=total - passed,
+      created_at=_NOW,
+      session_scores=[
+          SessionScore(
+              session_id=_SESSION_IDS[i % len(_SESSION_IDS)],
+              scores={"correctness": 0.9 if i < passed else 0.2},
+              passed=i < passed,
+              llm_feedback=None if i < passed else "Wrong table joined.",
+          )
+          for i in range(total)
+      ],
+  )
+
+
+def _patch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    report: EvaluationReport | None = None,
+    pinned: evalbench.EvalBenchImportSessions = _PINNED,
+    pin_error: Exception | None = None,
+    evaluate_error: Exception | None = None,
+) -> tuple[MagicMock, list[dict], list[dict]]:
+  """Stub the client factory and the manifest/session resolver."""
+  client = MagicMock()
+  if evaluate_error is not None:
+    client.evaluate.side_effect = evaluate_error
+  else:
+    client.evaluate.return_value = report or _report(2, 2)
+  build_calls: list[dict] = []
+
+  def fake_build_client(project_id, dataset_id, table_id, location=None, **kw):
+    build_calls.append(
+        {
+            "project_id": project_id,
+            "dataset_id": dataset_id,
+            "table_id": table_id,
+            "location": location,
+            **kw,
+        }
+    )
+    return client
+
+  pin_calls: list[dict] = []
+
+  def fake_import_sessions(**kwargs):
+    pin_calls.append(kwargs)
+    if pin_error is not None:
+      raise pin_error
+    return pinned
+
+  monkeypatch.setattr(cli, "_build_client", fake_build_client)
+  monkeypatch.setattr(evalbench, "import_sessions", fake_import_sessions)
+  return client, build_calls, pin_calls
+
+
+def test_scores_latest_version_with_correctness_judge_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client, build_calls, pin_calls = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 0, result.output
+  assert build_calls == [
+      {
+          "project_id": "analytics-project",
+          "dataset_id": "bqaa",
+          "table_id": "evalbench_agent_events",
+          "location": None,
+          "endpoint": None,
+          "connection_id": None,
+      }
+  ]
+  assert pin_calls == [
+      {
+          "target_project": "analytics-project",
+          "target_dataset": "bqaa",
+          "job_id": "job-123",
+          "import_version": None,
+          "location": None,
+          "bq_client": client.bq_client,
+      }
+  ]
+  client.evaluate.assert_called_once()
+  kwargs = client.evaluate.call_args.kwargs
+  judge = kwargs["evaluator"]
+  assert isinstance(judge, LLMAsJudge)
+  assert judge.name == "correctness_judge"
+  assert [(c.name, c.threshold) for c in judge._criteria] == [
+      ("correctness", 0.5)
+  ]
+  filters = kwargs["filters"]
+  assert isinstance(filters, TraceFilter)
+  assert filters.experiment_id == "job-123"
+  assert list(filters.session_ids) == list(_SESSION_IDS)
+  assert filters.limit == len(_SESSION_IDS)
+  assert kwargs["strict"] is False
+
+  payload = json.loads(result.output)
+  assert payload["total_sessions"] == 2
+  assert payload["details"]["evalbench"] == {
+      "job_id": "job-123",
+      "import_version": "v2",
+      "events_table": "analytics-project.bqaa.evalbench_agent_events",
+      "pinned_sessions": 2,
+  }
+
+
+def test_pins_version_and_passes_judge_options_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client, build_calls, pin_calls = _patch(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      _BASE_ARGS
+      + [
+          "--import-version",
+          "v2",
+          "--evaluator",
+          "hallucination",
+          "--threshold",
+          "0.8",
+          "--strict",
+          "--location",
+          "US",
+          "--endpoint",
+          "gemini-2.5-pro",
+          "--connection-id",
+          "proj.us.conn",
+          "--format",
+          "text",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  (build,) = build_calls
+  assert build["location"] == "US"
+  assert build["endpoint"] == "gemini-2.5-pro"
+  assert build["connection_id"] == "proj.us.conn"
+  (pin,) = pin_calls
+  assert pin["import_version"] == "v2"
+  assert pin["location"] == "US"
+  kwargs = client.evaluate.call_args.kwargs
+  judge = kwargs["evaluator"]
+  assert judge.name == "hallucination_judge"
+  assert [c.threshold for c in judge._criteria] == [0.8]
+  assert kwargs["strict"] is True
+  assert "Evaluation Report: correctness_judge" in result.output
+
+
+def test_sentiment_judge_is_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+  client, _, _ = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--evaluator", "sentiment"])
+
+  assert result.exit_code == 0, result.output
+  judge = client.evaluate.call_args.kwargs["evaluator"]
+  assert judge.name == "sentiment_judge"
+
+
+def test_unknown_evaluator_exits_2_before_any_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client, build_calls, pin_calls = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--evaluator", "latency"])
+
+  assert result.exit_code == 2
+  assert "unknown evaluator: 'latency'" in result.output
+  assert "correctness|hallucination|sentiment" in result.output
+  assert build_calls == []
+  assert pin_calls == []
+  client.evaluate.assert_not_called()
+
+
+def test_reserved_agent_events_table_exits_2_before_any_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client, build_calls, pin_calls = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--table-id", "agent_events"])
+
+  assert result.exit_code == 2
+  assert "reserved ADK plugin table" in result.output
+  assert build_calls == []
+  assert pin_calls == []
+  client.evaluate.assert_not_called()
+
+
+def test_table_not_bound_to_version_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client, _, _ = _patch(monkeypatch)
+
+  result = runner.invoke(app, _BASE_ARGS + ["--table-id", "other_events"])
+
+  assert result.exit_code == 2
+  assert "analytics-project.bqaa.evalbench_agent_events" in result.output
+  assert "analytics-project.bqaa.other_events" in result.output
+  client.evaluate.assert_not_called()
+
+
+def test_unpublished_job_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+  client, _, _ = _patch(
+      monkeypatch,
+      pin_error=ValueError(
+          "EvalBench job 'job-123' has no published import in"
+          " 'analytics-project.bqaa.evalbench_import_manifest'"
+      ),
+  )
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 2
+  assert "no published import" in result.output
+  client.evaluate.assert_not_called()
+
+
+def test_version_without_sessions_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  empty = evalbench.EvalBenchImportSessions(
+      job_id="job-123",
+      import_version="v2",
+      events_table="analytics-project.bqaa.evalbench_agent_events",
+      scores_table="analytics-project.bqaa.evalbench_scores_imported",
+      session_ids=(),
+  )
+  client, _, _ = _patch(monkeypatch, pinned=empty)
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 2
+  assert "no sessions" in result.output
+  client.evaluate.assert_not_called()
+
+
+def test_bigquery_error_during_evaluate_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  _patch(monkeypatch, evaluate_error=RuntimeError("403 Access Denied"))
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 2
+  assert "403 Access Denied" in result.output
+
+
+def test_exit_code_flag_returns_1_and_emits_fail_lines_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  _patch(monkeypatch, report=_report(1, 2))
+
+  result = runner.invoke(app, _BASE_ARGS + ["--exit-code"])
+
+  assert result.exit_code == 1
+  assert "--exit-code: 1 session(s) failed (of 2 evaluated)" in result.output
+  assert (
+      "FAIL session=evalbench-import:job-123:v2:scenario-b"
+      " metric=correctness" in result.output
+  )
+  assert 'feedback="Wrong table joined."' in result.output
+
+
+def test_exit_code_flag_returns_0_when_all_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  _patch(monkeypatch, report=_report(2, 2))
+
+  result = runner.invoke(app, _BASE_ARGS + ["--exit-code"])
+
+  assert result.exit_code == 0, result.output
+  assert "FAIL session=" not in result.output
+
+
+def test_without_exit_code_flag_failures_still_exit_0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  _patch(monkeypatch, report=_report(0, 2))
+
+  result = runner.invoke(app, _BASE_ARGS)
+
+  assert result.exit_code == 0, result.output
+  assert json.loads(result.output)["failed_sessions"] == 2

--- a/tests/test_evalbench_import_sessions.py
+++ b/tests/test_evalbench_import_sessions.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``evalbench.import_sessions`` (#435 slice 3, #97)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+import pytest
+
+from bigquery_agent_analytics import evalbench
+from bigquery_agent_analytics.trace import TraceFilter
+
+_MANIFEST_REF = "analytics-project.bqaa.evalbench_import_manifest"
+_EVENTS_REF = "analytics-project.bqaa.evalbench_agent_events"
+_SCORES_REF = "analytics-project.bqaa.evalbench_scores_imported"
+
+
+def _manifest(import_version: str, imported_at: datetime) -> dict[str, Any]:
+  return {
+      "job_id": "job-123",
+      "import_version": import_version,
+      "events_table": _EVENTS_REF,
+      "scores_table": _SCORES_REF,
+      "imported_at": imported_at,
+      "generation_id": f"gen-{import_version}",
+  }
+
+
+class _FakeResult:
+
+  def __init__(self, rows: list[dict[str, Any]]) -> None:
+    self._rows = rows
+
+  def result(self) -> list[dict[str, Any]]:
+    return list(self._rows)
+
+
+class _FakeClient:
+  """Answers the manifest and session queries; records every call."""
+
+  def __init__(
+      self,
+      manifests: list[dict[str, Any]],
+      sessions: dict[str, list[str]],
+  ) -> None:
+    self._manifests = manifests
+    self._sessions = sessions
+    self.calls: list[dict[str, Any]] = []
+
+  def query(self, sql: str, **kwargs: Any) -> _FakeResult:
+    job_config = kwargs["job_config"]
+    params = {p.name: p.value for p in job_config.query_parameters}
+    self.calls.append(
+        {"sql": sql, "params": params, "labels": dict(job_config.labels or {})}
+    )
+    if sql.startswith("SELECT DISTINCT session_id"):
+      assert f"`{_EVENTS_REF}`" in sql
+      rows = self._sessions.get(params["import_version"], [])
+      return _FakeResult([{"session_id": s} for s in rows])
+    assert f"`{_MANIFEST_REF}`" in sql
+    rows = [m for m in self._manifests if m["job_id"] == params["job_id"]]
+    if "import_version" in params:
+      rows = [
+          m for m in rows if m["import_version"] == params["import_version"]
+      ]
+    else:
+      rows.sort(
+          key=lambda m: (m["imported_at"], m["import_version"]), reverse=True
+      )
+      rows = rows[:1]
+    return _FakeResult(rows)
+
+
+def _client(
+    sessions: dict[str, list[str]] | None = None,
+) -> _FakeClient:
+  return _FakeClient(
+      manifests=[
+          _manifest("v1", datetime(2026, 4, 1, tzinfo=timezone.utc)),
+          _manifest("v2", datetime(2026, 4, 2, tzinfo=timezone.utc)),
+      ],
+      sessions=sessions
+      if sessions is not None
+      else {
+          "v1": ["evalbench-import:job-123:v1:a"],
+          "v2": [
+              "evalbench-import:job-123:v2:a",
+              "evalbench-import:job-123:v2:b",
+          ],
+      },
+  )
+
+
+def test_defaults_to_latest_successful_import() -> None:
+  client = _client()
+
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      bq_client=client,
+  )
+
+  assert pinned.job_id == "job-123"
+  assert pinned.import_version == "v2"
+  assert pinned.events_table == _EVENTS_REF
+  assert pinned.scores_table == _SCORES_REF
+  assert pinned.session_ids == (
+      "evalbench-import:job-123:v2:a",
+      "evalbench-import:job-123:v2:b",
+  )
+  assert pinned.session_count == 2
+  assert pinned.manifest["generation_id"] == "gen-v2"
+  # Manifest first, then the version's sessions from the bound table.
+  assert [c["params"] for c in client.calls] == [
+      {"job_id": "job-123"},
+      {"job_id": "job-123", "import_version": "v2"},
+  ]
+  assert all(
+      c["labels"].get("sdk_feature") == "evalbench-score" for c in client.calls
+  ), client.calls
+
+
+def test_pins_explicit_version() -> None:
+  client = _client()
+
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      import_version="v1",
+      bq_client=client,
+  )
+
+  assert pinned.import_version == "v1"
+  assert pinned.session_ids == ("evalbench-import:job-123:v1:a",)
+  assert [c["params"] for c in client.calls] == [
+      {"job_id": "job-123", "import_version": "v1"},
+      {"job_id": "job-123", "import_version": "v1"},
+  ]
+
+
+def test_passes_location_to_every_query() -> None:
+  client = _client()
+  seen: list[Any] = []
+  original = client.query
+
+  def query(sql: str, **kwargs: Any) -> _FakeResult:
+    seen.append(kwargs.get("location"))
+    return original(sql, **kwargs)
+
+  client.query = query  # type: ignore[method-assign]
+
+  evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      location="US",
+      bq_client=client,
+  )
+
+  assert seen == ["US", "US"]
+
+
+def test_unpublished_job_raises_before_reading_events() -> None:
+  client = _client()
+
+  with pytest.raises(ValueError, match="no published import"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-999",
+        bq_client=client,
+    )
+  assert len(client.calls) == 1
+
+
+def test_unpublished_version_raises_before_reading_events() -> None:
+  client = _client()
+
+  with pytest.raises(ValueError, match="is not published"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        import_version="v9",
+        bq_client=client,
+    )
+  assert len(client.calls) == 1
+
+
+def test_malformed_version_and_job_are_rejected() -> None:
+  client = _client()
+
+  with pytest.raises(ValueError):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        import_version="bad version!",
+        bq_client=client,
+    )
+  with pytest.raises(ValueError, match="job_id"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="",
+        bq_client=client,
+    )
+  assert client.calls == []
+
+
+def test_trace_filter_pins_job_and_exact_sessions() -> None:
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      bq_client=_client(),
+  )
+
+  filters = pinned.trace_filter()
+
+  assert isinstance(filters, TraceFilter)
+  assert filters.experiment_id == "job-123"
+  assert list(filters.session_ids) == list(pinned.session_ids)
+  assert filters.limit == 2
+  where, params = filters.to_sql_conditions()
+  assert "experiment_id" in where
+  assert "session_id" in where
+  values = {p.name: getattr(p, "values", None) or p.value for p in params}
+  assert values["experiment_id"] == "job-123"
+
+
+def test_trace_filter_refuses_empty_session_set() -> None:
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      bq_client=_client(sessions={}),
+  )
+
+  assert pinned.session_ids == ()
+  with pytest.raises(ValueError, match="no sessions"):
+    pinned.trace_filter()
+
+
+def test_to_dict_is_json_safe() -> None:
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      bq_client=_client(),
+  )
+
+  payload = pinned.to_dict()
+
+  assert payload["import_version"] == "v2"
+  assert payload["session_ids"] == list(pinned.session_ids)
+  assert isinstance(payload["manifest"]["imported_at"], str)

--- a/tests/test_evalbench_import_sessions.py
+++ b/tests/test_evalbench_import_sessions.py
@@ -224,6 +224,141 @@ def test_malformed_version_and_job_are_rejected() -> None:
   assert client.calls == []
 
 
+_HOSTILE_EVENTS_TABLES = (
+    # Closes the identifier and appends a second statement.
+    "analytics-project.bqaa.evalbench_agent_events`; DROP TABLE"
+    " `analytics-project.bqaa.agent_events",
+    # Semicolon-delimited script without a closing backtick.
+    "analytics-project.bqaa.evalbench_agent_events; SELECT 1",
+    # Bound to another project / dataset than the one being scored.
+    "other-project.bqaa.evalbench_agent_events",
+    "analytics-project.other.evalbench_agent_events",
+    # Not a canonical three-part reference.
+    "evalbench_agent_events",
+    "analytics-project.bqaa",
+    "analytics-project.bqaa.evalbench_agent_events.extra",
+    # The reserved ADK plugin table.
+    "analytics-project.bqaa.agent_events",
+    "analytics-project.bqaa.AGENT_EVENTS",
+    "",
+)
+
+
+def _hostile_client(events_table: object) -> _FakeClient:
+  manifest = _manifest("v2", datetime(2026, 4, 2, tzinfo=timezone.utc))
+  manifest["events_table"] = events_table
+  return _FakeClient(
+      manifests=[manifest],
+      sessions={"v2": ["evalbench-import:job-123:v2:a"]},
+  )
+
+
+@pytest.mark.parametrize("events_table", _HOSTILE_EVENTS_TABLES + (None, 7))
+def test_hostile_manifest_events_table_raises_before_reading_events(
+    events_table: object,
+) -> None:
+  """A persisted ``events_table`` is re-validated before it is queried.
+
+  The manifest writer and the scorer are different identities; a stored
+  value that is not ``target_project.target_dataset.<mirror table>`` must
+  never be formatted into the session query (confused deputy).
+  """
+  client = _hostile_client(events_table)
+
+  with pytest.raises(ValueError, match="events_table"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        bq_client=client,
+    )
+  assert len(client.calls) == 1
+  assert f"`{_MANIFEST_REF}`" in client.calls[0]["sql"]
+  assert not any(
+      c["sql"].startswith("SELECT DISTINCT session_id") for c in client.calls
+  )
+
+
+def test_hostile_manifest_events_table_is_rejected_for_pinned_version() -> None:
+  client = _hostile_client(_HOSTILE_EVENTS_TABLES[0])
+
+  with pytest.raises(ValueError, match="events_table"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        import_version="v2",
+        bq_client=client,
+    )
+  assert len(client.calls) == 1
+  assert not any(
+      c["sql"].startswith("SELECT DISTINCT session_id") for c in client.calls
+  )
+
+
+def test_expected_events_table_mismatch_raises_before_reading_events() -> None:
+  client = _client()
+
+  with pytest.raises(ValueError) as excinfo:
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        events_table="other_events",
+        bq_client=client,
+    )
+  message = str(excinfo.value)
+  assert _EVENTS_REF in message
+  assert "analytics-project.bqaa.other_events" in message
+  assert len(client.calls) == 1
+  assert f"`{_MANIFEST_REF}`" in client.calls[0]["sql"]
+
+
+def test_expected_events_table_match_reads_sessions() -> None:
+  client = _client()
+
+  pinned = evalbench.import_sessions(
+      target_project="analytics-project",
+      target_dataset="bqaa",
+      job_id="job-123",
+      events_table="evalbench_agent_events",
+      bq_client=client,
+  )
+
+  assert pinned.events_table == _EVENTS_REF
+  assert pinned.session_ids == (
+      "evalbench-import:job-123:v2:a",
+      "evalbench-import:job-123:v2:b",
+  )
+  assert len(client.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "events_table",
+    [
+        "agent_events",
+        "AGENT_EVENTS",
+        "evalbench_agent_events`; SELECT 1",
+        "",
+        7,
+    ],
+)
+def test_expected_events_table_is_validated_before_any_query(
+    events_table: object,
+) -> None:
+  client = _client()
+
+  with pytest.raises(ValueError, match="events_table"):
+    evalbench.import_sessions(
+        target_project="analytics-project",
+        target_dataset="bqaa",
+        job_id="job-123",
+        events_table=events_table,
+        bq_client=client,
+    )
+  assert client.calls == []
+
+
 def test_trace_filter_pins_job_and_exact_sessions() -> None:
   pinned = evalbench.import_sessions(
       target_project="analytics-project",


### PR DESCRIPTION
## Summary
Slice 3 of #435 (W0.2 leftover / remaining #97). Thin `bq-agent-sdk evalbench-score` CLI wrapping existing `Client.evaluate` + `LLMAsJudge` prebuilts over the EvalBench mirror table, filtered by `TraceFilter(experiment_id=job_id)` and pinned to one import version (latest successful, or `--import-version`). `--exit-code` reuses the evaluate CI gate.

## Depends on
#451 (slice 1 writer) and #452 (slice 2 failed_sessions view / version pin). Stacked on #452. Merge after those, or together.

Closes the W0.2 leftover of #97 for the score CLI; does not close #97 or #435 (taxonomy / localization / live harness remain).

## Out of scope
Taxonomy, localization, live W0.3 harness, dashboards, D4, partner-job import, modifying `Client.evaluate`.

## Test plan
- [x] Unit tests stub Client / manifest (no live BigQuery): wiring, version pin, `--strict`, `--exit-code` pass/fail, invalid evaluator, BQ error
- [ ] Codex + Kimi review this PR on GitHub