### PR TITLE
feat(evalbench): native agent_events snapshot writer (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Failed-session rows carry scaffold taxonomy categories (#435 slice 9)**
+  — `failed_sessions()` / `bq-agent-sdk evalbench-failed-sessions` now
+  attach `taxonomy_categories` to each session row: `EvalBenchSession`
+  exposes it as a property computed from the row's three mechanical flags
+  via `failure_taxonomy.categorize_failed_session`, and `to_dict()` (what
+  the CLI JSON/text output serializes) includes it as a list. All-flags-false
+  rows (`--include-passed`) emit `[]` — no invented `unknown` bucket. Pure
+  Python over the flags already returned; no extra BigQuery work, and still
+  NOT the G1 taxonomy (ids stay the unfrozen flag names).
 - **Mechanical failure-taxonomy scaffold (#435 slice 8)** — new
   `failure_taxonomy` module: a versioned scaffold config
   (`taxonomy_version: 0.0.0-scaffold`, `g1_frozen: false`) in the #431

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **REAL Week 0 freeze: partner, D4 boundary, G1 taxonomy v0.1 (#435)** —
+  the Week 0 gates are frozen for real, distinct from the EXAMPLE pack
+  below (which stays illustrative). `docs/week0_partner.md` records the
+  real pilot partner — Google Cloud BigQuery Agent Analytics (this SDK),
+  piloting the ADK `support_agent` traces as EvalBench job
+  `mvp-e2e-real-traces`; SANA-adjacent, not a SANA fork and not a named
+  collaboration with SANA authors, not duplicating LakeQA/KramaBench.
+  `docs/week0_d4_memo.md` lands the fail-closed D4 boundary for exactly
+  this pilot's datasets with one named report consumer (Hai-Yuan Cao) and
+  a text-only grants policy (no IAM API calls); fixtures/synthetic runs
+  validate ingestion, taxonomy mechanics, and stability ONLY and never
+  produce a Part II funding recommendation. `docs/week0_g1_taxonomy.md`
+  documents the G1 freeze (below) and `docs/week0_preregistration.md`
+  copies the v4 floors as the freeze-candidate. Machine-readable copies in
+  `examples/fixtures/week0_real_*.json` (`example: false`,
+  `clock_started: false`), guarded by `tests/test_week0_real_freeze.py`.
+  **The six-week clock has NOT started**: it starts only when the first
+  Week 1 snapshot job is kicked, not at merge of this freeze.
 - **EXAMPLE Week 0 scenario pack (#435 slice 10)** — new
   `examples/evalbench_week0_full_idea.md` / `.sh --fixture` walk all five
   Week 0 human gates of `docs/agentforensics_mvp_plan.md` (partner + SANA
@@ -123,6 +141,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ETag-conditional replace after re-reading the view and latest manifest,
   so concurrent imports cannot overwrite a newer pin or attach an older
   caller's policy to a newer generation.
+
+### Changed
+
+- **`failure_taxonomy` frozen at G1 v0.1.0 (#435)** — the scaffold era
+  ends: `taxonomy_version` is `0.1.0` and `g1_frozen` is `true`. The
+  frozen vocabulary (`FROZEN_CATEGORY_NAMES`, also exported as
+  `CORE_CATEGORY_IDS`) is the SANA-neighborhood seven plus `unknown` —
+  `task/planning`, `wrong source`, `execution/computation`,
+  `incomplete evidence`, `turn-waste`, `finalization`, `tool blockers`,
+  `unknown` — replacing the three flag ids, which live on as the mapper's
+  input contract `MECHANICAL_FLAGS`. `categorize_failed_session` now
+  returns frozen names in frozen order (`missing_completion` →
+  `finalization`, `process_failed` → `tool blockers`, `score_failed` →
+  `task/planning`; all flags false still returns `()`, never `unknown`),
+  so `EvalBenchSession.taxonomy_categories` and the
+  `evalbench-failed-sessions` CLI output carry frozen names. The config
+  accessor is renamed `taxonomy_config()`; `scaffold_taxonomy_config()`
+  remains as a compatibility wrapper returning the same frozen config.
+  Assignment stays mechanical until the labeler study; the six-week clock
+  has not started.
 
 ## [0.5.1] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Native `agent_events` snapshot writer — the EvalBench-adapter exit ramp
+  (#463, parent #435)** — new
+  `bigquery_agent_analytics.native_events.NativeAgentEventsRun` (and thin
+  CLI `bq-agent-sdk evalbench-native-import`) starts from production ADK
+  `agent_events` rows and publishes the same BQAA-owned contract
+  `EvalBenchRun.materialize` produces — an immutable
+  `(job_id, import_version)` snapshot (events + deterministic
+  `goal_completion` scores + manifest with the `view_policy` pin) plus the
+  `failed_sessions` view pinned to the latest successful publication —
+  with **no EvalBench `configs`/`results`/`scores` tables anywhere in the
+  path**. Identity stays joinable (scenario id = first eight characters of
+  the ADK session id, full id on collision; event/score rows keep the real
+  `session_id`), scores are derived from the session alone (1.0 iff
+  `AGENT_COMPLETED` — *completed*, not *passed*; only the
+  `EvalScorePolicy` gate decides passed), and failed sessions carry the
+  frozen G1 v0.1.0 names — the widget-stock silence session `7e352c34`
+  yields `task/planning`, `finalization`, `tool blockers`. The
+  `evalbench-import` adapter (#97) stays as an optional on-ramp, the
+  production `agent_events` table is never written (reserved-name guard),
+  and **the six-week clock has still NOT started**. Offline fixture tests
+  only; no live BigQuery.
 - **REAL Week 0 freeze: partner, D4 boundary, G1 taxonomy v0.1 (#435)** —
   the Week 0 gates are frozen for real, distinct from the EXAMPLE pack
   below (which stays illustrative). `docs/week0_partner.md` records the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EXAMPLE Week 0 scenario pack (#435 slice 10)** — new
+  `examples/evalbench_week0_full_idea.md` / `.sh --fixture` walk all five
+  Week 0 human gates of `docs/agentforensics_mvp_plan.md` (partner + SANA
+  relationship, runtime + route, pilot-benchmark rubric, D4 boundary memo,
+  preregistration) as one concrete story on the widget-stock failed session,
+  ending in the mechanical `taxonomy_categories` row and an EXAMPLE mapping
+  onto SANA-seeded names in `examples/fixtures/week0_example_*.json`.
+  Offline only (no BigQuery, no network) and entirely illustrative: not a
+  freeze, `g1_frozen` stays false, the six-week clock has not started, no
+  real partner is named, and `src/` is untouched — Week 0 remains
+  human-gated.
 - **Failed-session rows carry scaffold taxonomy categories (#435 slice 9)**
   — `failed_sessions()` / `bq-agent-sdk evalbench-failed-sessions` now
   attach `taxonomy_categories` to each session row: `EvalBenchSession`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mechanical failure-taxonomy scaffold (#435 slice 8)** — new
+  `failure_taxonomy` module: a versioned scaffold config
+  (`taxonomy_version: 0.0.0-scaffold`, `g1_frozen: false`) in the #431
+  `{"metrics": [...]}` schema shape whose one core metric carries the three
+  mechanical categories of the landed failed-session contract
+  (`process_failed` / `missing_completion` / `score_failed`), an empty D2
+  `dialects` slot (per-benchmark extension categories on the same core), and
+  a pure `categorize_failed_session()` that maps one failed-session row
+  (dict or `SessionVerdict`) to the tripped categories — no BigQuery, no
+  LLM, no network. NOT the G1 taxonomy: names are unfrozen and the six-week
+  clock has not started.
 - **EvalBench MVP e2e demo tells one session's story (#435 slice 5, #97)**
   — the `--fixture` walkthrough of `examples/evalbench_mvp_e2e.sh` now
   follows `support_agent` session `7e352c34` ("How many widgets are in

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -27,7 +27,10 @@ A mechanical taxonomy *scaffold* also exists
 (`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
 failed-session flags (`process_failed` / `missing_completion` /
 `score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
-with an empty D2 dialects slot. It is **not** G1 — no category names are
+with an empty D2 dialects slot. The failed-session consumer now uses it:
+`failed_sessions` / `bq-agent-sdk evalbench-failed-sessions` attach the
+mechanical categories to each session row as `taxonomy_categories`, computed
+in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,16 +23,39 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
-A mechanical taxonomy *scaffold* also exists
-(`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
-failed-session flags (`process_failed` / `missing_completion` /
-`score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
-with an empty D2 dialects slot. The failed-session consumer now uses it:
+**G1 is frozen at v0.1.0 in `failure_taxonomy.py`**
+(`src/bigquery_agent_analytics/failure_taxonomy.py`, `g1_frozen: true`): the
+frozen vocabulary is the SANA-neighborhood seven plus `unknown`
+(`docs/week0_g1_taxonomy.md`). Assignment stays mechanical until the labeler
+study: the landed failed-session flags (`process_failed` /
+`missing_completion` / `score_failed`) map to `tool blockers` /
+`finalization` / `task/planning`, returned in frozen order, and the D2
+dialects slot stays empty. The failed-session consumer uses it:
 `failed_sessions` / `bq-agent-sdk evalbench-failed-sessions` attach the
-mechanical categories to each session row as `taxonomy_categories`, computed
-in Python from the row's flags. It is **not** G1 — no category names are
-frozen, the six-week clock has still not started, and the partner job, D4
-boundary, and live-trace ingestion remain parked.
+frozen names to each session row as `taxonomy_categories`, computed in
+Python from the row's flags.
+
+**Week 0 partner, D4 boundary, and G1 are frozen** by the Week 0 freeze PR:
+`docs/week0_partner.md` (real partner: Google Cloud BigQuery Agent
+Analytics — this SDK — piloting the ADK `support_agent` traces via EvalBench
+job `mvp-e2e-real-traces`), `docs/week0_d4_memo.md` (fail-closed, named
+consumer Hai-Yuan Cao only), and `docs/week0_g1_taxonomy.md`, with
+machine-readable copies in `examples/fixtures/week0_real_*.json`
+(`example: false`). The remaining Week 0 item is **preregistration
+execution**; `docs/week0_preregistration.md` carries the v4 floors as the
+freeze-candidate. **The six-week clock has still not started**: it starts
+only when the first Week 1 snapshot job is kicked, not at merge of the
+freeze.
+
+An **example scenario pack** also exists
+(`examples/evalbench_week0_full_idea.md`, run with
+`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
+every Week 0 human gate below as one concrete story on the widget-stock
+failed session. Everything in it is labeled EXAMPLE / illustrative / not a
+freeze — its fixtures keep `example: true` / `g1_frozen: false` and its
+partner is the fictional "Acme Retail Support". The pack **remains
+illustrative** now that the real freeze landed; the real artifacts are the
+`week0_*.md` docs and `week0_real_*.json` fixtures above.
 
 ---
 

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,6 +23,14 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
+A mechanical taxonomy *scaffold* also exists
+(`src/bigquery_agent_analytics/failure_taxonomy.py`): it maps the landed
+failed-session flags (`process_failed` / `missing_completion` /
+`score_failed`) to a versioned config (`0.0.0-scaffold`, `g1_frozen: false`)
+with an empty D2 dialects slot. It is **not** G1 — no category names are
+frozen, the six-week clock has still not started, and the partner job, D4
+boundary, and live-trace ingestion remain parked.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -34,6 +34,15 @@ in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 
+An **example scenario pack** also exists
+(`examples/evalbench_week0_full_idea.md`, run with
+`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
+every Week 0 human gate below as one concrete story on the widget-stock
+failed session. Everything in it is labeled EXAMPLE / illustrative / not a
+freeze — `g1_frozen` stays false, the six-week clock has **not** started,
+and no real partner is named (the example partner is "Acme Retail
+Support"). **Week 0 remains human-gated**; the pack clears nothing.
+
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -34,15 +34,6 @@ in Python from the row's flags. It is **not** G1 — no category names are
 frozen, the six-week clock has still not started, and the partner job, D4
 boundary, and live-trace ingestion remain parked.
 
-An **example scenario pack** also exists
-(`examples/evalbench_week0_full_idea.md`, run with
-`bash examples/evalbench_week0_full_idea.sh --fixture`): it demonstrates
-every Week 0 human gate below as one concrete story on the widget-stock
-failed session. Everything in it is labeled EXAMPLE / illustrative / not a
-freeze — `g1_frozen` stays false, the six-week clock has **not** started,
-and no real partner is named (the example partner is "Acme Retail
-Support"). **Week 0 remains human-gated**; the pack clears nothing.
-
 ---
 
 ## Preface — what was verified before acceptance

--- a/docs/agentforensics_mvp_plan.md
+++ b/docs/agentforensics_mvp_plan.md
@@ -23,6 +23,15 @@ three rounds of review; the issue body points here.
 Those slices build the Week 1–2 substrate; they do not start the clock and do
 not touch the partner job, the D4 boundary, taxonomy content, or live traces.
 
+A **native writer** also exists as the EvalBench-adapter exit ramp
+([#463](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/463):
+`native_events.NativeAgentEventsRun` / `bq-agent-sdk
+evalbench-native-import`): it produces the same pinned snapshot +
+`failed_sessions` view + G1 labels directly from production ADK
+`agent_events` rows, with no EvalBench source tables in the path. The
+`evalbench-import` adapter (#97) stays as an optional on-ramp, and the
+native writer does not start the clock either.
+
 **G1 is frozen at v0.1.0 in `failure_taxonomy.py`**
 (`src/bigquery_agent_analytics/failure_taxonomy.py`, `g1_frozen: true`): the
 frozen vocabulary is the SANA-neighborhood seven plus `unknown`

--- a/docs/week0_d4_memo.md
+++ b/docs/week0_d4_memo.md
@@ -1,0 +1,42 @@
+# Week 0 — D4 Boundary Memo (frozen, fail-closed)
+
+**Status:** frozen by the #435 Week 0 freeze PR. This is the REAL D4
+boundary for exactly this pilot's data, not the example pack. The six-week
+clock has **not** started; it starts only when the
+first Week 1 snapshot job is kicked. Machine-readable copy:
+`examples/fixtures/week0_real_d4_memo.json` (`example: false`).
+
+## Scope — this pilot data only
+
+- Project: `test-project-0728-467323`
+- Datasets: `bqaa_e2e_real`, `bqaa_evalbench_mvp_demo`,
+  `bqaa_evalbench_mvp_mirror`
+- Derived artifacts: `failed_sessions` rows and taxonomy labels computed
+  from them
+
+## Named report consumers
+
+- **Hai-Yuan Cao** (`caohy1988` / `haiyuan-eng-google`)
+
+No other consumer is named. **Fail-closed:** if a consumer is not named in
+this memo, access is denied.
+
+## Per-user grants and notebook/export policy (text only, no IAM API)
+
+No additional per-user grants and no notebook/export access beyond
+Hai-Yuan Cao until a later D4 amendment. This policy is recorded as text in
+this governed memo; **no IAM API calls** are made by the freeze, and none
+are needed until an amendment names a new consumer.
+
+## What synthetic / fixture / example runs can prove
+
+The `--fixture` path, synthetic data, and the example pack validate
+**ingestion, taxonomy mechanics, and stability ONLY** — they can **never**
+produce a Part II funding recommendation.
+
+## Standing restrictions under this memo
+
+- No new live judge calls.
+- No new BigQuery jobs.
+- No labeler access expansion.
+- The stop/go memo is itself a governed artifact inside this D4 boundary.

--- a/docs/week0_g1_taxonomy.md
+++ b/docs/week0_g1_taxonomy.md
@@ -1,0 +1,62 @@
+# Week 0 — G1 Taxonomy Freeze (v0.1.0)
+
+**Status:** frozen by the #435 Week 0 freeze PR, in production code:
+`src/bigquery_agent_analytics/failure_taxonomy.py` now carries
+`taxonomy_version: 0.1.0` / `g1_frozen: true`. **Freezing G1 is not a clock
+start**: the six-week clock has **not** started and starts only when the
+first Week 1 snapshot job is kicked. Machine-readable copy:
+`examples/fixtures/week0_real_taxonomy.json` (`example: false`,
+`g1_frozen: true`).
+
+## Frozen vocabulary (names and spellings are stable)
+
+The SANA-neighborhood seven, then `unknown`, in **frozen order**:
+
+1. `task/planning`
+2. `wrong source`
+3. `execution/computation`
+4. `incomplete evidence`
+5. `turn-waste`
+6. `finalization`
+7. `tool blockers`
+8. `unknown`
+
+`unknown` is in the vocabulary as the residual bucket for the labeler
+study. The mechanical mapper never emits it: a row with all flags false
+returns `()`, not `("unknown",)`.
+
+## Mechanical assignment until the labeler study
+
+`categorize_failed_session` maps the three landed failed-session flags
+(`MECHANICAL_FLAGS`) onto frozen names:
+
+| Flag | Frozen category |
+|---|---|
+| `missing_completion` | `finalization` |
+| `process_failed` | `tool blockers` |
+| `score_failed` | `task/planning` |
+
+When multiple flags trip, the returned names follow the **frozen order
+above, not flag order**. The other four categories and `unknown` are never
+emitted by the three-flag mapper; they become assignable when the labeler
+study runs.
+
+## The widget-stock pilot session
+
+Session `7e352c34-4c1c-4395-acd5-fb3c8f215346` (`7e352c34`) trips all three
+flags, so its `taxonomy_categories` are:
+
+```
+("task/planning", "finalization", "tool blockers")
+```
+
+## What did not change
+
+- `dialects` stays `[]` (D2: one taxonomy, optional per-benchmark
+  extension categories on the same core — still empty).
+- The config keeps the #431 `{"metrics": [...]}` schema shape;
+  `evaluation_rubrics.build_metrics` interprets it unchanged.
+- `scaffold_taxonomy_config()` survives as a compatibility wrapper for
+  `taxonomy_config()` (see CHANGELOG).
+- No six-week execution starts here: no ≥100-session study, no labeler
+  study, no live-trace ingestion job.

--- a/docs/week0_partner.md
+++ b/docs/week0_partner.md
@@ -1,0 +1,43 @@
+# Week 0 — Real Pilot Partner (frozen)
+
+**Status:** frozen by the #435 Week 0 freeze PR. This is the REAL partner
+record, not the example pack (`examples/evalbench_week0_full_idea.md`, which
+stays illustrative). The six-week clock has **not** started; it starts only
+when the first Week 1 snapshot job is kicked, not at merge of this freeze.
+
+Machine-readable copy: `examples/fixtures/week0_real_partner.json`
+(`example: false`).
+
+## Partner
+
+**Google Cloud BigQuery Agent Analytics (this SDK / BQAA).** The pilot is
+self-hosted: the ADK `support_agent` traces in
+`test-project-0728-467323.bqaa_e2e_real.agent_events`, imported as EvalBench
+job `mvp-e2e-real-traces`.
+
+## Relationship to SANA
+
+AgentForensics is **SANA-adjacent published work — not a SANA fork and not a
+named collaboration with SANA authors**. SANA is LakeQA + KramaBench on the
+Strands runtime, with a seven-category failure taxonomy (task/planning,
+wrong source, execution/computation, incomplete evidence, turn-waste,
+finalization, tool blockers). This pilot is ADK+EvalBench on widget-stock
+support — a different benchmark and a different runtime — so it is
+**not duplicating** published work on LakeQA or KramaBench. Taxonomy v0.1 starts
+from SANA's seven categories per Week 0 item 1 (see
+`docs/week0_g1_taxonomy.md`).
+
+## Runtime and route (recorded as real, already true)
+
+ADK plugin → BQAA `agent_events` → EvalBench-hosted. The partner's benchmark
+runs are EvalBench-hosted, so the **EvalBench-only MVP route is correct and
+D1 does not need re-decision**.
+
+## Pilot-benchmark rubric (recorded as real)
+
+The predeclared rubric selected the widget-stock support benchmark on
+session `7e352c34-4c1c-4395-acd5-fb3c8f215346` (`7e352c34`): sibling gold
+session `ab7535a5` answered "There are 0 widgets in stock." for the same
+prompt, and `goal_completion` is 0 for the failed session vs 1 for the gold
+against a definable threshold. Machine-readable copy:
+`examples/fixtures/week0_real_rubric.json`.

--- a/docs/week0_preregistration.md
+++ b/docs/week0_preregistration.md
@@ -1,0 +1,42 @@
+# Week 0 — Preregistration Freeze-Candidate
+
+**Banner:** these numbers are the plan of record (FINAL v4,
+`docs/agentforensics_mvp_plan.md`), copied here as the freeze-candidate.
+**The six-week clock has NOT started** — this is not a clock start and not
+Week 1 execution; the clock starts only when the first Week 1 snapshot job
+is kicked. Nothing here invents a new number. Machine-readable copy:
+`examples/fixtures/week0_real_preregistration.json` (`example: false`,
+`clock_started: false`).
+
+## Floors (from v4)
+
+| Floor | Value |
+|---|---|
+| Replicate agreement | ≥80% |
+| Non-`unknown` coverage | ≥80% |
+| Human-human / classifier-vs-adjudicated κ (point) | ≥0.6 |
+| κ 95% CI lower bound | ≥0.45 |
+| Localization coverage | ≥70% |
+| Paired hit@1 uplift CI lower bound | >0 |
+| Paired hit@1 point uplift | ≥ +10pp |
+
+## Decision rules (same as the v4 plan)
+
+- **Reserved revision week:** one taxonomy revision slot (week 7); a
+  stability miss invokes it once with fresh labels and a re-gate; a second
+  miss ends the MVP with the analysis as the deliverable.
+- **Value gate:** at least the preregistered fraction of randomly assigned
+  investigations where the report changed or materially narrowed the next
+  action, adjudicated by a non-investigator; a stated preference or
+  unverified acceptance counts for nothing.
+- **Noisy-small-n localization:** point-clears-but-CI-spans-zero resolves
+  per the preregistered week-0 rule, not week-6 judgment; no metric
+  conditions on successful localizations only.
+- **Sealed sets:** `P-blind` is frozen before any tuning and scored exactly
+  once at week 6.
+
+## Remaining Week 0 item
+
+With partner, D4, and G1 frozen, the remaining Week 0 item is
+**preregistration execution** (adopting this freeze-candidate as the sealed
+preregistration). That step, not this document, precedes any clock start.

--- a/examples/evalbench_week0_full_idea.md
+++ b/examples/evalbench_week0_full_idea.md
@@ -8,6 +8,15 @@ Retail Support*). Week 0 of
 [`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
 remains human-gated.
 
+> **Predates the G1 freeze
+> ([#461](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/461)):**
+> this walkthrough is the pre-freeze illustrative story. Production has
+> since frozen taxonomy **v0.1.0** (`g1_frozen: true`) and
+> `failed_sessions` now emits the frozen names (`task/planning`,
+> `finalization`, `tool blockers`) in `taxonomy_categories` — not the
+> mechanical flag ids shown below. Only this example pack keeps the
+> pre-freeze behavior.
+
 What it does show: all **five Week 0 human gates** of the plan of record
 ([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435))
 worked through as **one concrete story** on the widget-stock failed
@@ -112,6 +121,13 @@ Then the through-line the gates exist to serve:
    scaffold config stays `0.0.0-scaffold`, `g1_frozen: false`.
 10. **`Punchline`** — *This widget-stock session failed because the
     agent never answered; goal_completion=0.0.*
+
+> **Post-[#461](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/461)
+> note:** items 8–9 describe the pre-freeze scaffold and predate the G1
+> freeze. Production `failure_taxonomy.py` is now G1-frozen at v0.1.0
+> (`g1_frozen: true`) and emits the frozen category names
+> (`task/planning`, `finalization`, `tool blockers`) in
+> `taxonomy_categories`, not the mechanical flag ids.
 
 ## What this pack is NOT
 

--- a/examples/evalbench_week0_full_idea.md
+++ b/examples/evalbench_week0_full_idea.md
@@ -1,0 +1,136 @@
+# EXAMPLE Week 0 scenario pack: the full AgentForensics idea on one failed session
+
+**This is an EXAMPLE pack — every artifact in it is illustrative, not a
+freeze.** No partner freeze, no G1 freeze, no preregistration freeze:
+`g1_frozen` is **false** everywhere, the six-week clock has **not**
+started, and no real partner is named (the example partner is *Acme
+Retail Support*). Week 0 of
+[`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
+remains human-gated.
+
+What it does show: all **five Week 0 human gates** of the plan of record
+([#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435))
+worked through as **one concrete story** on the widget-stock failed
+session from the e2e demo — so a reader can see, end to end, what
+AgentForensics is *for* before any human clears a gate for real.
+
+```bash
+bash examples/evalbench_week0_full_idea.sh --fixture
+```
+
+`--fixture` (or `EVALBENCH_FIXTURE=1`) is the only mode: offline, no
+BigQuery, no network, no live judge, exit `0`. Any other invocation
+prints one line saying so and exits `2` without running anything. The
+facts printed under each banner come from the JSON files in
+[`examples/fixtures/`](fixtures/) (`week0_example_*.json`), each of
+which carries `"example": true`, `"g1_frozen": false`,
+`"clock_started": false`.
+
+## The protagonist (same session as the e2e demo)
+
+A terse support agent was asked how many widgets are in stock and never
+answered. Real trace from `bqaa_e2e_real.agent_events` (reference
+project `test-project-0728-467323`), EvalBench job `mvp-e2e-real-traces`:
+
+| | |
+|---|---|
+| agent | `support_agent` |
+| user | `real-user-0` |
+| prompt | `How many widgets are in stock?` |
+| session_id | `7e352c34-4c1c-4395-acd5-fb3c8f215346` |
+| eval_id / scenario_id | `7e352c34` |
+| events | `USER_MESSAGE_RECEIVED` → `INVOCATION_STARTING` → `AGENT_STARTING`, then silence |
+| what never happened | no `check_inventory` call, no `LLM_RESPONSE`, no `AGENT_COMPLETED` |
+| score | `goal_completion` 0.0 vs threshold 1 |
+
+Sibling session `ab7535a5` answered *"There are 0 widgets in stock."* —
+the agent could do it; this session just never did.
+
+## The five gates, as this session's story
+
+The fixture prints these in order, each under an `=== ... ===` banner;
+`tests/test_evalbench_week0_full_idea.py` asserts the same order.
+
+1. **`EXAMPLE — Week 0 is not a freeze. Clock has not started.`** — the
+   disclaimer first: everything below is illustrative, `g1_frozen:
+   false`, `clock_started: false`.
+2. **`EXAMPLE partner + SANA relationship`** — example partner **Acme
+   Retail Support**. AgentForensics here is **SANA-adjacent, not a SANA
+   fork**: SANA is LakeQA + KramaBench on the Strands runtime with seven
+   categories (task/planning, wrong source, execution/computation,
+   incomplete evidence, turn-waste, finalization, tool blockers); this
+   example pilot is ADK+EvalBench on widget-stock support. Taxonomy v0.1
+   EXAMPLE seeds from those seven because the failure modes overlap —
+   and it is not duplicating LakeQA/KramaBench, which study different
+   benchmarks on a different runtime.
+3. **`EXAMPLE runtime + route`** — the pilot traces already exist: the
+   ADK plugin logged `support_agent` into `bqaa_e2e_real.agent_events`,
+   folded into EvalBench job `mvp-e2e-real-traces`. Runtime is ADK
+   plugin → BQAA `agent_events` → EvalBench-hosted, so the
+   EvalBench-only MVP route is **CORRECT** for this example and D1 does
+   not need re-decision.
+4. **`EXAMPLE pilot-benchmark rubric`** — the benchmark is selected by
+   the predeclared rubric, not import convenience, and each criterion is
+   *scored* in the fixture: collaborator relevance (retail support
+   inventory questions — pass), failure-mode coverage (silent
+   non-completion — pass), score availability / threshold-definability
+   (`goal_completion` 0.0 vs 1.0, threshold 1 — pass), ground-truth
+   depth (sibling `ab7535a5`'s gold answer — pass), then trace fidelity
+   (the three real ADK events, then silence — pass).
+5. **`EXAMPLE D4 boundary memo`** — fail-closed, with **example** report
+   consumers ("Alex Rivera (example collaborator)", "Jordan Lee (example
+   collaborator)" — not real people). A `--fixture`/synthetic run
+   validates **ingestion, taxonomy mechanics, and stability ONLY** and
+   can never produce a Part II funding recommendation; without clearance
+   the pilot runs on pre-redacted reference traces
+   (`test-project-0728-467323`) or pauses. The stop/go memo is itself a
+   governed artifact.
+6. **`EXAMPLE preregistration (not a week-1 freeze)`** — the plan's
+   floors and decision rules copied as an example: replicate agreement
+   ≥80%, non-`unknown` coverage ≥80%, κ point ≥0.6 with CI lower ≥0.45,
+   localization coverage ≥70%, hit@1 CI lower >0 and point uplift
+   ≥ +10pp, plus the value-gate rubric, the noisy-small-n localization
+   rule, the sealed `P-blind` set, and the reserved revision week.
+
+Then the through-line the gates exist to serve:
+
+7. **`This agent was asked to check widget stock. Here is the session.`**
+   — the protagonist, verbatim.
+8. **`This session in failed_sessions (mechanical taxonomy_categories)`**
+   — the slice-9 consumer attaches
+   `taxonomy_categories: ["process_failed", "missing_completion",
+   "score_failed"]` to the row: which gates tripped, mechanically, not
+   why the agent failed.
+9. **`EXAMPLE mapping of mechanical flags onto SANA-seeded names`** —
+   the judgment layer the MVP would build, shown as an EXAMPLE (**not
+   G1**): `missing_completion` → *finalization* (never finalized an
+   answer), `process_failed` → *tool blockers* (never called
+   `check_inventory`), plus *task/planning* as an overlapping seed. This
+   mapping lives only in
+   [`fixtures/week0_example_taxonomy_seed.json`](fixtures/week0_example_taxonomy_seed.json)
+   — never in `src/bigquery_agent_analytics/failure_taxonomy.py`, whose
+   scaffold config stays `0.0.0-scaffold`, `g1_frozen: false`.
+10. **`Punchline`** — *This widget-stock session failed because the
+    agent never answered; goal_completion=0.0.*
+
+## What this pack is NOT
+
+- It does **not** clear any Week 0 gate — those remain human decisions.
+- It does **not** start the six-week clock, the partner job, the real D4
+  boundary, live-trace ingestion, or the labeler study.
+- It does **not** freeze taxonomy names: the SANA-seeded names appear
+  only in the example fixture, and the production scaffold module is
+  untouched.
+
+## Related
+
+- [`docs/agentforensics_mvp_plan.md`](../docs/agentforensics_mvp_plan.md)
+  — the plan of record whose Week 0 gates this pack illustrates.
+- `examples/evalbench_mvp_e2e.md` / `.sh` (PR
+  [#455](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/pull/455))
+  — the e2e demo this pack's session comes from.
+- [`docs/evalbench.md`](../docs/evalbench.md) — the failed-session
+  contract and CLI reference.
+- Issue
+  [#435](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/issues/435)
+  — AgentForensics MVP tracking.

--- a/examples/evalbench_week0_full_idea.sh
+++ b/examples/evalbench_week0_full_idea.sh
@@ -21,6 +21,12 @@
 # false, the six-week clock has NOT started, and no real partner is named
 # (the example partner is "Acme Retail Support").
 #
+# NOTE: this pack PREDATES the G1 freeze (PR #461). Production has since
+# frozen taxonomy v0.1.0 (g1_frozen: true) and failed_sessions now emits the
+# frozen names (task/planning, finalization, tool blockers) in
+# taxonomy_categories — not the mechanical flag ids shown below. Only this
+# example pack keeps the pre-freeze behavior.
+#
 # This pack is --fixture only: no BigQuery, no network, no live judge.
 #
 #   bash examples/evalbench_week0_full_idea.sh --fixture
@@ -133,6 +139,8 @@ echo "                AGENT_STARTING, then silence"
 echo "  it never called check_inventory; no LLM_RESPONSE; no AGENT_COMPLETED"
 echo
 
+# Pre-freeze snapshot: since PR #461, production failed_sessions emits the
+# frozen v0.1.0 names in taxonomy_categories, not these mechanical flag ids.
 echo "=== This session in failed_sessions (mechanical taxonomy_categories) ==="
 echo "The slice-9 consumer attaches the mechanical scaffold categories to"
 echo "the row — which gates tripped, not why the agent failed:"

--- a/examples/evalbench_week0_full_idea.sh
+++ b/examples/evalbench_week0_full_idea.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EXAMPLE Week 0 scenario pack for the AgentForensics MVP (#435).
+#
+# Demonstrates all five Week 0 human gates of
+# docs/agentforensics_mvp_plan.md as ONE concrete story on the widget-stock
+# failed session — as EXAMPLES. Nothing here is a freeze: g1_frozen stays
+# false, the six-week clock has NOT started, and no real partner is named
+# (the example partner is "Acme Retail Support").
+#
+# This pack is --fixture only: no BigQuery, no network, no live judge.
+#
+#   bash examples/evalbench_week0_full_idea.sh --fixture
+#
+# Narrative companion: examples/evalbench_week0_full_idea.md
+# Facts printed under each banner come from examples/fixtures/week0_example_*.json.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="${SCRIPT_DIR}/fixtures"
+
+fixture=0
+for arg in "$@"; do
+  case "$arg" in
+    --fixture) fixture=1 ;;
+    *)
+      echo "evalbench_week0_full_idea.sh: unknown argument '${arg}'." \
+        "This EXAMPLE pack is --fixture only — no BigQuery, no --synth, no" \
+        "live mode; the six-week clock has not started." >&2
+      exit 2
+      ;;
+  esac
+done
+if [[ "${EVALBENCH_FIXTURE:-}" == "1" ]]; then
+  fixture=1
+fi
+if (( ! fixture )); then
+  echo "evalbench_week0_full_idea.sh: this EXAMPLE pack is --fixture only" \
+    "(no BigQuery, no live mode; the clock has not started). Run:" \
+    "bash examples/evalbench_week0_full_idea.sh --fixture" >&2
+  exit 2
+fi
+
+show_json() {
+  # Pretty-print one fixture JSON file (also proves it parses).
+  python3 -m json.tool "${FIXTURE_DIR}/$1"
+}
+
+echo "=== EXAMPLE — Week 0 is not a freeze. Clock has not started. ==="
+echo "This is an EXAMPLE scenario pack — every artifact below is"
+echo "illustrative. It is not a freeze: not a partner freeze, not a G1"
+echo "freeze, not a preregistration freeze."
+echo "  g1_frozen: false"
+echo "  clock_started: false — the six-week clock has not started."
+echo "fixture mode: offline; no BigQuery, no network, no live judge."
+echo "It walks the five Week 0 human gates of docs/agentforensics_mvp_plan.md"
+echo "as one story on the widget-stock failed session from the #435 e2e demo."
+echo
+
+echo "=== EXAMPLE partner + SANA relationship ==="
+echo "Example partner: Acme Retail Support (illustrative — no real partner"
+echo "is named). AgentForensics here is SANA-adjacent, not a SANA fork:"
+echo "SANA is LakeQA + KramaBench on Strands with seven categories; this"
+echo "example pilot is ADK+EvalBench on widget-stock support, seeding"
+echo "taxonomy v0.1 EXAMPLE from those seven because failure modes overlap"
+echo "— and it is not duplicating LakeQA/KramaBench work."
+show_json week0_example_partner.json
+echo
+
+echo "=== EXAMPLE runtime + route ==="
+echo "The pilot traces already exist: support_agent, logged by the ADK"
+echo "plugin into bqaa_e2e_real.agent_events and folded into EvalBench job"
+echo "mvp-e2e-real-traces. Runtime is ADK plugin -> BQAA agent_events ->"
+echo "EvalBench-hosted, so the EvalBench-only MVP route is CORRECT for this"
+echo "example and D1 does not need re-decision here."
+echo
+
+echo "=== EXAMPLE pilot-benchmark rubric ==="
+echo "Selected by the predeclared rubric, not import convenience:"
+echo "widget-stock support, session 7e352c34-4c1c-4395-acd5-fb3c8f215346"
+echo "(eval_id 7e352c34). All five criteria pass in this example:"
+echo "goal_completion 0.0 vs threshold 1; sibling ab7535a5 answered"
+echo "\"There are 0 widgets in stock.\"; real ADK events"
+echo "USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then"
+echo "silence."
+show_json week0_example_rubric.json
+echo
+
+echo "=== EXAMPLE D4 boundary memo ==="
+echo "Fail-closed: no clearance means the pilot runs on pre-redacted"
+echo "reference traces (project test-project-0728-467323) or pauses."
+echo "A --fixture/synthetic run validates ingestion, taxonomy mechanics,"
+echo "and stability ONLY — it can never produce a Part II funding"
+echo "recommendation. Report consumers below are examples, not real people;"
+echo "the stop/go memo is itself a governed artifact."
+show_json week0_example_d4_memo.json
+echo
+
+echo "=== EXAMPLE preregistration (not a week-1 freeze) ==="
+echo "EXAMPLE copy of the plan's floors and decision rules — not week-1"
+echo "freeze; clock not started. Floors: replicate agreement >=80%;"
+echo "non-unknown coverage >=80%; kappa point >=0.6 with CI lower >=0.45;"
+echo "localization coverage >=70%; hit@1 CI lower >0 and point uplift"
+echo ">= +10pp. Plus the reserved revision week, the value-gate rubric, and"
+echo "the noisy-small-n localization rule."
+show_json week0_example_preregistration.json
+echo
+
+echo "=== This agent was asked to check widget stock. Here is the session. ==="
+echo "  agent:        support_agent"
+echo "  user:         real-user-0"
+echo "  prompt:       How many widgets are in stock?"
+echo "  session_id:   7e352c34-4c1c-4395-acd5-fb3c8f215346"
+echo "  eval_id:      7e352c34"
+echo "  job:          mvp-e2e-real-traces"
+echo "  source:       bqaa_e2e_real.agent_events (test-project-0728-467323)"
+echo "  events:       USER_MESSAGE_RECEIVED -> INVOCATION_STARTING ->"
+echo "                AGENT_STARTING, then silence"
+echo "  it never called check_inventory; no LLM_RESPONSE; no AGENT_COMPLETED"
+echo
+
+echo "=== This session in failed_sessions (mechanical taxonomy_categories) ==="
+echo "The slice-9 consumer attaches the mechanical scaffold categories to"
+echo "the row — which gates tripped, not why the agent failed:"
+echo "  process_failed:      True"
+echo "  missing_completion:  True"
+echo "  score_failed:        True   (goal_completion 0.0 vs threshold 1)"
+echo '  taxonomy_categories: ["process_failed", "missing_completion", "score_failed"]'
+echo
+
+echo "=== EXAMPLE mapping of mechanical flags onto SANA-seeded names ==="
+echo "EXAMPLE only — not G1; g1_frozen: false. These SANA-seeded names live"
+echo "only in this fixture, never in src/. For this session: the agent"
+echo "never called check_inventory (tool blockers), never finalized an"
+echo "answer (finalization), and the plan to answer never formed"
+echo "(task/planning as an overlapping seed)."
+show_json week0_example_taxonomy_seed.json
+echo
+
+echo "=== Punchline ==="
+echo "This widget-stock session failed because the agent never answered; goal_completion=0.0."

--- a/examples/fixtures/week0_example_d4_memo.json
+++ b/examples/fixtures/week0_example_d4_memo.json
@@ -1,0 +1,18 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "fail_closed": true,
+  "report_consumers": [
+    "Alex Rivera (example collaborator)",
+    "Jordan Lee (example collaborator)"
+  ],
+  "fixture_validates": ["ingestion", "taxonomy mechanics", "stability"],
+  "fixture_validates_only": true,
+  "never_produces": "Part II funding recommendation",
+  "reference_project": "test-project-0728-467323",
+  "pre_redacted": true,
+  "stop_go_memo_is_governed_artifact": true
+}

--- a/examples/fixtures/week0_example_partner.json
+++ b/examples/fixtures/week0_example_partner.json
@@ -1,0 +1,21 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "partner_name": "Acme Retail Support",
+  "relationship_to_sana": "SANA-adjacent, not a SANA fork: SANA is LakeQA + KramaBench on the Strands runtime with a seven-category failure taxonomy; this example pilot is ADK+EvalBench on widget-stock support, and taxonomy v0.1 EXAMPLE seeds from SANA's seven categories because the failure modes overlap.",
+  "sana_runtime": "Strands",
+  "this_pilot_runtime": "ADK+EvalBench",
+  "sana_categories": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers"
+  ],
+  "not_duplicating_lakeqa_kramabench": "This example pilot is not duplicating LakeQA/KramaBench: it studies a different benchmark (widget-stock support) on a different runtime (ADK+EvalBench, not Strands), reusing SANA's seven category names only as unfrozen seeds."
+}

--- a/examples/fixtures/week0_example_preregistration.json
+++ b/examples/fixtures/week0_example_preregistration.json
@@ -1,0 +1,24 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "not_week_1_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "banner": "EXAMPLE — not week-1 freeze, clock not started",
+  "floors": {
+    "replicate_agreement_pct": 80,
+    "non_unknown_coverage_pct": 80,
+    "kappa_point": 0.6,
+    "kappa_ci_lower": 0.45,
+    "localization_coverage_pct": 70,
+    "hit_at_1_ci_lower_gt_0": true,
+    "hit_at_1_point_uplift_pp": 10
+  },
+  "decision_rules": {
+    "reserved_revision_week": "One taxonomy revision slot (week 7): a stability miss invokes it once with fresh labels and a re-gate; a second miss ends the MVP with the analysis as the deliverable.",
+    "value_gate": "At least the preregistered fraction of randomly assigned investigations where the report changed or materially narrowed the next action, adjudicated by a non-investigator; a stated preference or unverified acceptance counts for nothing.",
+    "noisy_small_n_localization": "Point-clears-but-CI-spans-zero resolves per the preregistered week-0 rule, not week-6 judgment; no metric conditions on successful localizations only.",
+    "sealed_sets": "P-blind is frozen before any tuning and scored exactly once at week 6."
+  }
+}

--- a/examples/fixtures/week0_example_rubric.json
+++ b/examples/fixtures/week0_example_rubric.json
@@ -1,0 +1,38 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "selected_benchmark": "widget-stock support",
+  "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+  "eval_id": "7e352c34",
+  "job_id": "mvp-e2e-real-traces",
+  "criteria": {
+    "collaborator_relevance": {
+      "name": "collaborator relevance",
+      "result": "pass",
+      "reason": "Retail support inventory questions are exactly what the example partner (Acme Retail Support) debugs."
+    },
+    "failure_mode_coverage": {
+      "name": "failure-mode coverage",
+      "result": "pass",
+      "reason": "Covers silent non-completion: the agent never answered the widget-stock question."
+    },
+    "score_availability": {
+      "name": "score availability / threshold-definability",
+      "result": "pass",
+      "reason": "goal_completion is 0.0 against a definable threshold of 1."
+    },
+    "ground_truth_depth": {
+      "name": "ground-truth depth",
+      "result": "pass",
+      "reason": "Sibling session ab7535a5 answered \"There are 0 widgets in stock.\" — a gold answer for the same prompt."
+    },
+    "trace_fidelity": {
+      "name": "trace fidelity",
+      "result": "pass",
+      "reason": "Real ADK events: USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then silence."
+    }
+  }
+}

--- a/examples/fixtures/week0_example_taxonomy_seed.json
+++ b/examples/fixtures/week0_example_taxonomy_seed.json
@@ -1,0 +1,38 @@
+{
+  "example": true,
+  "illustrative": true,
+  "not_a_freeze": true,
+  "not_g1": true,
+  "g1_frozen": false,
+  "clock_started": false,
+  "taxonomy_version": "0.1.0-example",
+  "sana_categories": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers"
+  ],
+  "mechanical_flags": ["process_failed", "missing_completion", "score_failed"],
+  "widget_session": {
+    "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+    "eval_id": "7e352c34",
+    "taxonomy_categories": [
+      "process_failed",
+      "missing_completion",
+      "score_failed"
+    ]
+  },
+  "example_mapping": {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning"
+  },
+  "example_mapping_notes": {
+    "missing_completion": "No AGENT_COMPLETED event and no final answer -> SANA's finalization seed.",
+    "process_failed": "The agent never called check_inventory before going silent -> SANA's tool blockers seed.",
+    "score_failed": "goal_completion 0.0 against threshold 1; the plan to answer never formed -> the overlapping task/planning seed."
+  }
+}

--- a/examples/fixtures/week0_real_d4_memo.json
+++ b/examples/fixtures/week0_real_d4_memo.json
@@ -1,0 +1,22 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 D4 freeze",
+  "clock_started": false,
+  "fail_closed": true,
+  "scope_project": "test-project-0728-467323",
+  "scope_datasets": [
+    "bqaa_e2e_real",
+    "bqaa_evalbench_mvp_demo",
+    "bqaa_evalbench_mvp_mirror"
+  ],
+  "scope_derived": ["failed_sessions", "taxonomy labels"],
+  "report_consumers": ["Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"],
+  "grants_policy": "No additional per-user grants or notebook/export access beyond Hai-Yuan Cao until a later D4 amendment; fail closed (deny) if a consumer is not named here. Documented as policy text only — no IAM API calls.",
+  "fixture_validates": ["ingestion", "taxonomy mechanics", "stability"],
+  "fixture_validates_only": true,
+  "never_produces": "Part II funding recommendation",
+  "no_new_live_judge_calls": true,
+  "no_new_bq_jobs": true,
+  "no_labeler_access_expansion": true,
+  "stop_go_memo_is_governed_artifact": true
+}

--- a/examples/fixtures/week0_real_partner.json
+++ b/examples/fixtures/week0_real_partner.json
@@ -1,0 +1,22 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 partner freeze",
+  "clock_started": false,
+  "partner_name": "Google Cloud BigQuery Agent Analytics (this SDK / BQAA)",
+  "pilot": {
+    "agent": "ADK support_agent",
+    "events_table": "test-project-0728-467323.bqaa_e2e_real.agent_events",
+    "evalbench_job_id": "mvp-e2e-real-traces"
+  },
+  "relationship_to_sana": "AgentForensics is SANA-adjacent published work, NOT a SANA fork and NOT a named collaboration with SANA authors. SANA is LakeQA + KramaBench on the Strands runtime with a seven-category failure taxonomy (task/planning, wrong source, execution/computation, incomplete evidence, turn-waste, finalization, tool blockers); this pilot is ADK+EvalBench on widget-stock support — a different benchmark and runtime.",
+  "not_a_sana_fork": true,
+  "not_a_named_sana_collaboration": true,
+  "sana_runtime": "Strands",
+  "this_pilot_runtime": "ADK+EvalBench",
+  "not_duplicating_lakeqa_kramabench": "This pilot is not duplicating LakeQA/KramaBench: it studies a different benchmark (widget-stock support) on a different runtime (ADK+EvalBench, not Strands).",
+  "route": {
+    "path": "ADK plugin -> BQAA agent_events -> EvalBench-hosted",
+    "evalbench_only_mvp_route_correct": true,
+    "d1_needs_redecision": false
+  }
+}

--- a/examples/fixtures/week0_real_preregistration.json
+++ b/examples/fixtures/week0_real_preregistration.json
@@ -1,0 +1,23 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 preregistration freeze-candidate",
+  "clock_started": false,
+  "freeze_candidate": true,
+  "not_week_1_execution": true,
+  "banner": "Plan-of-record freeze-candidate — numbers copied from the v4 plan; the six-week clock has NOT started and starts only when the first Week 1 snapshot job is kicked.",
+  "floors": {
+    "replicate_agreement_pct": 80,
+    "non_unknown_coverage_pct": 80,
+    "kappa_point": 0.6,
+    "kappa_ci_lower": 0.45,
+    "localization_coverage_pct": 70,
+    "hit_at_1_ci_lower_gt_0": true,
+    "hit_at_1_point_uplift_pp": 10
+  },
+  "decision_rules": {
+    "reserved_revision_week": "One taxonomy revision slot (week 7): a stability miss invokes it once with fresh labels and a re-gate; a second miss ends the MVP with the analysis as the deliverable.",
+    "value_gate": "At least the preregistered fraction of randomly assigned investigations where the report changed or materially narrowed the next action, adjudicated by a non-investigator; a stated preference or unverified acceptance counts for nothing.",
+    "noisy_small_n_localization": "Point-clears-but-CI-spans-zero resolves per the preregistered week-0 rule, not week-6 judgment; no metric conditions on successful localizations only.",
+    "sealed_sets": "P-blind is frozen before any tuning and scored exactly once at week 6."
+  }
+}

--- a/examples/fixtures/week0_real_rubric.json
+++ b/examples/fixtures/week0_real_rubric.json
@@ -1,0 +1,19 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 rubric freeze",
+  "clock_started": false,
+  "selected_benchmark": "widget-stock support",
+  "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+  "eval_id": "7e352c34",
+  "job_id": "mvp-e2e-real-traces",
+  "gold": {
+    "sibling_session": "ab7535a5",
+    "gold_answer": "There are 0 widgets in stock."
+  },
+  "score": {
+    "metric": "goal_completion",
+    "failed_session_score": 0,
+    "gold_session_score": 1,
+    "threshold": 1
+  }
+}

--- a/examples/fixtures/week0_real_taxonomy.json
+++ b/examples/fixtures/week0_real_taxonomy.json
@@ -1,0 +1,31 @@
+{
+  "example": false,
+  "frozen_by": "#435 Week 0 G1 freeze",
+  "clock_started": false,
+  "g1_frozen": true,
+  "taxonomy_version": "0.1.0",
+  "frozen_category_names": [
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown"
+  ],
+  "mechanical_flags": ["process_failed", "missing_completion", "score_failed"],
+  "flag_to_category": {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning"
+  },
+  "unknown_is_residual_only": "unknown is in the frozen vocabulary as the residual bucket for the labeler study; the mechanical three-flag mapper never emits it (all flags false returns an empty list).",
+  "widget_session": {
+    "session_id": "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+    "eval_id": "7e352c34",
+    "tripped_flags": ["process_failed", "missing_completion", "score_failed"],
+    "taxonomy_categories": ["task/planning", "finalization", "tool blockers"]
+  },
+  "dialects": []
+}

--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -2430,6 +2430,161 @@ def evalbench_import(
     raise typer.Exit(code=2)
 
 
+@app.command("evalbench-native-import")
+def evalbench_native_import(
+    source_table: str = typer.Option(
+        ...,
+        "--source-table",
+        help=(
+            "Fully-qualified project.dataset.table reference of the"
+            " production ADK agent_events table to read (read-only)."
+        ),
+    ),
+    job_id: str = typer.Option(
+        ..., "--job-id", help="Native snapshot job_id (the pin's first half)."
+    ),
+    target_dataset: str = typer.Option(
+        ...,
+        "--target-dataset",
+        help="BQAA-owned dataset that receives the snapshot tables.",
+    ),
+    target_project: Optional[str] = typer.Option(
+        None,
+        "--target-project",
+        help="Target project (defaults to the source table's project).",
+    ),
+    events_table: str = typer.Option(
+        "evalbench_agent_events",
+        "--events-table",
+        help="Snapshot event table name in --target-dataset.",
+    ),
+    scores_table: str = typer.Option(
+        "evalbench_scores_imported",
+        "--scores-table",
+        help="Native score table name in --target-dataset.",
+    ),
+    session_id: Optional[list[str]] = typer.Option(
+        None,
+        "--session-id",
+        help="Optional session id filter for the source read (repeatable).",
+    ),
+    import_version: Optional[str] = typer.Option(
+        None,
+        "--import-version",
+        help=(
+            "Version label for this snapshot. Defaults to a fingerprint of"
+            " the source rows so an unchanged source is a no-op."
+        ),
+    ),
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help="Atomically overwrite an existing import version.",
+    ),
+    snapshot_at: Optional[str] = typer.Option(
+        None,
+        "--snapshot-at",
+        help=(
+            "ISO-8601 timestamp; read agent_events FOR SYSTEM_TIME AS OF"
+            " this instant so a live table cannot mix versions."
+        ),
+    ),
+    failed_sessions_view: str = typer.Option(
+        "evalbench_failed_sessions",
+        "--failed-sessions-view",
+        help=(
+            "Failed-session view name in --target-dataset, kept pinned to"
+            " this job's latest successful publication."
+        ),
+    ),
+    skip_failed_sessions_view: bool = typer.Option(
+        False,
+        "--skip-failed-sessions-view",
+        help="Do not create or update the failed-session view.",
+    ),
+    min_score: Optional[list[str]] = typer.Option(
+        None,
+        "--min-score",
+        help=_MIN_SCORE_HELP + " Rendered into the failed-session view.",
+    ),
+    missing_score_passes: bool = typer.Option(
+        False, "--missing-score-passes", help=_MISSING_SCORE_PASSES_HELP
+    ),
+    location: Optional[str] = typer.Option(
+        None, "--location", help="BigQuery location."
+    ),
+    fmt: str = typer.Option(
+        "json", "--format", help="Output format: json|text|table."
+    ),
+) -> None:
+  """Snapshot production agent_events natively (no EvalBench tables, #463).
+
+  The EvalBench-adapter exit ramp: reads production ADK ``agent_events``
+  rows (read-only), derives one deterministic ``goal_completion`` score per
+  session (1.0 iff the session logged AGENT_COMPLETED — completed, not
+  passed), and publishes events, scores, and a manifest row as one
+  immutable ``(job_id, import_version)`` snapshot exactly as
+  ``evalbench-import`` does, keeping the ``--failed-sessions-view`` pinned
+  to the job's latest successful publication. No EvalBench ``configs`` /
+  ``results`` / ``scores`` tables are read, and the production
+  ``agent_events`` table is never written. ``evalbench-import`` (#97)
+  stays as the optional adapter on-ramp.
+
+  Exit codes:
+      0 — imported, replaced, or unchanged (see ``status`` in the output).
+      2 — invalid input (including the reserved ``agent_events``
+          destination name), a changed source under an explicit
+          --import-version, a version already bound to other destination
+          tables, a failed-session view at that name that belongs to
+          another job, or a BigQuery error.
+  """
+  try:
+    from .evalbench import _parse_timestamp
+    from .evalbench import _validate_destination_table
+    from .native_events import NativeAgentEventsRun
+
+    # Reject the reserved ADK plugin table before any BigQuery read or write.
+    _validate_destination_table("events_table", events_table)
+    _validate_destination_table("scores_table", scores_table)
+    if not skip_failed_sessions_view:
+      _validate_destination_table("failed_sessions_view", failed_sessions_view)
+    policy = _evalbench_score_policy(min_score, missing_score_passes)
+
+    parsed_snapshot = None
+    if snapshot_at is not None:
+      parsed_snapshot = _parse_timestamp(snapshot_at)
+      if parsed_snapshot is None:
+        raise ValueError(
+            f"--snapshot-at must be an ISO-8601 timestamp, got {snapshot_at!r}"
+        )
+
+    run = NativeAgentEventsRun.from_bigquery(
+        source_table=source_table,
+        job_id=job_id,
+        session_ids=session_id,
+        location=location,
+        snapshot_at=parsed_snapshot,
+    )
+    result = run.materialize(
+        target_project=target_project,
+        target_dataset=target_dataset,
+        events_table=events_table,
+        scores_table=scores_table,
+        import_version=import_version,
+        replace=replace,
+        failed_sessions_view=(
+            None if skip_failed_sessions_view else failed_sessions_view
+        ),
+        policy=policy,
+    )
+    typer.echo(format_output(result.to_dict(), fmt))
+  except typer.Exit:
+    raise
+  except Exception as exc:  # noqa: BLE001
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=2)
+
+
 @app.command("evalbench-failed-sessions")
 def evalbench_failed_sessions(
     project_id: str = typer.Option(

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -440,6 +440,7 @@ WHERE e.session_id = @session_id
   AND COALESCE(JSON_TYPE(e.attributes), 'null') IN ('object', 'null')
   AND JSON_VALUE(e.attributes, '$.root_agent_name')
       IS NOT DISTINCT FROM @anchor_root_agent_name
+  AND {version_where}
 """
 
 # NOTE (PR #371 review round 6, P2-11): the persisted schema carries
@@ -983,6 +984,7 @@ class Client:
       scope_signature: Optional[str] = None,
       allow_mixed_scope: bool = False,
       event_types: Optional[list[str]] = None,
+      import_version: Optional[str] = None,
   ) -> Trace:
     """Fetches all spans for one resolved session identity.
 
@@ -1020,6 +1022,16 @@ class Client:
             matches no rows, the resolved identity/scope is returned
             as a zero-span :class:`Trace`; this does not raise the
             unfiltered not-found error.
+        import_version: Optional EvalBench mirror version pin (#464).
+            When set, every discovery and fetch statement of this
+            lookup additionally requires the top-level
+            ``import_version`` column that EvalBench ``materialize``
+            stamps on published rows, so retained versions sharing
+            the real session id and job-scoped experiment id cannot
+            mix. Only meaningful against a mirror ``table_id`` — the
+            production ADK ``agent_events`` table has no such column,
+            and the pinned query fails there instead of silently
+            widening.
 
     Returns:
         A Trace for the single resolved identity/scope, with
@@ -1043,6 +1055,7 @@ class Client:
         selector,
         allow_mixed_scope=allow_mixed_scope,
         event_types=event_types,
+        import_version=import_version,
     )
 
   def get_trace_by_selector(
@@ -1051,6 +1064,7 @@ class Client:
       *,
       allow_mixed_scope: bool = False,
       event_types: Optional[list[str]] = None,
+      import_version: Optional[str] = None,
   ) -> Trace:
     """Fetches the single trace pinned by a :class:`TraceSelector`.
 
@@ -1082,6 +1096,10 @@ class Client:
             When the restriction matches no rows, the resolved
             identity/scope is returned as a zero-span :class:`Trace`;
             this does not raise the unfiltered not-found error.
+        import_version: Optional EvalBench mirror version pin (#464);
+            see :meth:`get_session_trace`. Applied as an
+            ``import_version`` column predicate to every discovery
+            and fetch statement of this lookup.
 
     Raises:
         ValueError: If no events match the selector, if the
@@ -1091,9 +1109,13 @@ class Client:
         AmbiguousSessionError: If the selector still matches more
             than one resolved candidate.
     """
+    if import_version is not None and not isinstance(import_version, str):
+      raise TypeError("import_version must be a string or None.")
     if event_types is not None:
       event_types = list(TraceFilter(event_types=event_types).event_types or [])
-    pushdown, pin_params = self._selector_pushdown_pins(selector)
+    pushdown, pin_params = self._selector_pushdown_pins(
+        selector, import_version=import_version
+    )
     resolve_query = _RESOLVE_SESSION_CANDIDATES_QUERY.format(
         project=self.project_id,
         dataset=self.dataset_id,
@@ -1171,6 +1193,7 @@ class Client:
           resolved_scope=matching[0],
           scope_trace_id=_resolved_scope_trace_id(candidate_rows, matching[0]),
           event_types=event_types,
+          import_version=import_version,
       )
     if not truncated and allow_mixed_scope and len(matching) >= 2:
       # A complete candidate page already proves the full
@@ -1191,6 +1214,7 @@ class Client:
           selector,
           discovered=(matched_identities, False),
           event_types=event_types,
+          import_version=import_version,
       )
     if len(matching) == 1 and truncated:
       # Under truncation the singleton needs TWO proofs (rounds 7-10).
@@ -1204,7 +1228,9 @@ class Client:
       if selector.scope_signature is None:
         if allow_mixed_scope:
           return self._fetch_mixed_scope_trace(
-              selector, event_types=event_types
+              selector,
+              event_types=event_types,
+              import_version=import_version,
           )
       if (
           selector.scope_signature is not None
@@ -1218,10 +1244,13 @@ class Client:
                 candidate_rows, matching[0]
             ),
             event_types=event_types,
+            import_version=import_version,
         )
       discovered = None
       if selector.scope_signature is not None:
-        discovered = self._discover_session_identities(selector)
+        discovered = self._discover_session_identities(
+            selector, import_version=import_version
+        )
         identities, identity_page_truncated = discovered
         if (
             not identity_page_truncated
@@ -1235,6 +1264,7 @@ class Client:
                   candidate_rows, matching[0]
               ),
               event_types=event_types,
+              import_version=import_version,
           )
       if allow_mixed_scope:
         # Reuse the page just fetched — the mixed path would otherwise
@@ -1243,9 +1273,12 @@ class Client:
             selector,
             discovered=discovered,
             event_types=event_types,
+            import_version=import_version,
         )
     if allow_mixed_scope and truncated:
-      return self._fetch_mixed_scope_trace(selector, event_types=event_types)
+      return self._fetch_mixed_scope_trace(
+          selector, event_types=event_types, import_version=import_version
+      )
     if len(matching) >= 2:
       # The typed ambiguity surface: real, executable retries. The
       # truncation marker tells callers the set is a lower bound.
@@ -1267,7 +1300,9 @@ class Client:
     raise ValueError("No candidates match the requested session.")
 
   def _selector_pushdown_pins(
-      self, selector: TraceSelector
+      self,
+      selector: TraceSelector,
+      import_version: Optional[str] = None,
   ) -> tuple[str, list]:
     """SQL pushdown fragment + params for the selector's pins.
 
@@ -1276,10 +1311,18 @@ class Client:
     stay resolvable under the enumeration bound (PR #371 review
     round 4, P1-2). NULL pins use IS NULL; UNSET pins add no
     predicate; unaddressable label keys and scope_signature remain
-    Python-side.
+    Python-side. The caller-level ``import_version`` pin (#464) is a
+    plain top-level column predicate on the EvalBench mirror table.
     """
     fragment = ""
     params: list = []
+    if import_version is not None:
+      fragment += "\n  AND import_version = @pin_import_version"
+      params.append(
+          bigquery.ScalarQueryParameter(
+              "pin_import_version", "STRING", import_version
+          )
+      )
     if selector.user_id is not UNSET:
       if selector.user_id is None:
         fragment += "\n  AND user_id IS NULL"
@@ -1349,7 +1392,9 @@ class Client:
     return fragment, params
 
   def _discover_session_identities(
-      self, selector: TraceSelector
+      self,
+      selector: TraceSelector,
+      import_version: Optional[str] = None,
   ) -> tuple[list, bool]:
     """Bounded DISTINCT-identity page for the selector's pushdown.
 
@@ -1360,7 +1405,9 @@ class Client:
     single-match proof in ``get_trace_by_selector`` (PR #371 review
     round 9, P1-1).
     """
-    pushdown, pin_params = self._selector_pushdown_pins(selector)
+    pushdown, pin_params = self._selector_pushdown_pins(
+        selector, import_version=import_version
+    )
     query = _RESOLVE_SESSION_IDENTITIES_QUERY.format(
         project=self.project_id,
         dataset=self.dataset_id,
@@ -1406,6 +1453,7 @@ class Client:
       selector: TraceSelector,
       discovered: Optional[tuple] = None,
       event_types: Optional[list[str]] = None,
+      import_version: Optional[str] = None,
   ) -> Trace:
     """Conversation-complete object-or-null-attested read for one identity.
 
@@ -1426,7 +1474,9 @@ class Client:
     identities, identity_page_truncated = (
         discovered
         if discovered is not None
-        else self._discover_session_identities(selector)
+        else self._discover_session_identities(
+            selector, import_version=import_version
+        )
     )
     if len(identities) > 1:
       # Python-only pins are applied BEFORE deciding identity
@@ -1434,7 +1484,7 @@ class Client:
       # pins alone may keep several identities whose scopes the full
       # selector actually excludes.
       ambiguous, truncated = self._real_candidates_for_identities(
-          selector, identities
+          selector, identities, import_version=import_version
       )
       truncated = truncated or identity_page_truncated
       matched_identities = list(
@@ -1470,6 +1520,17 @@ class Client:
             identity.root_agent_name,
         ),
     ]
+    # The mirror version pin (#464) restricts every read of this
+    # lookup — metadata and row fetch alike — so retained versions
+    # sharing the identity cannot merge into the mixed trace.
+    version_where = "TRUE"
+    if import_version is not None:
+      version_where = "e.import_version = @pin_import_version"
+      params.append(
+          bigquery.ScalarQueryParameter(
+              "pin_import_version", "STRING", import_version
+          )
+      )
     scope_results = None
     event_where = "TRUE"
     if event_types is not None:
@@ -1480,6 +1541,7 @@ class Client:
           project=self.project_id,
           dataset=self.dataset_id,
           table=self.table_id,
+          version_where=version_where,
       )
       metadata_config = bigquery.QueryJobConfig(query_parameters=params)
       metadata_config = with_sdk_labels(metadata_config, feature="trace-read")
@@ -1504,7 +1566,7 @@ class Client:
         project=self.project_id,
         dataset=self.dataset_id,
         table=self.table_id,
-        row_where="TRUE",
+        row_where=version_where,
         event_where=event_where,
     )
     job_config = bigquery.QueryJobConfig(query_parameters=params)
@@ -1605,6 +1667,7 @@ class Client:
       self,
       selector: TraceSelector,
       identities: list,
+      import_version: Optional[str] = None,
   ) -> tuple[list, bool]:
     """Selector-constrained candidates covering EVERY ambiguous identity.
 
@@ -1619,7 +1682,9 @@ class Client:
     per_identity_limit = max(
         2, _MAX_SCOPE_CANDIDATES // max(1, len(identities))
     )
-    pushdown, pin_params = self._selector_pushdown_pins(selector)
+    pushdown, pin_params = self._selector_pushdown_pins(
+        selector, import_version=import_version
+    )
     disjunction_terms = []
     identity_params = []
     for index, identity in enumerate(identities):
@@ -1732,6 +1797,7 @@ class Client:
       resolved_scope: ResolvedTraceSelector,
       scope_trace_id: Optional[str] = None,
       event_types: Optional[list[str]] = None,
+      import_version: Optional[str] = None,
   ) -> Trace:
     """Anchored row fetch for one resolved identity and scope.
 
@@ -1756,6 +1822,16 @@ class Client:
     ]
     row_filter = resolved_scope.to_selector().to_trace_filter()
     row_where = row_filter.row_scope_where()
+    if import_version is not None:
+      # The mirror version pin (#464): retained versions share the
+      # resolved identity AND scope, so only the top-level column
+      # separates their rows.
+      row_where = f"({row_where})\n  AND e.import_version = @pin_import_version"
+      params.append(
+          bigquery.ScalarQueryParameter(
+              "pin_import_version", "STRING", import_version
+          )
+      )
     scope_param_names = {"experiment_id"}
     label_count = len(row_filter.custom_labels or {})
     for i in range(label_count):

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -2223,13 +2223,15 @@ class EvalBenchSession:
 
   @property
   def taxonomy_categories(self) -> tuple[str, ...]:
-    """Scaffold taxonomy ids tripped by this session's mechanical flags.
+    """G1-frozen taxonomy names tripped by this session's mechanical flags.
 
     Computed from the three flags via
     ``failure_taxonomy.categorize_failed_session`` (a property, not a stored
-    field, so it can never drift from the flags). Scaffold vocabulary only:
-    the ids equal the flag names and are NOT the G1 taxonomy. All flags
-    false (an ``include_passed`` row) yields ``()``.
+    field, so it can never drift from the flags). Frozen vocabulary
+    (taxonomy v0.1.0): each tripped flag maps to its frozen name and the
+    names come back in ``FROZEN_CATEGORY_NAMES`` order — assignment stays
+    mechanical until the labeler study. All flags false (an
+    ``include_passed`` row) yields ``()``, never ``("unknown",)``.
     """
     return categorize_failed_session(self)
 

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -2197,14 +2197,24 @@ class EvalBenchSession:
   def trace_selector(self) -> dict[str, Any]:
     """Keyword arguments that drill this session into ``get_session_trace``.
 
-    ``session_id`` alone already pins the import version (it is part of the
-    identity); ``experiment_id`` additionally pins the job scope, matching
-    ``attributes.experiment_id`` that every published row carries. Use with
-    a ``Client`` whose ``table_id`` is the mirror events table::
+    ``experiment_id`` pins the job scope, matching
+    ``attributes.experiment_id`` that every published row carries, and
+    ``import_version`` pins the published version through the top-level
+    ``import_version`` column ``materialize`` stamps on every mirror row.
+    On the adapter path the version pin is redundant (the versioned
+    ``session_id`` is already unique per version); on the native path
+    (#463) retained versions share the real ADK ``session_id`` and the
+    job-scoped ``experiment_id``, so the version pin is what keeps a v2
+    read from replaying v1 rows. Use with a ``Client`` whose ``table_id``
+    is the mirror events table::
 
         client.get_session_trace(**session.trace_selector())
     """
-    return {"session_id": self.session_id, "experiment_id": self.job_id}
+    return {
+        "session_id": self.session_id,
+        "experiment_id": self.job_id,
+        "import_version": self.import_version,
+    }
 
   def get_trace(self, client: Any, **overrides: Any) -> Any:
     """Thin wrapper: ``client.get_session_trace(**trace_selector())``."""
@@ -2429,11 +2439,16 @@ class EvalBenchImportSessions:
   def trace_filter(self) -> "TraceFilter":
     """``TraceFilter`` selecting exactly this version's sessions.
 
-    Pins ``experiment_id`` to the job and ``session_ids`` to the version's
-    identities, with ``limit`` raised to the session count so no session is
-    truncated. Refuses an empty session set: ``TraceFilter`` treats no
-    ``session_ids`` as "unfiltered", which would silently widen the
-    evaluation to every retained version of the job.
+    Pins ``experiment_id`` to the job, ``session_ids`` to the version's
+    identities, and ``import_version`` to the published version (the
+    top-level mirror column), with ``limit`` raised to the session count
+    so no session is truncated. The version pin is a no-op on the adapter
+    path (versioned session ids are already unique per version) but load-
+    bearing on the native path (#463), where retained versions share the
+    real ADK session ids — without it the listing would widen to every
+    retained version of those sessions. Refuses an empty session set:
+    ``TraceFilter`` treats no ``session_ids`` as "unfiltered", which would
+    silently widen the evaluation to every retained version of the job.
     """
     from .trace import TraceFilter  # local: keep evalbench import-light
 
@@ -2447,6 +2462,7 @@ class EvalBenchImportSessions:
         experiment_id=self.job_id,
         session_ids=list(self.session_ids),
         limit=len(self.session_ids),
+        import_version=self.import_version,
     )
 
   def to_dict(self) -> dict[str, Any]:

--- a/src/bigquery_agent_analytics/evalbench.py
+++ b/src/bigquery_agent_analytics/evalbench.py
@@ -62,6 +62,7 @@ from google.cloud import bigquery
 
 from ._telemetry import make_bq_client
 from ._telemetry import with_sdk_labels
+from .failure_taxonomy import categorize_failed_session
 
 if TYPE_CHECKING:
   from .trace import TraceFilter
@@ -2220,8 +2221,22 @@ class EvalBenchSession:
         failed=self.failed,
     )
 
+  @property
+  def taxonomy_categories(self) -> tuple[str, ...]:
+    """Scaffold taxonomy ids tripped by this session's mechanical flags.
+
+    Computed from the three flags via
+    ``failure_taxonomy.categorize_failed_session`` (a property, not a stored
+    field, so it can never drift from the flags). Scaffold vocabulary only:
+    the ids equal the flag names and are NOT the G1 taxonomy. All flags
+    false (an ``include_passed`` row) yields ``()``.
+    """
+    return categorize_failed_session(self)
+
   def to_dict(self) -> dict[str, Any]:
-    return _json_safe(dataclasses.asdict(self))
+    payload = _json_safe(dataclasses.asdict(self))
+    payload["taxonomy_categories"] = list(self.taxonomy_categories)
+    return payload
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2243,7 +2258,11 @@ class EvalBenchFailedSessions:
   manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
-    return _json_safe(dataclasses.asdict(self))
+    # Nested sessions go through EvalBenchSession.to_dict so each row also
+    # carries the computed taxonomy_categories (asdict only sees fields).
+    payload = _json_safe(dataclasses.asdict(self))
+    payload["sessions"] = [session.to_dict() for session in self.sessions]
+    return payload
 
 
 def failed_sessions(

--- a/src/bigquery_agent_analytics/failure_taxonomy.py
+++ b/src/bigquery_agent_analytics/failure_taxonomy.py
@@ -12,37 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mechanical failure-taxonomy SCAFFOLD over EvalBench failed-session flags.
+"""G1-frozen failure taxonomy v0.1 over EvalBench failed-session flags.
 
-This is #435 slice 8: the thinnest testable bridge between the failed-session
-contract that already landed (#451/#452 -- ``SessionVerdict`` /
-``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) and the
-future AgentForensics failure taxonomy. It maps the three mechanical flags a
-failed-session row already carries -- ``process_failed``,
-``missing_completion``, ``score_failed`` -- to categories in a versioned
-config. Nothing here interprets *why* an agent failed; that judgment layer is
-the G1 taxonomy study in ``docs/agentforensics_mvp_plan.md`` and has not run.
+This is the #435 Week 0 G1 freeze (``docs/week0_g1_taxonomy.md``). The
+vocabulary is frozen at ``taxonomy_version: 0.1.0`` / ``g1_frozen: True``:
+the SANA-neighborhood seven categories plus ``unknown`` as the residual
+bucket. Names and spellings are stable and may only change through a
+versioned taxonomy revision (the reserved revision week of
+``docs/agentforensics_mvp_plan.md``).
 
-What this module is NOT:
+Category *assignment* stays mechanical until the labeler study runs:
+``categorize_failed_session`` maps the three boolean flags of the landed
+failed-session contract (#451/#452 — ``SessionVerdict`` /
+``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) onto
+frozen names:
 
-- It is **not** G1. The category names are scaffold ids derived from the
-  flag names, marked ``g1_frozen: False`` in the config; nothing downstream
-  may treat them as the frozen taxonomy vocabulary. SANA's seven categories
-  stay unfrozen and do not appear here.
-- It does **not** start the six-week MVP clock, the partner job, the D4
-  boundary, or live-trace ingestion.
-- It does **not** classify sessions: ``evalbench.classify_sessions`` remains
-  the reference implementation of the flags. This module only maps an
-  already-classified row to category ids.
+- ``missing_completion`` → ``finalization``
+- ``process_failed`` → ``tool blockers``
+- ``score_failed`` → ``task/planning``
+
+The other four SANA-neighborhood categories and ``unknown`` are in the
+frozen vocabulary but are never emitted by this three-flag mapper; a row
+with all flags false returns ``()``, not ``("unknown",)`` — a session no
+mechanical gate tripped is not a mechanical failure.
+
+Freezing G1 does **not** start the six-week clock: the clock starts only
+when the first Week 1 snapshot job is kicked. This module still does not
+classify sessions (``evalbench.classify_sessions`` remains the reference
+implementation of the flags), and nothing here reaches BigQuery, an LLM,
+or the network — everything is pure and deterministic.
 
 The config uses the #431 ``evaluation_rubrics`` schema shape
 (``{"metrics": [{"name", "definition", "categories": [{name, definition}]}]}``)
-so ``evaluation_rubrics.build_metrics`` could interpret the core metric later,
-and encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
-per-benchmark *extension categories on the same core* -- empty by default,
+so ``evaluation_rubrics.build_metrics`` can interpret the core metric, and
+encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
+per-benchmark *extension categories on the same core* — empty by default,
 never a second taxonomy.
-
-No BigQuery, no LLM, no network: everything here is pure and deterministic.
 """
 
 from __future__ import annotations
@@ -51,81 +56,139 @@ from collections.abc import Mapping
 import copy
 from typing import Any
 
-# Obviously-scaffold version label. This is NOT taxonomy v0.1 (the G1
-# starting point per the plan of record); it must be replaced wholesale when
-# the G1 study produces frozen names.
-SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"
+# G1-frozen taxonomy version. Bumping this requires a versioned taxonomy
+# revision per the plan of record, not an edit.
+TAXONOMY_VERSION = "0.1.0"
 
 # The three mechanical flags of the landed failed-session contract, in the
-# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. Category
-# ids deliberately equal the flag names: they describe *which gate tripped*,
-# not a failure mode, and renaming them here would only invent unfrozen
-# vocabulary.
-CORE_CATEGORY_IDS = ("process_failed", "missing_completion", "score_failed")
+# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. These are
+# the *input* contract of the mapper; they are not category names.
+MECHANICAL_FLAGS = ("process_failed", "missing_completion", "score_failed")
 
-_CORE_CATEGORY_DEFINITIONS = {
-    "process_failed": (
-        "The session emitted at least one ERROR event (non-zero returncode"
-        " or source error fields). Mechanical: read from the"
-        " process_failed flag of the failed-session contract."
+# The G1-frozen vocabulary, in frozen order: the SANA-neighborhood seven,
+# then ``unknown`` as the residual bucket. ``categorize_failed_session``
+# returns tripped names in THIS order, never in flag order.
+FROZEN_CATEGORY_NAMES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown",
+)
+
+# Frozen names double as the core category ids. Kept as a distinct alias so
+# pre-freeze importers of CORE_CATEGORY_IDS keep working; the three flag ids
+# they used to hold live on as MECHANICAL_FLAGS.
+CORE_CATEGORY_IDS = FROZEN_CATEGORY_NAMES
+
+# Mechanical assignment until the labeler study: which frozen name each
+# tripped flag maps to. The remaining frozen names (including ``unknown``)
+# are never emitted by the three-flag mapper.
+FLAG_TO_CATEGORY = {
+    "missing_completion": "finalization",
+    "process_failed": "tool blockers",
+    "score_failed": "task/planning",
+}
+
+_FROZEN_CATEGORY_DEFINITIONS = {
+    "task/planning": (
+        "The agent formed a wrong or incomplete plan for the assigned task."
+        " Mechanical assignment until the labeler study: mapped from the"
+        " failed-session score_failed flag."
     ),
-    "missing_completion": (
-        "The session has no AGENT_COMPLETED event: the agent never produced"
-        " a final response. Mechanical: read from the missing_completion"
-        " flag of the failed-session contract."
+    "wrong source": (
+        "The agent retrieved, cited, or relied on the wrong source."
+        " Mechanical assignment until the labeler study: not emitted by the"
+        " three-flag mapper."
     ),
-    "score_failed": (
-        "The per-benchmark score policy (EvalScorePolicy) was not met;"
-        " missing scores fail by default. returncode == 0 means completed,"
-        " never passed. Mechanical: read from the score_failed flag of the"
-        " failed-session contract."
+    "execution/computation": (
+        "The agent chose a reasonable plan but failed while executing or"
+        " computing it. Mechanical assignment until the labeler study: not"
+        " emitted by the three-flag mapper."
+    ),
+    "incomplete evidence": (
+        "The agent stopped without gathering enough evidence to support a"
+        " correct answer. Mechanical assignment until the labeler study: not"
+        " emitted by the three-flag mapper."
+    ),
+    "turn-waste": (
+        "The agent spent turns without advancing the task. Mechanical"
+        " assignment until the labeler study: not emitted by the three-flag"
+        " mapper."
+    ),
+    "finalization": (
+        "The agent did not produce a completed final response. Mechanical"
+        " assignment until the labeler study: mapped from the failed-session"
+        " missing_completion flag."
+    ),
+    "tool blockers": (
+        "A required tool was missing, failed, or never invoked. Mechanical"
+        " assignment until the labeler study: mapped from the failed-session"
+        " process_failed flag."
+    ),
+    "unknown": (
+        "Residual bucket for failures that do not match a frozen category"
+        " after labeling. In the vocabulary as residual; the mechanical"
+        " three-flag mapper does not emit unknown (all flags false returns"
+        " ())."
     ),
 }
 
-_SCAFFOLD_TAXONOMY_CONFIG = {
-    # Scaffold bookkeeping (not part of the #431 metric schema, which
+_TAXONOMY_CONFIG = {
+    # Freeze bookkeeping (not part of the #431 metric schema, which
     # ignores unknown top-level keys).
-    "taxonomy_version": SCAFFOLD_TAXONOMY_VERSION,
-    # Nothing in this config is G1-frozen vocabulary. Consumers must check
-    # this flag before treating category names as the taxonomy.
-    "g1_frozen": False,
+    "taxonomy_version": TAXONOMY_VERSION,
+    # G1 is frozen: category names below ARE the taxonomy vocabulary.
+    "g1_frozen": True,
     # D2: optional per-benchmark extension categories on the same core (each
     # entry would carry a benchmark name plus #431-shaped categories with
-    # optional ``insert_after``). Empty until G1 work fills it; an empty
-    # slot is the encoding, not a placeholder to invent labels for.
+    # optional ``insert_after``). Still empty at the freeze; an empty slot
+    # is the encoding, not a placeholder to invent labels for.
     "dialects": [],
     # The #431 schema shape (``evaluation_rubrics``): the one core metric a
-    # future ``build_metrics()`` caller could interpret.
+    # ``build_metrics()`` caller can interpret.
     "metrics": [
         {
             "name": "failure_category",
             "definition": (
-                "Which mechanical gate(s) of the EvalBench failed-session"
-                " contract a session tripped. Scaffold only: these are not"
-                " failure modes and not the G1 taxonomy."
+                "Which G1-frozen failure categories (taxonomy v0.1.0) a"
+                " failed session falls into. Assignment is mechanical from"
+                " the failed-session flags until the labeler study runs."
             ),
             "categories": [
-                {"name": name, "definition": _CORE_CATEGORY_DEFINITIONS[name]}
-                for name in CORE_CATEGORY_IDS
+                {"name": name, "definition": _FROZEN_CATEGORY_DEFINITIONS[name]}
+                for name in FROZEN_CATEGORY_NAMES
             ],
         }
     ],
 }
 
 
-def scaffold_taxonomy_config() -> dict:
-  """A deep copy of the scaffold taxonomy config (mutate freely).
+def taxonomy_config() -> dict:
+  """A deep copy of the G1-frozen taxonomy config (mutate freely).
 
   Same access pattern as ``evaluation_rubrics.builtin_metric_config``. The
   ``metrics`` entry follows the #431 config schema; ``taxonomy_version``,
-  ``g1_frozen`` and ``dialects`` are scaffold/D2 bookkeeping documented in
+  ``g1_frozen`` and ``dialects`` are freeze/D2 bookkeeping documented in
   the module docstring.
   """
-  return copy.deepcopy(_SCAFFOLD_TAXONOMY_CONFIG)
+  return copy.deepcopy(_TAXONOMY_CONFIG)
+
+
+def scaffold_taxonomy_config() -> dict:
+  """Compatibility wrapper for the pre-freeze name: ``taxonomy_config()``.
+
+  The scaffold era ended with the G1 freeze; this returns the same frozen
+  config (see CHANGELOG). New callers should use ``taxonomy_config``.
+  """
+  return taxonomy_config()
 
 
 def categorize_failed_session(row: Any) -> tuple[str, ...]:
-  """Map one failed-session row to its mechanical scaffold categories.
+  """Map one failed-session row to its G1-frozen categories.
 
   Pure and deterministic: no BigQuery, no LLM, no network. ``row`` is one
   failed-session row -- a mapping (e.g. a ``failed_sessions`` /
@@ -134,19 +197,23 @@ def categorize_failed_session(row: Any) -> tuple[str, ...]:
   contract: ``process_failed``, ``missing_completion``, ``score_failed``.
   Extra fields are ignored.
 
-  Returns the tripped category ids in ``CORE_CATEGORY_IDS`` order; a row can
-  trip several (e.g. process_failed AND missing_completion). All three flags
-  false returns ``()``: this scaffold does not invent an ``unknown`` bucket,
-  because a session no mechanical gate tripped is simply not a mechanical
-  failure (the future G1 taxonomy owns residual categories).
+  Mechanical assignment until the labeler study: each tripped flag maps to
+  its frozen name per ``FLAG_TO_CATEGORY``, and the tripped names are
+  returned in ``FROZEN_CATEGORY_NAMES`` order (never flag order). A row can
+  trip several (e.g. all three flags gives ``("task/planning",
+  "finalization", "tool blockers")``). All three flags false returns
+  ``()`` -- never ``("unknown",)``: ``unknown`` is the residual bucket of
+  the labeling study, and a session no mechanical gate tripped is simply
+  not a mechanical failure.
 
   Raises:
     ValueError: A flag is absent or not a bool -- silently defaulting a
       missing flag would miscategorize sessions.
   """
-  return tuple(
-      category for category in CORE_CATEGORY_IDS if _flag(row, category)
-  )
+  tripped = {
+      FLAG_TO_CATEGORY[flag] for flag in MECHANICAL_FLAGS if _flag(row, flag)
+  }
+  return tuple(name for name in FROZEN_CATEGORY_NAMES if name in tripped)
 
 
 def _flag(row: Any, name: str) -> bool:

--- a/src/bigquery_agent_analytics/failure_taxonomy.py
+++ b/src/bigquery_agent_analytics/failure_taxonomy.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mechanical failure-taxonomy SCAFFOLD over EvalBench failed-session flags.
+
+This is #435 slice 8: the thinnest testable bridge between the failed-session
+contract that already landed (#451/#452 -- ``SessionVerdict`` /
+``classify_sessions`` / ``failed_sessions_sql`` in ``evalbench.py``) and the
+future AgentForensics failure taxonomy. It maps the three mechanical flags a
+failed-session row already carries -- ``process_failed``,
+``missing_completion``, ``score_failed`` -- to categories in a versioned
+config. Nothing here interprets *why* an agent failed; that judgment layer is
+the G1 taxonomy study in ``docs/agentforensics_mvp_plan.md`` and has not run.
+
+What this module is NOT:
+
+- It is **not** G1. The category names are scaffold ids derived from the
+  flag names, marked ``g1_frozen: False`` in the config; nothing downstream
+  may treat them as the frozen taxonomy vocabulary. SANA's seven categories
+  stay unfrozen and do not appear here.
+- It does **not** start the six-week MVP clock, the partner job, the D4
+  boundary, or live-trace ingestion.
+- It does **not** classify sessions: ``evalbench.classify_sessions`` remains
+  the reference implementation of the flags. This module only maps an
+  already-classified row to category ids.
+
+The config uses the #431 ``evaluation_rubrics`` schema shape
+(``{"metrics": [{"name", "definition", "categories": [{name, definition}]}]}``)
+so ``evaluation_rubrics.build_metrics`` could interpret the core metric later,
+and encodes D2 (one taxonomy with dialects) as a ``dialects`` list of optional
+per-benchmark *extension categories on the same core* -- empty by default,
+never a second taxonomy.
+
+No BigQuery, no LLM, no network: everything here is pure and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import copy
+from typing import Any
+
+# Obviously-scaffold version label. This is NOT taxonomy v0.1 (the G1
+# starting point per the plan of record); it must be replaced wholesale when
+# the G1 study produces frozen names.
+SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"
+
+# The three mechanical flags of the landed failed-session contract, in the
+# order ``failed_sessions_sql`` / ``SessionVerdict`` define them. Category
+# ids deliberately equal the flag names: they describe *which gate tripped*,
+# not a failure mode, and renaming them here would only invent unfrozen
+# vocabulary.
+CORE_CATEGORY_IDS = ("process_failed", "missing_completion", "score_failed")
+
+_CORE_CATEGORY_DEFINITIONS = {
+    "process_failed": (
+        "The session emitted at least one ERROR event (non-zero returncode"
+        " or source error fields). Mechanical: read from the"
+        " process_failed flag of the failed-session contract."
+    ),
+    "missing_completion": (
+        "The session has no AGENT_COMPLETED event: the agent never produced"
+        " a final response. Mechanical: read from the missing_completion"
+        " flag of the failed-session contract."
+    ),
+    "score_failed": (
+        "The per-benchmark score policy (EvalScorePolicy) was not met;"
+        " missing scores fail by default. returncode == 0 means completed,"
+        " never passed. Mechanical: read from the score_failed flag of the"
+        " failed-session contract."
+    ),
+}
+
+_SCAFFOLD_TAXONOMY_CONFIG = {
+    # Scaffold bookkeeping (not part of the #431 metric schema, which
+    # ignores unknown top-level keys).
+    "taxonomy_version": SCAFFOLD_TAXONOMY_VERSION,
+    # Nothing in this config is G1-frozen vocabulary. Consumers must check
+    # this flag before treating category names as the taxonomy.
+    "g1_frozen": False,
+    # D2: optional per-benchmark extension categories on the same core (each
+    # entry would carry a benchmark name plus #431-shaped categories with
+    # optional ``insert_after``). Empty until G1 work fills it; an empty
+    # slot is the encoding, not a placeholder to invent labels for.
+    "dialects": [],
+    # The #431 schema shape (``evaluation_rubrics``): the one core metric a
+    # future ``build_metrics()`` caller could interpret.
+    "metrics": [
+        {
+            "name": "failure_category",
+            "definition": (
+                "Which mechanical gate(s) of the EvalBench failed-session"
+                " contract a session tripped. Scaffold only: these are not"
+                " failure modes and not the G1 taxonomy."
+            ),
+            "categories": [
+                {"name": name, "definition": _CORE_CATEGORY_DEFINITIONS[name]}
+                for name in CORE_CATEGORY_IDS
+            ],
+        }
+    ],
+}
+
+
+def scaffold_taxonomy_config() -> dict:
+  """A deep copy of the scaffold taxonomy config (mutate freely).
+
+  Same access pattern as ``evaluation_rubrics.builtin_metric_config``. The
+  ``metrics`` entry follows the #431 config schema; ``taxonomy_version``,
+  ``g1_frozen`` and ``dialects`` are scaffold/D2 bookkeeping documented in
+  the module docstring.
+  """
+  return copy.deepcopy(_SCAFFOLD_TAXONOMY_CONFIG)
+
+
+def categorize_failed_session(row: Any) -> tuple[str, ...]:
+  """Map one failed-session row to its mechanical scaffold categories.
+
+  Pure and deterministic: no BigQuery, no LLM, no network. ``row`` is one
+  failed-session row -- a mapping (e.g. a ``failed_sessions`` /
+  ``failed_sessions_sql`` row as a dict) or an object with attributes (e.g.
+  a ``SessionVerdict``) -- carrying the three boolean flags of the landed
+  contract: ``process_failed``, ``missing_completion``, ``score_failed``.
+  Extra fields are ignored.
+
+  Returns the tripped category ids in ``CORE_CATEGORY_IDS`` order; a row can
+  trip several (e.g. process_failed AND missing_completion). All three flags
+  false returns ``()``: this scaffold does not invent an ``unknown`` bucket,
+  because a session no mechanical gate tripped is simply not a mechanical
+  failure (the future G1 taxonomy owns residual categories).
+
+  Raises:
+    ValueError: A flag is absent or not a bool -- silently defaulting a
+      missing flag would miscategorize sessions.
+  """
+  return tuple(
+      category for category in CORE_CATEGORY_IDS if _flag(row, category)
+  )
+
+
+def _flag(row: Any, name: str) -> bool:
+  """Read one required boolean flag from a mapping or attribute row."""
+  missing = object()
+  if isinstance(row, Mapping):
+    value = row.get(name, missing)
+  else:
+    value = getattr(row, name, missing)
+  if value is missing:
+    raise ValueError(
+        f"failed-session row is missing required flag {name!r}; expected the"
+        " process_failed/missing_completion/score_failed contract of"
+        " evalbench.classify_sessions / failed_sessions_sql"
+    )
+  if not isinstance(value, bool):
+    raise ValueError(
+        f"failed-session flag {name!r} must be a bool, got"
+        f" {type(value).__name__}"
+    )
+  return value

--- a/src/bigquery_agent_analytics/native_events.py
+++ b/src/bigquery_agent_analytics/native_events.py
@@ -79,7 +79,14 @@ from .evalbench import _structured
 from .evalbench import _usable_text
 from .evalbench import _validate_import_version
 from .evalbench import _validate_source_segment
+from .evalbench import DEFAULT_EVENTS_TABLE
+from .evalbench import DEFAULT_FAILED_SESSIONS_VIEW
+from .evalbench import DEFAULT_SCORES_TABLE
+from .evalbench import EvalBenchImportResult
 from .evalbench import EvalBenchRun
+from .evalbench import EvalScorePolicy
+from .evalbench import LOCK_TABLE
+from .evalbench import MANIFEST_TABLE
 
 # The one deterministic native comparator: completion, not correctness.
 NATIVE_COMPARATOR = "goal_completion"
@@ -106,6 +113,17 @@ FROM `{source_table}`{snapshot_clause}{where_clause}
 ORDER BY session_id, timestamp
 """
 
+# The only table basename the native path may read. Everything else fails
+# closed BEFORE any BigQuery client is created or query is built: the exit
+# ramp reads production ``agent_events`` and nothing else, so an EvalBench
+# source table or a BQAA-owned mirror (e.g. ``evalbench_agent_events``,
+# which would resolve to the inherited default destination and self-feed)
+# is rejected at parse time.
+_SOURCE_TABLE_BASENAME = "agent_events"
+# Rejected explicitly (not just by the agent_events rule) so the frozen
+# no-EvalBench-tables contract has its own named guard and error.
+_EVALBENCH_SOURCE_BASENAMES = frozenset({"configs", "results", "scores"})
+
 
 def _parse_source_table(source_table: Any) -> tuple[str, str, str]:
   """Split and validate a ``project.dataset.table`` agent_events reference."""
@@ -118,6 +136,18 @@ def _parse_source_table(source_table: Any) -> tuple[str, str, str]:
   _validate_source_segment("source_table project", project)
   _validate_source_segment("source_table dataset", dataset)
   _validate_source_segment("source_table table", table)
+  if table in _EVALBENCH_SOURCE_BASENAMES:
+    raise ValueError(
+        f"source_table {source_table!r} names the EvalBench source table"
+        f" {table!r}; the native path reads no EvalBench tables"
+        " (#463 exit ramp)"
+    )
+  if table != _SOURCE_TABLE_BASENAME:
+    raise ValueError(
+        f"source_table {source_table!r} must reference a production"
+        f" {_SOURCE_TABLE_BASENAME!r} table; refusing basename {table!r}"
+        " before any query"
+    )
   return project, dataset, table
 
 
@@ -166,6 +196,55 @@ class NativeAgentEventsRun(EvalBenchRun):
   @property
   def source_dataset(self) -> str:
     return self.evalbench_dataset
+
+  def materialize(
+      self,
+      *,
+      target_dataset: str,
+      target_project: Optional[str] = None,
+      events_table: str = DEFAULT_EVENTS_TABLE,
+      scores_table: str = DEFAULT_SCORES_TABLE,
+      import_version: Optional[str] = None,
+      replace: bool = False,
+      imported_at: Optional[datetime] = None,
+      failed_sessions_view: Optional[str] = DEFAULT_FAILED_SESSIONS_VIEW,
+      policy: Optional[EvalScorePolicy] = None,
+      bq_client: Optional[Any] = None,
+  ) -> EvalBenchImportResult:
+    """Publish the native snapshot; the read-only source is never a target.
+
+    Defense in depth over ``_parse_source_table``'s agent_events-only rule
+    and the inherited reserved-destination check: every fully-qualified
+    destination this publish can write (events, scores, manifest, lock,
+    and the failed-sessions view) is compared against ``source_table``
+    BEFORE any BigQuery client is created, so a self-feeding publish is
+    rejected with zero queries and zero writes.
+    """
+    resolved_project = target_project or self.project_id
+    prefix = f"{resolved_project}.{target_dataset}"
+    destinations = [events_table, scores_table, MANIFEST_TABLE, LOCK_TABLE]
+    if failed_sessions_view is not None:
+      destinations.append(failed_sessions_view)
+    for destination in destinations:
+      destination_ref = f"{prefix}.{destination}"
+      if destination_ref == self.source_table:
+        raise ValueError(
+            f"destination {destination_ref!r} is the read-only native"
+            f" source table {self.source_table!r}; the native path never"
+            " writes its source (#463 exit ramp)"
+        )
+    return super().materialize(
+        target_dataset=target_dataset,
+        target_project=target_project,
+        events_table=events_table,
+        scores_table=scores_table,
+        import_version=import_version,
+        replace=replace,
+        imported_at=imported_at,
+        failed_sessions_view=failed_sessions_view,
+        policy=policy,
+        bq_client=bq_client,
+    )
 
   @classmethod
   def from_agent_events(

--- a/src/bigquery_agent_analytics/native_events.py
+++ b/src/bigquery_agent_analytics/native_events.py
@@ -1,0 +1,549 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Native ``agent_events`` snapshot writer — the EvalBench-adapter exit ramp.
+
+Issue #463 (parent #435). ``NativeAgentEventsRun`` starts from production ADK
+``agent_events`` rows and publishes the same BQAA-owned contract
+``EvalBenchRun.materialize`` already produces — a pinned, immutable
+``(job_id, import_version)`` snapshot (events + scores + manifest) plus the
+``failed_sessions`` view pinned to the latest successful publication — with
+**no EvalBench source tables anywhere in the path**: no ``configs``, no
+``results``, no ``scores`` reads. The ``evalbench-import`` adapter (#97)
+stays as an optional on-ramp; this class is the exit ramp, not a removal.
+
+Contracts honored (all frozen by the Week 0 evidence, #455–#461):
+
+* **Read vs write.** The production ``agent_events`` table is only ever
+  read. Publishing goes through the inherited ``materialize``, whose
+  destination validation rejects the reserved ``agent_events`` name before
+  any BigQuery call, so the native writer can never write the plugin's
+  production table.
+* **Identity.** The joinable scenario id (EvalBench ``results.id`` /
+  ``eval_id``) is the first eight characters of the ADK ``session_id``
+  (``7e352c34`` from ``7e352c34-4c1c-...``), falling back to the full
+  session id on collision — the same rule the slice-5 synthesizer froze.
+  Published event and score rows keep the **real** ADK ``session_id``, so
+  the same session is the same object with or without the adapter; the
+  ``(job_id, import_version)`` columns pin versions, exactly as the
+  adapter's snapshot tables are pinned.
+* **Denominator.** ``failed_sessions`` is the denominator; a live/LLM
+  judge is not. The only synthesized value is the deterministic
+  ``goal_completion`` score: ``1.0`` when the session logged
+  ``AGENT_COMPLETED``, ``0.0`` otherwise. That mirrors the frozen slice-5
+  rule (``returncode`` mirrors completion) and says *completed*, not
+  *passed* — only the ``EvalScorePolicy`` gate decides *passed*. For the
+  same reason a session that never completed is published with its first
+  prompt row marked ``status=ERROR`` (original status preserved in
+  ``attributes.bqaa_native_source_status``), which is byte-for-byte the
+  process-failure marker the adapter publishes for ``returncode != 0``.
+* **G1 labels.** Failed sessions map onto the frozen taxonomy v0.1.0
+  (``failure_taxonomy.py``) through the unchanged
+  ``classify_sessions`` / ``failed_sessions`` consumers: the widget-stock
+  silence session ``7e352c34`` trips all three mechanical flags and yields
+  ``task/planning``, ``finalization``, ``tool blockers``.
+* **Clock.** Nothing here starts the six-week clock, seals the
+  preregistration, or kicks a Week 1 snapshot job.
+
+Everything except the optional BigQuery read is pure and offline
+(fixture-testable): ``from_agent_events`` takes in-memory rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import dataclasses
+from datetime import datetime
+from typing import Any, Optional
+
+from google.cloud import bigquery
+
+from ._telemetry import make_bq_client
+from ._telemetry import with_sdk_labels
+from .evalbench import _as_mapping
+from .evalbench import _fingerprint_rows
+from .evalbench import _json_safe
+from .evalbench import _parse_timestamp
+from .evalbench import _plain_row
+from .evalbench import _structured
+from .evalbench import _usable_text
+from .evalbench import _validate_import_version
+from .evalbench import _validate_source_segment
+from .evalbench import EvalBenchRun
+
+# The one deterministic native comparator: completion, not correctness.
+NATIVE_COMPARATOR = "goal_completion"
+_NATIVE_FEATURE = "evalbench-native-import"
+_SHORT_ID_LENGTH = 8
+_PROMPT_EVENT = "USER_MESSAGE_RECEIVED"
+_COMPLETION_EVENT = "AGENT_COMPLETED"
+_TOOL_START_EVENT = "TOOL_STARTING"
+# Same rule the slice-5 synthesizer + importer composition froze: a session
+# that never completed publishes as a process failure (the synthesizer's
+# returncode=1, which the importer maps to an ERROR-status prompt row).
+_NATIVE_SCORE_RULE = (
+    "goal_completion is 1.0 iff the session logged AGENT_COMPLETED;"
+    " completed is not passed — only the score policy decides passed"
+)
+_MISSING_COMPLETION_ERROR = (
+    "native snapshot: session never logged AGENT_COMPLETED"
+    " (slice-5 returncode=1 equivalent)"
+)
+
+_READ_EVENTS_QUERY = """\
+SELECT *
+FROM `{source_table}`{snapshot_clause}{where_clause}
+ORDER BY session_id, timestamp
+"""
+
+
+def _parse_source_table(source_table: Any) -> tuple[str, str, str]:
+  """Split and validate a ``project.dataset.table`` agent_events reference."""
+  if not isinstance(source_table, str) or source_table.count(".") != 2:
+    raise ValueError(
+        "source_table must be a fully-qualified project.dataset.table"
+        f" reference, got {source_table!r}"
+    )
+  project, dataset, table = source_table.split(".")
+  _validate_source_segment("source_table project", project)
+  _validate_source_segment("source_table dataset", dataset)
+  _validate_source_segment("source_table table", table)
+  return project, dataset, table
+
+
+@dataclasses.dataclass(frozen=True)
+class NativeAgentEventsRun(EvalBenchRun):
+  """One production ``agent_events`` corpus loaded for native publication.
+
+  A sibling of ``EvalBenchRun`` that reuses its frozen publish machinery:
+  ``materialize`` (pin identity, lock, publish transaction, manifest with
+  ``view_policy``, ``failed_sessions`` view sync) is inherited verbatim, so
+  the native snapshot carries exactly the adapter's ``(job_id,
+  import_version)`` contract. Only the inputs differ: ``source_events``
+  holds ADK ``agent_events``-shaped rows read from ``source_table``, and
+  the EvalBench source fields (``results`` / ``scores`` / ``config_rows``)
+  are required to stay empty — this path reads no EvalBench tables.
+
+  The inherited ``project_id`` / ``evalbench_dataset`` fields record the
+  *source* project and dataset of ``source_table`` (they land in the
+  manifest as ``source_project`` / ``source_dataset``, so equal rows read
+  from another source are a different version, exactly as for the adapter).
+  """
+
+  source_table: str = ""
+  source_events: tuple[dict[str, Any], ...] = dataclasses.field(
+      default_factory=tuple, repr=False
+  )
+
+  def __post_init__(self) -> None:
+    if self.results or self.scores or self.config_rows:
+      raise ValueError(
+          "NativeAgentEventsRun reads no EvalBench source tables; results,"
+          " scores, and config_rows must stay empty (#463 exit ramp)"
+      )
+    project, dataset, _ = _parse_source_table(self.source_table)
+    if project != self.project_id or dataset != self.evalbench_dataset:
+      raise ValueError(
+          f"source_table {self.source_table!r} does not live in the declared"
+          f" source project/dataset {self.project_id!r}."
+          f"{self.evalbench_dataset!r}"
+      )
+
+  @property
+  def source_project(self) -> str:
+    return self.project_id
+
+  @property
+  def source_dataset(self) -> str:
+    return self.evalbench_dataset
+
+  @classmethod
+  def from_agent_events(
+      cls,
+      events: Any,
+      *,
+      source_table: str,
+      job_id: str,
+      location: Optional[str] = None,
+      snapshot_at: Optional[datetime] = None,
+  ) -> "NativeAgentEventsRun":
+    """Build a run from in-memory ``agent_events``-shaped rows (offline).
+
+    ``events`` is any iterable of mappings shaped like the ADK plugin's
+    ``agent_events`` rows; ``source_table`` is the fully-qualified
+    ``project.dataset.table`` they came from (provenance only — nothing is
+    read here). This is the fixture-testable path: no BigQuery client is
+    created and no query runs.
+    """
+    project, dataset, _ = _parse_source_table(source_table)
+    if not isinstance(job_id, str) or not job_id:
+      raise ValueError("job_id must be a non-empty string")
+    return cls(
+        project_id=project,
+        evalbench_dataset=dataset,
+        job_id=job_id,
+        location=location,
+        snapshot_at=snapshot_at,
+        source_table=source_table,
+        source_events=tuple(dict(event) for event in events),
+    )
+
+  # Replaces (does not extend) the EvalBench-source reader: the native path
+  # reads exactly one table, the production agent_events, and only reads it.
+  @classmethod
+  def from_bigquery(  # type: ignore[override]  # pylint: disable=arguments-differ
+      cls,
+      *,
+      source_table: str,
+      job_id: str,
+      session_ids: Optional[list[str]] = None,
+      location: Optional[str] = None,
+      snapshot_at: Optional[datetime] = None,
+      bq_client: Optional[Any] = None,
+  ) -> "NativeAgentEventsRun":
+    """Read production ``agent_events`` rows (SELECT only, never DML).
+
+    Args:
+      source_table: Fully-qualified ``project.dataset.table`` reference of
+        the production ADK ``agent_events`` table to read.
+      job_id: The native snapshot's job identifier (the pin's first half).
+      session_ids: Optional session ids to restrict the read to.
+      location: Optional BigQuery location.
+      snapshot_at: Optional timezone-aware timestamp; when set, the read
+        uses ``FOR SYSTEM_TIME AS OF`` so a live table cannot mix versions.
+      bq_client: Optional test-compatible or caller-configured client.
+    """
+    project, _, _ = _parse_source_table(source_table)
+    if not isinstance(job_id, str) or not job_id:
+      raise ValueError("job_id must be a non-empty string")
+    if snapshot_at is not None and (
+        not isinstance(snapshot_at, datetime) or snapshot_at.tzinfo is None
+    ):
+      raise ValueError("snapshot_at must be a timezone-aware datetime")
+
+    client = bq_client or make_bq_client(project, location=location)
+    parameters: list[bigquery.ScalarQueryParameter] = []
+    snapshot_clause = ""
+    if snapshot_at is not None:
+      snapshot_clause = " FOR SYSTEM_TIME AS OF @snapshot_at"
+      parameters.append(
+          bigquery.ScalarQueryParameter("snapshot_at", "TIMESTAMP", snapshot_at)
+      )
+    where_clause = ""
+    if session_ids:
+      where_clause = "\nWHERE session_id IN UNNEST(@session_ids)"
+      parameters.append(
+          bigquery.ArrayQueryParameter(
+              "session_ids", "STRING", [str(value) for value in session_ids]
+          )
+      )
+    job_config = bigquery.QueryJobConfig(query_parameters=parameters)
+    job_config = with_sdk_labels(job_config, feature=_NATIVE_FEATURE)
+    query_args: dict[str, Any] = {"job_config": job_config}
+    if location is not None:
+      query_args["location"] = location
+    query = _READ_EVENTS_QUERY.format(
+        source_table=source_table,
+        snapshot_clause=snapshot_clause,
+        where_clause=where_clause,
+    )
+    rows = tuple(
+        _plain_row(row) for row in client.query(query, **query_args).result()
+    )
+    return cls.from_agent_events(
+        rows,
+        source_table=source_table,
+        job_id=job_id,
+        location=location,
+        snapshot_at=snapshot_at,
+    )
+
+  def skipped_session_ids(self) -> tuple[str, ...]:
+    """Sessions dropped from the snapshot: no ``USER_MESSAGE_RECEIVED``.
+
+    Mirrors the slice-5 synthesizer: a trace with no user prompt is skipped
+    rather than given one, so the denominator stays the prompted sessions.
+    """
+    _, skipped = self._kept_and_skipped()
+    return skipped
+
+  def to_agent_event_rows(
+      self, *, import_version: Optional[str] = None
+  ) -> list[dict[str, Any]]:
+    """Normalize the source rows to the published snapshot event shape.
+
+    Rows keep their real ``session_id`` / ``user_id`` / timestamps /
+    statuses; ``attributes`` additionally carry the joinable
+    ``evalbench_scenario_id`` (first-8 identity), ``experiment_id`` (the
+    job) and ``bqaa_native_source_table`` provenance. A session that never
+    logged ``AGENT_COMPLETED`` has its first prompt row published with
+    ``status=ERROR`` (original status preserved in
+    ``attributes.bqaa_native_source_status``) — the same process-failure
+    marker the adapter publishes for a failed returncode, so
+    ``failed_sessions_sql`` reports it as ``process_failed``.
+    """
+    if import_version is not None:
+      _validate_import_version(import_version)
+    kept, _ = self._kept_and_skipped()
+    scenario_ids = _native_scenario_ids(tuple(sorted(kept)))
+    rows: list[dict[str, Any]] = []
+    for session_id in sorted(kept):
+      events = kept[session_id]
+      completed = any(
+          event.get("event_type") == _COMPLETION_EVENT for event in events
+      )
+      marker_index = next(
+          (
+              index
+              for index, event in enumerate(events)
+              if event.get("event_type") == _PROMPT_EVENT
+          ),
+          0,
+      )
+      for index, source in enumerate(events):
+        row = self._native_event_row(
+            source, scenario_id=scenario_ids[session_id]
+        )
+        if not completed and index == marker_index:
+          row["attributes"]["bqaa_native_source_status"] = row["status"]
+          row["status"] = "ERROR"
+          if row["error_message"] is None:
+            row["error_message"] = _MISSING_COMPLETION_ERROR
+        rows.append(row)
+    return rows
+
+  def to_score_rows(self, *, import_version: str) -> list[dict[str, Any]]:
+    """One deterministic ``goal_completion`` score row per kept session.
+
+    Derived from the session alone — no live BigQuery, no live/LLM judge:
+    ``1.0`` when the session logged ``AGENT_COMPLETED``, ``0.0`` otherwise.
+    ``session_id`` is the real ADK id (matching the event rows, so the
+    ``failed_sessions_sql`` join stays aligned) and ``scenario_id`` is the
+    joinable first-8 identity.
+    """
+    _validate_import_version(import_version)
+    rows: list[dict[str, Any]] = []
+    for fact, prompt in self._score_facts_with_prompts():
+      rows.append(
+          {
+              "job_id": self.job_id,
+              "import_version": import_version,
+              "scenario_id": fact["scenario_id"],
+              "session_id": fact["session_id"],
+              "comparator": fact["comparator"],
+              "score": fact["score"],
+              "source_row": {
+                  "derived_from": self.source_table,
+                  "rule": _NATIVE_SCORE_RULE,
+                  "completed": fact["score"] == 1.0,
+                  "prompt": prompt,
+              },
+          }
+      )
+    return rows
+
+  def fingerprints(self) -> dict[str, str]:
+    """Content identity of the native snapshot (adapter guard semantics).
+
+    ``results_fingerprint`` covers the source event rows and
+    ``scores_fingerprint`` the deterministic score facts, so a changed
+    source (or a changed derivation) is a new derived ``import_version``
+    and a conflicting explicit one. ``configs_fingerprint`` pins the
+    source table reference — equal rows read from another table are a
+    different version, matching the adapter's provenance rule.
+    """
+    return {
+        "results_fingerprint": _fingerprint_rows(self.source_events),
+        "scores_fingerprint": _fingerprint_rows(
+            tuple(fact for fact, _ in self._score_facts_with_prompts())
+        ),
+        "configs_fingerprint": _fingerprint_rows(
+            ({"bqaa_native_source_table": self.source_table},)
+        ),
+    }
+
+  def _score_facts_with_prompts(
+      self,
+  ) -> list[tuple[dict[str, Any], Optional[str]]]:
+    """Version-independent score derivation, in ``session_id`` order."""
+    kept, _ = self._kept_and_skipped()
+    scenario_ids = _native_scenario_ids(tuple(sorted(kept)))
+    facts: list[tuple[dict[str, Any], Optional[str]]] = []
+    for session_id in sorted(kept):
+      events = kept[session_id]
+      completed = any(
+          event.get("event_type") == _COMPLETION_EVENT for event in events
+      )
+      fact = {
+          "session_id": session_id,
+          "scenario_id": scenario_ids[session_id],
+          "comparator": NATIVE_COMPARATOR,
+          "score": 1.0 if completed else 0.0,
+      }
+      facts.append((fact, _prompt_text(events)))
+    return facts
+
+  def _kept_and_skipped(
+      self,
+  ) -> tuple[dict[str, list[dict[str, Any]]], tuple[str, ...]]:
+    """Group source rows by session; keep prompted sessions only."""
+    sessions: dict[str, list[tuple[datetime, int, dict[str, Any]]]] = {}
+    for index, source in enumerate(self.source_events):
+      if not isinstance(source, Mapping):
+        raise ValueError(
+            f"agent_events row {index} must be a mapping, got"
+            f" {type(source).__name__}"
+        )
+      session_id = _usable_text(source.get("session_id"))
+      if session_id is None:
+        raise ValueError(f"agent_events row {index} is missing session_id")
+      timestamp = _parse_timestamp(source.get("timestamp"))
+      if timestamp is None:
+        raise ValueError(
+            f"agent_events row {index} (session {session_id!r}) has no"
+            " parseable timestamp"
+        )
+      sessions.setdefault(session_id, []).append(
+          (timestamp, index, dict(source))
+      )
+    kept: dict[str, list[dict[str, Any]]] = {}
+    skipped: list[str] = []
+    for session_id, entries in sessions.items():
+      ordered = [row for _, _, row in sorted(entries, key=lambda e: e[:2])]
+      if any(row.get("event_type") == _PROMPT_EVENT for row in ordered):
+        kept[session_id] = ordered
+      else:
+        skipped.append(session_id)
+    return kept, tuple(sorted(skipped))
+
+  def _native_event_row(
+      self, source: Mapping[str, Any], *, scenario_id: str
+  ) -> dict[str, Any]:
+    """One source row normalized to the published event columns."""
+    attributes = dict(_as_mapping(_structured(source.get("attributes"))))
+    attributes["experiment_id"] = self.job_id
+    attributes["evalbench_scenario_id"] = scenario_id
+    attributes["bqaa_native_source_table"] = self.source_table
+    timestamp = _parse_timestamp(source.get("timestamp"))
+    assert timestamp is not None  # _kept_and_skipped validated it.
+    return {
+        "timestamp": timestamp.isoformat(),
+        "event_type": _text_or_none(source.get("event_type")),
+        "agent": _text_or_none(source.get("agent")),
+        "session_id": _usable_text(source.get("session_id")),
+        "invocation_id": _text_or_none(source.get("invocation_id")),
+        "user_id": _text_or_none(source.get("user_id")),
+        "trace_id": _text_or_none(source.get("trace_id")),
+        "span_id": _text_or_none(source.get("span_id")),
+        "parent_span_id": _text_or_none(source.get("parent_span_id")),
+        "content": _json_safe(_structured(source.get("content"))),
+        "content_parts": _json_safe(source.get("content_parts") or []),
+        "attributes": _json_safe(attributes),
+        "latency_ms": _json_safe(
+            _as_mapping(_structured(source.get("latency_ms")))
+        ),
+        "status": _text_or_none(source.get("status")),
+        "error_message": _text_or_none(source.get("error_message")),
+        "is_truncated": bool(source.get("is_truncated") or False),
+    }
+
+
+def _native_scenario_ids(session_ids: tuple[str, ...]) -> dict[str, str]:
+  """First-8 joinable identity, falling back to the full id on collision.
+
+  Same frozen rule as the slice-5 synthesizer and the Week 0 identity table
+  (``examples/evalbench_mvp_e2e.md``): the scenario id is the first
+  ``_SHORT_ID_LENGTH`` characters of the ADK session id unless two kept
+  sessions share that prefix, in which case both keep their full ids.
+  """
+  prefixes: dict[str, list[str]] = {}
+  for session_id in session_ids:
+    prefixes.setdefault(session_id[:_SHORT_ID_LENGTH], []).append(session_id)
+  return {
+      session_id: (prefix if len(owners) == 1 else session_id)
+      for prefix, owners in prefixes.items()
+      for session_id in owners
+  }
+
+
+def _prompt_text(events: list[dict[str, Any]]) -> Optional[str]:
+  """The session's real prompt: first ``USER_MESSAGE_RECEIVED`` text."""
+  for event in events:
+    if event.get("event_type") != _PROMPT_EVENT:
+      continue
+    content = _structured(event.get("content"))
+    if isinstance(content, Mapping):
+      for key in ("text_summary", "text"):
+        text = _usable_text(content.get(key))
+        if text is not None:
+          return text
+      return None
+    return _usable_text(content)
+  return None
+
+
+def _text_or_none(value: Any) -> Optional[str]:
+  return None if value is None else str(value)
+
+
+def native_next_action(
+    session_events: Sequence[Mapping[str, Any]],
+    *,
+    gold_events: Sequence[Mapping[str, Any]] = (),
+) -> str:
+  """Deterministic punchline next-action for one session (no judge).
+
+  Derived from the events alone: whether the session completed, and which
+  tools a completed gold sibling called that this session never did. For
+  the widget-stock silence session with sibling ``ab7535a5`` this yields
+  "the agent never answered ... never called check_inventory".
+  """
+  completed = any(
+      event.get("event_type") == _COMPLETION_EVENT for event in session_events
+  )
+  if completed:
+    return (
+        "The session completed; only the score policy decides whether it"
+        " passed."
+    )
+  called = _tool_names(session_events)
+  missing = sorted(_tool_names(gold_events) - called)
+  if missing:
+    tools = ", ".join(missing)
+    return (
+        "The agent never answered (no AGENT_COMPLETED) and never called"
+        f" {tools} (the completed sibling did); find why the agent stalled"
+        " after its last event."
+    )
+  if not called:
+    return (
+        "The agent never answered (no AGENT_COMPLETED) and never called any"
+        " tool; find why the agent stalled after its last event."
+    )
+  return (
+      "The agent never answered (no AGENT_COMPLETED); find why the agent"
+      " stalled after its last event."
+  )
+
+
+def _tool_names(events: Sequence[Mapping[str, Any]]) -> set[str]:
+  names: set[str] = set()
+  for event in events:
+    if event.get("event_type") != _TOOL_START_EVENT:
+      continue
+    content = _structured(event.get("content"))
+    if isinstance(content, Mapping):
+      name = _usable_text(content.get("tool"))
+      if name is not None:
+        names.add(name)
+  return names

--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -465,6 +465,21 @@ def _validated_filter_pin(name: str, value: Any) -> Any:
   return value
 
 
+def _validated_import_version_pin(value: Any) -> Optional[str]:
+  """Validate the TraceFilter ``import_version`` pin (two-state).
+
+  Same boundary rule as ``_validated_filter_pin``: revalidated at the
+  SQL boundary because ``vars(filt)`` writes bypass ``__setattr__``.
+  Two-state (no SQL_NULL): the mirror column is REQUIRED, so "pinned
+  to NULL" selects nothing meaningful and stays unrepresentable.
+  """
+  if value is None:
+    return None
+  if not isinstance(value, str):
+    raise TypeError("TraceFilter.import_version must be a string or None.")
+  return _exact_str(value)
+
+
 def _is_unaddressable_label_key(key: str) -> bool:
   """True if BigQuery JSONPath cannot encode this member key.
 
@@ -536,6 +551,14 @@ class TraceFilter:
   dimension unfiltered (legacy behavior), the :data:`SQL_NULL`
   sentinel matches only rows where the dimension is SQL ``NULL``, and
   a string — including the empty string — matches by equality.
+
+  ``import_version`` pins the top-level ``import_version`` column that
+  EvalBench ``materialize`` stamps on every published mirror row
+  (#464): retained native versions share the real ADK ``session_id``
+  and the job-scoped ``experiment_id``, so only this column separates
+  them. Set it only against mirror tables — the production ADK
+  ``agent_events`` table has no such column, and the pinned query
+  fails there instead of silently widening.
   """
 
   start_time: Optional[datetime] = None
@@ -553,6 +576,7 @@ class TraceFilter:
   tool_origin: Optional[str] = None
   root_agent_name: _FilterPin = None
   limit: int = 100
+  import_version: Optional[str] = None
 
   def __setattr__(self, name: str, value: Any) -> None:
     # Validated on every write, not just construction: the filter is
@@ -582,6 +606,8 @@ class TraceFilter:
         value = _normalized_session_ids(value)
     if name == "event_types" and value is not None:
       value = _normalized_event_types(value)
+    if name == "import_version":
+      value = _validated_import_version_pin(value)
     object.__setattr__(self, name, value)
 
   @classmethod
@@ -831,6 +857,16 @@ class TraceFilter:
               root_agent_name,
           )
       )
+    import_version = _validated_import_version_pin(self.import_version)
+    if import_version is not None:
+      conditions.append("import_version = @import_version")
+      params.append(
+          bigquery.ScalarQueryParameter(
+              "import_version",
+              "STRING",
+              import_version,
+          )
+      )
 
     params.append(
         bigquery.ScalarQueryParameter(
@@ -965,6 +1001,12 @@ class TraceFilter:
             f" = @label_val_{i}"
             f" OR {untagged})"
         )
+    # A published mirror row carries the version pin in a REQUIRED
+    # top-level column, so unlike experiment/label predicates there is
+    # no shared-row escape hatch: rows of another retained version are
+    # never this version's rows (#464).
+    if _validated_import_version_pin(self.import_version) is not None:
+      conditions.append(f"{alias}.import_version = @import_version")
     return " AND ".join(conditions) if conditions else "TRUE"
 
 

--- a/tests/test_cli_evalbench_failed_sessions.py
+++ b/tests/test_cli_evalbench_failed_sessions.py
@@ -103,6 +103,13 @@ def test_lists_latest_version_by_default(
   assert (
       payload["sessions"][0]["trace_id"] == payload["sessions"][0]["session_id"]
   )
+  # Slice 9: each session row carries the scaffold taxonomy categories
+  # computed from its mechanical flags (process_failed + missing_completion
+  # for this fixture) -- no extra field on the fixture, no BigQuery.
+  assert payload["sessions"][0]["taxonomy_categories"] == [
+      "process_failed",
+      "missing_completion",
+  ]
 
 
 def test_pins_version_and_policy_options(

--- a/tests/test_cli_evalbench_failed_sessions.py
+++ b/tests/test_cli_evalbench_failed_sessions.py
@@ -103,12 +103,14 @@ def test_lists_latest_version_by_default(
   assert (
       payload["sessions"][0]["trace_id"] == payload["sessions"][0]["session_id"]
   )
-  # Slice 9: each session row carries the scaffold taxonomy categories
-  # computed from its mechanical flags (process_failed + missing_completion
-  # for this fixture) -- no extra field on the fixture, no BigQuery.
+  # Slice 9 + G1 freeze: each session row carries the frozen taxonomy
+  # names computed from its mechanical flags (process_failed +
+  # missing_completion for this fixture map to tool blockers +
+  # finalization, returned in frozen order) -- no extra field on the
+  # fixture, no BigQuery.
   assert payload["sessions"][0]["taxonomy_categories"] == [
-      "process_failed",
-      "missing_completion",
+      "finalization",
+      "tool blockers",
   ]
 
 

--- a/tests/test_cli_evalbench_native_import.py
+++ b/tests/test_cli_evalbench_native_import.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``bq-agent-sdk evalbench-native-import`` (#463)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from bigquery_agent_analytics import evalbench
+from bigquery_agent_analytics import native_events
+from bigquery_agent_analytics.cli import app
+
+runner = CliRunner()
+
+_SOURCE_TABLE = "test-project-0728-467323.bqaa_e2e_real.agent_events"
+
+
+class _RecordingRun:
+
+  def __init__(self, calls: list[dict]) -> None:
+    self._calls = calls
+
+  def materialize(self, **kwargs) -> evalbench.EvalBenchImportResult:
+    self._calls.append({"materialize": kwargs})
+    return evalbench.EvalBenchImportResult(
+        job_id="mvp-e2e-real-traces",
+        import_version=kwargs.get("import_version") or "abc123",
+        status="imported",
+        events_table="test-project-0728-467323.bqaa.evalbench_agent_events",
+        scores_table="test-project-0728-467323.bqaa.evalbench_scores_imported",
+        manifest_table=(
+            "test-project-0728-467323.bqaa.evalbench_import_manifest"
+        ),
+        event_row_count=8,
+        score_row_count=2,
+        manifest={"job_id": "mvp-e2e-real-traces"},
+    )
+
+
+def _patch_from_bigquery(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+  calls: list[dict] = []
+
+  def fake_from_bigquery(cls, **kwargs):
+    calls.append({"from_bigquery": kwargs})
+    return _RecordingRun(calls)
+
+  monkeypatch.setattr(
+      native_events.NativeAgentEventsRun,
+      "from_bigquery",
+      classmethod(fake_from_bigquery),
+  )
+  return calls
+
+
+def test_native_import_reads_agent_events_and_materializes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-native-import",
+          "--source-table",
+          _SOURCE_TABLE,
+          "--job-id",
+          "mvp-e2e-real-traces",
+          "--target-dataset",
+          "bqaa",
+          "--session-id",
+          "7e352c34-4c1c-4395-acd5-fb3c8f215346",
+          "--location",
+          "US",
+          "--snapshot-at",
+          "2026-08-30T08:00:00Z",
+          "--import-version",
+          "v1",
+          "--min-score",
+          "goal_completion=1.0",
+      ],
+  )
+
+  assert result.exit_code == 0, result.output
+  assert calls[0]["from_bigquery"] == {
+      "source_table": _SOURCE_TABLE,
+      "job_id": "mvp-e2e-real-traces",
+      "session_ids": ["7e352c34-4c1c-4395-acd5-fb3c8f215346"],
+      "location": "US",
+      "snapshot_at": datetime(2026, 8, 30, 8, 0, tzinfo=timezone.utc),
+  }
+  materialize = calls[1]["materialize"]
+  assert materialize["target_project"] is None
+  assert materialize["target_dataset"] == "bqaa"
+  assert materialize["events_table"] == "evalbench_agent_events"
+  assert materialize["scores_table"] == "evalbench_scores_imported"
+  assert materialize["import_version"] == "v1"
+  assert materialize["replace"] is False
+  assert materialize["failed_sessions_view"] == "evalbench_failed_sessions"
+  assert materialize["policy"] == evalbench.EvalScorePolicy(
+      {"goal_completion": 1.0}, missing_score_fails=True
+  )
+  payload = json.loads(result.output)
+  assert payload["status"] == "imported"
+  assert payload["import_version"] == "v1"
+  assert payload["event_row_count"] == 8
+
+
+def test_native_import_rejects_reserved_agent_events_destination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-native-import",
+          "--source-table",
+          _SOURCE_TABLE,
+          "--job-id",
+          "mvp-e2e-real-traces",
+          "--target-dataset",
+          "bqaa",
+          "--events-table",
+          "agent_events",
+      ],
+  )
+  assert result.exit_code == 2
+  assert "reserved ADK plugin table" in result.output
+  assert calls == []
+
+
+def test_native_import_rejects_bad_snapshot_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  calls = _patch_from_bigquery(monkeypatch)
+  result = runner.invoke(
+      app,
+      [
+          "evalbench-native-import",
+          "--source-table",
+          _SOURCE_TABLE,
+          "--job-id",
+          "mvp-e2e-real-traces",
+          "--target-dataset",
+          "bqaa",
+          "--snapshot-at",
+          "not-a-timestamp",
+      ],
+  )
+  assert result.exit_code == 2
+  assert "--snapshot-at" in result.output
+  assert calls == []

--- a/tests/test_evalbench_importer.py
+++ b/tests/test_evalbench_importer.py
@@ -4071,9 +4071,13 @@ def test_session_trace_selector_pins_the_versioned_identity() -> None:
       failed=True,
   )
   selector = session.trace_selector()
+  # The version pin (#464) is redundant on the adapter path (the versioned
+  # session_id is unique per version) but load-bearing on the native path,
+  # where retained versions share the real ADK session_id.
   assert selector == {
       "session_id": "evalbench-import:job-123:v1:crash-1",
       "experiment_id": "job-123",
+      "import_version": "v1",
   }
   # Accepted verbatim by the existing reader (no new client surface).
   inspect.signature(Client.get_session_trace).bind(None, **selector)

--- a/tests/test_evalbench_week0_full_idea.py
+++ b/tests/test_evalbench_week0_full_idea.py
@@ -1,0 +1,358 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``examples/evalbench_week0_full_idea.sh`` (#435 slice 10).
+
+The EXAMPLE Week 0 scenario pack is ``--fixture`` only: nothing here
+reaches BigQuery or the network, and nothing here freezes anything —
+every asserted artifact says ``g1_frozen: false`` and that the six-week
+clock has not started. The tests also guard the boundary the pack must
+never cross: the SANA-seeded example mapping lives only in the fixtures,
+never in ``src/bigquery_agent_analytics/failure_taxonomy.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "examples" / "evalbench_week0_full_idea.sh"
+_FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
+_TAXONOMY_SRC = (
+    _REPO_ROOT / "src" / "bigquery_agent_analytics" / "failure_taxonomy.py"
+)
+
+_SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+_EVAL_ID = "7e352c34"
+
+_SANA_CATEGORIES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+)
+
+# The five Week 0 gates, then the widget-session through-line, in order.
+_BANNERS = (
+    "=== EXAMPLE — Week 0 is not a freeze. Clock has not started. ===",
+    "=== EXAMPLE partner + SANA relationship ===",
+    "=== EXAMPLE runtime + route ===",
+    "=== EXAMPLE pilot-benchmark rubric ===",
+    "=== EXAMPLE D4 boundary memo ===",
+    "=== EXAMPLE preregistration (not a week-1 freeze) ===",
+    "=== This agent was asked to check widget stock. Here is the session. ===",
+    "=== This session in failed_sessions (mechanical taxonomy_categories) ===",
+    "=== EXAMPLE mapping of mechanical flags onto SANA-seeded names ===",
+    "=== Punchline ===",
+)
+
+_PUNCHLINE = (
+    "This widget-stock session failed because the agent never answered;"
+    " goal_completion=0.0."
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _run(*args: str, env: dict[str, str] | None = None):
+  # Start from a clean environment so a developer's exported
+  # EVALBENCH_* / BQ_AGENT_* values cannot change what is asserted.
+  clean = {
+      k: v
+      for k, v in os.environ.items()
+      if not k.startswith(("EVALBENCH_", "BQ_AGENT_"))
+  }
+  return subprocess.run(
+      ["bash", str(_SCRIPT), *args],
+      capture_output=True,
+      text=True,
+      timeout=60,
+      env={**clean, **(env or {})},
+  )
+
+
+def _fixture(name: str) -> dict:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  # Every fixture in the pack is labeled example-only and frozen-nothing.
+  assert data["example"] is True
+  assert data["g1_frozen"] is False
+  assert data["clock_started"] is False
+  return data
+
+
+def _assert_walkthrough(stdout: str) -> None:
+  for banner in _BANNERS:
+    assert banner in stdout
+  # The gates and the through-line appear in narrative order.
+  positions = [stdout.index(b) for b in _BANNERS]
+  assert positions == sorted(positions)
+  opening = stdout[positions[0] : positions[1]]
+  partner = stdout[positions[1] : positions[2]]
+  runtime = stdout[positions[2] : positions[3]]
+  rubric = stdout[positions[3] : positions[4]]
+  d4 = stdout[positions[4] : positions[5]]
+  prereg = stdout[positions[5] : positions[6]]
+  session = stdout[positions[6] : positions[7]]
+  failed = stdout[positions[7] : positions[8]]
+  mapping = stdout[positions[8] : positions[9]]
+  punchline = stdout[positions[9] :]
+  # Opening disclaimer: example-only, nothing frozen, clock not started.
+  assert "EXAMPLE" in opening
+  assert "illustrative" in opening
+  assert "not a freeze" in opening
+  assert "g1_frozen: false" in opening
+  assert "clock has not started" in opening
+  assert "clock_started: false" in opening
+  # Gate 1: partner + SANA relationship.
+  assert "Acme Retail Support" in partner
+  assert "SANA-adjacent" in partner
+  assert "not a SANA fork" in partner
+  for category in _SANA_CATEGORIES:
+    assert category in partner
+  assert "LakeQA" in partner
+  assert "KramaBench" in partner
+  assert "not duplicating" in partner
+  # Gate 2: runtime + route.
+  assert "ADK" in runtime
+  assert "bqaa_e2e_real.agent_events" in runtime
+  assert "mvp-e2e-real-traces" in runtime
+  assert "EvalBench-hosted" in runtime
+  assert "EvalBench-only MVP route is CORRECT" in runtime
+  assert "D1 does not need re-decision" in runtime
+  # Gate 3: pilot-benchmark rubric, scored per criterion.
+  for criterion in (
+      "collaborator relevance",
+      "failure-mode coverage",
+      "score availability / threshold-definability",
+      "ground-truth depth",
+      "trace fidelity",
+  ):
+    assert criterion in rubric
+  assert "pass" in rubric
+  assert _EVAL_ID in rubric
+  assert "goal_completion" in rubric
+  assert "0.0" in rubric
+  assert "threshold 1" in rubric
+  assert "ab7535a5" in rubric
+  assert "There are 0 widgets in stock." in rubric
+  assert "USER_MESSAGE_RECEIVED" in rubric
+  assert "INVOCATION_STARTING" in rubric
+  assert "AGENT_STARTING" in rubric
+  # Gate 4: D4 boundary memo.
+  assert "fail-closed" in d4.lower()
+  assert "Alex Rivera (example collaborator)" in d4
+  assert "Jordan Lee (example collaborator)" in d4
+  assert "ingestion" in d4
+  assert "taxonomy mechanics" in d4
+  assert "stability" in d4
+  assert "ONLY" in d4
+  assert "never" in d4
+  assert "Part II funding recommendation" in d4
+  assert "test-project-0728-467323" in d4
+  assert "pre-redacted" in d4
+  # Gate 5: preregistration floors, copied as an example.
+  assert "EXAMPLE" in prereg
+  assert "not week-1 freeze" in prereg
+  assert "clock not started" in prereg
+  assert "80%" in prereg
+  assert "0.6" in prereg
+  assert "0.45" in prereg
+  assert "70%" in prereg
+  assert "+10pp" in prereg
+  assert ">0" in prereg
+  # Through-line: the widget session.
+  assert "support_agent" in session
+  assert "real-user-0" in session
+  assert "How many widgets are in stock?" in session
+  assert _SESSION_ID in session
+  assert _EVAL_ID in session
+  # Its failed_sessions row with the mechanical categories.
+  assert "process_failed" in failed
+  assert "missing_completion" in failed
+  assert "score_failed" in failed
+  assert (
+      'taxonomy_categories: ["process_failed", "missing_completion",'
+      ' "score_failed"]'
+  ) in failed
+  # The EXAMPLE mapping onto SANA-seeded names — labeled not-G1.
+  assert "EXAMPLE" in mapping
+  assert "not G1" in mapping
+  assert "g1_frozen: false" in mapping
+  assert "task/planning" in mapping
+  assert "finalization" in mapping
+  assert "tool blockers" in mapping
+  assert "never called check_inventory" in mapping
+  # Punchline: exactly one sentence, then nothing else.
+  assert punchline.strip().splitlines()[1:] == [_PUNCHLINE]
+
+
+def test_fixture_flag_walks_all_five_gates_and_exits_zero() -> None:
+  result = _run("--fixture")
+  assert result.returncode == 0, result.stderr
+  assert result.stderr == ""
+  assert "fixture mode" in result.stdout
+  assert _PUNCHLINE in result.stdout
+  _assert_walkthrough(result.stdout)
+
+
+def test_fixture_env_var_is_honored() -> None:
+  result = _run(env={"EVALBENCH_FIXTURE": "1"})
+  assert result.returncode == 0, result.stderr
+  _assert_walkthrough(result.stdout)
+
+
+def test_without_fixture_flag_exits_two_and_launches_nothing() -> None:
+  result = _run()
+  assert result.returncode == 2
+  assert result.stdout == ""
+  assert "--fixture only" in result.stderr
+  # No live job is mentioned, let alone launched.
+  assert "bq " not in result.stderr
+  assert "Step" not in result.stderr
+
+
+def test_synth_flag_is_rejected_without_launching_anything() -> None:
+  result = _run("--synth")
+  assert result.returncode == 2
+  assert result.stdout == ""
+  assert "--fixture only" in result.stderr
+
+
+def test_partner_fixture_names_the_example_partner_and_sana_seeds() -> None:
+  data = _fixture("week0_example_partner.json")
+  assert data["illustrative"] is True
+  assert data["not_a_freeze"] is True
+  assert data["partner_name"] == "Acme Retail Support"
+  assert data["sana_runtime"] == "Strands"
+  assert data["this_pilot_runtime"] == "ADK+EvalBench"
+  assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
+  assert "not duplicating" in data["not_duplicating_lakeqa_kramabench"]
+
+
+def test_rubric_fixture_scores_all_five_criteria_on_the_session() -> None:
+  data = _fixture("week0_example_rubric.json")
+  assert data["selected_benchmark"] == "widget-stock support"
+  assert data["session_id"] == _SESSION_ID
+  assert data["eval_id"] == _EVAL_ID
+  assert data["job_id"] == "mvp-e2e-real-traces"
+  criteria = data["criteria"]
+  assert len(criteria) == 5
+  for entry in criteria.values():
+    assert entry["result"] == "pass"
+    assert entry["reason"]
+  names = {entry["name"] for entry in criteria.values()}
+  assert names == {
+      "collaborator relevance",
+      "failure-mode coverage",
+      "score availability / threshold-definability",
+      "ground-truth depth",
+      "trace fidelity",
+  }
+
+
+def test_d4_fixture_is_fail_closed_with_example_consumers() -> None:
+  data = _fixture("week0_example_d4_memo.json")
+  assert data["fail_closed"] is True
+  assert data["report_consumers"]
+  for consumer in data["report_consumers"]:
+    assert "example" in consumer
+  assert set(data["fixture_validates"]) == {
+      "ingestion",
+      "taxonomy mechanics",
+      "stability",
+  }
+  assert "Part II" in data["never_produces"]
+  assert data["reference_project"] == "test-project-0728-467323"
+  assert data["pre_redacted"] is True
+  assert data["stop_go_memo_is_governed_artifact"] is True
+
+
+def test_preregistration_fixture_copies_the_plan_floors() -> None:
+  data = _fixture("week0_example_preregistration.json")
+  assert data["not_week_1_freeze"] is True
+  floors = data["floors"]
+  assert floors["replicate_agreement_pct"] == 80
+  assert floors["non_unknown_coverage_pct"] == 80
+  assert floors["kappa_point"] == 0.6
+  assert floors["kappa_ci_lower"] == 0.45
+  assert floors["localization_coverage_pct"] == 70
+  assert floors["hit_at_1_ci_lower_gt_0"] is True
+  assert floors["hit_at_1_point_uplift_pp"] == 10
+  assert "reserved_revision_week" in data["decision_rules"]
+  assert "value_gate" in data["decision_rules"]
+  assert "noisy_small_n_localization" in data["decision_rules"]
+
+
+def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
+  data = _fixture("week0_example_taxonomy_seed.json")
+  assert data["not_g1"] is True
+  assert data["taxonomy_version"] == "0.1.0-example"
+  assert data["taxonomy_version"] != failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION
+  assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.CORE_CATEGORY_IDS
+  widget = data["widget_session"]
+  assert widget["session_id"] == _SESSION_ID
+  assert widget["eval_id"] == _EVAL_ID
+  assert tuple(widget["taxonomy_categories"]) == (
+      failure_taxonomy.CORE_CATEGORY_IDS
+  )
+  mapping = data["example_mapping"]
+  assert mapping["missing_completion"] == "finalization"
+  assert mapping["process_failed"] == "tool blockers"
+  assert "task/planning" in mapping.values()
+  for seeded in mapping.values():
+    assert seeded in _SANA_CATEGORIES
+
+
+def test_example_mapping_never_touches_the_production_scaffold() -> None:
+  # The pack's SANA-seeded names must live only in the fixtures: the
+  # production scaffold module stays unfrozen and unchanged.
+  assert failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION == "0.0.0-scaffold"
+  assert failure_taxonomy.CORE_CATEGORY_IDS == (
+      "process_failed",
+      "missing_completion",
+      "score_failed",
+  )
+  config = failure_taxonomy.scaffold_taxonomy_config()
+  assert config["g1_frozen"] is False
+  assert config["taxonomy_version"] == "0.0.0-scaffold"
+  assert config["dialects"] == []
+  category_names = {
+      category["name"]
+      for metric in config["metrics"]
+      for category in metric["categories"]
+  }
+  assert category_names == set(failure_taxonomy.CORE_CATEGORY_IDS)
+  assert not category_names.intersection(_SANA_CATEGORIES)
+  # And as source text: g1_frozen stays False, no frozen SANA vocabulary.
+  source = _TAXONOMY_SRC.read_text()
+  assert '"g1_frozen": False' in source
+  assert '"g1_frozen": True' not in source
+  assert 'SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"' in source
+  # The module docstring's disclaimer mentions SANA only to say its
+  # categories "do not appear here" — no seeded name may appear at all.
+  for name in _SANA_CATEGORIES:
+    assert name not in source

--- a/tests/test_evalbench_week0_full_idea.py
+++ b/tests/test_evalbench_week0_full_idea.py
@@ -14,11 +14,13 @@
 """Tests for ``examples/evalbench_week0_full_idea.sh`` (#435 slice 10).
 
 The EXAMPLE Week 0 scenario pack is ``--fixture`` only: nothing here
-reaches BigQuery or the network, and nothing here freezes anything —
-every asserted artifact says ``g1_frozen: false`` and that the six-week
-clock has not started. The tests also guard the boundary the pack must
-never cross: the SANA-seeded example mapping lives only in the fixtures,
-never in ``src/bigquery_agent_analytics/failure_taxonomy.py``.
+reaches BigQuery or the network, and every asserted artifact says
+``example: true`` / ``g1_frozen: false`` and that the six-week clock has
+not started. The pack itself freezes nothing — it stays illustrative even
+now that the Week 0 freeze landed for real: production
+``failure_taxonomy.py`` is G1-frozen at v0.1.0 and the real freeze
+artifacts live in ``examples/fixtures/week0_real_*.json``
+(``tests/test_week0_real_freeze.py``), distinct from this pack.
 """
 
 from __future__ import annotations
@@ -310,14 +312,16 @@ def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
   data = _fixture("week0_example_taxonomy_seed.json")
   assert data["not_g1"] is True
   assert data["taxonomy_version"] == "0.1.0-example"
-  assert data["taxonomy_version"] != failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION
+  assert data["taxonomy_version"] != failure_taxonomy.TAXONOMY_VERSION
   assert tuple(data["sana_categories"]) == _SANA_CATEGORIES
-  assert tuple(data["mechanical_flags"]) == failure_taxonomy.CORE_CATEGORY_IDS
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.MECHANICAL_FLAGS
   widget = data["widget_session"]
   assert widget["session_id"] == _SESSION_ID
   assert widget["eval_id"] == _EVAL_ID
+  # The EXAMPLE narrative predates the G1 freeze and hardcodes the
+  # mechanical flag ids as its categories — correct for an example pack.
   assert tuple(widget["taxonomy_categories"]) == (
-      failure_taxonomy.CORE_CATEGORY_IDS
+      failure_taxonomy.MECHANICAL_FLAGS
   )
   mapping = data["example_mapping"]
   assert mapping["missing_completion"] == "finalization"
@@ -327,32 +331,37 @@ def test_taxonomy_seed_fixture_maps_this_session_without_freezing() -> None:
     assert seeded in _SANA_CATEGORIES
 
 
-def test_example_mapping_never_touches_the_production_scaffold() -> None:
-  # The pack's SANA-seeded names must live only in the fixtures: the
-  # production scaffold module stays unfrozen and unchanged.
-  assert failure_taxonomy.SCAFFOLD_TAXONOMY_VERSION == "0.0.0-scaffold"
-  assert failure_taxonomy.CORE_CATEGORY_IDS == (
-      "process_failed",
-      "missing_completion",
-      "score_failed",
-  )
-  config = failure_taxonomy.scaffold_taxonomy_config()
-  assert config["g1_frozen"] is False
-  assert config["taxonomy_version"] == "0.0.0-scaffold"
+def test_example_pack_stays_example_while_production_is_frozen() -> None:
+  # The pack stays illustrative (example: true, g1_frozen: false — the
+  # _fixture helper asserts both) while production froze G1 at v0.1.0.
+  # The example fixtures are NOT the freeze artifacts; the real freeze
+  # lives in examples/fixtures/week0_real_*.json and failure_taxonomy.py.
+  for name in (
+      "week0_example_partner.json",
+      "week0_example_rubric.json",
+      "week0_example_d4_memo.json",
+      "week0_example_preregistration.json",
+      "week0_example_taxonomy_seed.json",
+  ):
+    _fixture(name)
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  config = failure_taxonomy.taxonomy_config()
+  assert config["g1_frozen"] is True
+  assert config["taxonomy_version"] == "0.1.0"
   assert config["dialects"] == []
   category_names = {
       category["name"]
       for metric in config["metrics"]
       for category in metric["categories"]
   }
-  assert category_names == set(failure_taxonomy.CORE_CATEGORY_IDS)
-  assert not category_names.intersection(_SANA_CATEGORIES)
-  # And as source text: g1_frozen stays False, no frozen SANA vocabulary.
+  assert category_names == set(_SANA_CATEGORIES) | {"unknown"}
+  # The example pack's mapping agrees with the frozen FLAG_TO_CATEGORY,
+  # so the story it tells matches what production now does.
+  seed = json.loads(
+      (_FIXTURE_DIR / "week0_example_taxonomy_seed.json").read_text()
+  )
+  assert seed["example_mapping"] == dict(failure_taxonomy.FLAG_TO_CATEGORY)
+  # And as source text: the freeze is in the production module.
   source = _TAXONOMY_SRC.read_text()
-  assert '"g1_frozen": False' in source
-  assert '"g1_frozen": True' not in source
-  assert 'SCAFFOLD_TAXONOMY_VERSION = "0.0.0-scaffold"' in source
-  # The module docstring's disclaimer mentions SANA only to say its
-  # categories "do not appear here" — no seeded name may appear at all.
-  for name in _SANA_CATEGORIES:
-    assert name not in source
+  assert '"g1_frozen": True' in source
+  assert 'TAXONOMY_VERSION = "0.1.0"' in source

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8)."""
+"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8).
 
+Slice 9 adds the consumer tests: ``EvalBenchSession`` (the row
+``failed_sessions`` returns and the CLI serializes) exposes
+``taxonomy_categories`` computed from its flags via
+``categorize_failed_session``.
+"""
+
+from datetime import datetime
+from datetime import timezone
 import itertools
 
 import pytest
 
+from bigquery_agent_analytics.evalbench import EvalBenchSession
 from bigquery_agent_analytics.evalbench import SessionVerdict
 from bigquery_agent_analytics.evaluation_rubrics import build_metrics
 from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
@@ -166,3 +175,45 @@ def test_config_returns_a_deep_copy():
   assert fresh["g1_frozen"] is False
   assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
   assert fresh["dialects"] == []
+
+
+# --- EvalBenchSession consumer (slice 9) ----------------------------------
+
+
+def _session(**overrides):
+  # The same constructor shape the pre-slice-9 tests use: no taxonomy
+  # field exists, so existing callers keep working unchanged.
+  return EvalBenchSession(
+      job_id="job-123",
+      import_version="v1",
+      session_id="evalbench-import:job-123:v1:s1",
+      trace_id="evalbench-import:job-123:v1:s1",
+      scenario_id="s1",
+      started_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+      failed=any(overrides.values()),
+      **_row(**overrides),
+  )
+
+
+@pytest.mark.parametrize(
+    "tripped",
+    [
+        combo
+        for size in (1, 2, 3)
+        for combo in itertools.combinations(_FLAGS, size)
+    ],
+)
+def test_session_to_dict_carries_the_tripped_categories(tripped):
+  session = _session(**{flag: True for flag in tripped})
+  assert session.taxonomy_categories == categorize_failed_session(session)
+  assert session.to_dict()["taxonomy_categories"] == list(
+      categorize_failed_session(session)
+  )
+  assert session.to_dict()["taxonomy_categories"] == list(tripped)
+
+
+def test_session_with_all_flags_false_serializes_empty_categories():
+  # An include_passed row: empty list, never an invented "unknown" bucket.
+  session = _session()
+  assert session.taxonomy_categories == ()
+  assert session.to_dict()["taxonomy_categories"] == []

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8).
+"""Tests for the G1-frozen failure taxonomy v0.1 (#435).
 
-Slice 9 adds the consumer tests: ``EvalBenchSession`` (the row
-``failed_sessions`` returns and the CLI serializes) exposes
-``taxonomy_categories`` computed from its flags via
-``categorize_failed_session``.
+Slices 8/9 landed the mechanical mapper and its ``EvalBenchSession``
+consumer; the Week 0 G1 freeze replaced the scaffold vocabulary with the
+frozen names (SANA-neighborhood seven + ``unknown``) at
+``taxonomy_version: 0.1.0`` / ``g1_frozen: True``. Assignment stays
+mechanical: each tripped flag maps to one frozen name, returned in frozen
+order.
 """
 
 from datetime import datetime
@@ -31,10 +33,25 @@ from bigquery_agent_analytics.evalbench import SessionVerdict
 from bigquery_agent_analytics.evaluation_rubrics import build_metrics
 from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
 from bigquery_agent_analytics.failure_taxonomy import CORE_CATEGORY_IDS
+from bigquery_agent_analytics.failure_taxonomy import FLAG_TO_CATEGORY
+from bigquery_agent_analytics.failure_taxonomy import FROZEN_CATEGORY_NAMES
+from bigquery_agent_analytics.failure_taxonomy import MECHANICAL_FLAGS
 from bigquery_agent_analytics.failure_taxonomy import scaffold_taxonomy_config
-from bigquery_agent_analytics.failure_taxonomy import SCAFFOLD_TAXONOMY_VERSION
+from bigquery_agent_analytics.failure_taxonomy import taxonomy_config
+from bigquery_agent_analytics.failure_taxonomy import TAXONOMY_VERSION
 
 _FLAGS = ("process_failed", "missing_completion", "score_failed")
+
+_FROZEN_NAMES = (
+    "task/planning",
+    "wrong source",
+    "execution/computation",
+    "incomplete evidence",
+    "turn-waste",
+    "finalization",
+    "tool blockers",
+    "unknown",
+)
 
 
 def _row(**overrides):
@@ -53,12 +70,25 @@ def _verdict(**overrides):
   )
 
 
+def _expected(*tripped_flags):
+  # Frozen names for the tripped flags, in FROZEN_CATEGORY_NAMES order.
+  mapped = {FLAG_TO_CATEGORY[flag] for flag in tripped_flags}
+  return tuple(name for name in FROZEN_CATEGORY_NAMES if name in mapped)
+
+
 # --- mapper ---------------------------------------------------------------
 
 
-@pytest.mark.parametrize("flag", _FLAGS)
-def test_each_flag_alone_maps_to_its_category(flag):
-  assert categorize_failed_session(_row(**{flag: True})) == (flag,)
+@pytest.mark.parametrize(
+    "flag,frozen_name",
+    [
+        ("process_failed", "tool blockers"),
+        ("missing_completion", "finalization"),
+        ("score_failed", "task/planning"),
+    ],
+)
+def test_each_flag_alone_maps_to_its_frozen_name(flag, frozen_name):
+  assert categorize_failed_session(_row(**{flag: True})) == (frozen_name,)
 
 
 @pytest.mark.parametrize(
@@ -69,21 +99,35 @@ def test_each_flag_alone_maps_to_its_category(flag):
         for combo in itertools.combinations(_FLAGS, size)
     ],
 )
-def test_flag_combinations_map_to_every_tripped_category(tripped):
+def test_flag_combinations_map_to_every_tripped_frozen_name(tripped):
   row = _row(**{flag: True for flag in tripped})
-  assert categorize_failed_session(row) == tripped
+  assert categorize_failed_session(row) == _expected(*tripped)
 
 
-def test_all_flags_false_returns_empty_not_an_unknown_bucket():
+def test_all_flags_false_returns_empty_never_unknown():
+  # unknown is in the frozen vocabulary as the residual bucket of the
+  # labeling study; the mechanical mapper never emits it.
   assert categorize_failed_session(_row()) == ()
 
 
-def test_category_order_follows_the_core_config_order():
+def test_category_order_follows_the_frozen_order_not_flag_order():
+  # score_failed maps to task/planning, which precedes tool blockers in
+  # FROZEN_CATEGORY_NAMES even though process_failed precedes score_failed
+  # in flag order.
   row = _row(score_failed=True, process_failed=True)
-  assert categorize_failed_session(row) == ("process_failed", "score_failed")
+  assert categorize_failed_session(row) == ("task/planning", "tool blockers")
   assert categorize_failed_session(
-      _row(**{flag: True for flag in _FLAGS})
-  ) == tuple(CORE_CATEGORY_IDS)
+      _row(process_failed=True, missing_completion=True)
+  ) == ("finalization", "tool blockers")
+
+
+def test_widget_session_with_all_three_flags_maps_in_frozen_order():
+  # The widget-stock pilot session 7e352c34 trips all three flags.
+  assert categorize_failed_session(_row(**{flag: True for flag in _FLAGS})) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
 
 
 def test_extra_fields_are_ignored():
@@ -95,14 +139,14 @@ def test_extra_fields_are_ignored():
       failed=True,
       failing_scores=[{"comparator": "exact_match", "score": 0.0}],
   )
-  assert categorize_failed_session(row) == ("process_failed",)
+  assert categorize_failed_session(row) == ("tool blockers",)
 
 
 def test_session_verdict_objects_are_accepted():
   verdict = _verdict(missing_completion=True, score_failed=True)
   assert categorize_failed_session(verdict) == (
-      "missing_completion",
-      "score_failed",
+      "task/planning",
+      "finalization",
   )
   assert categorize_failed_session(_verdict()) == ()
 
@@ -125,56 +169,99 @@ def test_mapper_is_deterministic():
   assert categorize_failed_session(row) == categorize_failed_session(row)
 
 
+def test_mapper_never_returns_flag_ids():
+  for size in (1, 2, 3):
+    for tripped in itertools.combinations(_FLAGS, size):
+      names = categorize_failed_session(_row(**{f: True for f in tripped}))
+      assert not set(names).intersection(_FLAGS)
+      assert set(names) <= set(FROZEN_CATEGORY_NAMES)
+      assert "unknown" not in names
+
+
 # --- config ---------------------------------------------------------------
 
 
-def test_config_version_is_obviously_scaffold_and_not_g1_frozen():
-  config = scaffold_taxonomy_config()
-  assert config["taxonomy_version"] == SCAFFOLD_TAXONOMY_VERSION
-  assert "scaffold" in config["taxonomy_version"]
-  assert config["g1_frozen"] is False
+def test_config_is_g1_frozen_at_v0_1_0():
+  config = taxonomy_config()
+  assert TAXONOMY_VERSION == "0.1.0"
+  assert config["taxonomy_version"] == "0.1.0"
+  assert "scaffold" not in config["taxonomy_version"]
+  assert config["g1_frozen"] is True
 
 
 def test_config_dialects_slot_exists_and_is_empty_by_default():
   # D2: one taxonomy with optional per-benchmark extension categories on
-  # the same core. The slot must exist and must not ship invented labels.
-  assert scaffold_taxonomy_config()["dialects"] == []
+  # the same core. The slot must exist and stays empty at the freeze.
+  assert taxonomy_config()["dialects"] == []
 
 
-def test_config_core_categories_match_the_landed_flags():
-  config = scaffold_taxonomy_config()
+def test_frozen_names_are_the_sana_seven_plus_unknown_in_frozen_order():
+  assert FROZEN_CATEGORY_NAMES == _FROZEN_NAMES
+  assert CORE_CATEGORY_IDS == FROZEN_CATEGORY_NAMES
+  assert FROZEN_CATEGORY_NAMES[-1] == "unknown"
+
+
+def test_mechanical_flags_keep_the_landed_contract_keys():
+  assert MECHANICAL_FLAGS == _FLAGS
+  assert set(FLAG_TO_CATEGORY) == set(MECHANICAL_FLAGS)
+  assert FLAG_TO_CATEGORY["missing_completion"] == "finalization"
+  assert FLAG_TO_CATEGORY["process_failed"] == "tool blockers"
+  assert FLAG_TO_CATEGORY["score_failed"] == "task/planning"
+
+
+def test_config_core_categories_are_the_frozen_names_with_definitions():
+  config = taxonomy_config()
   (metric,) = config["metrics"]
   assert metric["name"] == "failure_category"
-  assert [c["name"] for c in metric["categories"]] == list(CORE_CATEGORY_IDS)
-  assert list(CORE_CATEGORY_IDS) == list(_FLAGS)
+  assert [c["name"] for c in metric["categories"]] == list(
+      FROZEN_CATEGORY_NAMES
+  )
   for category in metric["categories"]:
-    assert category["definition"]
+    # Every definition states how mechanical assignment works until the
+    # labeler study (mapped from a flag, or not emitted by the mapper).
+    assert "mechanical" in category["definition"].lower()
+    if category["name"] in FLAG_TO_CATEGORY.values():
+      assert "mapped from" in category["definition"]
+    else:
+      assert "not emit" in category["definition"]
 
 
-def test_config_does_not_contain_unfrozen_sana_names():
-  # The SANA seven-category vocabulary stays out of this scaffold entirely.
-  text = repr(scaffold_taxonomy_config()).lower()
-  for sana_name in ("planning", "wrong source", "turn-waste", "finalization"):
-    assert sana_name not in text
+def test_unknown_is_residual_in_vocabulary_but_not_mapped():
+  config = taxonomy_config()
+  (metric,) = config["metrics"]
+  unknown = next(c for c in metric["categories"] if c["name"] == "unknown")
+  assert "residual" in unknown["definition"].lower()
+  assert "unknown" not in FLAG_TO_CATEGORY.values()
 
 
 def test_config_metrics_shape_is_interpretable_by_build_metrics():
   # #431 schema shape: build_metrics() can turn the core metric into a
   # CategoricalMetricDefinition without special-casing.
-  (metric,) = build_metrics(scaffold_taxonomy_config())
+  (metric,) = build_metrics(taxonomy_config())
   assert metric.name == "failure_category"
-  assert [c.name for c in metric.categories] == list(CORE_CATEGORY_IDS)
+  assert [c.name for c in metric.categories] == list(FROZEN_CATEGORY_NAMES)
+
+
+def test_scaffold_taxonomy_config_is_a_wrapper_for_the_frozen_config():
+  # The pre-freeze name survives as a compatibility wrapper; it returns
+  # the same frozen config, not the retired scaffold.
+  assert scaffold_taxonomy_config() == taxonomy_config()
+  assert scaffold_taxonomy_config()["g1_frozen"] is True
+  assert scaffold_taxonomy_config()["taxonomy_version"] == "0.1.0"
 
 
 def test_config_returns_a_deep_copy():
-  first = scaffold_taxonomy_config()
-  first["g1_frozen"] = True
+  first = taxonomy_config()
+  first["g1_frozen"] = False
   first["metrics"][0]["categories"].clear()
   first["dialects"].append({"benchmark": "nope"})
-  fresh = scaffold_taxonomy_config()
-  assert fresh["g1_frozen"] is False
-  assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
+  fresh = taxonomy_config()
+  assert fresh["g1_frozen"] is True
+  assert len(fresh["metrics"][0]["categories"]) == len(FROZEN_CATEGORY_NAMES)
   assert fresh["dialects"] == []
+  wrapped = scaffold_taxonomy_config()
+  wrapped["g1_frozen"] = False
+  assert scaffold_taxonomy_config()["g1_frozen"] is True
 
 
 # --- EvalBenchSession consumer (slice 9) ----------------------------------
@@ -203,17 +290,15 @@ def _session(**overrides):
         for combo in itertools.combinations(_FLAGS, size)
     ],
 )
-def test_session_to_dict_carries_the_tripped_categories(tripped):
+def test_session_to_dict_carries_the_tripped_frozen_names(tripped):
   session = _session(**{flag: True for flag in tripped})
   assert session.taxonomy_categories == categorize_failed_session(session)
-  assert session.to_dict()["taxonomy_categories"] == list(
-      categorize_failed_session(session)
-  )
-  assert session.to_dict()["taxonomy_categories"] == list(tripped)
+  assert session.taxonomy_categories == _expected(*tripped)
+  assert session.to_dict()["taxonomy_categories"] == list(_expected(*tripped))
 
 
 def test_session_with_all_flags_false_serializes_empty_categories():
-  # An include_passed row: empty list, never an invented "unknown" bucket.
+  # An include_passed row: empty list, never the residual "unknown" bucket.
   session = _session()
   assert session.taxonomy_categories == ()
   assert session.to_dict()["taxonomy_categories"] == []

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the mechanical failure-taxonomy scaffold (#435 slice 8)."""
+
+import itertools
+
+import pytest
+
+from bigquery_agent_analytics.evalbench import SessionVerdict
+from bigquery_agent_analytics.evaluation_rubrics import build_metrics
+from bigquery_agent_analytics.failure_taxonomy import categorize_failed_session
+from bigquery_agent_analytics.failure_taxonomy import CORE_CATEGORY_IDS
+from bigquery_agent_analytics.failure_taxonomy import scaffold_taxonomy_config
+from bigquery_agent_analytics.failure_taxonomy import SCAFFOLD_TAXONOMY_VERSION
+
+_FLAGS = ("process_failed", "missing_completion", "score_failed")
+
+
+def _row(**overrides):
+  row = {flag: False for flag in _FLAGS}
+  row.update(overrides)
+  return row
+
+
+def _verdict(**overrides):
+  return SessionVerdict(
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      failing_scores={},
+      failed=any(overrides.values()),
+      **_row(**overrides),
+  )
+
+
+# --- mapper ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", _FLAGS)
+def test_each_flag_alone_maps_to_its_category(flag):
+  assert categorize_failed_session(_row(**{flag: True})) == (flag,)
+
+
+@pytest.mark.parametrize(
+    "tripped",
+    [
+        combo
+        for size in (2, 3)
+        for combo in itertools.combinations(_FLAGS, size)
+    ],
+)
+def test_flag_combinations_map_to_every_tripped_category(tripped):
+  row = _row(**{flag: True for flag in tripped})
+  assert categorize_failed_session(row) == tripped
+
+
+def test_all_flags_false_returns_empty_not_an_unknown_bucket():
+  assert categorize_failed_session(_row()) == ()
+
+
+def test_category_order_follows_the_core_config_order():
+  row = _row(score_failed=True, process_failed=True)
+  assert categorize_failed_session(row) == ("process_failed", "score_failed")
+  assert categorize_failed_session(
+      _row(**{flag: True for flag in _FLAGS})
+  ) == tuple(CORE_CATEGORY_IDS)
+
+
+def test_extra_fields_are_ignored():
+  row = _row(
+      process_failed=True,
+      session_id="evalbench-import:job:v1:s1",
+      scenario_id="s1",
+      started_at="2026-08-30T00:00:00Z",
+      failed=True,
+      failing_scores=[{"comparator": "exact_match", "score": 0.0}],
+  )
+  assert categorize_failed_session(row) == ("process_failed",)
+
+
+def test_session_verdict_objects_are_accepted():
+  verdict = _verdict(missing_completion=True, score_failed=True)
+  assert categorize_failed_session(verdict) == (
+      "missing_completion",
+      "score_failed",
+  )
+  assert categorize_failed_session(_verdict()) == ()
+
+
+def test_missing_flag_raises_instead_of_defaulting():
+  row = _row(process_failed=True)
+  del row["score_failed"]
+  with pytest.raises(ValueError, match="missing required flag 'score_failed'"):
+    categorize_failed_session(row)
+
+
+@pytest.mark.parametrize("bad", [None, 0, 1, "true"])
+def test_non_bool_flag_raises(bad):
+  with pytest.raises(ValueError, match="'process_failed' must be a bool"):
+    categorize_failed_session(_row(process_failed=bad))
+
+
+def test_mapper_is_deterministic():
+  row = _row(process_failed=True, missing_completion=True)
+  assert categorize_failed_session(row) == categorize_failed_session(row)
+
+
+# --- config ---------------------------------------------------------------
+
+
+def test_config_version_is_obviously_scaffold_and_not_g1_frozen():
+  config = scaffold_taxonomy_config()
+  assert config["taxonomy_version"] == SCAFFOLD_TAXONOMY_VERSION
+  assert "scaffold" in config["taxonomy_version"]
+  assert config["g1_frozen"] is False
+
+
+def test_config_dialects_slot_exists_and_is_empty_by_default():
+  # D2: one taxonomy with optional per-benchmark extension categories on
+  # the same core. The slot must exist and must not ship invented labels.
+  assert scaffold_taxonomy_config()["dialects"] == []
+
+
+def test_config_core_categories_match_the_landed_flags():
+  config = scaffold_taxonomy_config()
+  (metric,) = config["metrics"]
+  assert metric["name"] == "failure_category"
+  assert [c["name"] for c in metric["categories"]] == list(CORE_CATEGORY_IDS)
+  assert list(CORE_CATEGORY_IDS) == list(_FLAGS)
+  for category in metric["categories"]:
+    assert category["definition"]
+
+
+def test_config_does_not_contain_unfrozen_sana_names():
+  # The SANA seven-category vocabulary stays out of this scaffold entirely.
+  text = repr(scaffold_taxonomy_config()).lower()
+  for sana_name in ("planning", "wrong source", "turn-waste", "finalization"):
+    assert sana_name not in text
+
+
+def test_config_metrics_shape_is_interpretable_by_build_metrics():
+  # #431 schema shape: build_metrics() can turn the core metric into a
+  # CategoricalMetricDefinition without special-casing.
+  (metric,) = build_metrics(scaffold_taxonomy_config())
+  assert metric.name == "failure_category"
+  assert [c.name for c in metric.categories] == list(CORE_CATEGORY_IDS)
+
+
+def test_config_returns_a_deep_copy():
+  first = scaffold_taxonomy_config()
+  first["g1_frozen"] = True
+  first["metrics"][0]["categories"].clear()
+  first["dialects"].append({"benchmark": "nope"})
+  fresh = scaffold_taxonomy_config()
+  assert fresh["g1_frozen"] is False
+  assert len(fresh["metrics"][0]["categories"]) == len(CORE_CATEGORY_IDS)
+  assert fresh["dialects"] == []

--- a/tests/test_native_events_writer.py
+++ b/tests/test_native_events_writer.py
@@ -30,7 +30,9 @@ from pathlib import Path
 import pytest
 
 from bigquery_agent_analytics import failure_taxonomy
+from bigquery_agent_analytics.client import Client
 from bigquery_agent_analytics.evalbench import classify_sessions
+from bigquery_agent_analytics.evalbench import EvalBenchImportSessions
 from bigquery_agent_analytics.evalbench import EvalScorePolicy
 from bigquery_agent_analytics.evalbench import failed_sessions
 from bigquery_agent_analytics.native_events import native_next_action
@@ -398,6 +400,62 @@ class _FakeReadClient:
     return _FakeQueryJob(self.rows)
 
 
+def test_evalbench_source_basenames_fail_closed_with_zero_queries() -> None:
+  # configs/results/scores are refused by name BEFORE any query is built
+  # or any client is touched, on both the read path and the offline path.
+  for basename in ("configs", "results", "scores"):
+    source = f"{_SOURCE_PROJECT}.bqaa_e2e_real.{basename}"
+    fake = _FakeWriteClient()
+    with pytest.raises(ValueError, match="names the EvalBench source table"):
+      NativeAgentEventsRun.from_bigquery(
+          source_table=source, job_id=_JOB_ID, bq_client=fake
+      )
+    with pytest.raises(ValueError, match="names the EvalBench source table"):
+      NativeAgentEventsRun.from_agent_events(
+          [], source_table=source, job_id=_JOB_ID
+      )
+    assert fake.queries == []
+    assert fake.loads == []
+    assert fake.created == []
+    assert fake.store.events == []
+    assert fake.store.scores == []
+    assert fake.store.rows == []
+
+
+def test_source_basename_must_be_agent_events_with_zero_queries() -> None:
+  # A non-reserved basename such as the default mirror table would resolve
+  # to the inherited default destination and self-feed; refused at parse.
+  source = f"{_SOURCE_PROJECT}.bqaa_e2e_real.evalbench_agent_events"
+  fake = _FakeWriteClient()
+  with pytest.raises(ValueError, match="must reference a production"):
+    NativeAgentEventsRun.from_bigquery(
+        source_table=source, job_id=_JOB_ID, bq_client=fake
+    )
+  with pytest.raises(ValueError, match="must reference a production"):
+    NativeAgentEventsRun.from_agent_events(
+        [], source_table=source, job_id=_JOB_ID
+    )
+  assert fake.queries == [] and fake.loads == []
+
+
+def test_destination_equal_to_source_fails_closed_with_zero_writes() -> None:
+  # Defense in depth: a destination that IS the read-only source table is
+  # rejected before any BigQuery call, ahead of the reserved-name check.
+  fake = _FakeWriteClient()
+  with pytest.raises(ValueError, match="read-only native source table"):
+    _acceptance_run().materialize(
+        target_dataset="bqaa_e2e_real",
+        events_table="agent_events",
+        bq_client=fake,
+    )
+  assert fake.queries == []
+  assert fake.loads == []
+  assert fake.created == []
+  assert fake.store.events == []
+  assert fake.store.scores == []
+  assert fake.store.rows == []
+
+
 def test_from_bigquery_reads_only_the_agent_events_table() -> None:
   fake = _FakeReadClient(_stuck_events() + _gold_events())
   run = NativeAgentEventsRun.from_bigquery(
@@ -453,6 +511,180 @@ def test_nothing_is_written_into_an_agent_events_table() -> None:
     assert _SOURCE_TABLE not in target
     for segment in target.replace("`", " ").replace("\n", " ").split():
       assert not segment.endswith(".agent_events")
+
+
+# --- retained versions stay isolated for trace consumers (#464) -----------
+
+
+def _mirror_event_row(import_version, *, span_id):
+  """One published mirror row: the REAL session id, versioned by column."""
+  return {
+      "event_type": "USER_MESSAGE_RECEIVED",
+      "agent": "support_agent",
+      "timestamp": _T0,
+      "session_id": _SESSION_STUCK,
+      "invocation_id": "inv-1",
+      "user_id": "real-user-0",
+      "trace_id": _SESSION_STUCK,
+      "span_id": span_id,
+      "parent_span_id": None,
+      "content": "{}",
+      "content_parts": [],
+      "attributes": json.dumps({"experiment_id": _JOB_ID}),
+      "latency_ms": None,
+      "status": "OK",
+      "error_message": None,
+      "is_truncated": False,
+      "import_version": import_version,
+  }
+
+
+class _VersionPredicateFake:
+  """Mirror-table fake honoring only the SQL predicates actually emitted.
+
+  Holds retained v1+v2 rows of ONE real session id. If a discovery or
+  fetch statement omits the ``import_version`` predicate, both versions'
+  rows come back — exactly the pre-#464 replay hole — so asserting on the
+  returned spans proves the pin is honored, not merely forwarded.
+  """
+
+  def __init__(self, rows) -> None:
+    self.rows = list(rows)
+    self.calls: list[tuple[str, dict]] = []
+
+  def query(self, sql, job_config=None, **kwargs):
+    params = {p.name: p.value for p in job_config.query_parameters}
+    self.calls.append((sql, params))
+    selected = [
+        row for row in self.rows if row["session_id"] == params["session_id"]
+    ]
+    if "@pin_import_version" in sql:
+      selected = [
+          row
+          for row in selected
+          if row["import_version"] == params["pin_import_version"]
+      ]
+    if "GROUP BY" in sql:  # candidate discovery over the selected rows
+      if not selected:
+        return _FakeQueryJob([])
+      return _FakeQueryJob(
+          [
+              {
+                  "session_id": _SESSION_STUCK,
+                  "user_id": "real-user-0",
+                  "root_agent_name": None,
+                  "experiment_id": json.dumps(_JOB_ID),
+                  "tag_payload": None,
+                  "attributes_valid": True,
+                  "scope_trace_id": None,
+                  "row_count": len(selected),
+              }
+          ]
+      )
+    return _FakeQueryJob(selected)
+
+
+def _publish_v1_and_v2():
+  """Publish the same real sessions as v1 then v2; v1 rows stay retained."""
+  fake = _FakeWriteClient()
+  _materialize(_acceptance_run(), fake)
+  changed = [
+      _event(_SESSION_STUCK, "AGENT_STARTING", "retry the plan", offset=3)
+  ]
+  _materialize(
+      _acceptance_run(changed),
+      fake,
+      import_version="v2",
+      imported_at=_IMPORTED_AT + timedelta(hours=1),
+  )
+  return fake
+
+
+def test_two_publications_v2_trace_selector_returns_no_v1_rows() -> None:
+  fake = _publish_v1_and_v2()
+  versions_by_session: dict[str, set] = {}
+  for row in fake.store.events:
+    versions_by_session.setdefault(row["session_id"], set()).add(
+        row["import_version"]
+    )
+  # The native hazard: retained versions share the real ADK session id
+  # (and the job-scoped experiment_id), so only import_version splits them.
+  assert versions_by_session[_SESSION_STUCK] == {"v1", "v2"}
+
+  listing = failed_sessions(
+      target_project=_SOURCE_PROJECT,
+      target_dataset="bqaa_native",
+      job_id=_JOB_ID,
+      policy=_POLICY,
+      bq_client=fake,
+  )
+  assert listing.import_version == "v2"
+  (session,) = listing.sessions
+  selector = session.trace_selector()
+  assert selector == {
+      "session_id": _SESSION_STUCK,
+      "experiment_id": _JOB_ID,
+      "import_version": "v2",
+  }
+
+  # The real reader honors the pin in SQL: with retained v1+v2 rows behind
+  # the mirror table, v2's selector materializes only the v2 span.
+  bq = _VersionPredicateFake(
+      [
+          _mirror_event_row("v1", span_id="v1-span"),
+          _mirror_event_row("v2", span_id="v2-span"),
+      ]
+  )
+  client = Client(
+      project_id=_SOURCE_PROJECT,
+      dataset_id="bqaa_native",
+      table_id="evalbench_agent_events",
+      verify_schema=False,
+      bq_client=bq,
+  )
+  trace = client.get_session_trace(**selector)
+  assert {span.span_id for span in trace.spans} == {"v2-span"}
+  resolve_sql, resolve_params = bq.calls[0]
+  fetch_sql, fetch_params = bq.calls[-1]
+  assert "import_version = @pin_import_version" in resolve_sql
+  assert "e.import_version = @pin_import_version" in fetch_sql
+  assert resolve_params["pin_import_version"] == "v2"
+  assert fetch_params["pin_import_version"] == "v2"
+
+
+def test_two_publications_v2_trace_filter_cannot_widen_to_v1() -> None:
+  fake = _publish_v1_and_v2()
+  listing = EvalBenchImportSessions(
+      job_id=_JOB_ID,
+      import_version="v2",
+      events_table=f"{_SOURCE_PROJECT}.bqaa_native.evalbench_agent_events",
+      scores_table=f"{_SOURCE_PROJECT}.bqaa_native.evalbench_scores_imported",
+      session_ids=(_SESSION_GOLD, _SESSION_STUCK),
+  )
+  trace_filter = listing.trace_filter()
+  assert trace_filter.import_version == "v2"
+  where, params = trace_filter.to_sql_conditions()
+  assert "import_version = @import_version" in where
+  (version_param,) = [p for p in params if p.name == "import_version"]
+  assert version_param.value == "v2"
+  # The row-scope fragment re-applies the pin, so the anchored row fetch
+  # cannot merge retained versions back into a listed trace.
+  assert "e.import_version = @import_version" in trace_filter.row_scope_where()
+
+  # session_ids alone (the pre-#464 predicate) match BOTH retained
+  # versions of the published rows; the version pin is what isolates v2.
+  in_listing = [
+      row
+      for row in fake.store.events
+      if row["session_id"] in trace_filter.session_ids
+  ]
+  assert {row["import_version"] for row in in_listing} == {"v1", "v2"}
+  pinned = [
+      row
+      for row in in_listing
+      if row["import_version"] == trace_filter.import_version
+  ]
+  assert pinned and {row["import_version"] for row in pinned} == {"v2"}
 
 
 # --- the six-week clock does not start ------------------------------------

--- a/tests/test_native_events_writer.py
+++ b/tests/test_native_events_writer.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the native ``agent_events`` snapshot writer (#463, parent #435).
+
+Everything is offline: the acceptance widget-stock session is an in-memory
+fixture shaped like production ADK ``agent_events`` rows, and publishing
+runs against the fake BigQuery client of ``test_evalbench_importer``.
+Nothing here reaches BigQuery, and nothing starts the six-week clock.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import json
+from pathlib import Path
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+from bigquery_agent_analytics.evalbench import classify_sessions
+from bigquery_agent_analytics.evalbench import EvalScorePolicy
+from bigquery_agent_analytics.evalbench import failed_sessions
+from bigquery_agent_analytics.native_events import native_next_action
+from bigquery_agent_analytics.native_events import NativeAgentEventsRun
+from tests.test_evalbench_importer import _FakeQueryJob
+from tests.test_evalbench_importer import _FakeWriteClient
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "examples" / "fixtures"
+
+_T0 = datetime(2026, 7, 27, 20, 30, 39, tzinfo=timezone.utc)
+_IMPORTED_AT = datetime(2026, 8, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+# The acceptance corpus (#463): production project/dataset the widget-stock
+# evidence lives in, read-only.
+_SOURCE_PROJECT = "test-project-0728-467323"
+_SOURCE_TABLE = f"{_SOURCE_PROJECT}.bqaa_e2e_real.agent_events"
+_JOB_ID = "mvp-e2e-real-traces"
+_SESSION_STUCK = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+# Only the first eight characters of the gold sibling are frozen evidence
+# (``examples/fixtures/week0_real_rubric.json``); the suffix is fixture.
+_SESSION_GOLD = "ab7535a5-1111-4111-8111-111111111111"
+_PROMPT = "How many widgets are in stock?"
+_GOLD_ANSWER = "There are 0 widgets in stock."
+
+# The frozen Week 0 rubric gate: goal_completion >= 1.0, missing fails.
+_POLICY = EvalScorePolicy({"goal_completion": 1.0}, missing_score_fails=True)
+
+
+def _event(session_id, event_type, content, *, offset=0, status="OK", **extra):
+  row = {
+      "timestamp": _T0 + timedelta(seconds=offset),
+      "event_type": event_type,
+      "agent": "support_agent",
+      "session_id": session_id,
+      "user_id": "real-user-0",
+      "content": content,
+      "attributes": {
+          "adk": {"app_name": "bqaa-e2e", "schema_version": "1"},
+          "root_agent_name": "support_agent",
+      },
+      "status": status,
+      "error_message": None,
+  }
+  row.update(extra)
+  return row
+
+
+def _stuck_events():
+  # USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then
+  # silence: no check_inventory, no LLM_RESPONSE, no AGENT_COMPLETED.
+  return [
+      _event(
+          _SESSION_STUCK,
+          "USER_MESSAGE_RECEIVED",
+          {"text_summary": _PROMPT},
+      ),
+      _event(_SESSION_STUCK, "INVOCATION_STARTING", None, offset=1),
+      _event(
+          _SESSION_STUCK,
+          "AGENT_STARTING",
+          "You are a support agent.",
+          offset=2,
+      ),
+  ]
+
+
+def _gold_events():
+  # The completed sibling: asked the same question and answered it.
+  return [
+      _event(_SESSION_GOLD, "USER_MESSAGE_RECEIVED", {"text_summary": _PROMPT}),
+      _event(
+          _SESSION_GOLD,
+          "TOOL_STARTING",
+          {"tool": "check_inventory", "args": {"item": "widget"}},
+          offset=1,
+      ),
+      _event(
+          _SESSION_GOLD,
+          "TOOL_COMPLETED",
+          {"tool": "check_inventory", "result": {"in_stock": 0}},
+          offset=2,
+      ),
+      _event(
+          _SESSION_GOLD,
+          "LLM_RESPONSE",
+          {"response": _GOLD_ANSWER},
+          offset=3,
+      ),
+      # content as a JSON string, as TO_JSON_STRING(content) returns it.
+      _event(_SESSION_GOLD, "AGENT_COMPLETED", "null", offset=4),
+  ]
+
+
+def _acceptance_run(extra_events=()):
+  return NativeAgentEventsRun.from_agent_events(
+      _stuck_events() + _gold_events() + list(extra_events),
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+
+
+def _materialize(run, fake, *, import_version="v1", imported_at=_IMPORTED_AT):
+  return run.materialize(
+      target_dataset="bqaa_native",
+      import_version=import_version,
+      imported_at=imported_at,
+      policy=_POLICY,
+      bq_client=fake,
+  )
+
+
+# --- acceptance: widget-stock silence, no EvalBench tables anywhere -------
+
+
+def test_widget_stock_session_fails_with_all_three_g1_names() -> None:
+  fake = _FakeWriteClient()
+  result = _materialize(_acceptance_run(), fake)
+  assert result.status == "imported"
+
+  listing = failed_sessions(
+      target_project=_SOURCE_PROJECT,
+      target_dataset="bqaa_native",
+      job_id=_JOB_ID,
+      policy=_POLICY,
+      bq_client=fake,
+  )
+  assert listing.import_version == "v1"
+  assert listing.session_count == 2
+  assert listing.failed_count == 1
+  (session,) = listing.sessions
+  # The same object with or without the adapter: the real ADK session id
+  # and the joinable first-8 identity.
+  assert session.session_id == _SESSION_STUCK
+  assert session.scenario_id == "7e352c34"
+  assert session.process_failed is True
+  assert session.missing_completion is True
+  assert session.score_failed is True
+  assert session.failed is True
+  assert session.failing_scores == {"goal_completion": 0.0}
+  # G1-frozen names (taxonomy v0.1.0), in frozen order, never flag order.
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  assert session.taxonomy_categories == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
+
+
+def test_punchline_next_action_names_the_missing_answer_and_tool() -> None:
+  text = native_next_action(_stuck_events(), gold_events=_gold_events())
+  assert "never answered" in text
+  assert "never called check_inventory" in text
+  # A completed session gets no failure punchline.
+  done = native_next_action(_gold_events())
+  assert "never answered" not in done
+  assert "score policy" in done
+
+
+def test_classify_sessions_agrees_without_a_publish() -> None:
+  # The in-memory reference implementation sees the same three flags the
+  # published view reports, straight from the mapped rows.
+  run = _acceptance_run()
+  verdicts = classify_sessions(
+      run.to_agent_event_rows(import_version="v1"),
+      run.to_score_rows(import_version="v1"),
+      _POLICY,
+  )
+  by_session = {verdict.session_id: verdict for verdict in verdicts}
+  stuck = by_session[_SESSION_STUCK]
+  assert (
+      stuck.process_failed,
+      stuck.missing_completion,
+      stuck.score_failed,
+      stuck.failed,
+  ) == (True, True, True, True)
+  assert failure_taxonomy.categorize_failed_session(stuck) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
+  gold = by_session[_SESSION_GOLD]
+  assert gold.failed is False
+  assert gold.scenario_id == "ab7535a5"
+
+
+# --- pin identity ---------------------------------------------------------
+
+
+def test_events_scores_and_manifest_all_carry_the_pin() -> None:
+  fake = _FakeWriteClient()
+  result = _materialize(_acceptance_run(), fake)
+  pin = (_JOB_ID, "v1")
+  assert result.event_row_count == len(fake.store.events) == 8
+  assert result.score_row_count == len(fake.store.scores) == 2
+  for row in fake.store.events + fake.store.scores:
+    assert (row["job_id"], row["import_version"]) == pin
+  (manifest,) = fake.store.rows
+  assert (manifest["job_id"], manifest["import_version"]) == pin
+  assert manifest["generation_id"]
+  assert manifest["source_project"] == _SOURCE_PROJECT
+  assert manifest["source_dataset"] == "bqaa_e2e_real"
+  # Real ADK identities, not the adapter's versioned namespace: the pin
+  # lives in the (job_id, import_version) columns.
+  assert {row["session_id"] for row in fake.store.events} == {
+      _SESSION_STUCK,
+      _SESSION_GOLD,
+  }
+
+
+def test_view_is_pinned_to_the_latest_successful_native_publication() -> None:
+  fake = _FakeWriteClient()
+  _materialize(_acceptance_run(), fake)
+  view_ref = f"{_SOURCE_PROJECT}.bqaa_native.evalbench_failed_sessions"
+  body_v1 = fake.store.views[view_ref]
+  assert body_v1.startswith("-- evalbench_failed_sessions pin: ")
+  assert f'"{_JOB_ID}"' in body_v1
+  assert '"v1"' in body_v1
+  assert "@job_id" not in body_v1 and "@import_version" not in body_v1
+
+  # A later successful publication (changed source, new version) moves the
+  # view; the pin follows the newest committed manifest row.
+  extra = [_event("99999999-aaaa", "USER_MESSAGE_RECEIVED", {"text": "hi"})]
+  _materialize(
+      _acceptance_run(extra),
+      fake,
+      import_version="v2",
+      imported_at=_IMPORTED_AT + timedelta(hours=1),
+  )
+  body_v2 = fake.store.views[view_ref]
+  assert '"v2"' in body_v2
+  assert '"v1"' not in body_v2
+
+
+def test_view_policy_pin_matches_the_frozen_week0_rubric() -> None:
+  rubric = json.loads((_FIXTURE_DIR / "week0_real_rubric.json").read_text())
+  assert rubric["clock_started"] is False
+  assert rubric["session_id"] == _SESSION_STUCK
+  assert rubric["eval_id"] == "7e352c34"
+  assert rubric["gold"]["sibling_session"] == "ab7535a5"
+  policy = EvalScorePolicy(
+      {rubric["score"]["metric"]: float(rubric["score"]["threshold"])},
+      missing_score_fails=True,
+  )
+  assert policy == _POLICY
+
+  fake = _FakeWriteClient()
+  _materialize(_acceptance_run(), fake)
+  (manifest,) = fake.store.rows
+  assert manifest["view_policy"] == json.dumps(
+      {"min_scores": {"goal_completion": 1.0}, "missing_score_fails": True},
+      sort_keys=True,
+  )
+
+
+# --- deterministic native scores ------------------------------------------
+
+
+def test_scores_are_deterministic_from_the_session_no_judge() -> None:
+  rows = _acceptance_run().to_score_rows(import_version="v1")
+  assert [
+      (row["session_id"], row["scenario_id"], row["comparator"], row["score"])
+      for row in rows
+  ] == [
+      (_SESSION_STUCK, "7e352c34", "goal_completion", 0.0),
+      (_SESSION_GOLD, "ab7535a5", "goal_completion", 1.0),
+  ]
+  stuck_row, gold_row = rows
+  assert stuck_row["source_row"]["completed"] is False
+  assert stuck_row["source_row"]["prompt"] == _PROMPT
+  assert stuck_row["source_row"]["derived_from"] == _SOURCE_TABLE
+  assert "score policy decides passed" in stuck_row["source_row"]["rule"]
+  assert gold_row["source_row"]["completed"] is True
+
+
+def test_never_completed_session_publishes_the_process_failure_marker() -> None:
+  rows = _acceptance_run().to_agent_event_rows(import_version="v1")
+  stuck_rows = [row for row in rows if row["session_id"] == _SESSION_STUCK]
+  assert [row["event_type"] for row in stuck_rows] == [
+      "USER_MESSAGE_RECEIVED",
+      "INVOCATION_STARTING",
+      "AGENT_STARTING",
+  ]
+  prompt_row = stuck_rows[0]
+  # Same marker the adapter publishes for a failed returncode: the prompt
+  # row goes out as ERROR, with the original status kept for provenance.
+  assert prompt_row["status"] == "ERROR"
+  assert "never logged AGENT_COMPLETED" in prompt_row["error_message"]
+  assert prompt_row["attributes"]["bqaa_native_source_status"] == "OK"
+  assert prompt_row["user_id"] == "real-user-0"
+  assert prompt_row["agent"] == "support_agent"
+  assert prompt_row["content"]["text_summary"] == _PROMPT
+  assert prompt_row["attributes"]["evalbench_scenario_id"] == "7e352c34"
+  assert prompt_row["attributes"]["experiment_id"] == _JOB_ID
+  assert prompt_row["attributes"]["bqaa_native_source_table"] == _SOURCE_TABLE
+  # The rest of the stuck session and the completed sibling stay verbatim.
+  for row in stuck_rows[1:]:
+    assert row["status"] == "OK"
+    assert "bqaa_native_source_status" not in row["attributes"]
+  for row in rows:
+    if row["session_id"] == _SESSION_GOLD:
+      assert row["status"] == "OK"
+      assert row["error_message"] is None
+
+
+def test_sessions_without_a_prompt_are_skipped_not_invented() -> None:
+  promptless = [
+      _event("dddddddd-0000", "AGENT_STARTING", "You are a support agent."),
+      _event("dddddddd-0000", "AGENT_COMPLETED", None, offset=1),
+  ]
+  run = _acceptance_run(promptless)
+  assert run.skipped_session_ids() == ("dddddddd-0000",)
+  rows = run.to_agent_event_rows(import_version="v1")
+  assert {row["session_id"] for row in rows} == {_SESSION_STUCK, _SESSION_GOLD}
+  scores = run.to_score_rows(import_version="v1")
+  assert {row["session_id"] for row in scores} == {
+      _SESSION_STUCK,
+      _SESSION_GOLD,
+  }
+
+
+# --- identity -------------------------------------------------------------
+
+
+def test_identity_is_first_8_with_collision_fallback_to_full_id() -> None:
+  colliding = [
+      _event("29ae300e-aaaa", "USER_MESSAGE_RECEIVED", {"text_summary": "a"}),
+      _event("29ae300e-bbbb", "USER_MESSAGE_RECEIVED", {"text_summary": "b"}),
+  ]
+  run = NativeAgentEventsRun.from_agent_events(
+      _stuck_events() + colliding,
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+  scores = run.to_score_rows(import_version="v1")
+  assert {row["session_id"]: row["scenario_id"] for row in scores} == {
+      _SESSION_STUCK: "7e352c34",
+      "29ae300e-aaaa": "29ae300e-aaaa",
+      "29ae300e-bbbb": "29ae300e-bbbb",
+  }
+
+
+# --- no EvalBench source tables on the native path ------------------------
+
+
+def test_native_run_refuses_evalbench_source_rows() -> None:
+  with pytest.raises(ValueError, match="no EvalBench source tables"):
+    NativeAgentEventsRun(
+        project_id=_SOURCE_PROJECT,
+        evalbench_dataset="bqaa_e2e_real",
+        job_id=_JOB_ID,
+        results=({"eval_id": "x", "prompt": "y"},),
+        source_table=_SOURCE_TABLE,
+    )
+
+
+class _FakeReadClient:
+  """Read-only fake: records queries, returns the fixture rows once."""
+
+  def __init__(self, rows) -> None:
+    self.rows = list(rows)
+    self.calls: list[tuple[str, dict]] = []
+
+  def query(self, query: str, **kwargs) -> _FakeQueryJob:
+    self.calls.append((query, kwargs))
+    return _FakeQueryJob(self.rows)
+
+
+def test_from_bigquery_reads_only_the_agent_events_table() -> None:
+  fake = _FakeReadClient(_stuck_events() + _gold_events())
+  run = NativeAgentEventsRun.from_bigquery(
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+      session_ids=[_SESSION_STUCK, _SESSION_GOLD],
+      bq_client=fake,
+  )
+  ((query, kwargs),) = fake.calls
+  assert query.startswith("SELECT")
+  assert f"`{_SOURCE_TABLE}`" in query
+  assert "session_id IN UNNEST(@session_ids)" in query
+  for evalbench_source in (".configs`", ".results`", ".scores`"):
+    assert evalbench_source not in query
+  assert kwargs["job_config"].labels["sdk_feature"] == (
+      "evalbench-native-import"
+  )
+  assert len(run.source_events) == 8
+  assert run.results == () and run.scores == () and run.config_rows == ()
+
+
+def test_publish_never_touches_the_source_dataset() -> None:
+  fake = _FakeWriteClient()
+  _materialize(_acceptance_run(), fake)
+  for query, _ in fake.queries:
+    assert "bqaa_e2e_real" not in query
+  for destination, _, _ in fake.loads:
+    assert "bqaa_e2e_real" not in destination
+
+
+# --- production agent_events is never written -----------------------------
+
+
+def test_reserved_agent_events_destination_is_rejected() -> None:
+  run = _acceptance_run()
+  with pytest.raises(ValueError, match="reserved ADK plugin table"):
+    run.materialize(
+        target_dataset="bqaa_native",
+        events_table="agent_events",
+        bq_client=_FakeWriteClient(),
+    )
+
+
+def test_nothing_is_written_into_an_agent_events_table() -> None:
+  fake = _FakeWriteClient()
+  _materialize(_acceptance_run(), fake)
+  written = (
+      [ref for ref, _, _ in fake.loads]
+      + fake.created
+      + [query for query, _ in fake.queries if not query.startswith("SELECT")]
+  )
+  for target in written:
+    assert _SOURCE_TABLE not in target
+    for segment in target.replace("`", " ").replace("\n", " ").split():
+      assert not segment.endswith(".agent_events")
+
+
+# --- the six-week clock does not start ------------------------------------
+
+
+def test_native_publication_does_not_start_the_clock() -> None:
+  fake = _FakeWriteClient()
+  result = _materialize(_acceptance_run(), fake)
+  payload = json.dumps(result.to_dict()).lower()
+  assert "clock" not in payload
+  rubric = json.loads((_FIXTURE_DIR / "week0_real_rubric.json").read_text())
+  assert rubric["clock_started"] is False

--- a/tests/test_week0_real_freeze.py
+++ b/tests/test_week0_real_freeze.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the REAL Week 0 freeze artifacts (#435).
+
+The freeze PR lands the real partner record, the fail-closed D4 memo, the
+G1 taxonomy v0.1.0 freeze, and the preregistration freeze-candidate —
+distinct from the slice-10 EXAMPLE pack, which stays illustrative
+(``example: true`` / ``g1_frozen: false``). Freezing is not a clock start:
+every real fixture says ``clock_started: false``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOCS = _REPO_ROOT / "docs"
+_FIXTURE_DIR = _REPO_ROOT / "examples" / "fixtures"
+
+_REAL_FIXTURES = (
+    "week0_real_partner.json",
+    "week0_real_rubric.json",
+    "week0_real_d4_memo.json",
+    "week0_real_taxonomy.json",
+    "week0_real_preregistration.json",
+)
+
+_EXAMPLE_FIXTURES = (
+    "week0_example_partner.json",
+    "week0_example_rubric.json",
+    "week0_example_d4_memo.json",
+    "week0_example_preregistration.json",
+    "week0_example_taxonomy_seed.json",
+)
+
+_FREEZE_DOCS = (
+    "week0_partner.md",
+    "week0_d4_memo.md",
+    "week0_g1_taxonomy.md",
+    "week0_preregistration.md",
+)
+
+_SESSION_ID = "7e352c34-4c1c-4395-acd5-fb3c8f215346"
+
+
+def _real(name: str) -> dict:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  # Every real freeze fixture is example: false and does not start the
+  # six-week clock.
+  assert data["example"] is False
+  assert data["clock_started"] is False
+  return data
+
+
+# --- production module is frozen ------------------------------------------
+
+
+def test_production_taxonomy_is_g1_frozen_at_v0_1_0() -> None:
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  config = failure_taxonomy.taxonomy_config()
+  assert config["g1_frozen"] is True
+  assert config["taxonomy_version"] == "0.1.0"
+
+
+def test_widget_session_flags_map_to_frozen_names_in_frozen_order() -> None:
+  # The widget-stock pilot session trips all three mechanical flags.
+  row = {
+      "session_id": _SESSION_ID,
+      "process_failed": True,
+      "missing_completion": True,
+      "score_failed": True,
+  }
+  assert failure_taxonomy.categorize_failed_session(row) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
+
+
+# --- real fixtures --------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _REAL_FIXTURES)
+def test_real_fixtures_are_not_examples_and_do_not_start_the_clock(
+    name: str,
+) -> None:
+  _real(name)
+
+
+def test_real_taxonomy_fixture_matches_the_production_freeze() -> None:
+  data = _real("week0_real_taxonomy.json")
+  assert data["g1_frozen"] is True
+  assert data["taxonomy_version"] == "0.1.0"
+  assert tuple(data["frozen_category_names"]) == (
+      failure_taxonomy.FROZEN_CATEGORY_NAMES
+  )
+  assert tuple(data["mechanical_flags"]) == failure_taxonomy.MECHANICAL_FLAGS
+  assert data["flag_to_category"] == dict(failure_taxonomy.FLAG_TO_CATEGORY)
+  assert data["dialects"] == []
+  widget = data["widget_session"]
+  assert widget["session_id"] == _SESSION_ID
+  assert tuple(widget["taxonomy_categories"]) == (
+      failure_taxonomy.categorize_failed_session(
+          {flag: True for flag in failure_taxonomy.MECHANICAL_FLAGS}
+      )
+  )
+
+
+def test_real_partner_is_bqaa_not_acme_and_not_a_sana_fork() -> None:
+  data = _real("week0_real_partner.json")
+  assert "Google Cloud BigQuery Agent Analytics" in data["partner_name"]
+  assert data["not_a_sana_fork"] is True
+  assert data["not_a_named_sana_collaboration"] is True
+  assert "not duplicating" in data["not_duplicating_lakeqa_kramabench"]
+  assert data["route"]["evalbench_only_mvp_route_correct"] is True
+  assert data["route"]["d1_needs_redecision"] is False
+  assert data["pilot"]["evalbench_job_id"] == "mvp-e2e-real-traces"
+  assert "Acme" not in json.dumps(data)
+
+
+def test_real_partner_doc_has_no_acme() -> None:
+  text = (_DOCS / "week0_partner.md").read_text()
+  assert "Acme" not in text
+  assert "Google Cloud BigQuery Agent Analytics" in text
+  assert "not a SANA fork" in text
+  assert "not duplicating" in text
+
+
+def test_real_rubric_pins_the_widget_session_and_gold() -> None:
+  data = _real("week0_real_rubric.json")
+  assert data["session_id"] == _SESSION_ID
+  assert data["eval_id"] == "7e352c34"
+  assert data["job_id"] == "mvp-e2e-real-traces"
+  assert data["gold"]["sibling_session"] == "ab7535a5"
+  assert data["gold"]["gold_answer"] == "There are 0 widgets in stock."
+  assert data["score"]["metric"] == "goal_completion"
+  assert data["score"]["failed_session_score"] == 0
+  assert data["score"]["gold_session_score"] == 1
+
+
+def test_real_d4_memo_is_fail_closed_with_one_named_consumer() -> None:
+  data = _real("week0_real_d4_memo.json")
+  assert data["fail_closed"] is True
+  assert data["report_consumers"] == [
+      "Hai-Yuan Cao (caohy1988 / haiyuan-eng-google)"
+  ]
+  assert data["scope_project"] == "test-project-0728-467323"
+  assert set(data["scope_datasets"]) == {
+      "bqaa_e2e_real",
+      "bqaa_evalbench_mvp_demo",
+      "bqaa_evalbench_mvp_mirror",
+  }
+  assert data["never_produces"] == "Part II funding recommendation"
+  assert data["no_new_live_judge_calls"] is True
+  assert data["no_new_bq_jobs"] is True
+  assert data["no_labeler_access_expansion"] is True
+  assert data["stop_go_memo_is_governed_artifact"] is True
+  assert "no IAM API calls" in data["grants_policy"]
+  # No fabricated people from the example pack.
+  memo_text = json.dumps(data)
+  assert "Alex Rivera" not in memo_text
+  assert "Jordan Lee" not in memo_text
+
+
+def test_real_preregistration_copies_the_v4_floors_without_a_clock() -> None:
+  data = _real("week0_real_preregistration.json")
+  assert data["freeze_candidate"] is True
+  assert data["not_week_1_execution"] is True
+  floors = data["floors"]
+  assert floors["replicate_agreement_pct"] == 80
+  assert floors["non_unknown_coverage_pct"] == 80
+  assert floors["kappa_point"] == 0.6
+  assert floors["kappa_ci_lower"] == 0.45
+  assert floors["localization_coverage_pct"] == 70
+  assert floors["hit_at_1_ci_lower_gt_0"] is True
+  assert floors["hit_at_1_point_uplift_pp"] == 10
+  for rule in (
+      "reserved_revision_week",
+      "value_gate",
+      "noisy_small_n_localization",
+      "sealed_sets",
+  ):
+    assert data["decision_rules"][rule]
+
+
+# --- the example pack stays example ---------------------------------------
+
+
+@pytest.mark.parametrize("name", _EXAMPLE_FIXTURES)
+def test_example_fixtures_are_still_present_and_still_examples(
+    name: str,
+) -> None:
+  data = json.loads((_FIXTURE_DIR / name).read_text())
+  assert data["example"] is True
+  assert data["g1_frozen"] is False
+  assert data["clock_started"] is False
+
+
+def test_example_pack_shell_and_md_are_still_present() -> None:
+  assert (_REPO_ROOT / "examples" / "evalbench_week0_full_idea.sh").is_file()
+  assert (_REPO_ROOT / "examples" / "evalbench_week0_full_idea.md").is_file()
+
+
+# --- docs -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _FREEZE_DOCS)
+def test_freeze_docs_exist_and_do_not_start_the_clock(name: str) -> None:
+  text = (_DOCS / name).read_text()
+  assert (
+      "NOT started" in text
+      or "not started" in text
+      or ("has **not** started" in text)
+  )
+  assert "first Week 1 snapshot job" in text


### PR DESCRIPTION
Implements #463 (parent: #435): a **native `agent_events` snapshot writer** — the EvalBench-adapter **exit ramp**. The `evalbench-import` adapter (#97) **stays** as an optional on-ramp; nothing is deleted.

## Stacking (do not merge; review only)

- **Stacked on the #461 freeze HEAD `2c4804b`** so the frozen G1 taxonomy v0.1.0 (`src/bigquery_agent_analytics/failure_taxonomy.py`, `g1_frozen: true`) is importable. Base is merged #455 plus the 461 freeze stack (458–461), so GitHub shows those commits vs `main` — expected.
- **Explicitly does NOT include or merge #456, #457, or #462** (the post-freeze e2e demo). The unique #463 commit is `e438c0e` on top of `2c4804b`.
- **Do not merge** this PR as part of review; human gate is @haiyuan-eng-google.

## What it does

`bigquery_agent_analytics.native_events.NativeAgentEventsRun` (plus thin CLI `bq-agent-sdk evalbench-native-import`) starts from production ADK `agent_events` rows and publishes the **same BQAA-owned contract `EvalBenchRun.materialize` already produces** — it *subclasses* `EvalBenchRun` and inherits `materialize` verbatim (staging, lock, publish transaction, manifest, view sync), overriding only the inputs:

- **Pin identity:** the same `(job_id, import_version)` tuple on snapshot event rows, score rows, and the manifest row; the `failed_sessions` view body is `failed_sessions_sql` with the pin rendered as literals for the **latest successful native publication** (newest committed manifest row; `generation_id` + `view_policy` pin the body exactly as the adapter does). Job for this slice: `mvp-e2e-real-traces`.
- **No EvalBench source tables in the path:** no `configs` / `results` / `scores` reads anywhere; the constructor fail-closes if EvalBench source rows are passed. `evalbench-import` remains untouched.
- **Joinable identity:** scenario id / `eval_id` is the first eight characters of the ADK `session_id` (`7e352c34` from `7e352c34-4c1c-4395-acd5-fb3c8f215346`), falling back to the full id on collision; published rows keep the **real** ADK `session_id`, so the same session is the same object with or without the adapter.
- **Native scores + policy:** score rows live in the BQAA-owned snapshot scores table (same schema the adapter writes) and are derived **deterministically from the session** — `goal_completion` is `1.0` iff the session logged `AGENT_COMPLETED`, `0.0` otherwise (*completed*, not *passed*). The gate is the existing `EvalScorePolicy` — `goal_completion` / `min_score` 1.0 / `missing_score_fails: true` per the frozen rubric (`examples/fixtures/week0_real_rubric.json`) — persisted as canonical JSON on the manifest `view_policy`. A never-completed session publishes the same ERROR-status prompt-row marker the adapter publishes for `returncode != 0`, so `process_failed` holds.
- **G1 mapping (frozen v0.1.0, imported, not reimplemented):** `missing_completion` → `finalization`, `process_failed` → `tool blockers`, `score_failed` → `task/planning`; names come back in frozen order. The widget-stock silence session `7e352c34` yields `task/planning`, `finalization`, `tool blockers`, and the deterministic punchline next-action names the missing answer and the never-called `check_inventory`.
- **Never writes production `agent_events`:** the source table is only read (SELECT-only), and the inherited reserved-name guard rejects `agent_events` as a destination before any BigQuery call.

## Tests

**Fixture-only, offline** — `tests/test_native_events_writer.py` + `tests/test_cli_evalbench_native_import.py` (19 new tests; 331 pass across the evalbench suites). No live BigQuery, no jobs, no IAM, no live/LLM judge, no `--synth`. Covered: the widget-stock acceptance (all three G1 names), pin identity on events/scores/manifest, view pinned to the latest successful native publication, the frozen policy pin, first-8 identity with collision fallback, no-EvalBench-tables and no-`agent_events`-writes guards, skipped promptless sessions, and clock-not-started.

## Boundaries

- **Clock OFF:** this PR does **not** start the six-week clock, seal the preregistration, or kick a Week 1 snapshot job.
- **D4 fail-closed:** consumer remains **Hai-Yuan Cao only**.
- Docs: one short exit-ramp pointer in `docs/agentforensics_mvp_plan.md`; CHANGELOG bullet at the top of Unreleased → Added.
