### PR TITLE
feat: make skill evolution host runs auditable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Auditable skill-evolution host contract (#397)** —
+  `scripts/skill_evolution.py` now declares its supported integration surface
+  with `__all__` and documents the additive quality-report session contract;
+  incompatible session-schema changes must be recorded here. The host analyst
+  contract also marks user corrections as hypotheses that require tool
+  verification. Evolution patch artifacts now include `source: builtin|host`
+  for every quality-gated patch, so runs using `error_analyst_fn` can be audited
+  without changing the existing `collect_patches() -> list[str]` API.
 - **Span-level G1 labels persisted on the native snapshot (#469, parent
   #435)** — the existing `bq-agent-sdk evalbench-native-import` command
   gains a thin `--span-labels-table` flag (no new command family): when

--- a/scripts/skill_evolution.py
+++ b/scripts/skill_evolution.py
@@ -50,6 +50,7 @@ import argparse
 from collections import Counter
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 import json
 import logging
 import math
@@ -70,6 +71,15 @@ __all__ = [
     "partition_trajectories",
     "select_candidate",
 ]
+
+# ``collect_patches`` is an established replacement seam, so its signature and
+# exact ``list[str]`` result must stay unchanged. During ``evolve_skill`` only,
+# this context-local identity map carries provenance alongside the returned
+# string objects. Wrappers that reorder, filter, or deduplicate those objects
+# therefore retain correct provenance without receiving a new private keyword.
+_PATCH_PROVENANCE: ContextVar[Optional[dict[int, list[str]]]] = ContextVar(
+    "skill_evolution_patch_provenance", default=None
+)
 
 # Segment outcome icons shared by both sub-trajectory renderers.
 _SEGMENT_OUTCOME_ICONS = {"recovered": "+", "parroted": "~"}
@@ -1040,7 +1050,6 @@ def collect_patches(
     tools=None,
     error_analyst_fn: Optional[ErrorAnalystFn] = None,
     analyst_timeout_s: Optional[float] = None,
-    _patch_sources: Optional[list[str]] = None,
 ):
   """Run the analyst fleet over the report. Returns the list of kept patches.
 
@@ -1210,12 +1219,13 @@ def collect_patches(
     )
 
   kept = []
-  kept_sources = []
+  provenance = _PATCH_PROVENANCE.get()
   for patch, source in patches:
     reason = _quality_gate_reason(patch)
     if reason is None:
       kept.append(patch)
-      kept_sources.append(source)
+      if provenance is not None:
+        provenance.setdefault(id(patch), []).append(source)
     else:
       logger.warning("Quality gate rejected a patch (%s): %.80r", reason, patch)
   logger.info(
@@ -1223,8 +1233,6 @@ def collect_patches(
       len(patches),
       len(kept),
   )
-  if _patch_sources is not None:
-    _patch_sources.extend(kept_sources)
   return kept
 
 
@@ -1425,29 +1433,34 @@ def evolve_skill(
   # applies to standalone collect_patches usage only.
   client = client or _make_client(project, location)
 
-  patch_sources: list[str] = []
-  patches = collect_patches(
-      report,
-      current_skill,
-      client=client,
-      model=model,
-      max_workers=max_workers,
-      max_success_samples=max_success_samples,
-      analyst_mode=analyst_mode,
-      tools=tools,
-      error_analyst_fn=error_analyst_fn,
-      analyst_timeout_s=analyst_timeout_s,
-      _patch_sources=patch_sources,
-  )
+  patch_provenance: dict[int, list[str]] = {}
+  provenance_token = _PATCH_PROVENANCE.set(patch_provenance)
+  try:
+    patches = collect_patches(
+        report,
+        current_skill,
+        client=client,
+        model=model,
+        max_workers=max_workers,
+        max_success_samples=max_success_samples,
+        analyst_mode=analyst_mode,
+        tools=tools,
+        error_analyst_fn=error_analyst_fn,
+        analyst_timeout_s=analyst_timeout_s,
+    )
+  finally:
+    _PATCH_PROVENANCE.reset(provenance_token)
   if not patches:
     logger.warning("No patches to consolidate; returning the current skill.")
     return current_skill
-  # Older hosts and tests may replace ``collect_patches`` with a compatible
-  # callable that returns ``list[str]`` but does not know about the private
-  # provenance sink. Preserve that extension pattern and conservatively label
-  # those patches as builtin-generated.
-  if not patch_sources:
-    patch_sources = ["builtin"] * len(patches)
+  # Plain strings from a legacy replacement have no recorded provenance, so use
+  # the conservative builtin fallback. Identity-retaining wrappers around the
+  # SDK collector resolve through the context map even when they reorder or
+  # filter the result.
+  patch_sources = []
+  for patch in patches:
+    sources = patch_provenance.get(id(patch), [])
+    patch_sources.append(sources.pop(0) if sources else "builtin")
 
   logger.info("Generating %d candidate(s)...", candidates)
   cands = []

--- a/scripts/skill_evolution.py
+++ b/scripts/skill_evolution.py
@@ -36,6 +36,14 @@ Or run as a CLI:
 Auth: uses Vertex AI via the google-genai client. Set GOOGLE_CLOUD_PROJECT and
 GOOGLE_CLOUD_LOCATION (or pass project/location), and authenticate with ADC
 (gcloud auth application-default login).
+
+Host contract: integrations should import only the names listed in ``__all__``.
+``evolve_skill`` and ``collect_patches`` accept the quality-report session
+mapping described in their docstrings; new optional session fields are additive,
+and any incompatible schema change must be called out in ``CHANGELOG.md``.
+``error_analyst_fn`` is the supported extension seam for failure analysis and
+must return patch text or ``None``. The public return value of
+``collect_patches`` remains ``list[str]``.
 """
 
 import argparse
@@ -53,6 +61,15 @@ from typing import Any, Callable, Optional
 # Host analyst signature: fn(client, model, session, current_skill, tools)
 # -> patch text or None (see collect_patches).
 ErrorAnalystFn = Callable[[Any, str, dict, str, Optional[str]], Optional[str]]
+
+__all__ = [
+    "ErrorAnalystFn",
+    "collect_patches",
+    "evolve_skill",
+    "format_trajectory",
+    "partition_trajectories",
+    "select_candidate",
+]
 
 # Segment outcome icons shared by both sub-trajectory renderers.
 _SEGMENT_OUTCOME_ICONS = {"recovered": "+", "parroted": "~"}
@@ -639,12 +656,14 @@ def _write_evolution_artifacts(
     current_skill,
     version_label="v1",
     selection_note=None,
+    patch_sources=None,
 ):
   """Persist the engine's intermediate reasoning for inspection/audit.
 
   When ``evolve_skill`` is given ``artifacts_dir`` it writes, under that dir
   (``<label>`` is ``version_label``, so a V1->V2 round writes ``v2_*``):
-    - ``<label>_patches.json``  -- every analyst patch (root-cause category + text)
+    - ``<label>_patches.json``  -- every analyst patch (source, root-cause
+                                   category, and text)
     - ``<label>_candidates/``   -- each best-of-N consolidation candidate (the
                                    chosen one tagged ``_SELECTED``)
     - ``<label>_prevalence.txt``-- root-cause category tally across the patches
@@ -653,14 +672,26 @@ def _write_evolution_artifacts(
   """
   os.makedirs(artifacts_dir, exist_ok=True)
 
+  if patch_sources is None:
+    patch_sources = ["builtin"] * len(patches)
+  if len(patch_sources) != len(patches):
+    raise ValueError("patch_sources must align one-to-one with patches")
+  unexpected_sources = set(patch_sources) - {"builtin", "host"}
+  if unexpected_sources:
+    raise ValueError(
+        "patch_sources entries must be 'builtin' or 'host'; got"
+        f" {sorted(unexpected_sources)!r}"
+    )
+
   records = []
-  for i, patch in enumerate(patches):
+  for i, (patch, source) in enumerate(zip(patches, patch_sources)):
     match = re.search(r"## Root Cause\s*\n\s*\[?(\w+)\]?", patch) or re.search(
         r"## Pattern\s*\n\s*\[?(\w+)\]?", patch
     )
     records.append(
         {
             "index": i + 1,
+            "source": source,
             "category": match.group(1) if match else None,
             "patch": patch,
         }
@@ -1009,6 +1040,7 @@ def collect_patches(
     tools=None,
     error_analyst_fn: Optional[ErrorAnalystFn] = None,
     analyst_timeout_s: Optional[float] = None,
+    _patch_sources: Optional[list[str]] = None,
 ):
   """Run the analyst fleet over the report. Returns the list of kept patches.
 
@@ -1030,7 +1062,10 @@ def collect_patches(
       with a warning and counts as a host failure. If EVERY host call
       fails, collect_patches raises RuntimeError instead of degrading a
       broken host analyst into a clean-looking zero-patch run (partial
-      failures stay tolerated).
+      failures stay tolerated). Host analysts must treat
+      ``correction_boundaries[*].correct_fact`` as an unverified user
+      hypothesis: verify it with available tools and never copy it into a
+      patch as fact.
     analyst_timeout_s: Optional per-analyst timeout in seconds. A call
       exceeding it is treated like any other analyst failure (warning,
       skipped) and QUARANTINED: its daemon thread may linger until the
@@ -1066,7 +1101,7 @@ def collect_patches(
     failures = []
   successes = successes[:max_success_samples]
 
-  patches = []
+  patches: list[tuple[str, str]] = []
   # Dispatch goes through _AnalystCall + a lazy dispatcher thread rather than
   # a ThreadPoolExecutor: a timed-out call is quarantined and its slot handed
   # to the next queued analyst (within the bounded donation budget), so one
@@ -1163,7 +1198,7 @@ def collect_patches(
             question,
         )
       continue
-    patches.append(result)
+    patches.append((result, "host" if is_host else "builtin"))
 
   if error_analyst_fn is not None and host_total and host_failed == host_total:
     raise RuntimeError(
@@ -1175,10 +1210,12 @@ def collect_patches(
     )
 
   kept = []
-  for patch in patches:
+  kept_sources = []
+  for patch, source in patches:
     reason = _quality_gate_reason(patch)
     if reason is None:
       kept.append(patch)
+      kept_sources.append(source)
     else:
       logger.warning("Quality gate rejected a patch (%s): %.80r", reason, patch)
   logger.info(
@@ -1186,6 +1223,8 @@ def collect_patches(
       len(patches),
       len(kept),
   )
+  if _patch_sources is not None:
+    _patch_sources.extend(kept_sources)
   return kept
 
 
@@ -1386,6 +1425,7 @@ def evolve_skill(
   # applies to standalone collect_patches usage only.
   client = client or _make_client(project, location)
 
+  patch_sources: list[str] = []
   patches = collect_patches(
       report,
       current_skill,
@@ -1397,10 +1437,17 @@ def evolve_skill(
       tools=tools,
       error_analyst_fn=error_analyst_fn,
       analyst_timeout_s=analyst_timeout_s,
+      _patch_sources=patch_sources,
   )
   if not patches:
     logger.warning("No patches to consolidate; returning the current skill.")
     return current_skill
+  # Older hosts and tests may replace ``collect_patches`` with a compatible
+  # callable that returns ``list[str]`` but does not know about the private
+  # provenance sink. Preserve that extension pattern and conservatively label
+  # those patches as builtin-generated.
+  if not patch_sources:
+    patch_sources = ["builtin"] * len(patches)
 
   logger.info("Generating %d candidate(s)...", candidates)
   cands = []
@@ -1469,6 +1516,7 @@ def evolve_skill(
         current_skill,
         version_label=version_label,
         selection_note=selection_note,
+        patch_sources=patch_sources,
     )
   return selected
 

--- a/scripts/skill_evolution.py
+++ b/scripts/skill_evolution.py
@@ -77,8 +77,8 @@ __all__ = [
 # this context-local identity map carries provenance alongside the returned
 # string objects. Wrappers that reorder, filter, or deduplicate those objects
 # therefore retain correct provenance without receiving a new private keyword.
-_PATCH_PROVENANCE: ContextVar[Optional[dict[int, list[str]]]] = ContextVar(
-    "skill_evolution_patch_provenance", default=None
+_PATCH_PROVENANCE: ContextVar[Optional[dict[int, tuple[str, str]]]] = (
+    ContextVar("skill_evolution_patch_provenance", default=None)
 )
 
 # Segment outcome icons shared by both sub-trajectory renderers.
@@ -1223,9 +1223,17 @@ def collect_patches(
   for patch, source in patches:
     reason = _quality_gate_reason(patch)
     if reason is None:
-      kept.append(patch)
+      # Each accepted occurrence needs its own identity: host and builtin
+      # analysts may return the same cached string object. Prefix-and-slice
+      # creates an equal, exact ``str`` without encoding assumptions.
+      kept_patch = (" " + patch)[1:]
+      kept.append(kept_patch)
       if provenance is not None:
-        provenance.setdefault(id(patch), []).append(source)
+        # Keep a strong reference for the map's lifetime so a wrapper can
+        # discard this patch without letting Python recycle its ID for a later
+        # collection. The identity check at lookup closes the other half of
+        # that invariant.
+        provenance[id(kept_patch)] = (kept_patch, source)
     else:
       logger.warning("Quality gate rejected a patch (%s): %.80r", reason, patch)
   logger.info(
@@ -1433,7 +1441,7 @@ def evolve_skill(
   # applies to standalone collect_patches usage only.
   client = client or _make_client(project, location)
 
-  patch_provenance: dict[int, list[str]] = {}
+  patch_provenance: dict[int, tuple[str, str]] = {}
   provenance_token = _PATCH_PROVENANCE.set(patch_provenance)
   try:
     patches = collect_patches(
@@ -1459,8 +1467,13 @@ def evolve_skill(
   # filter the result.
   patch_sources = []
   for patch in patches:
-    sources = patch_provenance.get(id(patch), [])
-    patch_sources.append(sources.pop(0) if sources else "builtin")
+    provenance_entry = patch_provenance.get(id(patch))
+    source = (
+        provenance_entry[1]
+        if provenance_entry is not None and provenance_entry[0] is patch
+        else "builtin"
+    )
+    patch_sources.append(source)
 
   logger.info("Generating %d candidate(s)...", candidates)
   cands = []

--- a/scripts/skill_evolution.py
+++ b/scripts/skill_evolution.py
@@ -1461,18 +1461,28 @@ def evolve_skill(
   if not patches:
     logger.warning("No patches to consolidate; returning the current skill.")
     return current_skill
-  # Plain strings from a legacy replacement have no recorded provenance, so use
-  # the conservative builtin fallback. Identity-retaining wrappers around the
-  # SDK collector resolve through the context map even when they reorder or
-  # filter the result.
+  # Identity-retaining wrappers resolve each occurrence exactly, even when they
+  # reorder or filter equal patch strings. For wrappers that reconstruct the
+  # strings (for example, via serialization), fall back to text only when every
+  # recorded occurrence of that text has the same source. Plain strings from a
+  # legacy replacement and ambiguous equal-text copies remain conservative.
+  recorded_sources_by_patch: dict[str, set[str]] = {}
+  for recorded_patch, recorded_source in patch_provenance.values():
+    recorded_sources_by_patch.setdefault(recorded_patch, set()).add(
+        recorded_source
+    )
   patch_sources = []
   for patch in patches:
     provenance_entry = patch_provenance.get(id(patch))
-    source = (
-        provenance_entry[1]
-        if provenance_entry is not None and provenance_entry[0] is patch
-        else "builtin"
-    )
+    if provenance_entry is not None and provenance_entry[0] is patch:
+      source = provenance_entry[1]
+    else:
+      matching_sources = recorded_sources_by_patch.get(patch, set())
+      source = (
+          next(iter(matching_sources))
+          if len(matching_sources) == 1
+          else "builtin"
+      )
     patch_sources.append(source)
 
   logger.info("Generating %d candidate(s)...", candidates)

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -45,6 +45,22 @@ def _session(category, **extra):
   return s
 
 
+def test_public_host_contract_exports_stable_surface():
+  import skill_evolution
+
+  assert skill_evolution.__all__ == [
+      "ErrorAnalystFn",
+      "collect_patches",
+      "evolve_skill",
+      "format_trajectory",
+      "partition_trajectories",
+      "select_candidate",
+  ]
+  assert "unverified user hypothesis" in " ".join(
+      collect_patches.__doc__.split()
+  )
+
+
 # --- partition_trajectories -------------------------------------------------
 
 
@@ -846,6 +862,51 @@ def test_non_string_host_patch_dropped_not_crashed(caplog):
   assert any("instead of patch text" in r.message for r in caplog.records)
 
 
+def test_collect_patches_tracks_sources_after_quality_gate(monkeypatch):
+  import skill_evolution as _se
+
+  host_results = iter(
+      [
+          "too short",
+          (
+              "## Root Cause\nTOOL_USAGE: skipped the available lookup.\n"
+              "## Proposed Patch\nContent: call the lookup before answering."
+          ),
+      ]
+  )
+
+  def host_analyst(client, model, session, current_skill, tools):
+    return next(host_results)
+
+  def builtin_analyst(client, model, prompt, session, current_skill, tools):
+    return (
+        "## Pattern\nRESPONSE_PATTERN: verified the result before replying.\n"
+        "## Proposed Patch\nContent: keep verifying tool results."
+    )
+
+  monkeypatch.setattr(_se, "run_analyst", builtin_analyst)
+  report = {
+      "sessions": [
+          _session("unhelpful", question="rejected host"),
+          _session("partial", question="kept host"),
+          _session("meaningful", question="kept builtin"),
+      ]
+  }
+  sources = []
+  patches = collect_patches(
+      report,
+      "BASE",
+      client=object(),
+      model="unused",
+      analyst_mode="both",
+      error_analyst_fn=host_analyst,
+      _patch_sources=sources,
+  )
+
+  assert len(patches) == 2
+  assert sources == ["host", "builtin"]
+
+
 def test_raising_host_analyst_partial_failure_tolerated(caplog):
   # One raising host analyst degrades to a warning; the surviving patch is
   # still collected and no exception propagates.
@@ -1409,7 +1470,14 @@ def test_write_evolution_artifacts(tmp_path):
   selected = "CAND TWO"
 
   out = str(tmp_path)
-  _write_evolution_artifacts(out, patches, candidates, selected, base)
+  _write_evolution_artifacts(
+      out,
+      patches,
+      candidates,
+      selected,
+      base,
+      patch_sources=["host", "builtin", "builtin"],
+  )
 
   # Patches: one record per patch, with parsed category.
   records = json.load(open(os.path.join(out, "v1_patches.json")))
@@ -1417,6 +1485,11 @@ def test_write_evolution_artifacts(tmp_path):
   assert records[0]["category"] == "TOOL_USAGE"
   assert records[2]["category"] == "RESPONSE_PATTERN"
   assert records[0]["patch"] == patches[0]
+  assert [record["source"] for record in records] == [
+      "host",
+      "builtin",
+      "builtin",
+  ]
 
   # Candidates: base/empty filtered; selected one tagged.
   cand_dir = os.path.join(out, "v1_candidates")
@@ -1453,6 +1526,80 @@ def test_write_evolution_artifacts_version_label_and_selection(tmp_path):
   assert os.listdir(os.path.join(out, "v2_candidates")) == []
   note = open(os.path.join(out, "v2_selection.txt")).read()
   assert note.startswith("kept incumbent:")
+
+
+def test_write_evolution_artifacts_rejects_misaligned_sources(tmp_path):
+  import pytest
+
+  with pytest.raises(ValueError, match="align one-to-one"):
+    _write_evolution_artifacts(
+        str(tmp_path),
+        ["patch one", "patch two"],
+        [],
+        "BASE",
+        "BASE",
+        patch_sources=["host"],
+    )
+
+
+def test_evolve_skill_writes_host_patch_provenance(monkeypatch, tmp_path):
+  import skill_evolution as _se
+
+  def host_analyst(client, model, session, current_skill, tools):
+    return (
+        "## Root Cause\nTOOL_USAGE: skipped the available lookup.\n"
+        "## Proposed Patch\nContent: call the lookup before answering."
+    )
+
+  monkeypatch.setattr(
+      _se,
+      "_consolidate_once",
+      lambda *args, **kwargs: _BASE + "\n## C\nnew rule c\n",
+  )
+  result = _se.evolve_skill(
+      {"sessions": [_session("unhelpful", question="q")]},
+      _BASE,
+      client=object(),
+      candidates=1,
+      analyst_mode="error-only",
+      error_analyst_fn=host_analyst,
+      artifacts_dir=str(tmp_path),
+  )
+
+  assert "## C" in result
+  records = json.load(open(tmp_path / "v1_patches.json"))
+  assert [(record["source"], record["category"]) for record in records] == [
+      ("host", "TOOL_USAGE")
+  ]
+
+
+def test_evolve_skill_preserves_legacy_collect_patches_replacements(
+    monkeypatch, tmp_path
+):
+  import skill_evolution as _se
+
+  patch = (
+      "## Root Cause\nTOOL_USAGE: skipped the available lookup.\n"
+      "## Proposed Patch\nContent: call the lookup before answering."
+  )
+  monkeypatch.setattr(_se, "collect_patches", lambda *args, **kwargs: [patch])
+  monkeypatch.setattr(
+      _se,
+      "_consolidate_once",
+      lambda *args, **kwargs: _BASE + "\n## C\nnew rule c\n",
+  )
+
+  result = _se.evolve_skill(
+      {"sessions": [_session("unhelpful", question="q")]},
+      _BASE,
+      client=object(),
+      candidates=1,
+      artifacts_dir=str(tmp_path),
+  )
+
+  assert "## C" in result
+  records = json.load(open(tmp_path / "v1_patches.json"))
+  assert records[0]["source"] == "builtin"
 
 
 def test_prevalence_exact_tie_stays_strong():

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -892,19 +892,25 @@ def test_collect_patches_tracks_sources_after_quality_gate(monkeypatch):
           _session("meaningful", question="kept builtin"),
       ]
   }
-  sources = []
-  patches = collect_patches(
-      report,
-      "BASE",
-      client=object(),
-      model="unused",
-      analyst_mode="both",
-      error_analyst_fn=host_analyst,
-      _patch_sources=sources,
-  )
+  provenance = {}
+  token = _se._PATCH_PROVENANCE.set(provenance)
+  try:
+    patches = collect_patches(
+        report,
+        "BASE",
+        client=object(),
+        model="unused",
+        analyst_mode="both",
+        error_analyst_fn=host_analyst,
+    )
+  finally:
+    _se._PATCH_PROVENANCE.reset(token)
 
   assert len(patches) == 2
-  assert sources == ["host", "builtin"]
+  assert [provenance[id(patch)] for patch in patches] == [
+      ["host"],
+      ["builtin"],
+  ]
 
 
 def test_raising_host_analyst_partial_failure_tolerated(caplog):
@@ -1582,7 +1588,23 @@ def test_evolve_skill_preserves_legacy_collect_patches_replacements(
       "## Root Cause\nTOOL_USAGE: skipped the available lookup.\n"
       "## Proposed Patch\nContent: call the lookup before answering."
   )
-  monkeypatch.setattr(_se, "collect_patches", lambda *args, **kwargs: [patch])
+
+  def legacy_collector(
+      report,
+      current_skill,
+      *,
+      client,
+      model,
+      max_workers=10,
+      max_success_samples=15,
+      analyst_mode="both",
+      tools=None,
+      error_analyst_fn=None,
+      analyst_timeout_s=None,
+  ):
+    return [patch]
+
+  monkeypatch.setattr(_se, "collect_patches", legacy_collector)
   monkeypatch.setattr(
       _se,
       "_consolidate_once",
@@ -1600,6 +1622,129 @@ def test_evolve_skill_preserves_legacy_collect_patches_replacements(
   assert "## C" in result
   records = json.load(open(tmp_path / "v1_patches.json"))
   assert records[0]["source"] == "builtin"
+
+
+def _legacy_collector_wrapper(original_collector, transform):
+  """Wrap a collector without accepting any post-#395 private keywords."""
+
+  def collector(
+      report,
+      current_skill,
+      *,
+      client,
+      model,
+      max_workers=10,
+      max_success_samples=15,
+      analyst_mode="both",
+      tools=None,
+      error_analyst_fn=None,
+      analyst_timeout_s=None,
+  ):
+    patches = original_collector(
+        report,
+        current_skill,
+        client=client,
+        model=model,
+        max_workers=max_workers,
+        max_success_samples=max_success_samples,
+        analyst_mode=analyst_mode,
+        tools=tools,
+        error_analyst_fn=error_analyst_fn,
+        analyst_timeout_s=analyst_timeout_s,
+    )
+    return transform(patches)
+
+  return collector
+
+
+def _run_wrapped_provenance_case(monkeypatch, tmp_path, transform):
+  import skill_evolution as _se
+
+  host_patch = (
+      "## Root Cause\nTOOL_USAGE: host patch skipped the lookup.\n"
+      "## Proposed Patch\nContent: host should call the lookup first."
+  )
+  builtin_patch = (
+      "## Pattern\nRESPONSE_PATTERN: builtin patch verified the result.\n"
+      "## Proposed Patch\nContent: builtin should keep verification."
+  )
+
+  def host_analyst(client, model, session, current_skill, tools):
+    return host_patch
+
+  def builtin_analyst(client, model, prompt, session, current_skill, tools):
+    return builtin_patch
+
+  monkeypatch.setattr(_se, "run_analyst", builtin_analyst)
+  monkeypatch.setattr(
+      _se,
+      "collect_patches",
+      _legacy_collector_wrapper(_se.collect_patches, transform),
+  )
+  monkeypatch.setattr(
+      _se,
+      "_consolidate_once",
+      lambda *args, **kwargs: _BASE + "\n## C\nnew rule c\n",
+  )
+
+  _se.evolve_skill(
+      {
+          "sessions": [
+              _session("unhelpful", question="host"),
+              _session("meaningful", question="builtin"),
+          ]
+      },
+      _BASE,
+      client=object(),
+      candidates=1,
+      error_analyst_fn=host_analyst,
+      artifacts_dir=str(tmp_path),
+  )
+
+  return (
+      json.load(open(tmp_path / "v1_patches.json")),
+      host_patch,
+      builtin_patch,
+  )
+
+
+def test_evolve_skill_keeps_provenance_when_wrapper_reorders(
+    monkeypatch, tmp_path
+):
+  records, host_patch, builtin_patch = _run_wrapped_provenance_case(
+      monkeypatch, tmp_path, lambda patches: list(reversed(patches))
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (builtin_patch, "builtin"),
+      (host_patch, "host"),
+  ]
+
+
+def test_evolve_skill_keeps_provenance_when_wrapper_filters(
+    monkeypatch, tmp_path
+):
+  records, host_patch, _ = _run_wrapped_provenance_case(
+      monkeypatch,
+      tmp_path,
+      lambda patches: [patch for patch in patches if "host patch" in patch],
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (host_patch, "host")
+  ]
+
+
+def test_evolve_skill_keeps_provenance_when_wrapper_deduplicates(
+    monkeypatch, tmp_path
+):
+  records, host_patch, builtin_patch = _run_wrapped_provenance_case(
+      monkeypatch,
+      tmp_path,
+      lambda patches: list(dict.fromkeys([patches[0], *patches])),
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (host_patch, "host"),
+      (builtin_patch, "builtin"),
+  ]
 
 
 def test_prevalence_exact_tie_stays_strong():

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -907,10 +907,9 @@ def test_collect_patches_tracks_sources_after_quality_gate(monkeypatch):
     _se._PATCH_PROVENANCE.reset(token)
 
   assert len(patches) == 2
-  assert [provenance[id(patch)] for patch in patches] == [
-      ["host"],
-      ["builtin"],
-  ]
+  assert all(type(patch) is str for patch in patches)
+  assert all(provenance[id(patch)][0] is patch for patch in patches)
+  assert [provenance[id(patch)][1] for patch in patches] == ["host", "builtin"]
 
 
 def test_raising_host_analyst_partial_failure_tolerated(caplog):
@@ -1657,7 +1656,9 @@ def _legacy_collector_wrapper(original_collector, transform):
   return collector
 
 
-def _run_wrapped_provenance_case(monkeypatch, tmp_path, transform):
+def _run_wrapped_provenance_case(
+    monkeypatch, tmp_path, transform, *, shared_patch=False
+):
   import skill_evolution as _se
 
   host_patch = (
@@ -1668,6 +1669,8 @@ def _run_wrapped_provenance_case(monkeypatch, tmp_path, transform):
       "## Pattern\nRESPONSE_PATTERN: builtin patch verified the result.\n"
       "## Proposed Patch\nContent: builtin should keep verification."
   )
+  if shared_patch:
+    builtin_patch = host_patch
 
   def host_analyst(client, model, session, current_skill, tools):
     return host_patch
@@ -1744,6 +1747,127 @@ def test_evolve_skill_keeps_provenance_when_wrapper_deduplicates(
   assert [(record["patch"], record["source"]) for record in records] == [
       (host_patch, "host"),
       (builtin_patch, "builtin"),
+  ]
+
+
+def test_evolve_skill_distinguishes_shared_patch_occurrences_when_filtered(
+    monkeypatch, tmp_path
+):
+  def keep_second_occurrence(patches):
+    assert patches[0] == patches[1]
+    assert patches[0] is not patches[1]
+    assert all(type(patch) is str for patch in patches)
+    return patches[1:]
+
+  records, shared_patch, _ = _run_wrapped_provenance_case(
+      monkeypatch,
+      tmp_path,
+      keep_second_occurrence,
+      shared_patch=True,
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (shared_patch, "builtin")
+  ]
+
+
+def test_evolve_skill_distinguishes_shared_patch_occurrences_when_reordered(
+    monkeypatch, tmp_path
+):
+  records, shared_patch, _ = _run_wrapped_provenance_case(
+      monkeypatch,
+      tmp_path,
+      lambda patches: list(reversed(patches)),
+      shared_patch=True,
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (shared_patch, "builtin"),
+      (shared_patch, "host"),
+  ]
+
+
+def test_evolve_skill_keeps_discarded_batch_alive_for_provenance(
+    monkeypatch, tmp_path
+):
+  import skill_evolution as _se
+
+  host_patch = (
+      "## Root Cause\nTOOL_USAGE: discarded host patch skipped lookup.\n"
+      "## Proposed Patch\nContent: call the host lookup first."
+  )
+  builtin_patch = (
+      "## Pattern\nRESPONSE_PATTERN: returned builtin patch verified data.\n"
+      "## Proposed Patch\nContent: keep builtin verification."
+  )
+
+  def host_analyst(client, model, session, current_skill, tools):
+    return host_patch
+
+  def builtin_analyst(client, model, prompt, session, current_skill, tools):
+    return builtin_patch
+
+  original_collector = _se.collect_patches
+
+  def discarding_collector(
+      report,
+      current_skill,
+      *,
+      client,
+      model,
+      max_workers=10,
+      max_success_samples=15,
+      analyst_mode="both",
+      tools=None,
+      error_analyst_fn=None,
+      analyst_timeout_s=None,
+  ):
+    discarded = original_collector(
+        {"sessions": [_session("unhelpful", question="discarded host")]},
+        current_skill,
+        client=client,
+        model=model,
+        max_workers=max_workers,
+        max_success_samples=max_success_samples,
+        analyst_mode="error-only",
+        tools=tools,
+        error_analyst_fn=error_analyst_fn,
+        analyst_timeout_s=analyst_timeout_s,
+    )
+    provenance = _se._PATCH_PROVENANCE.get()
+    assert provenance[id(discarded[0])][0] is discarded[0]
+    del discarded
+    return original_collector(
+        {"sessions": [_session("meaningful", question="returned builtin")]},
+        current_skill,
+        client=client,
+        model=model,
+        max_workers=max_workers,
+        max_success_samples=max_success_samples,
+        analyst_mode="success-only",
+        tools=tools,
+        error_analyst_fn=error_analyst_fn,
+        analyst_timeout_s=analyst_timeout_s,
+    )
+
+  monkeypatch.setattr(_se, "run_analyst", builtin_analyst)
+  monkeypatch.setattr(_se, "collect_patches", discarding_collector)
+  monkeypatch.setattr(
+      _se,
+      "_consolidate_once",
+      lambda *args, **kwargs: _BASE + "\n## C\nnew rule c\n",
+  )
+
+  _se.evolve_skill(
+      {"sessions": []},
+      _BASE,
+      client=object(),
+      candidates=1,
+      error_analyst_fn=host_analyst,
+      artifacts_dir=str(tmp_path),
+  )
+
+  records = json.load(open(tmp_path / "v1_patches.json"))
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (builtin_patch, "builtin")
   ]
 
 

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -1656,6 +1656,13 @@ def _legacy_collector_wrapper(original_collector, transform):
   return collector
 
 
+def _copy_patch_text(patches):
+  copies = [patch.encode("utf-8").decode("utf-8") for patch in patches]
+  assert all(copy == patch for copy, patch in zip(copies, patches))
+  assert all(copy is not patch for copy, patch in zip(copies, patches))
+  return copies
+
+
 def _run_wrapped_provenance_case(
     monkeypatch, tmp_path, transform, *, shared_patch=False
 ):
@@ -1747,6 +1754,33 @@ def test_evolve_skill_keeps_provenance_when_wrapper_deduplicates(
   assert [(record["patch"], record["source"]) for record in records] == [
       (host_patch, "host"),
       (builtin_patch, "builtin"),
+  ]
+
+
+def test_evolve_skill_keeps_unambiguous_provenance_when_wrapper_copies_text(
+    monkeypatch, tmp_path
+):
+  records, host_patch, builtin_patch = _run_wrapped_provenance_case(
+      monkeypatch, tmp_path, _copy_patch_text
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (host_patch, "host"),
+      (builtin_patch, "builtin"),
+  ]
+
+
+def test_evolve_skill_does_not_guess_provenance_for_conflicting_equal_text(
+    monkeypatch, tmp_path
+):
+  records, shared_patch, _ = _run_wrapped_provenance_case(
+      monkeypatch,
+      tmp_path,
+      _copy_patch_text,
+      shared_patch=True,
+  )
+  assert [(record["patch"], record["source"]) for record in records] == [
+      (shared_patch, "builtin"),
+      (shared_patch, "builtin"),
   ]
 
 


### PR DESCRIPTION
## Summary

Complete the remaining host-contract hardening tracked in #397 so hosted skill-evolution runs are both auditable and safer to integrate.

## Changes

- Record `source: "builtin" | "host"` on every quality-gated patch in `*_patches.json`.
- Keep patch text and provenance aligned through the quality gate, including mixed builtin/host fleets.
- Preserve provenance through collector wrappers that reorder, filter, deduplicate, or reconstruct patch strings when equal-text provenance is unambiguous.
- Fall back conservatively when equal recorded patch text has conflicting sources.
- Preserve the public `collect_patches() -> list[str]` return contract and compatibility with hosts that replace `collect_patches`.
- Define the supported integration surface with `__all__` and document the additive session-schema policy.
- Document that host analysts must treat `correction_boundaries[*].correct_fact` as an unverified user hypothesis and verify it through tools before producing a patch.
- Add the host-contract stability and artifact-schema change to the changelog.

The non-string result handling and bounded analyst timeout described in #397 are already present on `main`; this change covers the remaining provenance and stability/documentation items.

## Validation

- `pytest -q tests/test_skill_evolution.py tests/test_skill_evo_job_selection_regressions.py` — 150 passed
- Full sandbox suite — 4,933 passed, 74 skipped; the four local permission-sensitive failures (`ps` access and browser smoke port binding) were rerun outside the sandbox and all 4 passed
- `pyink --check scripts/skill_evolution.py tests/test_skill_evolution.py`
- `isort --check-only scripts/skill_evolution.py tests/test_skill_evolution.py`
- `git diff --check`

Closes #397