### PR TITLE
docs(evalbench): recordable MVP e2e demo of import → failed-sessions → score (#435, #97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `examples/evalbench_synth_from_traces.py`, which folds a real BQAA
   `agent_events` table into EvalBench-shaped `configs`/`results`/`scores`
   tables (one scenario per trace, grouped on the full
-  `(session_id, user_id, root_agent_name)` identity; prompts and
+  `(session_id, user_id, root_agent_name)` identity taken as exact strings
+  — whitespace kept, `NULL` distinct from `""` — with percent-escaped,
+  collision-proof scenario ids when session ids are reused; prompts and
   `LLM_RESPONSE` / `AGENT_COMPLETED` responses are the real trace text,
   never invented; `goal_completion` = 1.0 when the trace reached
   `AGENT_COMPLETED`, else 0.0; every source/target name is validated as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the fixture path and the offline `--synth` guards, and
   `tests/test_evalbench_synth_from_traces.py` checks the synthesizer's
   mapping in memory and round-trips its rows through
-  `EvalBenchRun.to_agent_event_rows` / `to_score_rows`. No CLI or Python
-  library behavior changes; `examples/evalbench_score_gate.sh` stays the
-  CI gate.
+  `EvalBenchRun.to_agent_event_rows` / `to_score_rows`. A source trace
+  that reached `AGENT_COMPLETED` with a non-tool `status=ERROR` /
+  `error_message` is written with the importer-recognized `results.error`
+  field (alongside `error_message` for provenance), so it imports as
+  `status=ERROR` and stays `process_failed` in `failed_sessions`;
+  `returncode` / `goal_completion` remain tied to completion only. No CLI
+  or Python library behavior changes; `examples/evalbench_score_gate.sh`
+  stays the CI gate.
 - **EvalBench LLM-judge scoring of one import version (#435 slice 3, #97)**
   — new `bq-agent-sdk evalbench-score` command: a thin wrapper over the
   existing `Client.evaluate` + `LLMAsJudge` (`correctness` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without an EvalBench run: step 0 runs the new
   `examples/evalbench_synth_from_traces.py`, which folds a real BQAA
   `agent_events` table into EvalBench-shaped `configs`/`results`/`scores`
-  tables (one scenario per session; prompts and responses are the real
-  trace text, never invented; `goal_completion` = 1.0 when the session
-  reached `AGENT_COMPLETED`, else 0.0), then steps 1–3 run on that job
+  tables (one scenario per trace, grouped on the full
+  `(session_id, user_id, root_agent_name)` identity; prompts and
+  `LLM_RESPONSE` / `AGENT_COMPLETED` responses are the real trace text,
+  never invented; `goal_completion` = 1.0 when the trace reached
+  `AGENT_COMPLETED`, else 0.0; every source/target name is validated as a
+  plain identifier before any SQL is built), then steps 1–3 run on that job
   with the demo's default dataset names. Walkthrough in
   `examples/evalbench_mvp_e2e.md`; `tests/test_evalbench_mvp_e2e.py` runs
   the fixture path and the offline `--synth` guards, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EVALBENCH_FIXTURE=1`) prints annotated sample output for all three
   steps without calling BigQuery so the demo is recordable and CI-safe,
   and live mode calls the three CLIs from `BQ_AGENT_*` / `EVALBENCH_*`
-  environment variables. Walkthrough in `examples/evalbench_mvp_e2e.md`;
-  `tests/test_evalbench_mvp_e2e.py` runs the fixture path. No CLI or
-  Python behavior changes; `examples/evalbench_score_gate.sh` stays the
+  environment variables. `--synth` (or `EVALBENCH_SYNTH=1`) is live mode
+  without an EvalBench run: step 0 runs the new
+  `examples/evalbench_synth_from_traces.py`, which folds a real BQAA
+  `agent_events` table into EvalBench-shaped `configs`/`results`/`scores`
+  tables (one scenario per session; prompts and responses are the real
+  trace text, never invented; `goal_completion` = 1.0 when the session
+  reached `AGENT_COMPLETED`, else 0.0), then steps 1–3 run on that job
+  with the demo's default dataset names. Walkthrough in
+  `examples/evalbench_mvp_e2e.md`; `tests/test_evalbench_mvp_e2e.py` runs
+  the fixture path and the offline `--synth` guards, and
+  `tests/test_evalbench_synth_from_traces.py` checks the synthesizer's
+  mapping in memory and round-trips its rows through
+  `EvalBenchRun.to_agent_event_rows` / `to_score_rows`. No CLI or Python
+  library behavior changes; `examples/evalbench_score_gate.sh` stays the
   CI gate.
 - **EvalBench LLM-judge scoring of one import version (#435 slice 3, #97)**
   — new `bq-agent-sdk evalbench-score` command: a thin wrapper over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lands the FINAL v4 execution plan: Week 0 pre-clock gate, the six-week MVP
   table with preregistered exit criteria, labeler ledger, staged Part II, and
   standing invariants. Docs only; Week-0 items stay human-gated.
+- **EvalBench MVP end-to-end demo (#435 slice 5, #97)** —
+  `examples/evalbench_mvp_e2e.sh` walks `bq-agent-sdk evalbench-import` →
+  `evalbench-failed-sessions` → `evalbench-score` in order on one
+  EvalBench job, printing a banner per step; `--fixture` (or
+  `EVALBENCH_FIXTURE=1`) prints annotated sample output for all three
+  steps without calling BigQuery so the demo is recordable and CI-safe,
+  and live mode calls the three CLIs from `BQ_AGENT_*` / `EVALBENCH_*`
+  environment variables. Walkthrough in `examples/evalbench_mvp_e2e.md`;
+  `tests/test_evalbench_mvp_e2e.py` runs the fixture path. No CLI or
+  Python behavior changes; `examples/evalbench_score_gate.sh` stays the
+  CI gate.
 - **EvalBench LLM-judge scoring of one import version (#435 slice 3, #97)**
   — new `bq-agent-sdk evalbench-score` command: a thin wrapper over the
   existing `Client.evaluate` + `LLMAsJudge` (`correctness` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EvalBench MVP e2e demo tells one session's story (#435 slice 5, #97)**
+  — the `--fixture` walkthrough of `examples/evalbench_mvp_e2e.sh` now
+  follows `support_agent` session `7e352c34` ("How many widgets are in
+  stock?", never answered; trace stops after `AGENT_STARTING`) through
+  import → its one `failed_sessions` row → score, ending on the punchline
+  `goal_completion=0.0`, instead of touring CLI flags; fixture defaults are
+  job `mvp-e2e-real-traces` / 7 scenarios, matching the `--synth` run.
 - **AgentForensics MVP plan of record (#435)** — `docs/agentforensics_mvp_plan.md`
   lands the FINAL v4 execution plan: Week 0 pre-clock gate, the six-week MVP
   table with preregistered exit criteria, labeler ledger, staged Part II, and

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -603,10 +603,12 @@ version with no sessions — or a BigQuery error. `examples/evalbench_score_gate
 shows the CI gate form.
 
 `examples/evalbench_mvp_e2e.sh` runs the three commands above in order on
-one job (import → failed-sessions → score); `--fixture` (or
-`EVALBENCH_FIXTURE=1`) prints annotated sample output for all three steps
-without touching BigQuery, so the walkthrough can be recorded or run in
-CI. `--synth` (or `EVALBENCH_SYNTH=1`) is the live path when no EvalBench
+one job (import → failed-sessions → score), following one failed
+support-agent session ("How many widgets are in stock?", never answered)
+from its trace to its `goal_completion=0.0`; `--fixture` (or
+`EVALBENCH_FIXTURE=1`) tells that story with sample output for all three
+steps without touching BigQuery, so the walkthrough can be recorded or run
+in CI. `--synth` (or `EVALBENCH_SYNTH=1`) is the live path when no EvalBench
 run exists: step 0 runs `examples/evalbench_synth_from_traces.py`, which
 folds a real BQAA `agent_events` table into EvalBench-shaped
 `configs`/`results`/`scores` tables (one scenario per session, prompts and

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -602,6 +602,13 @@ published import, a `--table-id` the version was not published to, or a
 version with no sessions — or a BigQuery error. `examples/evalbench_score_gate.sh`
 shows the CI gate form.
 
+`examples/evalbench_mvp_e2e.sh` runs the three commands above in order on
+one job (import → failed-sessions → score); `--fixture` (or
+`EVALBENCH_FIXTURE=1`) prints annotated sample output for all three steps
+without touching BigQuery, so the walkthrough can be recorded or run in
+CI. `examples/evalbench_mvp_e2e.md` explains each step, the environment
+variables, and fixture versus live mode.
+
 ## Why These Fields Matter
 
 The mapping follows the SDK queries that consume the mirror table:

--- a/docs/evalbench.md
+++ b/docs/evalbench.md
@@ -606,8 +606,14 @@ shows the CI gate form.
 one job (import → failed-sessions → score); `--fixture` (or
 `EVALBENCH_FIXTURE=1`) prints annotated sample output for all three steps
 without touching BigQuery, so the walkthrough can be recorded or run in
-CI. `examples/evalbench_mvp_e2e.md` explains each step, the environment
-variables, and fixture versus live mode.
+CI. `--synth` (or `EVALBENCH_SYNTH=1`) is the live path when no EvalBench
+run exists: step 0 runs `examples/evalbench_synth_from_traces.py`, which
+folds a real BQAA `agent_events` table into EvalBench-shaped
+`configs`/`results`/`scores` tables (one scenario per session, prompts and
+responses taken verbatim from the traces, `goal_completion` = 1.0 when the
+session reached `AGENT_COMPLETED`), and steps 1–3 then run on that job.
+`examples/evalbench_mvp_e2e.md` explains each step, the environment
+variables, and fixture versus synth versus live mode.
 
 ## Why These Fields Matter
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ artifacts that demonstrate SDK capabilities.
 | [e2e_demo.py](e2e_demo.py) | Complete end-to-end workflow |
 | [cli_agent_tool.py](cli_agent_tool.py) | CLI agent tool example with structured ambiguous-session retry selectors |
 | [ci_eval_pipeline.sh](ci_eval_pipeline.sh) | CI evaluation pipeline |
-| [evalbench_mvp_e2e.sh](evalbench_mvp_e2e.sh) | EvalBench MVP end to end on one job: `evalbench-import` → `evalbench-failed-sessions` → `evalbench-score`; `--fixture` runs offline, `--synth` first builds the job from real traces (walkthrough: [evalbench_mvp_e2e.md](evalbench_mvp_e2e.md)) |
+| [evalbench_mvp_e2e.sh](evalbench_mvp_e2e.sh) | EvalBench MVP end to end, told through one failed support-agent session ("How many widgets are in stock?", never answered): `evalbench-import` → `evalbench-failed-sessions` → `evalbench-score`; `--fixture` runs the story offline, `--synth` replays it live from real traces (walkthrough: [evalbench_mvp_e2e.md](evalbench_mvp_e2e.md)) |
 | [evalbench_synth_from_traces.py](evalbench_synth_from_traces.py) | Fold a real BQAA `agent_events` table into EvalBench-shaped `configs`/`results`/`scores` tables (one scenario per session, real prompts and responses, `goal_completion` from `AGENT_COMPLETED`) for the demo above |
 | [evalbench_score_gate.sh](evalbench_score_gate.sh) | CI gate on the LLM-judge score of one EvalBench import version |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,8 @@ artifacts that demonstrate SDK capabilities.
 | [e2e_demo.py](e2e_demo.py) | Complete end-to-end workflow |
 | [cli_agent_tool.py](cli_agent_tool.py) | CLI agent tool example with structured ambiguous-session retry selectors |
 | [ci_eval_pipeline.sh](ci_eval_pipeline.sh) | CI evaluation pipeline |
+| [evalbench_mvp_e2e.sh](evalbench_mvp_e2e.sh) | EvalBench MVP end to end on one job: `evalbench-import` → `evalbench-failed-sessions` → `evalbench-score`; `--fixture` runs offline (walkthrough: [evalbench_mvp_e2e.md](evalbench_mvp_e2e.md)) |
+| [evalbench_score_gate.sh](evalbench_score_gate.sh) | CI gate on the LLM-judge score of one EvalBench import version |
 
 ## Demo Bundles
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,8 @@ artifacts that demonstrate SDK capabilities.
 | [e2e_demo.py](e2e_demo.py) | Complete end-to-end workflow |
 | [cli_agent_tool.py](cli_agent_tool.py) | CLI agent tool example with structured ambiguous-session retry selectors |
 | [ci_eval_pipeline.sh](ci_eval_pipeline.sh) | CI evaluation pipeline |
-| [evalbench_mvp_e2e.sh](evalbench_mvp_e2e.sh) | EvalBench MVP end to end on one job: `evalbench-import` → `evalbench-failed-sessions` → `evalbench-score`; `--fixture` runs offline (walkthrough: [evalbench_mvp_e2e.md](evalbench_mvp_e2e.md)) |
+| [evalbench_mvp_e2e.sh](evalbench_mvp_e2e.sh) | EvalBench MVP end to end on one job: `evalbench-import` → `evalbench-failed-sessions` → `evalbench-score`; `--fixture` runs offline, `--synth` first builds the job from real traces (walkthrough: [evalbench_mvp_e2e.md](evalbench_mvp_e2e.md)) |
+| [evalbench_synth_from_traces.py](evalbench_synth_from_traces.py) | Fold a real BQAA `agent_events` table into EvalBench-shaped `configs`/`results`/`scores` tables (one scenario per session, real prompts and responses, `goal_completion` from `AGENT_COMPLETED`) for the demo above |
 | [evalbench_score_gate.sh](evalbench_score_gate.sh) | CI gate on the LLM-judge score of one EvalBench import version |
 
 ## Demo Bundles

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -89,18 +89,23 @@ and then runs steps 1–3 unchanged on the job it produced:
 ```
 
 The synthesizer reads a real BQAA `agent_events` table (the ADK plugin's
-output for an agent that actually ran) and folds **each session into one
-EvalBench scenario**:
+output for an agent that actually ran) and folds **each trace into one
+EvalBench scenario**. A trace is the full BQAA identity
+`(session_id, user_id, root_agent_name)` — the grouping
+`Client.list_traces` uses — so a session id reused across users or root
+agents yields one scenario per trace, never one row with user A's prompt
+and user B's answer:
 
-| EvalBench column | Taken from the session's events |
-|------------------|----------------------------------|
-| `results.id` / `eval_id` | The first eight characters of the `session_id` (the full id if that would collide). |
-| `results.prompt` / `nl_prompt` | `USER_MESSAGE_RECEIVED` → `content.text_summary`. Required: a session without one is **skipped**, never given an invented prompt. |
-| `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `AGENT_RESPONSE` → `content.response`. Omitted when the session never answered. |
+| EvalBench column | Taken from the trace's events |
+|------------------|--------------------------------|
+| `results.id` / `eval_id` | The first eight characters of the `session_id`; the full id if that would collide; `session_id:user_id:root_agent_name` if session ids themselves are reused. |
+| `results.prompt` / `nl_prompt` | `USER_MESSAGE_RECEIVED` → `content.text_summary`. Required: a trace without one is **skipped**, never given an invented prompt. |
+| `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `LLM_RESPONSE` → `content.response` (the ADK plugin logs `AGENT_COMPLETED` without content; `AGENT_RESPONSE` is accepted as an alias). Omitted when the trace never answered. |
 | `results.returncode` | `0` if an `AGENT_COMPLETED` event exists, else `1` (*completed*, not *correct*). |
 | `results.run_time` | Timestamp of the `USER_MESSAGE_RECEIVED` event. |
 | `results.tool_calls` | `TOOL_STARTING` / `TOOL_COMPLETED` (or `TOOL_ERROR`) pairs, matched by `span_id`, as a JSON list of `{tool_name, args, result, error}`. |
-| `results.error_message` | The first `error_message` logged in the session. |
+| `results.error_message` | The first `error_message` logged in the trace. |
+| `results.source_session_id` / `source_user_id` / `source_root_agent_name` / `source_table` | The trace identity and table the row came from (also on `scores`). |
 | `scores` | One row per scenario, `comparator = goal_completion`, `score = 1.0` if the session reached `AGENT_COMPLETED`, else `0.0`. |
 | `configs` | `experiment_config.orchestrator` = the traces' agent name, `model_config.generator` = the ADK `app_name`, `bqaa.source_table` = the source table; `run_time` = the earliest prompt. |
 
@@ -112,7 +117,10 @@ traces reproduces the importer's source fingerprints and step 1 reports
 `status: unchanged` instead of minting a new version. The script creates
 both datasets when missing, overwrites the three tables on each run, and
 refuses to write into the source dataset or the ADK plugin's
-`agent_analytics` dataset. `--dry-run` prints the rows instead of writing.
+`agent_analytics` dataset, and validates every project / dataset / table
+name as a plain identifier (`^[A-Za-z0-9_-]+$`, the SDK's own policy)
+before creating a BigQuery client or building any SQL. `--dry-run` prints
+the rows instead of writing.
 
 Every variable has a default so the whole thing works with only `gcloud`
 configured (`BQ_AGENT_PROJECT` falls back to `gcloud config get-value

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -98,7 +98,7 @@ and user B's answer:
 
 | EvalBench column | Taken from the trace's events |
 |------------------|--------------------------------|
-| `results.id` / `eval_id` | The first eight characters of the `session_id`; the full id if that would collide; `session_id:user_id:root_agent_name` if session ids themselves are reused. |
+| `results.id` / `eval_id` | The first eight characters of the `session_id`; the full id if that would collide; `session_id:user_id:root_agent_name` if session ids themselves are reused (components percent-escaped, `:` → `%3A`, `%` → `%25`, `~` → `%7E`; a NULL component is `~`, so distinct identities never share an id). |
 | `results.prompt` / `nl_prompt` | `USER_MESSAGE_RECEIVED` → `content.text_summary`. Required: a trace without one is **skipped**, never given an invented prompt. |
 | `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `LLM_RESPONSE` → `content.response` (the ADK plugin logs `AGENT_COMPLETED` without content; `AGENT_RESPONSE` is accepted as an alias). Omitted when the trace never answered. |
 | `results.returncode` | `0` if an `AGENT_COMPLETED` event exists, else `1` (*completed*, not *correct*). |

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -1,0 +1,84 @@
+# EvalBench MVP end to end: import → failed-sessions → score
+
+`examples/evalbench_mvp_e2e.sh` walks the EvalBench import bridge
+([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435),
+[#97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97))
+on **one EvalBench job**, in the order a user would run it: mirror the job
+into BigQuery Agent Analytics, list the failed sessions of that one
+published version, then score that same version with the LLM judge.
+Reference for every command is in [`docs/evalbench.md`](../docs/evalbench.md).
+
+```bash
+bash examples/evalbench_mvp_e2e.sh --fixture   # offline, recordable
+bash examples/evalbench_mvp_e2e.sh             # live, against BigQuery
+```
+
+## The three steps
+
+| Step | Command | What it does | What you should see |
+|------|---------|--------------|---------------------|
+| 1 | `bq-agent-sdk evalbench-import` | Reads the job's `results`/`scores`/`configs` rows from the EvalBench dataset and publishes them atomically as one `import_version` into the BQAA-owned mirror tables (`evalbench_agent_events`, `evalbench_scores_imported`), records the version in `evalbench_import_manifest`, and pins the `evalbench_failed_sessions` view to it. | The `EvalBenchImportResult`: `status` (`imported` / `replaced` / `unchanged`), row counts, the `manifest` row (source fingerprints, `generation_id`, `view_policy`), and `failed_sessions_view`. |
+| 2 | `bq-agent-sdk evalbench-failed-sessions` | Resolves exactly one published version from the manifest (the job's latest successful import unless `EVALBENCH_IMPORT_VERSION` pins one) and lists its failed sessions — the W0.4 denominator. | One row per failed session: versioned `session_id` (`evalbench-import:{job_id}:{import_version}:{scenario_id}`), `process_failed`, `missing_completion`, `score_failed`, `failing_scores`. Each `session_id` drills into `Client.get_session_trace` without mixing versions. |
+| 3 | `bq-agent-sdk evalbench-score` | Runs `LLMAsJudge` (default `correctness`) through the ordinary `Client.evaluate` path over the mirror table, narrowed to the pinned session ids of that same version. The ADK plugin's `agent_events` table is never read. | The ordinary `EvaluationReport` (`total_sessions`, `pass_rate`, `aggregate_scores`) plus `details.evalbench` naming the scored `job_id`, `import_version`, `events_table`, and `pinned_sessions`. |
+
+Each step prints a banner (`=== Step 1: evalbench-import ===`, and so on)
+followed by the command it runs and that command's output, so a recording
+and `tests/test_evalbench_mvp_e2e.py` can both follow along.
+
+Step 3 here exits `0` even when sessions fail the judge — the demo shows
+the scorecard, it does not gate on it. The CI gate form (step 3 alone with
+`--exit-code`) stays in
+[`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh).
+
+## Environment variables (live mode)
+
+| Variable | Meaning |
+|----------|---------|
+| `BQ_AGENT_PROJECT` | Project holding the BQAA mirror tables (import target; steps 2 and 3 read from here). |
+| `BQ_AGENT_DATASET` | BQAA-owned target dataset (must exist; the tables and view are auto-created). |
+| `EVALBENCH_PROJECT` | Project holding the EvalBench BigQuery dataset (import source). |
+| `EVALBENCH_DATASET` | The EvalBench dataset with `results`, `scores`, `configs`. |
+| `EVALBENCH_JOB_ID` | The one EvalBench `job_id` to walk. |
+| `EVALBENCH_IMPORT_VERSION` | Optional. Pins one version for all three steps; otherwise step 1 mints one and steps 2–3 use the job's latest successful import. |
+| `EVALBENCH_JUDGE` | Optional. `correctness` (default), `hallucination`, or `sentiment` for step 3. |
+
+Missing required variables stop the script (exit `1`) before any command
+runs. A step's own exit code (`2` for invalid input, an unpublished
+job/version, or a BigQuery error — see the CLI section of
+[`docs/evalbench.md`](../docs/evalbench.md#cli)) stops the script with exit `2`.
+
+The intended job family is **gemini-cli-tools**: supply a real
+`EVALBENCH_JOB_ID` from an EvalBench run of the gemini-cli tools suite and
+the script mirrors, lists, and scores that run. Any EvalBench job whose
+`results`/`scores`/`configs` rows carry the `job_id` works the same way.
+
+## `--fixture` vs live
+
+`--fixture` (or `EVALBENCH_FIXTURE=1`) is the offline path: **no BigQuery
+call is made and the live CLI is not invoked.** The script prints the same
+three banners and, under each, the command it would run and annotated
+sample output shaped like that command's real output (an import result with
+`manifest` and `failed_sessions_view`, a small failed-sessions table, a
+score report with `details.evalbench`), then exits `0`. Sample identities
+default to `analytics-project.bqaa` / `benchmark-project.evalbench` / job
+`gemini-cli-tools-2026-08-30`; set the environment variables above to
+change the names that appear. This is the path to record, and the path
+`tests/test_evalbench_mvp_e2e.py` runs.
+
+Live mode requires the environment variables, needs Application Default
+Credentials with read access to the EvalBench dataset and write access to
+the target dataset, and calls the three CLIs in order. Step 3 additionally
+needs the `AI.GENERATE`-capable connection `bq-agent-sdk evaluate` uses
+(`--endpoint` / `--connection-id` defaults apply).
+
+## Related
+
+- [`docs/evalbench.md`](../docs/evalbench.md) — data flow, event mapping,
+  atomic publish, the failed-session contract (W0.4), judge scoring, CLI.
+- [`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh) — CI gate
+  on step 3.
+- Issues
+  [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
+  (EvalBench import bridge) and
+  [#97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97)
+  (LLM-judge scoring of EvalBench runs).

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -1,84 +1,107 @@
-# EvalBench MVP end to end: import → failed-sessions → score
+# EvalBench MVP end to end: one failed session, import → failed-sessions → score
 
 `examples/evalbench_mvp_e2e.sh` walks the EvalBench import bridge
 ([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435),
 [#97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97))
-on **one EvalBench job**, in the order a user would run it: mirror the job
-into BigQuery Agent Analytics, list the failed sessions of that one
-published version, then score that same version with the LLM judge.
-Reference for every command is in [`docs/evalbench.md`](../docs/evalbench.md).
+by following **one real session that failed** through the three CLI
+steps. Reference for every command is in
+[`docs/evalbench.md`](../docs/evalbench.md).
 
 ```bash
-bash examples/evalbench_mvp_e2e.sh --fixture   # offline, recordable
-bash examples/evalbench_mvp_e2e.sh --synth     # live, job built from real traces
-bash examples/evalbench_mvp_e2e.sh             # live, against an EvalBench job
+bash examples/evalbench_mvp_e2e.sh --fixture   # offline: the story below, recordable
+bash examples/evalbench_mvp_e2e.sh --synth     # live: build the job from the real traces, then steps 1-3
+bash examples/evalbench_mvp_e2e.sh             # live: steps 1-3 on an existing EvalBench job
 ```
 
-## The three steps
+`--fixture` is the path to record: no BigQuery, no live CLI, exit `0`.
 
-| Step | Command | What it does | What you should see |
-|------|---------|--------------|---------------------|
-| 1 | `bq-agent-sdk evalbench-import` | Reads the job's `results`/`scores`/`configs` rows from the EvalBench dataset and publishes them atomically as one `import_version` into the BQAA-owned mirror tables (`evalbench_agent_events`, `evalbench_scores_imported`), records the version in `evalbench_import_manifest`, and pins the `evalbench_failed_sessions` view to it. | The `EvalBenchImportResult`: `status` (`imported` / `replaced` / `unchanged`), row counts, the `manifest` row (source fingerprints, `generation_id`, `view_policy`), and `failed_sessions_view`. |
-| 2 | `bq-agent-sdk evalbench-failed-sessions` | Resolves exactly one published version from the manifest (the job's latest successful import unless `EVALBENCH_IMPORT_VERSION` pins one) and lists its failed sessions — the W0.4 denominator. | One row per failed session: versioned `session_id` (`evalbench-import:{job_id}:{import_version}:{scenario_id}`), `process_failed`, `missing_completion`, `score_failed`, `failing_scores`. Each `session_id` drills into `Client.get_session_trace` without mixing versions. |
-| 3 | `bq-agent-sdk evalbench-score` | Runs `LLMAsJudge` (default `correctness`) through the ordinary `Client.evaluate` path over the mirror table, narrowed to the pinned session ids of that same version. The ADK plugin's `agent_events` table is never read. | The ordinary `EvaluationReport` (`total_sessions`, `pass_rate`, `aggregate_scores`) plus `details.evalbench` naming the scored `job_id`, `import_version`, `events_table`, and `pinned_sessions`. |
+## The session
 
-Each step prints a banner (`=== Step 1: evalbench-import ===`, and so on)
-followed by the command it runs and that command's output, so a recording
-and `tests/test_evalbench_mvp_e2e.py` can both follow along.
+A terse support agent was asked how many widgets are in stock and never
+answered. The session is a real trace from `bqaa_e2e_real.agent_events`
+(reference project `test-project-0728-467323`, 7 sessions / 77 events of
+`support_agent` handling inventory and ticket requests), folded by
+`--synth` into scenario `7e352c34` of EvalBench job `mvp-e2e-real-traces`:
 
-Step 3 here exits `0` even when sessions fail the judge — the demo shows
-the scorecard, it does not gate on it. The CI gate form (step 3 alone with
+| | |
+|---|---|
+| agent | `support_agent` — *"You are a terse support agent. Use tools when asked about inventory or tickets. Keep answers to one sentence."* |
+| user | `real-user-0` |
+| session_id | `7e352c34-4c1c-4395-acd5-fb3c8f215346` |
+| scenario_id / eval_id | `7e352c34` |
+| prompt | `How many widgets are in stock?` |
+| events | `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING`, then silence |
+| final_response / tool_calls / error_message | `null` / `[]` / `null`; `returncode` `1` |
+
+Sibling session `ab7535a5` asked the same question and answered
+*"There are 0 widgets in stock."* — so the agent could do it; this session
+just never did.
+
+## The story, in six beats
+
+The fixture prints these in order, each under an `=== ... ===` banner a
+viewer can read; `tests/test_evalbench_mvp_e2e.py` asserts the same order.
+
+1. **`This agent was asked to check widget stock. Here is the session.`** —
+   agent, system prompt, user, `session_id`, `scenario_id`.
+2. **`What happened`** — the prompt verbatim, `agent: (no response)`, the
+   three events and the silence after `AGENT_STARTING`: no
+   `check_inventory` tool call, no `LLM_RESPONSE`, no `AGENT_COMPLETED`.
+3. **`Import those traces into EvalBench so we can query this failure`**,
+   then `=== Step 1: evalbench-import ===` — `bq-agent-sdk evalbench-import`
+   mirrors the job's `results`/`scores`/`configs` into the BQAA-owned
+   tables as one `import_version`, records the version in
+   `evalbench_import_manifest` (`generation_id`, source fingerprints,
+   `view_policy`), and pins the `evalbench_failed_sessions` view to it.
+   The result: `status: imported`, 7 scenarios → 27 events + 7 score rows,
+   `failed_sessions_view`. We import so the next step can list this
+   session.
+4. **`This session in failed_sessions`**, then
+   `=== Step 2: evalbench-failed-sessions ===` — 1 of 7 sessions failed,
+   and this is the row:
+
+   ```
+   session_id                                        scenario_id  process_failed  missing_completion  score_failed  failing_scores
+   evalbench-import:mvp-e2e-real-traces:v1:7e352c34  7e352c34     True            True                True          [{"comparator": "goal_completion", "score": 0.0}]
+   ```
+
+   `process_failed` (returncode 1), `missing_completion` (no
+   `AGENT_COMPLETED`), `score_failed` (`goal_completion` 0.0 misses
+   `--min-score goal_completion=1`). The `session_id` embeds the version,
+   so `Client.get_session_trace` drills into `v1`'s rows only.
+5. **`Score this session`**, then `=== Step 3: evalbench-score ===` —
+   `Client.evaluate` + `LLMAsJudge` (`correctness`) over the same version,
+   narrowed to its 7 pinned session ids; `details.evalbench` names the
+   job, version, table, and `pinned_sessions: 7`. For this scenario the
+   imported `goal_completion` is 0.0, yet the live judge scored the
+   unanswered session `1.0` with `llm_feedback: null` — there was nothing
+   to judge. That is why `failed_sessions`, not the judge, is the W0.4
+   denominator.
+6. **`Punchline`** — one sentence:
+   *This widget-stock session failed because the agent never answered;
+   goal_completion=0.0.*
+
+Step 3 exits `0` even when sessions fail the judge — the demo shows the
+scorecard, it does not gate on it. The CI gate form (step 3 alone with
 `--exit-code`) stays in
 [`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh).
 
-## Environment variables (live mode)
+## Modes
 
-| Variable | Meaning |
-|----------|---------|
-| `BQ_AGENT_PROJECT` | Project holding the BQAA mirror tables (import target; steps 2 and 3 read from here). |
-| `BQ_AGENT_DATASET` | BQAA-owned target dataset (must exist; the tables and view are auto-created). |
-| `EVALBENCH_PROJECT` | Project holding the EvalBench BigQuery dataset (import source). |
-| `EVALBENCH_DATASET` | The EvalBench dataset with `results`, `scores`, `configs`. |
-| `EVALBENCH_JOB_ID` | The one EvalBench `job_id` to walk. |
-| `EVALBENCH_IMPORT_VERSION` | Optional. Pins one version for all three steps; otherwise step 1 mints one and steps 2–3 use the job's latest successful import. |
-| `EVALBENCH_JUDGE` | Optional. `correctness` (default), `hallucination`, or `sentiment` for step 3. |
-| `EVALBENCH_MIN_SCORE` | Optional. A `COMPARATOR=MIN` gate passed as `--min-score` to steps 1 and 2 (rendered into the failed-session view). `--synth` defaults it to `goal_completion=1`; set it to `""` to omit. |
+**`--fixture`** (or `EVALBENCH_FIXTURE=1`) prints the six beats above with
+sample output shaped like each command's real output. Names default to
+`analytics-project.bqaa` (mirror) / `benchmark-project.evalbench` (source)
+/ job `mvp-e2e-real-traces` / `import_version` `v1`; `BQ_AGENT_PROJECT`,
+`BQ_AGENT_DATASET`, `EVALBENCH_PROJECT`, `EVALBENCH_DATASET`,
+`EVALBENCH_JOB_ID` and `EVALBENCH_IMPORT_VERSION` rename what is printed
+(including the versioned `session_id`); the protagonist scenario stays
+`7e352c34`. If `--fixture` and `--synth` are both given, `--fixture` wins
+and nothing is written.
 
-Missing required variables stop the script (exit `1`) before any command
-runs. A step's own exit code (`2` for invalid input, an unpublished
-job/version, or a BigQuery error — see the CLI section of
-[`docs/evalbench.md`](../docs/evalbench.md#cli)) stops the script with exit `2`.
-
-The intended job family is **gemini-cli-tools**: supply a real
-`EVALBENCH_JOB_ID` from an EvalBench run of the gemini-cli tools suite and
-the script mirrors, lists, and scores that run. Any EvalBench job whose
-`results`/`scores`/`configs` rows carry the `job_id` works the same way.
-
-## `--fixture` vs live
-
-`--fixture` (or `EVALBENCH_FIXTURE=1`) is the offline path: **no BigQuery
-call is made and the live CLI is not invoked.** The script prints the same
-three banners and, under each, the command it would run and annotated
-sample output shaped like that command's real output (an import result with
-`manifest` and `failed_sessions_view`, a small failed-sessions table, a
-score report with `details.evalbench`), then exits `0`. Sample identities
-default to `analytics-project.bqaa` / `benchmark-project.evalbench` / job
-`gemini-cli-tools-2026-08-30`; set the environment variables above to
-change the names that appear. This is the path to record, and the path
-`tests/test_evalbench_mvp_e2e.py` runs.
-
-Live mode requires the environment variables, needs Application Default
-Credentials with read access to the EvalBench dataset and write access to
-the target dataset, and calls the three CLIs in order. Step 3 additionally
-needs the `AI.GENERATE`-capable connection `bq-agent-sdk evaluate` uses
-(`--endpoint` / `--connection-id` defaults apply).
-
-## `--synth`: the live demo built from real traces
-
-`--synth` (or `EVALBENCH_SYNTH=1`) is live mode for when **no EvalBench
-run exists**. It adds a step 0 that runs
+**`--synth`** (or `EVALBENCH_SYNTH=1`) replays the story live when no
+EvalBench run exists. It adds a step 0 that runs
 [`examples/evalbench_synth_from_traces.py`](evalbench_synth_from_traces.py)
-and then runs steps 1–3 unchanged on the job it produced:
+and then runs steps 1–3 on the job it produced:
 
 ```
 === Step 0: synthesize EvalBench tables from real traces ===
@@ -87,6 +110,39 @@ and then runs steps 1–3 unchanged on the job it produced:
 { "job_id": "mvp-e2e-real-traces", "source_event_count": 77, "scenarios": 7,
   "completed": 6, "not_completed": 1, "skipped_sessions": [], ... }
 ```
+
+The recorded run on the reference project produced exactly the story
+above: 7 scenarios, 6 completed, 1 (`7e352c34`) stopped after
+`AGENT_STARTING`; step 1 imported 27 events + 7 score rows; step 2 listed
+that one session; step 3's `correctness` judge scored all 7 sessions 1.0,
+the unanswered one with `llm_feedback: null`.
+
+**Live** (no flag) runs steps 1–3 on an EvalBench job you already have.
+It needs Application Default Credentials with read access to the
+EvalBench dataset and write access to the target dataset; step 3
+additionally needs the `AI.GENERATE`-capable connection
+`bq-agent-sdk evaluate` uses (`--endpoint` / `--connection-id` defaults
+apply). Missing required variables stop the script (exit `1`) before any
+command runs; a step's own exit code (`2` for invalid input, an
+unpublished job/version, or a BigQuery error — see
+[`docs/evalbench.md`](../docs/evalbench.md#cli)) stops it with exit `2`.
+
+## Environment variables
+
+| Variable | Live mode | `--synth` default |
+|----------|-----------|-------------------|
+| `BQ_AGENT_PROJECT` | Required. Project holding the BQAA mirror tables. | gcloud's current project |
+| `BQ_AGENT_DATASET` | Required. BQAA-owned target dataset (must exist; tables and view are auto-created). | `bqaa_evalbench_mvp_mirror` |
+| `EVALBENCH_PROJECT` | Required. Project holding the EvalBench dataset. | `= BQ_AGENT_PROJECT` (step 0 builds both datasets in one project; a different value is an error) |
+| `EVALBENCH_DATASET` | Required. The EvalBench dataset with `results`, `scores`, `configs`. | `bqaa_evalbench_mvp_demo` (built by step 0) |
+| `EVALBENCH_JOB_ID` | Required. The one EvalBench `job_id` to walk. | `mvp-e2e-real-traces` |
+| `EVALBENCH_SOURCE_TABLE` | — | `bqaa_e2e_real.agent_events` — the real traces (`dataset.table` or `project.dataset.table`) |
+| `EVALBENCH_IMPORT_VERSION` | Optional. Pins one version for all three steps; otherwise step 1 mints one and steps 2–3 use the job's latest successful import. | same |
+| `EVALBENCH_MIN_SCORE` | Optional `COMPARATOR=MIN` gate passed as `--min-score` to steps 1 and 2. | `goal_completion=1` (`""` to omit) |
+| `EVALBENCH_JUDGE` | Optional. `correctness` (default), `hallucination`, or `sentiment` for step 3. | same |
+| `EVALBENCH_PYTHON` | — | `python3` — an interpreter with `google-cloud-bigquery` (e.g. the repo venv's) |
+
+## How step 0 folds a trace into a scenario
 
 The synthesizer reads a real BQAA `agent_events` table (the ADK plugin's
 output for an agent that actually ran) and folds **each trace into one
@@ -98,9 +154,9 @@ and user B's answer:
 
 | EvalBench column | Taken from the trace's events |
 |------------------|--------------------------------|
-| `results.id` / `eval_id` | The first eight characters of the `session_id`; the full id if that would collide; `session_id:user_id:root_agent_name` if session ids themselves are reused (components percent-escaped, `:` → `%3A`, `%` → `%25`, `~` → `%7E`; a NULL component is `~`, so distinct identities never share an id). |
+| `results.id` / `eval_id` | The first eight characters of the `session_id` (`7e352c34`); the full id if that would collide; `session_id:user_id:root_agent_name` if session ids themselves are reused (components percent-escaped, `:` → `%3A`, `%` → `%25`, `~` → `%7E`; a NULL component is `~`, so distinct identities never share an id). |
 | `results.prompt` / `nl_prompt` | `USER_MESSAGE_RECEIVED` → `content.text_summary`. Required: a trace without one is **skipped**, never given an invented prompt. |
-| `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `LLM_RESPONSE` → `content.response` (the ADK plugin logs `AGENT_COMPLETED` without content; `AGENT_RESPONSE` is accepted as an alias). Omitted when the trace never answered. |
+| `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `LLM_RESPONSE` → `content.response` (the ADK plugin logs `AGENT_COMPLETED` without content; `AGENT_RESPONSE` is accepted as an alias). Omitted when the trace never answered — as for `7e352c34`. |
 | `results.returncode` | `0` if an `AGENT_COMPLETED` event exists, else `1` (*completed*, not *correct*). |
 | `results.run_time` | Timestamp of the `USER_MESSAGE_RECEIVED` event. |
 | `results.tool_calls` | `TOOL_STARTING` / `TOOL_COMPLETED` (or `TOOL_ERROR`) pairs, matched by `span_id`, as a JSON list of `{tool_name, args, result, error}`. |
@@ -115,43 +171,12 @@ session finished; whether the answer was right is step 3's job. Rows are
 deterministic (no "now" timestamps), so re-running step 0 on unchanged
 traces reproduces the importer's source fingerprints and step 1 reports
 `status: unchanged` instead of minting a new version. The script creates
-both datasets when missing, overwrites the three tables on each run, and
+both datasets when missing, overwrites the three tables on each run,
 refuses to write into the source dataset or the ADK plugin's
 `agent_analytics` dataset, and validates every project / dataset / table
 name as a plain identifier (`^[A-Za-z0-9_-]+$`, the SDK's own policy)
 before creating a BigQuery client or building any SQL. `--dry-run` prints
 the rows instead of writing.
-
-Every variable has a default so the whole thing works with only `gcloud`
-configured (`BQ_AGENT_PROJECT` falls back to `gcloud config get-value
-project`):
-
-| Variable | `--synth` default |
-|----------|-------------------|
-| `BQ_AGENT_PROJECT` | gcloud's current project |
-| `EVALBENCH_PROJECT` | `= BQ_AGENT_PROJECT` (step 0 builds both datasets in one project; a different value is an error) |
-| `EVALBENCH_SOURCE_TABLE` | `bqaa_e2e_real.agent_events` — the real traces (`dataset.table` or `project.dataset.table`) |
-| `EVALBENCH_DATASET` | `bqaa_evalbench_mvp_demo` — the EvalBench-shaped dataset step 0 builds |
-| `BQ_AGENT_DATASET` | `bqaa_evalbench_mvp_mirror` — the mirror dataset steps 1–3 use |
-| `EVALBENCH_JOB_ID` | `mvp-e2e-real-traces` |
-| `EVALBENCH_MIN_SCORE` | `goal_completion=1` |
-| `EVALBENCH_PYTHON` | `python3` — an interpreter with `google-cloud-bigquery` (e.g. the repo venv's) |
-
-On the reference project (`test-project-0728-467323`, dataset
-`bqaa_e2e_real`, 7 sessions / 77 events of a terse support agent handling
-inventory and ticket requests) the recorded run produced 7 scenarios, 6
-completed and 1 (`7e352c34`, "How many widgets are in stock?") that stopped
-after `AGENT_STARTING`. Step 1 imported them as 27 events and 7 score rows;
-step 2 listed exactly that one session with `process_failed`,
-`missing_completion`, and `score_failed` (`goal_completion: 0.0`) all true;
-step 3's `correctness` judge scored all 7 sessions 1.0 with per-session
-feedback — including 1.0 with `llm_feedback: null` for the session that
-never answered, which is why the failed-session view of step 2, not the
-judge, is the W0.4 denominator.
-
-`--synth` and `--fixture` are exclusive in purpose: `--fixture` prints
-sample output without BigQuery; `--synth` calls BigQuery four times. If
-both are given, `--fixture` wins (nothing is written).
 
 ## Related
 

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -10,7 +10,8 @@ Reference for every command is in [`docs/evalbench.md`](../docs/evalbench.md).
 
 ```bash
 bash examples/evalbench_mvp_e2e.sh --fixture   # offline, recordable
-bash examples/evalbench_mvp_e2e.sh             # live, against BigQuery
+bash examples/evalbench_mvp_e2e.sh --synth     # live, job built from real traces
+bash examples/evalbench_mvp_e2e.sh             # live, against an EvalBench job
 ```
 
 ## The three steps
@@ -41,6 +42,7 @@ the scorecard, it does not gate on it. The CI gate form (step 3 alone with
 | `EVALBENCH_JOB_ID` | The one EvalBench `job_id` to walk. |
 | `EVALBENCH_IMPORT_VERSION` | Optional. Pins one version for all three steps; otherwise step 1 mints one and steps 2–3 use the job's latest successful import. |
 | `EVALBENCH_JUDGE` | Optional. `correctness` (default), `hallucination`, or `sentiment` for step 3. |
+| `EVALBENCH_MIN_SCORE` | Optional. A `COMPARATOR=MIN` gate passed as `--min-score` to steps 1 and 2 (rendered into the failed-session view). `--synth` defaults it to `goal_completion=1`; set it to `""` to omit. |
 
 Missing required variables stop the script (exit `1`) before any command
 runs. A step's own exit code (`2` for invalid input, an unpublished
@@ -71,10 +73,84 @@ the target dataset, and calls the three CLIs in order. Step 3 additionally
 needs the `AI.GENERATE`-capable connection `bq-agent-sdk evaluate` uses
 (`--endpoint` / `--connection-id` defaults apply).
 
+## `--synth`: the live demo built from real traces
+
+`--synth` (or `EVALBENCH_SYNTH=1`) is live mode for when **no EvalBench
+run exists**. It adds a step 0 that runs
+[`examples/evalbench_synth_from_traces.py`](evalbench_synth_from_traces.py)
+and then runs steps 1–3 unchanged on the job it produced:
+
+```
+=== Step 0: synthesize EvalBench tables from real traces ===
+  # bqaa_e2e_real.agent_events -> <project>.bqaa_evalbench_mvp_demo.{configs,results,scores}
+  # one scenario per session; prompts and responses are the real trace text
+{ "job_id": "mvp-e2e-real-traces", "source_event_count": 77, "scenarios": 7,
+  "completed": 6, "not_completed": 1, "skipped_sessions": [], ... }
+```
+
+The synthesizer reads a real BQAA `agent_events` table (the ADK plugin's
+output for an agent that actually ran) and folds **each session into one
+EvalBench scenario**:
+
+| EvalBench column | Taken from the session's events |
+|------------------|----------------------------------|
+| `results.id` / `eval_id` | The first eight characters of the `session_id` (the full id if that would collide). |
+| `results.prompt` / `nl_prompt` | `USER_MESSAGE_RECEIVED` → `content.text_summary`. Required: a session without one is **skipped**, never given an invented prompt. |
+| `results.final_response` / `stdout` | `AGENT_COMPLETED` text if the plugin logged any, else the last `AGENT_RESPONSE` → `content.response`. Omitted when the session never answered. |
+| `results.returncode` | `0` if an `AGENT_COMPLETED` event exists, else `1` (*completed*, not *correct*). |
+| `results.run_time` | Timestamp of the `USER_MESSAGE_RECEIVED` event. |
+| `results.tool_calls` | `TOOL_STARTING` / `TOOL_COMPLETED` (or `TOOL_ERROR`) pairs, matched by `span_id`, as a JSON list of `{tool_name, args, result, error}`. |
+| `results.error_message` | The first `error_message` logged in the session. |
+| `scores` | One row per scenario, `comparator = goal_completion`, `score = 1.0` if the session reached `AGENT_COMPLETED`, else `0.0`. |
+| `configs` | `experiment_config.orchestrator` = the traces' agent name, `model_config.generator` = the ADK `app_name`, `bqaa.source_table` = the source table; `run_time` = the earliest prompt. |
+
+Every prompt and response is the real trace text. The only value the
+synthesizer *decides* is `goal_completion`, and it says only that the
+session finished; whether the answer was right is step 3's job. Rows are
+deterministic (no "now" timestamps), so re-running step 0 on unchanged
+traces reproduces the importer's source fingerprints and step 1 reports
+`status: unchanged` instead of minting a new version. The script creates
+both datasets when missing, overwrites the three tables on each run, and
+refuses to write into the source dataset or the ADK plugin's
+`agent_analytics` dataset. `--dry-run` prints the rows instead of writing.
+
+Every variable has a default so the whole thing works with only `gcloud`
+configured (`BQ_AGENT_PROJECT` falls back to `gcloud config get-value
+project`):
+
+| Variable | `--synth` default |
+|----------|-------------------|
+| `BQ_AGENT_PROJECT` | gcloud's current project |
+| `EVALBENCH_PROJECT` | `= BQ_AGENT_PROJECT` (step 0 builds both datasets in one project; a different value is an error) |
+| `EVALBENCH_SOURCE_TABLE` | `bqaa_e2e_real.agent_events` — the real traces (`dataset.table` or `project.dataset.table`) |
+| `EVALBENCH_DATASET` | `bqaa_evalbench_mvp_demo` — the EvalBench-shaped dataset step 0 builds |
+| `BQ_AGENT_DATASET` | `bqaa_evalbench_mvp_mirror` — the mirror dataset steps 1–3 use |
+| `EVALBENCH_JOB_ID` | `mvp-e2e-real-traces` |
+| `EVALBENCH_MIN_SCORE` | `goal_completion=1` |
+| `EVALBENCH_PYTHON` | `python3` — an interpreter with `google-cloud-bigquery` (e.g. the repo venv's) |
+
+On the reference project (`test-project-0728-467323`, dataset
+`bqaa_e2e_real`, 7 sessions / 77 events of a terse support agent handling
+inventory and ticket requests) the recorded run produced 7 scenarios, 6
+completed and 1 (`7e352c34`, "How many widgets are in stock?") that stopped
+after `AGENT_STARTING`. Step 1 imported them as 27 events and 7 score rows;
+step 2 listed exactly that one session with `process_failed`,
+`missing_completion`, and `score_failed` (`goal_completion: 0.0`) all true;
+step 3's `correctness` judge scored all 7 sessions 1.0 with per-session
+feedback — including 1.0 with `llm_feedback: null` for the session that
+never answered, which is why the failed-session view of step 2, not the
+judge, is the W0.4 denominator.
+
+`--synth` and `--fixture` are exclusive in purpose: `--fixture` prints
+sample output without BigQuery; `--synth` calls BigQuery four times. If
+both are given, `--fixture` wins (nothing is written).
+
 ## Related
 
 - [`docs/evalbench.md`](../docs/evalbench.md) — data flow, event mapping,
   atomic publish, the failed-session contract (W0.4), judge scoring, CLI.
+- [`examples/evalbench_synth_from_traces.py`](evalbench_synth_from_traces.py)
+  — step 0 of `--synth`: real traces → EvalBench-shaped tables.
 - [`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh) — CI gate
   on step 3.
 - Issues

--- a/examples/evalbench_mvp_e2e.sh
+++ b/examples/evalbench_mvp_e2e.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example: the EvalBench MVP end to end, on one job (#435, #97).
+#
+# Walks the three CLI steps in order over a single EvalBench job:
+#
+#   Step 1: bq-agent-sdk evalbench-import
+#           source EvalBench BigQuery -> BQAA mirror tables (+ manifest row
+#           + the pinned evalbench_failed_sessions view)
+#   Step 2: bq-agent-sdk evalbench-failed-sessions
+#           the W0.4 failed-session listing of that one published version
+#   Step 3: bq-agent-sdk evalbench-score
+#           the LLM judge (Client.evaluate + LLMAsJudge) over that same
+#           version of the mirror table; details.evalbench names the version
+#
+# This is the full pipeline walkthrough. `examples/evalbench_score_gate.sh`
+# stays the CI gate (step 3 alone, with --exit-code).
+#
+# Prerequisites (live mode):
+#   pip install bigquery-agent-analytics
+#   export BQ_AGENT_PROJECT=analytics-project   # project holding the mirror
+#   export BQ_AGENT_DATASET=bqaa                # BQAA-owned target dataset
+#   export EVALBENCH_PROJECT=benchmark-project  # project holding EvalBench
+#   export EVALBENCH_DATASET=evalbench          # EvalBench's own dataset
+#   export EVALBENCH_JOB_ID=abc123              # one EvalBench job_id
+#
+# Optional:
+#   export EVALBENCH_IMPORT_VERSION=v1          # pin one version for all
+#                                               # three steps; default: the
+#                                               # importer mints one and
+#                                               # steps 2-3 use the latest
+#                                               # successful import
+#
+# Usage:
+#   bash examples/evalbench_mvp_e2e.sh             # live: calls BigQuery
+#   bash examples/evalbench_mvp_e2e.sh --fixture   # offline: sample output
+#   EVALBENCH_FIXTURE=1 bash examples/evalbench_mvp_e2e.sh
+#
+# --fixture (or EVALBENCH_FIXTURE=1) never touches BigQuery and never
+# invokes the live CLI: it prints the same three step banners followed by
+# annotated sample output shaped like each command's real output, and
+# exits 0. Use it to record the demo or to run this script in CI.
+#
+# Exit codes (live mode):
+#   0 all three steps ran (step 3 exits 0 even when sessions fail the
+#     judge; add --exit-code via the gate script when you want a CI gate)
+#   1 a required environment variable is missing
+#   2 a step failed (each CLI's own exit code propagates; see docs/evalbench.md)
+
+set -euo pipefail
+
+usage() {
+  # Print the header comment (from "Example:" up to `set -euo pipefail`).
+  awk 'NR >= 16 && /^set -euo pipefail/ { exit }
+       NR >= 16 { sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+}
+
+FIXTURE="${EVALBENCH_FIXTURE:-0}"
+for arg in "$@"; do
+  case "${arg}" in
+    --fixture) FIXTURE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Error: unknown argument '${arg}'; expected --fixture or --help" >&2
+      exit 2
+      ;;
+  esac
+done
+
+banner() {
+  echo
+  echo "=== $* ==="
+}
+
+note() {
+  echo "  # $*"
+}
+
+# --------------------------------------------------------------------------- #
+# Fixture mode: recordable without BigQuery.
+# --------------------------------------------------------------------------- #
+if [[ "${FIXTURE}" == "1" ]]; then
+  # Sample identities only; nothing below is read from or written to BigQuery.
+  bq_project="${BQ_AGENT_PROJECT:-analytics-project}"
+  bq_dataset="${BQ_AGENT_DATASET:-bqaa}"
+  eb_project="${EVALBENCH_PROJECT:-benchmark-project}"
+  eb_dataset="${EVALBENCH_DATASET:-evalbench}"
+  job_id="${EVALBENCH_JOB_ID:-gemini-cli-tools-2026-08-30}"
+  version="${EVALBENCH_IMPORT_VERSION:-v1}"
+  events_table="${bq_project}.${bq_dataset}.evalbench_agent_events"
+  scores_table="${bq_project}.${bq_dataset}.evalbench_scores_imported"
+  manifest_table="${bq_project}.${bq_dataset}.evalbench_import_manifest"
+  view="${bq_project}.${bq_dataset}.evalbench_failed_sessions"
+  sid="evalbench-import:${job_id}:${version}"
+
+  echo "EvalBench MVP e2e (fixture mode): job ${job_id}, import_version ${version}"
+  note "No BigQuery call is made in fixture mode. Output below is sample"
+  note "output shaped like each command's real output; run without"
+  note "--fixture against a real job to see live values."
+
+  banner "Step 1: evalbench-import"
+  note "source EvalBench BigQuery -> BQAA mirror tables + manifest + view"
+  echo "\$ bq-agent-sdk evalbench-import \\"
+  echo "    --project-id ${eb_project} --evalbench-dataset ${eb_dataset} \\"
+  echo "    --job-id ${job_id} --import-version ${version} \\"
+  echo "    --target-project ${bq_project} --target-dataset ${bq_dataset} \\"
+  echo "    --min-score goal_completion=0.9 --format json"
+  cat <<JSON
+{
+  "job_id": "${job_id}",
+  "import_version": "${version}",
+  "status": "imported",
+  "events_table": "${events_table}",
+  "scores_table": "${scores_table}",
+  "manifest_table": "${manifest_table}",
+  "event_row_count": 12,
+  "score_row_count": 4,
+  "manifest": {
+    "job_id": "${job_id}",
+    "import_version": "${version}",
+    "source_project": "${eb_project}",
+    "source_dataset": "${eb_dataset}",
+    "source_snapshot_at": "2026-08-30T08:00:00+00:00",
+    "results_count": 4,
+    "scores_count": 4,
+    "configs_count": 1,
+    "results_fingerprint": "sha256:5d1c…e2a9",
+    "scores_fingerprint": "sha256:9b7f…04c1",
+    "configs_fingerprint": "sha256:c3a0…77de",
+    "events_table": "${events_table}",
+    "scores_table": "${scores_table}",
+    "event_row_count": 12,
+    "score_row_count": 4,
+    "imported_at": "2026-08-30T08:05:12+00:00",
+    "generation_id": "3f9c2c1e0b7a4d6e9a1b5c8d7e6f4a2b",
+    "view_policy": "{\"min_scores\": {\"goal_completion\": 0.9}, \"missing_score_fails\": true}",
+    "superseded_generations": []
+  },
+  "failed_sessions_view": "${view}"
+}
+JSON
+  note "status=imported: 4 scenarios became 12 events + 4 score rows under"
+  note "import_version ${version}; the manifest row is the version's contract"
+  note "and failed_sessions_view is now pinned to this generation."
+
+  banner "Step 2: evalbench-failed-sessions"
+  note "the W0.4 denominator: every session of this one published version,"
+  note "failed rows listed (same rules the pinned view renders)"
+  echo "\$ bq-agent-sdk evalbench-failed-sessions \\"
+  echo "    --project-id ${bq_project} --target-dataset ${bq_dataset} \\"
+  echo "    --job-id ${job_id} --import-version ${version} \\"
+  echo "    --min-score goal_completion=0.9 --format table"
+  fmt="%-*s  %-11s  %-14s  %-18s  %-12s  %s\n"
+  width=$(( ${#sid} + 11 ))
+  printf "${fmt}" "${width}" session_id scenario_id process_failed \
+    missing_completion score_failed failing_scores
+  printf "${fmt}" "${width}" "$(printf '%*s' "${width}" '' | tr ' ' -)" \
+    ----------- -------------- ------------------ ------------ --------------
+  printf "${fmt}" "${width}" "${sid}:read-file" read-file False False True \
+    '{"goal_completion": 0.6}'
+  printf "${fmt}" "${width}" "${sid}:shell-grep" shell-grep True True False '{}'
+
+  note "session_count=4 failed_count=2 for import_version ${version}."
+  note "Each session_id embeds the version, so"
+  note "client.get_session_trace(session_id=..., experiment_id=${job_id})"
+  note "can only return rows of ${version}."
+
+  banner "Step 3: evalbench-score"
+  note "LLM judge over the same version: Client.evaluate + LLMAsJudge,"
+  note "narrowed to the pinned session ids of ${version} (never agent_events)"
+  echo "\$ bq-agent-sdk evalbench-score \\"
+  echo "    --project-id ${bq_project} --dataset-id ${bq_dataset} \\"
+  echo "    --job-id ${job_id} --import-version ${version} \\"
+  echo "    --evaluator correctness --threshold 0.7 --format json"
+  cat <<JSON
+{
+  "evaluator_name": "llm_judge_correctness",
+  "dataset": "${events_table}",
+  "total_sessions": 4,
+  "passed_sessions": 3,
+  "failed_sessions": 1,
+  "pass_rate": 0.75,
+  "aggregate_scores": {
+    "correctness": 0.81
+  },
+  "details": {
+    "evalbench": {
+      "job_id": "${job_id}",
+      "import_version": "${version}",
+      "events_table": "${events_table}",
+      "pinned_sessions": 4
+    }
+  }
+}
+JSON
+  note "details.evalbench ties the scorecard back to job ${job_id},"
+  note "import_version ${version}, and the 4 pinned sessions it judged."
+  note "For a CI gate on this number, see examples/evalbench_score_gate.sh."
+
+  echo
+  echo "Done (fixture mode): import -> failed-sessions -> score for job ${job_id}."
+  exit 0
+fi
+
+# --------------------------------------------------------------------------- #
+# Live mode: calls BigQuery through the three CLIs.
+# --------------------------------------------------------------------------- #
+: "${BQ_AGENT_PROJECT:?set BQ_AGENT_PROJECT}"
+: "${BQ_AGENT_DATASET:?set BQ_AGENT_DATASET}"
+: "${EVALBENCH_PROJECT:?set EVALBENCH_PROJECT}"
+: "${EVALBENCH_DATASET:?set EVALBENCH_DATASET}"
+: "${EVALBENCH_JOB_ID:?set EVALBENCH_JOB_ID}"
+
+version_args=()
+if [[ -n "${EVALBENCH_IMPORT_VERSION:-}" ]]; then
+  version_args+=(--import-version "${EVALBENCH_IMPORT_VERSION}")
+fi
+
+run_step() {
+  # Propagate the CLI's own exit code as this script's exit 2.
+  if ! "$@"; then
+    echo "Error: step failed: $*" >&2
+    exit 2
+  fi
+}
+
+echo "EvalBench MVP e2e: job ${EVALBENCH_JOB_ID}" \
+  "(${EVALBENCH_PROJECT}.${EVALBENCH_DATASET} -> ${BQ_AGENT_PROJECT}.${BQ_AGENT_DATASET})"
+
+banner "Step 1: evalbench-import"
+run_step bq-agent-sdk evalbench-import \
+  --project-id "${EVALBENCH_PROJECT}" \
+  --evalbench-dataset "${EVALBENCH_DATASET}" \
+  --job-id "${EVALBENCH_JOB_ID}" \
+  --target-project "${BQ_AGENT_PROJECT}" \
+  --target-dataset "${BQ_AGENT_DATASET}" \
+  ${version_args[@]+"${version_args[@]}"} \
+  --format json
+
+banner "Step 2: evalbench-failed-sessions"
+run_step bq-agent-sdk evalbench-failed-sessions \
+  --project-id "${BQ_AGENT_PROJECT}" \
+  --target-dataset "${BQ_AGENT_DATASET}" \
+  --job-id "${EVALBENCH_JOB_ID}" \
+  ${version_args[@]+"${version_args[@]}"} \
+  --format table
+
+banner "Step 3: evalbench-score"
+run_step bq-agent-sdk evalbench-score \
+  --project-id "${BQ_AGENT_PROJECT}" \
+  --dataset-id "${BQ_AGENT_DATASET}" \
+  --job-id "${EVALBENCH_JOB_ID}" \
+  ${version_args[@]+"${version_args[@]}"} \
+  --evaluator "${EVALBENCH_JUDGE:-correctness}" \
+  --format json
+
+echo
+echo "Done: import -> failed-sessions -> score for job ${EVALBENCH_JOB_ID}."

--- a/examples/evalbench_mvp_e2e.sh
+++ b/examples/evalbench_mvp_e2e.sh
@@ -46,6 +46,7 @@
 #
 # Usage:
 #   bash examples/evalbench_mvp_e2e.sh             # live: calls BigQuery
+#   bash examples/evalbench_mvp_e2e.sh --synth     # live, on real traces
 #   bash examples/evalbench_mvp_e2e.sh --fixture   # offline: sample output
 #   EVALBENCH_FIXTURE=1 bash examples/evalbench_mvp_e2e.sh
 #
@@ -53,6 +54,24 @@
 # invokes the live CLI: it prints the same three step banners followed by
 # annotated sample output shaped like each command's real output, and
 # exits 0. Use it to record the demo or to run this script in CI.
+#
+# --synth (or EVALBENCH_SYNTH=1) is live mode without an EvalBench run:
+# step 0 runs examples/evalbench_synth_from_traces.py, which folds a real
+# BQAA agent_events table into EvalBench-shaped configs/results/scores
+# tables (one scenario per session; every prompt and response is the real
+# trace text, never invented; goal_completion = 1.0 when the session
+# reached AGENT_COMPLETED, else 0.0), then steps 1-3 run on that job. Every
+# variable has a default so it works with just gcloud configured:
+#
+#   BQ_AGENT_PROJECT        gcloud's current project (or set it)
+#   EVALBENCH_PROJECT       = BQ_AGENT_PROJECT (synth writes both datasets)
+#   EVALBENCH_SOURCE_TABLE  bqaa_e2e_real.agent_events  (the real traces)
+#   EVALBENCH_DATASET       bqaa_evalbench_mvp_demo     (built by step 0)
+#   BQ_AGENT_DATASET        bqaa_evalbench_mvp_mirror   (import target)
+#   EVALBENCH_JOB_ID        mvp-e2e-real-traces
+#   EVALBENCH_MIN_SCORE     goal_completion=1  (--min-score for steps 1-2;
+#                           set to "" to omit)
+#   EVALBENCH_PYTHON        python3 (interpreter with google-cloud-bigquery)
 #
 # Exit codes (live mode):
 #   0 all three steps ran (step 3 exits 0 even when sessions fail the
@@ -69,12 +88,14 @@ usage() {
 }
 
 FIXTURE="${EVALBENCH_FIXTURE:-0}"
+SYNTH="${EVALBENCH_SYNTH:-0}"
 for arg in "$@"; do
   case "${arg}" in
     --fixture) FIXTURE=1 ;;
+    --synth) SYNTH=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
-      echo "Error: unknown argument '${arg}'; expected --fixture or --help" >&2
+      echo "Error: unknown argument '${arg}'; expected --fixture, --synth or --help" >&2
       exit 2
       ;;
   esac
@@ -216,6 +237,28 @@ JSON
 fi
 
 # --------------------------------------------------------------------------- #
+# Synth mode defaults: the demo's own names, on gcloud's current project.
+# --------------------------------------------------------------------------- #
+if [[ "${SYNTH}" == "1" ]]; then
+  if [[ -z "${BQ_AGENT_PROJECT:-}" ]] && command -v gcloud >/dev/null 2>&1; then
+    BQ_AGENT_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+  fi
+  : "${BQ_AGENT_PROJECT:?set BQ_AGENT_PROJECT (or gcloud config set project ...)}"
+  EVALBENCH_PROJECT="${EVALBENCH_PROJECT:-${BQ_AGENT_PROJECT}}"
+  if [[ "${EVALBENCH_PROJECT}" != "${BQ_AGENT_PROJECT}" ]]; then
+    echo "Error: --synth builds the EvalBench dataset and the mirror dataset in" \
+      "one project; EVALBENCH_PROJECT=${EVALBENCH_PROJECT} differs from" \
+      "BQ_AGENT_PROJECT=${BQ_AGENT_PROJECT}" >&2
+    exit 1
+  fi
+  EVALBENCH_SOURCE_TABLE="${EVALBENCH_SOURCE_TABLE:-bqaa_e2e_real.agent_events}"
+  EVALBENCH_DATASET="${EVALBENCH_DATASET:-bqaa_evalbench_mvp_demo}"
+  BQ_AGENT_DATASET="${BQ_AGENT_DATASET:-bqaa_evalbench_mvp_mirror}"
+  EVALBENCH_JOB_ID="${EVALBENCH_JOB_ID:-mvp-e2e-real-traces}"
+  EVALBENCH_MIN_SCORE="${EVALBENCH_MIN_SCORE-goal_completion=1}"
+fi
+
+# --------------------------------------------------------------------------- #
 # Live mode: calls BigQuery through the three CLIs.
 # --------------------------------------------------------------------------- #
 : "${BQ_AGENT_PROJECT:?set BQ_AGENT_PROJECT}"
@@ -227,6 +270,10 @@ fi
 version_args=()
 if [[ -n "${EVALBENCH_IMPORT_VERSION:-}" ]]; then
   version_args+=(--import-version "${EVALBENCH_IMPORT_VERSION}")
+fi
+min_score_args=()
+if [[ -n "${EVALBENCH_MIN_SCORE:-}" ]]; then
+  min_score_args+=(--min-score "${EVALBENCH_MIN_SCORE}")
 fi
 
 run_step() {
@@ -240,6 +287,19 @@ run_step() {
 echo "EvalBench MVP e2e: job ${EVALBENCH_JOB_ID}" \
   "(${EVALBENCH_PROJECT}.${EVALBENCH_DATASET} -> ${BQ_AGENT_PROJECT}.${BQ_AGENT_DATASET})"
 
+if [[ "${SYNTH}" == "1" ]]; then
+  banner "Step 0: synthesize EvalBench tables from real traces"
+  note "${EVALBENCH_SOURCE_TABLE} -> ${EVALBENCH_PROJECT}.${EVALBENCH_DATASET}.{configs,results,scores}"
+  note "one scenario per session; prompts and responses are the real trace text"
+  run_step "${EVALBENCH_PYTHON:-python3}" \
+    "$(dirname "${BASH_SOURCE[0]}")/evalbench_synth_from_traces.py" \
+    --project "${EVALBENCH_PROJECT}" \
+    --source-table "${EVALBENCH_SOURCE_TABLE}" \
+    --evalbench-dataset "${EVALBENCH_DATASET}" \
+    --mirror-dataset "${BQ_AGENT_DATASET}" \
+    --job-id "${EVALBENCH_JOB_ID}"
+fi
+
 banner "Step 1: evalbench-import"
 run_step bq-agent-sdk evalbench-import \
   --project-id "${EVALBENCH_PROJECT}" \
@@ -248,6 +308,7 @@ run_step bq-agent-sdk evalbench-import \
   --target-project "${BQ_AGENT_PROJECT}" \
   --target-dataset "${BQ_AGENT_DATASET}" \
   ${version_args[@]+"${version_args[@]}"} \
+  ${min_score_args[@]+"${min_score_args[@]}"} \
   --format json
 
 banner "Step 2: evalbench-failed-sessions"
@@ -256,6 +317,7 @@ run_step bq-agent-sdk evalbench-failed-sessions \
   --target-dataset "${BQ_AGENT_DATASET}" \
   --job-id "${EVALBENCH_JOB_ID}" \
   ${version_args[@]+"${version_args[@]}"} \
+  ${min_score_args[@]+"${min_score_args[@]}"} \
   --format table
 
 banner "Step 3: evalbench-score"

--- a/examples/evalbench_mvp_e2e.sh
+++ b/examples/evalbench_mvp_e2e.sh
@@ -13,55 +13,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Example: the EvalBench MVP end to end, on one job (#435, #97).
+# Example: the EvalBench MVP end to end, told through one failed session
+# (#435, #97).
 #
-# Walks the three CLI steps in order over a single EvalBench job:
+# A terse support agent (support_agent) was asked "How many widgets are in
+# stock?" and never answered: its trace stops after AGENT_STARTING. This
+# script follows that one session -- scenario 7e352c34 of job
+# mvp-e2e-real-traces, a real trace from bqaa_e2e_real.agent_events --
+# through the three EvalBench CLI steps:
 #
 #   Step 1: bq-agent-sdk evalbench-import
-#           source EvalBench BigQuery -> BQAA mirror tables (+ manifest row
-#           + the pinned evalbench_failed_sessions view)
+#           the job's EvalBench tables -> BQAA mirror tables + manifest row
+#           + the pinned evalbench_failed_sessions view, so the session can
+#           be queried
 #   Step 2: bq-agent-sdk evalbench-failed-sessions
-#           the W0.4 failed-session listing of that one published version
+#           the W0.4 failed-session listing of that one published version;
+#           this session is its one failed row
 #   Step 3: bq-agent-sdk evalbench-score
-#           the LLM judge (Client.evaluate + LLMAsJudge) over that same
-#           version of the mirror table; details.evalbench names the version
+#           the LLM judge (Client.evaluate + LLMAsJudge) over the same
+#           version; details.evalbench names the version it judged
 #
-# This is the full pipeline walkthrough. `examples/evalbench_score_gate.sh`
-# stays the CI gate (step 3 alone, with --exit-code).
-#
-# Prerequisites (live mode):
-#   pip install bigquery-agent-analytics
-#   export BQ_AGENT_PROJECT=analytics-project   # project holding the mirror
-#   export BQ_AGENT_DATASET=bqaa                # BQAA-owned target dataset
-#   export EVALBENCH_PROJECT=benchmark-project  # project holding EvalBench
-#   export EVALBENCH_DATASET=evalbench          # EvalBench's own dataset
-#   export EVALBENCH_JOB_ID=abc123              # one EvalBench job_id
-#
-# Optional:
-#   export EVALBENCH_IMPORT_VERSION=v1          # pin one version for all
-#                                               # three steps; default: the
-#                                               # importer mints one and
-#                                               # steps 2-3 use the latest
-#                                               # successful import
+# `examples/evalbench_score_gate.sh` stays the CI gate (step 3 alone, with
+# --exit-code).
 #
 # Usage:
-#   bash examples/evalbench_mvp_e2e.sh             # live: calls BigQuery
-#   bash examples/evalbench_mvp_e2e.sh --synth     # live, on real traces
-#   bash examples/evalbench_mvp_e2e.sh --fixture   # offline: sample output
-#   EVALBENCH_FIXTURE=1 bash examples/evalbench_mvp_e2e.sh
+#   bash examples/evalbench_mvp_e2e.sh --fixture   # offline: the story, recordable
+#   bash examples/evalbench_mvp_e2e.sh --synth     # live: build the job from real
+#                                                  # traces, then steps 1-3
+#   bash examples/evalbench_mvp_e2e.sh             # live: steps 1-3 on an
+#                                                  # existing EvalBench job
 #
 # --fixture (or EVALBENCH_FIXTURE=1) never touches BigQuery and never
-# invokes the live CLI: it prints the same three step banners followed by
-# annotated sample output shaped like each command's real output, and
-# exits 0. Use it to record the demo or to run this script in CI.
+# invokes the live CLI: it prints the session, then each step's command
+# with sample output shaped like that command's real output, and exits 0.
+# Names default to analytics-project.bqaa (mirror), benchmark-project.evalbench
+# (source), job mvp-e2e-real-traces, import_version v1; BQ_AGENT_PROJECT,
+# BQ_AGENT_DATASET, EVALBENCH_PROJECT, EVALBENCH_DATASET, EVALBENCH_JOB_ID
+# and EVALBENCH_IMPORT_VERSION rename them.
 #
 # --synth (or EVALBENCH_SYNTH=1) is live mode without an EvalBench run:
 # step 0 runs examples/evalbench_synth_from_traces.py, which folds a real
-# BQAA agent_events table into EvalBench-shaped configs/results/scores
-# tables (one scenario per session; every prompt and response is the real
-# trace text, never invented; goal_completion = 1.0 when the session
-# reached AGENT_COMPLETED, else 0.0), then steps 1-3 run on that job. Every
-# variable has a default so it works with just gcloud configured:
+# BQAA agent_events table (default: bqaa_e2e_real.agent_events, the table
+# this session came from) into EvalBench-shaped configs/results/scores
+# tables -- one scenario per trace, real prompt and response text,
+# goal_completion 1.0 when the trace reached AGENT_COMPLETED else 0.0 --
+# then steps 1-3 run on that job. Defaults (only gcloud is needed):
 #
 #   BQ_AGENT_PROJECT        gcloud's current project (or set it)
 #   EVALBENCH_PROJECT       = BQ_AGENT_PROJECT (synth writes both datasets)
@@ -73,9 +69,15 @@
 #                           set to "" to omit)
 #   EVALBENCH_PYTHON        python3 (interpreter with google-cloud-bigquery)
 #
+# Live mode (no flag) needs BQ_AGENT_PROJECT, BQ_AGENT_DATASET,
+# EVALBENCH_PROJECT, EVALBENCH_DATASET and EVALBENCH_JOB_ID. Optional:
+# EVALBENCH_IMPORT_VERSION pins one version for all three steps (default:
+# step 1 mints one, steps 2-3 use the latest successful import);
+# EVALBENCH_JUDGE picks step 3's judge (default correctness).
+#
 # Exit codes (live mode):
-#   0 all three steps ran (step 3 exits 0 even when sessions fail the
-#     judge; add --exit-code via the gate script when you want a CI gate)
+#   0 all steps ran (step 3 exits 0 even when sessions fail the judge;
+#     add --exit-code via the gate script when you want a CI gate)
 #   1 a required environment variable is missing
 #   2 a step failed (each CLI's own exit code propagates; see docs/evalbench.md)
 
@@ -111,7 +113,7 @@ note() {
 }
 
 # --------------------------------------------------------------------------- #
-# Fixture mode: recordable without BigQuery.
+# Fixture mode: the story of one failed session, recordable without BigQuery.
 # --------------------------------------------------------------------------- #
 if [[ "${FIXTURE}" == "1" ]]; then
   # Sample identities only; nothing below is read from or written to BigQuery.
@@ -119,26 +121,59 @@ if [[ "${FIXTURE}" == "1" ]]; then
   bq_dataset="${BQ_AGENT_DATASET:-bqaa}"
   eb_project="${EVALBENCH_PROJECT:-benchmark-project}"
   eb_dataset="${EVALBENCH_DATASET:-evalbench}"
-  job_id="${EVALBENCH_JOB_ID:-gemini-cli-tools-2026-08-30}"
+  job_id="${EVALBENCH_JOB_ID:-mvp-e2e-real-traces}"
   version="${EVALBENCH_IMPORT_VERSION:-v1}"
   events_table="${bq_project}.${bq_dataset}.evalbench_agent_events"
   scores_table="${bq_project}.${bq_dataset}.evalbench_scores_imported"
   manifest_table="${bq_project}.${bq_dataset}.evalbench_import_manifest"
   view="${bq_project}.${bq_dataset}.evalbench_failed_sessions"
-  sid="evalbench-import:${job_id}:${version}"
+  # The protagonist: a real trace from bqaa_e2e_real.agent_events.
+  scenario_id="7e352c34"
+  session_id="7e352c34-4c1c-4395-acd5-fb3c8f215346"
+  sid="evalbench-import:${job_id}:${version}:${scenario_id}"
 
   echo "EvalBench MVP e2e (fixture mode): job ${job_id}, import_version ${version}"
-  note "No BigQuery call is made in fixture mode. Output below is sample"
-  note "output shaped like each command's real output; run without"
-  note "--fixture against a real job to see live values."
+  note "No BigQuery call is made in fixture mode. The session below is a real"
+  note "trace; each command's output is sample output shaped like the real"
+  note "thing. Run with --synth to replay it live from the traces."
 
+  # ---- 1. Setup -------------------------------------------------------- #
+  banner "This agent was asked to check widget stock. Here is the session."
+  echo "  agent:         support_agent"
+  echo "  system prompt: \"You are a terse support agent. Use tools when asked"
+  echo "                 about inventory or tickets. Keep answers to one sentence.\""
+  echo "  user:          real-user-0"
+  echo "  session_id:    ${session_id}"
+  echo "  scenario_id:   ${scenario_id}   (EvalBench eval_id: the session_id's first 8 chars)"
+  note "support_agent was asked to answer an inventory question."
+
+  # ---- 2. What happened ------------------------------------------------ #
+  banner "What happened"
+  echo "  user:  How many widgets are in stock?"
+  echo "  agent: (no response)"
+  echo
+  echo "  events, in order:"
+  echo "    USER_MESSAGE_RECEIVED"
+  echo "    INVOCATION_STARTING"
+  echo "    AGENT_STARTING"
+  echo "    ... then silence"
+  note "The trace stops after AGENT_STARTING: no check_inventory tool call, no"
+  note "LLM_RESPONSE, no AGENT_COMPLETED. final_response=null, tool_calls=[],"
+  note "error_message=null, returncode=1. Sibling session ab7535a5 asked the"
+  note "same question and answered \"There are 0 widgets in stock.\""
+
+  # ---- 3. Import ------------------------------------------------------- #
+  banner "Import those traces into EvalBench so we can query this failure"
+  note "evalbench-import mirrors the job's EvalBench tables into BQAA-owned"
+  note "tables, records the version in a manifest row, and pins the"
+  note "evalbench_failed_sessions view to it. After this, failed_sessions can"
+  note "list session ${scenario_id}."
   banner "Step 1: evalbench-import"
-  note "source EvalBench BigQuery -> BQAA mirror tables + manifest + view"
   echo "\$ bq-agent-sdk evalbench-import \\"
   echo "    --project-id ${eb_project} --evalbench-dataset ${eb_dataset} \\"
   echo "    --job-id ${job_id} --import-version ${version} \\"
   echo "    --target-project ${bq_project} --target-dataset ${bq_dataset} \\"
-  echo "    --min-score goal_completion=0.9 --format json"
+  echo "    --min-score goal_completion=1 --format json"
   cat <<JSON
 {
   "job_id": "${job_id}",
@@ -147,94 +182,115 @@ if [[ "${FIXTURE}" == "1" ]]; then
   "events_table": "${events_table}",
   "scores_table": "${scores_table}",
   "manifest_table": "${manifest_table}",
-  "event_row_count": 12,
-  "score_row_count": 4,
+  "event_row_count": 27,
+  "score_row_count": 7,
   "manifest": {
     "job_id": "${job_id}",
     "import_version": "${version}",
     "source_project": "${eb_project}",
     "source_dataset": "${eb_dataset}",
     "source_snapshot_at": "2026-08-30T08:00:00+00:00",
-    "results_count": 4,
-    "scores_count": 4,
+    "results_count": 7,
+    "scores_count": 7,
     "configs_count": 1,
     "results_fingerprint": "sha256:5d1c…e2a9",
     "scores_fingerprint": "sha256:9b7f…04c1",
     "configs_fingerprint": "sha256:c3a0…77de",
     "events_table": "${events_table}",
     "scores_table": "${scores_table}",
-    "event_row_count": 12,
-    "score_row_count": 4,
+    "event_row_count": 27,
+    "score_row_count": 7,
     "imported_at": "2026-08-30T08:05:12+00:00",
     "generation_id": "3f9c2c1e0b7a4d6e9a1b5c8d7e6f4a2b",
-    "view_policy": "{\"min_scores\": {\"goal_completion\": 0.9}, \"missing_score_fails\": true}",
+    "view_policy": "{\"min_scores\": {\"goal_completion\": 1.0}, \"missing_score_fails\": true}",
     "superseded_generations": []
   },
   "failed_sessions_view": "${view}"
 }
 JSON
-  note "status=imported: 4 scenarios became 12 events + 4 score rows under"
-  note "import_version ${version}; the manifest row is the version's contract"
-  note "and failed_sessions_view is now pinned to this generation."
+  note "status=imported: 7 scenarios became 27 events + 7 score rows under"
+  note "import_version ${version}. Session ${scenario_id} is 3 of those events and 1 of"
+  note "those score rows. The manifest row is the version's contract, and"
+  note "failed_sessions_view is pinned to this generation, so the next step"
+  note "can only see rows of ${version}."
 
+  # ---- 4. This session in failed_sessions ------------------------------ #
+  banner "This session in failed_sessions"
+  note "1 of 7 sessions failed the W0.4 contract for import_version ${version};"
+  note "this is the row."
   banner "Step 2: evalbench-failed-sessions"
-  note "the W0.4 denominator: every session of this one published version,"
-  note "failed rows listed (same rules the pinned view renders)"
   echo "\$ bq-agent-sdk evalbench-failed-sessions \\"
   echo "    --project-id ${bq_project} --target-dataset ${bq_dataset} \\"
   echo "    --job-id ${job_id} --import-version ${version} \\"
-  echo "    --min-score goal_completion=0.9 --format table"
+  echo "    --min-score goal_completion=1 --format table"
   fmt="%-*s  %-11s  %-14s  %-18s  %-12s  %s\n"
-  width=$(( ${#sid} + 11 ))
+  width=${#sid}
   printf "${fmt}" "${width}" session_id scenario_id process_failed \
     missing_completion score_failed failing_scores
   printf "${fmt}" "${width}" "$(printf '%*s' "${width}" '' | tr ' ' -)" \
     ----------- -------------- ------------------ ------------ --------------
-  printf "${fmt}" "${width}" "${sid}:read-file" read-file False False True \
-    '{"goal_completion": 0.6}'
-  printf "${fmt}" "${width}" "${sid}:shell-grep" shell-grep True True False '{}'
+  printf "${fmt}" "${width}" "${sid}" "${scenario_id}" True True True \
+    '[{"comparator": "goal_completion", "score": 0.0}]'
+  echo
+  note "process_failed=True      returncode 1: the run did not finish cleanly"
+  note "missing_completion=True  no AGENT_COMPLETED event in the trace"
+  note "score_failed=True        goal_completion 0.0 misses --min-score goal_completion=1"
+  note "session_count=7 failed_count=1. The session_id embeds the version, so"
+  note "client.get_session_trace(session_id=\"${sid}\","
+  note "experiment_id=\"${job_id}\") returns only ${version}'s rows for it."
 
-  note "session_count=4 failed_count=2 for import_version ${version}."
-  note "Each session_id embeds the version, so"
-  note "client.get_session_trace(session_id=..., experiment_id=${job_id})"
-  note "can only return rows of ${version}."
-
+  # ---- 5. Score this session ------------------------------------------- #
+  banner "Score this session"
+  note "evalbench-score runs Client.evaluate + LLMAsJudge over the same"
+  note "version, narrowed to its 7 pinned session ids (never agent_events)."
   banner "Step 3: evalbench-score"
-  note "LLM judge over the same version: Client.evaluate + LLMAsJudge,"
-  note "narrowed to the pinned session ids of ${version} (never agent_events)"
   echo "\$ bq-agent-sdk evalbench-score \\"
   echo "    --project-id ${bq_project} --dataset-id ${bq_dataset} \\"
   echo "    --job-id ${job_id} --import-version ${version} \\"
-  echo "    --evaluator correctness --threshold 0.7 --format json"
+  echo "    --evaluator correctness --format json"
   cat <<JSON
 {
   "evaluator_name": "llm_judge_correctness",
   "dataset": "${events_table}",
-  "total_sessions": 4,
-  "passed_sessions": 3,
-  "failed_sessions": 1,
-  "pass_rate": 0.75,
+  "total_sessions": 7,
+  "passed_sessions": 7,
+  "failed_sessions": 0,
+  "pass_rate": 1.0,
   "aggregate_scores": {
-    "correctness": 0.81
+    "correctness": 1.0
   },
+  "session_scores": [
+    {
+      "session_id": "${sid}",
+      "scores": {"correctness": 1.0},
+      "passed": true,
+      "llm_feedback": null
+    }
+  ],
   "details": {
     "evalbench": {
       "job_id": "${job_id}",
       "import_version": "${version}",
       "events_table": "${events_table}",
-      "pinned_sessions": 4
+      "pinned_sessions": 7
     }
   }
 }
 JSON
-  note "details.evalbench ties the scorecard back to job ${job_id},"
-  note "import_version ${version}, and the 4 pinned sessions it judged."
-  note "For a CI gate on this number, see examples/evalbench_score_gate.sh."
+  note "(the six answered sessions are elided from session_scores above)"
+  note "Scenario ${scenario_id}: the imported goal_completion is 0.0 (step 2), yet"
+  note "the correctness judge on this job scored the unanswered session 1.0"
+  note "with llm_feedback null -- there was no answer to judge. That is why"
+  note "failed_sessions, not the judge, is the W0.4 denominator."
+  note "details.evalbench ties the scorecard to job ${job_id},"
+  note "import_version ${version}, and the 7 pinned sessions it judged."
 
-  echo
-  echo "Done (fixture mode): import -> failed-sessions -> score for job ${job_id}."
+  # ---- 6. Punchline ---------------------------------------------------- #
+  banner "Punchline"
+  echo "This widget-stock session failed because the agent never answered; goal_completion=0.0."
   exit 0
 fi
+
 
 # --------------------------------------------------------------------------- #
 # Synth mode defaults: the demo's own names, on gcloud's current project.

--- a/examples/evalbench_synth_from_traces.py
+++ b/examples/evalbench_synth_from_traces.py
@@ -40,7 +40,10 @@ the demo, the LLM judge, is for.
 
 Mapping (one result per trace, keyed by the first eight characters of the
 session id; on collision the full session id; if session ids themselves are
-reused, ``session_id:user_id:root_agent_name``):
+reused, ``session_id:user_id:root_agent_name`` with each component
+percent-escaped -- ``:`` -> ``%3A``, ``%`` -> ``%25``, ``~`` -> ``%7E`` --
+and a NULL component written as ``~``, so distinct identities always get
+distinct ids):
 
   results.id / eval_id       scenario id
   results.prompt / nl_prompt first USER_MESSAGE_RECEIVED content.text_summary
@@ -236,8 +239,10 @@ def synthesize(
   ``user_id`` from the top-level column, ``root_agent_name`` from the
   top-level column when the reader selected it, else from
   ``attributes.root_agent_name`` -- and processed in timestamp order within
-  each trace. Traces without a usable ``USER_MESSAGE_RECEIVED`` text are
-  reported in ``skipped_sessions``.
+  each trace. Identity strings are taken exactly as stored, like the SDK's
+  ``TraceIdentity``: whitespace is kept and SQL ``NULL`` is distinct from
+  ``""``. Only content fields are trimmed. Traces without a usable
+  ``USER_MESSAGE_RECEIVED`` text are reported in ``skipped_sessions``.
   """
   sessions: dict[_TraceKey, _Session] = {}
   ordered = sorted(
@@ -250,7 +255,7 @@ def synthesize(
       ),
   )
   for row in ordered:
-    session_id = _text(row.get("session_id"))
+    session_id = _identity_text(row.get("session_id"))
     if session_id is None:
       continue
     user_id, root_agent_name = _identity(row)
@@ -352,20 +357,38 @@ def _identity(row: Mapping[str, Any]) -> tuple[Optional[str], Optional[str]]:
 
   ``root_agent_name`` is read from the top-level column the reader query
   projects, falling back to ``attributes.root_agent_name`` for rows handed
-  in without that projection (tests, other readers).
+  in without that projection (tests, other readers). Values are exact
+  strings (no stripping; ``""`` stays ``""``), never content-normalized.
   """
-  user_id = _text(row.get("user_id"))
-  root_agent_name = _text(row.get("root_agent_name"))
+  user_id = _identity_text(row.get("user_id"))
+  root_agent_name = _identity_text(row.get("root_agent_name"))
   if root_agent_name is None:
     attributes = _structured(row.get("attributes"))
     if isinstance(attributes, Mapping):
-      root_agent_name = _text(attributes.get("root_agent_name"))
+      root_agent_name = _identity_text(attributes.get("root_agent_name"))
   return user_id, root_agent_name
 
 
-def _identity_key(row: Mapping[str, Any]) -> tuple[str, str]:
+def _identity_text(value: Any) -> Optional[str]:
+  """Exact-string identity dimension: a ``str`` as stored, else ``None``.
+
+  Mirrors the SDK's ``TraceIdentity`` contract -- whitespace is preserved
+  and the empty string is a value, not ``NULL``. Non-strings are ``NULL``.
+  """
+  if isinstance(value, str):
+    return str(value)
+  return None
+
+
+def _identity_key(row: Mapping[str, Any]) -> tuple[bool, str, bool, str]:
+  """Sort key over the exact identity (``None`` orders before ``""``)."""
   user_id, root_agent_name = _identity(row)
-  return (user_id or "", root_agent_name or "")
+  return (
+      user_id is not None,
+      user_id or "",
+      root_agent_name is not None,
+      root_agent_name or "",
+  )
 
 
 def _fold_event(session: _Session, row: Mapping[str, Any]) -> None:
@@ -451,18 +474,40 @@ def _scenario_ids(keys: Sequence[_TraceKey]) -> dict[_TraceKey, str]:
   Short session-id prefixes when they are unique; full session ids when
   prefixes collide; the full ``session_id:user_id:root_agent_name``
   identity when session ids themselves are reused across users or root
-  agents. Deterministic, so re-runs reproduce the importer's fingerprints.
+  agents. That last form is injective (``_encode_identity``), so distinct
+  identities can never share an id. Blank ids are never used -- the
+  importer rejects them. Deterministic, so re-runs reproduce the
+  importer's fingerprints.
   """
   candidates = (
       lambda key: key[0][:_SHORT_ID_LENGTH],
       lambda key: key[0],
-      lambda key: ":".join(part if part is not None else "" for part in key),
+      _encode_identity,
   )
   for candidate in candidates:
     ids = {key: candidate(key) for key in keys}
-    if len(set(ids.values())) == len(keys):
+    if len(set(ids.values())) == len(keys) and all(
+        value.strip() for value in ids.values()
+    ):
       return ids
   raise ValueError("duplicate trace identities cannot be given scenario ids")
+
+
+def _encode_identity(key: _TraceKey) -> str:
+  """``session_id:user_id:root_agent_name`` with component boundaries kept.
+
+  Each component is percent-escaped (``%`` -> ``%25``, ``:`` -> ``%3A``,
+  ``~`` -> ``%7E``) and a ``None`` component is written as ``~``, so the
+  encoding is injective: ``("s", "a:b", "c")`` and ``("s", "a", "b:c")``
+  differ, as do ``None``, ``""``, and a literal ``"~"``. Always contains
+  two ``:`` separators, hence never blank.
+  """
+  return ":".join(
+      "~"
+      if part is None
+      else part.replace("%", "%25").replace(":", "%3A").replace("~", "%7E")
+      for part in key
+  )
 
 
 def _first_text(

--- a/examples/evalbench_synth_from_traces.py
+++ b/examples/evalbench_synth_from_traces.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthesize an EvalBench-shaped dataset from real BQAA agent traces.
+
+The EvalBench MVP demo (`examples/evalbench_mvp_e2e.sh`, #435 slice 5, #97)
+needs an EvalBench job to import. When no EvalBench run is available this
+script builds one from traces an agent really produced: it reads a BQAA
+``agent_events`` table, folds each session into one EvalBench ``results``
+row plus one ``scores`` row, and writes ``configs`` / ``results`` /
+``scores`` tables that ``EvalBenchRun.from_bigquery`` reads unchanged.
+
+Nothing textual is invented. Every prompt is the session's real
+``USER_MESSAGE_RECEIVED`` text, every final response is the real
+``AGENT_COMPLETED`` / ``AGENT_RESPONSE`` text, and sessions with no user
+prompt are skipped rather than given one. The only synthesized value is the
+``goal_completion`` score: ``1.0`` when the session reached
+``AGENT_COMPLETED``, ``0.0`` otherwise (``returncode`` mirrors this as
+``0`` / ``1``). It says *completed*, not *correct* -- that is what step 3 of
+the demo, the LLM judge, is for.
+
+Mapping (one result per session, keyed by the first eight characters of the
+session id unless that would collide, then the full session id):
+
+  results.id / eval_id       scenario id
+  results.prompt / nl_prompt first USER_MESSAGE_RECEIVED content.text_summary
+  results.final_response     AGENT_COMPLETED text, else last AGENT_RESPONSE
+  results.stdout             same text (EvalBench's agentic field name)
+  results.returncode         0 if AGENT_COMPLETED was logged, else 1
+  results.run_time           timestamp of the USER_MESSAGE_RECEIVED event
+  results.tool_calls         JSON list of TOOL_STARTING / TOOL_COMPLETED pairs
+  results.error_message      first error_message logged in the session
+  scores                     comparator=goal_completion, score=1.0|0.0
+  configs                    experiment_config.orchestrator=<agent>,
+                             model_config.generator=<adk app_name>
+
+Usage (defaults are the demo's own names; only the project is required):
+
+  python examples/evalbench_synth_from_traces.py \
+      --project test-project-0728-467323 \
+      --source-table bqaa_e2e_real.agent_events \
+      --evalbench-dataset bqaa_evalbench_mvp_demo \
+      --mirror-dataset bqaa_evalbench_mvp_mirror \
+      --job-id mvp-e2e-real-traces
+
+  --dry-run prints the synthesized rows as JSON and writes nothing.
+
+The EvalBench-shaped dataset and the mirror dataset are created when
+missing. The script refuses to write into the source dataset or into the
+ADK plugin's ``agent_analytics`` dataset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+from datetime import datetime
+from datetime import timezone
+import json
+import os
+import sys
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+DEFAULT_SOURCE_TABLE = "bqaa_e2e_real.agent_events"
+DEFAULT_EVALBENCH_DATASET = "bqaa_evalbench_mvp_demo"
+DEFAULT_MIRROR_DATASET = "bqaa_evalbench_mvp_mirror"
+DEFAULT_JOB_ID = "mvp-e2e-real-traces"
+DEFAULT_LOCATION = "US"
+COMPARATOR = "goal_completion"
+_SHORT_ID_LENGTH = 8
+_RESERVED_TARGET_DATASETS = frozenset({"agent_analytics"})
+
+_RESULT_SCHEMA = (
+    ("job_id", "STRING", "REQUIRED"),
+    ("id", "STRING", "REQUIRED"),
+    ("eval_id", "STRING", "REQUIRED"),
+    ("prompt", "STRING", "REQUIRED"),
+    ("nl_prompt", "STRING", "REQUIRED"),
+    ("final_response", "STRING", "NULLABLE"),
+    ("stdout", "STRING", "NULLABLE"),
+    ("returncode", "INT64", "REQUIRED"),
+    ("run_time", "TIMESTAMP", "REQUIRED"),
+    ("tool_calls", "STRING", "REQUIRED"),
+    ("error_message", "STRING", "NULLABLE"),
+    ("source_session_id", "STRING", "REQUIRED"),
+    ("source_table", "STRING", "REQUIRED"),
+)
+_SCORE_SCHEMA = (
+    ("job_id", "STRING", "REQUIRED"),
+    ("id", "STRING", "REQUIRED"),
+    ("eval_id", "STRING", "REQUIRED"),
+    ("comparator", "STRING", "REQUIRED"),
+    ("score", "FLOAT64", "REQUIRED"),
+    ("run_time", "TIMESTAMP", "REQUIRED"),
+    ("source_session_id", "STRING", "REQUIRED"),
+)
+_CONFIG_SCHEMA = (
+    ("job_id", "STRING", "REQUIRED"),
+    ("run_time", "TIMESTAMP", "REQUIRED"),
+    ("config", "STRING", "REQUIRED"),
+    ("value", "STRING", "NULLABLE"),
+)
+
+_READ_EVENTS_QUERY = """\
+SELECT
+  timestamp,
+  event_type,
+  agent,
+  session_id,
+  span_id,
+  TO_JSON_STRING(content) AS content,
+  TO_JSON_STRING(attributes) AS attributes,
+  status,
+  error_message
+FROM `{source_table}`
+ORDER BY session_id, timestamp, span_id
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class SynthTables:
+  """The three EvalBench-shaped row lists plus the sessions left out."""
+
+  results: list[dict[str, Any]]
+  scores: list[dict[str, Any]]
+  configs: list[dict[str, Any]]
+  skipped_sessions: list[str]
+
+  @property
+  def completed(self) -> int:
+    return sum(1 for row in self.results if row["returncode"] == 0)
+
+
+@dataclasses.dataclass
+class _Session:
+  session_id: str
+  prompt: Optional[str] = None
+  run_time: Optional[datetime] = None
+  agent: Optional[str] = None
+  app_name: Optional[str] = None
+  completed: bool = False
+  completed_text: Optional[str] = None
+  last_response: Optional[str] = None
+  error_message: Optional[str] = None
+  tool_calls: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+  _open_by_span: dict[str, dict[str, Any]] = dataclasses.field(
+      default_factory=dict
+  )
+
+
+def check_targets(
+    *, source_table: str, evalbench_dataset: str, mirror_dataset: str
+) -> None:
+  """Refuse to write into the source dataset or the ADK plugin's dataset."""
+  source_dataset = source_table.split(".")[-2] if "." in source_table else ""
+  for name, dataset in (
+      ("--evalbench-dataset", evalbench_dataset),
+      ("--mirror-dataset", mirror_dataset),
+  ):
+    if dataset == source_dataset:
+      raise ValueError(
+          f"{name} {dataset!r} must not be the source dataset of"
+          f" {source_table!r}"
+      )
+    if dataset.lower() in _RESERVED_TARGET_DATASETS:
+      raise ValueError(
+          f"{name} {dataset!r} must not be the ADK plugin's dataset"
+      )
+  if evalbench_dataset == mirror_dataset:
+    raise ValueError(
+        "--evalbench-dataset and --mirror-dataset must differ (the importer"
+        " reads the first and writes the second)"
+    )
+
+
+def synthesize(
+    events: Iterable[Mapping[str, Any]], *, job_id: str, source_table: str
+) -> SynthTables:
+  """Fold ``agent_events`` rows into EvalBench ``results``/``scores``/``configs``.
+
+  ``events`` are plain mappings shaped like ``agent_events`` rows;
+  ``content`` / ``attributes`` may be dicts, JSON strings (as
+  ``TO_JSON_STRING`` returns them), or ``None``. Rows are processed in
+  ``(session_id, timestamp)`` order. Sessions without a usable
+  ``USER_MESSAGE_RECEIVED`` text are reported in ``skipped_sessions``.
+  """
+  sessions: dict[str, _Session] = {}
+  ordered = sorted(
+      events,
+      key=lambda row: (
+          str(row.get("session_id") or ""),
+          _timestamp(row.get("timestamp"))
+          or datetime.min.replace(tzinfo=timezone.utc),
+      ),
+  )
+  for row in ordered:
+    session_id = _text(row.get("session_id"))
+    if session_id is None:
+      continue
+    session = sessions.setdefault(session_id, _Session(session_id=session_id))
+    _fold_event(session, row)
+
+  prompted = [s for s in sessions.values() if s.prompt is not None]
+  skipped = sorted(s.session_id for s in sessions.values() if s.prompt is None)
+  if not prompted:
+    raise ValueError(
+        f"no session in {source_table!r} has a USER_MESSAGE_RECEIVED text;"
+        " nothing to synthesize (prompts are never invented)"
+    )
+
+  scenario_ids = _scenario_ids([s.session_id for s in prompted])
+  results: list[dict[str, Any]] = []
+  scores: list[dict[str, Any]] = []
+  for session in prompted:
+    scenario_id = scenario_ids[session.session_id]
+    final_text = session.completed_text or session.last_response
+    result: dict[str, Any] = {
+        "job_id": job_id,
+        "id": scenario_id,
+        "eval_id": scenario_id,
+        "prompt": session.prompt,
+        "nl_prompt": session.prompt,
+    }
+    if final_text is not None:
+      result["final_response"] = final_text
+      result["stdout"] = final_text
+    result.update(
+        {
+            "returncode": 0 if session.completed else 1,
+            "run_time": session.run_time,
+            "tool_calls": json.dumps(session.tool_calls, sort_keys=True),
+            "error_message": session.error_message,
+            "source_session_id": session.session_id,
+            "source_table": source_table,
+        }
+    )
+    results.append(result)
+    scores.append(
+        {
+            "job_id": job_id,
+            "id": scenario_id,
+            "eval_id": scenario_id,
+            "comparator": COMPARATOR,
+            "score": 1.0 if session.completed else 0.0,
+            "run_time": session.run_time,
+            "source_session_id": session.session_id,
+        }
+    )
+  results.sort(key=lambda row: row["id"])
+  scores.sort(key=lambda row: row["id"])
+
+  first_run_time = min(s.run_time for s in prompted if s.run_time is not None)
+  agent = _most_common(s.agent for s in prompted) or "unknown"
+  app_name = _most_common(s.app_name for s in prompted)
+  configs = [
+      {
+          "job_id": job_id,
+          "run_time": first_run_time,
+          "config": "experiment_config.orchestrator",
+          "value": agent,
+      },
+      {
+          "job_id": job_id,
+          "run_time": first_run_time,
+          "config": "model_config.generator",
+          "value": app_name,
+      },
+      {
+          "job_id": job_id,
+          "run_time": first_run_time,
+          "config": "bqaa.source_table",
+          "value": source_table,
+      },
+  ]
+  return SynthTables(
+      results=results, scores=scores, configs=configs, skipped_sessions=skipped
+  )
+
+
+def _fold_event(session: _Session, row: Mapping[str, Any]) -> None:
+  event_type = _text(row.get("event_type")) or ""
+  content = _structured(row.get("content"))
+  content_map = content if isinstance(content, Mapping) else {}
+  attributes = _structured(row.get("attributes"))
+  attributes_map = attributes if isinstance(attributes, Mapping) else {}
+
+  if session.agent is None:
+    session.agent = _text(row.get("agent")) or _text(
+        attributes_map.get("root_agent_name")
+    )
+  if session.app_name is None:
+    adk = attributes_map.get("adk")
+    if isinstance(adk, Mapping):
+      session.app_name = _text(adk.get("app_name"))
+  error = _text(row.get("error_message"))
+  if error is not None and session.error_message is None:
+    session.error_message = error
+
+  if event_type == "USER_MESSAGE_RECEIVED":
+    if session.prompt is None:
+      prompt = _first_text(content_map, ("text_summary", "text"))
+      if prompt is None and isinstance(content, str):
+        prompt = _text(content)
+      if prompt is not None:
+        session.prompt = prompt
+        session.run_time = _timestamp(row.get("timestamp"))
+  elif event_type == "AGENT_COMPLETED":
+    session.completed = True
+    text = _first_text(content_map, ("text_summary", "response", "text"))
+    if text is None and isinstance(content, str):
+      text = _text(content)
+    if text is not None:
+      session.completed_text = text
+  elif event_type == "AGENT_RESPONSE":
+    text = _first_text(content_map, ("response", "text_summary", "text"))
+    if text is None and isinstance(content, str):
+      text = _text(content)
+    if text is not None:
+      session.last_response = text
+  elif event_type == "TOOL_STARTING":
+    name = _first_text(content_map, ("tool", "tool_name", "name"))
+    if name is None:
+      return
+    call: dict[str, Any] = {
+        "tool_name": name,
+        "args": content_map.get("args") or {},
+    }
+    session.tool_calls.append(call)
+    span_id = _text(row.get("span_id"))
+    if span_id is not None:
+      session._open_by_span[span_id] = call
+  elif event_type in ("TOOL_COMPLETED", "TOOL_ERROR"):
+    name = _first_text(content_map, ("tool", "tool_name", "name"))
+    call = _match_tool_call(session, _text(row.get("span_id")), name)
+    if call is None:
+      return
+    if "result" in content_map:
+      call["result"] = content_map.get("result")
+    if event_type == "TOOL_ERROR" or _text(row.get("status")) == "ERROR":
+      call["error"] = error or content_map.get("error") or "TOOL_ERROR"
+
+
+def _match_tool_call(
+    session: _Session, span_id: Optional[str], name: Optional[str]
+) -> Optional[dict[str, Any]]:
+  if span_id is not None and span_id in session._open_by_span:
+    return session._open_by_span.pop(span_id)
+  for call in session.tool_calls:
+    if "result" in call or "error" in call:
+      continue
+    if name is None or call["tool_name"] == name:
+      return call
+  return None
+
+
+def _scenario_ids(session_ids: Sequence[str]) -> dict[str, str]:
+  short = {sid: sid[:_SHORT_ID_LENGTH] for sid in session_ids}
+  if len(set(short.values())) == len(session_ids):
+    return short
+  return {sid: sid for sid in session_ids}
+
+
+def _first_text(
+    mapping: Mapping[str, Any], keys: Sequence[str]
+) -> Optional[str]:
+  for key in keys:
+    text = _text(mapping.get(key))
+    if text is not None:
+      return text
+  return None
+
+
+def _text(value: Any) -> Optional[str]:
+  if value is None or isinstance(value, bool):
+    return None
+  if not isinstance(value, str):
+    return None
+  stripped = value.strip()
+  return stripped or None
+
+
+def _structured(value: Any) -> Any:
+  if isinstance(value, str):
+    stripped = value.strip()
+    if stripped.startswith(("{", "[", '"')) or stripped == "null":
+      try:
+        return json.loads(stripped)
+      except ValueError:
+        return value
+  return value
+
+
+def _timestamp(value: Any) -> Optional[datetime]:
+  if isinstance(value, datetime):
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+  if isinstance(value, str) and value.strip():
+    text = value.strip().replace(" ", "T", 1)
+    if text.endswith("Z"):
+      text = text[:-1] + "+00:00"
+    try:
+      parsed = datetime.fromisoformat(text)
+    except ValueError:
+      return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+  return None
+
+
+def _most_common(values: Iterable[Optional[str]]) -> Optional[str]:
+  counts: dict[str, int] = {}
+  for value in values:
+    if value is not None:
+      counts[value] = counts.get(value, 0) + 1
+  if not counts:
+    return None
+  return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+# --------------------------------------------------------------------------- #
+# BigQuery I/O (only reached from main()).
+# --------------------------------------------------------------------------- #
+def _qualify(project: str, table: str) -> str:
+  parts = table.split(".")
+  if len(parts) == 2:
+    return f"{project}.{table}"
+  if len(parts) == 3:
+    return table
+  raise ValueError(
+      f"--source-table must be dataset.table or project.dataset.table, got {table!r}"
+  )
+
+
+def load_events(
+    client: Any, *, source_table: str, location: str
+) -> list[dict[str, Any]]:
+  query = _READ_EVENTS_QUERY.format(source_table=source_table)
+  return [
+      dict(row.items())
+      for row in client.query(query, location=location).result()
+  ]
+
+
+def _schema(fields: Sequence[tuple[str, str, str]]) -> list:
+  from google.cloud import bigquery
+
+  return [
+      bigquery.SchemaField(name, kind, mode=mode) for name, kind, mode in fields
+  ]
+
+
+def _json_ready(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+  ready = []
+  for row in rows:
+    ready.append(
+        {
+            key: (value.isoformat() if isinstance(value, datetime) else value)
+            for key, value in row.items()
+        }
+    )
+  return ready
+
+
+def write_tables(
+    client: Any,
+    *,
+    project: str,
+    evalbench_dataset: str,
+    mirror_dataset: str,
+    tables: SynthTables,
+    location: str,
+) -> dict[str, int]:
+  """Create both datasets if missing and (re)load the three source tables."""
+  from google.cloud import bigquery
+
+  for dataset in (evalbench_dataset, mirror_dataset):
+    ref = bigquery.Dataset(f"{project}.{dataset}")
+    ref.location = location
+    client.create_dataset(ref, exists_ok=True)
+
+  written: dict[str, int] = {}
+  for name, rows, fields in (
+      ("configs", tables.configs, _CONFIG_SCHEMA),
+      ("results", tables.results, _RESULT_SCHEMA),
+      ("scores", tables.scores, _SCORE_SCHEMA),
+  ):
+    table_id = f"{project}.{evalbench_dataset}.{name}"
+    job_config = bigquery.LoadJobConfig(
+        schema=_schema(fields),
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+    )
+    client.load_table_from_json(
+        _json_ready(rows), table_id, job_config=job_config, location=location
+    ).result()
+    written[table_id] = len(rows)
+  return written
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+      description=(
+          "Synthesize EvalBench-shaped configs/results/scores tables from a"
+          " real BQAA agent_events table (#435 slice 5, #97)."
+      )
+  )
+  parser.add_argument(
+      "--project",
+      default=os.environ.get("BQ_AGENT_PROJECT")
+      or os.environ.get("GOOGLE_CLOUD_PROJECT"),
+      help="Project holding the source traces and both target datasets"
+      " (default: $BQ_AGENT_PROJECT or $GOOGLE_CLOUD_PROJECT).",
+  )
+  parser.add_argument(
+      "--source-table",
+      default=os.environ.get("EVALBENCH_SOURCE_TABLE", DEFAULT_SOURCE_TABLE),
+      help="Real agent_events table, dataset.table or project.dataset.table"
+      f" (default: {DEFAULT_SOURCE_TABLE}).",
+  )
+  parser.add_argument(
+      "--evalbench-dataset",
+      default=os.environ.get("EVALBENCH_DATASET", DEFAULT_EVALBENCH_DATASET),
+      help="EvalBench-shaped dataset to (re)build"
+      f" (default: {DEFAULT_EVALBENCH_DATASET}).",
+  )
+  parser.add_argument(
+      "--mirror-dataset",
+      default=os.environ.get("BQ_AGENT_DATASET", DEFAULT_MIRROR_DATASET),
+      help="BQAA mirror dataset evalbench-import will write to; created if"
+      f" missing (default: {DEFAULT_MIRROR_DATASET}).",
+  )
+  parser.add_argument(
+      "--job-id",
+      default=os.environ.get("EVALBENCH_JOB_ID", DEFAULT_JOB_ID),
+      help=f"EvalBench job_id stamped on every row (default: {DEFAULT_JOB_ID}).",
+  )
+  parser.add_argument(
+      "--location",
+      default=os.environ.get("BQ_AGENT_LOCATION", DEFAULT_LOCATION),
+      help=f"BigQuery location for new datasets (default: {DEFAULT_LOCATION}).",
+  )
+  parser.add_argument(
+      "--dry-run",
+      action="store_true",
+      help="Read the traces and print the synthesized rows as JSON; write nothing.",
+  )
+  args = parser.parse_args(argv)
+  if not args.project:
+    parser.error(
+        "--project (or $BQ_AGENT_PROJECT / $GOOGLE_CLOUD_PROJECT) is required"
+    )
+  return args
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+  args = _parse_args(argv)
+  source_table = _qualify(args.project, args.source_table)
+  check_targets(
+      source_table=source_table,
+      evalbench_dataset=args.evalbench_dataset,
+      mirror_dataset=args.mirror_dataset,
+  )
+
+  from google.cloud import bigquery
+
+  client = bigquery.Client(project=args.project)
+  events = load_events(
+      client, source_table=source_table, location=args.location
+  )
+  tables = synthesize(events, job_id=args.job_id, source_table=source_table)
+
+  summary = {
+      "job_id": args.job_id,
+      "source_table": source_table,
+      "source_event_count": len(events),
+      "scenarios": len(tables.results),
+      "completed": tables.completed,
+      "not_completed": len(tables.results) - tables.completed,
+      "skipped_sessions": tables.skipped_sessions,
+  }
+  if args.dry_run:
+    print(
+        json.dumps(
+            {
+                **summary,
+                "configs": _json_ready(tables.configs),
+                "results": _json_ready(tables.results),
+                "scores": _json_ready(tables.scores),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+  written = write_tables(
+      client,
+      project=args.project,
+      evalbench_dataset=args.evalbench_dataset,
+      mirror_dataset=args.mirror_dataset,
+      tables=tables,
+      location=args.location,
+  )
+  print(
+      json.dumps(
+          {
+              **summary,
+              "evalbench_dataset": f"{args.project}.{args.evalbench_dataset}",
+              "mirror_dataset": f"{args.project}.{args.mirror_dataset}",
+              "written": written,
+          },
+          indent=2,
+      )
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/examples/evalbench_synth_from_traces.py
+++ b/examples/evalbench_synth_from_traces.py
@@ -18,30 +18,40 @@
 The EvalBench MVP demo (`examples/evalbench_mvp_e2e.sh`, #435 slice 5, #97)
 needs an EvalBench job to import. When no EvalBench run is available this
 script builds one from traces an agent really produced: it reads a BQAA
-``agent_events`` table, folds each session into one EvalBench ``results``
+``agent_events`` table, folds each trace into one EvalBench ``results``
 row plus one ``scores`` row, and writes ``configs`` / ``results`` /
 ``scores`` tables that ``EvalBenchRun.from_bigquery`` reads unchanged.
 
-Nothing textual is invented. Every prompt is the session's real
+A trace is the full BQAA trace identity ``(session_id, user_id,
+root_agent_name)`` -- the same grouping ``Client.list_traces`` uses -- not
+the bare ``session_id``, so a session id reused across users or root agents
+never splices one trace's prompt onto another trace's response.
+
+Nothing textual is invented. Every prompt is the trace's real
 ``USER_MESSAGE_RECEIVED`` text, every final response is the real
-``AGENT_COMPLETED`` / ``AGENT_RESPONSE`` text, and sessions with no user
-prompt are skipped rather than given one. The only synthesized value is the
-``goal_completion`` score: ``1.0`` when the session reached
+``AGENT_COMPLETED`` text or, when the plugin logs ``AGENT_COMPLETED`` with
+no content (the ADK plugin does), the last ``LLM_RESPONSE`` text
+(``AGENT_RESPONSE`` is accepted as a compatibility alias), and traces with
+no user prompt are skipped rather than given one. The only synthesized
+value is the ``goal_completion`` score: ``1.0`` when the trace reached
 ``AGENT_COMPLETED``, ``0.0`` otherwise (``returncode`` mirrors this as
 ``0`` / ``1``). It says *completed*, not *correct* -- that is what step 3 of
 the demo, the LLM judge, is for.
 
-Mapping (one result per session, keyed by the first eight characters of the
-session id unless that would collide, then the full session id):
+Mapping (one result per trace, keyed by the first eight characters of the
+session id; on collision the full session id; if session ids themselves are
+reused, ``session_id:user_id:root_agent_name``):
 
   results.id / eval_id       scenario id
   results.prompt / nl_prompt first USER_MESSAGE_RECEIVED content.text_summary
-  results.final_response     AGENT_COMPLETED text, else last AGENT_RESPONSE
+  results.final_response     AGENT_COMPLETED text, else last LLM_RESPONSE
   results.stdout             same text (EvalBench's agentic field name)
   results.returncode         0 if AGENT_COMPLETED was logged, else 1
   results.run_time           timestamp of the USER_MESSAGE_RECEIVED event
   results.tool_calls         JSON list of TOOL_STARTING / TOOL_COMPLETED pairs
-  results.error_message      first error_message logged in the session
+  results.error_message      first error_message logged in the trace
+  results.source_session_id  the trace identity, alongside
+    / source_user_id         source_root_agent_name and source_table
   scores                     comparator=goal_completion, score=1.0|0.0
   configs                    experiment_config.orchestrator=<agent>,
                              model_config.generator=<adk app_name>
@@ -59,7 +69,9 @@ Usage (defaults are the demo's own names; only the project is required):
 
 The EvalBench-shaped dataset and the mirror dataset are created when
 missing. The script refuses to write into the source dataset or into the
-ADK plugin's ``agent_analytics`` dataset.
+ADK plugin's ``agent_analytics`` dataset, and every project / dataset /
+table name is validated as a plain identifier (ASCII letters, digits,
+``_`` or ``-``) before a BigQuery client is created or any SQL is built.
 """
 
 from __future__ import annotations
@@ -70,6 +82,7 @@ from datetime import datetime
 from datetime import timezone
 import json
 import os
+import re
 import sys
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
@@ -81,6 +94,14 @@ DEFAULT_LOCATION = "US"
 COMPARATOR = "goal_completion"
 _SHORT_ID_LENGTH = 8
 _RESERVED_TARGET_DATASETS = frozenset({"agent_analytics"})
+# Same fail-closed identifier policy as ``bigquery_agent_analytics.evalbench``:
+# names are interpolated into SQL between backticks, so anything else
+# (backticks, semicolons, comment markers, whitespace) is rejected up front.
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+# Event types carrying the model's answer text. ``LLM_RESPONSE`` is the SDK
+# contract (``event_semantics.RESPONSE_EVENT_TYPES``); ``AGENT_RESPONSE`` is
+# kept as a compatibility alias for producers that used that name.
+_RESPONSE_EVENT_TYPES = frozenset({"LLM_RESPONSE", "AGENT_RESPONSE"})
 
 _RESULT_SCHEMA = (
     ("job_id", "STRING", "REQUIRED"),
@@ -95,6 +116,8 @@ _RESULT_SCHEMA = (
     ("tool_calls", "STRING", "REQUIRED"),
     ("error_message", "STRING", "NULLABLE"),
     ("source_session_id", "STRING", "REQUIRED"),
+    ("source_user_id", "STRING", "NULLABLE"),
+    ("source_root_agent_name", "STRING", "NULLABLE"),
     ("source_table", "STRING", "REQUIRED"),
 )
 _SCORE_SCHEMA = (
@@ -105,6 +128,8 @@ _SCORE_SCHEMA = (
     ("score", "FLOAT64", "REQUIRED"),
     ("run_time", "TIMESTAMP", "REQUIRED"),
     ("source_session_id", "STRING", "REQUIRED"),
+    ("source_user_id", "STRING", "NULLABLE"),
+    ("source_root_agent_name", "STRING", "NULLABLE"),
 )
 _CONFIG_SCHEMA = (
     ("job_id", "STRING", "REQUIRED"),
@@ -113,19 +138,23 @@ _CONFIG_SCHEMA = (
     ("value", "STRING", "NULLABLE"),
 )
 
+# The identity columns match ``Client.list_traces``: a trace is
+# ``(session_id, user_id, root_agent_name)``, never ``session_id`` alone.
 _READ_EVENTS_QUERY = """\
 SELECT
   timestamp,
   event_type,
   agent,
   session_id,
+  user_id,
+  JSON_VALUE(attributes, '$.root_agent_name') AS root_agent_name,
   span_id,
   TO_JSON_STRING(content) AS content,
   TO_JSON_STRING(attributes) AS attributes,
   status,
   error_message
 FROM `{source_table}`
-ORDER BY session_id, timestamp, span_id
+ORDER BY session_id, user_id, root_agent_name, timestamp, span_id
 """
 
 
@@ -136,16 +165,22 @@ class SynthTables:
   results: list[dict[str, Any]]
   scores: list[dict[str, Any]]
   configs: list[dict[str, Any]]
-  skipped_sessions: list[str]
+  skipped_sessions: list[str]  # session ids of traces without a prompt
 
   @property
   def completed(self) -> int:
     return sum(1 for row in self.results if row["returncode"] == 0)
 
 
+# One BQAA trace: the full identity, not just the session id.
+_TraceKey = tuple[str, Optional[str], Optional[str]]
+
+
 @dataclasses.dataclass
 class _Session:
   session_id: str
+  user_id: Optional[str] = None
+  root_agent_name: Optional[str] = None
   prompt: Optional[str] = None
   run_time: Optional[datetime] = None
   agent: Optional[str] = None
@@ -158,6 +193,10 @@ class _Session:
   _open_by_span: dict[str, dict[str, Any]] = dataclasses.field(
       default_factory=dict
   )
+
+  @property
+  def key(self) -> _TraceKey:
+    return (self.session_id, self.user_id, self.root_agent_name)
 
 
 def check_targets(
@@ -192,15 +231,20 @@ def synthesize(
 
   ``events`` are plain mappings shaped like ``agent_events`` rows;
   ``content`` / ``attributes`` may be dicts, JSON strings (as
-  ``TO_JSON_STRING`` returns them), or ``None``. Rows are processed in
-  ``(session_id, timestamp)`` order. Sessions without a usable
-  ``USER_MESSAGE_RECEIVED`` text are reported in ``skipped_sessions``.
+  ``TO_JSON_STRING`` returns them), or ``None``. Rows are grouped by the
+  full BQAA trace identity ``(session_id, user_id, root_agent_name)`` --
+  ``user_id`` from the top-level column, ``root_agent_name`` from the
+  top-level column when the reader selected it, else from
+  ``attributes.root_agent_name`` -- and processed in timestamp order within
+  each trace. Traces without a usable ``USER_MESSAGE_RECEIVED`` text are
+  reported in ``skipped_sessions``.
   """
-  sessions: dict[str, _Session] = {}
+  sessions: dict[_TraceKey, _Session] = {}
   ordered = sorted(
       events,
       key=lambda row: (
           str(row.get("session_id") or ""),
+          _identity_key(row),
           _timestamp(row.get("timestamp"))
           or datetime.min.replace(tzinfo=timezone.utc),
       ),
@@ -209,22 +253,32 @@ def synthesize(
     session_id = _text(row.get("session_id"))
     if session_id is None:
       continue
-    session = sessions.setdefault(session_id, _Session(session_id=session_id))
+    user_id, root_agent_name = _identity(row)
+    key: _TraceKey = (session_id, user_id, root_agent_name)
+    session = sessions.get(key)
+    if session is None:
+      session = sessions[key] = _Session(
+          session_id=session_id,
+          user_id=user_id,
+          root_agent_name=root_agent_name,
+      )
     _fold_event(session, row)
 
   prompted = [s for s in sessions.values() if s.prompt is not None]
-  skipped = sorted(s.session_id for s in sessions.values() if s.prompt is None)
+  skipped = sorted(
+      {s.session_id for s in sessions.values() if s.prompt is None}
+  )
   if not prompted:
     raise ValueError(
-        f"no session in {source_table!r} has a USER_MESSAGE_RECEIVED text;"
+        f"no trace in {source_table!r} has a USER_MESSAGE_RECEIVED text;"
         " nothing to synthesize (prompts are never invented)"
     )
 
-  scenario_ids = _scenario_ids([s.session_id for s in prompted])
+  scenario_ids = _scenario_ids([s.key for s in prompted])
   results: list[dict[str, Any]] = []
   scores: list[dict[str, Any]] = []
   for session in prompted:
-    scenario_id = scenario_ids[session.session_id]
+    scenario_id = scenario_ids[session.key]
     final_text = session.completed_text or session.last_response
     result: dict[str, Any] = {
         "job_id": job_id,
@@ -243,6 +297,8 @@ def synthesize(
             "tool_calls": json.dumps(session.tool_calls, sort_keys=True),
             "error_message": session.error_message,
             "source_session_id": session.session_id,
+            "source_user_id": session.user_id,
+            "source_root_agent_name": session.root_agent_name,
             "source_table": source_table,
         }
     )
@@ -256,6 +312,8 @@ def synthesize(
             "score": 1.0 if session.completed else 0.0,
             "run_time": session.run_time,
             "source_session_id": session.session_id,
+            "source_user_id": session.user_id,
+            "source_root_agent_name": session.root_agent_name,
         }
     )
   results.sort(key=lambda row: row["id"])
@@ -287,6 +345,27 @@ def synthesize(
   return SynthTables(
       results=results, scores=scores, configs=configs, skipped_sessions=skipped
   )
+
+
+def _identity(row: Mapping[str, Any]) -> tuple[Optional[str], Optional[str]]:
+  """``(user_id, root_agent_name)`` of one ``agent_events`` row.
+
+  ``root_agent_name`` is read from the top-level column the reader query
+  projects, falling back to ``attributes.root_agent_name`` for rows handed
+  in without that projection (tests, other readers).
+  """
+  user_id = _text(row.get("user_id"))
+  root_agent_name = _text(row.get("root_agent_name"))
+  if root_agent_name is None:
+    attributes = _structured(row.get("attributes"))
+    if isinstance(attributes, Mapping):
+      root_agent_name = _text(attributes.get("root_agent_name"))
+  return user_id, root_agent_name
+
+
+def _identity_key(row: Mapping[str, Any]) -> tuple[str, str]:
+  user_id, root_agent_name = _identity(row)
+  return (user_id or "", root_agent_name or "")
 
 
 def _fold_event(session: _Session, row: Mapping[str, Any]) -> None:
@@ -323,8 +402,9 @@ def _fold_event(session: _Session, row: Mapping[str, Any]) -> None:
       text = _text(content)
     if text is not None:
       session.completed_text = text
-  elif event_type == "AGENT_RESPONSE":
-    text = _first_text(content_map, ("response", "text_summary", "text"))
+  elif event_type in _RESPONSE_EVENT_TYPES:
+    # Same key priority as ``event_semantics.extract_response_text``.
+    text = _first_text(content_map, ("response", "text_summary", "text", "raw"))
     if text is None and isinstance(content, str):
       text = _text(content)
     if text is not None:
@@ -365,11 +445,24 @@ def _match_tool_call(
   return None
 
 
-def _scenario_ids(session_ids: Sequence[str]) -> dict[str, str]:
-  short = {sid: sid[:_SHORT_ID_LENGTH] for sid in session_ids}
-  if len(set(short.values())) == len(session_ids):
-    return short
-  return {sid: sid for sid in session_ids}
+def _scenario_ids(keys: Sequence[_TraceKey]) -> dict[_TraceKey, str]:
+  """Collision-safe scenario id per trace identity.
+
+  Short session-id prefixes when they are unique; full session ids when
+  prefixes collide; the full ``session_id:user_id:root_agent_name``
+  identity when session ids themselves are reused across users or root
+  agents. Deterministic, so re-runs reproduce the importer's fingerprints.
+  """
+  candidates = (
+      lambda key: key[0][:_SHORT_ID_LENGTH],
+      lambda key: key[0],
+      lambda key: ":".join(part if part is not None else "" for part in key),
+  )
+  for candidate in candidates:
+    ids = {key: candidate(key) for key in keys}
+    if len(set(ids.values())) == len(keys):
+      return ids
+  raise ValueError("duplicate trace identities cannot be given scenario ids")
 
 
 def _first_text(
@@ -430,20 +523,48 @@ def _most_common(values: Iterable[Optional[str]]) -> Optional[str]:
 # --------------------------------------------------------------------------- #
 # BigQuery I/O (only reached from main()).
 # --------------------------------------------------------------------------- #
+def validate_identifier(name: str, value: Any) -> str:
+  """Fail closed on anything but a plain BigQuery identifier segment."""
+  if not isinstance(value, str) or not _IDENTIFIER_PATTERN.fullmatch(value):
+    raise ValueError(
+        f"{name} must contain only ASCII letters, digits, '_' or '-',"
+        f" got {value!r}"
+    )
+  return value
+
+
 def _qualify(project: str, table: str) -> str:
-  parts = table.split(".")
+  """Return ``project.dataset.table`` with every segment validated.
+
+  Runs before a BigQuery client exists and before any SQL is formatted,
+  so a hostile ``--source-table`` (backticks, semicolons, comments, ...)
+  can never reach ``client.query``.
+  """
+  validate_identifier("--project", project)
+  parts = table.split(".") if isinstance(table, str) else []
   if len(parts) == 2:
-    return f"{project}.{table}"
-  if len(parts) == 3:
-    return table
-  raise ValueError(
-      f"--source-table must be dataset.table or project.dataset.table, got {table!r}"
-  )
+    parts = [project, *parts]
+  elif len(parts) != 3:
+    raise ValueError(
+        "--source-table must be dataset.table or project.dataset.table,"
+        f" got {table!r}"
+    )
+  for label, segment in zip(("project", "dataset", "table"), parts):
+    validate_identifier(f"--source-table {label}", segment)
+  return ".".join(parts)
 
 
 def load_events(
     client: Any, *, source_table: str, location: str
 ) -> list[dict[str, Any]]:
+  # Re-validated here so the guard holds for direct callers, not only main().
+  parts = source_table.split(".")
+  if len(parts) != 3:
+    raise ValueError(
+        f"source_table must be project.dataset.table, got {source_table!r}"
+    )
+  for label, segment in zip(("project", "dataset", "table"), parts):
+    validate_identifier(f"source_table {label}", segment)
   query = _READ_EVENTS_QUERY.format(source_table=source_table)
   return [
       dict(row.items())
@@ -565,6 +686,8 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
 def main(argv: Optional[Sequence[str]] = None) -> int:
   args = _parse_args(argv)
   source_table = _qualify(args.project, args.source_table)
+  validate_identifier("--evalbench-dataset", args.evalbench_dataset)
+  validate_identifier("--mirror-dataset", args.mirror_dataset)
   check_targets(
       source_table=source_table,
       evalbench_dataset=args.evalbench_dataset,

--- a/examples/evalbench_synth_from_traces.py
+++ b/examples/evalbench_synth_from_traces.py
@@ -52,7 +52,13 @@ distinct ids):
   results.returncode         0 if AGENT_COMPLETED was logged, else 1
   results.run_time           timestamp of the USER_MESSAGE_RECEIVED event
   results.tool_calls         JSON list of TOOL_STARTING / TOOL_COMPLETED pairs
-  results.error_message      first error_message logged in the trace
+  results.error              first non-tool event with status=ERROR or an
+                             error_message (the importer reads this field
+                             and publishes the session as status=ERROR, so a
+                             completed-but-errored trace stays a failed
+                             session); NULL for clean traces
+  results.error_message      first error_message logged in the trace, kept
+                             verbatim for provenance (tool errors included)
   results.source_session_id  the trace identity, alongside
     / source_user_id         source_root_agent_name and source_table
   scores                     comparator=goal_completion, score=1.0|0.0
@@ -105,6 +111,10 @@ _IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 # contract (``event_semantics.RESPONSE_EVENT_TYPES``); ``AGENT_RESPONSE`` is
 # kept as a compatibility alias for producers that used that name.
 _RESPONSE_EVENT_TYPES = frozenset({"LLM_RESPONSE", "AGENT_RESPONSE"})
+# Tool outcome events carry their own error into ``tool_calls[].error`` (the
+# importer replays them as ``TOOL_ERROR`` rows); they are not a trace-level
+# ``error``.
+_TOOL_OUTCOME_EVENT_TYPES = frozenset({"TOOL_COMPLETED", "TOOL_ERROR"})
 
 _RESULT_SCHEMA = (
     ("job_id", "STRING", "REQUIRED"),
@@ -117,6 +127,7 @@ _RESULT_SCHEMA = (
     ("returncode", "INT64", "REQUIRED"),
     ("run_time", "TIMESTAMP", "REQUIRED"),
     ("tool_calls", "STRING", "REQUIRED"),
+    ("error", "STRING", "NULLABLE"),
     ("error_message", "STRING", "NULLABLE"),
     ("source_session_id", "STRING", "REQUIRED"),
     ("source_user_id", "STRING", "NULLABLE"),
@@ -191,7 +202,8 @@ class _Session:
   completed: bool = False
   completed_text: Optional[str] = None
   last_response: Optional[str] = None
-  error_message: Optional[str] = None
+  error: Optional[str] = None  # first non-tool source error (importer field)
+  error_message: Optional[str] = None  # first error_message, for provenance
   tool_calls: list[dict[str, Any]] = dataclasses.field(default_factory=list)
   _open_by_span: dict[str, dict[str, Any]] = dataclasses.field(
       default_factory=dict
@@ -300,6 +312,12 @@ def synthesize(
             "returncode": 0 if session.completed else 1,
             "run_time": session.run_time,
             "tool_calls": json.dumps(session.tool_calls, sort_keys=True),
+            # ``error`` is one of the fields EvalBenchRun._source_error_fields
+            # reads, so a source trace that completed with status=ERROR is
+            # published as status=ERROR (process_failed) rather than as a
+            # clean AGENT_COMPLETED. ``returncode`` / goal_completion stay
+            # tied to completion only.
+            "error": session.error,
             "error_message": session.error_message,
             "source_session_id": session.session_id,
             "source_user_id": session.user_id,
@@ -409,6 +427,12 @@ def _fold_event(session: _Session, row: Mapping[str, Any]) -> None:
   error = _text(row.get("error_message"))
   if error is not None and session.error_message is None:
     session.error_message = error
+  if (
+      session.error is None
+      and event_type not in _TOOL_OUTCOME_EVENT_TYPES
+      and (error is not None or _text(row.get("status")) == "ERROR")
+  ):
+    session.error = error or f"{event_type or 'event'} status=ERROR"
 
   if event_type == "USER_MESSAGE_RECEIVED":
     if session.prompt is None:

--- a/tests/test_evalbench_mvp_e2e.py
+++ b/tests/test_evalbench_mvp_e2e.py
@@ -31,10 +31,23 @@ _SCRIPT = (
     Path(__file__).resolve().parents[1] / "examples" / "evalbench_mvp_e2e.sh"
 )
 
+# The fixture tells one session's story in six beats; each CLI step banner
+# serves the beat it follows.
 _BANNERS = (
+    "=== This agent was asked to check widget stock. Here is the session. ===",
+    "=== What happened ===",
+    "=== Import those traces into EvalBench so we can query this failure ===",
     "=== Step 1: evalbench-import ===",
+    "=== This session in failed_sessions ===",
     "=== Step 2: evalbench-failed-sessions ===",
+    "=== Score this session ===",
     "=== Step 3: evalbench-score ===",
+    "=== Punchline ===",
+)
+
+_PUNCHLINE = (
+    "This widget-stock session failed because the agent never answered;"
+    " goal_completion=0.0."
 )
 
 pytestmark = pytest.mark.skipif(
@@ -62,33 +75,58 @@ def _run(*args: str, env: dict[str, str] | None = None):
 def _assert_fixture_walkthrough(stdout: str) -> None:
   for banner in _BANNERS:
     assert banner in stdout
-  # Banners appear in pipeline order.
+  # Story beats and step banners appear in narrative order.
   positions = [stdout.index(b) for b in _BANNERS]
   assert positions == sorted(positions)
-  # Step 1: import result with manifest + failed_sessions_view.
-  assert '"status": "imported"' in stdout
-  assert '"manifest": {' in stdout
-  assert '"generation_id"' in stdout
+  setup = stdout[positions[0] : positions[1]]
+  happened = stdout[positions[1] : positions[2]]
+  imported = stdout[positions[2] : positions[4]]
+  failed = stdout[positions[4] : positions[6]]
+  scored = stdout[positions[6] : positions[8]]
+  punchline = stdout[positions[8] :]
+  # 1. Setup: the protagonist session.
+  assert "support_agent" in setup
+  assert "real-user-0" in setup
+  assert "7e352c34-4c1c-4395-acd5-fb3c8f215346" in setup
+  assert "scenario_id:   7e352c34" in setup
+  # 2. What happened: the verbatim prompt and no answer.
+  assert "How many widgets are in stock?" in happened
+  assert "(no response)" in happened
+  assert "AGENT_STARTING" in happened
+  assert "no AGENT_COMPLETED" in happened
+  # 3. Import result with manifest + failed_sessions_view.
+  assert '"status": "imported"' in imported
+  assert '"manifest": {' in imported
+  assert '"generation_id"' in imported
   assert (
       '"failed_sessions_view": "analytics-project.bqaa.evalbench_failed_sessions"'
-      in stdout
+      in imported
   )
-  # Step 2: a failed-sessions table with versioned session ids.
-  assert "session_id" in stdout
-  assert "evalbench-import:gemini-cli-tools-2026-08-30:v1:read-file" in stdout
-  assert "session_count=4 failed_count=2" in stdout
-  # Step 3: a score report with details.evalbench.
-  assert '"details": {' in stdout
-  assert '"evalbench": {' in stdout
-  assert '"pinned_sessions": 4' in stdout
-  assert '"pass_rate": 0.75' in stdout
+  # 4. This session's one failed_sessions row, with the versioned id.
+  assert "session_id" in failed
+  assert "evalbench-import:mvp-e2e-real-traces:v1:7e352c34" in failed
+  assert "process_failed" in failed
+  assert "missing_completion" in failed
+  assert '[{"comparator": "goal_completion", "score": 0.0}]' in failed
+  assert "1 of 7 sessions failed" in failed
+  assert "session_count=7 failed_count=1" in failed
+  # 5. Score report with details.evalbench; the judge is not the denominator.
+  assert '"details": {' in scored
+  assert '"evalbench": {' in scored
+  assert '"pinned_sessions": 7' in scored
+  assert '"pass_rate": 1.0' in scored
+  assert '"llm_feedback": null' in scored
+  assert "goal_completion is 0.0" in scored
+  # 6. Punchline: exactly one sentence, then nothing else.
+  assert punchline.strip().splitlines()[1:] == [_PUNCHLINE]
 
 
-def test_fixture_flag_walks_three_steps_and_exits_zero() -> None:
+def test_fixture_flag_tells_the_session_story_and_exits_zero() -> None:
   result = _run("--fixture")
   assert result.returncode == 0, result.stderr
   assert result.stderr == ""
   assert "fixture mode" in result.stdout
+  assert _PUNCHLINE in result.stdout
   _assert_fixture_walkthrough(result.stdout)
 
 
@@ -109,7 +147,10 @@ def test_fixture_uses_supplied_names_without_bigquery() -> None:
       },
   )
   assert result.returncode == 0, result.stderr
-  assert "evalbench-import:gemini-cli-tools-42:v3:read-file" in result.stdout
+  # The names change; the protagonist session does not.
+  assert "evalbench-import:gemini-cli-tools-42:v3:7e352c34" in result.stdout
+  assert "How many widgets are in stock?" in result.stdout
+  assert _PUNCHLINE in result.stdout
   assert (
       '"failed_sessions_view": "my-analytics.mirror.evalbench_failed_sessions"'
       in result.stdout

--- a/tests/test_evalbench_mvp_e2e.py
+++ b/tests/test_evalbench_mvp_e2e.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``examples/evalbench_mvp_e2e.sh`` (#435 slice 5, #97).
+
+Only the offline ``--fixture`` path is exercised; nothing here reaches
+BigQuery. Live mode is checked only as far as "refuses to start without
+its environment", which also never reaches BigQuery.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1] / "examples" / "evalbench_mvp_e2e.sh"
+)
+
+_BANNERS = (
+    "=== Step 1: evalbench-import ===",
+    "=== Step 2: evalbench-failed-sessions ===",
+    "=== Step 3: evalbench-score ===",
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _run(*args: str, env: dict[str, str] | None = None):
+  # Start from a clean environment so a developer's exported
+  # EVALBENCH_* / BQ_AGENT_* values cannot change what is asserted.
+  clean = {
+      k: v
+      for k, v in os.environ.items()
+      if not k.startswith(("EVALBENCH_", "BQ_AGENT_"))
+  }
+  return subprocess.run(
+      ["bash", str(_SCRIPT), *args],
+      capture_output=True,
+      text=True,
+      timeout=60,
+      env={**clean, **(env or {})},
+  )
+
+
+def _assert_fixture_walkthrough(stdout: str) -> None:
+  for banner in _BANNERS:
+    assert banner in stdout
+  # Banners appear in pipeline order.
+  positions = [stdout.index(b) for b in _BANNERS]
+  assert positions == sorted(positions)
+  # Step 1: import result with manifest + failed_sessions_view.
+  assert '"status": "imported"' in stdout
+  assert '"manifest": {' in stdout
+  assert '"generation_id"' in stdout
+  assert (
+      '"failed_sessions_view": "analytics-project.bqaa.evalbench_failed_sessions"'
+      in stdout
+  )
+  # Step 2: a failed-sessions table with versioned session ids.
+  assert "session_id" in stdout
+  assert "evalbench-import:gemini-cli-tools-2026-08-30:v1:read-file" in stdout
+  assert "session_count=4 failed_count=2" in stdout
+  # Step 3: a score report with details.evalbench.
+  assert '"details": {' in stdout
+  assert '"evalbench": {' in stdout
+  assert '"pinned_sessions": 4' in stdout
+  assert '"pass_rate": 0.75' in stdout
+
+
+def test_fixture_flag_walks_three_steps_and_exits_zero() -> None:
+  result = _run("--fixture")
+  assert result.returncode == 0, result.stderr
+  assert result.stderr == ""
+  assert "fixture mode" in result.stdout
+  _assert_fixture_walkthrough(result.stdout)
+
+
+def test_fixture_env_var_is_honored() -> None:
+  result = _run(env={"EVALBENCH_FIXTURE": "1"})
+  assert result.returncode == 0, result.stderr
+  _assert_fixture_walkthrough(result.stdout)
+
+
+def test_fixture_uses_supplied_names_without_bigquery() -> None:
+  result = _run(
+      "--fixture",
+      env={
+          "BQ_AGENT_PROJECT": "my-analytics",
+          "BQ_AGENT_DATASET": "mirror",
+          "EVALBENCH_JOB_ID": "gemini-cli-tools-42",
+          "EVALBENCH_IMPORT_VERSION": "v3",
+      },
+  )
+  assert result.returncode == 0, result.stderr
+  assert "evalbench-import:gemini-cli-tools-42:v3:read-file" in result.stdout
+  assert (
+      '"failed_sessions_view": "my-analytics.mirror.evalbench_failed_sessions"'
+      in result.stdout
+  )
+  assert '"import_version": "v3"' in result.stdout
+
+
+def test_live_mode_requires_environment_before_any_command() -> None:
+  result = _run()
+  assert result.returncode == 1
+  assert "BQ_AGENT_PROJECT" in result.stderr
+  assert "=== Step 1" not in result.stdout
+
+
+def test_unknown_argument_is_rejected() -> None:
+  result = _run("--bogus")
+  assert result.returncode == 2
+  assert "unknown argument '--bogus'" in result.stderr

--- a/tests/test_evalbench_mvp_e2e.py
+++ b/tests/test_evalbench_mvp_e2e.py
@@ -128,3 +128,43 @@ def test_unknown_argument_is_rejected() -> None:
   result = _run("--bogus")
   assert result.returncode == 2
   assert "unknown argument '--bogus'" in result.stderr
+
+
+def test_synth_mode_rejects_split_projects_before_any_command() -> None:
+  # --synth builds the EvalBench-shaped dataset and the mirror dataset in one
+  # project, so split projects stop the script before step 0 runs anything.
+  result = _run(
+      "--synth",
+      env={
+          "BQ_AGENT_PROJECT": "analytics-project",
+          "EVALBENCH_PROJECT": "benchmark-project",
+          "EVALBENCH_PYTHON": "/nonexistent/python",
+      },
+  )
+  assert result.returncode == 1
+  assert "EVALBENCH_PROJECT=benchmark-project differs" in result.stderr
+  assert "=== Step 0" not in result.stdout
+
+
+def test_synth_mode_defaults_names_and_runs_step_zero_first() -> None:
+  # With a project set, --synth fills in the demo's dataset/job defaults and
+  # step 0 is the first thing it runs. An interpreter that cannot start makes
+  # step 0 fail (exit 2) before any BigQuery call.
+  result = _run(
+      "--synth",
+      env={
+          "BQ_AGENT_PROJECT": "analytics-project",
+          "EVALBENCH_PYTHON": "/nonexistent/python",
+      },
+  )
+  assert result.returncode == 2
+  assert "=== Step 0: synthesize EvalBench tables from real traces ===" in (
+      result.stdout
+  )
+  assert "=== Step 1" not in result.stdout
+  assert (
+      "job mvp-e2e-real-traces (analytics-project.bqaa_evalbench_mvp_demo ->"
+      " analytics-project.bqaa_evalbench_mvp_mirror)"
+  ) in result.stdout
+  assert "bqaa_e2e_real.agent_events ->" in result.stdout
+  assert "step failed: /nonexistent/python" in result.stderr

--- a/tests/test_evalbench_synth_from_traces.py
+++ b/tests/test_evalbench_synth_from_traces.py
@@ -27,6 +27,7 @@ import json
 
 import pytest
 
+from bigquery_agent_analytics.evalbench import classify_sessions
 from bigquery_agent_analytics.evalbench import EvalBenchRun
 from examples import evalbench_synth_from_traces as synth
 
@@ -685,3 +686,86 @@ def test_scenario_id_encoding_is_deterministic_and_injective() -> None:
   assert ids[("s", "", None)] == "s::~"
   assert ids[("", None, None)] == ":~:~"
   assert all(value.strip() for value in ids.values())
+
+
+def test_completed_trace_with_source_error_stays_a_failed_session() -> None:
+  # Codex P1 (round 3) on PR #455: a trace can reach AGENT_COMPLETED with
+  # status=ERROR / error_message and no TOOL_ERROR at all. The synthesizer
+  # used to write that failure only to results.error_message, which the
+  # importer does not read, so the session round-tripped as status=OK and
+  # the failed-sessions view reported process_failed=false.
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+      _event("s1", "LLM_RESPONSE", {"response": "partial answer"}, offset=1),
+      _event(
+          "s1",
+          "AGENT_COMPLETED",
+          None,
+          offset=2,
+          status="ERROR",
+          error_message="model call failed: 503",
+      ),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  (result,) = tables.results
+  # Completion and goal_completion stay tied to AGENT_COMPLETED ...
+  assert result["returncode"] == 0
+  assert tables.scores[0]["score"] == 1.0
+  # ... but the failure is emitted in an importer-recognized field and kept
+  # verbatim for provenance.
+  assert result["error"] == "model call failed: 503"
+  assert result["error_message"] == "model call failed: 503"
+  assert "error" in [name for name, _, _ in synth._RESULT_SCHEMA]
+
+  run = EvalBenchRun(
+      project_id="p",
+      evalbench_dataset="d",
+      job_id="j",
+      results=tuple(tables.results),
+      scores=tuple(tables.scores),
+      config_rows=tuple(tables.configs),
+  )
+  rows = run.to_agent_event_rows(import_version="v1")
+  assert [r["event_type"] for r in rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "AGENT_COMPLETED",
+  ]
+  terminal = rows[-1]
+  assert terminal["status"] == "ERROR"
+  assert "model call failed: 503" in terminal["error_message"]
+  (verdict,) = classify_sessions(rows, run.to_score_rows(import_version="v1"))
+  assert verdict.process_failed is True
+  assert verdict.missing_completion is False
+
+
+def test_tool_error_alone_does_not_mark_the_completion_row_as_error() -> None:
+  # A recovered tool error is already a TOOL_ERROR row (status=ERROR); it
+  # must not also be promoted to a session-level ``error``.
+  tables = synth.synthesize(_events(), job_id="j", source_table="t")
+  done = next(
+      r for r in tables.results if r["source_session_id"] == _SESSION_DONE
+  )
+  assert done["error"] is None
+  assert done["error_message"] == "inventory backend timed out"
+
+
+def test_clean_completed_trace_has_no_error_field() -> None:
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+      _event("s1", "AGENT_COMPLETED", {"text": "done"}, offset=1),
+  ]
+  (result,) = synth.synthesize(events, job_id="j", source_table="t").results
+  assert result["error"] is None
+  assert result["error_message"] is None
+
+
+def test_non_tool_error_status_without_message_is_still_an_error() -> None:
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+      _event("s1", "LLM_RESPONSE", {"response": "x"}, offset=1, status="ERROR"),
+      _event("s1", "AGENT_COMPLETED", None, offset=2),
+  ]
+  (result,) = synth.synthesize(events, job_id="j", source_table="t").results
+  assert result["returncode"] == 0
+  assert result["error"] == "LLM_RESPONSE status=ERROR"
+  assert result["error_message"] is None

--- a/tests/test_evalbench_synth_from_traces.py
+++ b/tests/test_evalbench_synth_from_traces.py
@@ -1,0 +1,296 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``examples/evalbench_synth_from_traces.py`` (#435 slice 5, #97).
+
+The synthesizer's mapping is exercised on a tiny in-memory event list shaped
+like ``agent_events`` rows; nothing here reaches BigQuery. The synthesized
+rows are then fed through ``EvalBenchRun.to_agent_event_rows`` /
+``to_score_rows`` to prove the importer accepts what the synthesizer emits.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+import pytest
+
+from bigquery_agent_analytics.evalbench import EvalBenchRun
+from examples import evalbench_synth_from_traces as synth
+
+_T0 = datetime(2026, 7, 27, 20, 30, 39, tzinfo=timezone.utc)
+_SESSION_DONE = "29ae300e-986c-42b9-83ec-8d38898f6062"
+_SESSION_STUCK = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+_SESSION_NO_PROMPT = "ffffffff-0000-0000-0000-000000000000"
+
+
+def _event(session_id, event_type, content, *, offset=0, status="OK", **extra):
+  row = {
+      "timestamp": _T0.replace(second=39 + offset),
+      "event_type": event_type,
+      "agent": "support_agent",
+      "session_id": session_id,
+      "content": content,
+      "attributes": {
+          "adk": {"app_name": "bqaa-e2e", "schema_version": "1"},
+          "root_agent_name": "support_agent",
+      },
+      "status": status,
+      "error_message": None,
+  }
+  row.update(extra)
+  return row
+
+
+def _content(value):
+  return json.loads(value) if isinstance(value, str) else value
+
+
+def _events():
+  return [
+      # A completed session with two tool calls; the final text lives on
+      # AGENT_RESPONSE because the plugin logs AGENT_COMPLETED with no content.
+      _event(
+          _SESSION_DONE,
+          "USER_MESSAGE_RECEIVED",
+          {"text_summary": "Check inventory for widget and doohickey."},
+      ),
+      _event(
+          _SESSION_DONE, "AGENT_STARTING", "You are a support agent.", offset=1
+      ),
+      _event(
+          _SESSION_DONE,
+          "TOOL_STARTING",
+          {"tool": "check_inventory", "args": {"item": "widget"}},
+          offset=2,
+      ),
+      _event(
+          _SESSION_DONE,
+          "TOOL_COMPLETED",
+          {"tool": "check_inventory", "result": {"in_stock": 42}},
+          offset=2,
+      ),
+      _event(
+          _SESSION_DONE,
+          "TOOL_STARTING",
+          {"tool": "check_inventory", "args": {"item": "doohickey"}},
+          offset=3,
+      ),
+      _event(
+          _SESSION_DONE,
+          "TOOL_ERROR",
+          {"tool": "check_inventory", "result": None},
+          offset=3,
+          status="ERROR",
+          error_message="inventory backend timed out",
+      ),
+      _event(
+          _SESSION_DONE,
+          "AGENT_RESPONSE",
+          {"response": "text: 'There are 42 widgets in stock.'"},
+          offset=4,
+      ),
+      # content as a JSON *string*, as TO_JSON_STRING(content) returns it.
+      _event(_SESSION_DONE, "AGENT_COMPLETED", "null", offset=4),
+      # A session that never completed: only the prompt and AGENT_STARTING.
+      _event(
+          _SESSION_STUCK,
+          "USER_MESSAGE_RECEIVED",
+          json.dumps({"text_summary": "How many widgets are in stock?"}),
+      ),
+      _event(
+          _SESSION_STUCK, "AGENT_STARTING", "You are a support agent.", offset=1
+      ),
+      # A session with no user prompt at all: must be skipped, never invented.
+      _event(_SESSION_NO_PROMPT, "AGENT_STARTING", "You are a support agent."),
+      _event(_SESSION_NO_PROMPT, "AGENT_COMPLETED", None, offset=1),
+  ]
+
+
+def test_one_result_per_prompted_session_with_real_text() -> None:
+  tables = synth.synthesize(
+      _events(), job_id="mvp-e2e-real-traces", source_table="p.d.agent_events"
+  )
+  assert [r["id"] for r in tables.results] == ["29ae300e", "7e352c34"]
+  assert tables.skipped_sessions == [_SESSION_NO_PROMPT]
+
+  done, stuck = tables.results
+  assert done["eval_id"] == done["id"] == "29ae300e"
+  assert done["job_id"] == "mvp-e2e-real-traces"
+  assert done["prompt"] == done["nl_prompt"]
+  assert done["prompt"] == "Check inventory for widget and doohickey."
+  assert done["final_response"] == "text: 'There are 42 widgets in stock.'"
+  assert done["stdout"] == done["final_response"]
+  assert done["returncode"] == 0
+  assert done["run_time"] == _T0
+  assert done["source_session_id"] == _SESSION_DONE
+  assert done["source_table"] == "p.d.agent_events"
+  assert done["error_message"] == "inventory backend timed out"
+  tool_calls = json.loads(done["tool_calls"])
+  assert [c["tool_name"] for c in tool_calls] == [
+      "check_inventory",
+      "check_inventory",
+  ]
+  assert tool_calls[0]["args"] == {"item": "widget"}
+  assert tool_calls[0]["result"] == {"in_stock": 42}
+  assert tool_calls[0].get("error") is None
+  assert tool_calls[1]["args"] == {"item": "doohickey"}
+  assert tool_calls[1]["error"] == "inventory backend timed out"
+
+  assert stuck["prompt"] == "How many widgets are in stock?"
+  assert stuck["returncode"] == 1
+  assert "final_response" not in stuck
+  assert "stdout" not in stuck
+  assert stuck["tool_calls"] == "[]"
+
+
+def test_scores_and_configs_follow_completion() -> None:
+  tables = synth.synthesize(
+      _events(), job_id="mvp-e2e-real-traces", source_table="p.d.agent_events"
+  )
+  assert tables.scores == [
+      {
+          "job_id": "mvp-e2e-real-traces",
+          "id": "29ae300e",
+          "eval_id": "29ae300e",
+          "comparator": "goal_completion",
+          "score": 1.0,
+          "run_time": _T0,
+          "source_session_id": _SESSION_DONE,
+      },
+      {
+          "job_id": "mvp-e2e-real-traces",
+          "id": "7e352c34",
+          "eval_id": "7e352c34",
+          "comparator": "goal_completion",
+          "score": 0.0,
+          "run_time": _T0,
+          "source_session_id": _SESSION_STUCK,
+      },
+  ]
+  configs = {row["config"]: row["value"] for row in tables.configs}
+  assert configs == {
+      "experiment_config.orchestrator": "support_agent",
+      "model_config.generator": "bqaa-e2e",
+      "bqaa.source_table": "p.d.agent_events",
+  }
+  assert {row["job_id"] for row in tables.configs} == {"mvp-e2e-real-traces"}
+  # The earliest prompt timestamp, not "now": the rows are deterministic so
+  # a re-run of the synthesizer reproduces the importer's fingerprints.
+  assert {row["run_time"] for row in tables.configs} == {_T0}
+
+
+def test_synthesized_rows_round_trip_through_the_importer() -> None:
+  tables = synth.synthesize(
+      _events(), job_id="mvp-e2e-real-traces", source_table="p.d.agent_events"
+  )
+  run = EvalBenchRun(
+      project_id="p",
+      evalbench_dataset="bqaa_evalbench_mvp_demo",
+      job_id="mvp-e2e-real-traces",
+      results=tuple(tables.results),
+      scores=tuple(tables.scores),
+      config_rows=tuple(tables.configs),
+  )
+  rows = run.to_agent_event_rows(import_version="v1")
+  by_session: dict[str, list[str]] = {}
+  for row in rows:
+    by_session.setdefault(row["session_id"], []).append(row["event_type"])
+  done = "evalbench-import:mvp-e2e-real-traces:v1:29ae300e"
+  stuck = "evalbench-import:mvp-e2e-real-traces:v1:7e352c34"
+  assert by_session == {
+      done: [
+          "USER_MESSAGE_RECEIVED",
+          "TOOL_STARTING",
+          "TOOL_COMPLETED",
+          "TOOL_STARTING",
+          "TOOL_ERROR",
+          "AGENT_COMPLETED",
+      ],
+      stuck: ["USER_MESSAGE_RECEIVED"],
+  }
+  prompts = {
+      row["session_id"]: _content(row["content"])["text"]
+      for row in rows
+      if row["event_type"] == "USER_MESSAGE_RECEIVED"
+  }
+  assert prompts == {
+      done: "Check inventory for widget and doohickey.",
+      stuck: "How many widgets are in stock?",
+  }
+  assert {row["agent"] for row in rows} == {"evalbench:support_agent:bqaa-e2e"}
+
+  score_rows = run.to_score_rows(import_version="v1")
+  assert [
+      (r["session_id"], r["comparator"], r["score"]) for r in score_rows
+  ] == [
+      (done, "goal_completion", 1.0),
+      (stuck, "goal_completion", 0.0),
+  ]
+
+
+def test_short_scenario_ids_fall_back_to_full_session_id_on_collision() -> None:
+  events = [
+      _event("29ae300e-aaaa", "USER_MESSAGE_RECEIVED", {"text_summary": "a"}),
+      _event("29ae300e-bbbb", "USER_MESSAGE_RECEIVED", {"text_summary": "b"}),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert [r["id"] for r in tables.results] == ["29ae300e-aaaa", "29ae300e-bbbb"]
+
+
+def test_prompt_prefers_text_summary_then_text_and_rejects_blank() -> None:
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text": "from text field"}),
+      _event("s2", "USER_MESSAGE_RECEIVED", {"text_summary": "   "}),
+      _event("s2", "AGENT_COMPLETED", None, offset=1),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert [(r["id"], r["prompt"]) for r in tables.results] == [
+      ("s1", "from text field")
+  ]
+  assert tables.skipped_sessions == ["s2"]
+
+
+def test_no_prompted_sessions_is_an_error() -> None:
+  with pytest.raises(ValueError, match="no session"):
+    synth.synthesize(
+        [_event("s1", "AGENT_STARTING", "x")], job_id="j", source_table="t"
+    )
+
+
+def test_target_dataset_must_differ_from_source() -> None:
+  with pytest.raises(ValueError, match="must not"):
+    synth.check_targets(
+        source_table="p.bqaa_e2e_real.agent_events",
+        evalbench_dataset="bqaa_e2e_real",
+        mirror_dataset="bqaa_evalbench_mvp_mirror",
+    )
+  with pytest.raises(ValueError, match="must not"):
+    synth.check_targets(
+        source_table="p.bqaa_e2e_real.agent_events",
+        evalbench_dataset="bqaa_evalbench_mvp_demo",
+        mirror_dataset="agent_analytics",
+    )
+  with pytest.raises(ValueError, match="must differ"):
+    synth.check_targets(
+        source_table="p.bqaa_e2e_real.agent_events",
+        evalbench_dataset="same",
+        mirror_dataset="same",
+    )
+  synth.check_targets(
+      source_table="p.bqaa_e2e_real.agent_events",
+      evalbench_dataset="bqaa_evalbench_mvp_demo",
+      mirror_dataset="bqaa_evalbench_mvp_mirror",
+  )

--- a/tests/test_evalbench_synth_from_traces.py
+++ b/tests/test_evalbench_synth_from_traces.py
@@ -61,7 +61,8 @@ def _content(value):
 def _events():
   return [
       # A completed session with two tool calls; the final text lives on
-      # AGENT_RESPONSE because the plugin logs AGENT_COMPLETED with no content.
+      # LLM_RESPONSE (the SDK contract) because the ADK plugin logs
+      # AGENT_COMPLETED with no content.
       _event(
           _SESSION_DONE,
           "USER_MESSAGE_RECEIVED",
@@ -98,7 +99,7 @@ def _events():
       ),
       _event(
           _SESSION_DONE,
-          "AGENT_RESPONSE",
+          "LLM_RESPONSE",
           {"response": "text: 'There are 42 widgets in stock.'"},
           offset=4,
       ),
@@ -136,6 +137,8 @@ def test_one_result_per_prompted_session_with_real_text() -> None:
   assert done["returncode"] == 0
   assert done["run_time"] == _T0
   assert done["source_session_id"] == _SESSION_DONE
+  assert done["source_user_id"] is None
+  assert done["source_root_agent_name"] == "support_agent"
   assert done["source_table"] == "p.d.agent_events"
   assert done["error_message"] == "inventory backend timed out"
   tool_calls = json.loads(done["tool_calls"])
@@ -169,6 +172,8 @@ def test_scores_and_configs_follow_completion() -> None:
           "score": 1.0,
           "run_time": _T0,
           "source_session_id": _SESSION_DONE,
+          "source_user_id": None,
+          "source_root_agent_name": "support_agent",
       },
       {
           "job_id": "mvp-e2e-real-traces",
@@ -178,6 +183,8 @@ def test_scores_and_configs_follow_completion() -> None:
           "score": 0.0,
           "run_time": _T0,
           "source_session_id": _SESSION_STUCK,
+          "source_user_id": None,
+          "source_root_agent_name": "support_agent",
       },
   ]
   configs = {row["config"]: row["value"] for row in tables.configs}
@@ -264,7 +271,7 @@ def test_prompt_prefers_text_summary_then_text_and_rejects_blank() -> None:
 
 
 def test_no_prompted_sessions_is_an_error() -> None:
-  with pytest.raises(ValueError, match="no session"):
+  with pytest.raises(ValueError, match="no trace"):
     synth.synthesize(
         [_event("s1", "AGENT_STARTING", "x")], job_id="j", source_table="t"
     )
@@ -294,3 +301,229 @@ def test_target_dataset_must_differ_from_source() -> None:
       evalbench_dataset="bqaa_evalbench_mvp_demo",
       mirror_dataset="bqaa_evalbench_mvp_mirror",
   )
+
+
+def test_llm_response_is_the_final_response_when_completed_has_no_content() -> (
+    None
+):
+  # Codex P1 on PR #455: the ADK plugin emits USER_MESSAGE_RECEIVED ->
+  # LLM_RESPONSE -> AGENT_COMPLETED(no content). LLM_RESPONSE is the SDK's
+  # response event (event_semantics.RESPONSE_EVENT_TYPES), so its text must
+  # become final_response instead of a phantom "completed but never answered".
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+      _event("s1", "LLM_RESPONSE", {"response": "first draft"}, offset=1),
+      _event("s1", "LLM_RESPONSE", {"response": "hello there"}, offset=2),
+      _event("s1", "AGENT_COMPLETED", None, offset=3),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  (row,) = tables.results
+  assert row["returncode"] == 0
+  assert row["final_response"] == "hello there"
+  assert row["stdout"] == "hello there"
+  run = EvalBenchRun(
+      project_id="p",
+      evalbench_dataset="d",
+      job_id="j",
+      results=tuple(tables.results),
+      scores=tuple(tables.scores),
+      config_rows=tuple(tables.configs),
+  )
+  event_types = [
+      r["event_type"] for r in run.to_agent_event_rows(import_version="v1")
+  ]
+  assert event_types == ["USER_MESSAGE_RECEIVED", "AGENT_COMPLETED"]
+
+
+def test_agent_response_remains_a_compatibility_alias() -> None:
+  events = [
+      _event("s1", "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+      _event("s1", "AGENT_RESPONSE", {"response": "legacy name"}, offset=1),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.results[0]["final_response"] == "legacy name"
+  assert tables.results[0]["returncode"] == 1
+
+
+def test_reused_session_id_across_identities_is_never_spliced() -> None:
+  # Codex P1 on PR #455: BQAA trace identity is (session_id, user_id,
+  # root_agent_name). Two traces sharing a session_id must become two
+  # scenarios, each with its own prompt and response, never one row with
+  # user A's prompt and user B's answer.
+  def trace(user_id, root_agent_name, prompt, answer, offset):
+    attrs = {
+        "adk": {"app_name": "bqaa-e2e"},
+        "root_agent_name": root_agent_name,
+    }
+    return [
+        _event(
+            "reused",
+            "USER_MESSAGE_RECEIVED",
+            {"text_summary": prompt},
+            offset=offset,
+            user_id=user_id,
+            attributes=attrs,
+        ),
+        _event(
+            "reused",
+            "LLM_RESPONSE",
+            {"response": answer},
+            offset=offset + 1,
+            user_id=user_id,
+            attributes=attrs,
+        ),
+        _event(
+            "reused",
+            "AGENT_COMPLETED",
+            None,
+            offset=offset + 2,
+            user_id=user_id,
+            attributes=attrs,
+        ),
+    ]
+
+  events = (
+      trace("user-a", "support_agent", "prompt A", "answer A", 0)
+      + trace("user-b", "support_agent", "prompt B", "answer B", 4)
+      # Same user, different root agent: still a distinct trace.
+      + trace("user-a", "billing_agent", "prompt C", "answer C", 8)
+  )
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.skipped_sessions == []
+  by_id = {
+      r["id"]: (
+          r["prompt"],
+          r["final_response"],
+          r["source_user_id"],
+          r["source_root_agent_name"],
+      )
+      for r in tables.results
+  }
+  assert by_id == {
+      "reused:user-a:support_agent": (
+          "prompt A",
+          "answer A",
+          "user-a",
+          "support_agent",
+      ),
+      "reused:user-b:support_agent": (
+          "prompt B",
+          "answer B",
+          "user-b",
+          "support_agent",
+      ),
+      "reused:user-a:billing_agent": (
+          "prompt C",
+          "answer C",
+          "user-a",
+          "billing_agent",
+      ),
+  }
+  assert {r["source_session_id"] for r in tables.results} == {"reused"}
+  # Scores carry the same identity as results, one per trace.
+  assert sorted(
+      (s["id"], s["source_user_id"], s["source_root_agent_name"])
+      for s in tables.scores
+  ) == sorted(
+      (r["id"], r["source_user_id"], r["source_root_agent_name"])
+      for r in tables.results
+  )
+  # The three traces stay distinct through the importer as well.
+  run = EvalBenchRun(
+      project_id="p",
+      evalbench_dataset="d",
+      job_id="j",
+      results=tuple(tables.results),
+      scores=tuple(tables.scores),
+      config_rows=tuple(tables.configs),
+  )
+  sessions = {
+      r["session_id"] for r in run.to_agent_event_rows(import_version="v1")
+  }
+  assert len(sessions) == 3
+
+
+def test_top_level_root_agent_name_column_wins_over_attributes() -> None:
+  # The reader query projects root_agent_name from attributes; rows that
+  # carry the column already use it as-is.
+  events = [
+      _event(
+          "s1",
+          "USER_MESSAGE_RECEIVED",
+          {"text_summary": "a"},
+          root_agent_name="from_column",
+      ),
+  ]
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.results[0]["source_root_agent_name"] == "from_column"
+
+
+class _NeverQueriedClient:
+  """A fake BigQuery client that fails the test if any SQL reaches it."""
+
+  def __init__(self):
+    self.queries = []
+
+  def query(self, query, **kwargs):  # pragma: no cover - must not run
+    self.queries.append(query)
+    raise AssertionError(f"client.query must not be reached: {query!r}")
+
+
+_HOSTILE_TABLES = [
+    "d.t` WHERE FALSE; SELECT 1; --",
+    "d.t`; DROP TABLE x; --",
+    "d.t -- comment",
+    "d.`t`",
+    "d.t;",
+    "d. t",
+    "d.t\n",
+    "d.t.u.v",
+    "t",
+    "",
+]
+
+
+@pytest.mark.parametrize("table", _HOSTILE_TABLES)
+def test_hostile_source_table_fails_before_client_query(table) -> None:
+  # Codex P1 on PR #455: --source-table is interpolated into SQL between
+  # backticks, so every segment must satisfy the repository's identifier
+  # policy (^[A-Za-z0-9_-]+$) before any statement is formatted.
+  client = _NeverQueriedClient()
+  with pytest.raises(ValueError):
+    synth.load_events(client, source_table=table, location="US")
+  assert client.queries == []
+  with pytest.raises(ValueError):
+    synth._qualify("p", table)
+
+
+def test_hostile_identifiers_fail_before_the_client_is_created(
+    monkeypatch,
+) -> None:
+  from google.cloud import bigquery
+
+  def _no_client(*args, **kwargs):  # pragma: no cover - must not run
+    raise AssertionError("bigquery.Client must not be created")
+
+  monkeypatch.setattr(bigquery, "Client", _no_client)
+  base = ["--project", "p", "--dry-run"]
+  hostile = "d.t` WHERE FALSE; SELECT 1; --"
+  with pytest.raises(ValueError, match="--source-table table"):
+    synth.main(base + ["--source-table", hostile])
+  with pytest.raises(ValueError, match="--source-table dataset"):
+    synth.main(base + ["--source-table", "bad dataset.t"])
+  with pytest.raises(ValueError, match="--source-table project"):
+    synth.main(base + ["--source-table", "pro`ject.d.t"])
+  with pytest.raises(ValueError, match="--project"):
+    synth.main(["--project", "p;", "--dry-run", "--source-table", "d.t"])
+  with pytest.raises(ValueError, match="--evalbench-dataset"):
+    synth.main(base + ["--source-table", "d.t", "--evalbench-dataset", "x`y"])
+  with pytest.raises(ValueError, match="--mirror-dataset"):
+    synth.main(base + ["--source-table", "d.t", "--mirror-dataset", "x;y"])
+
+
+def test_qualify_accepts_plain_identifiers() -> None:
+  assert synth._qualify("p", "d.t") == "p.d.t"
+  assert synth._qualify("my-proj", "bqaa_e2e_real.agent_events") == (
+      "my-proj.bqaa_e2e_real.agent_events"
+  )
+  assert synth._qualify("p", "other-proj.d.t") == "other-proj.d.t"

--- a/tests/test_evalbench_synth_from_traces.py
+++ b/tests/test_evalbench_synth_from_traces.py
@@ -527,3 +527,161 @@ def test_qualify_accepts_plain_identifiers() -> None:
       "my-proj.bqaa_e2e_real.agent_events"
   )
   assert synth._qualify("p", "other-proj.d.t") == "other-proj.d.t"
+
+
+def _trace(session_id, user_id, root_agent_name, prompt, answer, offset):
+  """One prompt → LLM_RESPONSE → AGENT_COMPLETED trace with exact identity."""
+  attrs = {"adk": {"app_name": "bqaa-e2e"}, "root_agent_name": root_agent_name}
+  return [
+      _event(
+          session_id,
+          "USER_MESSAGE_RECEIVED",
+          {"text_summary": prompt},
+          offset=offset,
+          user_id=user_id,
+          root_agent_name=root_agent_name,
+          attributes=attrs,
+      ),
+      _event(
+          session_id,
+          "LLM_RESPONSE",
+          {"response": answer},
+          offset=offset + 1,
+          user_id=user_id,
+          root_agent_name=root_agent_name,
+          attributes=attrs,
+      ),
+      _event(
+          session_id,
+          "AGENT_COMPLETED",
+          None,
+          offset=offset + 2,
+          user_id=user_id,
+          root_agent_name=root_agent_name,
+          attributes=attrs,
+      ),
+  ]
+
+
+def _imported_sessions(tables):
+  run = EvalBenchRun(
+      project_id="p",
+      evalbench_dataset="d",
+      job_id="j",
+      results=tuple(tables.results),
+      scores=tuple(tables.scores),
+      config_rows=tuple(tables.configs),
+  )
+  return {r["session_id"] for r in run.to_agent_event_rows(import_version="v1")}
+
+
+def test_null_and_empty_identity_dimensions_are_distinct_traces() -> None:
+  # Codex P1 (round 2) on PR #455: the SDK's TraceIdentity distinguishes
+  # SQL NULL from the empty string. user_id=None and user_id="" on the
+  # same session/root agent are two traces; neither prompt may be paired
+  # with the other's answer.
+  events = _trace("shared", None, "support_agent", "prompt N", "answer N", 0)
+  events += _trace("shared", "", "support_agent", "prompt E", "answer E", 4)
+  events += _trace("shared", "user-a", None, "prompt R", "answer R", 8)
+  events += _trace("shared", "user-a", "", "prompt S", "answer S", 12)
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.skipped_sessions == []
+  by_id = {
+      r["id"]: (
+          r["prompt"],
+          r["final_response"],
+          r["source_user_id"],
+          r["source_root_agent_name"],
+      )
+      for r in tables.results
+  }
+  assert by_id == {
+      "shared:~:support_agent": ("prompt N", "answer N", None, "support_agent"),
+      "shared::support_agent": ("prompt E", "answer E", "", "support_agent"),
+      "shared:user-a:~": ("prompt R", "answer R", "user-a", None),
+      "shared:user-a:": ("prompt S", "answer S", "user-a", ""),
+  }
+  assert sorted(
+      (s["id"], s["source_user_id"], s["source_root_agent_name"])
+      for s in tables.scores
+  ) == sorted(
+      (r["id"], r["source_user_id"], r["source_root_agent_name"])
+      for r in tables.results
+  )
+  assert len(_imported_sessions(tables)) == 4
+
+
+def test_whitespace_distinct_identities_stay_separate() -> None:
+  # Exact strings: " user-a" / "user-a " / "user-a" are three users, and
+  # "sess" / "sess " are two sessions. Nothing in the identity is stripped.
+  events = _trace("sess", "user-a", "support_agent", "p1", "a1", 0)
+  events += _trace("sess", " user-a", "support_agent", "p2", "a2", 4)
+  events += _trace("sess", "user-a ", "support_agent", "p3", "a3", 8)
+  events += _trace("sess ", "user-a", "support_agent", "p4", "a4", 12)
+  events += _trace("sess", "user-a", " support_agent", "p5", "a5", 16)
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.skipped_sessions == []
+  assert sorted(
+      (r["source_session_id"], r["source_user_id"], r["source_root_agent_name"])
+      for r in tables.results
+  ) == [
+      ("sess", " user-a", "support_agent"),
+      ("sess", "user-a", " support_agent"),
+      ("sess", "user-a", "support_agent"),
+      ("sess", "user-a ", "support_agent"),
+      ("sess ", "user-a", "support_agent"),
+  ]
+  assert {(r["prompt"], r["final_response"]) for r in tables.results} == {
+      ("p1", "a1"),
+      ("p2", "a2"),
+      ("p3", "a3"),
+      ("p4", "a4"),
+      ("p5", "a5"),
+  }
+  assert len({r["id"] for r in tables.results}) == 5
+  assert len(_imported_sessions(tables)) == 5
+
+
+def test_scenario_ids_are_injective_for_delimiter_bearing_identities() -> None:
+  # Codex P1 (round 2) on PR #455: a raw ":" join mapped ("shared","a:b","c")
+  # and ("shared","a","b:c") to the same id and the synthesizer aborted.
+  # Components are percent-escaped, so boundaries survive and NULL ("~")
+  # differs from "" and from a literal "~".
+  events = _trace("shared", "a:b", "c", "p1", "a1", 0)
+  events += _trace("shared", "a", "b:c", "p2", "a2", 3)
+  events += _trace("shared", "a%3Ab", "c", "p3", "a3", 6)
+  events += _trace("shared", "~", "c", "p4", "a4", 9)
+  events += _trace("shared", None, "c", "p5", "a5", 12)
+  events += _trace("shared:a", "b", "c", "p6", "a6", 15)
+  tables = synth.synthesize(events, job_id="j", source_table="t")
+  assert tables.skipped_sessions == []
+  by_id = {r["id"]: (r["prompt"], r["final_response"]) for r in tables.results}
+  assert by_id == {
+      "shared:a%3Ab:c": ("p1", "a1"),
+      "shared:a:b%3Ac": ("p2", "a2"),
+      "shared:a%253Ab:c": ("p3", "a3"),
+      "shared:%7E:c": ("p4", "a4"),
+      "shared:~:c": ("p5", "a5"),
+      "shared%3Aa:b:c": ("p6", "a6"),
+  }
+  assert len(_imported_sessions(tables)) == 6
+
+
+def test_scenario_id_encoding_is_deterministic_and_injective() -> None:
+  keys = [
+      ("s", "a:b", "c"),
+      ("s", "a", "b:c"),
+      ("s", None, ""),
+      ("s", "", None),
+      ("s", "~", "%"),
+      ("s", "%7E", "%25"),
+      ("", None, None),
+      (" ", None, None),
+  ]
+  ids = synth._scenario_ids(keys)
+  assert len(set(ids.values())) == len(keys)
+  assert ids == synth._scenario_ids(list(reversed(keys)))
+  assert ids[("s", None, "")] == "s:~:"
+  assert ids[("s", "", None)] == "s::~"
+  assert ids[("", None, None)] == ":~:~"
+  assert all(value.strip() for value in ids.values())


### PR DESCRIPTION
## Summary

Slice 5 of #435 (and the demo half of #97): a recordable end-to-end MVP demo that walks the three EvalBench CLI steps in order on one job.

- `examples/evalbench_mvp_e2e.sh` — **Step 1** `bq-agent-sdk evalbench-import` (source EvalBench BQ → BQAA mirror + manifest + `evalbench_failed_sessions` view) → **Step 2** `bq-agent-sdk evalbench-failed-sessions` (the W0.4 denominator for that one version) → **Step 3** `bq-agent-sdk evalbench-score` (LLM judge over that same version; `details.evalbench` names it). One `=== Step N: … ===` banner per step, driven by `BQ_AGENT_PROJECT`, `BQ_AGENT_DATASET`, `EVALBENCH_PROJECT`, `EVALBENCH_DATASET`, `EVALBENCH_JOB_ID`, optional `EVALBENCH_IMPORT_VERSION` (pins all three steps).
- **`--fixture` / `EVALBENCH_FIXTURE=1` is the offline path**: no BigQuery call, no live CLI invocation; prints annotated sample output shaped like each command's real output (import result with `manifest` + `failed_sessions_view`, a small failed-sessions table, a score report with `details.evalbench`) and exits 0. This is what we record and what CI runs.
- `examples/evalbench_mvp_e2e.md` — walkthrough: each step, what you should see, env vars, `--fixture` vs live, gemini-cli-tools as the intended job family, links to `docs/evalbench.md`, #435, #97.
- Pointers in `docs/evalbench.md` (CLI section) and `examples/README.md`; CHANGELOG Unreleased/Added slice-5 bullet (the 452 failed-sessions and 453 evalbench-score bullets are kept).
- `tests/test_evalbench_mvp_e2e.py` — runs the script via subprocess: `--fixture` and `EVALBENCH_FIXTURE=1` exit 0 with the three banners in order and the expected keywords; supplied env names flow into the sample output; live mode without env exits 1 before any command; unknown flag exits 2. Never touches BigQuery.

No Python/CLI behavior changes. `examples/evalbench_score_gate.sh` is untouched and stays the CI gate (step 3 alone with `--exit-code`); this script is the full pipeline walkthrough and does not gate.

## Stacking

Stacked on **#453** (`feat/435-evalbench-score`, `evalbench-score`) on top of **merged #452** (`2779b7e`). The demo's step 3 needs `evalbench-score`, which only exists on #453, so this branch is based on #453's HEAD (`186c5e7`), not on `main`. **Until #453 merges, GitHub will show #453's files in this PR's diff vs `main`; that is expected.** Once #453 lands, the diff reduces to the six files below.

## Files

- `examples/evalbench_mvp_e2e.sh` (new)
- `examples/evalbench_mvp_e2e.md` (new)
- `tests/test_evalbench_mvp_e2e.py` (new)
- `docs/evalbench.md`, `examples/README.md`, `CHANGELOG.md` (pointers + bullet)

## Verification

```
$ python -m pytest -q tests/test_evalbench_mvp_e2e.py
5 passed
$ bash examples/evalbench_mvp_e2e.sh --fixture   # exit 0, three banners
```

Script also checked on macOS `bash 3.2` (no `${var@Q}`, `set -u`-safe empty array expansion) and against a stub `bq-agent-sdk` on `PATH` to confirm live-mode argument wiring, `EVALBENCH_IMPORT_VERSION` pinning on all three steps, and step-failure propagation (exit 2).

Refs #435, #97.
