### PR TITLE
feat(evalbench): Week 0 freeze e2e team demo on the widget-stock session (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Week 0 freeze e2e demo (#435)** — new recordable
-  `examples/evalbench_week0_freeze_e2e.sh --fixture` walks the REAL
-  partner (Google Cloud BQAA), fail-closed D4 memo, and G1 taxonomy
-  v0.1.0 freeze on the widget-stock failed session `7e352c34`, printing
-  frozen `taxonomy_categories` (`task/planning`, `finalization`,
-  `tool blockers`) and the never-answered + G1 punchline. Offline only
-  (no BigQuery). Distinct from the merged 455 MVP e2e and from the 460
-  EXAMPLE Acme pack, which stays illustrative. The six-week clock has
-  NOT started.
+  `examples/evalbench_week0_freeze_e2e.sh --fixture`, a presenter-facing
+  team demo on the widget-stock failed session `7e352c34`: the customer
+  asked and the agent went silent, `failed_sessions` finds the session
+  and the frozen G1 taxonomy names it (`task/planning`, `finalization`,
+  `tool blockers`), ending in a punchline with the next debugging
+  action. Offline only (no BigQuery). Distinct from the merged 455 MVP
+  e2e and from the 460 EXAMPLE Acme pack, which stays illustrative. The
+  six-week clock has NOT started.
 - **REAL Week 0 freeze: partner, D4 boundary, G1 taxonomy v0.1 (#435)** —
   the Week 0 gates are frozen for real, distinct from the EXAMPLE pack
   below (which stays illustrative). `docs/week0_partner.md` records the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Failed-session rows carry scaffold taxonomy categories (#435 slice 9)**
+  — `failed_sessions()` / `bq-agent-sdk evalbench-failed-sessions` now
+  attach `taxonomy_categories` to each session row: `EvalBenchSession`
+  exposes it as a property computed from the row's three mechanical flags
+  via `failure_taxonomy.categorize_failed_session`, and `to_dict()` (what
+  the CLI JSON/text output serializes) includes it as a list. All-flags-false
+  rows (`--include-passed`) emit `[]` — no invented `unknown` bucket. Pure
+  Python over the flags already returned; no extra BigQuery work, and still
+  NOT the G1 taxonomy (ids stay the unfrozen flag names).
 - **Mechanical failure-taxonomy scaffold (#435 slice 8)** — new
   `failure_taxonomy` module: a versioned scaffold config
   (`taxonomy_version: 0.0.0-scaffold`, `g1_frozen: false`) in the #431

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **REAL Week 0 freeze: partner, D4 boundary, G1 taxonomy v0.1 (#435)** —
+  the Week 0 gates are frozen for real, distinct from the EXAMPLE pack
+  below (which stays illustrative). `docs/week0_partner.md` records the
+  real pilot partner — Google Cloud BigQuery Agent Analytics (this SDK),
+  piloting the ADK `support_agent` traces as EvalBench job
+  `mvp-e2e-real-traces`; SANA-adjacent, not a SANA fork and not a named
+  collaboration with SANA authors, not duplicating LakeQA/KramaBench.
+  `docs/week0_d4_memo.md` lands the fail-closed D4 boundary for exactly
+  this pilot's datasets with one named report consumer (Hai-Yuan Cao) and
+  a text-only grants policy (no IAM API calls); fixtures/synthetic runs
+  validate ingestion, taxonomy mechanics, and stability ONLY and never
+  produce a Part II funding recommendation. `docs/week0_g1_taxonomy.md`
+  documents the G1 freeze (below) and `docs/week0_preregistration.md`
+  copies the v4 floors as the freeze-candidate. Machine-readable copies in
+  `examples/fixtures/week0_real_*.json` (`example: false`,
+  `clock_started: false`), guarded by `tests/test_week0_real_freeze.py`.
+  **The six-week clock has NOT started**: it starts only when the first
+  Week 1 snapshot job is kicked, not at merge of this freeze.
 - **EXAMPLE Week 0 scenario pack (#435 slice 10)** — new
   `examples/evalbench_week0_full_idea.md` / `.sh --fixture` walk all five
   Week 0 human gates of `docs/agentforensics_mvp_plan.md` (partner + SANA
@@ -123,6 +141,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ETag-conditional replace after re-reading the view and latest manifest,
   so concurrent imports cannot overwrite a newer pin or attach an older
   caller's policy to a newer generation.
+
+### Changed
+
+- **`failure_taxonomy` frozen at G1 v0.1.0 (#435)** — the scaffold era
+  ends: `taxonomy_version` is `0.1.0` and `g1_frozen` is `true`. The
+  frozen vocabulary (`FROZEN_CATEGORY_NAMES`, also exported as
+  `CORE_CATEGORY_IDS`) is the SANA-neighborhood seven plus `unknown` —
+  `task/planning`, `wrong source`, `execution/computation`,
+  `incomplete evidence`, `turn-waste`, `finalization`, `tool blockers`,
+  `unknown` — replacing the three flag ids, which live on as the mapper's
+  input contract `MECHANICAL_FLAGS`. `categorize_failed_session` now
+  returns frozen names in frozen order (`missing_completion` →
+  `finalization`, `process_failed` → `tool blockers`, `score_failed` →
+  `task/planning`; all flags false still returns `()`, never `unknown`),
+  so `EvalBenchSession.taxonomy_categories` and the
+  `evalbench-failed-sessions` CLI output carry frozen names. The config
+  accessor is renamed `taxonomy_config()`; `scaffold_taxonomy_config()`
+  remains as a compatibility wrapper returning the same frozen config.
+  Assignment stays mechanical until the labeler study; the six-week clock
+  has not started.
 
 ## [0.5.1] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EXAMPLE Week 0 scenario pack (#435 slice 10)** — new
+  `examples/evalbench_week0_full_idea.md` / `.sh --fixture` walk all five
+  Week 0 human gates of `docs/agentforensics_mvp_plan.md` (partner + SANA
+  relationship, runtime + route, pilot-benchmark rubric, D4 boundary memo,
+  preregistration) as one concrete story on the widget-stock failed session,
+  ending in the mechanical `taxonomy_categories` row and an EXAMPLE mapping
+  onto SANA-seeded names in `examples/fixtures/week0_example_*.json`.
+  Offline only (no BigQuery, no network) and entirely illustrative: not a
+  freeze, `g1_frozen` stays false, the six-week clock has not started, no
+  real partner is named, and `src/` is untouched — Week 0 remains
+  human-gated.
 - **Failed-session rows carry scaffold taxonomy categories (#435 slice 9)**
   — `failed_sessions()` / `bq-agent-sdk evalbench-failed-sessions` now
   attach `taxonomy_categories` to each session row: `EvalBenchSession`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Week 0 freeze e2e demo (#435)** — new recordable
+  `examples/evalbench_week0_freeze_e2e.sh --fixture` walks the REAL
+  partner (Google Cloud BQAA), fail-closed D4 memo, and G1 taxonomy
+  v0.1.0 freeze on the widget-stock failed session `7e352c34`, printing
+  frozen `taxonomy_categories` (`task/planning`, `finalization`,
+  `tool blockers`) and the never-answered + G1 punchline. Offline only
+  (no BigQuery). Distinct from the merged 455 MVP e2e and from the 460
+  EXAMPLE Acme pack, which stays illustrative. The six-week clock has
+  NOT started.
 - **REAL Week 0 freeze: partner, D4 boundary, G1 taxonomy v0.1 (#435)** —
   the Week 0 gates are frozen for real, distinct from the EXAMPLE pack
   below (which stays illustrative). `docs/week0_partner.md` records the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mechanical failure-taxonomy scaffold (#435 slice 8)** — new
+  `failure_taxonomy` module: a versioned scaffold config
+  (`taxonomy_version: 0.0.0-scaffold`, `g1_frozen: false`) in the #431
+  `{"metrics": [...]}` schema shape whose one core metric carries the three
+  mechanical categories of the landed failed-session contract
+  (`process_failed` / `missing_completion` / `score_failed`), an empty D2
+  `dialects` slot (per-benchmark extension categories on the same core), and
+  a pure `categorize_failed_session()` that maps one failed-session row
+  (dict or `SessionVerdict`) to the tripped categories — no BigQuery, no
+  LLM, no network. NOT the G1 taxonomy: names are unfrozen and the six-week
+  clock has not started.
 - **EvalBench MVP e2e demo tells one session's story (#435 slice 5, #97)**
   — the `--fixture` walkthrough of `examples/evalbench_mvp_e2e.sh` now
   follows `support_agent` session `7e352c34` ("How many widgets are in

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -57,11 +57,12 @@ partner is the fictional "Acme Retail Support". The pack **remains
 illustrative** now that the real freeze landed; the real artifacts are the
 `week0_*.md` docs and `week0_real_*.json` fixtures above.
 
-There is also a **post-freeze recordable e2e**
+There is also a **presenter-facing team demo**
 (`examples/evalbench_week0_freeze_e2e.md`, run with
-`bash examples/evalbench_week0_freeze_e2e.sh --fixture`) that walks the
-frozen partner + D4 + G1 record on the widget-stock failed session. The
-six-week clock has still not started.
+`bash examples/evalbench_week0_freeze_e2e.sh --fixture`): a live
+walkthrough of the widget-stock failed session — customer silence,
+`failed_sessions` plus the frozen G1 names, then a punchline with the
+next debugging action. The six-week clock has still not started.
 
 ---
 

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -27,7 +27,10 @@ A mechanical taxonomy *scaffold* also exists
 (`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
 failed-session flags (`process_failed` / `missing_completion` /
 `score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
-with an empty D2 dialects slot. It is **not** G1 — no category names are
+with an empty D2 dialects slot. The failed-session consumer now uses it:
+`failed_sessions` / `bq-agent-sdk evalbench-failed-sessions` attach the
+mechanical categories to each session row as `taxonomy_categories`, computed
+in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,16 +23,39 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
-A mechanical taxonomy *scaffold* also exists
-(`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
-failed-session flags (`process_failed` / `missing_completion` /
-`score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
-with an empty D2 dialects slot. The failed-session consumer now uses it:
+**G1 is frozen at v0.1.0 in `failure_taxonomy.py`**
+(`src/bigquery_agent_analytics/failure_taxonomy.py`, `g1_frozen: true`): the
+frozen vocabulary is the SANA-neighborhood seven plus `unknown`
+(`docs/week0_g1_taxonomy.md`). Assignment stays mechanical until the labeler
+study: the landed failed-session flags (`process_failed` /
+`missing_completion` / `score_failed`) map to `tool blockers` /
+`finalization` / `task/planning`, returned in frozen order, and the D2
+dialects slot stays empty. The failed-session consumer uses it:
 `failed_sessions` / `bq-agent-sdk evalbench-failed-sessions` attach the
-mechanical categories to each session row as `taxonomy_categories`, computed
-in Python from the row's flags. It is **not** G1 — no category names are
-frozen, the six-week clock has still not started, and the partner job, D4
-boundary, and live-trace ingestion remain parked.
+frozen names to each session row as `taxonomy_categories`, computed in
+Python from the row's flags.
+
+**Week 0 partner, D4 boundary, and G1 are frozen** by the Week 0 freeze PR:
+`docs/week0_partner.md` (real partner: Google Cloud BigQuery Agent
+Analytics — this SDK — piloting the ADK `support_agent` traces via EvalBench
+job `mvp-e2e-real-traces`), `docs/week0_d4_memo.md` (fail-closed, named
+consumer Hai-Yuan Cao only), and `docs/week0_g1_taxonomy.md`, with
+machine-readable copies in `examples/fixtures/week0_real_*.json`
+(`example: false`). The remaining Week 0 item is **preregistration
+execution**; `docs/week0_preregistration.md` carries the v4 floors as the
+freeze-candidate. **The six-week clock has still not started**: it starts
+only when the first Week 1 snapshot job is kicked, not at merge of the
+freeze.
+
+An **example scenario pack** also exists
+(`examples/evalbench_week0_full_idea.md`, run with
+`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
+every Week 0 human gate below as one concrete story on the widget-stock
+failed session. Everything in it is labeled EXAMPLE / illustrative / not a
+freeze — its fixtures keep `example: true` / `g1_frozen: false` and its
+partner is the fictional "Acme Retail Support". The pack **remains
+illustrative** now that the real freeze landed; the real artifacts are the
+`week0_*.md` docs and `week0_real_*.json` fixtures above.
 
 ---
 

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,6 +23,14 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
+A mechanical taxonomy *scaffold* also exists
+(`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
+failed-session flags (`process_failed` / `missing_completion` /
+`score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
+with an empty D2 dialects slot. It is **not** G1 — no category names are
+frozen, the six-week clock has still not started, and the partner job, D4
+boundary, and live-trace ingestion remain parked.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -34,6 +34,15 @@ in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 
+An **example scenario pack** also exists
+(`examples/evalbench_week0_full_idea.md`, run with
+`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
+every Week 0 human gate below as one concrete story on the widget-stock
+failed session. Everything in it is labeled EXAMPLE / illustrative / not a
+freeze — `g1_frozen` stays false, the six-week clock has **not** started,
+and no real partner is named (the example partner is "Acme Retail
+Support"). **Week 0 remains human-gated**; the pack clears nothing.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -57,6 +57,12 @@ partner is the fictional "Acme Retail Support". The pack **remains
 illustrative** now that the real freeze landed; the real artifacts are the
 `week0_*.md` docs and `week0_real_*.json` fixtures above.
 
+There is also a **post-freeze recordable e2e**
+(`examples/evalbench_week0_freeze_e2e.md`, run with
+`bash examples/evalbench_week0_freeze_e2e.sh --fixture`) that walks the
+frozen partner + D4 + G1 record on the widget-stock failed session. The
+six-week clock has still not started.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -34,15 +34,6 @@ in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 
-An **example scenario pack** also exists
-(`examples/evalbench_week0_full_idea.md`, run with
-`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
-every Week 0 human gate below as one concrete story on the widget-stock
-failed session. Everything in it is labeled EXAMPLE / illustrative / not a
-freeze — `g1_frozen` stays false, the six-week clock has **not** started,
-and no real partner is named (the example partner is "Acme Retail
-Support"). **Week 0 remains human-gated**; the pack clears nothing.
-
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/week0_d4_memo.md
+++ b/docs/week0_d4_memo.md
@@ -1,0 +1,42 @@
+# Week 0 — D4 Boundary Memo (frozen, fail-closed)
+
+**Status:** frozen by the #435 Week 0 freeze PR. This is the REAL D4
+boundary for exactly this pilot's data, not the example pack. The six-week
+clock has **not** started; it starts only when the
+first Week 1 snapshot job is kicked. Machine-readable copy:
+`examples/fixtures/week0_real_d4_memo.json` (`example: false`).
+
+## Scope — this pilot data only
+
+- Project: `test-project-0728-467323`
+- Datasets: `bqaa_e2e_real`, `bqaa_evalbench_mvp_demo`,
+  `bqaa_evalbench_mvp_mirror`
+- Derived artifacts: `failed_sessions` rows and taxonomy labels computed
+  from them
+
+## Named report consumers
+
+- **Hai-Yuan Cao** (`caohy1988` / `haiyuan-eng-google`)
+
+No other consumer is named. **Fail-closed:** if a consumer is not named in
+this memo, access is denied.
+
+## Per-user grants and notebook/export policy (text only, no IAM API)
+
+No additional per-user grants and no notebook/export access beyond
+Hai-Yuan Cao until a later D4 amendment. This policy is recorded as text in
+this governed memo; **no IAM API calls** are made by the freeze, and none
+are needed until an amendment names a new consumer.
+
+## What synthetic / fixture / example runs can prove
+
+The `--fixture` path, synthetic data, and the example pack validate
+**ingestion, taxonomy mechanics, and stability ONLY** — they can **never**
+produce a Part II funding recommendation.
+
+## Standing restrictions under this memo
+
+- No new live judge calls.
+- No new BigQuery jobs.
+- No labeler access expansion.
+- The stop/go memo is itself a governed artifact inside this D4 boundary.

--- a/docs/week0_g1_taxonomy.md
+++ b/docs/week0_g1_taxonomy.md
@@ -1,0 +1,62 @@
+# Week 0 — G1 Taxonomy Freeze (v0.1.0)
+
+**Status:** frozen by the #435 Week 0 freeze PR, in production code:
+`src/bigquery_agent_analytics/failure_taxonomy.py` now carries
+`taxonomy_version: 0.1.0` / `g1_frozen: true`. **Freezing G1 is not a clock
+start**: the six-week clock has **not** started and starts only when the
+first Week 1 snapshot job is kicked. Machine-readable copy:
+`examples/fixtures/week0_real_taxonomy.json` (`example: false`,
+`g1_frozen: true`).
+
+## Frozen vocabulary (names and spellings are stable)
+
+The SANA-neighborhood seven, then `unknown`, in **frozen order**:
+
+1. `task/planning`
+2. `wrong source`
+3. `execution/computation`
+4. `incomplete evidence`
+5. `turn-waste`
+6. `finalization`
+7. `tool blockers`
+8. `unknown`
+
+`unknown` is in the vocabulary as the residual bucket for the labeler
+study. The mechanical mapper never emits it: a row with all flags false
+returns `()`, not `("unknown",)`.
+
+## Mechanical assignment until the labeler study
+
+`categorize_failed_session` maps the three landed failed-session flags
+(`MECHANICAL_FLAGS`) onto frozen names:
+
+| Flag | Frozen category |
+|---|---|
+| `missing_completion` | `finalization` |
+| `process_failed` | `tool blockers` |
+| `score_failed` | `task/planning` |
+
+When multiple flags trip, the returned names follow the **frozen order
+above, not flag order**. The other four categories and `unknown` are never
+emitted by the three-flag mapper; they become assignable when the labeler
+study runs.
+
+## The widget-stock pilot session
+
+Session `7e352c34-4c1c-4395-acd5-fb3c8f215346` (`7e352c34`) trips all three
+flags, so its `taxonomy_categories` are:
+
+```
+("task/planning", "finalization", "tool blockers")
+```
+
+## What did not change
+
+- `dialects` stays `[]` (D2: one taxonomy, optional per-benchmark
+  extension categories on the same core — still empty).
+- The config keeps the #431 `{"metrics": [...]}` schema shape;
+  `evaluation_rubrics.build_metrics` interprets it unchanged.
+- `scaffold_taxonomy_config()` survives as a compatibility wrapper for
+  `taxonomy_config()` (see CHANGELOG).
+- No six-week execution starts here: no ≥100-session study, no labeler
+  study, no live-trace ingestion job.

--- a/docs/week0_partner.md
+++ b/docs/week0_partner.md
@@ -1,0 +1,43 @@
+# Week 0 — Real Pilot Partner (frozen)
+
+**Status:** frozen by the #435 Week 0 freeze PR. This is the REAL partner
+record, not the example pack (`examples/evalbench_week0_full_idea.md`, which
+stays illustrative). The six-week clock has **not** started; it starts only
+when the first Week 1 snapshot job is kicked, not at merge of this freeze.
+
+Machine-readable copy: `examples/fixtures/week0_real_partner.json`
+(`example: false`).
+
+## Partner
+
+**Google Cloud BigQuery Agent Analytics (this SDK / BQAA).** The pilot is
+self-hosted: the ADK `support_agent` traces in
+`test-project-0728-467323.bqaa_e2e_real.agent_events`, imported as EvalBench
+job `mvp-e2e-real-traces`.
+
+## Relationship to SANA
+
+AgentForensics is **SANA-adjacent published work — not a SANA fork and not a
+named collaboration with SANA authors**. SANA is LakeQA + KramaBench on the
+Strands runtime, with a seven-category failure taxonomy (task/planning,
+wrong source, execution/computation, incomplete evidence, turn-waste,
+finalization, tool blockers). This pilot is ADK+EvalBench on widget-stock
+support — a different benchmark and a different runtime — so it is
+**not duplicating** published work on LakeQA or KramaBench. Taxonomy v0.1 starts
+from SANA's seven categories per Week 0 item 1 (see
+`docs/week0_g1_taxonomy.md`).
+
+## Runtime and route (recorded as real, already true)
+
+ADK plugin → BQAA `agent_events` → EvalBench-hosted. The partner's benchmark
+runs are EvalBench-hosted, so the **EvalBench-only MVP route is correct and
+D1 does not need re-decision**.
+
+## Pilot-benchmark rubric (recorded as real)
+
+The predeclared rubric selected the widget-stock support benchmark on
+session `7e352c34-4c1c-4395-acd5-fb3c8f215346` (`7e352c34`): sibling gold
+session `ab7535a5` answered "There are 0 widgets in stock." for the same
+prompt, and `goal_completion` is 0 for the failed session vs 1 for the gold
+against a definable threshold. Machine-readable copy:
+`examples/fixtures/week0_real_rubric.json`.

--- a/docs/week0_preregistration.md
+++ b/docs/week0_preregistration.md
@@ -1,0 +1,42 @@
+# Week 0 — Preregistration Freeze-Candidate
+
+**Banner:** these numbers are the plan of record (FINAL v4,
+`docs/agentforensics_mvp_plan.md`), copied here as the freeze-candidate.
+**The six-week clock has NOT started** — this is not a clock start and not
+Week 1 execution; the clock starts only when the first Week 1 snapshot job
+is kicked. Nothing here invents a new number. Machine-readable copy:
+`examples/fixtures/week0_real_preregistration.json` (`example: false`,
+`clock_started: false`).
+
+## Floors (from v4)
+
+| Floor | Value |
+|---|---|
+| Replicate agreement | ≥80% |
+| Non-`unknown` coverage | ≥80% |
+| Human-human / classifier-vs-adjudicated κ (point) | ≥0.6 |
+| κ 95% CI lower bound | ≥0.45 |
+| Localization coverage | ≥70% |
+| Paired hit@1 uplift CI lower bound | >0 |
+| Paired hit@1 point uplift | ≥ +10pp |
+
+## Decision rules (same as the v4 plan)
+
+- **Reserved revision week:** one taxonomy revision slot (week 7); a
+  stability miss invokes it once with fresh labels and a re-gate; a second
+  miss ends the MVP with the analysis as the deliverable.
+- **Value gate:** at least the preregistered fraction of randomly assigned
+  investigations where the report changed or materially narrowed the next
+  action, adjudicated by a non-investigator; a stated preference or
+  unverified acceptance counts for nothing.
+- **Noisy-small-n localization:** point-clears-but-CI-spans-zero resolves
+  per the preregistered week-0 rule, not week-6 judgment; no metric
+  conditions on successful localizations only.
+- **Sealed sets:** `P-blind` is frozen before any tuning and scored exactly
+  once at week 6.
+
+## Remaining Week 0 item
+
+With partner, D4, and G1 frozen, the remaining Week 0 item is
+**preregistration execution** (adopting this freeze-candidate as the sealed
+preregistration). That step, not this document, precedes any clock start.

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -186,6 +186,8 @@ the rows instead of writing.
   — step 0 of `--synth`: real traces → EvalBench-shaped tables.
 - [`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh) — CI gate
   on step 3.
+- [`examples/evalbench_week0_freeze_e2e.md`](evalbench_week0_freeze_e2e.md)
+  — the post-freeze Week 0 e2e (partner + D4 + G1) on this same session.
 - Issues
   [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
   (EvalBench import bridge) and

--- a/examples/evalbench_mvp_e2e.md
+++ b/examples/evalbench_mvp_e2e.md
@@ -187,7 +187,7 @@ the rows instead of writing.
 - [`examples/evalbench_score_gate.sh`](evalbench_score_gate.sh) — CI gate
   on step 3.
 - [`examples/evalbench_week0_freeze_e2e.md`](evalbench_week0_freeze_e2e.md)
-  — the post-freeze Week 0 e2e (partner + D4 + G1) on this same session.
+  — the presenter-facing team demo on this same session (post-freeze).
 - Issues
   [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
   (EvalBench import bridge) and

--- a/examples/evalbench_week0_freeze_e2e.md
+++ b/examples/evalbench_week0_freeze_e2e.md
@@ -24,10 +24,10 @@ Week 1 snapshot job is kicked, not at the freeze and not at this demo.
 bash examples/evalbench_week0_freeze_e2e.sh --fixture
 ```
 
-`--fixture` (or `EVALBENCH_FIXTURE=1`) is the only mode: offline, no
-BigQuery, no live judge, exit `0`. Any other invocation prints one line
-saying so and exits `2` without running anything (there is no `--synth`
-here).
+`--fixture` is the only mode: offline, no BigQuery, no live judge, exit
+`0`. Any other invocation prints one line saying so and exits `2`
+without running anything (there is no `--synth` here, and the
+`EVALBENCH_FIXTURE` environment variable is not read).
 
 ## The protagonist (same session as the MVP e2e demo)
 

--- a/examples/evalbench_week0_freeze_e2e.md
+++ b/examples/evalbench_week0_freeze_e2e.md
@@ -1,0 +1,132 @@
+# Post-freeze Week 0 e2e: the real freeze on the widget-stock session
+
+The Week 0 freeze landed for real
+([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)):
+the pilot partner is frozen in
+[`docs/week0_partner.md`](../docs/week0_partner.md), the fail-closed D4
+boundary in [`docs/week0_d4_memo.md`](../docs/week0_d4_memo.md), and the
+G1 taxonomy v0.1.0 in
+[`docs/week0_g1_taxonomy.md`](../docs/week0_g1_taxonomy.md). This demo
+replays that freeze as one recordable story on the same widget-stock
+failed session as the merged MVP e2e demo
+([`examples/evalbench_mvp_e2e.md`](evalbench_mvp_e2e.md)).
+
+**This is the REAL freeze demo, not the EXAMPLE Acme pack.** The Week 0
+example pack ([`examples/evalbench_week0_full_idea.md`](evalbench_week0_full_idea.md))
+remains illustrative — its partner is fictional and its fixtures keep
+`example: true` / `g1_frozen: false`. Everything printed by this demo is
+the frozen record.
+
+**The six-week clock has NOT started.** It starts only when the first
+Week 1 snapshot job is kicked, not at the freeze and not at this demo.
+
+```bash
+bash examples/evalbench_week0_freeze_e2e.sh --fixture
+```
+
+`--fixture` (or `EVALBENCH_FIXTURE=1`) is the only mode: offline, no
+BigQuery, no live judge, exit `0`. Any other invocation prints one line
+saying so and exits `2` without running anything (there is no `--synth`
+here).
+
+## The protagonist (same session as the MVP e2e demo)
+
+A terse support agent was asked how many widgets are in stock and never
+answered. Real trace from `bqaa_e2e_real.agent_events` (project
+`test-project-0728-467323`), EvalBench job `mvp-e2e-real-traces`:
+
+| | |
+|---|---|
+| agent | `support_agent` |
+| user | `real-user-0` |
+| prompt | `How many widgets are in stock?` |
+| session_id | `7e352c34-4c1c-4395-acd5-fb3c8f215346` |
+| eval_id / scenario_id | `7e352c34` |
+| events | `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING`, then silence |
+| what never happened | no `check_inventory` call, no `LLM_RESPONSE`, no `AGENT_COMPLETED` |
+| score | `goal_completion` 0.0 vs threshold 1 |
+
+Sibling session `ab7535a5` answered *"There are 0 widgets in stock."* —
+the agent could do it; this session just never did.
+
+## The story, in order
+
+The fixture prints these under `=== ... ===` banners, in this order:
+
+1. **Partner: Google Cloud BQAA (this SDK).** The real pilot partner is
+   Google Cloud BigQuery Agent Analytics itself — self-hosted: the ADK
+   `support_agent` traces in
+   `test-project-0728-467323.bqaa_e2e_real.agent_events`, imported as
+   EvalBench job `mvp-e2e-real-traces`. AgentForensics is SANA-adjacent
+   published work, **not a SANA fork** and not a named collaboration with
+   SANA authors; SANA is LakeQA + KramaBench on Strands, this pilot is
+   ADK+EvalBench on widget-stock support, so it is not duplicating those
+   benchmarks. Frozen record: `docs/week0_partner.md`.
+
+2. **D4: fail-closed memo for this pilot.** The boundary covers exactly
+   this pilot's data — project `test-project-0728-467323`, datasets
+   `bqaa_e2e_real`, `bqaa_evalbench_mvp_demo`,
+   `bqaa_evalbench_mvp_mirror` — with one named report consumer,
+   Hai-Yuan Cao (`caohy1988` / `haiyuan-eng-google`). Unnamed means
+   denied. `--fixture` validates ingestion, taxonomy mechanics, and
+   stability ONLY; it can never produce a Part II funding
+   recommendation. Frozen record: `docs/week0_d4_memo.md`.
+
+3. **G1 freeze: taxonomy v0.1.0.** Production `failure_taxonomy.py` is
+   frozen — `taxonomy_version: 0.1.0`, `g1_frozen: true`,
+   `clock_started: false`. Mechanical mapping until the labeler study:
+   `missing_completion` → `finalization`, `process_failed` →
+   `tool blockers`, `score_failed` → `task/planning`, with names
+   returned in frozen order (the SANA-neighborhood seven, then
+   `unknown`), not flag order. Freezing G1 is not a clock start. Frozen
+   record: `docs/week0_g1_taxonomy.md`.
+
+4. **The session**, then **What happened** — the widget-stock trace
+   above, same as the MVP e2e demo.
+
+5. **Step 1: `evalbench-import`** — sample output shaped like the real
+   command: `status: imported`, 7 scenarios → 27 events + 7 score rows,
+   `failed_sessions_view` pinned to `v1`.
+
+6. **Step 2: `evalbench-failed-sessions --format json`** — the one
+   failed row of 7 (the W0.4 denominator), with the mechanical flags
+   still true **and** the frozen labels attached:
+
+   ```json
+   "taxonomy_categories": ["task/planning", "finalization", "tool blockers"]
+   ```
+
+   JSON, not the table format, because the table historically omitted
+   `taxonomy_categories`.
+
+7. **Step 3: `evalbench-score`** — the same W0.4 punch as the MVP demo:
+   the imported `goal_completion` is 0.0, yet the correctness judge
+   scored the unanswered session 1.0 with `llm_feedback` null (there was
+   no answer to judge). That is why `failed_sessions`, not the judge, is
+   the W0.4 denominator.
+
+8. **Punchline:**
+
+   > This widget-stock session failed because the agent never answered;
+   > goal_completion=0.0. G1 frozen labels are task/planning,
+   > finalization, tool blockers.
+
+## Related
+
+- [`examples/evalbench_mvp_e2e.md`](evalbench_mvp_e2e.md) — the merged
+  MVP e2e on the same session (import → failed-sessions → score, plus
+  `--synth` and live modes).
+- [`examples/evalbench_week0_full_idea.md`](evalbench_week0_full_idea.md)
+  — the EXAMPLE Week 0 pack (Acme, pre-freeze), which stays
+  illustrative.
+- [`docs/evalbench.md`](../docs/evalbench.md) — data flow, the
+  failed-session contract (W0.4), judge scoring, CLI.
+- [`docs/week0_partner.md`](../docs/week0_partner.md),
+  [`docs/week0_d4_memo.md`](../docs/week0_d4_memo.md),
+  [`docs/week0_g1_taxonomy.md`](../docs/week0_g1_taxonomy.md) — the
+  frozen Week 0 record this demo replays.
+- Issues
+  [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
+  (EvalBench import bridge / AgentForensics MVP) and
+  [#97](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/97)
+  (LLM-judge scoring of EvalBench runs).

--- a/examples/evalbench_week0_freeze_e2e.md
+++ b/examples/evalbench_week0_freeze_e2e.md
@@ -1,24 +1,15 @@
-# Post-freeze Week 0 e2e: the real freeze on the widget-stock session
+# Week 0 freeze e2e: team demo on the widget-stock session
 
-The Week 0 freeze landed for real
+This is a live walkthrough for the team
 ([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)):
-the pilot partner is frozen in
-[`docs/week0_partner.md`](../docs/week0_partner.md), the fail-closed D4
-boundary in [`docs/week0_d4_memo.md`](../docs/week0_d4_memo.md), and the
-G1 taxonomy v0.1.0 in
-[`docs/week0_g1_taxonomy.md`](../docs/week0_g1_taxonomy.md). This demo
-replays that freeze as one recordable story on the same widget-stock
-failed session as the merged MVP e2e demo
-([`examples/evalbench_mvp_e2e.md`](evalbench_mvp_e2e.md)).
+one real failed session, told as a story a presenter reads aloud. A
+customer asked a support agent how many widgets are in stock, the agent
+went silent, and BQAA's EvalBench import path finds that session and
+names the failure with the frozen G1 taxonomy. A teammate should
+understand the failure in 60–90 seconds of reading the output, then see
+how BQAA names it.
 
-**This is the REAL freeze demo, not the EXAMPLE Acme pack.** The Week 0
-example pack ([`examples/evalbench_week0_full_idea.md`](evalbench_week0_full_idea.md))
-remains illustrative — its partner is fictional and its fixtures keep
-`example: true` / `g1_frozen: false`. Everything printed by this demo is
-the frozen record.
-
-**The six-week clock has NOT started.** It starts only when the first
-Week 1 snapshot job is kicked, not at the freeze and not at this demo.
+Run it, then use this file as speaker notes:
 
 ```bash
 bash examples/evalbench_week0_freeze_e2e.sh --fixture
@@ -29,87 +20,79 @@ bash examples/evalbench_week0_freeze_e2e.sh --fixture
 without running anything (there is no `--synth` here, and the
 `EVALBENCH_FIXTURE` environment variable is not read).
 
-## The protagonist (same session as the MVP e2e demo)
+The Week 0 freeze (partner, D4 boundary, G1 taxonomy v0.1.0 —
+`docs/week0_*.md`) already landed; this demo leans on it but does not
+re-teach it. **The six-week clock has NOT started.** It starts only when
+the first Week 1 snapshot job is kicked, not at this demo.
 
-A terse support agent was asked how many widgets are in stock and never
-answered. Real trace from `bqaa_e2e_real.agent_events` (project
-`test-project-0728-467323`), EvalBench job `mvp-e2e-real-traces`:
+## The session (same protagonist as the merged MVP e2e demo)
+
+Real trace from `test-project-0728-467323.bqaa_e2e_real.agent_events`,
+imported as EvalBench job `mvp-e2e-real-traces`:
 
 | | |
 |---|---|
 | agent | `support_agent` |
+| system prompt | terse support agent; use tools for inventory/tickets; one-sentence answers |
 | user | `real-user-0` |
-| prompt | `How many widgets are in stock?` |
+| asked | `How many widgets are in stock?` |
 | session_id | `7e352c34-4c1c-4395-acd5-fb3c8f215346` |
-| eval_id / scenario_id | `7e352c34` |
-| events | `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING`, then silence |
-| what never happened | no `check_inventory` call, no `LLM_RESPONSE`, no `AGENT_COMPLETED` |
-| score | `goal_completion` 0.0 vs threshold 1 |
+| eval_id | `7e352c34` (first 8 chars of session_id) |
 
-Sibling session `ab7535a5` answered *"There are 0 widgets in stock."* —
-the agent could do it; this session just never did.
+## The six acts, in banner order
 
-## The story, in order
+1. **The customer asked. The agent went silent.** Introduce the session:
+   who the agent is, what the customer asked, the session and eval ids.
+   No jargon yet — this is a support ticket that went unanswered.
 
-The fixture prints these under `=== ... ===` banners, in this order:
+2. **What the trace shows.** `USER_MESSAGE_RECEIVED` →
+   `INVOCATION_STARTING` → `AGENT_STARTING` → silence. No
+   `check_inventory` tool call, no `LLM_RESPONSE`, no `AGENT_COMPLETED`.
+   Sibling session `ab7535a5` answered *"There are 0 widgets in
+   stock."* — the agent **can** do this; this session just never did.
+   Land the human problem: a stock question with no answer.
 
-1. **Partner: Google Cloud BQAA (this SDK).** The real pilot partner is
-   Google Cloud BigQuery Agent Analytics itself — self-hosted: the ADK
-   `support_agent` traces in
-   `test-project-0728-467323.bqaa_e2e_real.agent_events`, imported as
-   EvalBench job `mvp-e2e-real-traces`. AgentForensics is SANA-adjacent
-   published work, **not a SANA fork** and not a named collaboration with
-   SANA authors; SANA is LakeQA + KramaBench on Strands, this pilot is
-   ADK+EvalBench on widget-stock support, so it is not duplicating those
-   benchmarks. Frozen record: `docs/week0_partner.md`.
+3. **Import the real job so we can query that failure.** Step 1:
+   `evalbench-import` — sample output shaped like the real command:
+   `status: imported`, 7 scenarios → 27 events + 7 score rows under
+   `import_version v1`, with events/scores/manifest tables and the
+   `evalbench_failed_sessions` view on `analytics-project.bqaa`.
 
-2. **D4: fail-closed memo for this pilot.** The boundary covers exactly
-   this pilot's data — project `test-project-0728-467323`, datasets
-   `bqaa_e2e_real`, `bqaa_evalbench_mvp_demo`,
-   `bqaa_evalbench_mvp_mirror` — with one named report consumer,
-   Hai-Yuan Cao (`caohy1988` / `haiyuan-eng-google`). Unnamed means
-   denied. `--fixture` validates ingestion, taxonomy mechanics, and
-   stability ONLY; it can never produce a Part II funding
-   recommendation. Frozen record: `docs/week0_d4_memo.md`.
-
-3. **G1 freeze: taxonomy v0.1.0.** Production `failure_taxonomy.py` is
-   frozen — `taxonomy_version: 0.1.0`, `g1_frozen: true`,
-   `clock_started: false`. Mechanical mapping until the labeler study:
-   `missing_completion` → `finalization`, `process_failed` →
-   `tool blockers`, `score_failed` → `task/planning`, with names
-   returned in frozen order (the SANA-neighborhood seven, then
-   `unknown`), not flag order. Freezing G1 is not a clock start. Frozen
-   record: `docs/week0_g1_taxonomy.md`.
-
-4. **The session**, then **What happened** — the widget-stock trace
-   above, same as the MVP e2e demo.
-
-5. **Step 1: `evalbench-import`** — sample output shaped like the real
-   command: `status: imported`, 7 scenarios → 27 events + 7 score rows,
-   `failed_sessions_view` pinned to `v1`.
-
-6. **Step 2: `evalbench-failed-sessions --format json`** — the one
-   failed row of 7 (the W0.4 denominator), with the mechanical flags
-   still true **and** the frozen labels attached:
+4. **failed_sessions finds the one that never answered.** Step 2:
+   `evalbench-failed-sessions --format json` (JSON, not the table
+   format — the table omits `taxonomy_categories`). 1 of 7 sessions
+   failed: the mechanical flags `process_failed`, `missing_completion`,
+   and `score_failed` are all true, `failing_scores` shows
+   `goal_completion 0.0`, and the same row carries the frozen labels:
 
    ```json
    "taxonomy_categories": ["task/planning", "finalization", "tool blockers"]
    ```
 
-   JSON, not the table format, because the table historically omitted
-   `taxonomy_categories`.
+   Read them in plain English, not as a taxonomy lecture:
 
-7. **Step 3: `evalbench-score`** — the same W0.4 punch as the MVP demo:
-   the imported `goal_completion` is 0.0, yet the correctness judge
-   scored the unanswered session 1.0 with `llm_feedback` null (there was
-   no answer to judge). That is why `failed_sessions`, not the judge, is
-   the W0.4 denominator.
+   - `task/planning` — never decided to look up stock
+   - `tool blockers` — never called `check_inventory`
+   - `finalization` — never produced an answer
 
-8. **Punchline:**
+   One short trust note here (not its own act): this is our real BQAA
+   ADK+EvalBench pilot (not SANA/Strands). Fail-closed D4: Hai-Yuan Cao
+   is the only named report consumer; a fixture can never produce a
+   funding rec. Clock not started.
 
-   > This widget-stock session failed because the agent never answered;
-   > goal_completion=0.0. G1 frozen labels are task/planning,
-   > finalization, tool blockers.
+5. **A live judge would miss this.** Step 3: `evalbench-score` — the
+   correctness judge scored the unanswered session 1.0 with
+   `llm_feedback` null and `pass_rate` 1.0 over the 7 pinned sessions,
+   because there was nothing to judge. That is why `failed_sessions`,
+   not the judge, is the denominator.
+
+6. **Punchline.**
+
+   > This widget-stock session failed because the agent never answered
+   > (goal_completion=0.0). G1 names it task/planning, tool blockers,
+   > and finalization — it never planned the lookup, never called
+   > check_inventory, never finished. Next debugging action: inspect why
+   > the trace died after AGENT_STARTING before the inventory tool.
 
 ## Related
 
@@ -124,7 +107,7 @@ The fixture prints these under `=== ... ===` banners, in this order:
 - [`docs/week0_partner.md`](../docs/week0_partner.md),
   [`docs/week0_d4_memo.md`](../docs/week0_d4_memo.md),
   [`docs/week0_g1_taxonomy.md`](../docs/week0_g1_taxonomy.md) — the
-  frozen Week 0 record this demo replays.
+  frozen Week 0 record this demo leans on.
 - Issues
   [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
   (EvalBench import bridge / AgentForensics MVP) and

--- a/examples/evalbench_week0_freeze_e2e.sh
+++ b/examples/evalbench_week0_freeze_e2e.sh
@@ -46,15 +46,17 @@ Usage: bash examples/evalbench_week0_freeze_e2e.sh --fixture
 Post-freeze Week 0 e2e demo (#435): walks the REAL frozen partner
 (Google Cloud BQAA), the fail-closed D4 memo, and the G1 taxonomy v0.1.0
 freeze on the widget-stock failed session 7e352c34, then the three
-EvalBench CLI steps as sample output. --fixture (or EVALBENCH_FIXTURE=1)
-is the only mode: no BigQuery, no --synth, no live CLI. The six-week
-clock has not started.
+EvalBench CLI steps as sample output. The --fixture argument is the only
+mode: no BigQuery, no --synth, no live CLI. The six-week clock has not
+started.
 
 Narrative companion: examples/evalbench_week0_freeze_e2e.md
 USAGE
 }
 
-FIXTURE="${EVALBENCH_FIXTURE:-0}"
+# The --fixture argument is the only way to run this demo; the
+# EVALBENCH_FIXTURE environment variable is deliberately not read.
+FIXTURE=0
 for arg in "$@"; do
   case "${arg}" in
     --fixture) FIXTURE=1 ;;

--- a/examples/evalbench_week0_freeze_e2e.sh
+++ b/examples/evalbench_week0_freeze_e2e.sh
@@ -13,19 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Post-freeze Week 0 e2e for the AgentForensics MVP (#435).
+# Team demo: the post-freeze Week 0 e2e as a live walkthrough (#435).
 #
-# The Week 0 freeze landed for real: partner (docs/week0_partner.md), D4
-# boundary (docs/week0_d4_memo.md), and G1 taxonomy v0.1.0
-# (docs/week0_g1_taxonomy.md). This demo replays that freeze as one
-# recordable story on the same widget-stock failed session as the merged
-# MVP e2e demo (examples/evalbench_mvp_e2e.sh): support_agent, session
-# 7e352c34, "How many widgets are in stock?", never answered.
+# This is a presenter script. Run it in front of the team and read the
+# banners aloud: a real customer asked a support agent how many widgets
+# are in stock, the agent went silent, and BQAA's EvalBench import path
+# finds that session and names the failure with the frozen G1 taxonomy.
+# A teammate should understand the failure in 60-90 seconds of reading
+# the output, then see how BQAA names it.
+#
+# Same real session as the merged MVP e2e demo
+# (examples/evalbench_mvp_e2e.sh): support_agent, session 7e352c34,
+# "How many widgets are in stock?", never answered. The Week 0 freeze
+# (partner, D4, G1 v0.1.0 -- docs/week0_*.md) already landed; this demo
+# leans on it but does not re-teach it.
 #
 # This is NOT the EXAMPLE Acme pack (examples/evalbench_week0_full_idea.sh),
-# which stays illustrative. Everything printed here is the REAL frozen
-# record. The six-week clock has NOT started; it starts only when the
-# first Week 1 snapshot job is kicked.
+# which stays illustrative. The six-week clock has NOT started; it starts
+# only when the first Week 1 snapshot job is kicked.
 #
 # This demo is --fixture only: no BigQuery, no --synth, no live CLI, no
 # judge calls. Sample identities are fixed at the 455 fixture defaults
@@ -35,7 +40,7 @@
 # Usage:
 #   bash examples/evalbench_week0_freeze_e2e.sh --fixture
 #
-# Narrative companion: examples/evalbench_week0_freeze_e2e.md
+# Speaker notes: examples/evalbench_week0_freeze_e2e.md
 
 set -euo pipefail
 
@@ -43,14 +48,14 @@ usage() {
   cat <<'USAGE'
 Usage: bash examples/evalbench_week0_freeze_e2e.sh --fixture
 
-Post-freeze Week 0 e2e demo (#435): walks the REAL frozen partner
-(Google Cloud BQAA), the fail-closed D4 memo, and the G1 taxonomy v0.1.0
-freeze on the widget-stock failed session 7e352c34, then the three
-EvalBench CLI steps as sample output. The --fixture argument is the only
+Team demo of the post-freeze Week 0 e2e (#435): a live walkthrough of
+the widget-stock failed session 7e352c34 -- the customer asked, the
+agent went silent, evalbench-import + failed_sessions find it, and the
+frozen G1 taxonomy v0.1.0 names it. The --fixture argument is the only
 mode: no BigQuery, no --synth, no live CLI. The six-week clock has not
 started.
 
-Narrative companion: examples/evalbench_week0_freeze_e2e.md
+Speaker notes: examples/evalbench_week0_freeze_e2e.md
 USAGE
 }
 
@@ -87,8 +92,8 @@ note() {
 }
 
 # Sample identities only; nothing below is read from or written to BigQuery.
-# These are the 455 fixture defaults; the frozen facts (partner, D4, G1)
-# are fixed and are not renamed by environment variables.
+# These are the 455 fixture defaults; the session facts are real and are
+# not renamed by environment variables.
 bq_project="analytics-project"
 bq_dataset="bqaa"
 eb_project="benchmark-project"
@@ -105,84 +110,39 @@ session_id="7e352c34-4c1c-4395-acd5-fb3c8f215346"
 sid="evalbench-import:${job_id}:${version}:${scenario_id}"
 
 echo "EvalBench Week 0 freeze e2e (fixture mode): job ${job_id}"
-note "No BigQuery call is made in fixture mode. Clock has not started."
-note "Partner + D4 + G1 are already frozen (#435 Week 0 freeze); this demo"
-note "replays that freeze on the widget-stock failed session from the"
-note "merged MVP e2e demo."
+note "Team walkthrough of one real failed session and how BQAA names it."
+note "No BigQuery call is made in fixture mode. Clock not started."
 
-# ---- 1. Partner ---------------------------------------------------------- #
-banner "Partner: Google Cloud BQAA (this SDK)"
-echo "The REAL pilot partner is Google Cloud BigQuery Agent Analytics"
-echo "(this SDK / BQAA). The pilot is self-hosted: the ADK support_agent"
-echo "traces in test-project-0728-467323.bqaa_e2e_real.agent_events,"
-echo "imported as EvalBench job ${job_id}."
-note "AgentForensics is SANA-adjacent published work -- not a SANA fork and"
-note "not a named collaboration with SANA authors. SANA is LakeQA +"
-note "KramaBench on Strands; this pilot is ADK+EvalBench on widget-stock"
-note "support, so it is not duplicating those two benchmarks."
-note "Frozen record: docs/week0_partner.md"
-
-# ---- 2. D4 --------------------------------------------------------------- #
-banner "D4: fail-closed memo for this pilot"
-echo "The D4 boundary is fail-closed and covers exactly this pilot's data:"
-echo "  project:   test-project-0728-467323"
-echo "  datasets:  bqaa_e2e_real, bqaa_evalbench_mvp_demo,"
-echo "             bqaa_evalbench_mvp_mirror"
-echo "  named report consumer: Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"
-note "No other consumer is named; if a consumer is not named in the memo,"
-note "access is denied."
-note "--fixture validates ingestion, taxonomy mechanics, and stability ONLY"
-note "-- it can never produce a Part II funding recommendation."
-note "Frozen record: docs/week0_d4_memo.md"
-
-# ---- 3. G1 --------------------------------------------------------------- #
-banner "G1 freeze: taxonomy v0.1.0"
-echo "Production failure_taxonomy.py is frozen:"
-echo "  taxonomy_version: 0.1.0"
-echo "  g1_frozen: true"
-echo "  clock_started: false"
-echo "Mechanical mapping until the labeler study:"
-echo "  missing_completion -> finalization"
-echo "  process_failed     -> tool blockers"
-echo "  score_failed       -> task/planning"
-note "Names come back in frozen order (the SANA-neighborhood seven, then"
-note "unknown) -- not flag order."
-note "Freezing G1 is NOT a clock start: the six-week clock has not started;"
-note "it starts only when the first Week 1 snapshot job is kicked."
-note "Frozen record: docs/week0_g1_taxonomy.md"
-
-# ---- 4. The session ------------------------------------------------------ #
-banner "This agent was asked to check widget stock. Here is the session."
+# ---- Act 1: the customer -------------------------------------------------- #
+banner "The customer asked. The agent went silent."
 echo "  agent:         support_agent"
 echo "  system prompt: \"You are a terse support agent. Use tools when asked"
 echo "                 about inventory or tickets. Keep answers to one sentence.\""
 echo "  user:          real-user-0"
+echo "  asked:         How many widgets are in stock?"
 echo "  session_id:    ${session_id}"
-echo "  scenario_id:   ${scenario_id}   (EvalBench eval_id: the session_id's first 8 chars)"
-echo "  job:           ${job_id}"
-note "The same session as the merged MVP e2e demo -- now read through the"
-note "frozen Week 0 record above."
+echo "  eval_id:       ${scenario_id}   (first 8 chars of session_id)"
+note "Real trace source: test-project-0728-467323.bqaa_e2e_real.agent_events"
 
-# ---- 5. What happened ---------------------------------------------------- #
-banner "What happened"
-echo "  user:  How many widgets are in stock?"
-echo "  agent: (no response)"
+# ---- Act 2: the trace ------------------------------------------------------ #
+banner "What the trace shows"
+echo "  USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING"
+echo "  ... then silence. Nothing else. No response ever reached the user."
 echo
-echo "  events, in order:"
-echo "    USER_MESSAGE_RECEIVED"
-echo "    INVOCATION_STARTING"
-echo "    AGENT_STARTING"
-echo "    ... then silence"
-note "The trace stops after AGENT_STARTING: no check_inventory tool call, no"
-note "LLM_RESPONSE, no AGENT_COMPLETED. Sibling session ab7535a5 asked the"
-note "same question and answered \"There are 0 widgets in stock.\""
+echo "  What never happened: no check_inventory tool call, no LLM_RESPONSE,"
+echo "  no AGENT_COMPLETED."
+echo
+echo "  Sibling session ab7535a5 asked the same question and answered"
+echo "  \"There are 0 widgets in stock.\" -- so the agent CAN do this; this"
+echo "  session just never did."
+note "This is the human problem: a stock question with no answer."
 
-# ---- 6. Import ----------------------------------------------------------- #
-banner "Import those traces into EvalBench so we can query this failure"
+# ---- Act 3: import --------------------------------------------------------- #
+banner "Import the real job so we can query that failure"
 note "evalbench-import mirrors the job's EvalBench tables into BQAA-owned"
 note "tables, records the version in a manifest row, and pins the"
-note "evalbench_failed_sessions view to it. After this, failed_sessions can"
-note "list session ${scenario_id} -- with its frozen G1 labels."
+note "evalbench_failed_sessions view to it. After this, we can query the"
+note "silent session like any other analytics row."
 banner "Step 1: evalbench-import"
 echo "\$ bq-agent-sdk evalbench-import \\"
 echo "    --project-id ${eb_project} --evalbench-dataset ${eb_dataset} \\"
@@ -206,11 +166,9 @@ note "status=imported: 7 scenarios became 27 events + 7 score rows under"
 note "import_version ${version}. Session ${scenario_id} is 3 of those events and 1 of"
 note "those score rows."
 
-# ---- 7. failed_sessions with the frozen labels --------------------------- #
-banner "This session in failed_sessions with frozen G1 labels"
-note "1 of 7 sessions failed the W0.4 contract for import_version ${version}."
-note "failed_sessions (not the judge) is the W0.4 denominator, and since the"
-note "G1 freeze each row carries taxonomy_categories in the frozen names."
+# ---- Act 4: failed_sessions ------------------------------------------------ #
+banner "failed_sessions finds the one that never answered"
+note "1 of 7 sessions failed for import_version ${version} -- ours."
 banner "Step 2: evalbench-failed-sessions"
 echo "\$ bq-agent-sdk evalbench-failed-sessions \\"
 echo "    --project-id ${bq_project} --target-dataset ${bq_dataset} \\"
@@ -236,16 +194,19 @@ cat <<JSON
   ]
 }
 JSON
-note "--format json, not table: the table format is not used for this step"
-note "in the fixture (it historically omitted taxonomy_categories)."
-note "The mechanical flags still trip -- process_failed, missing_completion,"
-note "score_failed all true -- and the frozen mapper turns them into the"
-note "G1 names, in frozen order: task/planning, finalization, tool blockers."
+note "task/planning  -- never decided to look up stock"
+note "tool blockers  -- never called check_inventory"
+note "finalization   -- never produced an answer"
+note "--format json, not table: the table format omits taxonomy_categories."
+note "This is our real BQAA ADK+EvalBench pilot (not SANA/Strands)."
+note "Fail-closed D4: Hai-Yuan Cao only; a fixture cannot produce a"
+note "funding rec. Clock not started."
 
-# ---- 8. Score ------------------------------------------------------------ #
-banner "Score this session"
+# ---- Act 5: the judge ------------------------------------------------------ #
+banner "A live judge would miss this"
 note "evalbench-score runs Client.evaluate + LLMAsJudge over the same"
-note "version, narrowed to its 7 pinned session ids."
+note "version, narrowed to its 7 pinned session ids. Watch what it says"
+note "about the silent session."
 banner "Step 3: evalbench-score"
 echo "\$ bq-agent-sdk evalbench-score \\"
 echo "    --project-id ${bq_project} --dataset-id ${bq_dataset} \\"
@@ -278,12 +239,11 @@ cat <<JSON
 }
 JSON
 note "(the six answered sessions are elided from session_scores above)"
-note "Scenario ${scenario_id}: the imported goal_completion is 0.0 (step 2), yet"
-note "the correctness judge on this job scored the unanswered session 1.0"
-note "with llm_feedback null -- there was no answer to judge. That is why"
-note "failed_sessions, not the judge, is the W0.4 denominator."
+note "correctness 1.0, llm_feedback null, pass_rate 1.0 -- because there"
+note "was nothing to judge. That is why failed_sessions, not the judge,"
+note "is the denominator."
 
-# ---- 9. Punchline -------------------------------------------------------- #
+# ---- Act 6: punchline ------------------------------------------------------ #
 banner "Punchline"
-echo "This widget-stock session failed because the agent never answered; goal_completion=0.0. G1 frozen labels are task/planning, finalization, tool blockers."
+echo "This widget-stock session failed because the agent never answered (goal_completion=0.0). G1 names it task/planning, tool blockers, and finalization — it never planned the lookup, never called check_inventory, never finished. Next debugging action: inspect why the trace died after AGENT_STARTING before the inventory tool."
 exit 0

--- a/examples/evalbench_week0_freeze_e2e.sh
+++ b/examples/evalbench_week0_freeze_e2e.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Post-freeze Week 0 e2e for the AgentForensics MVP (#435).
+#
+# The Week 0 freeze landed for real: partner (docs/week0_partner.md), D4
+# boundary (docs/week0_d4_memo.md), and G1 taxonomy v0.1.0
+# (docs/week0_g1_taxonomy.md). This demo replays that freeze as one
+# recordable story on the same widget-stock failed session as the merged
+# MVP e2e demo (examples/evalbench_mvp_e2e.sh): support_agent, session
+# 7e352c34, "How many widgets are in stock?", never answered.
+#
+# This is NOT the EXAMPLE Acme pack (examples/evalbench_week0_full_idea.sh),
+# which stays illustrative. Everything printed here is the REAL frozen
+# record. The six-week clock has NOT started; it starts only when the
+# first Week 1 snapshot job is kicked.
+#
+# This demo is --fixture only: no BigQuery, no --synth, no live CLI, no
+# judge calls. Sample identities are fixed at the 455 fixture defaults
+# (analytics-project.bqaa mirror, benchmark-project.evalbench source,
+# job mvp-e2e-real-traces, import_version v1).
+#
+# Usage:
+#   bash examples/evalbench_week0_freeze_e2e.sh --fixture
+#
+# Narrative companion: examples/evalbench_week0_freeze_e2e.md
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash examples/evalbench_week0_freeze_e2e.sh --fixture
+
+Post-freeze Week 0 e2e demo (#435): walks the REAL frozen partner
+(Google Cloud BQAA), the fail-closed D4 memo, and the G1 taxonomy v0.1.0
+freeze on the widget-stock failed session 7e352c34, then the three
+EvalBench CLI steps as sample output. --fixture (or EVALBENCH_FIXTURE=1)
+is the only mode: no BigQuery, no --synth, no live CLI. The six-week
+clock has not started.
+
+Narrative companion: examples/evalbench_week0_freeze_e2e.md
+USAGE
+}
+
+FIXTURE="${EVALBENCH_FIXTURE:-0}"
+for arg in "$@"; do
+  case "${arg}" in
+    --fixture) FIXTURE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "evalbench_week0_freeze_e2e.sh: unknown argument '${arg}'." \
+        "This demo is --fixture only -- no BigQuery, no --synth, no live" \
+        "mode; the six-week clock has not started. Run:" \
+        "bash examples/evalbench_week0_freeze_e2e.sh --fixture" >&2
+      exit 2
+      ;;
+  esac
+done
+if [[ "${FIXTURE}" != "1" ]]; then
+  echo "evalbench_week0_freeze_e2e.sh: this demo is --fixture only" \
+    "(no BigQuery, no live mode; the clock has not started). Run:" \
+    "bash examples/evalbench_week0_freeze_e2e.sh --fixture" >&2
+  exit 2
+fi
+
+banner() {
+  echo
+  echo "=== $* ==="
+}
+
+note() {
+  echo "  # $*"
+}
+
+# Sample identities only; nothing below is read from or written to BigQuery.
+# These are the 455 fixture defaults; the frozen facts (partner, D4, G1)
+# are fixed and are not renamed by environment variables.
+bq_project="analytics-project"
+bq_dataset="bqaa"
+eb_project="benchmark-project"
+eb_dataset="evalbench"
+job_id="mvp-e2e-real-traces"
+version="v1"
+events_table="${bq_project}.${bq_dataset}.evalbench_agent_events"
+scores_table="${bq_project}.${bq_dataset}.evalbench_scores_imported"
+manifest_table="${bq_project}.${bq_dataset}.evalbench_import_manifest"
+view="${bq_project}.${bq_dataset}.evalbench_failed_sessions"
+# The protagonist: the same real trace as the merged MVP e2e demo.
+scenario_id="7e352c34"
+session_id="7e352c34-4c1c-4395-acd5-fb3c8f215346"
+sid="evalbench-import:${job_id}:${version}:${scenario_id}"
+
+echo "EvalBench Week 0 freeze e2e (fixture mode): job ${job_id}"
+note "No BigQuery call is made in fixture mode. Clock has not started."
+note "Partner + D4 + G1 are already frozen (#435 Week 0 freeze); this demo"
+note "replays that freeze on the widget-stock failed session from the"
+note "merged MVP e2e demo."
+
+# ---- 1. Partner ---------------------------------------------------------- #
+banner "Partner: Google Cloud BQAA (this SDK)"
+echo "The REAL pilot partner is Google Cloud BigQuery Agent Analytics"
+echo "(this SDK / BQAA). The pilot is self-hosted: the ADK support_agent"
+echo "traces in test-project-0728-467323.bqaa_e2e_real.agent_events,"
+echo "imported as EvalBench job ${job_id}."
+note "AgentForensics is SANA-adjacent published work -- not a SANA fork and"
+note "not a named collaboration with SANA authors. SANA is LakeQA +"
+note "KramaBench on Strands; this pilot is ADK+EvalBench on widget-stock"
+note "support, so it is not duplicating those two benchmarks."
+note "Frozen record: docs/week0_partner.md"
+
+# ---- 2. D4 --------------------------------------------------------------- #
+banner "D4: fail-closed memo for this pilot"
+echo "The D4 boundary is fail-closed and covers exactly this pilot's data:"
+echo "  project:   test-project-0728-467323"
+echo "  datasets:  bqaa_e2e_real, bqaa_evalbench_mvp_demo,"
+echo "             bqaa_evalbench_mvp_mirror"
+echo "  named report consumer: Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"
+note "No other consumer is named; if a consumer is not named in the memo,"
+note "access is denied."
+note "--fixture validates ingestion, taxonomy mechanics, and stability ONLY"
+note "-- it can never produce a Part II funding recommendation."
+note "Frozen record: docs/week0_d4_memo.md"
+
+# ---- 3. G1 --------------------------------------------------------------- #
+banner "G1 freeze: taxonomy v0.1.0"
+echo "Production failure_taxonomy.py is frozen:"
+echo "  taxonomy_version: 0.1.0"
+echo "  g1_frozen: true"
+echo "  clock_started: false"
+echo "Mechanical mapping until the labeler study:"
+echo "  missing_completion -> finalization"
+echo "  process_failed     -> tool blockers"
+echo "  score_failed       -> task/planning"
+note "Names come back in frozen order (the SANA-neighborhood seven, then"
+note "unknown) -- not flag order."
+note "Freezing G1 is NOT a clock start: the six-week clock has not started;"
+note "it starts only when the first Week 1 snapshot job is kicked."
+note "Frozen record: docs/week0_g1_taxonomy.md"
+
+# ---- 4. The session ------------------------------------------------------ #
+banner "This agent was asked to check widget stock. Here is the session."
+echo "  agent:         support_agent"
+echo "  system prompt: \"You are a terse support agent. Use tools when asked"
+echo "                 about inventory or tickets. Keep answers to one sentence.\""
+echo "  user:          real-user-0"
+echo "  session_id:    ${session_id}"
+echo "  scenario_id:   ${scenario_id}   (EvalBench eval_id: the session_id's first 8 chars)"
+echo "  job:           ${job_id}"
+note "The same session as the merged MVP e2e demo -- now read through the"
+note "frozen Week 0 record above."
+
+# ---- 5. What happened ---------------------------------------------------- #
+banner "What happened"
+echo "  user:  How many widgets are in stock?"
+echo "  agent: (no response)"
+echo
+echo "  events, in order:"
+echo "    USER_MESSAGE_RECEIVED"
+echo "    INVOCATION_STARTING"
+echo "    AGENT_STARTING"
+echo "    ... then silence"
+note "The trace stops after AGENT_STARTING: no check_inventory tool call, no"
+note "LLM_RESPONSE, no AGENT_COMPLETED. Sibling session ab7535a5 asked the"
+note "same question and answered \"There are 0 widgets in stock.\""
+
+# ---- 6. Import ----------------------------------------------------------- #
+banner "Import those traces into EvalBench so we can query this failure"
+note "evalbench-import mirrors the job's EvalBench tables into BQAA-owned"
+note "tables, records the version in a manifest row, and pins the"
+note "evalbench_failed_sessions view to it. After this, failed_sessions can"
+note "list session ${scenario_id} -- with its frozen G1 labels."
+banner "Step 1: evalbench-import"
+echo "\$ bq-agent-sdk evalbench-import \\"
+echo "    --project-id ${eb_project} --evalbench-dataset ${eb_dataset} \\"
+echo "    --job-id ${job_id} --import-version ${version} \\"
+echo "    --target-project ${bq_project} --target-dataset ${bq_dataset} \\"
+echo "    --min-score goal_completion=1 --format json"
+cat <<JSON
+{
+  "job_id": "${job_id}",
+  "import_version": "${version}",
+  "status": "imported",
+  "events_table": "${events_table}",
+  "scores_table": "${scores_table}",
+  "manifest_table": "${manifest_table}",
+  "event_row_count": 27,
+  "score_row_count": 7,
+  "failed_sessions_view": "${view}"
+}
+JSON
+note "status=imported: 7 scenarios became 27 events + 7 score rows under"
+note "import_version ${version}. Session ${scenario_id} is 3 of those events and 1 of"
+note "those score rows."
+
+# ---- 7. failed_sessions with the frozen labels --------------------------- #
+banner "This session in failed_sessions with frozen G1 labels"
+note "1 of 7 sessions failed the W0.4 contract for import_version ${version}."
+note "failed_sessions (not the judge) is the W0.4 denominator, and since the"
+note "G1 freeze each row carries taxonomy_categories in the frozen names."
+banner "Step 2: evalbench-failed-sessions"
+echo "\$ bq-agent-sdk evalbench-failed-sessions \\"
+echo "    --project-id ${bq_project} --target-dataset ${bq_dataset} \\"
+echo "    --job-id ${job_id} --import-version ${version} \\"
+echo "    --min-score goal_completion=1 --format json"
+cat <<JSON
+{
+  "job_id": "${job_id}",
+  "import_version": "${version}",
+  "session_count": 7,
+  "failed_count": 1,
+  "sessions": [
+    {
+      "session_id": "${sid}",
+      "scenario_id": "${scenario_id}",
+      "process_failed": true,
+      "missing_completion": true,
+      "score_failed": true,
+      "failed": true,
+      "failing_scores": {"goal_completion": 0.0},
+      "taxonomy_categories": ["task/planning", "finalization", "tool blockers"]
+    }
+  ]
+}
+JSON
+note "--format json, not table: the table format is not used for this step"
+note "in the fixture (it historically omitted taxonomy_categories)."
+note "The mechanical flags still trip -- process_failed, missing_completion,"
+note "score_failed all true -- and the frozen mapper turns them into the"
+note "G1 names, in frozen order: task/planning, finalization, tool blockers."
+
+# ---- 8. Score ------------------------------------------------------------ #
+banner "Score this session"
+note "evalbench-score runs Client.evaluate + LLMAsJudge over the same"
+note "version, narrowed to its 7 pinned session ids."
+banner "Step 3: evalbench-score"
+echo "\$ bq-agent-sdk evalbench-score \\"
+echo "    --project-id ${bq_project} --dataset-id ${bq_dataset} \\"
+echo "    --job-id ${job_id} --import-version ${version} \\"
+echo "    --evaluator correctness --format json"
+cat <<JSON
+{
+  "evaluator_name": "llm_judge_correctness",
+  "dataset": "${events_table}",
+  "total_sessions": 7,
+  "passed_sessions": 7,
+  "failed_sessions": 0,
+  "pass_rate": 1.0,
+  "session_scores": [
+    {
+      "session_id": "${sid}",
+      "scores": {"correctness": 1.0},
+      "passed": true,
+      "llm_feedback": null
+    }
+  ],
+  "details": {
+    "evalbench": {
+      "job_id": "${job_id}",
+      "import_version": "${version}",
+      "events_table": "${events_table}",
+      "pinned_sessions": 7
+    }
+  }
+}
+JSON
+note "(the six answered sessions are elided from session_scores above)"
+note "Scenario ${scenario_id}: the imported goal_completion is 0.0 (step 2), yet"
+note "the correctness judge on this job scored the unanswered session 1.0"
+note "with llm_feedback null -- there was no answer to judge. That is why"
+note "failed_sessions, not the judge, is the W0.4 denominator."
+
+# ---- 9. Punchline -------------------------------------------------------- #
+banner "Punchline"
+echo "This widget-stock session failed because the agent never answered; goal_completion=0.0. G1 frozen labels are task/planning, finalization, tool blockers."
+exit 0

--- a/examples/evalbench_week0_full_idea.md
+++ b/examples/evalbench_week0_full_idea.md
@@ -8,6 +8,15 @@ Retail Support*). Week 0 of
 [`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
 remains human-gated.
 
+> **Predates the G1 freeze
+> ([#461](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/461)):**
+> this walkthrough is the pre-freeze illustrative story. Production has
+> since frozen taxonomy **v0.1.0** (`g1_frozen: true`) and
+> `failed_sessions` now emits the frozen names (`task/planning`,
+> `finalization`, `tool blockers`) in `taxonomy_categories` — not the
+> mechanical flag ids shown below. Only this example pack keeps the
+> pre-freeze behavior.
+
 What it does show: all **five Week 0 human gates** of the plan of record
 ([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435))
 worked through as **one concrete story** on the widget-stock failed
@@ -112,6 +121,13 @@ Then the through-line the gates exist to serve:
    scaffold config stays `0.0.0-scaffold`, `g1_frozen: false`.
 10. **`Punchline`** — *This widget-stock session failed because the
     agent never answered; goal_completion=0.0.*
+
+> **Post-[#461](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/461)
+> note:** items 8–9 describe the pre-freeze scaffold and predate the G1
+> freeze. Production `failure_taxonomy.py` is now G1-frozen at v0.1.0
+> (`g1_frozen: true`) and emits the frozen category names
+> (`task/planning`, `finalization`, `tool blockers`) in
+> `taxonomy_categories`, not the mechanical flag ids.
 
 ## What this pack is NOT
 

--- a/examples/evalbench_week0_full_idea.md
+++ b/examples/evalbench_week0_full_idea.md
@@ -1,0 +1,136 @@
+# EXAMPLE Week 0 scenario pack: the full AgentForensics idea on one failed session
+
+**This is an EXAMPLE pack — every artifact in it is illustrative, not a
+freeze.** No partner freeze, no G1 freeze, no preregistration freeze:
+`g1_frozen` is **false** everywhere, the six-week clock has **not**
+started, and no real partner is named (the example partner is *Acme
+Retail Support*). Week 0 of
+[`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
+remains human-gated.
+
+What it does show: all **five Week 0 human gates** of the plan of record
+([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435))
+worked through as **one concrete story** on the widget-stock failed
+session from the e2e demo — so a reader can see, end to end, what
+AgentForensics is *for* before any human clears a gate for real.
+
+```bash
+bash examples/evalbench_week0_full_idea.sh --fixture
+```
+
+`--fixture` (or `EVALBENCH_FIXTURE=1`) is the only mode: offline, no
+BigQuery, no network, no live judge, exit `0`. Any other invocation
+prints one line saying so and exits `2` without running anything. The
+facts printed under each banner come from the JSON files in
+[`examples/fixtures/`](fixtures/) (`week0_example_*.json`), each of
+which carries `"example": true`, `"g1_frozen": false`,
+`"clock_started": false`.
+
+## The protagonist (same session as the e2e demo)
+
+A terse support agent was asked how many widgets are in stock and never
+answered. Real trace from `bqaa_e2e_real.agent_events` (reference
+project `test-project-0728-467323`), EvalBench job `mvp-e2e-real-traces`:
+
+| | |
+|---|---|
+| agent | `support_agent` |
+| user | `real-user-0` |
+| prompt | `How many widgets are in stock?` |
+| session_id | `7e352c34-4c1c-4395-acd5-fb3c8f215346` |
+| eval_id / scenario_id | `7e352c34` |
+| events | `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING`, then silence |
+| what never happened | no `check_inventory` call, no `LLM_RESPONSE`, no `AGENT_COMPLETED` |
+| score | `goal_completion` 0.0 vs threshold 1 |
+
+Sibling session `ab7535a5` answered *"There are 0 widgets in stock."* —
+the agent could do it; this session just never did.
+
+## The five gates, as this session's story
+
+The fixture prints these in order, each under an `=== ... ===` banner;
+`tests/test_evalbench_week0_full_idea.py` asserts the same order.
+
+1. **`EXAMPLE — Week 0 is not a freeze. Clock has not started.`** — the
+   disclaimer first: everything below is illustrative, `g1_frozen:
+   false`, `clock_started: false`.
+2. **`EXAMPLE partner + SANA relationship`** — example partner **Acme
+   Retail Support**. AgentForensics here is **SANA-adjacent, not a SANA
+   fork**: SANA is LakeQA + KramaBench on the Strands runtime with seven
+   categories (task/planning, wrong source, execution/computation,
+   incomplete evidence, turn-waste, finalization, tool blockers); this
+   example pilot is ADK+EvalBench on widget-stock support. Taxonomy v0.1
+   EXAMPLE seeds from those seven because the failure modes overlap —
+   and it is not duplicating LakeQA/KramaBench, which study different
+   benchmarks on a different runtime.
+3. **`EXAMPLE runtime + route`** — the pilot traces already exist: the
+   ADK plugin logged `support_agent` into `bqaa_e2e_real.agent_events`,
+   folded into EvalBench job `mvp-e2e-real-traces`. Runtime is ADK
+   plugin → BQAA `agent_events` → EvalBench-hosted, so the
+   EvalBench-only MVP route is **CORRECT** for this example and D1 does
+   not need re-decision.
+4. **`EXAMPLE pilot-benchmark rubric`** — the benchmark is selected by
+   the predeclared rubric, not import convenience, and each criterion is
+   *scored* in the fixture: collaborator relevance (retail support
+   inventory questions — pass), failure-mode coverage (silent
+   non-completion — pass), score availability / threshold-definability
+   (`goal_completion` 0.0 vs 1.0, threshold 1 — pass), ground-truth
+   depth (sibling `ab7535a5`'s gold answer — pass), then trace fidelity
+   (the three real ADK events, then silence — pass).
+5. **`EXAMPLE D4 boundary memo`** — fail-closed, with **example** report
+   consumers ("Alex Rivera (example collaborator)", "Jordan Lee (example
+   collaborator)" — not real people). A `--fixture`/synthetic run
+   validates **ingestion, taxonomy mechanics, and stability ONLY** and
+   can never produce a Part II funding recommendation; without clearance
+   the pilot runs on pre-redacted reference traces
+   (`test-project-0728-467323`) or pauses. The stop/go memo is itself a
+   governed artifact.
+6. **`EXAMPLE preregistration (not a week-1 freeze)`** — the plan's
+   floors and decision rules copied as an example: replicate agreement
+   ≥80%, non-`unknown` coverage ≥80%, κ point ≥0.6 with CI lower ≥0.45,
+   localization coverage ≥70%, hit@1 CI lower >0 and point uplift
+   ≥ +10pp, plus the value-gate rubric, the noisy-small-n localization
+   rule, the sealed `P-blind` set, and the reserved revision week.
+
+Then the through-line the gates exist to serve:
+
+7. **`This agent was asked to check widget stock. Here is the session.`**
+   — the protagonist, verbatim.
+8. **`This session in failed_sessions (mechanical taxonomy_categories)`**
+   — the slice-9 consumer attaches
+   `taxonomy_categories: ["process_failed", "missing_completion",
+   "score_failed"]` to the row: which gates tripped, mechanically, not
+   why the agent failed.
+9. **`EXAMPLE mapping of mechanical flags onto SANA-seeded names`** —
+   the judgment layer the MVP would build, shown as an EXAMPLE (**not
+   G1**): `missing_completion` → *finalization* (never finalized an
+   answer), `process_failed` → *tool blockers* (never called
+   `check_inventory`), plus *task/planning* as an overlapping seed. This
+   mapping lives only in
+   [`fixtures/week0_example_taxonomy_seed.json`](fixtures/week0_example_taxonomy_seed.json)
+   — never in `src/bigquery_agent_analytics/failure_taxonomy.py`, whose
+   scaffold config stays `0.0.0-scaffold`, `g1_frozen: false`.
+10. **`Punchline`** — *This widget-stock session failed because the
+    agent never answered; goal_completion=0.0.*
+
+## What this pack is NOT
+
+- It does **not** clear any Week 0 gate — those remain human decisions.
+- It does **not** start the six-week clock, the partner job, the real D4
+  boundary, live-trace ingestion, or the labeler study.
+- It does **not** freeze taxonomy names: the SANA-seeded names appear
+  only in the example fixture, and the production scaffold module is
+  untouched.
+
+## Related
+
+- [`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
+  — the plan of record whose Week 0 gates this pack illustrates.
+- `examples/evalbench_mvp_e2e.md` / `.sh` (PR
+  [#455](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/455))
+  — the e2e demo this pack's session comes from.
+- [`docs/evalbench.md`](../docs/evalbench.md) — the failed-session
+  contract and CLI reference.
+- Issue
+  [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
+  — AgentForensics MVP tracking.

--- a/examples/evalbench_week0_full_idea.sh
+++ b/examples/evalbench_week0_full_idea.sh
@@ -21,6 +21,12 @@
 # false, the six-week clock has NOT started, and no real partner is named
 # (the example partner is "Acme Retail Support").
 #
+# NOTE: this pack PREDATES the G1 freeze (PR #461). Production has since
+# frozen taxonomy v0.1.0 (g1_frozen: true) and failed_sessions now emits the
+# frozen names (task/planning, finalization, tool blockers) in
+# taxonomy_categories — not the mechanical flag ids shown below. Only this
+# example pack keeps the pre-freeze behavior.
+#
 # This pack is --fixture only: no BigQuery, no network, no live judge.
 #
 #   bash examples/evalbench_week0_full_idea.sh --fixture
@@ -133,6 +139,8 @@ echo "                AGENT_STARTING, then silence"
 echo "  it never called check_inventory; no LLM_RESPONSE; no AGENT_COMPLETED"
 echo
 
+# Pre-freeze snapshot: since PR #461, production failed_sessions emits the
+# frozen v0.1.0 names in taxonomy_categories, not these mechanical flag ids.
 echo "=== This session in failed_sessions (mechanical taxonomy_categories) ==="
 echo "The slice-9 consumer attaches the mechanical scaffold categories to"
 echo "the row — which gates tripped, not why the agent failed:"

--- a/examples/evalbench_week0_full_idea.sh
+++ b/examples/evalbench_week0_full_idea.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EXAMPLE Week 0 scenario pack for the AgentForensics MVP (#435).
+#
+# Demonstrates all five Week 0 human gates of
+# docs/agentforensics_mvp_plan.md as ONE concrete story on the widget-stock
+# failed session — as EXAMPLES. Nothing here is a freeze: g1_frozen stays
+# false, the six-week clock has NOT started, and no real partner is named
+# (the example partner is "Acme Retail Support").
+#
+# This pack is --fixture only: no BigQuery, no network, no live judge.
+#
+#   bash examples/evalbench_week0_full_idea.sh --fixture
+#
+# Narrative companion: examples/evalbench_week0_full_idea.md
+# Facts printed under each banner come from examples/fixtures/week0_example_*.json.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="${SCRIPT_DIR}/fixtures"
+
+fixture=0
+for arg in "$@"; do
+  case "$arg" in
+    --fixture) fixture=1 ;;
+    *)
+      echo "evalbench_week0_full_idea.sh: unknown argument '${arg}'." \
+        "This EXAMPLE pack is --fixture only — no BigQuery, no --synth, no" \
+        "live mode; the six-week clock has not started." >&2
+      exit 2
+      ;;
+  esac
+done
+if [[ "${EVALBENCH_FIXTURE:-}" == "1" ]]; then
+  fixture=1
+fi
+if (( ! fixture )); then
+  echo "evalbench_week0_full_idea.sh: this EXAMPLE pack is --fixture only" \
+    "(no BigQuery, no live mode; the clock has not started). Run:" \
+    "bash examples/evalbench_week0_full_idea.sh --fixture" >&2
+  exit 2
+fi
+
+show_json() {
+  # Pretty-print one fixture JSON file (also proves it parses).
+  python3 -m json.tool "${FIXTURE_DIR}/$1"
+}
+
+echo "=== EXAMPLE — Week 0 is not a freeze. Clock has not started. ==="
+echo "This is an EXAMPLE scenario pack — every artifact below is"
+echo "illustrative. It is not a freeze: not a partner freeze, not a G1"
+echo "freeze, not a preregistration freeze."
+echo "  g1_frozen: false"
+echo "  clock_started: false — the six-week clock has not started."
+echo "fixture mode: offline; no BigQuery, no network, no live judge."
+echo "It walks the five Week 0 human gates of docs/agentforensics_mvp_plan.md"
+echo "as one story on the widget-stock failed session from the #435 e2e demo."
+echo
+
+echo "=== EXAMPLE partner + SANA relationship ==="
+echo "Example partner: Acme Retail Support (illustrative — no real partner"
+echo "is named). AgentForensics here is SANA-adjacent, not a SANA fork:"
+echo "SANA is LakeQA + KramaBench on Strands with seven categories; this"
+echo "example pilot is ADK+EvalBench on widget-stock support, seeding"
+echo "taxonomy v0.1 EXAMPLE from those seven because failure modes overlap"
+echo "— and it is not duplicating LakeQA/KramaBench work."
+show_json week0_example_partner.json
+echo
+
+echo "=== EXAMPLE runtime + route ==="
+echo "The pilot traces already exist: support_agent, logged by the ADK"
+echo "plugin into bqaa_e2e_real.agent_events and folded into EvalBench job"
+echo "mvp-e2e-real-traces. Runtime is ADK plugin -> BQAA agent_events ->"
+echo "EvalBench-hosted, so the EvalBench-only MVP route is CORRECT for this"
+echo "example and D1 does not need re-decision here."
+echo
+
+echo "=== EXAMPLE pilot-benchmark rubric ==="
+echo "Selected by the predeclared rubric, not import convenience:"
+echo "widget-stock support, session 7e352c34-4c1c-4395-acd5-fb3c8f215346"
+echo "(eval_id 7e352c34). All five criteria pass in this example:"
+echo "goal_completion 0.0 vs threshold 1; sibling ab7535a5 answered"
+echo "\"There are 0 widgets in stock.\"; real ADK events"
+echo "USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then"
+echo "silence."
+show_json week0_example_rubric.json
+echo
+
+echo "=== EXAMPLE D4 boundary memo ==="
+echo "Fail-closed: no clearance means the pilot runs on pre-redacted"
+echo "reference traces (project test-project-0728-467323) or pauses."
+echo "A --fixture/synthetic run validates ingestion, taxonomy mechanics,"
+echo "and stability ONLY — it can never produce a Part II funding"
+echo "recommendation. Report consumers below are examples, not real people;"
+echo "the stop/go memo is itself a governed artifact."
+show_json week0_example_d4_memo.json
+echo
+
+echo "=== EXAMPLE preregistration (not a week-1 freeze) ==="
+echo "EXAMPLE copy of the plan's floors and decision rules — not week-1"
+echo "freeze; clock not started. Floors: replicate agreement >=80%;"
+echo "non-unknown coverage >=80%; kappa point >=0.6 with CI lower >=0.45;"
+echo "localization coverage >=70%; hit@1 CI lower >0 and point uplift"
+echo ">= +10pp. Plus the reserved revision week, the value-gate rubric, and"
+echo "the noisy-small-n localization rule."
+show_json week0_example_preregistration.json
+echo
+
+echo "=== This agent was asked to check widget stock. Here is the session. ==="
+echo "  agent:        support_agent"
+echo "  user:         real-user-0"
+echo "  prompt:       How many widgets are in stock?"
+echo "  session_id:   7e352c34-4c1c-4395-acd5-fb3c8f215346"
+echo "  eval_id:      7e352c34"
+echo "  job:          mvp-e2e-real-traces"
+echo "  source:       bqaa_e2e_real.agent_events (test-project-0728-467323)"
+echo "  events:       USER_MESSAGE_RECEIVED -> INVOCATION_STARTING ->"
+echo "                AGENT_STARTING, then silence"
+echo "  it never called check_inventory; no LLM_RESPONSE; no AGENT_COMPLETED"
+echo
+
+echo "=== This session in failed_sessions (mechanical taxonomy_categories) ==="
+echo "The slice-9 consumer attaches the mechanical scaffold categories to"
+echo "the row — which gates tripped, not why the agent failed:"
+echo "  process_failed:      True"
+echo "  missing_completion:  True"
+echo "  score_failed:        True   (goal_completion 0.0 vs threshold 1)"
+echo '  taxonomy_categories: ["process_failed", "missing_completion", "score_failed"]'
+echo
+
+echo "=== EXAMPLE mapping of mechanical flags onto SANA-seeded names ==="
+echo "EXAMPLE only — not G1; g1_frozen: false. These SANA-seeded names live"
+echo "only in this fixture, never in src/. For this session: the agent"
+echo "never called check_inventory (tool blockers), never finalized an"
+echo "answer (finalization), and the plan to answer never formed"
+echo "(task/planning as an overlapping seed)."
+show_json week0_example_taxonomy_seed.json
+echo
+
+echo "=== Punchline ==="
+echo "This widget-stock session failed because the agent never answered; goal_completion=0.0."

--- a/examples/fixtures/week0_example_d4_memo.json
+++ b/examples/fixtures/week0_example_d4_memo.json
@@ -1,0 +1,18 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "fail_closed": true,
+  "report_consumers": [
+    "Alex Rivera (example collaborator)",
+    "Jordan Lee (example collaborator)"
+  ],
+  "fixture_validates": ["ingestion", "taxonomy mechanics", "stability"],
+  "fixture_validates_only": true,
+  "never_produces": "Part II funding recommendation",
+  "reference_project": "test-project-0728-467323",
+  "pre_redacted": true,
+  "stop_go_memo_is_governed_artifact": true
+}

--- a/examples/fixtures/week0_example_partner.json
+++ b/examples/fixtures/week0_example_partner.json
@@ -1,0 +1,21 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "partner_name": "Acme Retail Support",
+  "relationship_to_sana": "SANA-adjacent, not a SANA fork: SANA is LakeQA + KramaBench on the Strands runtime with a seven-category failure taxonomy; this example pilot is ADK+EvalBench on widget-stock support, and taxonomy v0.1 EXAMPLE seeds from SANA's seven categories because the failure modes overlap.",
+  "sana_runtime": "Strands",
+  "this_pilot_runtime": "ADK+EvalBench",
+  "sana_categories": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers"
+  ],
+  "not_duplicating_lakeqa_kramabench": "This example pilot is not duplicating LakeQA/KramaBench: it studies a different benchmark (widget-stock support) on a different runtime (ADK+EvalBench, not Strands), reusing SANA's seven category names only as unfrozen seeds."
+}

--- a/examples/fixtures/week0_example_preregistration.json
+++ b/examples/fixtures/week0_example_preregistration.json
@@ -1,0 +1,24 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "not_week_1_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "banner": "EXAMPLE — not week-1 freeze, clock not started",
+  "floors": {
+    "replicate_agreement_pct": 80,
+    "non_unknown_coverage_pct": 80,
+    "kappa_point": 0.6,
+    "kappa_ci_lower": 0.45,
+    "localization_coverage_pct": 70,
+    "hit_at_1_ci_lower_gt_0": true,
+    "hit_at_1_point_uplift_pp": 10
+  },
+  "decision_rules": {
+    "reserved_revision_week": "One taxonomy revision slot (week 7): a stability miss invokes it once with fresh labels and a re-gate; a second miss ends the MVP with the analysis as the deliverable.",
+    "value_gate": "At least the preregistered fraction of randomly assigned investigations where the report changed or materially narrowed the next action, adjudicated by a non-investigator; a stated preference or unverified acceptance counts for nothing.",
+    "noisy_small_n_localization": "Point-clears-but-CI-spans-zero resolves per the preregistered week-0 rule, not week-6 judgment; no metric conditions on successful localizations only.",
+    "sealed_sets": "P-blind is frozen before any tuning and scored exactly once at week 6."
+  }
+}

--- a/examples/fixtures/week0_example_rubric.json
+++ b/examples/fixtures/week0_example_rubric.json
@@ -1,0 +1,38 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "selected_benchmark": "widget-stock support",
+  "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+  "eval_id": "7e352c34",
+  "job_id": "mvp-e2e-real-traces",
+  "criteria": {
+    "collaborator_relevance": {
+      "name": "collaborator relevance",
+      "result": "pass",
+      "reason": "Retail support inventory questions are exactly what the example partner (Acme Retail Support) debugs."
+    },
+    "failure_mode_coverage": {
+      "name": "failure-mode coverage",
+      "result": "pass",
+      "reason": "Covers silent non-completion: the agent never answered the widget-stock question."
+    },
+    "score_availability": {
+      "name": "score availability / threshold-definability",
+      "result": "pass",
+      "reason": "goal_completion is 0.0 against a definable threshold of 1."
+    },
+    "ground_truth_depth": {
+      "name": "ground-truth depth",
+      "result": "pass",
+      "reason": "Sibling session ab7535a5 answered \"There are 0 widgets in stock.\" — a gold answer for the same prompt."
+    },
+    "trace_fidelity": {
+      "name": "trace fidelity",
+      "result": "pass",
+      "reason": "Real ADK events: USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then silence."
+    }
+  }
+}

--- a/examples/fixtures/week0_example_taxonomy_seed.json
+++ b/examples/fixtures/week0_example_taxonomy_seed.json
@@ -1,0 +1,38 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "not_g1": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "taxonomy_version": "0.1.0-example",
+  "sana_categories": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers"
+  ],
+  "mechanical_flags": ["process_failed", "missing_completion", "score_failed"],
+  "widget_session": {
+    "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+    "eval_id": "7e352c34",
+    "taxonomy_categories": [
+      "process_failed",
+      "missing_completion",
+      "score_failed"
+    ]
+  },
+  "example_mapping": {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning"
+  },
+  "example_mapping_notes": {
+    "missing_completion": "No AGENT_COMPLETED event and no final answer -> SANA's finalization seed.",
+    "process_failed": "The agent never called check_inventory before going silent -> SANA's tool blockers seed.",
+    "score_failed": "goal_completion 0.0 against threshold 1; the plan to answer never formed -> the overlapping task/planning seed."
+  }
+}

--- a/examples/fixtures/week0_real_d4_memo.json
+++ b/examples/fixtures/week0_real_d4_memo.json
@@ -1,0 +1,22 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 D4 freeze",
+  "clock_started": false,
+  "fail_closed": true,
+  "scope_project": "test-project-0728-467323",
+  "scope_datasets": [
+    "bqaa_e2e_real",
+    "bqaa_evalbench_mvp_demo",
+    "bqaa_evalbench_mvp_mirror"
+  ],
+  "scope_derived": ["failed_sessions", "taxonomy labels"],
+  "report_consumers": ["Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"],
+  "grants_policy": "No additional per-user grants or notebook/export access beyond Hai-Yuan Cao until a later D4 amendment; fail closed (deny) if a consumer is not named here. Documented as policy text only — no IAM API calls.",
+  "fixture_validates": ["ingestion", "taxonomy mechanics", "stability"],
+  "fixture_validates_only": true,
+  "never_produces": "Part II funding recommendation",
+  "no_new_live_judge_calls": true,
+  "no_new_bq_jobs": true,
+  "no_labeler_access_expansion": true,
+  "stop_go_memo_is_governed_artifact": true
+}

--- a/examples/fixtures/week0_real_partner.json
+++ b/examples/fixtures/week0_real_partner.json
@@ -1,0 +1,22 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 partner freeze",
+  "clock_started": false,
+  "partner_name": "Google Cloud BigQuery Agent Analytics (this SDK / BQAA)",
+  "pilot": {
+    "agent": "ADK support_agent",
+    "events_table": "test-project-0728-467323.bqaa_e2e_real.agent_events",
+    "evalbench_job_id": "mvp-e2e-real-traces"
+  },
+  "relationship_to_sana": "AgentForensics is SANA-adjacent published work, NOT a SANA fork and NOT a named collaboration with SANA authors. SANA is LakeQA + KramaBench on the Strands runtime with a seven-category failure taxonomy (task/planning, wrong source, execution/computation, incomplete evidence, turn-waste, finalization, tool blockers); this pilot is ADK+EvalBench on widget-stock support — a different benchmark and runtime.",
+  "not_a_sana_fork": true,
+  "not_a_named_sana_collaboration": true,
+  "sana_runtime": "Strands",
+  "this_pilot_runtime": "ADK+EvalBench",
+  "not_duplicating_lakeqa_kramabench": "This pilot is not duplicating LakeQA/KramaBench: it studies a different benchmark (widget-stock support) on a different runtime (ADK+EvalBench, not Strands).",
+  "route": {
+    "path": "ADK plugin -> BQAA agent_events -> EvalBench-hosted",
+    "evalbench_only_mvp_route_correct": true,
+    "d1_needs_redecision": false
+  }
+}

--- a/examples/fixtures/week0_real_preregistration.json
+++ b/examples/fixtures/week0_real_preregistration.json
@@ -1,0 +1,23 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 preregistration freeze-candidate",
+  "clock_started": false,
+  "freeze_candidate": true,
+  "not_week_1_execution": true,
+  "banner": "Plan-of-record freeze-candidate — numbers copied from the v4 plan; the six-week clock has NOT started and starts only when the first Week 1 snapshot job is kicked.",
+  "floors": {
+    "replicate_agreement_pct": 80,
+    "non_unknown_coverage_pct": 80,
+    "kappa_point": 0.6,
+    "kappa_ci_lower": 0.45,
+    "localization_coverage_pct": 70,
+    "hit_at_1_ci_lower_gt_0": true,
+    "hit_at_1_point_uplift_pp": 10
+  },
+  "decision_rules": {
+    "reserved_revision_week": "One taxonomy revision slot (week 7): a stability miss invokes it once with fresh labels and a re-gate; a second miss ends the MVP with the analysis as the deliverable.",
+    "value_gate": "At least the preregistered fraction of randomly assigned investigations where the report changed or materially narrowed the next action, adjudicated by a non-investigator; a stated preference or unverified acceptance counts for nothing.",
+    "noisy_small_n_localization": "Point-clears-but-CI-spans-zero resolves per the preregistered week-0 rule, not week-6 judgment; no metric conditions on successful localizations only.",
+    "sealed_sets": "P-blind is frozen before any tuning and scored exactly once at week 6."
+  }
+}

--- a/examples/fixtures/week0_real_rubric.json
+++ b/examples/fixtures/week0_real_rubric.json
@@ -1,0 +1,19 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 rubric freeze",
+  "clock_started": false,
+  "selected_benchmark": "widget-stock support",
+  "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+  "eval_id": "7e352c34",
+  "job_id": "mvp-e2e-real-traces",
+  "gold": {
+    "sibling_session": "ab7535a5",
+    "gold_answer": "There are 0 widgets in stock."
+  },
+  "score": {
+    "metric": "goal_completion",
+    "failed_session_score": 0,
+    "gold_session_score": 1,
+    "threshold": 1
+  }
+}

--- a/examples/fixtures/week0_real_taxonomy.json
+++ b/examples/fixtures/week0_real_taxonomy.json
@@ -1,0 +1,31 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 G1 freeze",
+  "clock_started": false,
+  "g1_frozen": true,
+  "taxonomy_version": "0.1.0",
+  "frozen_category_names": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown"
+  ],
+  "mechanical_flags": ["process_failed", "missing_completion", "score_failed"],
+  "flag_to_category": {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning"
+  },
+  "unknown_is_residual_only": "unknown is in the frozen vocabulary as the residual bucket for the labeler study; the mechanical three-flag mapper never emits it (all flags false returns an empty list).",
+  "widget_session": {
+    "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+    "eval_id": "7e352c34",
+    "tripped_flags": ["process_failed", "missing_completion", "score_failed"],
+    "taxonomy_categories": ["task/planning", "finalization", "tool blockers"]
+  },
+  "dialects": []
+}

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -2223,13 +2223,15 @@ class EvalBenchSession:
 
   @property
   def taxonomy_categories(self) -> tuple[str, ...]:
-    """Scaffold taxonomy ids tripped by this session's mechanical flags.
+    """G1-frozen taxonomy names tripped by this session's mechanical flags.
 
     Computed from the three flags via
     ``failure_taxonomy.categorize_failed_session`` (a property, not a stored
-    field, so it can never drift from the flags). Scaffold vocabulary only:
-    the ids equal the flag names and are NOT the G1 taxonomy. All flags
-    false (an ``include_passed`` row) yields ``()``.
+    field, so it can never drift from the flags). Frozen vocabulary
+    (taxonomy v0.1.0): each tripped flag maps to its frozen name and the
+    names come back in ``FROZEN_CATEGORY_NAMES`` order — assignment stays
+    mechanical until the labeler study. All flags false (an
+    ``include_passed`` row) yields ``()``, never ``("unknown",)``.
     """
     return categorize_failed_session(self)
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -62,6 +62,7 @@ from google.cloud import bigquery
 
 from ._telemetry import make_bq_client
 from ._telemetry import with_sdk_labels
+from .failure_taxonomy import categorize_failed_session
 
 if TYPE_CHECKING:
   from .trace import TraceFilter
@@ -2220,8 +2221,22 @@ class EvalBenchSession:
         failed=self.failed,
     )
 
+  @property
+  def taxonomy_categories(self) -> tuple[str, ...]:
+    """Scaffold taxonomy ids tripped by this session's mechanical flags.
+
+    Computed from the three flags via
+    ``failure_taxonomy.categorize_failed_session`` (a property, not a stored
+    field, so it can never drift from the flags). Scaffold vocabulary only:
+    the ids equal the flag names and are NOT the G1 taxonomy. All flags
+    false (an ``include_passed`` row) yields ``()``.
+    """
+    return categorize_failed_session(self)
+
   def to_dict(self) -> dict[str, Any]:
-    return _json_safe(dataclasses.asdict(self))
+    payload = _json_safe(dataclasses.asdict(self))
+    payload["taxonomy_categories"] = list(self.taxonomy_categories)
+    return payload
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2243,7 +2258,11 @@ class EvalBenchFailedSessions:
   manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
-    return _json_safe(dataclasses.asdict(self))
+    # Nested sessions go through EvalBenchSession.to_dict so each row also
+    # carries the computed taxonomy_categories (asdict only sees fields).
+    payload = _json_safe(dataclasses.asdict(self))
+    payload["sessions"] = [session.to_dict() for session in self.sessions]
+    return payload
 
 
 def failed_sessions(

--- a/src/bigquery_agent_analytics/failure_taxonomy.py
+++ b/src/bigquery_agent_analytics/failure_taxonomy.py
@@ -12,37 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mechanical failure-taxonomy SCAFFOLD over EvalBench failed-session flags.
+"""G1-frozen failure taxonomy v0.1 over EvalBench failed-session flags.
 
-This is #435 slice 8: the thinnest testable bridge between the failed-session
-contract that already landed (#451/#452 -- ``SessionVerdict`` /
-``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) and the
-future AgentForensics failure taxonomy. It maps the three mechanical flags a
-failed-session row already carries -- ``process_failed``,
-``missing_completion``, ``score_failed`` -- to categories in a versioned
-config. Nothing here interprets *why* an agent failed; that judgment layer is
-the G1 taxonomy study in ``docs/agentforensics_mvp_plan.md`` and has not run.
+This is the #435 Week 0 G1 freeze (``docs/week0_g1_taxonomy.md``). The
+vocabulary is frozen at ``taxonomy_version: 0.1.0`` / ``g1_frozen: True``:
+the SANA-neighborhood seven categories plus ``unknown`` as the residual
+bucket. Names and spellings are stable and may only change through a
+versioned taxonomy revision (the reserved revision week of
+``docs/agentforensics_mvp_plan.md``).
 
-What this module is NOT:
+Category *assignment* stays mechanical until the labeler study runs:
+``categorize_failed_session`` maps the three boolean flags of the landed
+failed-session contract (#451/#452 — ``SessionVerdict`` /
+``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) onto
+frozen names:
 
-- It is **not** G1. The category names are scaffold ids derived from the
-  flag names, marked ``g1_frozen: False`` in the config; nothing downstream
-  may treat them as the frozen taxonomy vocabulary. SANA's seven categories
-  stay unfrozen and do not appear here.
-- It does **not** start the six-week MVP clock, the partner job, the D4
-  boundary, or live-trace ingestion.
-- It does **not** classify sessions: ``evalbench.classify_sessions`` remains
-  the reference implementation of the flags. This module only maps an
-  already-classified row to category ids.
+- ``missing_completion`` → ``finalization``
+- ``process_failed`` → ``tool blockers``
+- ``score_failed`` → ``task/planning``
+
+The other four SANA-neighborhood categories and ``unknown`` are in the
+frozen vocabulary but are never emitted by this three-flag mapper; a row
+with all flags false returns ``()``, not ``("unknown",)`` — a session no
+mechanical gate tripped is not a mechanical failure.
+
+Freezing G1 does **not** start the six-week clock: the clock starts only
+when the first Week 1 snapshot job is kicked. This module still does not
+classify sessions (``evalbench.classify_sessions`` remains the reference
+implementation of the flags), and nothing here reaches BigQuery, an LLM,
+or the network — everything is pure and deterministic.
 
 The config uses the #431 ``evaluation_rubrics`` schema shape
 (``{"metrics": [{"name", "definition", "categories": [{name, definition}]}]}``)
-so ``evaluation_rubrics.build_metrics`` could interpret the core metric later,
-and encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
-per-benchmark *extension categories on the same core* -- empty by default,
+so ``evaluation_rubrics.build_metrics`` can interpret the core metric, and
+encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
+per-benchmark *extension categories on the same core* — empty by default,
 never a second taxonomy.
-
-No BigQuery, no LLM, no network: everything here is pure and deterministic.
 """
 
 from __future__ import annotations
@@ -51,81 +56,139 @@ from collections.abc import Mapping
 import copy
 from typing import Any
 
-# Obviously-scaffold version label. This is NOT taxonomy v0.1 (the G1
-# starting point per the plan of record); it must be replaced wholesale when
-# the G1 study produces frozen names.
-SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"
+# G1-frozen taxonomy version. Bumping this requires a versioned taxonomy
+# revision per the plan of record, not an edit.
+TAXONOMY_VERSION = "0.1.0"
 
 # The three mechanical flags of the landed failed-session contract, in the
-# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. Category
-# ids deliberately equal the flag names: they describe *which gate tripped*,
-# not a failure mode, and renaming them here would only invent unfrozen
-# vocabulary.
-CORE_CATEGORY_IDS = ("process_failed", "missing_completion", "score_failed")
+# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. These are
+# the *input* contract of the mapper; they are not category names.
+MECHANICAL_FLAGS = ("process_failed", "missing_completion", "score_failed")
 
-_CORE_CATEGORY_DEFINITIONS = {
-    "process_failed": (
-        "The session emitted at least one ERROR event (non-zero returncode"
-        " or source error fields). Mechanical: read from the"
-        " process_failed flag of the failed-session contract."
+# The G1-frozen vocabulary, in frozen order: the SANA-neighborhood seven,
+# then ``unknown`` as the residual bucket. ``categorize_failed_session``
+# returns tripped names in THIS order, never in flag order.
+FROZEN_CATEGORY_NAMES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown",
+)
+
+# Frozen names double as the core category ids. Kept as a distinct alias so
+# pre-freeze importers of CORE_CATEGORY_IDS keep working; the three flag ids
+# they used to hold live on as MECHANICAL_FLAGS.
+CORE_CATEGORY_IDS = FROZEN_CATEGORY_NAMES
+
+# Mechanical assignment until the labeler study: which frozen name each
+# tripped flag maps to. The remaining frozen names (including ``unknown``)
+# are never emitted by the three-flag mapper.
+FLAG_TO_CATEGORY = {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning",
+}
+
+_FROZEN_CATEGORY_DEFINITIONS = {
+    "task/planning": (
+        "The agent formed a wrong or incomplete plan for the assigned task."
+        " Mechanical assignment until the labeler study: mapped from the"
+        " failed-session score_failed flag."
     ),
-    "missing_completion": (
-        "The session has no AGENT_COMPLETED event: the agent never produced"
-        " a final response. Mechanical: read from the missing_completion"
-        " flag of the failed-session contract."
+    "wrong source": (
+        "The agent retrieved, cited, or relied on the wrong source."
+        " Mechanical assignment until the labeler study: not emitted by the"
+        " three-flag mapper."
     ),
-    "score_failed": (
-        "The per-benchmark score policy (EvalScorePolicy) was not met;"
-        " missing scores fail by default. returncode == 0 means completed,"
-        " never passed. Mechanical: read from the score_failed flag of the"
-        " failed-session contract."
+    "execution/computation": (
+        "The agent chose a reasonable plan but failed while executing or"
+        " computing it. Mechanical assignment until the labeler study: not"
+        " emitted by the three-flag mapper."
+    ),
+    "incomplete evidence": (
+        "The agent stopped without gathering enough evidence to support a"
+        " correct answer. Mechanical assignment until the labeler study: not"
+        " emitted by the three-flag mapper."
+    ),
+    "turn-waste": (
+        "The agent spent turns without advancing the task. Mechanical"
+        " assignment until the labeler study: not emitted by the three-flag"
+        " mapper."
+    ),
+    "finalization": (
+        "The agent did not produce a completed final response. Mechanical"
+        " assignment until the labeler study: mapped from the failed-session"
+        " missing_completion flag."
+    ),
+    "tool blockers": (
+        "A required tool was missing, failed, or never invoked. Mechanical"
+        " assignment until the labeler study: mapped from the failed-session"
+        " process_failed flag."
+    ),
+    "unknown": (
+        "Residual bucket for failures that do not match a frozen category"
+        " after labeling. In the vocabulary as residual; the mechanical"
+        " three-flag mapper does not emit unknown (all flags false returns"
+        " ())."
     ),
 }
 
-_SCAFFOLD_TAXONOMY_CONFIG = {
-    # Scaffold bookkeeping (not part of the #431 metric schema, which
+_TAXONOMY_CONFIG = {
+    # Freeze bookkeeping (not part of the #431 metric schema, which
     # ignores unknown top-level keys).
-    "taxonomy_version": SCAFFOLD_TAXONOMY_VERSION,
-    # Nothing in this config is G1-frozen vocabulary. Consumers must check
-    # this flag before treating category names as the taxonomy.
-    "g1_frozen": False,
+    "taxonomy_version": TAXONOMY_VERSION,
+    # G1 is frozen: category names below ARE the taxonomy vocabulary.
+    "g1_frozen": True,
     # D2: optional per-benchmark extension categories on the same core (each
     # entry would carry a benchmark name plus #431-shaped categories with
-    # optional ``insert_after``). Empty until G1 work fills it; an empty
-    # slot is the encoding, not a placeholder to invent labels for.
+    # optional ``insert_after``). Still empty at the freeze; an empty slot
+    # is the encoding, not a placeholder to invent labels for.
     "dialects": [],
     # The #431 schema shape (``evaluation_rubrics``): the one core metric a
-    # future ``build_metrics()`` caller could interpret.
+    # ``build_metrics()`` caller can interpret.
     "metrics": [
         {
             "name": "failure_category",
             "definition": (
-                "Which mechanical gate(s) of the EvalBench failed-session"
-                " contract a session tripped. Scaffold only: these are not"
-                " failure modes and not the G1 taxonomy."
+                "Which G1-frozen failure categories (taxonomy v0.1.0) a"
+                " failed session falls into. Assignment is mechanical from"
+                " the failed-session flags until the labeler study runs."
             ),
             "categories": [
-                {"name": name, "definition": _CORE_CATEGORY_DEFINITIONS[name]}
-                for name in CORE_CATEGORY_IDS
+                {"name": name, "definition": _FROZEN_CATEGORY_DEFINITIONS[name]}
+                for name in FROZEN_CATEGORY_NAMES
             ],
         }
     ],
 }
 
 
-def scaffold_taxonomy_config() -> dict:
-  """A deep copy of the scaffold taxonomy config (mutate freely).
+def taxonomy_config() -> dict:
+  """A deep copy of the G1-frozen taxonomy config (mutate freely).
 
   Same access pattern as ``evaluation_rubrics.builtin_metric_config``. The
   ``metrics`` entry follows the #431 config schema; ``taxonomy_version``,
-  ``g1_frozen`` and ``dialects`` are scaffold/D2 bookkeeping documented in
+  ``g1_frozen`` and ``dialects`` are freeze/D2 bookkeeping documented in
   the module docstring.
   """
-  return copy.deepcopy(_SCAFFOLD_TAXONOMY_CONFIG)
+  return copy.deepcopy(_TAXONOMY_CONFIG)
+
+
+def scaffold_taxonomy_config() -> dict:
+  """Compatibility wrapper for the pre-freeze name: ``taxonomy_config()``.
+
+  The scaffold era ended with the G1 freeze; this returns the same frozen
+  config (see CHANGELOG). New callers should use ``taxonomy_config``.
+  """
+  return taxonomy_config()
 
 
 def categorize_failed_session(row: Any) -> tuple[str, ...]:
-  """Map one failed-session row to its mechanical scaffold categories.
+  """Map one failed-session row to its G1-frozen categories.
 
   Pure and deterministic: no BigQuery, no LLM, no network. ``row`` is one
   failed-session row -- a mapping (e.g. a ``failed_sessions`` /
@@ -134,19 +197,23 @@ def categorize_failed_session(row: Any) -> tuple[str, ...]:
   contract: ``process_failed``, ``missing_completion``, ``score_failed``.
   Extra fields are ignored.
 
-  Returns the tripped category ids in ``CORE_CATEGORY_IDS`` order; a row can
-  trip several (e.g. process_failed AND missing_completion). All three flags
-  false returns ``()``: this scaffold does not invent an ``unknown`` bucket,
-  because a session no mechanical gate tripped is simply not a mechanical
-  failure (the future G1 taxonomy owns residual categories).
+  Mechanical assignment until the labeler study: each tripped flag maps to
+  its frozen name per ``FLAG_TO_CATEGORY``, and the tripped names are
+  returned in ``FROZEN_CATEGORY_NAMES`` order (never flag order). A row can
+  trip several (e.g. all three flags gives ``("task/planning",
+  "finalization", "tool blockers")``). All three flags false returns
+  ``()`` -- never ``("unknown",)``: ``unknown`` is the residual bucket of
+  the labeling study, and a session no mechanical gate tripped is simply
+  not a mechanical failure.
 
   Raises:
     ValueError: A flag is absent or not a bool -- silently defaulting a
       missing flag would miscategorize sessions.
   """
-  return tuple(
-      category for category in CORE_CATEGORY_IDS if _flag(row, category)
-  )
+  tripped = {
+      FLAG_TO_CATEGORY[flag] for flag in MECHANICAL_FLAGS if _flag(row, flag)
+  }
+  return tuple(name for name in FROZEN_CATEGORY_NAMES if name in tripped)
 
 
 def _flag(row: Any, name: str) -> bool:

--- a/src/bigquery_agent_analytics/failure_taxonomy.py
+++ b/src/bigquery_agent_analytics/failure_taxonomy.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mechanical failure-taxonomy SCAFFOLD over EvalBench failed-session flags.
+
+This is #435 slice 8: the thinnest testable bridge between the failed-session
+contract that already landed (#451/#452 -- ``SessionVerdict`` /
+``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) and the
+future AgentForensics failure taxonomy. It maps the three mechanical flags a
+failed-session row already carries -- ``process_failed``,
+``missing_completion``, ``score_failed`` -- to categories in a versioned
+config. Nothing here interprets *why* an agent failed; that judgment layer is
+the G1 taxonomy study in ``docs/agentforensics_mvp_plan.md`` and has not run.
+
+What this module is NOT:
+
+- It is **not** G1. The category names are scaffold ids derived from the
+  flag names, marked ``g1_frozen: False`` in the config; nothing downstream
+  may treat them as the frozen taxonomy vocabulary. SANA's seven categories
+  stay unfrozen and do not appear here.
+- It does **not** start the six-week MVP clock, the partner job, the D4
+  boundary, or live-trace ingestion.
+- It does **not** classify sessions: ``evalbench.classify_sessions`` remains
+  the reference implementation of the flags. This module only maps an
+  already-classified row to category ids.
+
+The config uses the #431 ``evaluation_rubrics`` schema shape
+(``{"metrics": [{"name", "definition", "categories": [{name, definition}]}]}``)
+so ``evaluation_rubrics.build_metrics`` could interpret the core metric later,
+and encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
+per-benchmark *extension categories on the same core* -- empty by default,
+never a second taxonomy.
+
+No BigQuery, no LLM, no network: everything here is pure and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import copy
+from typing import Any
+
+# Obviously-scaffold version label. This is NOT taxonomy v0.1 (the G1
+# starting point per the plan of record); it must be replaced wholesale when
+# the G1 study produces frozen names.
+SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"
+
+# The three mechanical flags of the landed failed-session contract, in the
+# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. Category
+# ids deliberately equal the flag names: they describe *which gate tripped*,
+# not a failure mode, and renaming them here would only invent unfrozen
+# vocabulary.
+CORE_CATEGORY_IDS = ("process_failed", "missing_completion", "score_failed")
+
+_CORE_CATEGORY_DEFINITIONS = {
+    "process_failed": (
+        "The session emitted at least one ERROR event (non-zero returncode"
+        " or source error fields). Mechanical: read from the"
+        " process_failed flag of the failed-session contract."
+    ),
+    "missing_completion": (
+        "The session has no AGENT_COMPLETED event: the agent never produced"
+        " a final response. Mechanical: read from the missing_completion"
+        " flag of the failed-session contract."
+    ),
+    "score_failed": (
+        "The per-benchmark score policy (EvalScorePolicy) was not met;"
+        " missing scores fail by default. returncode == 0 means completed,"
+        " never passed. Mechanical: read from the score_failed flag of the"
+        " failed-session contract."
+    ),
+}
+
+_SCAFFOLD_TAXONOMY_CONFIG = {
+    # Scaffold bookkeeping (not part of the #431 metric schema, which
+    # ignores unknown top-level keys).
+    "taxonomy_version": SCAFFOLD_TAXONOMY_VERSION,
+    # Nothing in this config is G1-frozen vocabulary. Consumers must check
+    # this flag before treating category names as the taxonomy.
+    "g1_frozen": False,
+    # D2: optional per-benchmark extension categories on the same core (each
+    # entry would carry a benchmark name plus #431-shaped categories with
+    # optional ``insert_after``). Empty until G1 work fills it; an empty
+    # slot is the encoding, not a placeholder to invent labels for.
+    "dialects": [],
+    # The #431 schema shape (``evaluation_rubrics``): the one core metric a
+    # future ``build_metrics()`` caller could interpret.
+    "metrics": [
+        {
+            "name": "failure_category",
+            "definition": (
+                "Which mechanical gate(s) of the EvalBench failed-session"
+                " contract a session tripped. Scaffold only: these are not"
+                " failure modes and not the G1 taxonomy."
+            ),
+            "categories": [
+                {"name": name, "definition": _CORE_CATEGORY_DEFINITIONS[name]}
+                for name in CORE_CATEGORY_IDS
+            ],
+        }
+    ],
+}
+
+
+def scaffold_taxonomy_config() -> dict:
+  """A deep copy of the scaffold taxonomy config (mutate freely).
+
+  Same access pattern as ``evaluation_rubrics.builtin_metric_config``. The
+  ``metrics`` entry follows the #431 config schema; ``taxonomy_version``,
+  ``g1_frozen`` and ``dialects`` are scaffold/D2 bookkeeping documented in
+  the module docstring.
+  """
+  return copy.deepcopy(_SCAFFOLD_TAXONOMY_CONFIG)
+
+
+def categorize_failed_session(row: Any) -> tuple[str, ...]:
+  """Map one failed-session row to its mechanical scaffold categories.
+
+  Pure and deterministic: no BigQuery, no LLM, no network. ``row`` is one
+  failed-session row -- a mapping (e.g. a ``failed_sessions`` /
+  ``failed_sessions_sql`` row as a dict) or an object with attributes (e.g.
+  a ``SessionVerdict``) -- carrying the three boolean flags of the landed
+  contract: ``process_failed``, ``missing_completion``, ``score_failed``.
+  Extra fields are ignored.
+
+  Returns the tripped category ids in ``CORE_CATEGORY_IDS`` order; a row can
+  trip several (e.g. process_failed AND missing_completion). All three flags
+  false returns ``()``: this scaffold does not invent an ``unknown`` bucket,
+  because a session no mechanical gate tripped is simply not a mechanical
+  failure (the future G1 taxonomy owns residual categories).
+
+  Raises:
+    ValueError: A flag is absent or not a bool -- silently defaulting a
+      missing flag would miscategorize sessions.
+  """
+  return tuple(
+      category for category in CORE_CATEGORY_IDS if _flag(row, category)
+  )
+
+
+def _flag(row: Any, name: str) -> bool:
+  """Read one required boolean flag from a mapping or attribute row."""
+  missing = object()
+  if isinstance(row, Mapping):
+    value = row.get(name, missing)
+  else:
+    value = getattr(row, name, missing)
+  if value is missing:
+    raise ValueError(
+        f"failed-session row is missing required flag {name!r}; expected the"
+        " process_failed/missing_completion/score_failed contract of"
+        " evalbench.classify_sessions / failed_sessions_sql"
+    )
+  if not isinstance(value, bool):
+    raise ValueError(
+        f"failed-session flag {name!r} must be a bool, got"
+        f" {type(value).__name__}"
+    )
+  return value

--- a/tests/test_cli_evalbench_failed_sessions.py
+++ b/tests/test_cli_evalbench_failed_sessions.py
@@ -103,6 +103,13 @@ def test_lists_latest_version_by_default(
   assert (
       payload["sessions"][0]["trace_id"] == payload["sessions"][0]["session_id"]
   )
+  # Slice 9: each session row carries the scaffold taxonomy categories
+  # computed from its mechanical flags (process_failed + missing_completion
+  # for this fixture) -- no extra field on the fixture, no BigQuery.
+  assert payload["sessions"][0]["taxonomy_categories"] == [
+      "process_failed",
+      "missing_completion",
+  ]
 
 
 def test_pins_version_and_policy_options(

--- a/tests/test_cli_evalbench_failed_sessions.py
+++ b/tests/test_cli_evalbench_failed_sessions.py
@@ -103,12 +103,14 @@ def test_lists_latest_version_by_default(
   assert (
       payload["sessions"][0]["trace_id"] == payload["sessions"][0]["session_id"]
   )
-  # Slice 9: each session row carries the scaffold taxonomy categories
-  # computed from its mechanical flags (process_failed + missing_completion
-  # for this fixture) -- no extra field on the fixture, no BigQuery.
+  # Slice 9 + G1 freeze: each session row carries the frozen taxonomy
+  # names computed from its mechanical flags (process_failed +
+  # missing_completion for this fixture map to tool blockers +
+  # finalization, returned in frozen order) -- no extra field on the
+  # fixture, no BigQuery.
   assert payload["sessions"][0]["taxonomy_categories"] == [
-      "process_failed",
-      "missing_completion",
+      "finalization",
+      "tool blockers",
   ]
 
 

--- a/tests/test_evalbench_week0_freeze_e2e.py
+++ b/tests/test_evalbench_week0_freeze_e2e.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Tests for ``examples/evalbench_week0_freeze_e2e.sh`` (#435).
 
-The post-freeze Week 0 e2e is ``--fixture`` only: nothing here reaches
-BigQuery. It replays the REAL Week 0 freeze (partner + D4 + G1, landed by
-the Week 0 freeze PR) on the same widget-stock failed session as the
-merged MVP e2e demo. It is distinct from the EXAMPLE Acme pack
+The post-freeze Week 0 e2e is a presenter-facing team demo, ``--fixture``
+only: nothing here reaches BigQuery. It tells the widget-stock failed
+session as a six-act story -- the customer asked, the agent went silent,
+evalbench-import + failed_sessions find it, the frozen G1 taxonomy names
+it, and a punchline states the next debugging action. Same real session
+as the merged MVP e2e demo; distinct from the EXAMPLE Acme pack
 (``examples/evalbench_week0_full_idea.sh``), which stays illustrative.
 The six-week clock has NOT started.
 """
@@ -41,27 +43,26 @@ _FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
 _SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
 _EVAL_ID = "7e352c34"
 
-# The frozen record first (partner, D4, G1), then the widget-session
-# through-line from the merged MVP e2e demo, in order.
+# The six-act story a presenter reads aloud, in order: customer, trace,
+# import, failed_sessions, judge, punchline.
 _BANNERS = (
-    "=== Partner: Google Cloud BQAA (this SDK) ===",
-    "=== D4: fail-closed memo for this pilot ===",
-    "=== G1 freeze: taxonomy v0.1.0 ===",
-    "=== This agent was asked to check widget stock. Here is the session. ===",
-    "=== What happened ===",
-    "=== Import those traces into EvalBench so we can query this failure ===",
+    "=== The customer asked. The agent went silent. ===",
+    "=== What the trace shows ===",
+    "=== Import the real job so we can query that failure ===",
     "=== Step 1: evalbench-import ===",
-    "=== This session in failed_sessions with frozen G1 labels ===",
+    "=== failed_sessions finds the one that never answered ===",
     "=== Step 2: evalbench-failed-sessions ===",
-    "=== Score this session ===",
+    "=== A live judge would miss this ===",
     "=== Step 3: evalbench-score ===",
     "=== Punchline ===",
 )
 
 _PUNCHLINE = (
-    "This widget-stock session failed because the agent never answered;"
-    " goal_completion=0.0. G1 frozen labels are task/planning, finalization,"
-    " tool blockers."
+    "This widget-stock session failed because the agent never answered "
+    "(goal_completion=0.0). G1 names it task/planning, tool blockers, and "
+    "finalization — it never planned the lookup, never called "
+    "check_inventory, never finished. Next debugging action: inspect why "
+    "the trace died after AGENT_STARTING before the inventory tool."
 )
 
 _FROZEN_CATEGORIES_LINE = (
@@ -93,55 +94,38 @@ def _run(*args: str, env: dict[str, str] | None = None):
 def _assert_freeze_walkthrough(stdout: str) -> None:
   for banner in _BANNERS:
     assert banner in stdout
-  # The frozen record and the through-line appear in narrative order.
+  # The six acts appear in story order.
   positions = [stdout.index(b) for b in _BANNERS]
   assert positions == sorted(positions)
-  partner = stdout[positions[0] : positions[1]]
-  d4 = stdout[positions[1] : positions[2]]
-  g1 = stdout[positions[2] : positions[3]]
-  session = stdout[positions[3] : positions[4]]
-  happened = stdout[positions[4] : positions[5]]
-  imported = stdout[positions[5] : positions[7]]
-  failed = stdout[positions[7] : positions[9]]
-  scored = stdout[positions[9] : positions[11]]
-  punchline = stdout[positions[11] :]
-  # 1. Partner: the REAL frozen partner, not the Acme example.
-  assert "Google Cloud BigQuery Agent Analytics" in partner
-  assert "mvp-e2e-real-traces" in partner
-  assert "SANA-adjacent" in partner
-  assert "not a SANA fork" in partner
-  assert "not duplicating" in partner
-  assert "docs/week0_partner.md" in partner
-  assert "Acme" not in stdout
-  # 2. D4: fail-closed, one named real consumer, no example people.
-  assert "fail-closed" in d4
-  assert "Hai-Yuan Cao" in d4
-  assert "test-project-0728-467323" in d4
-  assert "Part II funding recommendation" in d4
-  assert "docs/week0_d4_memo.md" in d4
-  assert "Alex Rivera" not in stdout
-  assert "Jordan Lee" not in stdout
-  # 3. G1: the frozen version, the mechanical mapping, no clock start.
-  assert "taxonomy_version: 0.1.0" in g1
-  assert "g1_frozen: true" in g1
-  assert "clock_started: false" in g1
-  assert "missing_completion -> finalization" in g1
-  assert "process_failed     -> tool blockers" in g1
-  assert "score_failed       -> task/planning" in g1
-  assert "frozen order" in g1
-  assert "docs/week0_g1_taxonomy.md" in g1
-  # 4. The session: the same protagonist as the merged MVP e2e demo.
-  assert "support_agent" in session
-  assert "real-user-0" in session
-  assert _SESSION_ID in session
-  assert f"scenario_id:   {_EVAL_ID}" in session
-  # 5. What happened: the verbatim prompt and no answer.
-  assert "How many widgets are in stock?" in happened
-  assert "(no response)" in happened
-  assert "AGENT_STARTING" in happened
-  assert "no AGENT_COMPLETED" in happened
-  assert "ab7535a5" in happened
-  # 6. Import result, shaped like the 455 fixture.
+  customer = stdout[positions[0] : positions[1]]
+  trace = stdout[positions[1] : positions[2]]
+  imported = stdout[positions[2] : positions[4]]
+  failed = stdout[positions[4] : positions[6]]
+  judged = stdout[positions[6] : positions[8]]
+  punchline = stdout[positions[8] :]
+  # Act 1: the customer and the session, no jargon.
+  assert "support_agent" in customer
+  assert "terse support agent" in customer
+  assert "inventory or tickets" in customer
+  assert "real-user-0" in customer
+  assert "How many widgets are in stock?" in customer
+  assert _SESSION_ID in customer
+  assert f"eval_id:       {_EVAL_ID}" in customer
+  assert (
+      "test-project-0728-467323.bqaa_e2e_real.agent_events" in customer
+  )
+  # Act 2: the trace stops after AGENT_STARTING; the silence is obvious.
+  assert "USER_MESSAGE_RECEIVED" in trace
+  assert "INVOCATION_STARTING" in trace
+  assert "AGENT_STARTING" in trace
+  assert "silence" in trace
+  assert "no check_inventory" in trace
+  assert "no LLM_RESPONSE" in trace
+  assert "no AGENT_COMPLETED" in trace
+  assert "ab7535a5" in trace
+  assert "There are 0 widgets in stock." in trace
+  assert "no answer" in trace
+  # Act 3: import result, shaped like the 455 fixture.
   assert '"status": "imported"' in imported
   assert '"event_row_count": 27' in imported
   assert '"score_row_count": 7' in imported
@@ -149,8 +133,8 @@ def _assert_freeze_walkthrough(stdout: str) -> None:
       '"failed_sessions_view": "analytics-project.bqaa.evalbench_failed_sessions"'
       in imported
   )
-  # 7. failed_sessions as JSON: mechanical flags still true, plus the
-  # FROZEN taxonomy_categories in frozen order.
+  # Act 4: failed_sessions as JSON -- mechanical flags, the FROZEN
+  # taxonomy_categories line, plain-English glosses, one trust note.
   assert "--format json" in failed
   assert "evalbench-import:mvp-e2e-real-traces:v1:7e352c34" in failed
   assert '"process_failed": true' in failed
@@ -160,22 +144,37 @@ def _assert_freeze_walkthrough(stdout: str) -> None:
   assert _FROZEN_CATEGORIES_LINE in failed
   assert '"session_count": 7' in failed
   assert '"failed_count": 1' in failed
-  assert "1 of 7 sessions failed" in failed
-  assert "W0.4 denominator" in failed
-  # 8. Score: the judge is not the denominator.
-  assert '"pass_rate": 1.0' in scored
-  assert '"llm_feedback": null' in scored
-  assert '"pinned_sessions": 7' in scored
-  assert "goal_completion is 0.0" in scored
-  assert "W0.4 denominator" in scored
-  # 9. Punchline: exactly one sentence, then nothing else.
+  assert "1 of 7" in failed
+  assert "never decided to look up stock" in failed
+  assert "never called check_inventory" in failed
+  assert "never produced an answer" in failed
+  assert "not SANA/Strands" in failed
+  assert "Fail-closed D4" in failed
+  assert "Hai-Yuan Cao" in failed
+  assert "funding rec" in failed
+  assert "Clock not started" in failed
+  # The demo is a story, not a G1 mapping lecture: no arrow table.
+  assert "missing_completion ->" not in stdout
+  assert "process_failed     ->" not in stdout
+  assert "score_failed       ->" not in stdout
+  # Act 5: the judge misses it; failed_sessions is the denominator.
+  assert '"pass_rate": 1.0' in judged
+  assert '"llm_feedback": null' in judged
+  assert '"pinned_sessions": 7' in judged
+  assert "failed_sessions, not the judge," in judged
+  assert "denominator" in judged
+  # Act 6: punchline is exactly one paragraph, then nothing else.
   assert punchline.strip().splitlines()[1:] == [_PUNCHLINE]
-  # Nowhere does the demo start the clock.
+  # Nowhere does the demo invent people, the example partner, or a
+  # started clock.
+  assert "Acme" not in stdout
+  assert "Alex Rivera" not in stdout
+  assert "Jordan Lee" not in stdout
   assert "clock has started" not in stdout
-  assert "clock has not started" in stdout or "Clock has not started" in stdout
+  assert "clock has not started" in stdout or "Clock not started" in stdout
 
 
-def test_fixture_flag_replays_the_freeze_and_exits_zero() -> None:
+def test_fixture_flag_tells_the_story_and_exits_zero() -> None:
   result = _run("--fixture")
   assert result.returncode == 0, result.stderr
   assert result.stderr == ""
@@ -190,7 +189,7 @@ def test_fixture_env_var_alone_is_rejected() -> None:
   result = _run(env={"EVALBENCH_FIXTURE": "1"})
   assert result.returncode == 2
   assert "--fixture only" in result.stderr
-  assert "=== Partner" not in result.stdout
+  assert "=== The customer asked" not in result.stdout
   assert result.stdout == ""
 
 
@@ -198,7 +197,7 @@ def test_without_fixture_flag_exits_two_and_runs_nothing() -> None:
   result = _run()
   assert result.returncode == 2
   assert "--fixture only" in result.stderr
-  assert "=== Partner" not in result.stdout
+  assert "=== The customer asked" not in result.stdout
   assert result.stdout == ""
 
 
@@ -207,7 +206,7 @@ def test_synth_flag_is_rejected_without_running() -> None:
   result = _run("--synth")
   assert result.returncode == 2
   assert "--fixture only" in result.stderr
-  assert "=== Partner" not in result.stdout
+  assert "=== The customer asked" not in result.stdout
   assert result.stdout == ""
 
 
@@ -222,7 +221,7 @@ def test_help_prints_usage_without_running() -> None:
   result = _run("--help")
   assert result.returncode == 0
   assert "--fixture" in result.stdout
-  assert "=== Partner" not in result.stdout
+  assert "=== The customer asked" not in result.stdout
 
 
 def test_example_acme_pack_is_not_the_freeze() -> None:
@@ -252,7 +251,7 @@ def test_production_taxonomy_is_frozen_at_v010() -> None:
   config = failure_taxonomy.taxonomy_config()
   assert config["g1_frozen"] is True
   assert config["taxonomy_version"] == "0.1.0"
-  # The demo's mapping lines match the frozen FLAG_TO_CATEGORY.
+  # The frozen mechanical mapping the demo's labels come from.
   assert dict(failure_taxonomy.FLAG_TO_CATEGORY) == {
       "missing_completion": "finalization",
       "process_failed": "tool blockers",

--- a/tests/test_evalbench_week0_freeze_e2e.py
+++ b/tests/test_evalbench_week0_freeze_e2e.py
@@ -184,10 +184,14 @@ def test_fixture_flag_replays_the_freeze_and_exits_zero() -> None:
   _assert_freeze_walkthrough(result.stdout)
 
 
-def test_fixture_env_var_is_honored() -> None:
+def test_fixture_env_var_alone_is_rejected() -> None:
+  # Regression: the demo is --fixture argv only. An inherited
+  # EVALBENCH_FIXTURE=1 with no arguments must not run the transcript.
   result = _run(env={"EVALBENCH_FIXTURE": "1"})
-  assert result.returncode == 0, result.stderr
-  _assert_freeze_walkthrough(result.stdout)
+  assert result.returncode == 2
+  assert "--fixture only" in result.stderr
+  assert "=== Partner" not in result.stdout
+  assert result.stdout == ""
 
 
 def test_without_fixture_flag_exits_two_and_runs_nothing() -> None:

--- a/tests/test_evalbench_week0_freeze_e2e.py
+++ b/tests/test_evalbench_week0_freeze_e2e.py
@@ -111,9 +111,7 @@ def _assert_freeze_walkthrough(stdout: str) -> None:
   assert "How many widgets are in stock?" in customer
   assert _SESSION_ID in customer
   assert f"eval_id:       {_EVAL_ID}" in customer
-  assert (
-      "test-project-0728-467323.bqaa_e2e_real.agent_events" in customer
-  )
+  assert "test-project-0728-467323.bqaa_e2e_real.agent_events" in customer
   # Act 2: the trace stops after AGENT_STARTING; the silence is obvious.
   assert "USER_MESSAGE_RECEIVED" in trace
   assert "INVOCATION_STARTING" in trace

--- a/tests/test_evalbench_week0_freeze_e2e.py
+++ b/tests/test_evalbench_week0_freeze_e2e.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``examples/evalbench_week0_freeze_e2e.sh`` (#435).
+
+The post-freeze Week 0 e2e is ``--fixture`` only: nothing here reaches
+BigQuery. It replays the REAL Week 0 freeze (partner + D4 + G1, landed by
+the Week 0 freeze PR) on the same widget-stock failed session as the
+merged MVP e2e demo. It is distinct from the EXAMPLE Acme pack
+(``examples/evalbench_week0_full_idea.sh``), which stays illustrative.
+The six-week clock has NOT started.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "examples" / "evalbench_week0_freeze_e2e.sh"
+_EXAMPLE_PACK = _REPO_ROOT / "examples" / "evalbench_week0_full_idea.sh"
+_FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
+
+_SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+_EVAL_ID = "7e352c34"
+
+# The frozen record first (partner, D4, G1), then the widget-session
+# through-line from the merged MVP e2e demo, in order.
+_BANNERS = (
+    "=== Partner: Google Cloud BQAA (this SDK) ===",
+    "=== D4: fail-closed memo for this pilot ===",
+    "=== G1 freeze: taxonomy v0.1.0 ===",
+    "=== This agent was asked to check widget stock. Here is the session. ===",
+    "=== What happened ===",
+    "=== Import those traces into EvalBench so we can query this failure ===",
+    "=== Step 1: evalbench-import ===",
+    "=== This session in failed_sessions with frozen G1 labels ===",
+    "=== Step 2: evalbench-failed-sessions ===",
+    "=== Score this session ===",
+    "=== Step 3: evalbench-score ===",
+    "=== Punchline ===",
+)
+
+_PUNCHLINE = (
+    "This widget-stock session failed because the agent never answered;"
+    " goal_completion=0.0. G1 frozen labels are task/planning, finalization,"
+    " tool blockers."
+)
+
+_FROZEN_CATEGORIES_LINE = (
+    '"taxonomy_categories": ["task/planning", "finalization", "tool blockers"]'
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _run(*args: str, env: dict[str, str] | None = None):
+  # Start from a clean environment so a developer's exported
+  # EVALBENCH_* / BQ_AGENT_* values cannot change what is asserted.
+  clean = {
+      k: v
+      for k, v in os.environ.items()
+      if not k.startswith(("EVALBENCH_", "BQ_AGENT_"))
+  }
+  return subprocess.run(
+      ["bash", str(_SCRIPT), *args],
+      capture_output=True,
+      text=True,
+      timeout=60,
+      env={**clean, **(env or {})},
+  )
+
+
+def _assert_freeze_walkthrough(stdout: str) -> None:
+  for banner in _BANNERS:
+    assert banner in stdout
+  # The frozen record and the through-line appear in narrative order.
+  positions = [stdout.index(b) for b in _BANNERS]
+  assert positions == sorted(positions)
+  partner = stdout[positions[0] : positions[1]]
+  d4 = stdout[positions[1] : positions[2]]
+  g1 = stdout[positions[2] : positions[3]]
+  session = stdout[positions[3] : positions[4]]
+  happened = stdout[positions[4] : positions[5]]
+  imported = stdout[positions[5] : positions[7]]
+  failed = stdout[positions[7] : positions[9]]
+  scored = stdout[positions[9] : positions[11]]
+  punchline = stdout[positions[11] :]
+  # 1. Partner: the REAL frozen partner, not the Acme example.
+  assert "Google Cloud BigQuery Agent Analytics" in partner
+  assert "mvp-e2e-real-traces" in partner
+  assert "SANA-adjacent" in partner
+  assert "not a SANA fork" in partner
+  assert "not duplicating" in partner
+  assert "docs/week0_partner.md" in partner
+  assert "Acme" not in stdout
+  # 2. D4: fail-closed, one named real consumer, no example people.
+  assert "fail-closed" in d4
+  assert "Hai-Yuan Cao" in d4
+  assert "test-project-0728-467323" in d4
+  assert "Part II funding recommendation" in d4
+  assert "docs/week0_d4_memo.md" in d4
+  assert "Alex Rivera" not in stdout
+  assert "Jordan Lee" not in stdout
+  # 3. G1: the frozen version, the mechanical mapping, no clock start.
+  assert "taxonomy_version: 0.1.0" in g1
+  assert "g1_frozen: true" in g1
+  assert "clock_started: false" in g1
+  assert "missing_completion -> finalization" in g1
+  assert "process_failed     -> tool blockers" in g1
+  assert "score_failed       -> task/planning" in g1
+  assert "frozen order" in g1
+  assert "docs/week0_g1_taxonomy.md" in g1
+  # 4. The session: the same protagonist as the merged MVP e2e demo.
+  assert "support_agent" in session
+  assert "real-user-0" in session
+  assert _SESSION_ID in session
+  assert f"scenario_id:   {_EVAL_ID}" in session
+  # 5. What happened: the verbatim prompt and no answer.
+  assert "How many widgets are in stock?" in happened
+  assert "(no response)" in happened
+  assert "AGENT_STARTING" in happened
+  assert "no AGENT_COMPLETED" in happened
+  assert "ab7535a5" in happened
+  # 6. Import result, shaped like the 455 fixture.
+  assert '"status": "imported"' in imported
+  assert '"event_row_count": 27' in imported
+  assert '"score_row_count": 7' in imported
+  assert (
+      '"failed_sessions_view": "analytics-project.bqaa.evalbench_failed_sessions"'
+      in imported
+  )
+  # 7. failed_sessions as JSON: mechanical flags still true, plus the
+  # FROZEN taxonomy_categories in frozen order.
+  assert "--format json" in failed
+  assert "evalbench-import:mvp-e2e-real-traces:v1:7e352c34" in failed
+  assert '"process_failed": true' in failed
+  assert '"missing_completion": true' in failed
+  assert '"score_failed": true' in failed
+  assert '"failing_scores": {"goal_completion": 0.0}' in failed
+  assert _FROZEN_CATEGORIES_LINE in failed
+  assert '"session_count": 7' in failed
+  assert '"failed_count": 1' in failed
+  assert "1 of 7 sessions failed" in failed
+  assert "W0.4 denominator" in failed
+  # 8. Score: the judge is not the denominator.
+  assert '"pass_rate": 1.0' in scored
+  assert '"llm_feedback": null' in scored
+  assert '"pinned_sessions": 7' in scored
+  assert "goal_completion is 0.0" in scored
+  assert "W0.4 denominator" in scored
+  # 9. Punchline: exactly one sentence, then nothing else.
+  assert punchline.strip().splitlines()[1:] == [_PUNCHLINE]
+  # Nowhere does the demo start the clock.
+  assert "clock has started" not in stdout
+  assert "clock has not started" in stdout or "Clock has not started" in stdout
+
+
+def test_fixture_flag_replays_the_freeze_and_exits_zero() -> None:
+  result = _run("--fixture")
+  assert result.returncode == 0, result.stderr
+  assert result.stderr == ""
+  assert "fixture mode" in result.stdout
+  assert _PUNCHLINE in result.stdout
+  _assert_freeze_walkthrough(result.stdout)
+
+
+def test_fixture_env_var_is_honored() -> None:
+  result = _run(env={"EVALBENCH_FIXTURE": "1"})
+  assert result.returncode == 0, result.stderr
+  _assert_freeze_walkthrough(result.stdout)
+
+
+def test_without_fixture_flag_exits_two_and_runs_nothing() -> None:
+  result = _run()
+  assert result.returncode == 2
+  assert "--fixture only" in result.stderr
+  assert "=== Partner" not in result.stdout
+  assert result.stdout == ""
+
+
+def test_synth_flag_is_rejected_without_running() -> None:
+  # The freeze demo has no --synth mode; it is an unknown argument.
+  result = _run("--synth")
+  assert result.returncode == 2
+  assert "--fixture only" in result.stderr
+  assert "=== Partner" not in result.stdout
+  assert result.stdout == ""
+
+
+def test_unknown_argument_is_rejected() -> None:
+  result = _run("--bogus")
+  assert result.returncode == 2
+  assert "unknown argument '--bogus'" in result.stderr
+  assert result.stdout == ""
+
+
+def test_help_prints_usage_without_running() -> None:
+  result = _run("--help")
+  assert result.returncode == 0
+  assert "--fixture" in result.stdout
+  assert "=== Partner" not in result.stdout
+
+
+def test_example_acme_pack_is_not_the_freeze() -> None:
+  # The EXAMPLE pack still exists and stays illustrative; the freeze demo
+  # neither sources it nor mentions its fictional partner.
+  assert _EXAMPLE_PACK.exists()
+  partner = json.loads(
+      (_FIXTURE_DIR / "week0_example_partner.json").read_text()
+  )
+  assert partner["example"] is True
+  assert partner["g1_frozen"] is False
+  # Only header comments may point readers at the pack; no code line runs
+  # it, sources it, or prints its fictional partner.
+  code_lines = [
+      line
+      for line in _SCRIPT.read_text().splitlines()
+      if not line.lstrip().startswith("#")
+  ]
+  assert not any("week0_full_idea" in line for line in code_lines)
+  assert not any("week0_example" in line for line in code_lines)
+  assert not any("Acme" in line for line in code_lines)
+
+
+def test_production_taxonomy_is_frozen_at_v010() -> None:
+  # The freeze the demo narrates is real, in production code.
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  config = failure_taxonomy.taxonomy_config()
+  assert config["g1_frozen"] is True
+  assert config["taxonomy_version"] == "0.1.0"
+  # The demo's mapping lines match the frozen FLAG_TO_CATEGORY.
+  assert dict(failure_taxonomy.FLAG_TO_CATEGORY) == {
+      "missing_completion": "finalization",
+      "process_failed": "tool blockers",
+      "score_failed": "task/planning",
+  }

--- a/tests/test_evalbench_week0_full_idea.py
+++ b/tests/test_evalbench_week0_full_idea.py
@@ -1,0 +1,358 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``examples/evalbench_week0_full_idea.sh`` (#435 slice 10).
+
+The EXAMPLE Week 0 scenario pack is ``--fixture`` only: nothing here
+reaches BigQuery or the network, and nothing here freezes anything —
+every asserted artifact says ``g1_frozen: false`` and that the six-week
+clock has not started. The tests also guard the boundary the pack must
+never cross: the SANA-seeded example mapping lives only in the fixtures,
+never in ``src/bigquery_agent_analytics/failure_taxonomy.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "examples" / "evalbench_week0_full_idea.sh"
+_FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
+_TAXONOMY_SRC = (
+    _REPO_ROOT / "src" / "bigquery_agent_analytics" / "failure_taxonomy.py"
+)
+
+_SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+_EVAL_ID = "7e352c34"
+
+_SANA_CATEGORIES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+)
+
+# The five Week 0 gates, then the widget-session through-line, in order.
+_BANNERS = (
+    "=== EXAMPLE — Week 0 is not a freeze. Clock has not started. ===",
+    "=== EXAMPLE partner + SANA relationship ===",
+    "=== EXAMPLE runtime + route ===",
+    "=== EXAMPLE pilot-benchmark rubric ===",
+    "=== EXAMPLE D4 boundary memo ===",
+    "=== EXAMPLE preregistration (not a week-1 freeze) ===",
+    "=== This agent was asked to check widget stock. Here is the session. ===",
+    "=== This session in failed_sessions (mechanical taxonomy_categories) ===",
+    "=== EXAMPLE mapping of mechanical flags onto SANA-seeded names ===",
+    "=== Punchline ===",
+)
+
+_PUNCHLINE = (
+    "This widget-stock session failed because the agent never answered;"
+    " goal_completion=0.0."
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _run(*args: str, env: dict[str, str] | None = None):
+  # Start from a clean environment so a developer's exported
+  # EVALBENCH_* / BQ_AGENT_* values cannot change what is asserted.
+  clean = {
+      k: v
+      for k, v in os.environ.items()
+      if not k.startswith(("EVALBENCH_", "BQ_AGENT_"))
+  }
+  return subprocess.run(
+      ["bash", str(_SCRIPT), *args],
+      capture_output=True,
+      text=True,
+      timeout=60,
+      env={**clean, **(env or {})},
+  )
+
+
+def _fixture(name: str) -> dict:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  # Every fixture in the pack is labeled example-only and frozen-nothing.
+  assert data["example"] is True
+  assert data["g1_frozen"] is False
+  assert data["clock_started"] is False
+  return data
+
+
+def _assert_walkthrough(stdout: str) -> None:
+  for banner in _BANNERS:
+    assert banner in stdout
+  # The gates and the through-line appear in narrative order.
+  positions = [stdout.index(b) for b in _BANNERS]
+  assert positions == sorted(positions)
+  opening = stdout[positions[0] : positions[1]]
+  partner = stdout[positions[1] : positions[2]]
+  runtime = stdout[positions[2] : positions[3]]
+  rubric = stdout[positions[3] : positions[4]]
+  d4 = stdout[positions[4] : positions[5]]
+  prereg = stdout[positions[5] : positions[6]]
+  session = stdout[positions[6] : positions[7]]
+  failed = stdout[positions[7] : positions[8]]
+  mapping = stdout[positions[8] : positions[9]]
+  punchline = stdout[positions[9] :]
+  # Opening disclaimer: example-only, nothing frozen, clock not started.
+  assert "EXAMPLE" in opening
+  assert "illustrative" in opening
+  assert "not a freeze" in opening
+  assert "g1_frozen: false" in opening
+  assert "clock has not started" in opening
+  assert "clock_started: false" in opening
+  # Gate 1: partner + SANA relationship.
+  assert "Acme Retail Support" in partner
+  assert "SANA-adjacent" in partner
+  assert "not a SANA fork" in partner
+  for category in _SANA_CATEGORIES:
+    assert category in partner
+  assert "LakeQA" in partner
+  assert "KramaBench" in partner
+  assert "not duplicating" in partner
+  # Gate 2: runtime + route.
+  assert "ADK" in runtime
+  assert "bqaa_e2e_real.agent_events" in runtime
+  assert "mvp-e2e-real-traces" in runtime
+  assert "EvalBench-hosted" in runtime
+  assert "EvalBench-only MVP route is CORRECT" in runtime
+  assert "D1 does not need re-decision" in runtime
+  # Gate 3: pilot-benchmark rubric, scored per criterion.
+  for criterion in (
+      "collaborator relevance",
+      "failure-mode coverage",
+      "score availability / threshold-definability",
+      "ground-truth depth",
+      "trace fidelity",
+  ):
+    assert criterion in rubric
+  assert "pass" in rubric
+  assert _EVAL_ID in rubric
+  assert "goal_completion" in rubric
+  assert "0.0" in rubric
+  assert "threshold 1" in rubric
+  assert "ab7535a5" in rubric
+  assert "There are 0 widgets in stock." in rubric
+  assert "USER_MESSAGE_RECEIVED" in rubric
+  assert "INVOCATION_STARTING" in rubric
+  assert "AGENT_STARTING" in rubric
+  # Gate 4: D4 boundary memo.
+  assert "fail-closed" in d4.lower()
+  assert "Alex Rivera (example collaborator)" in d4
+  assert "Jordan Lee (example collaborator)" in d4
+  assert "ingestion" in d4
+  assert "taxonomy mechanics" in d4
+  assert "stability" in d4
+  assert "ONLY" in d4
+  assert "never" in d4
+  assert "Part II funding recommendation" in d4
+  assert "test-project-0728-467323" in d4
+  assert "pre-redacted" in d4
+  # Gate 5: preregistration floors, copied as an example.
+  assert "EXAMPLE" in prereg
+  assert "not week-1 freeze" in prereg
+  assert "clock not started" in prereg
+  assert "80%" in prereg
+  assert "0.6" in prereg
+  assert "0.45" in prereg
+  assert "70%" in prereg
+  assert "+10pp" in prereg
+  assert ">0" in prereg
+  # Through-line: the widget session.
+  assert "support_agent" in session
+  assert "real-user-0" in session
+  assert "How many widgets are in stock?" in session
+  assert _SESSION_ID in session
+  assert _EVAL_ID in session
+  # Its failed_sessions row with the mechanical categories.
+  assert "process_failed" in failed
+  assert "missing_completion" in failed
+  assert "score_failed" in failed
+  assert (
+      'taxonomy_categories: ["process_failed", "missing_completion",'
+      ' "score_failed"]'
+  ) in failed
+  # The EXAMPLE mapping onto SANA-seeded names — labeled not-G1.
+  assert "EXAMPLE" in mapping
+  assert "not G1" in mapping
+  assert "g1_frozen: false" in mapping
+  assert "task/planning" in mapping
+  assert "finalization" in mapping
+  assert "tool blockers" in mapping
+  assert "never called check_inventory" in mapping
+  # Punchline: exactly one sentence, then nothing else.
+  assert punchline.strip().splitlines()[1:] == [_PUNCHLINE]
+
+
+def test_fixture_flag_walks_all_five_gates_and_exits_zero() -> None:
+  result = _run("--fixture")
+  assert result.returncode == 0, result.stderr
+  assert result.stderr == ""
+  assert "fixture mode" in result.stdout
+  assert _PUNCHLINE in result.stdout
+  _assert_walkthrough(result.stdout)
+
+
+def test_fixture_env_var_is_honored() -> None:
+  result = _run(env={"EVALBENCH_FIXTURE": "1"})
+  assert result.returncode == 0, result.stderr
+  _assert_walkthrough(result.stdout)
+
+
+def test_without_fixture_flag_exits_two_and_launches_nothing() -> None:
+  result = _run()
+  assert result.returncode == 2
+  assert result.stdout == ""
+  assert "--fixture only" in result.stderr
+  # No live job is mentioned, let alone launched.
+  assert "bq " not in result.stderr
+  assert "Step" not in result.stderr
+
+
+def test_synth_flag_is_rejected_without_launching_anything() -> None:
+  result = _run("--synth")
+  assert result.returncode == 2
+  assert result.stdout == ""
+  assert "--fixture only" in result.stderr
+
+
+def test_partner_fixture_names_the_example_partner_and_sana_seeds() -> None:
+  data = _fixture("week0_example_partner.json")
+  assert data["illustrative"] is True
+  assert data["not_a_freeze"] is True
+  assert data["partner_name"] == "Acme Retail Support"
+  assert data["sana_runtime"] == "Strands"
+  assert data["this_pilot_runtime"] == "ADK+EvalBench"
+  assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
+  assert "not duplicating" in data["not_duplicating_lakeqa_kramabench"]
+
+
+def test_rubric_fixture_scores_all_five_criteria_on_the_session() -> None:
+  data = _fixture("week0_example_rubric.json")
+  assert data["selected_benchmark"] == "widget-stock support"
+  assert data["session_id"] == _SESSION_ID
+  assert data["eval_id"] == _EVAL_ID
+  assert data["job_id"] == "mvp-e2e-real-traces"
+  criteria = data["criteria"]
+  assert len(criteria) == 5
+  for entry in criteria.values():
+    assert entry["result"] == "pass"
+    assert entry["reason"]
+  names = {entry["name"] for entry in criteria.values()}
+  assert names == {
+      "collaborator relevance",
+      "failure-mode coverage",
+      "score availability / threshold-definability",
+      "ground-truth depth",
+      "trace fidelity",
+  }
+
+
+def test_d4_fixture_is_fail_closed_with_example_consumers() -> None:
+  data = _fixture("week0_example_d4_memo.json")
+  assert data["fail_closed"] is True
+  assert data["report_consumers"]
+  for consumer in data["report_consumers"]:
+    assert "example" in consumer
+  assert set(data["fixture_validates"]) == {
+      "ingestion",
+      "taxonomy mechanics",
+      "stability",
+  }
+  assert "Part II" in data["never_produces"]
+  assert data["reference_project"] == "test-project-0728-467323"
+  assert data["pre_redacted"] is True
+  assert data["stop_go_memo_is_governed_artifact"] is True
+
+
+def test_preregistration_fixture_copies_the_plan_floors() -> None:
+  data = _fixture("week0_example_preregistration.json")
+  assert data["not_week_1_freeze"] is True
+  floors = data["floors"]
+  assert floors["replicate_agreement_pct"] == 80
+  assert floors["non_unknown_coverage_pct"] == 80
+  assert floors["kappa_point"] == 0.6
+  assert floors["kappa_ci_lower"] == 0.45
+  assert floors["localization_coverage_pct"] == 70
+  assert floors["hit_at_1_ci_lower_gt_0"] is True
+  assert floors["hit_at_1_point_uplift_pp"] == 10
+  assert "reserved_revision_week" in data["decision_rules"]
+  assert "value_gate" in data["decision_rules"]
+  assert "noisy_small_n_localization" in data["decision_rules"]
+
+
+def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
+  data = _fixture("week0_example_taxonomy_seed.json")
+  assert data["not_g1"] is True
+  assert data["taxonomy_version"] == "0.1.0-example"
+  assert data["taxonomy_version"] != failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION
+  assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.CORE_CATEGORY_IDS
+  widget = data["widget_session"]
+  assert widget["session_id"] == _SESSION_ID
+  assert widget["eval_id"] == _EVAL_ID
+  assert tuple(widget["taxonomy_categories"]) == (
+      failure_taxonomy.CORE_CATEGORY_IDS
+  )
+  mapping = data["example_mapping"]
+  assert mapping["missing_completion"] == "finalization"
+  assert mapping["process_failed"] == "tool blockers"
+  assert "task/planning" in mapping.values()
+  for seeded in mapping.values():
+    assert seeded in _SANA_CATEGORIES
+
+
+def test_example_mapping_never_touches_the_production_scaffold() -> None:
+  # The pack's SANA-seeded names must live only in the fixtures: the
+  # production scaffold module stays unfrozen and unchanged.
+  assert failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION == "0.0.0-scaffold"
+  assert failure_taxonomy.CORE_CATEGORY_IDS == (
+      "process_failed",
+      "missing_completion",
+      "score_failed",
+  )
+  config = failure_taxonomy.scaffold_taxonomy_config()
+  assert config["g1_frozen"] is False
+  assert config["taxonomy_version"] == "0.0.0-scaffold"
+  assert config["dialects"] == []
+  category_names = {
+      category["name"]
+      for metric in config["metrics"]
+      for category in metric["categories"]
+  }
+  assert category_names == set(failure_taxonomy.CORE_CATEGORY_IDS)
+  assert not category_names.intersection(_SANA_CATEGORIES)
+  # And as source text: g1_frozen stays False, no frozen SANA vocabulary.
+  source = _TAXONOMY_SRC.read_text()
+  assert '"g1_frozen": False' in source
+  assert '"g1_frozen": True' not in source
+  assert 'SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"' in source
+  # The module docstring's disclaimer mentions SANA only to say its
+  # categories "do not appear here" — no seeded name may appear at all.
+  for name in _SANA_CATEGORIES:
+    assert name not in source

--- a/tests/test_evalbench_week0_full_idea.py
+++ b/tests/test_evalbench_week0_full_idea.py
@@ -14,11 +14,13 @@
 """Tests for ``examples/evalbench_week0_full_idea.sh`` (#435 slice 10).
 
 The EXAMPLE Week 0 scenario pack is ``--fixture`` only: nothing here
-reaches BigQuery or the network, and nothing here freezes anything —
-every asserted artifact says ``g1_frozen: false`` and that the six-week
-clock has not started. The tests also guard the boundary the pack must
-never cross: the SANA-seeded example mapping lives only in the fixtures,
-never in ``src/bigquery_agent_analytics/failure_taxonomy.py``.
+reaches BigQuery or the network, and every asserted artifact says
+``example: true`` / ``g1_frozen: false`` and that the six-week clock has
+not started. The pack itself freezes nothing — it stays illustrative even
+now that the Week 0 freeze landed for real: production
+``failure_taxonomy.py`` is G1-frozen at v0.1.0 and the real freeze
+artifacts live in ``examples/fixtures/week0_real_*.json``
+(``tests/test_week0_real_freeze.py``), distinct from this pack.
 """
 
 from __future__ import annotations
@@ -310,14 +312,16 @@ def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
   data = _fixture("week0_example_taxonomy_seed.json")
   assert data["not_g1"] is True
   assert data["taxonomy_version"] == "0.1.0-example"
-  assert data["taxonomy_version"] != failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION
+  assert data["taxonomy_version"] != failure_taxonomy.TAXONOMY_VERSION
   assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
-  assert tuple(data["mechanical_flags"]) == failure_taxonomy.CORE_CATEGORY_IDS
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.MECHANICAL_FLAGS
   widget = data["widget_session"]
   assert widget["session_id"] == _SESSION_ID
   assert widget["eval_id"] == _EVAL_ID
+  # The EXAMPLE narrative predates the G1 freeze and hardcodes the
+  # mechanical flag ids as its categories — correct for an example pack.
   assert tuple(widget["taxonomy_categories"]) == (
-      failure_taxonomy.CORE_CATEGORY_IDS
+      failure_taxonomy.MECHANICAL_FLAGS
   )
   mapping = data["example_mapping"]
   assert mapping["missing_completion"] == "finalization"
@@ -327,32 +331,37 @@ def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
     assert seeded in _SANA_CATEGORIES
 
 
-def test_example_mapping_never_touches_the_production_scaffold() -> None:
-  # The pack's SANA-seeded names must live only in the fixtures: the
-  # production scaffold module stays unfrozen and unchanged.
-  assert failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION == "0.0.0-scaffold"
-  assert failure_taxonomy.CORE_CATEGORY_IDS == (
-      "process_failed",
-      "missing_completion",
-      "score_failed",
-  )
-  config = failure_taxonomy.scaffold_taxonomy_config()
-  assert config["g1_frozen"] is False
-  assert config["taxonomy_version"] == "0.0.0-scaffold"
+def test_example_pack_stays_example_while_production_is_frozen() -> None:
+  # The pack stays illustrative (example: true, g1_frozen: false — the
+  # _fixture helper asserts both) while production froze G1 at v0.1.0.
+  # The example fixtures are NOT the freeze artifacts; the real freeze
+  # lives in examples/fixtures/week0_real_*.json and failure_taxonomy.py.
+  for name in (
+      "week0_example_partner.json",
+      "week0_example_rubric.json",
+      "week0_example_d4_memo.json",
+      "week0_example_preregistration.json",
+      "week0_example_taxonomy_seed.json",
+  ):
+    _fixture(name)
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  config = failure_taxonomy.taxonomy_config()
+  assert config["g1_frozen"] is True
+  assert config["taxonomy_version"] == "0.1.0"
   assert config["dialects"] == []
   category_names = {
       category["name"]
       for metric in config["metrics"]
       for category in metric["categories"]
   }
-  assert category_names == set(failure_taxonomy.CORE_CATEGORY_IDS)
-  assert not category_names.intersection(_SANA_CATEGORIES)
-  # And as source text: g1_frozen stays False, no frozen SANA vocabulary.
+  assert category_names == set(_SANA_CATEGORIES) | {"unknown"}
+  # The example pack's mapping agrees with the frozen FLAG_TO_CATEGORY,
+  # so the story it tells matches what production now does.
+  seed = json.loads(
+      (_FIXTURE_DIR / "week0_example_taxonomy_seed.json").read_text()
+  )
+  assert seed["example_mapping"] == dict(failure_taxonomy.FLAG_TO_CATEGORY)
+  # And as source text: the freeze is in the production module.
   source = _TAXONOMY_SRC.read_text()
-  assert '"g1_frozen": False' in source
-  assert '"g1_frozen": True' not in source
-  assert 'SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"' in source
-  # The module docstring's disclaimer mentions SANA only to say its
-  # categories "do not appear here" — no seeded name may appear at all.
-  for name in _SANA_CATEGORIES:
-    assert name not in source
+  assert '"g1_frozen": True' in source
+  assert 'TAXONOMY_VERSION = "0.1.0"' in source

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8)."""
+"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8).
 
+Slice 9 adds the consumer tests: ``EvalBenchSession`` (the row
+``failed_sessions`` returns and the CLI serializes) exposes
+``taxonomy_categories`` computed from its flags via
+``categorize_failed_session``.
+"""
+
+from datetime import datetime
+from datetime import timezone
 import itertools
 
 import pytest
 
+from bigquery_agent_analytics.evalbench import EvalBenchSession
 from bigquery_agent_analytics.evalbench import SessionVerdict
 from bigquery_agent_analytics.evaluation_rubrics import build_metrics
 from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
@@ -166,3 +175,45 @@ def test_config_returns_a_deep_copy():
   assert fresh["g1_frozen"] is False
   assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
   assert fresh["dialects"] == []
+
+
+# --- EvalBenchSession consumer (slice 9) ----------------------------------
+
+
+def _session(**overrides):
+  # The same constructor shape the pre-slice-9 tests use: no taxonomy
+  # field exists, so existing callers keep working unchanged.
+  return EvalBenchSession(
+      job_id="job-123",
+      import_version="v1",
+      session_id="evalbench-import:job-123:v1:s1",
+      trace_id="evalbench-import:job-123:v1:s1",
+      scenario_id="s1",
+      started_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+      failed=any(overrides.values()),
+      **_row(**overrides),
+  )
+
+
+@pytest.mark.parametrize(
+    "tripped",
+    [
+        combo
+        for size in (1, 2, 3)
+        for combo in itertools.combinations(_FLAGS, size)
+    ],
+)
+def test_session_to_dict_carries_the_tripped_categories(tripped):
+  session = _session(**{flag: True for flag in tripped})
+  assert session.taxonomy_categories == categorize_failed_session(session)
+  assert session.to_dict()["taxonomy_categories"] == list(
+      categorize_failed_session(session)
+  )
+  assert session.to_dict()["taxonomy_categories"] == list(tripped)
+
+
+def test_session_with_all_flags_false_serializes_empty_categories():
+  # An include_passed row: empty list, never an invented "unknown" bucket.
+  session = _session()
+  assert session.taxonomy_categories == ()
+  assert session.to_dict()["taxonomy_categories"] == []

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8).
+"""Tests for the G1-frozen failure taxonomy v0.1 (#435).
 
-Slice 9 adds the consumer tests: ``EvalBenchSession`` (the row
-``failed_sessions`` returns and the CLI serializes) exposes
-``taxonomy_categories`` computed from its flags via
-``categorize_failed_session``.
+Slices 8/9 landed the mechanical mapper and its ``EvalBenchSession``
+consumer; the Week 0 G1 freeze replaced the scaffold vocabulary with the
+frozen names (SANA-neighborhood seven + ``unknown``) at
+``taxonomy_version: 0.1.0`` / ``g1_frozen: True``. Assignment stays
+mechanical: each tripped flag maps to one frozen name, returned in frozen
+order.
 """
 
 from datetime import datetime
@@ -31,10 +33,25 @@ from bigquery_agent_analytics.evalbench import SessionVerdict
 from bigquery_agent_analytics.evaluation_rubrics import build_metrics
 from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
 from bigquery_agent_analytics.failure_taxonomy import CORE_CATEGORY_IDS
+from bigquery_agent_analytics.failure_taxonomy import FLAG_TO_CATEGORY
+from bigquery_agent_analytics.failure_taxonomy import FROZEN_CATEGORY_NAMES
+from bigquery_agent_analytics.failure_taxonomy import MECHANICAL_FLAGS
 from bigquery_agent_analytics.failure_taxonomy import scaffold_taxonomy_config
-from bigquery_agent_analytics.failure_taxonomy import SCAFFOLD_TAXONOMY_VERSION
+from bigquery_agent_analytics.failure_taxonomy import taxonomy_config
+from bigquery_agent_analytics.failure_taxonomy import TAXONOMY_VERSION
 
 _FLAGS = ("process_failed", "missing_completion", "score_failed")
+
+_FROZEN_NAMES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown",
+)
 
 
 def _row(**overrides):
@@ -53,12 +70,25 @@ def _verdict(**overrides):
   )
 
 
+def _expected(*tripped_flags):
+  # Frozen names for the tripped flags, in FROZEN_CATEGORY_NAMES order.
+  mapped = {FLAG_TO_CATEGORY[flag] for flag in tripped_flags}
+  return tuple(name for name in FROZEN_CATEGORY_NAMES if name in mapped)
+
+
 # --- mapper ---------------------------------------------------------------
 
 
-@pytest.mark.parametrize("flag", _FLAGS)
-def test_each_flag_alone_maps_to_its_category(flag):
-  assert categorize_failed_session(_row(**{flag: True})) == (flag,)
+@pytest.mark.parametrize(
+    "flag,frozen_name",
+    [
+        ("process_failed", "tool blockers"),
+        ("missing_completion", "finalization"),
+        ("score_failed", "task/planning"),
+    ],
+)
+def test_each_flag_alone_maps_to_its_frozen_name(flag, frozen_name):
+  assert categorize_failed_session(_row(**{flag: True})) == (frozen_name,)
 
 
 @pytest.mark.parametrize(
@@ -69,21 +99,35 @@ def test_each_flag_alone_maps_to_its_category(flag):
         for combo in itertools.combinations(_FLAGS, size)
     ],
 )
-def test_flag_combinations_map_to_every_tripped_category(tripped):
+def test_flag_combinations_map_to_every_tripped_frozen_name(tripped):
   row = _row(**{flag: True for flag in tripped})
-  assert categorize_failed_session(row) == tripped
+  assert categorize_failed_session(row) == _expected(*tripped)
 
 
-def test_all_flags_false_returns_empty_not_an_unknown_bucket():
+def test_all_flags_false_returns_empty_never_unknown():
+  # unknown is in the frozen vocabulary as the residual bucket of the
+  # labeling study; the mechanical mapper never emits it.
   assert categorize_failed_session(_row()) == ()
 
 
-def test_category_order_follows_the_core_config_order():
+def test_category_order_follows_the_frozen_order_not_flag_order():
+  # score_failed maps to task/planning, which precedes tool blockers in
+  # FROZEN_CATEGORY_NAMES even though process_failed precedes score_failed
+  # in flag order.
   row = _row(score_failed=True, process_failed=True)
-  assert categorize_failed_session(row) == ("process_failed", "score_failed")
+  assert categorize_failed_session(row) == ("task/planning", "tool blockers")
   assert categorize_failed_session(
-      _row(**{flag: True for flag in _FLAGS})
-  ) == tuple(CORE_CATEGORY_IDS)
+      _row(process_failed=True, missing_completion=True)
+  ) == ("finalization", "tool blockers")
+
+
+def test_widget_session_with_all_three_flags_maps_in_frozen_order():
+  # The widget-stock pilot session 7e352c34 trips all three flags.
+  assert categorize_failed_session(_row(**{flag: True for flag in _FLAGS})) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
 
 
 def test_extra_fields_are_ignored():
@@ -95,14 +139,14 @@ def test_extra_fields_are_ignored():
       failed=True,
       failing_scores=[{"comparator": "exact_match", "score": 0.0}],
   )
-  assert categorize_failed_session(row) == ("process_failed",)
+  assert categorize_failed_session(row) == ("tool blockers",)
 
 
 def test_session_verdict_objects_are_accepted():
   verdict = _verdict(missing_completion=True, score_failed=True)
   assert categorize_failed_session(verdict) == (
-      "missing_completion",
-      "score_failed",
+      "task/planning",
+      "finalization",
   )
   assert categorize_failed_session(_verdict()) == ()
 
@@ -125,56 +169,99 @@ def test_mapper_is_deterministic():
   assert categorize_failed_session(row) == categorize_failed_session(row)
 
 
+def test_mapper_never_returns_flag_ids():
+  for size in (1, 2, 3):
+    for tripped in itertools.combinations(_FLAGS, size):
+      names = categorize_failed_session(_row(**{f: True for f in tripped}))
+      assert not set(names).intersection(_FLAGS)
+      assert set(names) <= set(FROZEN_CATEGORY_NAMES)
+      assert "unknown" not in names
+
+
 # --- config ---------------------------------------------------------------
 
 
-def test_config_version_is_obviously_scaffold_and_not_g1_frozen():
-  config = scaffold_taxonomy_config()
-  assert config["taxonomy_version"] == SCAFFOLD_TAXONOMY_VERSION
-  assert "scaffold" in config["taxonomy_version"]
-  assert config["g1_frozen"] is False
+def test_config_is_g1_frozen_at_v0_1_0():
+  config = taxonomy_config()
+  assert TAXONOMY_VERSION == "0.1.0"
+  assert config["taxonomy_version"] == "0.1.0"
+  assert "scaffold" not in config["taxonomy_version"]
+  assert config["g1_frozen"] is True
 
 
 def test_config_dialects_slot_exists_and_is_empty_by_default():
   # D2: one taxonomy with optional per-benchmark extension categories on
-  # the same core. The slot must exist and must not ship invented labels.
-  assert scaffold_taxonomy_config()["dialects"] == []
+  # the same core. The slot must exist and stays empty at the freeze.
+  assert taxonomy_config()["dialects"] == []
 
 
-def test_config_core_categories_match_the_landed_flags():
-  config = scaffold_taxonomy_config()
+def test_frozen_names_are_the_sana_seven_plus_unknown_in_frozen_order():
+  assert FROZEN_CATEGORY_NAMES == _FROZEN_NAMES
+  assert CORE_CATEGORY_IDS == FROZEN_CATEGORY_NAMES
+  assert FROZEN_CATEGORY_NAMES[-1] == "unknown"
+
+
+def test_mechanical_flags_keep_the_landed_contract_keys():
+  assert MECHANICAL_FLAGS == _FLAGS
+  assert set(FLAG_TO_CATEGORY) == set(MECHANICAL_FLAGS)
+  assert FLAG_TO_CATEGORY["missing_completion"] == "finalization"
+  assert FLAG_TO_CATEGORY["process_failed"] == "tool blockers"
+  assert FLAG_TO_CATEGORY["score_failed"] == "task/planning"
+
+
+def test_config_core_categories_are_the_frozen_names_with_definitions():
+  config = taxonomy_config()
   (metric,) = config["metrics"]
   assert metric["name"] == "failure_category"
-  assert [c["name"] for c in metric["categories"]] == list(CORE_CATEGORY_IDS)
-  assert list(CORE_CATEGORY_IDS) == list(_FLAGS)
+  assert [c["name"] for c in metric["categories"]] == list(
+      FROZEN_CATEGORY_NAMES
+  )
   for category in metric["categories"]:
-    assert category["definition"]
+    # Every definition states how mechanical assignment works until the
+    # labeler study (mapped from a flag, or not emitted by the mapper).
+    assert "mechanical" in category["definition"].lower()
+    if category["name"] in FLAG_TO_CATEGORY.values():
+      assert "mapped from" in category["definition"]
+    else:
+      assert "not emit" in category["definition"]
 
 
-def test_config_does_not_contain_unfrozen_sana_names():
-  # The SANA seven-category vocabulary stays out of this scaffold entirely.
-  text = repr(scaffold_taxonomy_config()).lower()
-  for sana_name in ("planning", "wrong source", "turn-waste", "finalization"):
-    assert sana_name not in text
+def test_unknown_is_residual_in_vocabulary_but_not_mapped():
+  config = taxonomy_config()
+  (metric,) = config["metrics"]
+  unknown = next(c for c in metric["categories"] if c["name"] == "unknown")
+  assert "residual" in unknown["definition"].lower()
+  assert "unknown" not in FLAG_TO_CATEGORY.values()
 
 
 def test_config_metrics_shape_is_interpretable_by_build_metrics():
   # #431 schema shape: build_metrics() can turn the core metric into a
   # CategoricalMetricDefinition without special-casing.
-  (metric,) = build_metrics(scaffold_taxonomy_config())
+  (metric,) = build_metrics(taxonomy_config())
   assert metric.name == "failure_category"
-  assert [c.name for c in metric.categories] == list(CORE_CATEGORY_IDS)
+  assert [c.name for c in metric.categories] == list(FROZEN_CATEGORY_NAMES)
+
+
+def test_scaffold_taxonomy_config_is_a_wrapper_for_the_frozen_config():
+  # The pre-freeze name survives as a compatibility wrapper; it returns
+  # the same frozen config, not the retired scaffold.
+  assert scaffold_taxonomy_config() == taxonomy_config()
+  assert scaffold_taxonomy_config()["g1_frozen"] is True
+  assert scaffold_taxonomy_config()["taxonomy_version"] == "0.1.0"
 
 
 def test_config_returns_a_deep_copy():
-  first = scaffold_taxonomy_config()
-  first["g1_frozen"] = True
+  first = taxonomy_config()
+  first["g1_frozen"] = False
   first["metrics"][0]["categories"].clear()
   first["dialects"].append({"benchmark": "nope"})
-  fresh = scaffold_taxonomy_config()
-  assert fresh["g1_frozen"] is False
-  assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
+  fresh = taxonomy_config()
+  assert fresh["g1_frozen"] is True
+  assert len(fresh["metrics"][0]["categories"]) == len(FROZEN_CATEGORY_NAMES)
   assert fresh["dialects"] == []
+  wrapped = scaffold_taxonomy_config()
+  wrapped["g1_frozen"] = False
+  assert scaffold_taxonomy_config()["g1_frozen"] is True
 
 
 # --- EvalBenchSession consumer (slice 9) ----------------------------------
@@ -203,17 +290,15 @@ def _session(**overrides):
         for combo in itertools.combinations(_FLAGS, size)
     ],
 )
-def test_session_to_dict_carries_the_tripped_categories(tripped):
+def test_session_to_dict_carries_the_tripped_frozen_names(tripped):
   session = _session(**{flag: True for flag in tripped})
   assert session.taxonomy_categories == categorize_failed_session(session)
-  assert session.to_dict()["taxonomy_categories"] == list(
-      categorize_failed_session(session)
-  )
-  assert session.to_dict()["taxonomy_categories"] == list(tripped)
+  assert session.taxonomy_categories == _expected(*tripped)
+  assert session.to_dict()["taxonomy_categories"] == list(_expected(*tripped))
 
 
 def test_session_with_all_flags_false_serializes_empty_categories():
-  # An include_passed row: empty list, never an invented "unknown" bucket.
+  # An include_passed row: empty list, never the residual "unknown" bucket.
   session = _session()
   assert session.taxonomy_categories == ()
   assert session.to_dict()["taxonomy_categories"] == []

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8)."""
+
+import itertools
+
+import pytest
+
+from bigquery_agent_analytics.evalbench import SessionVerdict
+from bigquery_agent_analytics.evaluation_rubrics import build_metrics
+from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
+from bigquery_agent_analytics.failure_taxonomy import CORE_CATEGORY_IDS
+from bigquery_agent_analytics.failure_taxonomy import scaffold_taxonomy_config
+from bigquery_agent_analytics.failure_taxonomy import SCAFFOLD_TAXONOMY_VERSION
+
+_FLAGS = ("process_failed", "missing_completion", "score_failed")
+
+
+def _row(**overrides):
+  row = {flag: False for flag in _FLAGS}
+  row.update(overrides)
+  return row
+
+
+def _verdict(**overrides):
+  return SessionVerdict(
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      failing_scores={},
+      failed=any(overrides.values()),
+      **_row(**overrides),
+  )
+
+
+# --- mapper ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", _FLAGS)
+def test_each_flag_alone_maps_to_its_category(flag):
+  assert categorize_failed_session(_row(**{flag: True})) == (flag,)
+
+
+@pytest.mark.parametrize(
+    "tripped",
+    [
+        combo
+        for size in (2, 3)
+        for combo in itertools.combinations(_FLAGS, size)
+    ],
+)
+def test_flag_combinations_map_to_every_tripped_category(tripped):
+  row = _row(**{flag: True for flag in tripped})
+  assert categorize_failed_session(row) == tripped
+
+
+def test_all_flags_false_returns_empty_not_an_unknown_bucket():
+  assert categorize_failed_session(_row()) == ()
+
+
+def test_category_order_follows_the_core_config_order():
+  row = _row(score_failed=True, process_failed=True)
+  assert categorize_failed_session(row) == ("process_failed", "score_failed")
+  assert categorize_failed_session(
+      _row(**{flag: True for flag in _FLAGS})
+  ) == tuple(CORE_CATEGORY_IDS)
+
+
+def test_extra_fields_are_ignored():
+  row = _row(
+      process_failed=True,
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      started_at="2026-08-30T00:00:00Z",
+      failed=True,
+      failing_scores=[{"comparator": "exact_match", "score": 0.0}],
+  )
+  assert categorize_failed_session(row) == ("process_failed",)
+
+
+def test_session_verdict_objects_are_accepted():
+  verdict = _verdict(missing_completion=True, score_failed=True)
+  assert categorize_failed_session(verdict) == (
+      "missing_completion",
+      "score_failed",
+  )
+  assert categorize_failed_session(_verdict()) == ()
+
+
+def test_missing_flag_raises_instead_of_defaulting():
+  row = _row(process_failed=True)
+  del row["score_failed"]
+  with pytest.raises(ValueError, match="missing required flag 'score_failed'"):
+    categorize_failed_session(row)
+
+
+@pytest.mark.parametrize("bad", [None, 0, 1, "true"])
+def test_non_bool_flag_raises(bad):
+  with pytest.raises(ValueError, match="'process_failed' must be a bool"):
+    categorize_failed_session(_row(process_failed=bad))
+
+
+def test_mapper_is_deterministic():
+  row = _row(process_failed=True, missing_completion=True)
+  assert categorize_failed_session(row) == categorize_failed_session(row)
+
+
+# --- config ---------------------------------------------------------------
+
+
+def test_config_version_is_obviously_scaffold_and_not_g1_frozen():
+  config = scaffold_taxonomy_config()
+  assert config["taxonomy_version"] == SCAFFOLD_TAXONOMY_VERSION
+  assert "scaffold" in config["taxonomy_version"]
+  assert config["g1_frozen"] is False
+
+
+def test_config_dialects_slot_exists_and_is_empty_by_default():
+  # D2: one taxonomy with optional per-benchmark extension categories on
+  # the same core. The slot must exist and must not ship invented labels.
+  assert scaffold_taxonomy_config()["dialects"] == []
+
+
+def test_config_core_categories_match_the_landed_flags():
+  config = scaffold_taxonomy_config()
+  (metric,) = config["metrics"]
+  assert metric["name"] == "failure_category"
+  assert [c["name"] for c in metric["categories"]] == list(CORE_CATEGORY_IDS)
+  assert list(CORE_CATEGORY_IDS) == list(_FLAGS)
+  for category in metric["categories"]:
+    assert category["definition"]
+
+
+def test_config_does_not_contain_unfrozen_sana_names():
+  # The SANA seven-category vocabulary stays out of this scaffold entirely.
+  text = repr(scaffold_taxonomy_config()).lower()
+  for sana_name in ("planning", "wrong source", "turn-waste", "finalization"):
+    assert sana_name not in text
+
+
+def test_config_metrics_shape_is_interpretable_by_build_metrics():
+  # #431 schema shape: build_metrics() can turn the core metric into a
+  # CategoricalMetricDefinition without special-casing.
+  (metric,) = build_metrics(scaffold_taxonomy_config())
+  assert metric.name == "failure_category"
+  assert [c.name for c in metric.categories] == list(CORE_CATEGORY_IDS)
+
+
+def test_config_returns_a_deep_copy():
+  first = scaffold_taxonomy_config()
+  first["g1_frozen"] = True
+  first["metrics"][0]["categories"].clear()
+  first["dialects"].append({"benchmark": "nope"})
+  fresh = scaffold_taxonomy_config()
+  assert fresh["g1_frozen"] is False
+  assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
+  assert fresh["dialects"] == []

--- a/tests/test_week0_real_freeze.py
+++ b/tests/test_week0_real_freeze.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the REAL Week 0 freeze artifacts (#435).
+
+The freeze PR lands the real partner record, the fail-closed D4 memo, the
+G1 taxonomy v0.1.0 freeze, and the preregistration freeze-candidate —
+distinct from the slice-10 EXAMPLE pack, which stays illustrative
+(``example: true`` / ``g1_frozen: false``). Freezing is not a clock start:
+every real fixture says ``clock_started: false``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOCS = _REPO_ROOT / "docs"
+_FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
+
+_REAL_FIXTURES = (
+    "week0_real_partner.json",
+    "week0_real_rubric.json",
+    "week0_real_d4_memo.json",
+    "week0_real_taxonomy.json",
+    "week0_real_preregistration.json",
+)
+
+_EXAMPLE_FIXTURES = (
+    "week0_example_partner.json",
+    "week0_example_rubric.json",
+    "week0_example_d4_memo.json",
+    "week0_example_preregistration.json",
+    "week0_example_taxonomy_seed.json",
+)
+
+_FREEZE_DOCS = (
+    "week0_partner.md",
+    "week0_d4_memo.md",
+    "week0_g1_taxonomy.md",
+    "week0_preregistration.md",
+)
+
+_SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+
+
+def _real(name: str) -> dict:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  # Every real freeze fixture is example: false and does not start the
+  # six-week clock.
+  assert data["example"] is False
+  assert data["clock_started"] is False
+  return data
+
+
+# --- production module is frozen ------------------------------------------
+
+
+def test_production_taxonomy_is_g1_frozen_at_v0_1_0() -> None:
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  config = failure_taxonomy.taxonomy_config()
+  assert config["g1_frozen"] is True
+  assert config["taxonomy_version"] == "0.1.0"
+
+
+def test_widget_session_flags_map_to_frozen_names_in_frozen_order() -> None:
+  # The widget-stock pilot session trips all three mechanical flags.
+  row = {
+      "session_id": _SESSION_ID,
+      "process_failed": True,
+      "missing_completion": True,
+      "score_failed": True,
+  }
+  assert failure_taxonomy.categorize_failed_session(row) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
+
+
+# --- real fixtures --------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _REAL_FIXTURES)
+def test_real_fixtures_are_not_examples_and_do_not_start_the_clock(
+    name: str,
+) -> None:
+  _real(name)
+
+
+def test_real_taxonomy_fixture_matches_the_production_freeze() -> None:
+  data = _real("week0_real_taxonomy.json")
+  assert data["g1_frozen"] is True
+  assert data["taxonomy_version"] == "0.1.0"
+  assert tuple(data["frozen_category_names"]) == (
+      failure_taxonomy.FROZEN_CATEGORY_NAMES
+  )
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.MECHANICAL_FLAGS
+  assert data["flag_to_category"] == dict(failure_taxonomy.FLAG_TO_CATEGORY)
+  assert data["dialects"] == []
+  widget = data["widget_session"]
+  assert widget["session_id"] == _SESSION_ID
+  assert tuple(widget["taxonomy_categories"]) == (
+      failure_taxonomy.categorize_failed_session(
+          {flag: True for flag in failure_taxonomy.MECHANICAL_FLAGS}
+      )
+  )
+
+
+def test_real_partner_is_bqaa_not_acme_and_not_a_sana_fork() -> None:
+  data = _real("week0_real_partner.json")
+  assert "Google Cloud BigQuery Agent Analytics" in data["partner_name"]
+  assert data["not_a_sana_fork"] is True
+  assert data["not_a_named_sana_collaboration"] is True
+  assert "not duplicating" in data["not_duplicating_lakeqa_kramabench"]
+  assert data["route"]["evalbench_only_mvp_route_correct"] is True
+  assert data["route"]["d1_needs_redecision"] is False
+  assert data["pilot"]["evalbench_job_id"] == "mvp-e2e-real-traces"
+  assert "Acme" not in json.dumps(data)
+
+
+def test_real_partner_doc_has_no_acme() -> None:
+  text = (_DOCS / "week0_partner.md").read_text()
+  assert "Acme" not in text
+  assert "Google Cloud BigQuery Agent Analytics" in text
+  assert "not a SANA fork" in text
+  assert "not duplicating" in text
+
+
+def test_real_rubric_pins_the_widget_session_and_gold() -> None:
+  data = _real("week0_real_rubric.json")
+  assert data["session_id"] == _SESSION_ID
+  assert data["eval_id"] == "7e352c34"
+  assert data["job_id"] == "mvp-e2e-real-traces"
+  assert data["gold"]["sibling_session"] == "ab7535a5"
+  assert data["gold"]["gold_answer"] == "There are 0 widgets in stock."
+  assert data["score"]["metric"] == "goal_completion"
+  assert data["score"]["failed_session_score"] == 0
+  assert data["score"]["gold_session_score"] == 1
+
+
+def test_real_d4_memo_is_fail_closed_with_one_named_consumer() -> None:
+  data = _real("week0_real_d4_memo.json")
+  assert data["fail_closed"] is True
+  assert data["report_consumers"] == [
+      "Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"
+  ]
+  assert data["scope_project"] == "test-project-0728-467323"
+  assert set(data["scope_datasets"]) == {
+      "bqaa_e2e_real",
+      "bqaa_evalbench_mvp_demo",
+      "bqaa_evalbench_mvp_mirror",
+  }
+  assert data["never_produces"] == "Part II funding recommendation"
+  assert data["no_new_live_judge_calls"] is True
+  assert data["no_new_bq_jobs"] is True
+  assert data["no_labeler_access_expansion"] is True
+  assert data["stop_go_memo_is_governed_artifact"] is True
+  assert "no IAM API calls" in data["grants_policy"]
+  # No fabricated people from the example pack.
+  memo_text = json.dumps(data)
+  assert "Alex Rivera" not in memo_text
+  assert "Jordan Lee" not in memo_text
+
+
+def test_real_preregistration_copies_the_v4_floors_without_a_clock() -> None:
+  data = _real("week0_real_preregistration.json")
+  assert data["freeze_candidate"] is True
+  assert data["not_week_1_execution"] is True
+  floors = data["floors"]
+  assert floors["replicate_agreement_pct"] == 80
+  assert floors["non_unknown_coverage_pct"] == 80
+  assert floors["kappa_point"] == 0.6
+  assert floors["kappa_ci_lower"] == 0.45
+  assert floors["localization_coverage_pct"] == 70
+  assert floors["hit_at_1_ci_lower_gt_0"] is True
+  assert floors["hit_at_1_point_uplift_pp"] == 10
+  for rule in (
+      "reserved_revision_week",
+      "value_gate",
+      "noisy_small_n_localization",
+      "sealed_sets",
+  ):
+    assert data["decision_rules"][rule]
+
+
+# --- the example pack stays example ---------------------------------------
+
+
+@pytest.mark.parametrize("name", _EXAMPLE_FIXTURES)
+def test_example_fixtures_are_still_present_and_still_examples(
+    name: str,
+) -> None:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  assert data["example"] is True
+  assert data["g1_frozen"] is False
+  assert data["clock_started"] is False
+
+
+def test_example_pack_shell_and_md_are_still_present() -> None:
+  assert (_REPO_ROOT / "examples" / "evalbench_week0_full_idea.sh").is_file()
+  assert (_REPO_ROOT / "examples" / "evalbench_week0_full_idea.md").is_file()
+
+
+# --- docs -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _FREEZE_DOCS)
+def test_freeze_docs_exist_and_do_not_start_the_clock(name: str) -> None:
+  text = (_DOCS / name).read_text()
+  assert (
+      "NOT started" in text
+      or "not started" in text
+      or ("has **not** started" in text)
+  )
+  assert "first Week 1 snapshot job" in text


### PR DESCRIPTION
Part of #435 (AgentForensics MVP). **Stacked on #461** (`feat/435-week0-partner-d4-g1`, HEAD `2c4804b`) — review the freeze-e2e commits vs `2c4804b` only.

## What this is

A **presenter-facing team demo** of the post-freeze EvalBench path. Partner + D4 + G1 already froze in #461. This PR is the live walkthrough Haiyuan can run for the team on the same widget-stock failed session as merged #455 (`support_agent` / `7e352c34` / "How many widgets are in stock?").

`--fixture` only: no BigQuery, no `--synth`, no live judge. **The six-week clock has NOT started.** #460 stays illustrative.

## The story (ordered banners)

1. **The customer asked. The agent went silent.** — `support_agent` / `real-user-0` / "How many widgets are in stock?" / session `7e352c34-4c1c-4395-acd5-fb3c8f215346`.
2. **What the trace shows** — `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING` → silence. No `check_inventory`. Sibling `ab7535a5` answered.
3. **Import the real job** — `evalbench-import` sample: job `mvp-e2e-real-traces`, 7 scenarios, 27 events, 7 scores, `v1`.
4. **failed_sessions finds the one that never answered** — `--format json` (not table). 1 of 7 failed. Same row carries `"taxonomy_categories": ["task/planning", "finalization", "tool blockers"]` plus plain English. Partner/D4 is one note, not acts 1–3.
5. **A live judge would miss this** — correctness 1.0 / `llm_feedback` null. `failed_sessions`, not the judge, is the denominator.
6. **Punchline + next action** — *This widget-stock session failed because the agent never answered (goal_completion=0.0). G1 names it task/planning, tool blockers, and finalization — it never planned the lookup, never called check_inventory, never finished. Next debugging action: inspect why the trace died after AGENT_STARTING before the inventory tool.*

## Test

```
PYTHONPATH=src python -m pytest tests/test_evalbench_week0_freeze_e2e.py tests/test_failure_taxonomy.py tests/test_week0_real_freeze.py -q
```