### PR TITLE
feat(evalbench): mechanical failure-taxonomy scaffold from failed-session flags (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mechanical failure-taxonomy scaffold (#435 slice 8)** — new
+  `failure_taxonomy` module: a versioned scaffold config
+  (`taxonomy_version: 0.0.0-scaffold`, `g1_frozen: false`) in the #431
+  `{"metrics": [...]}` schema shape whose one core metric carries the three
+  mechanical categories of the landed failed-session contract
+  (`process_failed` / `missing_completion` / `score_failed`), an empty D2
+  `dialects` slot (per-benchmark extension categories on the same core), and
+  a pure `categorize_failed_session()` that maps one failed-session row
+  (dict or `SessionVerdict`) to the tripped categories — no BigQuery, no
+  LLM, no network. NOT the G1 taxonomy: names are unfrozen and the six-week
+  clock has not started.
 - **EvalBench MVP e2e demo tells one session's story (#435 slice 5, #97)**
   — the `--fixture` walkthrough of `examples/evalbench_mvp_e2e.sh` now
   follows `support_agent` session `7e352c34` ("How many widgets are in

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,6 +23,14 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
+A mechanical taxonomy *scaffold* also exists
+(`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
+failed-session flags (`process_failed` / `missing_completion` /
+`score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
+with an empty D2 dialects slot. It is **not** G1 — no category names are
+frozen, the six-week clock has still not started, and the partner job, D4
+boundary, and live-trace ingestion remain parked.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/src/bigquery_agent_analytics/failure_taxonomy.py
+++ b/src/bigquery_agent_analytics/failure_taxonomy.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mechanical failure-taxonomy SCAFFOLD over EvalBench failed-session flags.
+
+This is #435 slice 8: the thinnest testable bridge between the failed-session
+contract that already landed (#451/#452 -- ``SessionVerdict`` /
+``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) and the
+future AgentForensics failure taxonomy. It maps the three mechanical flags a
+failed-session row already carries -- ``process_failed``,
+``missing_completion``, ``score_failed`` -- to categories in a versioned
+config. Nothing here interprets *why* an agent failed; that judgment layer is
+the G1 taxonomy study in ``docs/agentforensics_mvp_plan.md`` and has not run.
+
+What this module is NOT:
+
+- It is **not** G1. The category names are scaffold ids derived from the
+  flag names, marked ``g1_frozen: False`` in the config; nothing downstream
+  may treat them as the frozen taxonomy vocabulary. SANA's seven categories
+  stay unfrozen and do not appear here.
+- It does **not** start the six-week MVP clock, the partner job, the D4
+  boundary, or live-trace ingestion.
+- It does **not** classify sessions: ``evalbench.classify_sessions`` remains
+  the reference implementation of the flags. This module only maps an
+  already-classified row to category ids.
+
+The config uses the #431 ``evaluation_rubrics`` schema shape
+(``{"metrics": [{"name", "definition", "categories": [{name, definition}]}]}``)
+so ``evaluation_rubrics.build_metrics`` could interpret the core metric later,
+and encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
+per-benchmark *extension categories on the same core* -- empty by default,
+never a second taxonomy.
+
+No BigQuery, no LLM, no network: everything here is pure and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import copy
+from typing import Any
+
+# Obviously-scaffold version label. This is NOT taxonomy v0.1 (the G1
+# starting point per the plan of record); it must be replaced wholesale when
+# the G1 study produces frozen names.
+SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"
+
+# The three mechanical flags of the landed failed-session contract, in the
+# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. Category
+# ids deliberately equal the flag names: they describe *which gate tripped*,
+# not a failure mode, and renaming them here would only invent unfrozen
+# vocabulary.
+CORE_CATEGORY_IDS = ("process_failed", "missing_completion", "score_failed")
+
+_CORE_CATEGORY_DEFINITIONS = {
+    "process_failed": (
+        "The session emitted at least one ERROR event (non-zero returncode"
+        " or source error fields). Mechanical: read from the"
+        " process_failed flag of the failed-session contract."
+    ),
+    "missing_completion": (
+        "The session has no AGENT_COMPLETED event: the agent never produced"
+        " a final response. Mechanical: read from the missing_completion"
+        " flag of the failed-session contract."
+    ),
+    "score_failed": (
+        "The per-benchmark score policy (EvalScorePolicy) was not met;"
+        " missing scores fail by default. returncode == 0 means completed,"
+        " never passed. Mechanical: read from the score_failed flag of the"
+        " failed-session contract."
+    ),
+}
+
+_SCAFFOLD_TAXONOMY_CONFIG = {
+    # Scaffold bookkeeping (not part of the #431 metric schema, which
+    # ignores unknown top-level keys).
+    "taxonomy_version": SCAFFOLD_TAXONOMY_VERSION,
+    # Nothing in this config is G1-frozen vocabulary. Consumers must check
+    # this flag before treating category names as the taxonomy.
+    "g1_frozen": False,
+    # D2: optional per-benchmark extension categories on the same core (each
+    # entry would carry a benchmark name plus #431-shaped categories with
+    # optional ``insert_after``). Empty until G1 work fills it; an empty
+    # slot is the encoding, not a placeholder to invent labels for.
+    "dialects": [],
+    # The #431 schema shape (``evaluation_rubrics``): the one core metric a
+    # future ``build_metrics()`` caller could interpret.
+    "metrics": [
+        {
+            "name": "failure_category",
+            "definition": (
+                "Which mechanical gate(s) of the EvalBench failed-session"
+                " contract a session tripped. Scaffold only: these are not"
+                " failure modes and not the G1 taxonomy."
+            ),
+            "categories": [
+                {"name": name, "definition": _CORE_CATEGORY_DEFINITIONS[name]}
+                for name in CORE_CATEGORY_IDS
+            ],
+        }
+    ],
+}
+
+
+def scaffold_taxonomy_config() -> dict:
+  """A deep copy of the scaffold taxonomy config (mutate freely).
+
+  Same access pattern as ``evaluation_rubrics.builtin_metric_config``. The
+  ``metrics`` entry follows the #431 config schema; ``taxonomy_version``,
+  ``g1_frozen`` and ``dialects`` are scaffold/D2 bookkeeping documented in
+  the module docstring.
+  """
+  return copy.deepcopy(_SCAFFOLD_TAXONOMY_CONFIG)
+
+
+def categorize_failed_session(row: Any) -> tuple[str, ...]:
+  """Map one failed-session row to its mechanical scaffold categories.
+
+  Pure and deterministic: no BigQuery, no LLM, no network. ``row`` is one
+  failed-session row -- a mapping (e.g. a ``failed_sessions`` /
+  ``failed_sessions_sql`` row as a dict) or an object with attributes (e.g.
+  a ``SessionVerdict``) -- carrying the three boolean flags of the landed
+  contract: ``process_failed``, ``missing_completion``, ``score_failed``.
+  Extra fields are ignored.
+
+  Returns the tripped category ids in ``CORE_CATEGORY_IDS`` order; a row can
+  trip several (e.g. process_failed AND missing_completion). All three flags
+  false returns ``()``: this scaffold does not invent an ``unknown`` bucket,
+  because a session no mechanical gate tripped is simply not a mechanical
+  failure (the future G1 taxonomy owns residual categories).
+
+  Raises:
+    ValueError: A flag is absent or not a bool -- silently defaulting a
+      missing flag would miscategorize sessions.
+  """
+  return tuple(
+      category for category in CORE_CATEGORY_IDS if _flag(row, category)
+  )
+
+
+def _flag(row: Any, name: str) -> bool:
+  """Read one required boolean flag from a mapping or attribute row."""
+  missing = object()
+  if isinstance(row, Mapping):
+    value = row.get(name, missing)
+  else:
+    value = getattr(row, name, missing)
+  if value is missing:
+    raise ValueError(
+        f"failed-session row is missing required flag {name!r}; expected the"
+        " process_failed/missing_completion/score_failed contract of"
+        " evalbench.classify_sessions / failed_sessions_sql"
+    )
+  if not isinstance(value, bool):
+    raise ValueError(
+        f"failed-session flag {name!r} must be a bool, got"
+        f" {type(value).__name__}"
+    )
+  return value

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8)."""
+
+import itertools
+
+import pytest
+
+from bigquery_agent_analytics.evalbench import SessionVerdict
+from bigquery_agent_analytics.evaluation_rubrics import build_metrics
+from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
+from bigquery_agent_analytics.failure_taxonomy import CORE_CATEGORY_IDS
+from bigquery_agent_analytics.failure_taxonomy import scaffold_taxonomy_config
+from bigquery_agent_analytics.failure_taxonomy import SCAFFOLD_TAXONOMY_VERSION
+
+_FLAGS = ("process_failed", "missing_completion", "score_failed")
+
+
+def _row(**overrides):
+  row = {flag: False for flag in _FLAGS}
+  row.update(overrides)
+  return row
+
+
+def _verdict(**overrides):
+  return SessionVerdict(
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      failing_scores={},
+      failed=any(overrides.values()),
+      **_row(**overrides),
+  )
+
+
+# --- mapper ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", _FLAGS)
+def test_each_flag_alone_maps_to_its_category(flag):
+  assert categorize_failed_session(_row(**{flag: True})) == (flag,)
+
+
+@pytest.mark.parametrize(
+    "tripped",
+    [
+        combo
+        for size in (2, 3)
+        for combo in itertools.combinations(_FLAGS, size)
+    ],
+)
+def test_flag_combinations_map_to_every_tripped_category(tripped):
+  row = _row(**{flag: True for flag in tripped})
+  assert categorize_failed_session(row) == tripped
+
+
+def test_all_flags_false_returns_empty_not_an_unknown_bucket():
+  assert categorize_failed_session(_row()) == ()
+
+
+def test_category_order_follows_the_core_config_order():
+  row = _row(score_failed=True, process_failed=True)
+  assert categorize_failed_session(row) == ("process_failed", "score_failed")
+  assert categorize_failed_session(
+      _row(**{flag: True for flag in _FLAGS})
+  ) == tuple(CORE_CATEGORY_IDS)
+
+
+def test_extra_fields_are_ignored():
+  row = _row(
+      process_failed=True,
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      started_at="2026-08-30T00:00:00Z",
+      failed=True,
+      failing_scores=[{"comparator": "exact_match", "score": 0.0}],
+  )
+  assert categorize_failed_session(row) == ("process_failed",)
+
+
+def test_session_verdict_objects_are_accepted():
+  verdict = _verdict(missing_completion=True, score_failed=True)
+  assert categorize_failed_session(verdict) == (
+      "missing_completion",
+      "score_failed",
+  )
+  assert categorize_failed_session(_verdict()) == ()
+
+
+def test_missing_flag_raises_instead_of_defaulting():
+  row = _row(process_failed=True)
+  del row["score_failed"]
+  with pytest.raises(ValueError, match="missing required flag 'score_failed'"):
+    categorize_failed_session(row)
+
+
+@pytest.mark.parametrize("bad", [None, 0, 1, "true"])
+def test_non_bool_flag_raises(bad):
+  with pytest.raises(ValueError, match="'process_failed' must be a bool"):
+    categorize_failed_session(_row(process_failed=bad))
+
+
+def test_mapper_is_deterministic():
+  row = _row(process_failed=True, missing_completion=True)
+  assert categorize_failed_session(row) == categorize_failed_session(row)
+
+
+# --- config ---------------------------------------------------------------
+
+
+def test_config_version_is_obviously_scaffold_and_not_g1_frozen():
+  config = scaffold_taxonomy_config()
+  assert config["taxonomy_version"] == SCAFFOLD_TAXONOMY_VERSION
+  assert "scaffold" in config["taxonomy_version"]
+  assert config["g1_frozen"] is False
+
+
+def test_config_dialects_slot_exists_and_is_empty_by_default():
+  # D2: one taxonomy with optional per-benchmark extension categories on
+  # the same core. The slot must exist and must not ship invented labels.
+  assert scaffold_taxonomy_config()["dialects"] == []
+
+
+def test_config_core_categories_match_the_landed_flags():
+  config = scaffold_taxonomy_config()
+  (metric,) = config["metrics"]
+  assert metric["name"] == "failure_category"
+  assert [c["name"] for c in metric["categories"]] == list(CORE_CATEGORY_IDS)
+  assert list(CORE_CATEGORY_IDS) == list(_FLAGS)
+  for category in metric["categories"]:
+    assert category["definition"]
+
+
+def test_config_does_not_contain_unfrozen_sana_names():
+  # The SANA seven-category vocabulary stays out of this scaffold entirely.
+  text = repr(scaffold_taxonomy_config()).lower()
+  for sana_name in ("planning", "wrong source", "turn-waste", "finalization"):
+    assert sana_name not in text
+
+
+def test_config_metrics_shape_is_interpretable_by_build_metrics():
+  # #431 schema shape: build_metrics() can turn the core metric into a
+  # CategoricalMetricDefinition without special-casing.
+  (metric,) = build_metrics(scaffold_taxonomy_config())
+  assert metric.name == "failure_category"
+  assert [c.name for c in metric.categories] == list(CORE_CATEGORY_IDS)
+
+
+def test_config_returns_a_deep_copy():
+  first = scaffold_taxonomy_config()
+  first["g1_frozen"] = True
+  first["metrics"][0]["categories"].clear()
+  first["dialects"].append({"benchmark": "nope"})
+  fresh = scaffold_taxonomy_config()
+  assert fresh["g1_frozen"] is False
+  assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
+  assert fresh["dialects"] == []


### PR DESCRIPTION
## Summary

Part of #435 (AgentForensics MVP) — **slice 8**: a thin, testable
failure-taxonomy **scaffold** now that EvalBench ingest (#451/#452/#453/#454)
is on main. It maps the **already-landed failed-session flags** to a
versioned config; nothing more.

- **New module `src/bigquery_agent_analytics/failure_taxonomy.py`**
  - `scaffold_taxonomy_config()`: versioned config in the **#431
    `evaluation_rubrics` schema shape** (`{"metrics": [{name, definition,
    categories: [{name, definition}]}]}`, so `build_metrics()` can already
    interpret the core metric — covered by a test), plus scaffold
    bookkeeping: `taxonomy_version: "0.0.0-scaffold"` and an explicit
    `g1_frozen: false`.
  - Three **mechanical core categories** derived 1:1 from the landed
    failed-session contract: `process_failed` (any ERROR event),
    `missing_completion` (no `AGENT_COMPLETED`), `score_failed`
    (`EvalScorePolicy` not met; missing scores fail; `returncode == 0`
    means completed, never passed).
  - **D2 encoded as an empty `dialects` slot**: one taxonomy with optional
    per-benchmark extension categories on the same core — empty by default,
    no invented labels, never a second taxonomy.
  - `categorize_failed_session(row)`: **pure, deterministic** mapper from
    one failed-session row (dict or `SessionVerdict`) to the tripped
    categories, in config order; multi-flag rows return multiple
    categories; all-false returns `()` (no invented `unknown` bucket).
    Missing or non-bool flags raise instead of silently defaulting. No
    BigQuery, no LLM, no network. `classify_sessions` stays the reference
    implementation of the flags — this module does not re-implement it, and
    no SQL is added.
- **Tests** — `tests/test_failure_taxonomy.py` (23 tests): each flag alone,
  all combinations, all-false, extra fields ignored, `SessionVerdict`
  input, missing/non-bool flag errors, determinism, scaffold version +
  `g1_frozen: false`, empty dialects slot, category/flag alignment, no
  SANA names, `build_metrics()` interoperability, deep-copy semantics.
- **Docs** — one CHANGELOG Unreleased bullet; a short pointer in
  `docs/agentforensics_mvp_plan.md` under "Code already landed".

## What this is NOT

- **Not G1.** Category ids are scaffold ids equal to the flag names;
  **no taxonomy names are frozen** (`g1_frozen: false` in the config), and
  SANA's seven-category vocabulary appears nowhere. The G1 discrimination
  gate / human+judge study is later work.
- **The six-week clock has not started.** Week 0 (partner, D4 boundary,
  live traces) has not cleared and stays **parked** — this PR touches none
  of it.
- No new public API export from `__init__.py`; the module surface is the
  whole addition.

## Testing

```
PYTHONPATH=src python -m pytest tests/test_failure_taxonomy.py -q
23 passed
```

`isort` + `pyink` clean.

## Review note

Please review on GitHub. Independent of open PRs #455 / #456 / #457 — do
not wait on them (they remain blocked on haiyuan-eng-google).

Closes nothing; tracked under #435.
