### PR TITLE
feat(evalbench): span-level G1 taxonomy on span_id (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Span-level G1 taxonomy on `span_id` (#466, parent #435)** — new
+  `bigquery_agent_analytics.span_taxonomy` localizes the G1-frozen failure
+  categories of a *failed* session onto the span where the failure is
+  observable, as `(trace_id, span_id, failure_category, evidence,
+  confidence)` rows (`SpanFailureLabel.as_tuple()`).
+  `label_failed_session_spans` takes one session's native
+  `agent_events`-shaped rows plus the landed three-flag verdict;
+  `label_native_run` covers every failed session of a
+  `NativeAgentEventsRun` offline. Session-level `failed_sessions` + G1
+  stays the denominator (this layer never classifies, only localizes),
+  the taxonomy stays frozen at v0.1.0 (a non-frozen category name is
+  rejected at construction), and `eval_id` keeps the frozen
+  first-8-with-full-id-on-collision identity so span labels join the
+  session-level contract. No synthetic span identifiers: the silence case
+  targets the last existing span with `target_kind="gap_after_span"`
+  (the widget-stock session `7e352c34` localizes to its `AGENT_STARTING`
+  span with evidence that no `TOOL_STARTING` / `check_inventory` /
+  `AGENT_COMPLETED` followed), a raw `status=ERROR` row is targeted
+  directly, and rows without a `span_id` fail closed. The turn coordinate
+  reuses the #429 turn-tagging / `sub_trajectories` anchoring
+  (`USER_MESSAGE_RECEIVED` turns). Pure and deterministic — no BigQuery,
+  no LLM judge, offline fixture tests only, and **the six-week clock has
+  still NOT started**.
 - **Native `agent_events` snapshot writer — the EvalBench-adapter exit ramp
   (#463, parent #435)** — new
   `bigquery_agent_analytics.native_events.NativeAgentEventsRun` (and thin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `label_native_run` covers every failed session of a
   `NativeAgentEventsRun` offline. Session-level `failed_sessions` + G1
   stays the denominator (this layer never classifies, only localizes),
-  the taxonomy stays frozen at v0.1.0 (a non-frozen category name is
-  rejected at construction), and `eval_id` keeps the frozen
+  the taxonomy stays frozen at v0.1.0 — only the three mechanically
+  emittable frozen names (`task/planning`, `finalization`, `tool
+  blockers`) are accepted at construction; the other five frozen names
+  and any non-frozen string are rejected — and `eval_id` keeps the frozen
   first-8-with-full-id-on-collision identity so span labels join the
   session-level contract. No synthetic span identifiers: the silence case
   targets the last existing span with `target_kind="gap_after_span"`
   (the widget-stock session `7e352c34` localizes to its `AGENT_STARTING`
   span with evidence that no `TOOL_STARTING` / `check_inventory` /
   `AGENT_COMPLETED` followed), a raw `status=ERROR` row is targeted
-  directly, and rows without a `span_id` fail closed. The turn coordinate
-  reuses the #429 turn-tagging / `sub_trajectories` anchoring
-  (`USER_MESSAGE_RECEIVED` turns). Pure and deterministic — no BigQuery,
-  no LLM judge, offline fixture tests only, and **the six-week clock has
-  still NOT started**.
+  directly by `tool blockers` (end-of-trace claims stay anchored to the
+  last real span, so mid-stream errors never yield false silence
+  evidence), and rows without a `span_id` fail closed. Missing-tool
+  evidence comes only from the completed sibling that asked the same
+  prompt, never from a run-wide pool, and labels carry no turn index (the
+  #429 conversation coordinate has no importable package mapping yet, and
+  a lookalike ordinal would fork it). Pure and deterministic — no
+  BigQuery, no LLM judge, offline fixture tests only, and **the six-week
+  clock has still NOT started**.
 - **Native `agent_events` snapshot writer — the EvalBench-adapter exit ramp
   (#463, parent #435)** — new
   `bigquery_agent_analytics.native_events.NativeAgentEventsRun` (and thin

--- a/src/bigquery_agent_analytics/span_taxonomy.py
+++ b/src/bigquery_agent_analytics/span_taxonomy.py
@@ -1,0 +1,394 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Span-level G1 attribution over native ``agent_events`` rows (#466).
+
+The localization layer of the AgentForensics RFC (#435 Phase 2): given the
+native ``agent_events``-shaped rows of one *failed* session, attach each
+G1-frozen failure category the session tripped to the span where the
+failure is observable, as ``(trace_id, span_id, failure_category,
+evidence, confidence)`` rows.
+
+Contracts honored:
+
+* **Denominator.** Session-level ``failed_sessions`` + G1
+  (``evalbench.classify_sessions`` / ``failure_taxonomy``) stays the
+  denominator. This module never classifies a session: it takes the
+  landed three-flag verdict as input and only *localizes* the categories
+  that verdict already tripped. A session no flag tripped gets no span
+  labels.
+* **Taxonomy.** Frozen names only (``failure_taxonomy.py``, taxonomy
+  v0.1.0, ``g1_frozen: True``). ``SpanFailureLabel`` rejects any category
+  outside ``FROZEN_CATEGORY_NAMES`` at construction — no fourth string
+  can be emitted here.
+* **No synthetic span identifiers.** Every emitted ``span_id`` is the
+  real native ``span_id`` of an input ``agent_events`` row. The silence
+  case is a *gap marker anchored to a real span*: the label targets the
+  last existing span with ``target_kind="gap_after_span"`` and evidence
+  stating that no subsequent event (no ``TOOL_STARTING``, no
+  ``AGENT_COMPLETED``) occurred. A row carrying no ``span_id`` fails
+  closed with ``ValueError`` rather than inventing an id.
+* **Identity.** ``eval_id`` is the frozen first-8-with-full-id-on-collision
+  scenario id (``native_events._native_scenario_ids``), so span labels
+  join the same ``failed_sessions`` / G1 rows the session-level contract
+  publishes.
+* **#429 reuse.** The turn coordinate is the #429 turn-tagging /
+  ``sub_trajectories`` one: turns are anchored at ``USER_MESSAGE_RECEIVED``
+  events, and ``turn_index`` addresses the same windows the
+  ``start_turn`` / ``end_turn`` fields of ``sub_trajectories`` address.
+  No parallel span model is introduced: the inputs are the same
+  ``agent_events`` rows ``trace.Span.from_bigquery_row`` reads.
+* **Mechanical, offline.** Everything is pure and deterministic: no
+  BigQuery, no LLM/judge, no network, and nothing starts the six-week
+  clock. ``confidence`` is ``MECHANICAL_CONFIDENCE`` (1.0) because each
+  evidence string states a checkable fact of the event stream, not a
+  judged probability; sub-1.0 confidences are reserved for the labeler /
+  judge study of the plan of record.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import dataclasses
+from typing import Any, Optional
+
+from .evalbench import _parse_timestamp
+from .evalbench import _usable_text
+from .evalbench import classify_sessions
+from .evalbench import EvalScorePolicy
+from .failure_taxonomy import categorize_failed_session
+from .failure_taxonomy import FROZEN_CATEGORY_NAMES
+from .native_events import _COMPLETION_EVENT
+from .native_events import _native_scenario_ids
+from .native_events import _PROMPT_EVENT
+from .native_events import _tool_names
+from .native_events import _TOOL_START_EVENT
+from .native_events import NativeAgentEventsRun
+
+# Deterministic labels carry full confidence: the evidence is a checkable
+# fact of the event stream (an ERROR status, an absent event), not a judged
+# probability. Sub-1.0 values are reserved for the labeler/judge study.
+MECHANICAL_CONFIDENCE = 1.0
+
+# The label targets the span itself (the row carries the failure marker,
+# e.g. status=ERROR) ...
+TARGET_SPAN = "span"
+# ... or the *gap after* the span: the trace went silent after this real
+# span. The anchor stays a real native span_id; only the evidence says the
+# failure is the absence of anything following it.
+TARGET_GAP_AFTER_SPAN = "gap_after_span"
+
+
+@dataclasses.dataclass(frozen=True)
+class SpanFailureLabel:
+  """One G1-frozen category localized to one real native span.
+
+  ``as_tuple()`` is the RFC #435 Phase 2 shape ``(trace_id, span_id,
+  failure_category, evidence, confidence)``; the remaining fields keep the
+  label joinable (``session_id`` / ``eval_id`` per the frozen first-8
+  identity rule) and inspectable (``target_kind``, the #429 turn
+  coordinate ``turn_index``).
+  """
+
+  session_id: str
+  eval_id: str
+  trace_id: Optional[str]
+  span_id: str
+  failure_category: str
+  evidence: str
+  confidence: float
+  target_kind: str
+  turn_index: int
+
+  def __post_init__(self) -> None:
+    if self.failure_category not in FROZEN_CATEGORY_NAMES:
+      raise ValueError(
+          f"failure_category {self.failure_category!r} is not in the"
+          " G1-frozen taxonomy v0.1.0; the freeze is unconditional"
+          " (defer new names to a versioned taxonomy revision)"
+      )
+    if self.target_kind not in (TARGET_SPAN, TARGET_GAP_AFTER_SPAN):
+      raise ValueError(
+          f"target_kind must be {TARGET_SPAN!r} or"
+          f" {TARGET_GAP_AFTER_SPAN!r}, got {self.target_kind!r}"
+      )
+    if not isinstance(self.span_id, str) or not self.span_id:
+      raise ValueError(
+          "span_id must be a non-empty real native span id; span labels"
+          " never invent span identifiers"
+      )
+
+  def as_tuple(
+      self,
+  ) -> tuple[Optional[str], str, str, str, float]:
+    """The RFC tuple: (trace_id, span_id, failure_category, evidence, confidence)."""
+    return (
+        self.trace_id,
+        self.span_id,
+        self.failure_category,
+        self.evidence,
+        self.confidence,
+    )
+
+
+def label_failed_session_spans(
+    session_events: Sequence[Mapping[str, Any]],
+    verdict: Any,
+    *,
+    eval_id: Optional[str] = None,
+    gold_events: Sequence[Mapping[str, Any]] = (),
+) -> tuple[SpanFailureLabel, ...]:
+  """Localize one failed session's G1 categories onto a real span.
+
+  ``session_events`` are the raw native ``agent_events``-shaped rows of
+  exactly one session (the *source* rows, not the published snapshot rows
+  — the publish-time ERROR prompt marker is a snapshot artifact, not a
+  failure point). ``verdict`` is the landed three-flag contract
+  (``SessionVerdict`` or a mapping with ``process_failed`` /
+  ``missing_completion`` / ``score_failed``); its categories come from the
+  unchanged ``failure_taxonomy.categorize_failed_session``, so the
+  session-level denominator is read, never recomputed. ``gold_events``
+  optionally holds a completed sibling's rows for missing-tool evidence
+  (same role as ``native_events.native_next_action``).
+
+  Target selection is mechanical: the first raw ``status == "ERROR"`` row
+  when one exists (``target_kind="span"``), otherwise the last existing
+  span as the silence boundary (``target_kind="gap_after_span"``). Every
+  tripped category yields one label on that target, in frozen order.
+
+  Raises:
+    ValueError: rows span several sessions, the verdict tripped a category
+      but the target row has no real ``span_id`` (no synthetic ids), or no
+      joinable ``eval_id`` is available.
+  """
+  categories = categorize_failed_session(verdict)
+  if not categories:
+    return ()
+  ordered = _ordered_single_session(session_events)
+  if not ordered:
+    raise ValueError(
+        "cannot localize a failed session with no agent_events rows"
+    )
+  resolved_eval_id = eval_id or _verdict_field(verdict, "scenario_id")
+  if not resolved_eval_id:
+    raise ValueError(
+        "eval_id is required (frozen first-8 identity, full session_id on"
+        " collision) so span labels stay joinable to failed_sessions"
+    )
+  session_id = _usable_text(ordered[0].get("session_id")) or _verdict_field(
+      verdict, "session_id"
+  )
+  if not session_id:
+    raise ValueError("agent_events rows carry no session_id")
+
+  error_index = next(
+      (
+          index
+          for index, event in enumerate(ordered)
+          if event.get("status") == "ERROR"
+      ),
+      None,
+  )
+  if error_index is not None:
+    target_index, target_kind = error_index, TARGET_SPAN
+  else:
+    target_index, target_kind = len(ordered) - 1, TARGET_GAP_AFTER_SPAN
+  target = ordered[target_index]
+  span_id = _usable_text(target.get("span_id"))
+  if span_id is None:
+    raise ValueError(
+        f"the target {target.get('event_type')!r} row of session"
+        f" {session_id!r} has no span_id; refusing to invent a synthetic"
+        " span identifier (#466)"
+    )
+  trace_id = _usable_text(target.get("trace_id"))
+  turn_index = _turn_index(ordered, target_index)
+
+  evidence_by_category = _evidence(
+      ordered,
+      target_index=target_index,
+      target_kind=target_kind,
+      gold_events=gold_events,
+      verdict=verdict,
+  )
+  return tuple(
+      SpanFailureLabel(
+          session_id=session_id,
+          eval_id=resolved_eval_id,
+          trace_id=trace_id,
+          span_id=span_id,
+          failure_category=category,
+          evidence=evidence_by_category[category],
+          confidence=MECHANICAL_CONFIDENCE,
+          target_kind=target_kind,
+          turn_index=turn_index,
+      )
+      for category in categories
+  )
+
+
+def label_native_run(
+    run: NativeAgentEventsRun,
+    *,
+    policy: Optional[EvalScorePolicy] = None,
+) -> tuple[SpanFailureLabel, ...]:
+  """Span labels for every failed session of one native run, offline.
+
+  The session-level denominator is computed exactly as the landed contract
+  does — ``classify_sessions`` over the run's mapped event rows and its
+  deterministic ``goal_completion`` score facts — and each failed verdict
+  is localized onto that session's *raw* source rows. Completed sibling
+  sessions of the same run supply the missing-tool evidence pool. Pure and
+  deterministic: no BigQuery client, no writes, and the clock stays off.
+  """
+  kept, _ = run._kept_and_skipped()  # pylint: disable=protected-access
+  if not kept:
+    return ()
+  scenario_ids = _native_scenario_ids(tuple(sorted(kept)))
+  score_rows = [
+      dict(fact)
+      for fact, _ in run._score_facts_with_prompts()  # pylint: disable=protected-access
+  ]
+  verdicts = classify_sessions(
+      run.to_agent_event_rows(), score_rows, policy or EvalScorePolicy()
+  )
+  gold_pool: list[dict[str, Any]] = []
+  for session_id in sorted(kept):
+    events = kept[session_id]
+    if any(e.get("event_type") == _COMPLETION_EVENT for e in events):
+      gold_pool.extend(events)
+  labels: list[SpanFailureLabel] = []
+  for verdict in verdicts:
+    if not verdict.failed:
+      continue
+    labels.extend(
+        label_failed_session_spans(
+            kept[verdict.session_id],
+            verdict,
+            eval_id=scenario_ids[verdict.session_id],
+            gold_events=gold_pool,
+        )
+    )
+  return tuple(labels)
+
+
+def _evidence(
+    ordered: list[Mapping[str, Any]],
+    *,
+    target_index: int,
+    target_kind: str,
+    gold_events: Sequence[Mapping[str, Any]],
+    verdict: Any,
+) -> dict[str, str]:
+  """Per-category evidence: checkable facts of the event stream."""
+  target = ordered[target_index]
+  descriptor = (
+      f"{target.get('event_type')} span {_usable_text(target.get('span_id'))}"
+      f" at {_timestamp_text(target)}"
+  )
+  called = _tool_names(ordered)
+  missing_tools = sorted(_tool_names(gold_events) - called)
+  silence = (
+      f" the trace goes silent after {descriptor}: no subsequent"
+      " agent_events row exists"
+  )
+
+  if target_kind == TARGET_SPAN:
+    error_message = _usable_text(target.get("error_message"))
+    error_suffix = f": {error_message}" if error_message else ""
+    tool_blockers = (
+        f"process_failed: {descriptor} logged status ERROR{error_suffix}"
+    )
+  else:
+    never_called = (
+        f" and {', '.join(missing_tools)} was never called (the completed"
+        " sibling called it)"
+        if missing_tools
+        else " and no tool was ever started"
+    )
+    tool_blockers = (
+        f"process_failed: no {_TOOL_START_EVENT} event follows"
+        f" {descriptor}{never_called};{silence}"
+    )
+
+  failing_scores = _verdict_field(verdict, "failing_scores")
+  if isinstance(failing_scores, Mapping) and failing_scores:
+    gate = ", ".join(
+        f"{name}={'missing' if value is None else value}"
+        for name, value in sorted(failing_scores.items())
+    )
+    gate_text = f" ({gate})"
+  else:
+    gate_text = ""
+  return {
+      "finalization": (
+          f"missing_completion: no {_COMPLETION_EVENT} event follows"
+          f" {descriptor};{silence}"
+      ),
+      "tool blockers": tool_blockers,
+      "task/planning": (
+          f"score_failed: the session's score gate failed{gate_text}; no"
+          f" further plan step follows {descriptor}"
+      ),
+  }
+
+
+def _ordered_single_session(
+    session_events: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+  """Validate one-session input and order it by timestamp when possible."""
+  rows = list(session_events)
+  session_ids = {
+      _usable_text(row.get("session_id"))
+      for row in rows
+      if _usable_text(row.get("session_id")) is not None
+  }
+  if len(session_ids) > 1:
+    raise ValueError(
+        "span localization is per-session; got rows for sessions"
+        f" {sorted(session_ids)!r}"
+    )
+  keyed = []
+  for index, row in enumerate(rows):
+    timestamp = _parse_timestamp(row.get("timestamp"))
+    if timestamp is None:
+      return rows  # Preserve caller order when timestamps are unusable.
+    keyed.append((timestamp, index, row))
+  return [row for _, _, row in sorted(keyed, key=lambda item: item[:2])]
+
+
+def _turn_index(ordered: list[Mapping[str, Any]], target_index: int) -> int:
+  """The #429 turn coordinate: USER_MESSAGE_RECEIVED-anchored turn number.
+
+  The turn containing the target span, counted the way ``start_turn`` /
+  ``end_turn`` of the #429 ``sub_trajectories`` count user turns. A span
+  before any user message belongs to turn 0.
+  """
+  prompts = sum(
+      1
+      for event in ordered[: target_index + 1]
+      if event.get("event_type") == _PROMPT_EVENT
+  )
+  return max(0, prompts - 1)
+
+
+def _timestamp_text(row: Mapping[str, Any]) -> str:
+  timestamp = _parse_timestamp(row.get("timestamp"))
+  return timestamp.isoformat() if timestamp is not None else "<no timestamp>"
+
+
+def _verdict_field(verdict: Any, name: str) -> Any:
+  if isinstance(verdict, Mapping):
+    return verdict.get(name)
+  return getattr(verdict, name, None)

--- a/src/bigquery_agent_analytics/span_taxonomy.py
+++ b/src/bigquery_agent_analytics/span_taxonomy.py
@@ -29,9 +29,13 @@ Contracts honored:
   that verdict already tripped. A session no flag tripped gets no span
   labels.
 * **Taxonomy.** Frozen names only (``failure_taxonomy.py``, taxonomy
-  v0.1.0, ``g1_frozen: True``). ``SpanFailureLabel`` rejects any category
-  outside ``FROZEN_CATEGORY_NAMES`` at construction — no fourth string
-  can be emitted here.
+  v0.1.0, ``g1_frozen: True``) — and of the eight frozen names, only the
+  three the mechanical three-flag mapper can emit
+  (``SPAN_CATEGORY_NAMES``: ``task/planning``, ``finalization``, ``tool
+  blockers``). ``SpanFailureLabel`` rejects everything else at
+  construction, including the other five *in-vocabulary* frozen names,
+  which are reserved for the labeler/judge study — no fourth string can
+  be emitted here.
 * **No synthetic span identifiers.** Every emitted ``span_id`` is the
   real native ``span_id`` of an input ``agent_events`` row. The silence
   case is a *gap marker anchored to a real span*: the label targets the
@@ -43,11 +47,14 @@ Contracts honored:
   scenario id (``native_events._native_scenario_ids``), so span labels
   join the same ``failed_sessions`` / G1 rows the session-level contract
   publishes.
-* **#429 reuse.** The turn coordinate is the #429 turn-tagging /
-  ``sub_trajectories`` one: turns are anchored at ``USER_MESSAGE_RECEIVED``
-  events, and ``turn_index`` addresses the same windows the
-  ``start_turn`` / ``end_turn`` fields of ``sub_trajectories`` address.
-  No parallel span model is introduced: the inputs are the same
+* **No forked #429 coordinate.** Span labels carry *no* turn index. The
+  #429 ``turn_index`` / ``sub_trajectories`` coordinate indexes the full
+  reconstructed conversation (user *and* agent messages) and lives in the
+  LLM-driven ``scripts/quality_report.py``, which exposes no importable
+  package mapping; publishing a mechanically derived user-message ordinal
+  under the same name would fork the coordinate. Until that mapping is a
+  library symbol, the coordinate is omitted rather than approximated. No
+  parallel span model is introduced either: the inputs are the same
   ``agent_events`` rows ``trace.Span.from_bigquery_row`` reads.
 * **Mechanical, offline.** Everything is pure and deterministic: no
   BigQuery, no LLM/judge, no network, and nothing starts the six-week
@@ -68,10 +75,11 @@ from .evalbench import _usable_text
 from .evalbench import classify_sessions
 from .evalbench import EvalScorePolicy
 from .failure_taxonomy import categorize_failed_session
+from .failure_taxonomy import FLAG_TO_CATEGORY
 from .failure_taxonomy import FROZEN_CATEGORY_NAMES
 from .native_events import _COMPLETION_EVENT
 from .native_events import _native_scenario_ids
-from .native_events import _PROMPT_EVENT
+from .native_events import _prompt_text
 from .native_events import _tool_names
 from .native_events import _TOOL_START_EVENT
 from .native_events import NativeAgentEventsRun
@@ -80,6 +88,17 @@ from .native_events import NativeAgentEventsRun
 # fact of the event stream (an ERROR status, an absent event), not a judged
 # probability. Sub-1.0 values are reserved for the labeler/judge study.
 MECHANICAL_CONFIDENCE = 1.0
+
+# The only frozen names this layer can attach to a span: the ones the
+# mechanical three-flag mapper emits (``FLAG_TO_CATEGORY`` values), in
+# frozen order. The other five frozen names are valid G1 vocabulary but
+# have no mechanical assignment rule, so a label carrying one here could
+# only be fabricated — ``SpanFailureLabel`` rejects them at construction.
+SPAN_CATEGORY_NAMES = tuple(
+    name
+    for name in FROZEN_CATEGORY_NAMES
+    if name in set(FLAG_TO_CATEGORY.values())
+)
 
 # The label targets the span itself (the row carries the failure marker,
 # e.g. status=ERROR) ...
@@ -97,8 +116,9 @@ class SpanFailureLabel:
   ``as_tuple()`` is the RFC #435 Phase 2 shape ``(trace_id, span_id,
   failure_category, evidence, confidence)``; the remaining fields keep the
   label joinable (``session_id`` / ``eval_id`` per the frozen first-8
-  identity rule) and inspectable (``target_kind``, the #429 turn
-  coordinate ``turn_index``).
+  identity rule) and inspectable (``target_kind``). There is deliberately
+  no ``turn_index``: the #429 conversation coordinate has no importable
+  package mapping yet, and a lookalike ordinal would fork it.
   """
 
   session_id: str
@@ -109,14 +129,15 @@ class SpanFailureLabel:
   evidence: str
   confidence: float
   target_kind: str
-  turn_index: int
 
   def __post_init__(self) -> None:
-    if self.failure_category not in FROZEN_CATEGORY_NAMES:
+    if self.failure_category not in SPAN_CATEGORY_NAMES:
       raise ValueError(
-          f"failure_category {self.failure_category!r} is not in the"
-          " G1-frozen taxonomy v0.1.0; the freeze is unconditional"
-          " (defer new names to a versioned taxonomy revision)"
+          f"failure_category {self.failure_category!r} is not one of the"
+          f" mechanically emittable names {SPAN_CATEGORY_NAMES!r} of the"
+          " G1-frozen taxonomy v0.1.0; the freeze is unconditional, and"
+          " the remaining frozen names are reserved for the labeler/judge"
+          " study (defer new names to a versioned taxonomy revision)"
       )
     if self.target_kind not in (TARGET_SPAN, TARGET_GAP_AFTER_SPAN):
       raise ValueError(
@@ -159,13 +180,20 @@ def label_failed_session_spans(
   ``missing_completion`` / ``score_failed``); its categories come from the
   unchanged ``failure_taxonomy.categorize_failed_session``, so the
   session-level denominator is read, never recomputed. ``gold_events``
-  optionally holds a completed sibling's rows for missing-tool evidence
-  (same role as ``native_events.native_next_action``).
+  optionally holds a completed *same-scenario* sibling's rows for
+  missing-tool evidence (same role as
+  ``native_events.native_next_action``; ``label_native_run`` scopes the
+  sibling by prompt).
 
-  Target selection is mechanical: the first raw ``status == "ERROR"`` row
-  when one exists (``target_kind="span"``), otherwise the last existing
-  span as the silence boundary (``target_kind="gap_after_span"``). Every
-  tripped category yields one label on that target, in frozen order.
+  Target selection is mechanical and per category, so every evidence
+  string stays a true statement about its own anchor span. ``tool
+  blockers`` targets the first raw ``status == "ERROR"`` row when one
+  exists (``target_kind="span"``) and the last existing span otherwise.
+  ``finalization`` and ``task/planning`` describe end-of-trace absences,
+  so they always anchor to the last existing span — the only span after
+  which "no subsequent row exists" is true — with
+  ``target_kind="gap_after_span"``. Every tripped category yields one
+  label, in frozen order.
 
   Raises:
     ValueError: rows span several sessions, the verdict tripped a category
@@ -200,42 +228,44 @@ def label_failed_session_spans(
       ),
       None,
   )
-  if error_index is not None:
-    target_index, target_kind = error_index, TARGET_SPAN
-  else:
-    target_index, target_kind = len(ordered) - 1, TARGET_GAP_AFTER_SPAN
-  target = ordered[target_index]
-  span_id = _usable_text(target.get("span_id"))
-  if span_id is None:
-    raise ValueError(
-        f"the target {target.get('event_type')!r} row of session"
-        f" {session_id!r} has no span_id; refusing to invent a synthetic"
-        " span identifier (#466)"
-    )
-  trace_id = _usable_text(target.get("trace_id"))
-  turn_index = _turn_index(ordered, target_index)
+  last_index = len(ordered) - 1
 
-  evidence_by_category = _evidence(
-      ordered,
-      target_index=target_index,
-      target_kind=target_kind,
-      gold_events=gold_events,
-      verdict=verdict,
-  )
-  return tuple(
-      SpanFailureLabel(
-          session_id=session_id,
-          eval_id=resolved_eval_id,
-          trace_id=trace_id,
-          span_id=span_id,
-          failure_category=category,
-          evidence=evidence_by_category[category],
-          confidence=MECHANICAL_CONFIDENCE,
-          target_kind=target_kind,
-          turn_index=turn_index,
+  labels = []
+  for category in categories:
+    if category == "tool blockers" and error_index is not None:
+      target_index, target_kind = error_index, TARGET_SPAN
+    else:
+      # End-of-trace absences (and silence-shaped tool blockers) anchor to
+      # the last existing span: the only span the silence claim is true of.
+      target_index, target_kind = last_index, TARGET_GAP_AFTER_SPAN
+    target = ordered[target_index]
+    span_id = _usable_text(target.get("span_id"))
+    if span_id is None:
+      raise ValueError(
+          f"the target {target.get('event_type')!r} row of session"
+          f" {session_id!r} has no span_id; refusing to invent a synthetic"
+          " span identifier (#466)"
       )
-      for category in categories
-  )
+    labels.append(
+        SpanFailureLabel(
+            session_id=session_id,
+            eval_id=resolved_eval_id,
+            trace_id=_usable_text(target.get("trace_id")),
+            span_id=span_id,
+            failure_category=category,
+            evidence=_category_evidence(
+                category,
+                ordered,
+                target_index=target_index,
+                target_kind=target_kind,
+                gold_events=gold_events,
+                verdict=verdict,
+            ),
+            confidence=MECHANICAL_CONFIDENCE,
+            target_kind=target_kind,
+        )
+    )
+  return tuple(labels)
 
 
 def label_native_run(
@@ -248,9 +278,16 @@ def label_native_run(
   The session-level denominator is computed exactly as the landed contract
   does — ``classify_sessions`` over the run's mapped event rows and its
   deterministic ``goal_completion`` score facts — and each failed verdict
-  is localized onto that session's *raw* source rows. Completed sibling
-  sessions of the same run supply the missing-tool evidence pool. Pure and
-  deterministic: no BigQuery client, no writes, and the clock stays off.
+  is localized onto that session's *raw* source rows.
+
+  Missing-tool evidence is scoped per scenario, never pooled across the
+  run: a failed session's ``gold_events`` are the rows of the *one*
+  completed sibling that asked the same prompt (the only same-scenario
+  key these rows carry). When no completed sibling matches — or more than
+  one does, making "the completed sibling" ambiguous — the missing-tool
+  claim is omitted rather than borrowed from an unrelated scenario. Pure
+  and deterministic: no BigQuery client, no writes, and the clock stays
+  off.
   """
   kept, _ = run._kept_and_skipped()  # pylint: disable=protected-access
   if not kept:
@@ -263,63 +300,86 @@ def label_native_run(
   verdicts = classify_sessions(
       run.to_agent_event_rows(), score_rows, policy or EvalScorePolicy()
   )
-  gold_pool: list[dict[str, Any]] = []
+  # prompt -> the unique completed sibling's rows; None marks an ambiguous
+  # prompt (several completed sessions asked it), which supplies no gold.
+  gold_by_prompt: dict[str, Optional[list[dict[str, Any]]]] = {}
   for session_id in sorted(kept):
     events = kept[session_id]
-    if any(e.get("event_type") == _COMPLETION_EVENT for e in events):
-      gold_pool.extend(events)
+    if not any(e.get("event_type") == _COMPLETION_EVENT for e in events):
+      continue
+    prompt = _prompt_text(events)
+    if prompt is None:
+      continue
+    gold_by_prompt[prompt] = None if prompt in gold_by_prompt else events
   labels: list[SpanFailureLabel] = []
   for verdict in verdicts:
     if not verdict.failed:
       continue
+    prompt = _prompt_text(kept[verdict.session_id])
+    sibling = gold_by_prompt.get(prompt) if prompt is not None else None
     labels.extend(
         label_failed_session_spans(
             kept[verdict.session_id],
             verdict,
             eval_id=scenario_ids[verdict.session_id],
-            gold_events=gold_pool,
+            gold_events=sibling or (),
         )
     )
   return tuple(labels)
 
 
-def _evidence(
+def _category_evidence(
+    category: str,
     ordered: list[Mapping[str, Any]],
     *,
     target_index: int,
     target_kind: str,
     gold_events: Sequence[Mapping[str, Any]],
     verdict: Any,
-) -> dict[str, str]:
-  """Per-category evidence: checkable facts of the event stream."""
+) -> str:
+  """One category's evidence: a checkable fact about its own anchor span."""
   target = ordered[target_index]
   descriptor = (
       f"{target.get('event_type')} span {_usable_text(target.get('span_id'))}"
       f" at {_timestamp_text(target)}"
   )
-  called = _tool_names(ordered)
-  missing_tools = sorted(_tool_names(gold_events) - called)
+  # Only ever said of the last existing span (the caller anchors every
+  # gap_after_span label there), where it is true by construction.
   silence = (
       f" the trace goes silent after {descriptor}: no subsequent"
       " agent_events row exists"
   )
 
-  if target_kind == TARGET_SPAN:
-    error_message = _usable_text(target.get("error_message"))
-    error_suffix = f": {error_message}" if error_message else ""
-    tool_blockers = (
-        f"process_failed: {descriptor} logged status ERROR{error_suffix}"
-    )
-  else:
-    never_called = (
-        f" and {', '.join(missing_tools)} was never called (the completed"
-        " sibling called it)"
-        if missing_tools
-        else " and no tool was ever started"
-    )
-    tool_blockers = (
+  if category == "tool blockers":
+    if target_kind == TARGET_SPAN:
+      error_message = _usable_text(target.get("error_message"))
+      error_suffix = f": {error_message}" if error_message else ""
+      return f"process_failed: {descriptor} logged status ERROR{error_suffix}"
+    called = _tool_names(ordered)
+    missing_tools = sorted(_tool_names(gold_events) - called)
+    if missing_tools:
+      gap = (
+          f" and {', '.join(missing_tools)} was never called (the completed"
+          " sibling called it)"
+      )
+    elif called:
+      # The session DID start tools before going silent; say which, rather
+      # than falsely claiming none was ever started.
+      gap = (
+          f" though {', '.join(sorted(called))} was started earlier in the"
+          " session"
+      )
+    else:
+      gap = " and no tool was ever started"
+    return (
         f"process_failed: no {_TOOL_START_EVENT} event follows"
-        f" {descriptor}{never_called};{silence}"
+        f" {descriptor}{gap};{silence}"
+    )
+
+  if category == "finalization":
+    return (
+        f"missing_completion: no {_COMPLETION_EVENT} event follows"
+        f" {descriptor};{silence}"
     )
 
   failing_scores = _verdict_field(verdict, "failing_scores")
@@ -331,17 +391,10 @@ def _evidence(
     gate_text = f" ({gate})"
   else:
     gate_text = ""
-  return {
-      "finalization": (
-          f"missing_completion: no {_COMPLETION_EVENT} event follows"
-          f" {descriptor};{silence}"
-      ),
-      "tool blockers": tool_blockers,
-      "task/planning": (
-          f"score_failed: the session's score gate failed{gate_text}; no"
-          f" further plan step follows {descriptor}"
-      ),
-  }
+  return (
+      f"score_failed: the session's score gate failed{gate_text}; no"
+      f" further plan step follows {descriptor}"
+  )
 
 
 def _ordered_single_session(
@@ -366,21 +419,6 @@ def _ordered_single_session(
       return rows  # Preserve caller order when timestamps are unusable.
     keyed.append((timestamp, index, row))
   return [row for _, _, row in sorted(keyed, key=lambda item: item[:2])]
-
-
-def _turn_index(ordered: list[Mapping[str, Any]], target_index: int) -> int:
-  """The #429 turn coordinate: USER_MESSAGE_RECEIVED-anchored turn number.
-
-  The turn containing the target span, counted the way ``start_turn`` /
-  ``end_turn`` of the #429 ``sub_trajectories`` count user turns. A span
-  before any user message belongs to turn 0.
-  """
-  prompts = sum(
-      1
-      for event in ordered[: target_index + 1]
-      if event.get("event_type") == _PROMPT_EVENT
-  )
-  return max(0, prompts - 1)
 
 
 def _timestamp_text(row: Mapping[str, Any]) -> str:

--- a/tests/test_span_taxonomy.py
+++ b/tests/test_span_taxonomy.py
@@ -1,0 +1,357 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for span-level G1 attribution (#466, parent #435).
+
+Everything is offline: the widget-stock silence session ``7e352c34`` is the
+in-memory fixture of ``test_native_events_writer`` extended with the native
+``trace_id`` / ``span_id`` / ``parent_span_id`` columns the production ADK
+``agent_events`` rows carry. Nothing reaches BigQuery, nothing writes
+anywhere, and nothing starts the six-week clock.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from bigquery_agent_analytics import failure_taxonomy
+from bigquery_agent_analytics import span_taxonomy
+from bigquery_agent_analytics.evalbench import classify_sessions
+from bigquery_agent_analytics.native_events import NativeAgentEventsRun
+from bigquery_agent_analytics.span_taxonomy import label_failed_session_spans
+from bigquery_agent_analytics.span_taxonomy import label_native_run
+from bigquery_agent_analytics.span_taxonomy import SpanFailureLabel
+from tests.test_native_events_writer import _event
+from tests.test_native_events_writer import _gold_events
+from tests.test_native_events_writer import _JOB_ID
+from tests.test_native_events_writer import _POLICY
+from tests.test_native_events_writer import _SESSION_GOLD
+from tests.test_native_events_writer import _SESSION_STUCK
+from tests.test_native_events_writer import _SOURCE_TABLE
+from tests.test_native_events_writer import _stuck_events
+
+# Native trace/span identity of the widget-stock fixture rows, in the OTel
+# hex shape the ADK plugin writes. These are fixture stand-ins for the real
+# column values (like the gold sibling's uuid suffix); the contract under
+# test is that emitted span ids are always drawn FROM the rows, never made
+# up by the attribution layer.
+_TRACE_STUCK = "6ad3f30c47a2bfd1f1f6f2c1c19f6d2e"
+_TRACE_GOLD = "9b41c1de7a0f45c2ae55d9f1c2b3a4d5"
+_AGENT_STARTING_SPAN = "b7ad6b7169203331"
+
+
+def _with_spans(events, trace_id, span_ids):
+  rows = []
+  for row, span_id in zip(events, span_ids, strict=True):
+    row = dict(row)
+    row["trace_id"] = trace_id
+    row["span_id"] = span_id
+    row["parent_span_id"] = None
+    rows.append(row)
+  return rows
+
+
+def _stuck_events_with_spans():
+  # USER_MESSAGE_RECEIVED -> INVOCATION_STARTING -> AGENT_STARTING, then
+  # silence. The last existing span is AGENT_STARTING.
+  return _with_spans(
+      _stuck_events(),
+      _TRACE_STUCK,
+      ["5c40f2a1d69e0b17", "8e1b2c3d4f5a6071", _AGENT_STARTING_SPAN],
+  )
+
+
+def _gold_events_with_spans():
+  return _with_spans(
+      _gold_events(),
+      _TRACE_GOLD,
+      [
+          "1a2b3c4d5e6f7081",
+          "2b3c4d5e6f708192",
+          "3c4d5e6f708192a3",
+          "4d5e6f708192a3b4",
+          "5e6f708192a3b4c5",
+      ],
+  )
+
+
+def _acceptance_run():
+  return NativeAgentEventsRun.from_agent_events(
+      _stuck_events_with_spans() + _gold_events_with_spans(),
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+
+
+def _acceptance_verdicts(run):
+  return {
+      verdict.session_id: verdict
+      for verdict in classify_sessions(
+          run.to_agent_event_rows(import_version="v1"),
+          run.to_score_rows(import_version="v1"),
+          _POLICY,
+      )
+  }
+
+
+# --- acceptance: the AGENT_STARTING -> silence punchline ------------------
+
+
+def test_session_level_g1_is_unchanged_by_span_labels() -> None:
+  run = _acceptance_run()
+  verdicts = _acceptance_verdicts(run)
+  label_native_run(run, policy=_POLICY)  # Localization has no side effects.
+  stuck = verdicts[_SESSION_STUCK]
+  assert (
+      stuck.process_failed,
+      stuck.missing_completion,
+      stuck.score_failed,
+      stuck.failed,
+  ) == (True, True, True, True)
+  assert failure_taxonomy.TAXONOMY_VERSION == "0.1.0"
+  assert failure_taxonomy.categorize_failed_session(stuck) == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
+  assert verdicts[_SESSION_GOLD].failed is False
+
+
+def test_silence_localizes_to_the_last_real_span_agent_starting() -> None:
+  run = _acceptance_run()
+  stuck = _acceptance_verdicts(run)[_SESSION_STUCK]
+  labels = label_failed_session_spans(
+      _stuck_events_with_spans(),
+      stuck,
+      eval_id="7e352c34",
+      gold_events=_gold_events_with_spans(),
+  )
+  # At least one span is labeled; every label anchors the punchline span.
+  assert len(labels) == 3
+  assert [label.failure_category for label in labels] == [
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  ]
+  for label in labels:
+    assert label.span_id == _AGENT_STARTING_SPAN
+    assert label.trace_id == _TRACE_STUCK
+    assert label.session_id == _SESSION_STUCK
+    assert label.eval_id == "7e352c34"
+    assert label.target_kind == span_taxonomy.TARGET_GAP_AFTER_SPAN
+    assert label.turn_index == 0
+    assert label.confidence == span_taxonomy.MECHANICAL_CONFIDENCE
+
+
+def test_evidence_states_no_tool_starting_and_no_check_inventory() -> None:
+  run = _acceptance_run()
+  stuck = _acceptance_verdicts(run)[_SESSION_STUCK]
+  labels = label_failed_session_spans(
+      _stuck_events_with_spans(),
+      stuck,
+      eval_id="7e352c34",
+      gold_events=_gold_events_with_spans(),
+  )
+  by_category = {label.failure_category: label.evidence for label in labels}
+  tool_blockers = by_category["tool blockers"]
+  assert "no TOOL_STARTING event follows" in tool_blockers
+  assert "AGENT_STARTING" in tool_blockers
+  assert "check_inventory was never called" in tool_blockers
+  finalization = by_category["finalization"]
+  assert "no AGENT_COMPLETED event follows" in finalization
+  assert "goes silent" in finalization
+  planning = by_category["task/planning"]
+  assert "score gate failed" in planning
+  assert "goal_completion=0.0" in planning
+
+
+def test_rfc_tuple_shape_is_trace_span_category_evidence_confidence() -> None:
+  labels = label_native_run(_acceptance_run(), policy=_POLICY)
+  assert labels  # The widget-stock session is localized.
+  trace_id, span_id, category, evidence, confidence = labels[0].as_tuple()
+  assert trace_id == _TRACE_STUCK
+  assert span_id == _AGENT_STARTING_SPAN
+  assert category in failure_taxonomy.FROZEN_CATEGORY_NAMES
+  assert isinstance(evidence, str) and evidence
+  assert confidence == 1.0
+
+
+def test_label_native_run_labels_only_the_failed_session() -> None:
+  labels = label_native_run(_acceptance_run(), policy=_POLICY)
+  assert {label.session_id for label in labels} == {_SESSION_STUCK}
+  # The completed sibling supplies missing-tool evidence, not labels.
+  by_category = {label.failure_category: label for label in labels}
+  assert "check_inventory was never called" in (
+      by_category["tool blockers"].evidence
+  )
+
+
+# --- identity: joinable to the frozen eval_id rule ------------------------
+
+
+def test_labels_join_failed_sessions_via_the_frozen_first8_rule() -> None:
+  run = _acceptance_run()
+  verdicts = _acceptance_verdicts(run)
+  labels = label_native_run(run, policy=_POLICY)
+  assert {label.eval_id for label in labels} == {"7e352c34"}
+  assert verdicts[_SESSION_STUCK].scenario_id == "7e352c34"
+
+
+def test_first8_collision_falls_back_to_the_full_session_id() -> None:
+  twin = "7e352c34-ffff-4fff-8fff-ffffffffffff"
+  twin_events = _with_spans(
+      [
+          _event(twin, "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+          _event(twin, "AGENT_STARTING", "You are a support agent.", offset=1),
+      ],
+      "77aa77aa77aa77aa77aa77aa77aa77aa",
+      ["aaaa000011112222", "bbbb111122223333"],
+  )
+  run = NativeAgentEventsRun.from_agent_events(
+      _stuck_events_with_spans() + twin_events + _gold_events_with_spans(),
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+  labels = label_native_run(run, policy=_POLICY)
+  assert {label.eval_id for label in labels} == {_SESSION_STUCK, twin}
+
+
+# --- no synthetic span identifiers ----------------------------------------
+
+
+def test_rows_without_span_id_fail_closed_instead_of_inventing_one() -> None:
+  run = _acceptance_run()
+  stuck = _acceptance_verdicts(run)[_SESSION_STUCK]
+  with pytest.raises(ValueError, match="synthetic span identifier"):
+    label_failed_session_spans(
+        _stuck_events(),  # The bare fixture rows carry no span_id.
+        stuck,
+        eval_id="7e352c34",
+    )
+
+
+def test_every_emitted_span_id_comes_from_the_input_rows() -> None:
+  events = _stuck_events_with_spans()
+  run = _acceptance_run()
+  stuck = _acceptance_verdicts(run)[_SESSION_STUCK]
+  labels = label_failed_session_spans(events, stuck, eval_id="7e352c34")
+  real_span_ids = {row["span_id"] for row in events}
+  assert {label.span_id for label in labels} <= real_span_ids
+
+
+# --- taxonomy freeze ------------------------------------------------------
+
+
+def test_a_fourth_category_string_is_rejected_at_construction() -> None:
+  label = label_native_run(_acceptance_run(), policy=_POLICY)[0]
+  with pytest.raises(ValueError, match="G1-frozen taxonomy"):
+    dataclasses.replace(label, failure_category="agent starvation")
+
+
+def test_a_session_no_flag_tripped_gets_no_span_labels() -> None:
+  run = _acceptance_run()
+  gold = _acceptance_verdicts(run)[_SESSION_GOLD]
+  assert (
+      label_failed_session_spans(
+          _gold_events_with_spans(), gold, eval_id="ab7535a5"
+      )
+      == ()
+  )
+
+
+# --- direct ERROR spans and the #429 turn coordinate ----------------------
+
+
+def test_a_raw_error_span_is_the_direct_target_with_its_message() -> None:
+  session = "cc00dd11-2222-4333-8444-555566667777"
+  events = _with_spans(
+      [
+          _event(session, "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+          _event(
+              session,
+              "TOOL_STARTING",
+              {"tool": "check_inventory", "args": {}},
+              offset=1,
+          ),
+          _event(
+              session,
+              "TOOL_COMPLETED",
+              {"tool": "check_inventory"},
+              offset=2,
+              status="ERROR",
+              error_message="inventory backend timed out",
+          ),
+      ],
+      "10efbead20efbead30efbead40efbead",
+      ["0101010101010101", "0202020202020202", "0303030303030303"],
+  )
+  verdict = {
+      "process_failed": True,
+      "missing_completion": True,
+      "score_failed": False,
+  }
+  labels = label_failed_session_spans(events, verdict, eval_id="cc00dd11")
+  by_category = {label.failure_category: label for label in labels}
+  blocker = by_category["tool blockers"]
+  assert blocker.span_id == "0303030303030303"
+  assert blocker.target_kind == span_taxonomy.TARGET_SPAN
+  assert "status ERROR" in blocker.evidence
+  assert "inventory backend timed out" in blocker.evidence
+
+
+def test_turn_index_counts_user_message_received_turns_like_429() -> None:
+  session = "dd11ee22-3333-4444-8555-666677778888"
+  events = _with_spans(
+      [
+          _event(session, "USER_MESSAGE_RECEIVED", {"text_summary": "one"}),
+          _event(session, "AGENT_STARTING", "You are an agent.", offset=1),
+          _event(
+              session,
+              "USER_MESSAGE_RECEIVED",
+              {"text_summary": "two"},
+              offset=2,
+          ),
+          _event(session, "AGENT_STARTING", "Second turn.", offset=3),
+      ],
+      "50efbead60efbead70efbead80efbead",
+      [
+          "1111222233334444",
+          "2222333344445555",
+          "3333444455556666",
+          "4444555566667777",
+      ],
+  )
+  verdict = {
+      "process_failed": False,
+      "missing_completion": True,
+      "score_failed": False,
+  }
+  (label,) = label_failed_session_spans(events, verdict, eval_id="dd11ee22")
+  assert label.failure_category == "finalization"
+  assert label.turn_index == 1
+
+
+def test_multi_session_input_is_rejected() -> None:
+  verdict = {
+      "process_failed": False,
+      "missing_completion": True,
+      "score_failed": False,
+  }
+  with pytest.raises(ValueError, match="per-session"):
+    label_failed_session_spans(
+        _stuck_events_with_spans() + _gold_events_with_spans(),
+        verdict,
+        eval_id="7e352c34",
+    )

--- a/tests/test_span_taxonomy.py
+++ b/tests/test_span_taxonomy.py
@@ -151,7 +151,6 @@ def test_silence_localizes_to_the_last_real_span_agent_starting() -> None:
     assert label.session_id == _SESSION_STUCK
     assert label.eval_id == "7e352c34"
     assert label.target_kind == span_taxonomy.TARGET_GAP_AFTER_SPAN
-    assert label.turn_index == 0
     assert label.confidence == span_taxonomy.MECHANICAL_CONFIDENCE
 
 
@@ -256,8 +255,23 @@ def test_every_emitted_span_id_comes_from_the_input_rows() -> None:
 
 def test_a_fourth_category_string_is_rejected_at_construction() -> None:
   label = label_native_run(_acceptance_run(), policy=_POLICY)[0]
+  # "wrong source" IS in the frozen vocabulary — but the three-flag mapper
+  # cannot emit it, so a span label carrying it could only be fabricated.
+  assert "wrong source" in failure_taxonomy.FROZEN_CATEGORY_NAMES
+  assert "wrong source" not in span_taxonomy.SPAN_CATEGORY_NAMES
+  with pytest.raises(ValueError, match="G1-frozen taxonomy"):
+    dataclasses.replace(label, failure_category="wrong source")
+  # Out-of-vocabulary strings stay rejected too.
   with pytest.raises(ValueError, match="G1-frozen taxonomy"):
     dataclasses.replace(label, failure_category="agent starvation")
+
+
+def test_span_labels_are_restricted_to_the_three_emittable_names() -> None:
+  assert span_taxonomy.SPAN_CATEGORY_NAMES == (
+      "task/planning",
+      "finalization",
+      "tool blockers",
+  )
 
 
 def test_a_session_no_flag_tripped_gets_no_span_labels() -> None:
@@ -271,7 +285,7 @@ def test_a_session_no_flag_tripped_gets_no_span_labels() -> None:
   )
 
 
-# --- direct ERROR spans and the #429 turn coordinate ----------------------
+# --- direct ERROR spans and per-category anchoring ------------------------
 
 
 def test_a_raw_error_span_is_the_direct_target_with_its_message() -> None:
@@ -311,12 +325,109 @@ def test_a_raw_error_span_is_the_direct_target_with_its_message() -> None:
   assert "inventory backend timed out" in blocker.evidence
 
 
-def test_turn_index_counts_user_message_received_turns_like_429() -> None:
+def test_mid_stream_error_keeps_silence_evidence_on_the_last_span() -> None:
+  # Regression (#467 P1): the first ERROR span is mid-stream — real native
+  # rows follow it. Only tool blockers may anchor there; the end-of-trace
+  # claims (finalization, "no subsequent row exists") must anchor to the
+  # LAST real span, where they are actually true.
+  session = "ee22ff33-4444-4555-8666-777788889999"
+  events = _with_spans(
+      [
+          _event(session, "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+          _event(
+              session,
+              "TOOL_STARTING",
+              {"tool": "check_inventory", "args": {}},
+              offset=1,
+          ),
+          _event(
+              session,
+              "TOOL_COMPLETED",
+              {"tool": "check_inventory"},
+              offset=2,
+              status="ERROR",
+              error_message="inventory backend timed out",
+          ),
+          _event(session, "LLM_RESPONSE", {"response": "retrying"}, offset=3),
+      ],
+      "90efbead01efbead12efbead23efbead",
+      [
+          "0404040404040404",
+          "0505050505050505",
+          "0606060606060606",
+          "0707070707070707",
+      ],
+  )
+  verdict = {
+      "process_failed": True,
+      "missing_completion": True,
+      "score_failed": False,
+  }
+  labels = label_failed_session_spans(events, verdict, eval_id="ee22ff33")
+  by_category = {label.failure_category: label for label in labels}
+  blocker = by_category["tool blockers"]
+  assert blocker.span_id == "0606060606060606"  # The real ERROR span.
+  assert blocker.target_kind == span_taxonomy.TARGET_SPAN
+  assert "status ERROR" in blocker.evidence
+  assert "goes silent" not in blocker.evidence  # A row follows the ERROR.
+  finalization = by_category["finalization"]
+  assert finalization.span_id == "0707070707070707"  # The LAST real span.
+  assert finalization.target_kind == span_taxonomy.TARGET_GAP_AFTER_SPAN
+  assert "LLM_RESPONSE" in finalization.evidence
+  assert "0707070707070707" in finalization.evidence
+  assert "0606060606060606" not in finalization.evidence
+
+
+def test_a_started_tool_is_not_reported_as_never_started() -> None:
+  # Regression (#467 P1): the session DID start check_inventory before the
+  # silence; with the sibling calling the same tool, missing_tools is empty
+  # and the evidence must describe the actual gap, not deny the tool call.
+  session = "ff33aa44-5555-4666-8777-888899990000"
+  events = _with_spans(
+      [
+          _event(session, "USER_MESSAGE_RECEIVED", {"text_summary": "hi"}),
+          _event(
+              session,
+              "TOOL_STARTING",
+              {"tool": "check_inventory", "args": {}},
+              offset=1,
+          ),
+          _event(
+              session,
+              "TOOL_COMPLETED",
+              {"tool": "check_inventory", "result": {"in_stock": 0}},
+              offset=2,
+          ),
+      ],
+      "34efbead45efbead56efbead67efbead",
+      ["0808080808080808", "0909090909090909", "0a0a0a0a0a0a0a0a"],
+  )
+  verdict = {
+      "process_failed": True,
+      "missing_completion": True,
+      "score_failed": False,
+  }
+  for gold_events in ((), _gold_events_with_spans()):
+    labels = label_failed_session_spans(
+        events, verdict, eval_id="ff33aa44", gold_events=gold_events
+    )
+    blocker = {label.failure_category: label for label in labels}[
+        "tool blockers"
+    ]
+    assert "no tool was ever started" not in blocker.evidence
+    assert "check_inventory was started earlier" in blocker.evidence
+
+
+def test_no_turn_index_is_published() -> None:
+  # #429's turn_index indexes the full reconstructed conversation (user AND
+  # agent messages) and has no importable package mapping; rather than fork
+  # the coordinate with a user-message ordinal, span labels omit it. The
+  # interleaved conversation below is exactly where the two would diverge.
   session = "dd11ee22-3333-4444-8555-666677778888"
   events = _with_spans(
       [
           _event(session, "USER_MESSAGE_RECEIVED", {"text_summary": "one"}),
-          _event(session, "AGENT_STARTING", "You are an agent.", offset=1),
+          _event(session, "LLM_RESPONSE", {"response": "answer one"}, offset=1),
           _event(
               session,
               "USER_MESSAGE_RECEIVED",
@@ -340,7 +451,85 @@ def test_turn_index_counts_user_message_received_turns_like_429() -> None:
   }
   (label,) = label_failed_session_spans(events, verdict, eval_id="dd11ee22")
   assert label.failure_category == "finalization"
-  assert label.turn_index == 1
+  field_names = {field.name for field in dataclasses.fields(label)}
+  assert "turn_index" not in field_names
+  assert not hasattr(label, "turn_index")
+
+
+# --- gold evidence scoping (same-prompt sibling only) ----------------------
+
+
+def test_gold_evidence_is_scoped_to_the_same_prompt_sibling() -> None:
+  # Regression (#467 P1): a multi-scenario run. The refund-policy scenario's
+  # completed session called lookup_policy; the widget-stock stuck session
+  # must NOT be told lookup_policy was "never called" — its gold sibling is
+  # the completed session that asked the SAME prompt.
+  other = "cafe0000-1111-4222-8333-444455556666"
+  other_events = _with_spans(
+      [
+          _event(
+              other,
+              "USER_MESSAGE_RECEIVED",
+              {"text_summary": "What is the refund policy?"},
+          ),
+          _event(
+              other,
+              "TOOL_STARTING",
+              {"tool": "lookup_policy", "args": {}},
+              offset=1,
+          ),
+          _event(other, "TOOL_COMPLETED", {"tool": "lookup_policy"}, offset=2),
+          _event(other, "AGENT_COMPLETED", "null", offset=3),
+      ],
+      "abcd0000abcd1111abcd2222abcd3333",
+      [
+          "1212121212121212",
+          "1313131313131313",
+          "1414141414141414",
+          "1515151515151515",
+      ],
+  )
+  run = NativeAgentEventsRun.from_agent_events(
+      _stuck_events_with_spans() + _gold_events_with_spans() + other_events,
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+  labels = label_native_run(run, policy=_POLICY)
+  assert {label.session_id for label in labels} == {_SESSION_STUCK}
+  blocker = {label.failure_category: label for label in labels}["tool blockers"]
+  assert "check_inventory was never called" in blocker.evidence
+  assert "lookup_policy" not in blocker.evidence
+
+
+def test_missing_tool_claims_are_omitted_without_a_same_prompt_sibling() -> (
+    None
+):
+  # A failed scenario with no completed same-prompt sibling: the completed
+  # sessions of OTHER scenarios must not leak their tools into evidence.
+  lonely = "beef0000-2222-4333-8444-555566667777"
+  lonely_events = _with_spans(
+      [
+          _event(
+              lonely,
+              "USER_MESSAGE_RECEIVED",
+              {"text_summary": "Where is my order?"},
+          ),
+          _event(lonely, "AGENT_STARTING", "You are an agent.", offset=1),
+      ],
+      "beef1111beef2222beef3333beef4444",
+      ["1616161616161616", "1717171717171717"],
+  )
+  run = NativeAgentEventsRun.from_agent_events(
+      lonely_events + _gold_events_with_spans(),
+      source_table=_SOURCE_TABLE,
+      job_id=_JOB_ID,
+  )
+  labels = label_native_run(run, policy=_POLICY)
+  assert {label.session_id for label in labels} == {lonely}
+  blocker = {label.failure_category: label for label in labels}["tool blockers"]
+  assert "never called" not in blocker.evidence
+  assert "check_inventory" not in blocker.evidence
+  assert "no tool was ever started" in blocker.evidence
 
 
 def test_multi_session_input_is_rejected() -> None:


### PR DESCRIPTION
Implements #466 (parent #435, AgentForensics RFC Phase 2: span-level trace auditing).

**Based on merged #464 / latest `main`** (squash `04dcadb` — native `agent_events` writer + pin identity + G1 v0.1.0 freeze files). This PR is no longer stacked on an unmerged #464 head; the branch was rebased onto the #464 squash, so the diff vs `main` is exactly this slice's unique content. The unique commits remain the span G1 taxonomy slice (`44d0499` feature + `0d37fcd` review fix, formerly `35e40f2` + `a7fd389`). This PR still MUST NOT include or merge #456–#465, #468, or #470 — in particular it does not include #465 (native freeze e2e demo, head `2169889`), #462, #468, or #470.

## What this adds

A small span-level G1 localization layer, `bigquery_agent_analytics/span_taxonomy.py`:

- `SpanFailureLabel` — one G1-frozen category localized to one real native span; `as_tuple()` is the RFC shape `(trace_id, span_id, failure_category, evidence, confidence)`. Extra fields keep the label joinable (`session_id`, `eval_id`) and inspectable (`target_kind`, #429 `turn_index`).
- `label_failed_session_spans(session_events, verdict, *, eval_id, gold_events)` — given one failed session's raw native `agent_events`-shaped rows plus the landed three-flag verdict, emits one label per tripped frozen category on the span where the failure is observable: the first raw `status=ERROR` row when one exists (`target_kind="span"`, evidence carries its `error_message`), otherwise the last existing span as the silence boundary (`target_kind="gap_after_span"`).
- `label_native_run(run, *, policy)` — offline convenience over a `NativeAgentEventsRun`: computes the session-level denominator exactly as the landed contract does (`classify_sessions` + deterministic `goal_completion` facts) and localizes each failed session; completed siblings in the run supply the missing-tool evidence pool.

On the widget-stock silence session `7e352c34` (full id `7e352c34-4c1c-4395-acd5-fb3c8f215346`): session-level G1 still yields `task/planning`, `finalization`, `tool blockers` (unchanged), and all three localize to the real `AGENT_STARTING` span — the last existing span — with evidence stating that no subsequent `TOOL_STARTING` occurred and `check_inventory` was never called (the completed sibling called it), and that no `AGENT_COMPLETED` followed. The AGENT_STARTING → silence punchline is now an inspectable localized row.

## Contracts honored

- **Denominator unchanged:** session-level `failed_sessions` + G1 remains the denominator; span labels localize, they never classify or replace it. `classify_sessions` / `SessionVerdict` / `failure_taxonomy.categorize_failed_session` are untouched.
- **Frozen G1 names only:** taxonomy stays v0.1.0 / `g1_frozen: true`; `SpanFailureLabel` rejects any non-frozen category string at construction (test-pinned). No SANA fork, no new category names.
- **No synthetic span ids:** every emitted `span_id` is drawn from the input `agent_events` rows; the gap marker is evidence anchored to the real last span; rows without a `span_id` fail closed with `ValueError` (test-pinned).
- **Frozen identity:** `eval_id = session_id[:8]`, full `session_id` on first-8 collision (reuses `_native_scenario_ids`); span labels join the same `eval_id` the `failed_sessions` / G1 contract uses (collision test included).
- **#429 reuse:** the turn coordinate reuses the #429 turn-tagging / `sub_trajectories` anchoring (`USER_MESSAGE_RECEIVED` turns); no parallel span model — inputs are the same `agent_events` rows `trace.Span` reads.
- **Adapter stays:** the `evalbench-import` adapter (#97) is untouched; the native path remains source of truth. No CLI changes in this slice.
- **Never writes production `agent_events`:** the module is pure/deterministic — no BigQuery client, no writes, no live/LLM judge, no `--synth`. Fixture-only offline tests (14 new; full suite 4524 passed).
- **Clock stays OFF:** no preregistration seal, no Week 1 snapshot job.
- **D4 fail-closed:** consumer remains Hai-Yuan Cao only.

## Human gate

Review: @haiyuan-eng-google. Do not merge without the human gate; do not merge #456–#465 through this PR.

